### PR TITLE
sudo: update version to 1.8.28 - fix CVE-2019-14287

### DIFF
--- a/sysutils/sudo/Portfile
+++ b/sysutils/sudo/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                sudo
 epoch               1
-version             1.8.27
+version             1.8.28
 revision            0
 categories          sysutils security
 license             ISC
@@ -23,9 +23,9 @@ homepage            http://www.sudo.ws/sudo/
 master_sites        ${homepage}dist/ \
                     ${homepage}dist/OLD/
 
-checksums           rmd160  fb7b0eb0782011f9d87d20a694a6ff7c31abf052 \
-                    sha256  7beb68b94471ef56d8a1036dbcdc09a7b58a949a68ffce48b83f837dd33e2ec0 \
-                    size    3293178
+checksums           rmd160  5104faf846b59a0c04045e2f464ffeae3ddf95c2 \
+                    sha256  9129fa745a08caff0ce2042d2162b38eb9bf73bf43fcb248ac8b3a750c1f13a1 \
+                    size    3309744
 
 patchfiles          patch-sudoers.in.diff
 


### PR DESCRIPTION
#### Description

- bump version to 1.8.28
- fix CVE-2019-14287 - Potential bypass of Runas user restrictions
  https://www.sudo.ws/alerts/minus_1_uid.html

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
macOS 10.15 19A582a
Xcode 11.2 11B44

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->