### PR TITLE
zim: update version to 0.72.0

### DIFF
--- a/editors/zim/Portfile
+++ b/editors/zim/Portfile
@@ -3,9 +3,9 @@
 PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           app 1.0
+PortGroup           github 1.0
 
 name                zim
-version             0.68
 platforms           darwin
 categories          editors
 maintainers         nomaintainer
@@ -22,43 +22,46 @@ long_description \
     equation editor, a tray icon, and support for version control.
 
 homepage            http://zim-wiki.org
-master_sites        ${homepage}/downloads/
-distname            zim-${version}
+github.setup        zim-desktop-wiki zim-desktop-wiki 0.72.0
+distname            ${github.version}
+checksums           rmd160  6dc04c9ead36e148448f2773be3ec92b0554fb12 \
+                    sha256  bfa2b630eef496c4ec3383ee9c14e5773140e6149e937ce8680fcecd05c67240 \
+                    size    2590805
+revision            0
 
-checksums           rmd160  9297468ff1caa0d9ea0936d30c34bb659938c48e \
-                    sha256  d91518e010f6a6e951a75314138b5545a4c51151fc99f513aa7768a18858df15 \
-                    size    2044224
-
-python.default_version  27
+python.default_version  37
 python.link_binaries    no
 
-depends_run-append  port:desktop-file-utils
+destroot.destdir-append \
+    --install-data=${prefix}
 
-set app.icon        icons/zim48.png
-set app.executable  ${workpath}/zim-app
+depends_lib-append \
+    port:gtk3 \
+    port:py${python.version}-gobject3 \
+    port:py${python.version}-xdg
 
-depends_lib-append  port:py${python.version}-gobject \
-                    port:py${python.version}-pygtk \
-                    port:py${python.version}-xdg
+depends_run-append \
+    port:adwaita-icon-theme \
+    port:desktop-file-utils
 
 use_configure       no
 build               {}
-
-destroot.destdir-append --install-data=${prefix} \
-                        --skip-xdg-cmd
 
 pre-destroot {
     xinstall -m 755 ${filespath}/zim ${destroot}${prefix}/bin
     reinplace "s|__PREFIX__|${prefix}|g" ${destroot}${prefix}/bin/zim
     reinplace "s|__PYTHON_BINDIR__|${python.prefix}/bin|g" ${destroot}${prefix}/bin/zim
-    file copy ${filespath}/zim-app ${workpath}/zim-app
-    reinplace "s|__PREFIX__|${prefix}|g" ${workpath}/zim-app
-    reinplace "s|__PYTHON_BINDIR__|${python.prefix}/bin|g" ${workpath}/zim-app
 }
 
 post-activate {
     exec update-desktop-database
-    exec update-mime-database ${destroot}${prefix}/share/mime 2> /dev/null
 }
 
-universal_variant   no
+app.create yes
+app.name Zim
+app.executable zim
+app.icon icons/zim48.png
+app.retina yes
+
+test.run yes
+test.cmd ${python.bin} zim.py --help

--- a/editors/zim/files/zim
+++ b/editors/zim/files/zim
@@ -1,3 +1,9 @@
-#! /bin/sh
+#!/bin/sh
 
-XDG_DATA_DIRS=__PREFIX__/share:$XDG_DATA_DIRS __PYTHON_BINDIR__/zim $@
+# set the correct language otherwise
+# it doesn't start with launchservicesd
+export LANG=$(defaults read -g AppleLanguages | \
+                  sed -n 2p | \
+                  sed '/"/!d;s/["[:space:]]//g;s/-/_/;s/,//').UTF-8
+export XDG_DATA_DIRS=__PREFIX__/share:$XDG_DATA_DIRS
+exec __PYTHON_BINDIR__/zim $@

--- a/editors/zim/files/zim-app
+++ b/editors/zim/files/zim-app
@@ -1,3 +1,0 @@
-#! /bin/sh
-
-XDG_DATA_DIRS=__PREFIX__/share:$XDG_DATA_DIRS __PYTHON_BINDIR__/zim


### PR DESCRIPTION
#### Description

- bump version to 0.72.0
- move from python2 to python3
- use gobject3 instead pygtk2
- use github as main source; the development is there now

Closes: https://trac.macports.org/ticket/58588

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A582a
Xcode 11.2 11B44

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->