### PR TITLE
micronaut: update to 1.2.5

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-core 1.2.4 v
+github.setup    micronaut-projects micronaut-core 1.2.5 v
 name            micronaut
 categories      java
 platforms       darwin
@@ -41,9 +41,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        ${name}-${version}
 
-checksums       rmd160  7ef94775540ae43d5df8806a21b8a963ec6ca4f2 \
-                sha256  5311cb287fe00e184405318180cca78c6a523528d017845f6fa3753cb6776bf9 \
-                size    12927197
+checksums       rmd160  a51efb7a21b78e53512a25af5f3571181621f8ba \
+                sha256  834cadb0d5c0551e1514de4a5a93e33d1bfa8055da53993974cbe19b3c3e85b6 \
+                size    12928549
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 1.2.5.

###### Tested on

macOS 10.15 19A602
Xcode 11.1 11A1027

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?