### PR TITLE
libvpx: obey MacPorts-base

### DIFF
--- a/multimedia/libvpx/files/patch-build-make-configure.sh.diff
+++ b/multimedia/libvpx/files/patch-build-make-configure.sh.diff
@@ -1,5 +1,5 @@
---- build/make/configure.sh.orig	2019-09-25 18:56:09.000000000 -0400
-+++ build/make/configure.sh	2019-09-25 18:44:14.000000000 -0400
+--- build/make/configure.sh.orig.sh	2019-07-15 14:55:32.000000000 -0400
++++ build/make/configure.sh	        2019-10-16 22:59:42.000000000 -0400
 @@ -767,37 +767,9 @@
  
      # detect tgt_os
@@ -40,19 +40,19 @@
          ;;
        x86_64*mingw32*)
          tgt_os=win64
-@@ -882,7 +854,7 @@
+@@ -881,65 +853,6 @@
+         add_ldflags "-isysroot ${iphoneos_sdk_dir}"
        fi
        ;;
-     x86*-darwin*)
+-    x86*-darwin*)
 -      osx_sdk_dir="$(show_darwin_sdk_path macosx)"
-+      osx_sdk_dir="$(configure.sdkroot)"
-       if [ -d "${osx_sdk_dir}" ]; then
-         add_cflags  "-isysroot ${osx_sdk_dir}"
-         add_ldflags "-isysroot ${osx_sdk_dir}"
-@@ -890,58 +862,6 @@
-       ;;
-   esac
- 
+-      if [ -d "${osx_sdk_dir}" ]; then
+-        add_cflags  "-isysroot ${osx_sdk_dir}"
+-        add_ldflags "-isysroot ${osx_sdk_dir}"
+-      fi
+-      ;;
+-  esac
+-
 -  case ${toolchain} in
 -    *-darwin8-*)
 -      add_cflags  "-mmacosx-version-min=10.4"
@@ -103,8 +103,6 @@
 -        add_ldflags "-isysroot ${iossim_sdk_dir}"
 -      fi
 -      ;;
--  esac
--
+   esac
+ 
    # Handle Solaris variants. Solaris 10 needs -lposix4
-   case ${toolchain} in
-     sparc-solaris-*)


### PR DESCRIPTION
Remove `-isysroot flags`, letting macports-base handle as required
Resolves bug https://trac.macports.org/ticket/59360

#### Description
The previous patch was incorrect, while `libvpx` would build the following error would be found within the log;
`./build/make/configure.sh: line 857: configure.sdkroot: command not found`
The updated patch removes the related section and leaves SDK seletection upto macports-base.

This was tested using stock macports on macOS Mojave, also built when forcing the 10.13 SDK and deployment target to build a universal version of `libvpx`

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G103
Xcode 11.1 11A1027 

macOS 10.8.5 12F37
Xcode 5.1.1 5B1008

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->