### PR TITLE
PULL_REQUEST_TEMPLATE: remove `port test` instructions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,7 +25,6 @@ Have you
 - [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
 <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
 - [ ] checked your Portfile with `port lint`?
-- [ ] tried existing tests with `sudo port test`?
 - [ ] tried a full install with `sudo port -vst install`?
 - [ ] tested basic functionality of all binary files?
 


### PR DESCRIPTION
Some ports require port clean before running port test, testing could
take a long time, and some ports have broken unit tests that have been
broken for a long time.

Also, port test would fail if the port does not set `test.run` to yes,
which is not obvious to new contributors.
