### PR TITLE
fd: update to 7.4.0

### DIFF
--- a/sysutils/fd/Portfile
+++ b/sysutils/fd/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        sharkdp fd 7.3.0 v
+github.setup        sharkdp fd 7.4.0 v
 categories          sysutils
 platforms           darwin
 maintainers         {saagarjha.com:saagar @saagarjha} \
@@ -18,64 +18,63 @@ long_description    fd is a simple, fast and user-friendly alternative to find. 
                     for 80% of the use cases.
 
 checksums           fd-${version}.tar.gz \
-                    rmd160  41c9af67dfb384d08216037d664e8aa2f48cfa7d \
-                    sha256  5a37bd04cce61acd3f0cd8635eca9ae0fc621545d0cacf03acbcf4392d8d9bd5 \
-                    size    57703
+                    rmd160  0a4a238a5e5c1e750fbdf922ccb661d90189b992 \
+                    sha256  c0cd6e93744a584fe8ad4cf201eba9c5fcee36e32c6c616c32308b303b5a3d4c \
+                    size    60388
 
 cargo.crates \
-    aho-corasick                     0.6.9  1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e \
+    aho-corasick                     0.7.6  58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d \
+    ansi_term                       0.12.1  d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2 \
     ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
-    atty                            0.2.11  9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652 \
-    bitflags                         1.0.4  228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12 \
-    cc                              1.0.29  4390a3b5f4f6bce9c1d0c00128379df433e53777fdd30e92f16a529332baec4e \
-    cfg-if                           0.1.6  082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4 \
-    clap                            2.32.0  b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e \
-    crossbeam-channel                0.3.8  0f0ed1a4de2235cabda8558ff5840bffb97fcb64c97827f354a451307df5f72b \
-    crossbeam-utils                  0.6.5  f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c \
-    ctrlc                            3.1.1  630391922b1b893692c6334369ff528dcc3a9d8061ccf4c803aa8f83cb13db5e \
+    atty                            0.2.13  1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90 \
+    bitflags                         1.1.0  3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd \
+    bstr                             0.2.8  8d6c2c5b58ab920a4f5aeaaca34b4488074e8cc7596af94e6f8c6ff247c60245 \
+    cc                              1.0.45  4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be \
+    cfg-if                           0.1.9  b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33 \
+    clap                            2.33.0  5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9 \
+    crossbeam-channel                0.3.9  c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa \
+    crossbeam-utils                  0.6.6  04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6 \
+    ctrlc                            3.1.3  c7dfd2d8b4c82121dfdff120f818e09fc4380b0b7e17a742081a89b94853e87f \
     diff                            0.1.11  3c2b69f912779fbb121ceb775d74d51e915af17aaebc38d28a592843a2dd0a3a \
-    filetime                         0.2.4  a2df5c1a8c4be27e7707789dc42ae65976e60b394afd293d1419ab915833e646 \
+    filetime                         0.2.7  6bd7380b54ced79dda72ecc35cc4fbbd1da6bba54afaa37e96fd1c2a308cd469 \
     fnv                              1.0.6  2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3 \
+    fs_extra                         1.1.0  5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674 \
     fuchsia-cprng                    0.1.1  a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba \
-    globset                          0.4.2  4743617a7464bbda3c8aec8558ff2f9429047e025771037df561d383337ff865 \
-    humantime                        1.2.0  3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114 \
-    ignore                           0.4.6  ad03ca67dc12474ecd91fdb94d758cbd20cb4e7a78ebe831df26a9b7511e1162 \
+    globset                          0.4.4  925aa2cac82d8834e2b2a4415b6f6879757fb5c0928fc445ae76461a12eed8f2 \
+    humantime                        1.3.0  df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f \
+    ignore                          0.4.10  0ec16832258409d571aaef8273f3c3cc5b060d784e159d1a0f3b0017308f84a7 \
+    jemalloc-sys                     0.3.2  0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45 \
+    jemallocator                     0.3.2  43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69 \
     kernel32-sys                     0.2.2  7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d \
-    lazy_static                      1.2.0  a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1 \
-    libc                            0.2.48  e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047 \
-    log                              0.4.6  c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6 \
-    lscolors                         0.5.0  e9938fd8c379393454f73ec4c9c5b40f3d8332d80b25a29da05e41ee0ecbb559 \
-    memchr                           2.2.0  2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39 \
-    nix                             0.11.0  d37e713a259ff641624b6cb20e3b12b2952313ba36b6823c0f16e6cfd9e5de17 \
-    num_cpus                        1.10.0  1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    libc                            0.2.62  34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba \
+    log                              0.4.8  14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7 \
+    lscolors                         0.6.0  ea3b3414b2d015c4fd689815f2551797f3c2296bb241dd709c7da233ec7cba4b \
+    memchr                           2.2.1  88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e \
+    nix                             0.14.1  6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce \
+    num_cpus                        1.10.1  bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273 \
     quick-error                      1.2.2  9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0 \
     rand                             0.4.6  552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293 \
+    rand_core                        0.4.2  9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc \
     rand_core                        0.3.1  7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b \
-    rand_core                        0.4.0  d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0 \
     rdrand                           0.4.0  678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2 \
-    redox_syscall                   0.1.51  423e376fffca3dfa06c9e9790a9ccd282fafb3cc6e6397d01dbf64f9bacc6b85 \
-    redox_termios                    0.1.1  7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76 \
-    regex                            1.1.0  37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f \
-    regex-syntax                     0.6.5  8c2f35eedad5295fdf00a63d7d4b238135723f92b434ec06774dad15c7ab0861 \
-    remove_dir_all                   0.5.1  3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5 \
-    same-file                        1.0.4  8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267 \
-    smallvec                         0.6.8  88aea073965ab29f6edb5493faf96ad662fb18aa9eeb186a3b7057951605ed15 \
-    strsim                           0.7.0  bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550 \
+    redox_syscall                   0.1.56  2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84 \
+    regex                            1.3.1  dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd \
+    regex-syntax                    0.6.12  11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716 \
+    remove_dir_all                   0.5.2  4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e \
+    same-file                        1.0.5  585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421 \
+    strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
     tempdir                          0.3.7  15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8 \
     term_size                        0.3.1  9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327 \
-    termion                          1.5.1  689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096 \
-    textwrap                        0.10.0  307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6 \
+    textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
     thread_local                     0.3.6  c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b \
-    ucd-util                         0.1.3  535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86 \
-    unicode-width                    0.1.5  882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526 \
-    unreachable                      1.0.0  382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56 \
-    utf8-ranges                      1.0.2  796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737 \
+    unicode-width                    0.1.6  7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20 \
     vec_map                          0.8.1  05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a \
-    version_check                    0.1.5  914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd \
+    version_check                    0.9.1  078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce \
     void                             1.0.2  6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d \
-    walkdir                          2.2.7  9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1 \
+    walkdir                          2.2.9  9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e \
+    winapi                           0.3.8  8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6 \
     winapi                           0.2.8  167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
-    winapi                           0.3.6  92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0 \
     winapi-build                     0.1.1  2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
     winapi-util                      0.1.2  7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9 \


### PR DESCRIPTION
#### Description

Updates the `fd` port to [7.4.0.](https://github.com/sharkdp/fd/releases/tag/v7.4.0) I just changed the checksums and updated the cargo crates.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G103
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
