### PR TITLE
liblas: reference liblas by its actual ID

### DIFF
--- a/gis/liblas/Portfile
+++ b/gis/liblas/Portfile
@@ -26,6 +26,8 @@ checksums           rmd160  c6622541324b2483cdc0e4e3db459c4c9400fda0 \
                     sha256  327aea3d248d3921ec36a2866cbf98f940542ad1fe8b64079f7041a7e8005330 \
                     size    10734404
 
+compiler.cxx_standard   2011
+
 distname            libLAS-${version}
 
 patchfiles          patch-gt_wkt_srs_cpp.diff

--- a/gis/liblas/Portfile
+++ b/gis/liblas/Portfile
@@ -7,7 +7,7 @@ PortGroup           github  1.0
 github.setup        libLAS libLAS 8c7f310
 name                liblas
 version             1.8.1.99
-revision            1
+revision            2
 license             BSD
 categories          gis
 maintainers         nomaintainer
@@ -35,7 +35,8 @@ configure.args-append \
                     -DWITH_GDAL=ON \
                     -DWITH_LASZIP=OFF \
                     -DPROJ4_INCLUDE_DIR=${prefix}/lib/proj6 \
-                    -DPROJ4_LIBRARY=${prefix}/lib/proj6
+                    -DPROJ4_LIBRARY=${prefix}/lib/proj6 \
+                    -DCMAKE_INSTALL_NAME_DIR=${prefix}/lib
 
 configure.cxxflags-append   -std=c++11
 
@@ -47,9 +48,3 @@ depends_lib-append  port:boost \
                     port:zlib \
                     port:proj6 \
                     port:laszip
-
-post-destroot {
-    exec install_name_tool -id ${prefix}/lib/liblas.2.4.0.dylib ${destroot}${prefix}/lib/liblas.2.4.0.dylib
-    exec install_name_tool -id ${prefix}/lib/liblas_c.2.4.0.dylib ${destroot}${prefix}/lib/liblas_c.2.4.0.dylib
-    exec install_name_tool -change "@rpath/liblas.3.dylib" ${prefix}/lib/liblas.3.dylib ${destroot}${prefix}/lib/liblas_c.2.4.0.dylib
-}


### PR DESCRIPTION
References between libraries should be consistent. Without looking at
the filesystem to see that `liblas.3.dylib` and `liblas.2.4.0.dylib` are
actually the same file (via symlinks), realizing that these are the same
library with analysis tools can cause false positives.

#### Description

Maintains consistency between the libraries in the `liblas` port.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G8037
Xcode 10.1 10B61

Done by manually running the `-change` command on my existing installation.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

I'm not familiar with how to test the change locally from end-to-end, so I haven't done that part yet (if it is wanted/necessary for a change like this).