### PR TITLE
wireguard-go: update to 0.0.20191012

### DIFF
--- a/net/wireguard-go/Portfile
+++ b/net/wireguard-go/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-go
-version             0.0.20190908
+version             0.0.20191012
 revision            0
-checksums           rmd160  914f8e384c445af9fd749b7e7d36a7a74d5f79b9 \
-                    sha256  3c4cc802a521736d01d24bfb4fe29a5e74da07d69637ec7bcdee074decf62c6a \
-                    size    79212
+checksums           rmd160  2591aaaa7f576017c8124b9aba62be781129ad86 \
+                    sha256  f4b651b7da7c93a4318c1231204d7d4529e2610b57041ee99fd85c22301edbcc \
+                    size    78832
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
###### Tested on
macOS 10.13.6 17G8030
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?