### PR TITLE
Change x86 bootsystem to 64bit

### DIFF
--- a/lang/sbcl/Portfile
+++ b/lang/sbcl/Portfile
@@ -62,17 +62,17 @@ platform powerpc {
 }
 
 platform i386 {
-    set bootversion 1.1.6
-    master_sites-append sourceforge:project/sbcl/sbcl/${bootversion}:sbcl_i386
-    distfiles-append    ${name}-${bootversion}-x86-darwin-binary${extract.suffix}:sbcl_i386
-    checksums-append    ${name}-${bootversion}-x86-darwin-binary${extract.suffix} \
-        md5     cbf75b368e7770e3da2a23c835fe2b78 \
-        sha1    35a76b93f8714bc34ba127df4aaf69aacfc08164 \
-        rmd160  fb1ab24f3605b29af5716f0ba425ee178c6cfc06 \
-        sha256  5801c60e2a875d263fccde446308b613c0253a84a61ab63569be62eb086718b3 \
-        size    9091955
+    set bootversion 1.2.11
+    master_sites-append sourceforge:project/sbcl/sbcl/${bootversion}:sbcl_amd64
+    distfiles-append    ${name}-${bootversion}-x86-64-darwin-binary${extract.suffix}:sbcl_amd64
+    checksums-append    ${name}-${bootversion}-x86-64-darwin-binary${extract.suffix} \
+        md5     a7aa1fcb625dd437df91c550c2e2abd8 \
+        sha1    8479e96349f66e59d3f8ea101f6c1860ecccfec3 \
+        rmd160  7065f30033c0a38ea4bd5b2bdead76ed12eb8af4 \
+        sha256  057d3a1c033fb53deee994c0135110636a04f92d2f88919679864214f77d0452 \
+        size    10038928
     global host_lisp
-    set host_lisp "\"${workpath}/${name}-${bootversion}-x86-darwin/src/runtime/sbcl --core ${workpath}/${name}-${bootversion}-x86-darwin/output/sbcl.core --disable-debugger --sysinit /dev/null --userinit /dev/null\" "
+    set host_lisp "\"${workpath}/${name}-${bootversion}-x86-64-darwin/src/runtime/sbcl --core ${workpath}/${name}-${bootversion}-x86-64-darwin/output/sbcl.core --disable-debugger --sysinit /dev/null --userinit /dev/null\" "
 }
 
 post-patch {
@@ -94,7 +94,7 @@ post-patch {
 use_configure   no
 
 build {
-    system "ulimit -s 8192 && export SBCL_MACOSX_VERSION_MIN=${macosx_deployment_target} && cd ${worksrcpath} && export CC && CC=${configure.cc} && export CXX && CXX=${configure.cxx} && export CPP && CPP==${configure.cpp} && sh ./make.sh ${make_sh_options} --prefix=${prefix} --xc-host=${host_lisp}"
+    system "export SBCL_MACOSX_VERSION_MIN=${macosx_deployment_target} && cd ${worksrcpath} && export CC && CC=${configure.cc} && export CXX && CXX=${configure.cxx} && export CPP && CPP==${configure.cpp} && sh ./make.sh ${make_sh_options} --prefix=${prefix} --xc-host=${host_lisp}"
 }
 
 post-build {


### PR DESCRIPTION
#### Description

This should be the base trick to allow builds on 10.15 as the 32bit boot binaries no longer run.

It still needs to wait for 1.5.8 to be released I guess:
https://github.com/Homebrew/homebrew-core/issues/45229

I couldn't get it to work with other versions or trying to isolate the patch but new sbcl should be out in two weeks anyhow

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15
Xcode 11.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
