### PR TITLE
jtc: ensure compiler meets C++ 2014 standard

### DIFF
--- a/textproc/jtc/Portfile
+++ b/textproc/jtc/Portfile
@@ -26,6 +26,8 @@ checksums           rmd160  84ec627b6b0b34ab68bbac9cbf126949e18c7538 \
                     sha256  25a6da6d6d647f900a77d8271444015a62bee7ddef3140612e511312944d454c \
                     size    171694
 
+compiler.cxx_standard 2014
+
 installs_libs       no
 use_configure       no
 


### PR DESCRIPTION
#### Description

`jtc` requires a C++ 2014 -capable compiler.  Add port parameters to ensure this.

Resolves: https://trac.macports.org/ticket/59323

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G103
Xcode 11.1 11A1027

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
