### PR TITLE
clang_compilers: account for systems < 10.6

### DIFF
--- a/_resources/port1.0/compilers/clang_compilers.tcl
+++ b/_resources/port1.0/compilers/clang_compilers.tcl
@@ -4,19 +4,34 @@
 # clang_dependency PortGroup, add it to any new dependencies of the
 # new version, and update the blacklisting in the other clang ports.
 
-# does Clang work on all i386 and x86_64 systems?
-# according to https://packages.macports.org/clang-7.0/,
-# clang builds back to Mac OS X 10.6
-lappend compilers macports-clang-9.0 \
-                  macports-clang-8.0 \
-                  macports-clang-7.0 \
-                  macports-clang-6.0 \
-                  macports-clang-5.0
-if {${os.major} < 16} {
+# no macports clang compilers are available for PowerPC
+# macports-clang-9.0 and less are available for darwin10+
+# macports-clang-7.0 and less are available for darwin9+
+# macports-clang-3.4 and less are available for darwin8+
+
+platform darwin i386 {
+
+    if {${os.major} >= 10} {
+        lappend compilers macports-clang-9.0 \
+                          macports-clang-8.0
+    }
+
+    if {${os.major} >= 9} {
+        lappend compilers macports-clang-7.0 \
+                          macports-clang-6.0 \
+                          macports-clang-5.0
+    }
+
+    if {${os.major} < 16} {
     # The Sierra SDK requires a toolchain that supports class properties
-    lappend compilers macports-clang-3.7 \
-                      macports-clang-3.4
-    if {${os.major} < 9} {
-        lappend compilers macports-clang-3.3
+        if {${os.major} >= 9} {
+            lappend compilers macports-clang-3.7
+        }
+        if {${os.major} >= 8} {
+            lappend compilers macports-clang-3.4
+        }
+        if {${os.major} == 8} {
+            lappend compilers macports-clang-3.3
+        }
     }
 }


### PR DESCRIPTION
This is what I believe to be the current situation with macports-clang compilers across the breadth of OS versions we support.

I'm sorry if it looks a bit busy.