### PR TITLE
fossil: update version to 2.10

### DIFF
--- a/devel/fossil/Portfile
+++ b/devel/fossil/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 
 name                fossil
-version             2.9
-revision            1
+version             2.10
+revision            0
 epoch               20110901182519
 categories          devel
 platforms           darwin
@@ -26,9 +26,9 @@ distname            ${name}-src-${version}
 
 worksrcdir          ${name}-${version}
 
-checksums           rmd160  a95f8c784dbf633ba8f407db01bb151870d4dfb3 \
-                    sha256  1cb2ada92d43e3e7e008fe77f5e743d301c7ea34d4c36c42f255f873e73d8b4f \
-                    size    5440118
+checksums           rmd160  e4ac6020a0369b3aff8942e06f45fe0de6cd3f50 \
+                    sha256  d8a3776d2ce77385ed5ff20a2776d13bb534fb2508e87351e14e94f91cd12b10 \
+                    size    5634327
 
 test.run            yes
 


### PR DESCRIPTION


#### Description
- bump version to 2.10

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A602
Xcode 11.2 11B44

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
