### PR TITLE
upt: enable system wide man page

### DIFF
--- a/sysutils/upt/Portfile
+++ b/sysutils/upt/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                upt
 version             0.10.3
-revision            0
+revision            1
 
 categories-prepend  sysutils
 platforms           darwin
@@ -47,4 +47,8 @@ post-destroot {
     xinstall -d ${destroot}${docdir}
     xinstall -m 0644 -W ${worksrcpath} README.md LICENSE CHANGELOG \
         ${destroot}${docdir}
+
+    # link man page; must be only one upt version at time
+    ln -s ${python.prefix}/share/man/man1/${name}.1 \
+        ${destroot}${prefix}/share/man/man1/
 }


### PR DESCRIPTION
#### Description

link man page into global directory

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A582a
Xcode 11.2 11B41

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->