### PR TITLE
clang{5-9}: Use portconfigure::get_clang_compilers to get clang version list

### DIFF
--- a/lang/llvm-5.0/Portfile
+++ b/lang/llvm-5.0/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 # TODO:
 #  * Update clang and lldb subports to build against installed libLLVM/libclang
 
@@ -322,14 +324,25 @@ compiler.blacklist-append macports-clang-3.3 macports-clang-3.4
 
 # Override the normal compiler fallback list entirely since we have
 # such specific requirements.
-compiler.fallback   clang
+set old_fallback ${compiler.fallback}
+compiler.fallback clang
 # Use each macports-clang version only if already installed, to avoid
 # dependency cycles or chaining (8.0 depends on 7.0 depends on 6.0...)
-foreach ver {8.0 7.0 6.0 5.0} {
-    if {[file exists ${prefix}/bin/clang-mp-${ver}]} {
-        compiler.fallback-append macports-clang-${ver}
+ui_debug "Testing fallback list ${old_fallback} for MP clang compilers currently available."
+foreach clang_c ${old_fallback} {
+    if {[string match macports-clang-* $clang_c]} {
+        # Extract version number from macports clang compiler name
+        set clang_v [lindex [split $clang_c -] 2]
+        # add to fallback list it present
+        set clang_path ${prefix}/bin/clang-mp-${clang_v}
+        if {[file exists ${clang_path}]} {
+            ui_debug "${clang_path} is installed. Keeping as fallback."
+            compiler.fallback-append ${clang_c}
+        }
     }
 }
+ui_debug "Reset compiler.fallback to ${compiler.fallback}"
+
 # 3.7 is already needed to bootstrap cmake, so is a good last resort
 # when the system clang is too old.
 if {${os.platform} eq "darwin" && ${os.major} < 18} {

--- a/lang/llvm-6.0/Portfile
+++ b/lang/llvm-6.0/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 # TODO:
 #  * Update clang and lldb subports to build against installed libLLVM/libclang.
 
@@ -312,14 +314,25 @@ compiler.blacklist-append macports-clang-3.3 macports-clang-3.4
 
 # Override the normal compiler fallback list entirely since we have
 # such specific requirements.
-compiler.fallback   clang
+set old_fallback ${compiler.fallback}
+compiler.fallback clang
 # Use each macports-clang version only if already installed, to avoid
 # dependency cycles or chaining (8.0 depends on 7.0 depends on 6.0...)
-foreach ver {8.0 7.0 6.0 5.0} {
-    if {[file exists ${prefix}/bin/clang-mp-${ver}]} {
-        compiler.fallback-append macports-clang-${ver}
+ui_debug "Testing fallback list ${old_fallback} for MP clang compilers currently available."
+foreach clang_c ${old_fallback} {
+    if {[string match macports-clang-* $clang_c]} {
+        # Extract version number from macports clang compiler name
+        set clang_v [lindex [split $clang_c -] 2]
+        # add to fallback list it present
+        set clang_path ${prefix}/bin/clang-mp-${clang_v}
+        if {[file exists ${clang_path}]} {
+            ui_debug "${clang_path} is installed. Keeping as fallback."
+            compiler.fallback-append ${clang_c}
+        }
     }
 }
+ui_debug "Reset compiler.fallback to ${compiler.fallback}"
+
 # 3.7 is already needed to bootstrap cmake, so is a good last resort
 # when the system clang is too old.
 if {${os.platform} eq "darwin" && ${os.major} < 18} {

--- a/lang/llvm-7.0/Portfile
+++ b/lang/llvm-7.0/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 # TODO:
 #  * Update clang and lldb subports to build against installed libLLVM/libclang
 
@@ -317,14 +319,25 @@ compiler.blacklist-append macports-clang-3.3 macports-clang-3.4
 
 # Override the normal compiler fallback list entirely since we have
 # such specific requirements.
-compiler.fallback   clang
+set old_fallback ${compiler.fallback}
+compiler.fallback clang
 # Use each macports-clang version only if already installed, to avoid
 # dependency cycles or chaining (8.0 depends on 7.0 depends on 6.0...)
-foreach ver {8.0 7.0 6.0 5.0} {
-    if {[file exists ${prefix}/bin/clang-mp-${ver}]} {
-        compiler.fallback-append macports-clang-${ver}
+ui_debug "Testing fallback list ${old_fallback} for MP clang compilers currently available."
+foreach clang_c ${old_fallback} {
+    if {[string match macports-clang-* $clang_c]} {
+        # Extract version number from macports clang compiler name
+        set clang_v [lindex [split $clang_c -] 2]
+        # add to fallback list it present
+        set clang_path ${prefix}/bin/clang-mp-${clang_v}
+        if {[file exists ${clang_path}]} {
+            ui_debug "${clang_path} is installed. Keeping as fallback."
+            compiler.fallback-append ${clang_c}
+        }
     }
 }
+ui_debug "Reset compiler.fallback to ${compiler.fallback}"
+
 # 3.7 is already needed to bootstrap cmake, so is a good last resort
 # when the system clang is too old.
 if {${os.platform} eq "darwin" && ${os.major} < 18} {

--- a/lang/llvm-8.0/Portfile
+++ b/lang/llvm-8.0/Portfile
@@ -321,14 +321,25 @@ compiler.blacklist-append macports-clang-3.3 macports-clang-3.4
 
 # Override the normal compiler fallback list entirely since we have
 # such specific requirements.
-compiler.fallback   clang
+set old_fallback ${compiler.fallback}
+compiler.fallback clang
 # Use each macports-clang version only if already installed, to avoid
 # dependency cycles or chaining (8.0 depends on 7.0 depends on 6.0...)
-foreach ver {8.0 7.0 6.0 5.0} {
-    if {[file exists ${prefix}/bin/clang-mp-${ver}]} {
-        compiler.fallback-append macports-clang-${ver}
+ui_debug "Testing fallback list ${old_fallback} for MP clang compilers currently available."
+foreach clang_c ${old_fallback} {
+    if {[string match macports-clang-* $clang_c]} {
+        # Extract version number from macports clang compiler name
+        set clang_v [lindex [split $clang_c -] 2]
+        # add to fallback list it present
+        set clang_path ${prefix}/bin/clang-mp-${clang_v}
+        if {[file exists ${clang_path}]} {
+            ui_debug "${clang_path} is installed. Keeping as fallback."
+            compiler.fallback-append ${clang_c}
+        }
     }
 }
+ui_debug "Reset compiler.fallback to ${compiler.fallback}"
+
 # 3.7 is already needed to bootstrap cmake, so is a good last resort
 # when the system clang is too old.
 if {${os.platform} eq "darwin" && ${os.major} < 18} {

--- a/lang/llvm-9.0/Portfile
+++ b/lang/llvm-9.0/Portfile
@@ -327,14 +327,25 @@ compiler.blacklist-append macports-clang-3.3 macports-clang-3.4
 
 # Override the normal compiler fallback list entirely since we have
 # such specific requirements.
-compiler.fallback   clang
+set old_fallback ${compiler.fallback}
+compiler.fallback clang
 # Use each macports-clang version only if already installed, to avoid
 # dependency cycles or chaining (8.0 depends on 7.0 depends on 6.0...)
-foreach ver {8.0 7.0 6.0 5.0} {
-    if {[file exists ${prefix}/bin/clang-mp-${ver}]} {
-        compiler.fallback-append macports-clang-${ver}
+ui_debug "Testing fallback list ${old_fallback} for MP clang compilers currently available."
+foreach clang_c ${old_fallback} {
+    if {[string match macports-clang-* $clang_c]} {
+        # Extract version number from macports clang compiler name
+        set clang_v [lindex [split $clang_c -] 2]
+        # add to fallback list it present
+        set clang_path ${prefix}/bin/clang-mp-${clang_v}
+        if {[file exists ${clang_path}]} {
+            ui_debug "${clang_path} is installed. Keeping as fallback."
+            compiler.fallback-append ${clang_c}
+        }
     }
 }
+ui_debug "Reset compiler.fallback to ${compiler.fallback}"
+
 # 3.7 is already needed to bootstrap cmake, so is a good last resort
 # when the system clang is too old.
 if {${os.platform} eq "darwin" && ${os.major} < 18} {


### PR DESCRIPTION
See discussion in https://github.com/macports/macports-ports/pull/5563
