### PR TITLE
google-cloud-sdk: update to 268.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             267.0.0
+version             268.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  81c05cda044e12fdc480cff0055c3a8aa5a315c9 \
-                    sha256  b63c117a0d088b8fca1ebf9ee96f100ad4e7bd3c307f1590b39b03e40b0592e1 \
-                    size    22261128
+    checksums       rmd160  644da047b85ffd01a35d119b562d65ef9a8950c5 \
+                    sha256  881bf8ecf8abeb3effefe80d20f6aa68f1596a48bd95f0abe7c133437da9dc1d \
+                    size    22278903
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  f5e19e081b40be9871fc9a0dafca8fa8e184b150 \
-                    sha256  df6e08db13ff903abec406ee3c75f3eda5b985337c24ed17a5b3d0a2163379b6 \
-                    size    22261026
+    checksums       rmd160  bd788a4a2954ed1fd92b874c575037a51514e24c \
+                    sha256  759a9ecf9406b2a8758e8e1cedd6d461ad6f0834e80f785c91425e8b209c0082 \
+                    size    22279718
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 268.0.0.

###### Tested on

macOS 10.15 19A602
Xcode 11.1 11A1027

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?