### PR TITLE
lpcnetfreedv: update version to 1443da92

### DIFF
--- a/audio/lpcnetfreedv/Portfile
+++ b/audio/lpcnetfreedv/Portfile
@@ -15,11 +15,11 @@ description         Experimental Neural Net speech coding for FreeDV
 long_description    Experimental version of LPCNet being developed \
     for over the air Digital Voice experiments with FreeDV.
 
-github.setup        drowe67 LPCNet 8b78d3f5bcf7905ed3261e03f1082d587aab5371
-version             20190902
-checksums           rmd160  87a9ac0597c3f4cbed9b1f270bb229c9adb4da1b \
-                    sha256  2aa6831102bce3d690a50637ec997b5c844a8754cc58ae1cd8ffca930ea7fa2d \
-                    size    3307177
+github.setup        drowe67 LPCNet 1443da9221a041b4569e5d66f78f65a081320b05
+version             20191011-[string range ${github.version} 0 7]
+checksums           rmd160  a1de0f8c615a180ead03f0e0cee765cc921bf9bb \
+                    sha256  347febf6f8ac110fedee16036dc729bceb05d3500ffc05650720d753308b75c7 \
+                    size    33010957
 revision            0
 
 depends_lib-append \


### PR DESCRIPTION
#### Description

- bump version to 1443da92

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A582a
Xcode 11.2 11B44

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->