### PR TITLE
gr-iridium: add cppunit as build depends

### DIFF
--- a/science/gr-iridium/Portfile
+++ b/science/gr-iridium/Portfile
@@ -16,14 +16,15 @@ version   20190722-[string range ${github.version} 0 7]
 checksums rmd160 909c3ad0e0bdb12d53666d0ad85b6b95d8dcab80 \
           sha256 e0fe908b32e209b7b2e1a6b3f92d0a12ad4de5eb6ed517f632afdc8c5a87a9e5 \
           size   143041
-revision  0
+revision  1
 
 # use C++11
 compiler.cxx_standard 2011
 
 depends_build-append \
     port:pkgconfig \
-    port:swig-python
+    port:swig-python \
+    port:cppunit
 
 depends_lib-append \
     port:boost \


### PR DESCRIPTION
#### Description

adding cppunit on depends_build

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A582a
Xcode 11.2 11B44

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->