### PR TITLE
nodejs12: enable parallel build.

### DIFF
--- a/devel/nodejs12/Portfile
+++ b/devel/nodejs12/Portfile
@@ -86,8 +86,7 @@ universal_variant       no
 configure.ccache        no
 
 test.run                yes
-
-use_parallel_build      no
+test.cmd                ${build.cmd} -j${build.jobs}
 
 switch $build_arch {
     i386 {


### PR DESCRIPTION
#### Description

This enables parallel build of `nodejs12`.

I don't know why it was disabled so I'm not changing it for older versions. Current BUILDING manual of nodejs suggests to use `make -j` so it should be fine. With single process it takes forever to build.

See https://github.com/nodejs/node/blob/master/BUILDING.md#building-nodejs-1

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15
Xcode 11.1 (CLI tools only, without actual Xcode app)

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
-- test fails due to some unrelated issues, for example:
```
:info:test AssertionError [ERR_ASSERTION]: ifError got unwanted exception: Command failed: ps -p 87114 -o args=
:info:test /bin/sh: /bin/ps: Operation not permitted
```
and
```
=== release test-dgram-connect-send-empty-buffer ===
:info:test Path: parallel/test-dgram-connect-send-empty-buffer
:info:test Command: out/Release/node /opt/local/var/macports/build/_Users_xeron_workspace_devel_macports-ports_devel_nodejs12/nodejs12/work/node-v12.12.0/test/parallel/test-dgram-connect-send-empty-buffer.js
:info:test --- TIMEOUT ---
:info:test 
```
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?