### PR TITLE
llvm-*: build more reproducibly

### DIFF
--- a/lang/llvm-3.3/Portfile
+++ b/lang/llvm-3.3/Portfile
@@ -144,6 +144,9 @@ if {${subport} == "llvm-${llvm_version}"} {
 # Intel looks ok, but I prefer using gcc-4.2 for consistency
 compiler.blacklist gcc-4.0
 
+# avoid dependency cycles
+compiler.blacklist-append   macports-clang-*
+
 variant universal {
     if {[vercmp [macports_version] 2.5.99] >= 0} {
     build.env-append \
@@ -175,14 +178,6 @@ variant universal {
 variant assertions description "Enable assertions for error detection (has performance impacts, especially on JIT)" {
     configure.args-delete --disable-assertions
     configure.args-append --enable-assertions
-}
-
-# blacklist current and future versions if they're not available in order to
-# help break potential dependency cycles.
-foreach ver {3.3 3.4 3.7 3.8 3.9 4.0 5.0 6.0 7.0 8.0 devel} {
-    if {![file exists ${prefix}/bin/clang-mp-${ver}]} {
-        compiler.blacklist-append macports-clang-${ver}
-    }
 }
 
 platform darwin {

--- a/lang/llvm-3.4/Portfile
+++ b/lang/llvm-3.4/Portfile
@@ -202,6 +202,9 @@ if {${subport} eq "llvm-${llvm_version}"} {
 # Xcode 4.3's clang (318.x) fails per https://trac.macports.org/ticket/44161
 compiler.blacklist gcc-4.0 {gcc-4.2 <= 5577} {clang < 421}
 
+# avoid dependency cycles
+compiler.blacklist-append   macports-clang-*
+
 variant universal {
     if {[vercmp [macports_version] 2.5.99] >= 0} {
     build.env-append \
@@ -233,14 +236,6 @@ variant universal {
 variant assertions description "Enable assertions for error detection (has performance impacts, especially on JIT)" {
     configure.args-delete --disable-assertions
     configure.args-append --enable-assertions
-}
-
-# blacklist current and future versions if they're not available in order to
-# help break potential dependency cycles.
-foreach ver {3.4 3.7 3.8 3.9 4.0 5.0 6.0 7.0 8.0 devel} {
-    if {![file exists ${prefix}/bin/clang-mp-${ver}]} {
-        compiler.blacklist-append macports-clang-${ver}
-    }
 }
 
 platform darwin {

--- a/lang/llvm-3.5/Portfile
+++ b/lang/llvm-3.5/Portfile
@@ -39,13 +39,6 @@ if {${subport} eq "llvm-${llvm_version}"} {
     depends_lib         port:libedit port:libffi port:ncurses port:zlib
     depends_run         bin:perl:perl5 port:llvm_select
 
-    # 3.2.6's install_name_tool doesn't support load commands we might see with newer clang+ld64
-    # 4.3 is just a guess here and should be updated if there are additional reports with other Xcode versions
-    if {[vercmp $xcodeversion 4.3] < 0 && [string match "*macports*" ${configure.compiler}]} {
-        depends_build-append port:cctools
-        depends_skip_archcheck-append cctools
-    }
-
 version                 ${llvm_version}.2
 epoch                   1
 master_sites            https://releases.llvm.org/${version}
@@ -95,12 +88,21 @@ select.file         ${filespath}/mp-${subport}
 # Xcode 4.6.x's clang (425.0.28) works, assuming 425.0.24 from 4.6.0 works too
 compiler.blacklist *gcc* {clang < 425.0.24}
 
-# blacklist current and future versions if they're not available in order to
-# help break potential dependency cycles.
-foreach ver {3.5 3.6 3.7 3.8 3.9 4.0 5.0 6.0 7.0 8.0 devel} {
-    if {![file exists ${prefix}/bin/clang-mp-${ver}]} {
-        compiler.blacklist-append macports-clang-${ver}
-    }
+# Override the normal compiler fallback list entirely since we have
+# such specific requirements.
+compiler.fallback   clang
+
+# 3.4 is already needed to bootstrap libcxx, so is a good last resort
+# when the system clang is too old.
+if {${os.platform} eq "darwin" && ${os.major} < 16} {
+    compiler.fallback-append macports-clang-3.4
+}
+
+# 3.2.6's install_name_tool doesn't support load commands we might see with newer clang+ld64
+# 4.3 is just a guess here and should be updated if there are additional reports with other Xcode versions
+if {[vercmp $xcodeversion 4.3] < 0 && [string match "*macports*" ${configure.compiler}]} {
+    depends_build-append port:cctools
+    depends_skip_archcheck-append cctools
 }
 
 platform darwin {

--- a/lang/llvm-3.7/Portfile
+++ b/lang/llvm-3.7/Portfile
@@ -38,13 +38,6 @@ if {${subport} eq "llvm-${llvm_version}"} {
 
     depends_lib         port:libedit port:libffi port:ncurses port:zlib
     depends_run         bin:perl:perl5 port:llvm_select
-
-    # 3.2.6's install_name_tool doesn't support load commands we might see with newer clang+ld64
-    # 4.3 is just a guess here and should be updated if there are additional reports with other Xcode versions
-    if {[vercmp $xcodeversion 4.3] < 0 && [string match "*macports*" ${configure.compiler}]} {
-        depends_build-append port:cctools
-        depends_skip_archcheck-append cctools
-    }
 } elseif {${subport} eq "clang-${llvm_version}"} {
     homepage            https://clang.llvm.org/
     description         C, C++, Objective C and Objective C++ compiler
@@ -208,12 +201,21 @@ if {${subport} eq "llvm-${llvm_version}"} {
 # Xcode 4.6.3's clang (425.0.28) fails due to http://trac.macports.org/ticket/46897
 compiler.blacklist *gcc* {clang < 500}
 
-# blacklist current and future versions if they're not available in order to
-# help break potential dependency cycles.
-foreach ver {3.7 3.8 3.9 4.0 5.0 6.0 7.0 8.0 devel} {
-    if {![file exists ${prefix}/bin/clang-mp-${ver}]} {
-        compiler.blacklist-append macports-clang-${ver}
-    }
+# Override the normal compiler fallback list entirely since we have
+# such specific requirements.
+compiler.fallback   clang
+
+# 3.4 is already needed to bootstrap libcxx, so is a good last resort
+# when the system clang is too old.
+if {${os.platform} eq "darwin" && ${os.major} < 16} {
+    compiler.fallback-append macports-clang-3.4
+}
+
+if {${subport} eq "llvm-${llvm_version}" && [vercmp $xcodeversion 4.3] < 0 && [string match "*macports*" ${configure.compiler}]} {
+    # 3.2.6's install_name_tool doesn't support load commands we might see with newer clang+ld64
+    # 4.3 is just a guess here and should be updated if there are additional reports with other Xcode versions
+    depends_build-append port:cctools
+    depends_skip_archcheck-append cctools
 }
 
 platform darwin {

--- a/lang/llvm-5.0/Portfile
+++ b/lang/llvm-5.0/Portfile
@@ -323,13 +323,7 @@ compiler.blacklist-append macports-clang-3.3 macports-clang-3.4
 # Override the normal compiler fallback list entirely since we have
 # such specific requirements.
 compiler.fallback   clang
-# Use each macports-clang version only if already installed, to avoid
-# dependency cycles or chaining (8.0 depends on 7.0 depends on 6.0...)
-foreach ver {8.0 7.0 6.0 5.0} {
-    if {[file exists ${prefix}/bin/clang-mp-${ver}]} {
-        compiler.fallback-append macports-clang-${ver}
-    }
-}
+
 # 3.7 is already needed to bootstrap cmake, so is a good last resort
 # when the system clang is too old.
 if {${os.platform} eq "darwin" && ${os.major} < 18} {

--- a/lang/llvm-6.0/Portfile
+++ b/lang/llvm-6.0/Portfile
@@ -313,13 +313,7 @@ compiler.blacklist-append macports-clang-3.3 macports-clang-3.4
 # Override the normal compiler fallback list entirely since we have
 # such specific requirements.
 compiler.fallback   clang
-# Use each macports-clang version only if already installed, to avoid
-# dependency cycles or chaining (8.0 depends on 7.0 depends on 6.0...)
-foreach ver {8.0 7.0 6.0 5.0} {
-    if {[file exists ${prefix}/bin/clang-mp-${ver}]} {
-        compiler.fallback-append macports-clang-${ver}
-    }
-}
+
 # 3.7 is already needed to bootstrap cmake, so is a good last resort
 # when the system clang is too old.
 if {${os.platform} eq "darwin" && ${os.major} < 18} {

--- a/lang/llvm-7.0/Portfile
+++ b/lang/llvm-7.0/Portfile
@@ -318,13 +318,7 @@ compiler.blacklist-append macports-clang-3.3 macports-clang-3.4
 # Override the normal compiler fallback list entirely since we have
 # such specific requirements.
 compiler.fallback   clang
-# Use each macports-clang version only if already installed, to avoid
-# dependency cycles or chaining (8.0 depends on 7.0 depends on 6.0...)
-foreach ver {8.0 7.0 6.0 5.0} {
-    if {[file exists ${prefix}/bin/clang-mp-${ver}]} {
-        compiler.fallback-append macports-clang-${ver}
-    }
-}
+
 # 3.7 is already needed to bootstrap cmake, so is a good last resort
 # when the system clang is too old.
 if {${os.platform} eq "darwin" && ${os.major} < 18} {

--- a/lang/llvm-8.0/Portfile
+++ b/lang/llvm-8.0/Portfile
@@ -322,13 +322,7 @@ compiler.blacklist-append macports-clang-3.3 macports-clang-3.4
 # Override the normal compiler fallback list entirely since we have
 # such specific requirements.
 compiler.fallback   clang
-# Use each macports-clang version only if already installed, to avoid
-# dependency cycles or chaining (8.0 depends on 7.0 depends on 6.0...)
-foreach ver {8.0 7.0 6.0 5.0} {
-    if {[file exists ${prefix}/bin/clang-mp-${ver}]} {
-        compiler.fallback-append macports-clang-${ver}
-    }
-}
+
 # 3.7 is already needed to bootstrap cmake, so is a good last resort
 # when the system clang is too old.
 if {${os.platform} eq "darwin" && ${os.major} < 18} {

--- a/lang/llvm-9.0/Portfile
+++ b/lang/llvm-9.0/Portfile
@@ -328,13 +328,7 @@ compiler.blacklist-append macports-clang-3.3 macports-clang-3.4
 # Override the normal compiler fallback list entirely since we have
 # such specific requirements.
 compiler.fallback   clang
-# Use each macports-clang version only if already installed, to avoid
-# dependency cycles or chaining (8.0 depends on 7.0 depends on 6.0...)
-foreach ver {8.0 7.0 6.0 5.0} {
-    if {[file exists ${prefix}/bin/clang-mp-${ver}]} {
-        compiler.fallback-append macports-clang-${ver}
-    }
-}
+
 # 3.7 is already needed to bootstrap cmake, so is a good last resort
 # when the system clang is too old.
 if {${os.platform} eq "darwin" && ${os.major} < 18} {


### PR DESCRIPTION
No doubt building with newer macports-clang versions if they happen to
be installed already seemed like a good idea at the time, but it means
that different people will see different results when building these
ports on the same platform.

Also move some code that was checking the value of configure.compiler
before it's potentially changed by blacklisting.
