### PR TITLE
Add python.obsolete_versions to portgroup

### DIFF
--- a/_resources/port1.0/group/python-1.0.tcl
+++ b/_resources/port1.0/group/python-1.0.tcl
@@ -44,7 +44,8 @@ pre-destroot    {
 options python.rootname
 default python.rootname {[regsub ^py- [option name] ""]}
 
-options python.versions python.version python.default_version
+options python.versions python.version python.default_version \
+        python.obsolete_versions
 option_proc python.versions python_set_versions
 default python.default_version {[python_get_default_version]}
 default python.version {[python_get_version]}
@@ -72,6 +73,24 @@ proc python_get_default_version {} {
         return 37
     }
 }
+
+option_proc python.obsolete_versions python_set_obsolete
+proc python_set_obsolete {option action args} {
+    if {$action ne "set"} {
+        return
+    }
+    global name subport python.rootname
+    if {[string match py-* $name]} {
+        foreach v [option $option] {
+            subport py${v}-${python.rootname} {
+                global python.default_version
+                replaced_by py${python.default_version}-${python.rootname}
+                PortGroup obsolete 1.0
+            }
+        }
+    }
+}
+
 
 proc python_set_versions {option action args} {
     if {$action ne "set"} {


### PR DESCRIPTION
Adds a python.obsolete_versions (eg. 34 35) where each listed version will be
marked replaced_by py${python.default_version}-* and enables the obsolete
portgroup. This provides a shorthand for handling this rather than everyone
adding the code ad hoc.

An implementation of what was proposed here: https://trac.macports.org/ticket/59051#comment:11 ... but for Python. This (if everyone likes it and it works well) could be modified for the perl5 PG, as well.

Currently this (python.obsolete_versions) needs to be placed at the end of a Portfile so it can override anything from above; is there another way to handle this more gracefully?