### PR TITLE
icu: blacklist non-fully C11 compliant compilers

### DIFF
--- a/devel/icu/Portfile
+++ b/devel/icu/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem      1.0
 PortGroup       clang_dependency 1.0
+PortGroup       compiler_blacklist_versions 1.0
 
 name            icu
 set my_name     icu4c
@@ -62,6 +63,8 @@ if { [vercmp ${version} 59] < 0 } {
                             size    34655619
 } else {
     compiler.cxx_standard   2011
+    # see https://trac.macports.org/ticket/59391
+    compiler.blacklist-append {clang < 700}
 }
 
 worksrcdir      icu-release-[join [split ${version} .] -]/${my_name}/source

--- a/lang/llvm-3.4/Portfile
+++ b/lang/llvm-3.4/Portfile
@@ -10,7 +10,7 @@ set llvm_version        3.4
 set llvm_version_no_dot 34
 name                    llvm-${llvm_version}
 revision                12
-subport                 clang-${llvm_version} { revision 12 }
+subport                 clang-${llvm_version} { revision 13 }
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
 # prefix for deps using libstdc++ on a libc++ system
@@ -63,10 +63,15 @@ if {${subport} eq "llvm-${llvm_version}"} {
     }
 }
 
-if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {
+if {${os.platform} eq "darwin" && ${os.major} < 14 && ${cxx_stdlib} eq "libc++"} {
     configure.cxx_stdlib    libstdc++
     # Have to also use bootstrap versions of deps that use libstdc++ in
     # order to be able to build libc++.
+    #
+    # libxml2 depends on ICU.
+    # Up to and including OS X Mavericks (10.9), the system compiler cannot build ICU.
+    # ICU requires C++11 and C11 (specifically max_align_t in stdio.h).
+    # See https://trac.macports.org/ticket/59391
     depends_lib-replace port:libxml2 port:libxml2-bootstrap \
                         port:python27 port:python27-bootstrap \
                         port:ncurses port:ncurses-bootstrap

--- a/lang/llvm-3.7/Portfile
+++ b/lang/llvm-3.7/Portfile
@@ -17,7 +17,7 @@ set llvm_version        3.7
 set llvm_version_no_dot 37
 name                    llvm-${llvm_version}
 revision                4
-subport                 clang-${llvm_version} { revision 5 }
+subport                 clang-${llvm_version} { revision 6 }
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
 dist_subdir             llvm
@@ -70,6 +70,17 @@ if {${subport} eq "llvm-${llvm_version}"} {
     depends_lib-append  port:libedit port:libffi port:ncurses port:zlib
 
     default_variants    +analyzer
+}
+
+if {${os.platform} eq "darwin" && ${os.major} < 14 && ${cxx_stdlib} eq "libc++"} {
+    # libxml2 depends on ICU.
+    # Up to and including OS X Mavericks (10.9), the system compiler cannot build ICU.
+    # ICU requires C++11 and C11 (specifically max_align_t in stdio.h).
+    # See https://trac.macports.org/ticket/59391
+    depends_lib-replace port:libxml2 port:libxml2-bootstrap
+    configure.cppflags-prepend  -I${bootstrap_prefix}/include
+    configure.ldflags-prepend   -L${bootstrap_prefix}/lib
+    configure.env-append    PATH=${bootstrap_prefix}/bin:$::env(PATH)
 }
 
 #fetch.type              svn


### PR DESCRIPTION
Clang 6 from Xcode purports to be implant the C11 standard.
However, max_align_t is not defined in stddef.h.

Fixes https://trac.macports.org/ticket/59391

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14
Xcode 11.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
