### PR TITLE
libvpx: obey MacPorts configure.sdkroot

### DIFF
--- a/multimedia/libvpx/files/patch-build-make-configure.sh.diff
+++ b/multimedia/libvpx/files/patch-build-make-configure.sh.diff
@@ -1,5 +1,5 @@
---- build/make/configure.sh.orig	2019-02-09 23:18:41.000000000 -0800
-+++ build/make/configure.sh	2019-02-09 23:29:38.000000000 -0800
+--- build/make/configure.sh.orig	2019-09-25 18:56:09.000000000 -0400
++++ build/make/configure.sh	2019-09-25 18:44:14.000000000 -0400
 @@ -767,37 +767,9 @@
  
      # detect tgt_os
@@ -40,6 +40,15 @@
          ;;
        x86_64*mingw32*)
          tgt_os=win64
+@@ -882,7 +854,7 @@
+       fi
+       ;;
+     x86*-darwin*)
+-      osx_sdk_dir="$(show_darwin_sdk_path macosx)"
++      osx_sdk_dir="$(configure.sdkroot)"
+       if [ -d "${osx_sdk_dir}" ]; then
+         add_cflags  "-isysroot ${osx_sdk_dir}"
+         add_ldflags "-isysroot ${osx_sdk_dir}"
 @@ -890,58 +862,6 @@
        ;;
    esac


### PR DESCRIPTION
With the recent addition in mac-ports base to allow SDKROOT to be manually configured https://github.com/macports/macports-base/commit/ed8fa217461d29d63234c7e97418cf796b20742e

This change will have macports handle selecting the SDK selection, also making it compatible with a manually configured SDKROOT

#### Description
The changes made to [patch-build-make-configure.sh.diff](https://github.com/Gcenx/macports-wine-devel/blob/master/multimedia/libvpx/files/patch-build-make-configure.sh.diff) will have macports selecting the appropriate SDK instead of deciding on it's own, this also means that manually configuring SDKROOT will now also function.

This was tested on XCode10.3 and now XCode11.1 using the stock SDK versions and also forcing SDKROOT and forcing Deployment Target to 10.13 to allow +universal

https://trac.macports.org/ticket/56991#comment:63
This has been tested by myself (@gcenx) @kencu & recently also @gverm are the ones I'm aware of

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G103
Xcode 11.1 11A1027 

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
