### PR TITLE
py-poppler-qt5: restore workaround to find qmake

### DIFF
--- a/python/py-poppler-qt5/Portfile
+++ b/python/py-poppler-qt5/Portfile
@@ -41,12 +41,14 @@ if {${name} ne ${subport}} {
                             port:py${python.version}-pyqt5
 
     patchfiles              patch-fix-qtxml.diff \
+                            patch-fix-qt-dirs.diff \
                             patch-fix-cxx11.diff \
                             patch-fix-demo.diff \
                             patch-types.sip.diff
 
-    build.pre_args          build_ext \
-                            --qmake-bin=${qt_qmake_cmd}
+    post-patch {
+        reinplace "s|%%QMAKE%%|${qt_qmake_cmd}|g" ${worksrcpath}/setup.py
+    }
 
     post-destroot {
         set doc_dir ${destroot}${prefix}/share/doc/${subport}

--- a/python/py-poppler-qt5/files/patch-fix-qt-dirs.diff
+++ b/python/py-poppler-qt5/files/patch-fix-qt-dirs.diff
@@ -1,0 +1,11 @@
+--- setup.py
++++ setup.py
+@@ -137,7 +137,7 @@ class build_ext(build_ext_base):
+         build_ext_base.initialize_options(self)
+         self.poppler_version = None
+ 
+-        self.qmake_bin = 'qmake'
++        self.qmake_bin = '%%QMAKE%%'
+ 
+         self.qt_include_dir = None
+         self.pyqt_sip_dir = None


### PR DESCRIPTION
This partially reverts commit 363ab1ad713cd0e7c50669f084d045407ffcf5b5.

Closes: https://trac.macports.org/ticket/59370

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G22010
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
