### PR TITLE
gpredict: add application bundle

### DIFF
--- a/science/gpredict/Portfile
+++ b/science/gpredict/Portfile
@@ -1,10 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           app 1.0
 
 name                gpredict
 version             2.2.1
-revision            3
+revision            4
 categories          science
 license             GPL-2+
 platforms           darwin
@@ -39,5 +40,11 @@ depends_lib         port:goocanvas2 \
 # gpredict ships its own copy of the buggy intltool.m4, so just autoreconfing
 # won't help. Have to patch something and configure is easiest.
 patchfiles          configure-intltool_perl.patch
+
+app.create yes
+app.name Gpredict
+app.executable gpredict
+app.icon pixmaps/icons/gpredict-icon.png
+app.retina yes
 
 livecheck.regex     ${name}-(\[0-9.\]+)${extract.suffix}


### PR DESCRIPTION
#### Description

add application bundle to run the application from the finder

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A582a
Xcode 11.2 11B44

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->