### PR TITLE
ruby{24,25}: avoid setting DYLD_LIBRARY_PATH

### DIFF
--- a/lang/ruby24/Portfile
+++ b/lang/ruby24/Portfile
@@ -5,7 +5,7 @@ PortGroup           select 1.0
 
 name                ruby24
 version             2.4.9
-revision            0
+revision            1
 
 categories          lang ruby
 maintainers         {kimuraw @kimuraw} openmaintainer
@@ -62,6 +62,13 @@ configure.args      --enable-shared \
                     --with-opt-dir="${prefix}" \
                     --program-suffix=2.4 \
                     --with-rubylibprefix="${prefix}/lib/ruby2.4"
+
+# https://github.com/ruby/ruby/commit/1961c786aab243b3eb60e7238224e87975d88056
+# * configure.ac (LIBPATHENV): use DYLD_FALLBACK_LIBRARY_PATH instead of
+# DYLD_LIBRARY_PATH on macOS, to honor runtime paths embedded in the
+# binaries.  https://bugs.ruby-lang.org/issues/14992
+configure.args-append \
+                    LIBPATHENV=DYLD_FALLBACK_LIBRARY_PATH
 
 platform darwin {
     if {${os.major} < 10} {

--- a/lang/ruby25/Portfile
+++ b/lang/ruby25/Portfile
@@ -5,7 +5,7 @@ PortGroup           select 1.0
 
 name                ruby25
 version             2.5.7
-revision            0
+revision            1
 
 categories          lang ruby
 maintainers         {kimuraw @kimuraw} openmaintainer
@@ -61,6 +61,13 @@ configure.args      --enable-shared \
                     --with-opt-dir="${prefix}" \
                     --program-suffix=2.5 \
                     --with-rubylibprefix="${prefix}/lib/ruby2.5"
+
+# https://github.com/ruby/ruby/commit/1961c786aab243b3eb60e7238224e87975d88056
+# * configure.ac (LIBPATHENV): use DYLD_FALLBACK_LIBRARY_PATH instead of
+# DYLD_LIBRARY_PATH on macOS, to honor runtime paths embedded in the
+# binaries.  https://bugs.ruby-lang.org/issues/14992
+configure.args-append \
+                    LIBPATHENV=DYLD_FALLBACK_LIBRARY_PATH
 
 platform darwin {
     if {${os.major} < 10} {


### PR DESCRIPTION
#### Description
Fix building some [gems with extensions](https://guides.rubygems.org/gems-with-extensions/).

A similar issue was discovered and fixed in the `cargo` port, see https://trac.macports.org/ticket/57692.

Upstream fix was applied in Ruby 2.6:

```
$ grep LIBPATHENV=DYLD ruby-2.*/configure
ruby-2.4.9/configure:                 : ${LIBPATHENV=DYLD_LIBRARY_PATH}
ruby-2.5.7/configure:                 : ${LIBPATHENV=DYLD_LIBRARY_PATH}
ruby-2.6.5/configure:                 : ${LIBPATHENV=DYLD_FALLBACK_LIBRARY_PATH}
```

Upstream commit: https://github.com/ruby/ruby/commit/1961c786aab243b3eb60e7238224e87975d88056

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G103
Xcode 11.1 11A1027

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`? (only ruby24)
- [x] tested basic functionality of all binary files? (only ruby24)

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
