### PR TITLE
openjdk8: update openjdk11 subport to 11.0.5

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -36,10 +36,10 @@ subport openjdk10 {
 }
 
 subport openjdk11 {
-    version      11.0.4
+    version      11.0.5
     revision     0
 
-    set build    11
+    set build    10
     set major    11
 }
 
@@ -207,9 +207,9 @@ if {${subport} eq "openjdk8"} {
 } elseif {${subport} eq "openjdk11"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}/
 
-    checksums    rmd160  2bdf0011a0ee020841aad2c972b4f4e75ab5132c \
-                 sha256  a50b211f475b9497311c9b65594764d7b852b1653f249582bb20fc3c302846a5 \
-                 size    190345711
+    checksums    rmd160  d4099ff93dce27338c2675b356e4f2859082bf8e \
+                 sha256  0825d0d3177832320b697944cd8e7b2e7fe3893fafe8bfcf33ee3631aa5ca96b \
+                 size    188745854
 
     distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}_${build}
     worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to AdoptOpenJDK HotSpot 11.0.5.

###### Tested on

macOS 10.15 19A602
Xcode 11.1 11A1027

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?