### PR TITLE
thrift: update version to 0.13.0

### DIFF
--- a/devel/thrift/Portfile
+++ b/devel/thrift/Portfile
@@ -133,7 +133,7 @@ variant nodejs description "enable the NodeJS library" {
     depends_lib-append      port:nodejs12
 }
 
-variant nodejs description "enable the Swift library" {
+variant swift description "enable the Swift library" {
     configure.args-delete   --with-swift=no
     configure.args-append   --with-swift=yes
 

--- a/devel/thrift/Portfile
+++ b/devel/thrift/Portfile
@@ -6,10 +6,10 @@ PortGroup       conflicts_build 1.0
 name            thrift
 
 # NOTE: This port must be kept at the same version as port:py-thrift and port:p5-thrift
-version         0.12.0
-checksums       rmd160 dc6286d9523ae0e073f12057987b42fffdddd754 \
-                sha256 c336099532b765a6815173f62df0ed897528a9d551837d627c1f87fadad90428 \
-                size   3906291
+version         0.13.0
+checksums       rmd160 04cd735494a9d8558c2d22d1b99315ca859749c8 \
+                sha256 7ad348b88033af46ce49148097afe354d513c1fca7c607b59c33ebb6064b5179 \
+                size   4154357
 revision        0
 
 categories      devel
@@ -23,12 +23,10 @@ long_description \
     services development. It combines a software stack with a code \
     generation engine to build services that work efficiently and \
     seamlessly between C++, Java, Python, PHP, Ruby, Erlang, Perl, \
-    Haskell, C#, Cocoa, Smalltalk, and OCaml.
+    Haskell, C#, Swift, Smalltalk, and OCaml.
 
 homepage        https://thrift.apache.org/
 master_sites    apache:${name}/${version}
-
-use_parallel_build  no
 
 depends_build       port:autoconf \
                     port:automake \
@@ -44,10 +42,7 @@ compiler.cxx_standard   2011
 use_autoreconf      yes
 
 pre-configure {
-    reinplace \
-        "s#libboost_unit_test_framework\.a#libboost_unit_test_framework-mt.dylib#g" \
-        ${worksrcpath}/configure.ac
-    foreach l {chrono filesystem program_options system thread} {
+    foreach l {chrono filesystem system unit_test_framework thread} {
         reinplace \
             "s#libboost_${l}\.a#libboost_${l}-mt.dylib#g" \
             ${worksrcpath}/configure.ac
@@ -67,12 +62,14 @@ configure.args  --with-c_glib=no \
                 --with-haskell=no \
                 --with-java=no \
                 --with-lua=no \
+                --with-nodejs=no \
                 --with-perl=no \
                 --with-php=no \
                 --with-php_extension=no \
                 --with-python=no \
-                --with-qt4=no \
-                --with-ruby=no
+                --with-ruby=no \
+                --with-rs=no \
+                --with-swift=no
 
 configure.cppflags-append -DBOOST_TEST_DYN_LINK
 
@@ -83,6 +80,8 @@ variant java description "enable the Java library" {
     configure.args-append   --with-java=yes
 }
 
+# CSharp and Netcore targets are deprecated and will be removed with
+# the next release https://issues.apache.org/jira/browse/THRIFT-4723
 variant csharp description "enable the C# library" {
     configure.args-delete   --with-csharp=no
     configure.args-append   --with-csharp=yes
@@ -94,13 +93,6 @@ variant glib2 description "enable the C (GLib) library" {
     configure.args-append   --with-c_glib=yes
     depends_lib-append      path:lib/pkgconfig/glib-2.0.pc:glib2
 }
-
-# doesn't install into destroot
-#variant ruby description "enable the Ruby library" {
-#    configure.args-delete   --with-ruby=no
-#    configure.args-append   --with-ruby=yes
-#    depends_lib-append      port:ruby
-#}
 
 variant haskell description "enable the Haskell library" {
     configure.args-delete   --with-haskell=no
@@ -120,6 +112,33 @@ variant erlang description "enable the Erlang library" {
     configure.args-delete   --with-erlang=no
     configure.args-append   --with-erlang=yes
     depends_lib-append      port:erlang
+}
+
+# doesn't install into destroot
+# variant ruby description "enable the Ruby library" {
+#     configure.args-delete   --with-ruby=no
+#     configure.args-append   --with-ruby=yes
+#     depends_lib-append      port:ruby25
+# }
+
+variant rust description "enable the Rust library" {
+    configure.args-delete   --with-rs=no
+    configure.args-append   --with-rs=yes
+    depends_lib-append      port:rust
+}
+
+variant nodejs description "enable the NodeJS library" {
+    configure.args-delete   --with-nodejs=no
+    configure.args-append   --with-nodejs=yes
+    depends_lib-append      port:nodejs12
+}
+
+variant nodejs description "enable the Swift library" {
+    configure.args-delete   --with-swift=no
+    configure.args-append   --with-swift=yes
+
+    # require XCode
+    use_xcode yes
 }
 
 test.run        yes

--- a/perl/p5-thrift/Portfile
+++ b/perl/p5-thrift/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28 5.30
-perl5.setup         Thrift 0.12.0
+perl5.setup         Thrift 0.13.0
 platforms           darwin
 maintainers         nomaintainer
 license             BSD
@@ -24,10 +24,10 @@ dist_subdir         thrift
 distname            thrift-${version}
 
 # NOTE: This port must be kept at the same version as port:thrift and port:py-thrift
-checksums           rmd160 dc6286d9523ae0e073f12057987b42fffdddd754 \
-                    sha256 c336099532b765a6815173f62df0ed897528a9d551837d627c1f87fadad90428 \
-                    size   3906291
-revision            1
+checksums           rmd160 04cd735494a9d8558c2d22d1b99315ca859749c8 \
+                    sha256 7ad348b88033af46ce49148097afe354d513c1fca7c607b59c33ebb6064b5179 \
+                    size   4154357
+revision            0
 
 if {${perl5.major} != ""} {
     configure.dir   ${worksrcpath}/lib/perl
@@ -43,7 +43,7 @@ if {${perl5.major} != ""} {
         set docdir ${prefix}/share/doc/${subport}
         xinstall -d ${destroot}${docdir}
         xinstall -m 644 -W ${worksrcpath} \
-            CHANGES \
+            CHANGES.md \
             LICENSE \
             NOTICE \
             README.md \

--- a/python/py-thrift/Portfile
+++ b/python/py-thrift/Portfile
@@ -6,11 +6,11 @@ PortGroup       python 1.0
 name            py-thrift
 
 # NOTE: This port must be kept at the same version as port:thrift and port:p5-thrift
-version         0.12.0
-checksums       rmd160 dc6286d9523ae0e073f12057987b42fffdddd754 \
-                sha256 c336099532b765a6815173f62df0ed897528a9d551837d627c1f87fadad90428 \
-                size   3906291
-revision        1
+version         0.13.0
+checksums       rmd160 04cd735494a9d8558c2d22d1b99315ca859749c8 \
+                sha256 7ad348b88033af46ce49148097afe354d513c1fca7c607b59c33ebb6064b5179 \
+                size   4154357
+revision        0
 
 categories      python
 license         Apache-2
@@ -32,7 +32,7 @@ dist_subdir     thrift
 master_sites    apache:${dist_subdir}/${version}
 distname        thrift-${version}
 
-python.versions 27 35 36 37
+python.versions 27 35 36 37 38
 python.default_version 37
 
 if {${name} ne ${subport}} {
@@ -47,7 +47,7 @@ if {${name} ne ${subport}} {
         set docdir ${prefix}/share/doc/${subport}
         xinstall -d ${destroot}${docdir}
         xinstall -m 644 -W ${worksrcpath} \
-            CHANGES \
+            CHANGES.md \
             LICENSE \
             NOTICE \
             README.md \


### PR DESCRIPTION
#### Description

update thrift to 0.13.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A602
Xcode 11.2 11B44

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
