### PR TITLE
auto-multiple-choice-devel: update to revision b8e377a2

### DIFF
--- a/x11/auto-multiple-choice/Portfile
+++ b/x11/auto-multiple-choice/Portfile
@@ -6,7 +6,6 @@ PortGroup               texlive 1.0
 
 perl5.branches          5.28
 name                    auto-multiple-choice
-revision                1
 categories              x11 tex education
 platforms               darwin
 license                 GPL-2+
@@ -32,6 +31,7 @@ if {${subport} eq ${name}} {
     set gitlab.commit       "c6041a162202380b065b1b1abbdb016bb6d4b6a8"
     set amc_revision        "201812291614"
     set amc_date            "201812291614"
+    revision                1
     version                 1.4.0-${amc_revision}
     checksums               rmd160  205d1907927c3e3b230e19f3460d151dfa3dfa7d \
                             sha256  8362dd01bd902556940a1415f23d00278b36c27e1e3d62e2190e32d78864b0fe \
@@ -40,13 +40,13 @@ if {${subport} eq ${name}} {
     conflicts               auto-multiple-choice-devel
 } else {
     # devel
-    set gitlab.commit       "c6041a162202380b065b1b1abbdb016bb6d4b6a8"
-    set amc_revision        "201812291614"
-    set amc_date            "201812291614"
+    set gitlab.commit       "b8e377a2926dfccd860a63414b5f51c7abac6dd9"
+    set amc_revision        "201910131933"
+    set amc_date            "201910131933"
     version                 1.4.0-${amc_revision}
-    checksums               rmd160  205d1907927c3e3b230e19f3460d151dfa3dfa7d \
-                            sha256  8362dd01bd902556940a1415f23d00278b36c27e1e3d62e2190e32d78864b0fe \
-                            size    5125388
+    checksums               rmd160  5cb7dded388bd9b6acc329a0726f8acfd7cc8c36 \
+                            sha256  9e51ca3b79c2cb352ad01e8d49d992f924edd15c5c06f2eb7f19424571d40f17 \
+                            size    5768126
     build.cmd               ${prefix}/bin/gmake
     conflicts               auto-multiple-choice
 }


### PR DESCRIPTION
Update auto-multiple-choice-devel to revision b8e377a2 of oct 13, 2019.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15
MacPorts 2.6.2
Xcode 11.1

macOS 10.15
MacPorts 2.6.1
Xcode 11.1

macOS 10.13.6
MacPorts 2.6.1
Xcode 10.1

+mactex
macOS 10.15
MacPorts 2.6.2
Xcode 11.1

+mactex
macOS 10.14.6
MacPorts 2.6.1
Xcode 11.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
