### PR TITLE
dsdcc: update version to 1.8.6

### DIFF
--- a/audio/dsdcc/Portfile
+++ b/audio/dsdcc/Portfile
@@ -13,11 +13,10 @@ maintainers         {@ra1nb0w irh.it:rainbow} openmaintainer
 description         Digital Speech Decoder (DSD) rewritten as a C++ library
 long_description    ${description}
 
-github.setup        f4exb dsdcc 5dd8d1eeddb5df53c9e46f53b50781864cf5f6fe
-version             1.8.5
-checksums           rmd160  e6011b353ae560dca34566076b04b18c6b54c498 \
-                    sha256  689afa355b2fcb9f02f5ee6789a3844489e14fe8797146f94e2594fa0db308a7 \
-                    size    12745955
+github.setup        f4exb dsdcc 1.8.6 v
+checksums           rmd160  d8b118921a6cacba6c2f749d13e878fcb585d094 \
+                    sha256  55243f12b1932da479657ab44a5447a44144703ea41887b07390ec76aabad047 \
+                    size    12746095
 revision            0
 
 configure.args-append \


### PR DESCRIPTION
#### Description


- bump version to 1.8.6

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A582a
Xcode 11.2 11B44

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->