### PR TITLE
openjdk8: update to 8u232

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -3,10 +3,10 @@
 PortSystem       1.0
 
 name             openjdk8
-version          8u222
+version          8u232
 revision         0
 
-set build        10
+set build        09
 set major        8
 
 subport openjdk8-openj9 {
@@ -140,9 +140,9 @@ if {${subport} eq "openjdk8"} {
 if {${subport} eq "openjdk8"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}/
     
-    checksums    rmd160  b56170dfdc1da40b18b1f17f3f59a54eee7a5c79 \
-                 sha256  9605fd00d2960934422437f601c7a9a1c5537309b9199d5bc75f84f20cd29a76 \
-                 size    102266954
+    checksums    rmd160  c659d3f0f5611aa03859fb9442b6eca138485788 \
+                 sha256  c237b2c2c32c893e4ee60cdac8c4bcc34ca731a5445986c03b95cf79918e40c3 \
+                 size    102496705
 
     distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}b${build}
     worksrcdir   jdk${version}-b${build}


### PR DESCRIPTION
#### Description

Update to AdoptOpenJDK HotSpot 8u232.

###### Tested on

macOS 10.15 19A602
Xcode 11.1 11A1027

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?