### PR TITLE
spring-boot-cli: update to 2.2.0

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -3,7 +3,8 @@
 PortSystem 1.0
 
 name            spring-boot-cli
-version         2.1.9
+version         2.2.0
+revision        0
 
 categories      java
 platforms       darwin
@@ -28,9 +29,9 @@ master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/
 
 distname        ${name}-${version}.RELEASE-bin
 
-checksums       rmd160  33118e5f946a542e727b15df15596386b5fe385d \
-                sha256  9c37e7a48dc43bfde21cf953dd129699e03dcb3099bdd14779a42cab87bfff24 \
-                size    11223614
+checksums       rmd160  82f57dbbce76bdb570f384d8c1a651bac54450c9 \
+                sha256  d3be1dc619ef0cfb7f7fedb8e055dbaafa67ac16aecb14fd3b038d1a59241a9f \
+                size    11359147
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
#### Description

Update to Spring Boot CLI 2.2.0.RELEASE.

###### Tested on

macOS 10.15 19A602
Xcode 11.1 11A1027

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?