### PR TITLE
py-sphinx, etc.: add py38 support

### DIFF
--- a/python/py-alabaster/Portfile
+++ b/python/py-alabaster/Portfile
@@ -18,7 +18,7 @@ checksums           rmd160  c8a1853b067ad6a9e4d8d2cf9c33f4d47bbc0230 \
                     sha256  86363e9f894c0cff8c1a3e89a379ad4b38d329021462e18b35ef92f60559369f \
                     size    23144
 
-python.versions     27 34 35 36 37
+python.versions     27 34 35 36 37 38
 
 if {${subport} ne ${name}} {
     depends_build   port:py${python.version}-setuptools

--- a/python/py-babel/Portfile
+++ b/python/py-babel/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35 36 37
+python.versions     27 34 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-docutils/Portfile
+++ b/python/py-docutils/Portfile
@@ -25,7 +25,7 @@ checksums           md5    f51729f19e70a9dc4837433193a5e798 \
                     sha1   2fe4b3761a05c89ffccee6f7b4279696d4a7ebfe \
                     rmd160 13d54f73d3700637bd77d1c4196c395a5d5232db
 
-python.versions     26 27 33 34 35 36 37
+python.versions     26 27 33 34 35 36 37 38
 
 if {$subport ne $name} {
     depends_run         port:py${python.version}-roman

--- a/python/py-imagesize/Portfile
+++ b/python/py-imagesize/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  266d0cb2befd5bb93c980a7bb672cd99e41ad6b9 \
 
 distname            ${python.rootname}-${version}
 
-python.versions     27 34 35 36 37
+python.versions     27 34 35 36 37 38
 
 if {$subport ne $name} {
     depends_build    port:py${python.version}-setuptools

--- a/python/py-snowballstemmer/Portfile
+++ b/python/py-snowballstemmer/Portfile
@@ -24,7 +24,7 @@ checksums           sha256  df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8
                     rmd160  7bf4fe09842bfd07049336c19c3f56b500d48125 \
                     size    79284
 
-python.versions     27 34 35 36 37
+python.versions     27 34 35 36 37 38
 
 if {$subport ne $name} {
     depends_build-append \

--- a/python/py-sphinx/Portfile
+++ b/python/py-sphinx/Portfile
@@ -26,7 +26,7 @@ master_sites        pypi:S/Sphinx/
 checksums           rmd160 50e6e21c0877955a2a08528c41519c41707ef31f \
                     sha256 0d586b0f8c2fc3cc6559c5e8fd6124628110514fda0e5d7c82e682d749d2e845
 
-python.versions     27 34 35 36 37
+python.versions     27 34 35 36 37 38
 
 if {$subport ne $name} {
     depends_lib     port:py${python.version}-docutils \

--- a/python/py-sphinx/files/py38-sphinx
+++ b/python/py-sphinx/files/py38-sphinx
@@ -1,0 +1,4 @@
+${frameworks_dir}/Python.framework/Versions/3.8/bin/sphinx-apidoc
+${frameworks_dir}/Python.framework/Versions/3.8/bin/sphinx-quickstart
+${frameworks_dir}/Python.framework/Versions/3.8/bin/sphinx-autogen
+${frameworks_dir}/Python.framework/Versions/3.8/bin/sphinx-build

--- a/python/py-sphinxcontrib-applehelp/Portfile
+++ b/python/py-sphinxcontrib-applehelp/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  c4afa2e1711623167a2d880c849fc91b59ba035b \
                     sha256  edaa0ab2b2bc74403149cb0209d6775c96de797dfd5b5e2a71981309efab3897 \
                     size    22086
 
-python.versions     34 35 36 37
+python.versions     34 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-sphinxcontrib-bibtex/Portfile
+++ b/python/py-sphinxcontrib-bibtex/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  dfe9eb50f1278f05416f6c3f3a09cff7aa2d222b \
                     sha256  169afb3a3485775e5473934a0fdff1780e8bdcdd44db7ed286044a074331c729 \
                     size    49490
 
-python.versions     27 36 37
+python.versions     27 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-sphinxcontrib-devhelp/Portfile
+++ b/python/py-sphinxcontrib-devhelp/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  7a48f3d21aaee9f5405b7c3a778a697c5f3231cd \
                     sha256  6c64b077937330a9128a4da74586e8c2130262f014689b4b89e2d08ee7294a34 \
                     size    14016
 
-python.versions     34 35 36 37
+python.versions     34 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-sphinxcontrib-htmlhelp/Portfile
+++ b/python/py-sphinxcontrib-htmlhelp/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  d33e25e6b107f4a58064b6fea6219b51866fc766 \
                     sha256  4670f99f8951bd78cd4ad2ab962f798f5618b17675c35c5ac3b2132a14ea8422 \
                     size    25417
 
-python.versions     34 35 36 37
+python.versions     34 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-sphinxcontrib-jsmath/Portfile
+++ b/python/py-sphinxcontrib-jsmath/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  9ff064c88f8f121bd7876ae3f79b4c31f5a9264f \
                     sha256  a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8 \
                     size    5787
 
-python.versions     34 35 36 37
+python.versions     34 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-sphinxcontrib-qthelp/Portfile
+++ b/python/py-sphinxcontrib-qthelp/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  6aa1ee00851bf48b612bb4197387ee9f096595a3 \
                     sha256  79465ce11ae5694ff165becda529a600c754f4bc459778778c7017374d4d406f \
                     size    17804
 
-python.versions     34 35 36 37
+python.versions     34 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-sphinxcontrib-serializinghtml/Portfile
+++ b/python/py-sphinxcontrib-serializinghtml/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  62ad36be05e2dbccc0a0c1493fd7fd5bec5461b4 \
                     sha256  c0efb33f8052c04fd7a26c0a07f1678e8512e0faec19f4aa8f2473a8b81d5227 \
                     size    15799
 
-python.versions     34 35 36 37
+python.versions     34 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-sphinxcontrib-websupport/Portfile
+++ b/python/py-sphinxcontrib-websupport/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  4d7d6c831fae6234ce6a6700ccf0ecbbe42e6d59 \
                     sha256  1501befb0fdf1d1c29a800fdbf4ef5dc5369377300ddbdd16d2cd40e54c6eefc \
                     size    599000
 
-python.versions     27 34 35 36 37
+python.versions     27 34 35 36 37 38
 
 if {${subport} ne ${name}} {
     depends_build   port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

Add Python 3.8 support for Sphinx and its dependencies.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
