### PR TITLE
Update upt-pypi (to 0.5) and upt-rubygems (to 0.3).

### DIFF
--- a/python/py-upt-pypi/Portfile
+++ b/python/py-upt-pypi/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-upt-pypi
-version             0.4
+version             0.5
 revision            0
 
 platforms           darwin
@@ -19,9 +19,9 @@ homepage            https://framagit.org/upt/upt-pypi
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           sha256  6deb4a67716d2205c7bc6d75513ee184252aee03c2f2b21285393270cd4f5409 \
-                    rmd160  ed6b2a37120cec5442d3354f70f963be18efb683 \
-                    size    12427
+checksums           sha256  6cfe91ab916ab190d4d6440b829c2c13d42855724f681c39483e98a506cd9c94 \
+                    rmd160  283c92efd5bef46ce74f1b467ea017b40e7341cf \
+                    size    12414
 
 python.versions     37
 

--- a/python/py-upt-rubygems/Portfile
+++ b/python/py-upt-rubygems/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-upt-rubygems
-version             0.2
+version             0.3
 revision            0
 
 platforms           darwin
@@ -19,9 +19,9 @@ homepage            https://framagit.org/upt/upt-rubygems
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           sha256  5e71e20a43d0a6b263dc703a080df77e89ffd1cf3ce1a984f261958041c93406 \
-                    rmd160  1c3eaf3080ade1e5d4225aecd39c3b0eedbd1e64 \
-                    size    5180
+checksums           sha256  83ae82fef122a6351a882fbc5b49593b3bd2a1aac105896da4e28426a9f4422c \
+                    rmd160  e5eccca8256daf571cc50fdf952b758f2c3ca802 \
+                    size    5303
 
 python.versions     37
 


### PR DESCRIPTION
#### Description

Update upt-pypi to 0.5 and upt-rubygems to 0.3.

###### Type(s)
- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
Untested

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->