### PR TITLE
binwalk: update version to 2.2.0

### DIFF
--- a/cross/binwalk/Portfile
+++ b/cross/binwalk/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        ReFirmLabs binwalk 2.1.1 v
-revision            1
+github.setup        ReFirmLabs binwalk 2.2.0 v
+revision            0
 
 categories          cross
 platforms           darwin
@@ -14,14 +14,10 @@ supported_archs     noarch
 maintainers         {stromnov @stromnov} openmaintainer
 description         Binwalk is a fast, easy to use tool for analyzing, reverse engineering, and extracting firmware images
 long_description    ${description}
-homepage            http://binwalk.org
 
-checksums           rmd160  e666b01813647e2d90d64900276a4f583afb8d0d \
-                    sha256  5115b736f5aebda7059ed0c538befde46807f66f8071e6769a87a9263c6907ac \
-                    size    264047
-
-# enable stealth update https://trac.macports.org/wiki/PortfileRecipes#stealth-updates
-dist_subdir        ${name}/${version}_1
+checksums           rmd160  68677d4d97ba5dbcd765c17cd37689c270161112 \
+                    sha256  a88a2f81563278e9f341a9adc2adaa4b620d1d1a7c7e00e00f8da8ba5674e425 \
+                    size    39595170
 
 python.default_version  37
 


### PR DESCRIPTION


#### Description
- bump version to 2.2.0
- remove broken homepage
- bigger source because testing/tests/input-vectors

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A602
Xcode 11.2 11B44

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
