### PR TITLE
qbs: Update to 1.14.0

### DIFF
--- a/devel/qbs/Portfile
+++ b/devel/qbs/Portfile
@@ -6,7 +6,7 @@ PortGroup           cxx11 1.1
 
 name                qbs
 
-version             1.13.1
+version             1.14.0
 categories          devel
 platforms           darwin
 license             LGPL-2.1
@@ -18,12 +18,12 @@ homepage            https://wiki.qt.io/Qbs
 distname            qbs-src-${version}
 master_sites        https://download.qt.io/official_releases/qbs/${version}/
 
-checksums           rmd160  086df6cb640585d2ce21a0bb0c7dd322f2fb0b78 \
-                    sha256  e63b579694bdc9c7cf76fce49539c42f9a4ccb0f130cdd46c984e69dfd078299 \
-                    size    4324622
+checksums           rmd160  cfd501f6bd5c1632e51383c7b95f622c92220797\
+                    sha256  c90f3469e91b0c7970f2dc7eeadcbccf966fbf5f462b8f73206a2a5345413f6a\
+                    size    4364968
 
 qt5.depends_component qtscript
-qt5.min_version     5.9.0
+qt5.min_version     5.11.0
 
 configure.post_args QBS_INSTALL_PREFIX=${prefix} \
                     CONFIG+=qbs_disable_rpath \
@@ -58,6 +58,6 @@ subport ${name}-docs {
             ${worksrcpath}/doc/doc.pri
     }
 
-    qt5.depends_build_component sqlite-plugin
+    qt5.depends_build_component sqlite-plugin qttools
     depends_run-append   port:${name}
 }


### PR DESCRIPTION
#### Description
qbs: Update to 1.14.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G95
Xcode 11.0 11A420a 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
