### PR TITLE
zsh-completions: update version to 0.31.0

### DIFF
--- a/sysutils/zsh-completions/Portfile
+++ b/sysutils/zsh-completions/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        zsh-users zsh-completions 0.30.0
+github.setup        zsh-users zsh-completions 0.31.0
 maintainers         {g5pw @g5pw} openmaintainer
 categories          sysutils shells
 license             Permissive Apache-2
@@ -13,9 +13,9 @@ long_description    Additional completion definitions for Zsh. This package \
 platforms           darwin
 supported_archs     noarch
 
-checksums           rmd160  35b791dcad2428acf0bccbd71a48d2e5b7cfc9cb \
-                    sha256  c285dccf36af38d72e0b1093306ef2e8109e5bfd85fc25b8a0dbcdce91376bc2 \
-                    size    227945
+checksums           rmd160  b4c1d7ff7f272139b89f6fbe915cd1f138ec8f46 \
+                    sha256  9d8a3d782d1d5f83151e5d5af9370e91d0e4fa7a86bde2f04e0db4302818500d \
+                    size    247770
 
 use_configure       no
 


### PR DESCRIPTION


#### Description

- bump version to 0.31.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A602
Xcode 11.2 11B44

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
