### PR TITLE
xapian-core: update version to 1.4.13

### DIFF
--- a/devel/xapian-core/Portfile
+++ b/devel/xapian-core/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cxx11 1.1
 
 name                xapian-core
-version             1.4.12
+version             1.4.13
 categories          devel
 platforms           darwin
 maintainers         {ryandesign @ryandesign} openmaintainer
@@ -28,9 +28,9 @@ if {${subport} eq ${name}} {
     # version.h does not get generated properly when there are multiple -arch flags
     PortGroup                   muniversal 1.0
 
-    checksums                   rmd160  0a25d7792062f597cf26946ce4e1af56f2e6c5e9 \
-                                sha256  4f8a36da831712db41d38a039fefb5251869761a58be28ba802994bb930fac7c \
-                                size    2979052
+    checksums                   rmd160  409398b7374d166ddc3749c2d98366727ad8a7d9 \
+                                sha256  93f8ffffa80c5e6036befbf356f34456cc18c2f745cef85e9b4cfc254042137c \
+                                size    2985532
 
     # TODO: Fix xapian-config to not require the .la file
     # /opt/local/bin/xapian-config --ltlibs --cxxflags
@@ -57,9 +57,9 @@ if {${subport} eq ${name}} {
 
 subport xapian-omega {
     revision                    0
-    checksums                   rmd160  54b7d52a38b094bb2ebb10578d6458959d6c4c47 \
-                                sha256  0e6767d4571b6b58ae4e65b0b60cce57909f11aec245fc557eb9d13a47ca19ce \
-                                size    539324
+    checksums                   rmd160  e18903f1a0f424c7f42ec85ec9a0cace1a5a693b \
+                                sha256  c26ec4a99a210c26ce64ec08bc7dbb9cca78d82d9266351d498751f6575e8906 \
+                                size    540216
 
     description                 web application using the Xapian library
     long_description            Xapian Omega is an application built on the \
@@ -80,9 +80,9 @@ subport xapian-omega {
 }
 
 if [string match {xapian-bindings-*} ${subport}] {
-    checksums                   rmd160  b1743d1c67ae32af4074eb40b3eea90493bcbe1d \
-                                sha256  7577174efbee2b893b5387fb0bdf3b630e82f55288a00a4c3ec9fdc463e42a49 \
-                                size    1132048
+    checksums                   rmd160  1d91642bae3ba0bec4aae54eace763366d05840a \
+                                sha256  7a5a5d2712159ed0a5174a8aabedfc01452a69ebd6e2147d97e497122baa5892 \
+                                size    1132592
 
     homepage                    ${homepage}/docs/bindings/
 
@@ -104,15 +104,29 @@ if [string match {xapian-bindings-*} ${subport}] {
 
 # Java
 subport xapian-bindings-java {
+    PortGroup                   java 1.0
+
     revision                    0
 
     description                 Xapian bindings for Java
     long_description            ${description}
 
+    # Required java version
+    java.version                6+
+    # JDK port to install if required java not found
+    java.fallback               openjdk11
+
     configure.args-replace      --without-java --with-java
 
-    # TODO: libxapian_jni.jnilib gets "installed" into the work directory:
+    # jni destination violates the mtree layout
+    destroot.violate_mtree  yes
+
     # https://trac.xapian.org/ticket/774
+    post-destroot {
+        file mkdir ${destroot}/Library/Java/Extensions
+        move ${destroot}/${worksrcpath}/java/built/libxapian_jni.jnilib \
+            ${destroot}/Library/Java/Extensions/libxapian_jni.jnilib
+    }
 }
 
 # Perl


### PR DESCRIPTION

#### Description

- bump version to 1.4.13

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A602
Xcode 11.2 11B44

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->