### PR TITLE
py-matplotlib: remove py-pyobjc dependency, unnecessary since v2.0

### DIFF
--- a/python/py-matplotlib/Portfile
+++ b/python/py-matplotlib/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-matplotlib
 version             3.1.1
-revision            1
+revision            2
 categories-append   graphics math
 platforms           darwin
 license             {PSF BSD}
@@ -46,8 +46,7 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-dateutil \
                         port:py${python.version}-kiwisolver \
                         port:py${python.version}-numpy \
-                        port:py${python.version}-parsing \
-                        port:py${python.version}-pyobjc-cocoa
+                        port:py${python.version}-parsing
 
     patchfiles          patch-v31-setup.cfg.diff \
                         patch-v31-src-macosx.m.diff \
@@ -57,7 +56,7 @@ if {${name} ne ${subport}} {
 
     if {${python.version} in "27 34"} {
         version         2.2.4
-        revision        0
+        revision        1
         distname        ${python.rootname}-${version}
         checksums       rmd160  dc047125cdedb6371d400648059d70851e05ffc1 \
                         sha256  029620799e581802961ac1dcff5cb5d3ee2f602e0db9c0f202a90495b37d2126 \
@@ -80,7 +79,7 @@ if {${name} ne ${subport}} {
 
     if {${python.version} eq 35} {
         version         3.0.3
-        revision        0
+        revision        1
         distname        ${python.rootname}-${version}
         checksums       rmd160  98ecd1ca25d555bde5d43fcaef800f7436d7d738 \
                         sha256  e1d33589e32f482d0a7d1957bf473d43341115d40d33f578dad44432e47df7b7 \


### PR DESCRIPTION
See https://matplotlib.org/api/prev_api_changes/api_changes_2.0.0.html#cocoaagg-backend-removed

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

I am not a user of `matplotlib`, but I want to do some readjustments to the `pyobjc` ports. Most of the ports that depend on it seem quite old and unmaintained and only support Python 2.7. The exception is `py-matplotlib`, but from a bit of digging, they removed the “unfinished” PyObjC support some time ago:

https://matplotlib.org/api/prev_api_changes/api_changes_2.0.0.html#cocoaagg-backend-removed

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
