### PR TITLE
py-commpy: new port

### DIFF
--- a/python/py-commpy/Portfile
+++ b/python/py-commpy/Portfile
@@ -1,0 +1,44 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-commpy
+version             0.4.0
+revision            0
+
+platforms           darwin
+supported_archs     noarch
+license             BSD
+maintainers         {@ra1nb0w irh.it:rainbow} {michaelld @michaelld} openmaintainer
+
+description         Digital Communication Algorithms with Python
+long_description    ${description}
+
+homepage            https://veeresht.github.com/CommPy
+python.rootname     scikit-commpy
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+
+checksums           rmd160  dd1642d3fdbf7ef21dbcb2f58a1732dfdc338696 \
+                    sha256  a3903df1a9af50654f354eaf3371d13406514405d75a7c0f8f4cf5957fac90e0 \
+                    size    26768
+
+python.versions     27 34 35 36 37
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+        port:py${python.version}-setuptools
+
+    depends_lib-append \
+        port:py${python.version}-matplotlib \
+        port:py${python.version}-numpy \
+        port:py${python.version}-scipy
+
+    # some data is not present on the pypi package
+    # therefore it fails; disable
+    #depends_test-append port:py${python.version}-nose
+    #test.run no
+
+    livecheck.type  none
+}


### PR DESCRIPTION
#### Description

Digital Communication Algorithms with Python


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A582a
Xcode 11.2 11B41

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->