### PR TITLE
wireguard-tools: update to 0.0.20191012

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-tools
-version             0.0.20190913
+version             0.0.20191012
 revision            0
-checksums           rmd160  c12a9519efe753f74c3851bbd37632e7147a1622 \
-                    sha256  997327185d2d1b597dc118f737c0c165e2a2c21453387ea02659f1159d148518 \
-                    size    330788
+checksums           rmd160  fce033d725580c606145735a2f2f9cd4341cfe7d \
+                    sha256  93573193c9c1c22fde31eb1729ad428ca39da77a603a3d81561a9816ccecfa8e \
+                    size    331812
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
###### Tested on
macOS 10.13.6 17G8030
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?