### PR TITLE
nodejs12: Use system ICU

### DIFF
--- a/devel/nodejs12/Portfile
+++ b/devel/nodejs12/Portfile
@@ -11,6 +11,7 @@ PortGroup               cxx11 1.1
 
 name                    nodejs12
 version                 12.12.0
+revision                1
 
 categories              devel net
 platforms               darwin
@@ -38,7 +39,8 @@ distname                node-v${version}
 
 depends_build           port:pkgconfig
 
-depends_lib             port:python27 \
+depends_lib             port:icu \
+                        port:python27 \
                         path:lib/libssl.dylib:openssl
 
 proc rec_glob {basedir pattern} {
@@ -72,7 +74,7 @@ if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
 }
 
 configure.args-append   --without-npm
-configure.args-append   --with-intl=small-icu
+configure.args-append   --with-intl=system-icu
 configure.args-append   --shared-openssl
 configure.args-append   --shared-openssl-includes=${prefix}/include/openssl
 configure.args-append   --shared-openssl-libpath=${prefix}/lib


### PR DESCRIPTION
#### Description

MacPorts usually favours system version of libraries over built-in ones.
ICU has recently being updated to latest version (65.1) [1], by using it
we can get full Intl support in Node.js [2] without duplicating the ICU
locale data.

I'm updating Node.js 12 only for now, but I can submit the same change to 10.

[1] https://github.com/macports/macports-ports/commit/8cf9b206c3c2fcca0e0f6ee2a46f47bc828a3cb7
[2] https://github.com/nodejs/node/blob/master/doc/api/intl.md

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G103
Xcode 11.0 11A420a 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
