### PR TITLE
python38: update rev 1: patches, add +devel

### DIFF
--- a/lang/python38-devel/Portfile
+++ b/lang/python38-devel/Portfile
@@ -1,0 +1,15 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           obsolete 1.0
+
+name                python38-devel
+replaced_by         python38
+
+version             3.8.0rc1
+epoch               1
+revision            1
+categories          lang
+license             PSF
+
+# Can be removed after 2020-09-14


### PR DESCRIPTION
#### Description

python38: update to rev 1, patches, add +devel                                                                                      

- Fixing the issues that was brought up in: [#commitcomment-35510857](https://github.com/macports/macports-ports/commit/d5cee77445576a654a4dbaf5630acbbb0ea238fe#commitcomment-35510857)
- devel is re-added, with replaced_by + rev 1                                                               
- Portfiles is rev 1, and the patches have been updated

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503 

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

- - -

_// ping: @pmetzger, @reneeotten, @jmroot_