### PR TITLE
py-pyqt5: Add python2 qstring patch to address seg. faults

### DIFF
--- a/python/py-pyqt5/Portfile
+++ b/python/py-pyqt5/Portfile
@@ -6,7 +6,7 @@ PortGroup               python 1.0
 name                    py-pyqt5
 # we the next bump check --allow-sip-warnings if needed
 version                 5.12.3
-revision                0
+revision                1
 categories-append       devel
 platforms               darwin
 maintainers             {mmoll @mamoll} openmaintainer
@@ -53,7 +53,7 @@ if {${subport} eq "${name}-common"} {
     PortGroup           qmake5 1.0
 
     version             5.12.1
-    revision            0
+    revision            1
     description         PyQt5 Webengine bindings
     long_description    ${description}
     master_sites        https://www.riverbankcomputing.com/static/Downloads/PyQtWebEngine/${version}
@@ -128,6 +128,8 @@ if {${subport} eq "${name}-common"} {
     # (actually, the insistence appears to be on sip using a private module directory;
     # see the online pyqt5 build-from-source instructions).
     patchfiles-append   patch-use-default-sip.diff
+    # https://trac.macports.org/ticket/59358
+    patchfiles-append   python2_qstring.diff
 
     build.cmd           make
     build.target        all

--- a/python/py-pyqt5/files/python2_qstring.diff
+++ b/python/py-pyqt5/files/python2_qstring.diff
@@ -1,0 +1,36 @@
+From: Dmitry Shachnev <mitya57@debian.org>
+Date: Mon, 2 Sep 2019 15:51:37 +0300
+Subject: Fixes for building against Python v2
+
+Origin: upstream, changesets e5dd514fdba6 and 81b34c9373b6.
+---
+ qpy/QtCore/qpycore_qstring.cpp | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+diff --git qpy/QtCore/qpycore_qstring.cpp qpy/QtCore/qpycore_qstring.cpp
+index 2d04e3a..4a188ce 100644
+--- qpy/QtCore/qpycore_qstring.cpp
++++ qpy/QtCore/qpycore_qstring.cpp
+@@ -158,9 +158,21 @@ PyObject *qpycore_PyObject_FromQString(const QString &qstr)
+ }
+ 
+ 
+-// Convert a Python Unicode object to a QString.
++// Convert a Python string object to a QString.
+ QString qpycore_PyObject_AsQString(PyObject *obj)
+ {
++#if PY_MAJOR_VERSION < 3
++    if (PyString_Check(obj))
++    {
++        const char *obj_s = PyString_AsString(obj);
++
++        if (!obj_s)
++            return QString();
++
++        return QString::fromUtf8(obj_s);
++    }
++#endif
++
+ #if defined(PYQT_PEP_393)
+     int char_size;
+     Py_ssize_t len;


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/59358

