### PR TITLE
python27: update version to 2.7.17

### DIFF
--- a/lang/python27/Portfile
+++ b/lang/python27/Portfile
@@ -7,8 +7,8 @@ PortGroup           clang_dependency 1.0
 name                python27
 epoch               2
 # Remember to keep py27-tkinter and py27-gdbm's versions sync'd with this
-version             2.7.16
-revision            2
+version             2.7.17
+revision            0
 
 set major           [lindex [split $version .] 0]
 set branch          [join [lrange [split ${version} .] 0 1] .]
@@ -28,9 +28,9 @@ master_sites        ${homepage}ftp/python/${version}/
 distname            Python-${version}
 use_xz              yes
 
-checksums           md5 30157d85a2c0479c09ea2cbe61f2aaf5 \
-                    rmd160 2e4ab325a9c9edf1687b6a5969cdafeb3cc954da \
-                    sha256 f222ef602647eecb6853681156d32de4450a2c39f4de93bd5b20235f2e660ed7
+checksums           rmd160 55e05d1475d4e27873e71802529499361ba25e14 \
+                    sha256 4d43f033cdbd0aa7b7023c81b0e986fd11e653b5248dac9144d508f11812ba41 \
+                    size   12855568
 
 patchfiles          patch-Makefile.pre.in.diff \
                     patch-setup.py.diff \
@@ -38,8 +38,7 @@ patchfiles          patch-Makefile.pre.in.diff \
                     patch-Lib-ctypes-macholib-dyld.py.diff \
                     patch-configure.diff \
                     patch-libedit.diff \
-                    enable-loadable-sqlite-extensions.patch \
-                    lchmod.patch
+                    enable-loadable-sqlite-extensions.patch
 
 depends_build       port:pkgconfig
 depends_lib         port:bzip2 \
@@ -107,10 +106,6 @@ post-patch {
         ${worksrcpath}/configure
 }
 
-post-configure {
-    reinplace "s;/* #undef PY_FORMAT_LONG_LONG */;#define PY_FORMAT_LONG_LONG \"ll\";" ${worksrcpath}/pyconfig.h
-}
-
 build.target        all
 
 test.run            yes
@@ -164,7 +159,7 @@ platform darwin {
 
         xinstall -d ${destroot}${my_prefix}/share/man/man1 \
                     ${destroot}${my_prefix}/lib/pkgconfig
-        
+
         ln -s ${framewdir}/share/man/man1/python${branch}.1 ${destroot}${my_prefix}/share/man/man1/
         ln -s ${framewdir}/Python ${destroot}${my_prefix}/lib/libpython${branch}.dylib
         ln -s ${framewdir}/lib/pkgconfig/python-${branch}.pc ${destroot}${my_prefix}/lib/pkgconfig/


### PR DESCRIPTION


#### Description

- bump version to 2.7.17
- lchmod.patch is upstream
- remove reinplce PY_FORMAT_LONG_LONG because didn't change anything
- fix: CVE-2019-9948, CVE-2019-15903, CVE-2019-9740

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
macOS 10.15 19A602
Xcode 11.2 11B44

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
