### PR TITLE
libomp: Don't block Universal, let base handle it

### DIFF
--- a/lang/libomp/Portfile
+++ b/lang/libomp/Portfile
@@ -105,8 +105,6 @@ foreach ver {3.8 3.9 4.0 5.0 6.0 7.0 8.0 9.0 devel} {
 
 if {${os.major} <= 17} {
     default_variants        +universal
-} else {
-    universal_variant       no
 }
 
 # Do actual install into ${prefix}/(install|lib)/libomp


### PR DESCRIPTION
macOS Mojave will give the following error;
port install libomp +universal
Error: libomp cannot be installed for the configured universal_archs 'x86_64 i386' because the arch(s) 'i386' are not supported.
Error: Follow https://guide.macports.org/#project.tickets to report a bug.
Error: Processing of port libomp failed

#### Description
This slight change will still have Universal blocked on Mojave since that's now part of base, however if someone were to do the following https://trac.macports.org/ticket/56991#comment:84 
Force deployment target as 10.13 and force the 10.13 SDK universal version can be built.
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G103
Xcode 11.1 11A1027

###### Verification <!-- (delete not applicable items) -->

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
