### PR TITLE
prometheus: update to 2.13.1

### DIFF
--- a/net/prometheus/Portfile
+++ b/net/prometheus/Portfile
@@ -1,7 +1,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        prometheus prometheus 2.13.0 v
+github.setup        prometheus prometheus 2.13.1 v
 github.tarball_from archive
 
 description         The Prometheus monitoring system and time series database
@@ -18,7 +18,7 @@ platforms           darwin
 categories          net
 license             Apache-2
 
-maintainers         {gmail.com:herbygillot @herbygillot} openmaintainer
+maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
 
 depends_build       port:go \
                     port:promu
@@ -41,9 +41,9 @@ set prom_share_dir  ${prefix}/share/${name}
 set prom_log_dir    ${prefix}/var/log/${name}
 set prom_log_file   ${prom_log_dir}/${name}.log
 
-checksums   rmd160  0f420962162c7ed2dc22be439b6e45623d8dea60 \
-            sha256  0a11ecc28989ad984af551a5426e9989aa1ca628fc2e875bb913af445ab38288 \
-            size    15193225
+checksums   rmd160  1226d0bf75f7db7366ac24099dd53286f149c471 \
+            sha256  5624c16728679362cfa46b76ec1d247018106989f2260d35583c42c49c5142b5 \
+            size    15249891
 
 add_users           ${prom_user} \
                     group=${prom_user} \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15 19A583
Xcode 11.1 11A1027

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
