### PR TITLE
gr-limesdr: move to the new examples folder

### DIFF
--- a/science/gr-limesdr/Portfile
+++ b/science/gr-limesdr/Portfile
@@ -22,7 +22,7 @@ if {[string first "-devel" $subport] > 0} {
     checksums rmd160 b60458dc9e44768b2e97832c107958ac461c6a35 \
               sha256 97c48459ad564a32123530f2f90f0e5d4a9b14690222706643891372d3c28764 \
               size   3086348
-    revision  0
+    revision  1
 
     name            gr-limesdr-devel
     long_description ${description}. This port is kept up with the ${name} \
@@ -36,7 +36,7 @@ if {[string first "-devel" $subport] > 0} {
     checksums       rmd160  c8b2b7a745a316bcc7c6b7b0a1121da2bddea05a \
                     sha256  6f2fcf42dd45ca3893c914752f803dd811e046c21c567286fd1ad35a8d362f05 \
                     size    3083984
-    revision        2
+    revision        3
 
     conflicts       gr-limesdr-devel
 
@@ -93,7 +93,7 @@ default_variants +docs
 
 post-destroot {
     # copy GNU Radio examples
-    xinstall -m 755 -d ${destroot}${prefix}/share/gr-limesdr
-    file copy ${worksrcpath}/examples \
-        ${destroot}${prefix}/share/gr-limesdr/examples
+    xinstall -m 755 -d ${destroot}${prefix}/share/gnuradio/examples/limesdr
+    file copy {*}[glob ${worksrcpath}/examples/*] \
+        ${destroot}${prefix}/share/gnuradio/examples/limesdr
 }


### PR DESCRIPTION
#### Description

move the examples folder to gnuradio/examples

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A582a
Xcode 11.2 11B41

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->