### PR TITLE
freedv-gui: update version to 5272add1

### DIFF
--- a/science/freedv-gui/Portfile
+++ b/science/freedv-gui/Portfile
@@ -14,11 +14,11 @@ description         GUI Application for FreeDV – an open source digital \
     voice protocol that integrates the modems, codecs, and FEC
 long_description    ${description}
 
-github.setup        drowe67 freedv-gui 4a7e0addae008030a448a712a1c6858265dbcafd
-version             20191012-[string range ${github.version} 0 7]
-checksums           rmd160  b1efce9d74d0922c08b407af3c78ced07cc83631 \
-                    sha256  08fbf56a781648ad0036c0a71293c4866991b3850405e35c832d6b8de7c1d494 \
-                    size    5795367
+github.setup        drowe67 freedv-gui 5272add1d75bbaec3a6bac05cec3beb6e1b86614
+version             20191019-[string range ${github.version} 0 7]
+checksums           rmd160  85633df9407269006829447fdaf618b173d791bd \
+                    sha256  4cd9d704f3b5006f247913b1c65acc7ac67a577de0f13c44fd1ba3611ce1d5ab \
+                    size    5795343
 revision            0
 
 depends_build-append \


### PR DESCRIPTION


#### Description

- bump version to 5272add1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A602
Xcode 11.2 11B44

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
