### PR TITLE
iTerm2: Fix the version checking logic

### DIFF
--- a/aqua/iTerm2/Portfile
+++ b/aqua/iTerm2/Portfile
@@ -5,15 +5,7 @@ PortGroup           github 1.0
 PortGroup           xcodeversion 1.0
 use_xcode           yes
 
-if {[vercmp ${os.version} 17.0.0] < 0} {
-    version             3.2.0
-    revision            0
-    checksums \
-        rmd160  07915ff5db0545c0c059f47e7f71761e023a26e1 \
-        sha256  017aff348352369abcc994caaca0f6112e1f17c4d65041acdb9f19830b2b96bd \
-        size    11969144
-    patchfiles          patch-Makefile.diff
-} else {
+if {${os.major} > 16} {
     version             3.3.5
     revision            1
     checksums \
@@ -22,6 +14,14 @@ if {[vercmp ${os.version} 17.0.0] < 0} {
         size    18852672
     patchfiles          patch-Makefile-XC10.diff
     patchfiles-append   patch-CVE-2019-9535.diff
+} else {
+    version             3.2.0
+    revision            0
+    checksums \
+        rmd160  07915ff5db0545c0c059f47e7f71761e023a26e1 \
+        sha256  017aff348352369abcc994caaca0f6112e1f17c4d65041acdb9f19830b2b96bd \
+        size    11969144
+    patchfiles          patch-Makefile.diff
 }
 
 github.setup        gnachman iTerm2 ${version} v


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/58825

#### Description
Change the logic of the version checking to use `os.major` - can someone test it on an old version of macOS to see if the other logic works?

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15
Xcode 11.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
