### PR TITLE
py-prompt_toolkit: update to 1.0.18

### DIFF
--- a/python/py-prompt_toolkit/Portfile
+++ b/python/py-prompt_toolkit/Portfile
@@ -15,7 +15,7 @@ long_description    ${description}
 
 python.versions     27 34 35 36 37 38
 
-homepage            https://pypi.python.org/pypi/${python.rootname}/
+homepage            https://github.com/prompt-toolkit/python-prompt-toolkit
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 checksums           rmd160  7fef3cdd4d9c419124244191777ff0767bb6cb8f \
@@ -24,11 +24,11 @@ checksums           rmd160  7fef3cdd4d9c419124244191777ff0767bb6cb8f \
 
 if {${name} ne ${subport}} {
     if {${python.version} in "27 34"} {
-        version     1.0.15
+        version     1.0.18
         revision    0
-        checksums   rmd160  195e01e80e62e631f7c4b12d4f2cd5d4481a0752 \
-                    sha256  858588f1983ca497f1cf4ffde01d978a3ea02b01c8a26a8bbc5cd2e66d816917 \
-                    size    243734
+        checksums   rmd160  c0907914130f16c24cd543ef3bbcea655bca8968 \
+                    sha256  dd4fca02c8069497ad931a2d09914c6b0d1b50151ce876bc15bde4c747090126 \
+                    size    242335
     }
     distname        ${python.rootname}-${version}
 


### PR DESCRIPTION
## Description
- update to latest versions: 1.0.18 for PY27/PY34 and 2.0.10 for the rest
- update homepage
<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
