### PR TITLE
get_iplayer: update to version 3.22

### DIFF
--- a/net/get_iplayer/Portfile
+++ b/net/get_iplayer/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 PortGroup           github 1.0
 
-github.setup        get-iplayer get_iplayer 3.16 v
+github.setup        get-iplayer get_iplayer 3.22 v
 categories          net multimedia
 platforms           darwin
 maintainers         {gmail.com:davide.liessi @dliessi} openmaintainer
@@ -15,11 +15,9 @@ description         A utility for downloading TV and radio from BBC iPlayer
 long_description    ${description}. \
                     \nThis port does not install the Web PVR Manager (get_iplayer.cgi).
 
-checksums           rmd160  7171e71a1bb1d7426a168956c3312134ba98e8cb \
-                    sha256  9a6f780d616b66f7e890f380f90dc1d8918dc62165847343fe2ac44e95486757 \
-                    size    141452
-
-perl5.branches      5.26
+checksums           rmd160  011a63971723bb3597ea7c30f4118d7c05616952 \
+                    sha256  0c7721124f424bfc0ba1bbbc5d4965382ef1d473c307c60b2c273e65c9284e65 \
+                    size    146353
 
 depends_run         port:perl${perl5.major} \
                     port:p${perl5.major}-libwww-perl \


### PR DESCRIPTION
Port currently uses perl5.26.

Instead of specifying a specific perl version, use
the perl5 PortGroup's default (currently perl5.28).

See https://trac.macports.org/ticket/58361

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15 19A583
Xcode 11.1 11A1027 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
