### PR TITLE
libuv: update version to 1.33.1

### DIFF
--- a/devel/libuv/Portfile
+++ b/devel/libuv/Portfile
@@ -85,10 +85,10 @@ platform darwin {
         # 10.7 Lion and newer use the current, with a devel version also!
         if {${subport} eq ${name}} {
 
-            github.setup libuv libuv 1.33.0 v
-            checksums rmd160 57fd987c054ce25e88e629008c3572f7bd0a3202 \
-                      sha256 511aef55a5ae0d9f299db06ecda8e13922c36889f69246f2e920784b3879534a \
-                      size   1251599
+            github.setup libuv libuv 1.33.1 v
+            checksums rmd160 72fa6fbcdbb09d31374eee9b1d77d67dd64b7a3e \
+                      sha256 7ba5720f058a732b48f4ed7c728795bb4ccbf13326ed09595bfe3d46277243bf \
+                      size   1251686
             revision  0
 
             conflicts libuv-devel


### PR DESCRIPTION


#### Description

- bump version to 1.33.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A602
Xcode 11.2 11B44

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
