### PR TITLE
sudo: update version to 1.8.28p1

### DIFF
--- a/sysutils/sudo/Portfile
+++ b/sysutils/sudo/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                sudo
 epoch               1
-version             1.8.28
+version             1.8.28p1
 revision            0
 categories          sysutils security
 license             ISC
@@ -23,9 +23,9 @@ homepage            http://www.sudo.ws/sudo/
 master_sites        ${homepage}dist/ \
                     ${homepage}dist/OLD/
 
-checksums           rmd160  5104faf846b59a0c04045e2f464ffeae3ddf95c2 \
-                    sha256  9129fa745a08caff0ce2042d2162b38eb9bf73bf43fcb248ac8b3a750c1f13a1 \
-                    size    3309744
+checksums           rmd160  7e30500c26ab1b8ddf1a79a2282a9784c1a7ba38 \
+                    sha256  23ba5a84af31e3b5ded58d4be6d3f6939a495a55561fba92c6941b79a6e8b027 \
+                    size    3310254
 
 patchfiles          patch-sudoers.in.diff
 


### PR DESCRIPTION
#### Description

- bump version to 1.8.28p1

The fix for Bug #869 caused sudo -v to prompt for a password when
verifypw is set to all (the default) and all of the user's sudoers
entries are marked with NOPASSWD. Bug #901.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A602
Xcode 11.2 11B44

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->