### PR TITLE
limesuite-devel: update version to 627c82c7

### DIFF
--- a/science/limesuite/Portfile
+++ b/science/limesuite/Portfile
@@ -21,11 +21,11 @@ homepage            https://myriadrf.org/projects/lime-suite/
 subport limesuite-devel {}
 if {[string first "-devel" $subport] > 0} {
 
-    github.setup myriadrf LimeSuite e1c54ee2beca83787a045cca4c53250c83b3241b
-    version   20191014-[string range ${github.version} 0 7]
-    checksums rmd160 529a2de4a06dd94f0d1eb2cf47cfb3f076009168 \
-              sha256 d2da15a7d31153a4add7973dc9bb031126730c70730a5a220de9ea420d7729bc \
-              size   5348265
+    github.setup myriadrf LimeSuite 627c82c76938765e93e85784cb359ea4aa71554e
+    version   20191017-[string range ${github.version} 0 7]
+    checksums rmd160 715d241f795b049377695cac2c5ce533100fb6dd \
+              sha256 bee73d69cdfa2898a043fb96cb49050250998a5d6d1797a8dd261489e8001b6e \
+              size   5345631
     revision  0
 
     name            limesuite-devel


### PR DESCRIPTION


#### Description
- bump version to 627c82c7

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A602
Xcode 11.2 11B44

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
