### PR TITLE
rclone: update version to 1.49.5

### DIFF
--- a/net/rclone/Portfile
+++ b/net/rclone/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/ncw/rclone 1.49.3 v
+go.setup            github.com/ncw/rclone 1.49.5 v
 homepage            http://rclone.org
 categories          net
 maintainers         {eborisch @eborisch} openmaintainer
@@ -16,9 +16,9 @@ long_description \
 license             MIT
 
 checksums \
-    rmd160  2e26d81d709f4c86916645e99c7961ff0181a0b5 \
-    sha256  9da313157d0a7629af890f8eb45388bdf4a4391d5123f3bd3a752153d8c91167 \
-    size    18201462
+    rmd160  0af22331ef9fdd0e976f9f9fc4d5704d33815fb5 \
+    sha256  9781f1200f307841fcead2faaeee795649f64ecb494d61651161b8bf45f67bbb \
+    size    18200548
 
 platforms           darwin
 


### PR DESCRIPTION


#### Description
- bump version to 1.49.5

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A602
Xcode 11.2 11B44

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
