### PR TITLE
starship: update to 0.25.1

### DIFF
--- a/sysutils/starship/Portfile
+++ b/sysutils/starship/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        starship starship 0.25.0 v
+github.setup        starship starship 0.25.1 v
 categories          sysutils
 platforms           darwin
 maintainers         {l2dy @l2dy} openmaintainer
@@ -15,9 +15,9 @@ description         a minimal, blazing fast, and extremely customizable prompt f
 long_description    Starship is ${description}.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  bdc60ada4225229894f2cd57d36a6ae254abc497 \
-                    sha256  1c2f530447c1ed772af23b25726584ef00b1cdc182fefef392ad967612595b0f \
-                    size    4330653
+                    rmd160  892ab0de2c43cb86b873dce1b3d29c00a7538f33 \
+                    sha256  9e60826dad38ef568fd432ac681f02b4cd9a4cf34ffb1df928bc5ed088f88387 \
+                    size    4331442
 
 # For crate:openssl-sys
 depends_build       port:pkgconfig


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15 19A602
Xcode 11.0 11A420a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
