### PR TITLE
terraform: update to 0.12.12

### DIFF
--- a/sysutils/terraform/Portfile
+++ b/sysutils/terraform/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                terraform
-version             0.12.10
+version             0.12.12
 
 categories          sysutils
 license             MPL-2
@@ -25,9 +25,9 @@ homepage            https://www.terraform.io/downloads.html
 master_sites        https://releases.hashicorp.com/${name}/${version}
 distname            ${name}_${version}_darwin_amd64
 
-checksums           rmd160  a6369c3c97263eb3c16d88c367564aaf1cdcee1b \
-                    sha256  d97db2217c6050926eedf517b7b0427b1b5f1bda989742cfd33d8fe56c95bb05 \
-                    size    17095466
+checksums           rmd160  2c856201287993f5e1a7a3c0b889d18824b979b4 \
+                    sha256  51507dedba7fcc2638c5c2c40206ec604155e2d3067a132b618f4e99ea9f1db9 \
+                    size    17138312
 
 use_configure       no
 use_zip             yes


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15 19A583
Xcode 11.1 11A1027

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
