### PR TITLE
codec2: update version to 81ca4442

### DIFF
--- a/audio/codec2/Portfile
+++ b/audio/codec2/Portfile
@@ -22,11 +22,11 @@ long_description    Codec 2 is an open source speech codec designed for \
     designed for digital voice over HF radio.
 homepage            http://www.rowetel.com/codec2.html
 
-github.setup        drowe67 codec2 34292702a68102a70f8367f1feab9f39ef17ce7c
-version             20191009-[string range ${github.version} 0 7]
-checksums           rmd160  a639f5d603a6e85eecfcdfef6d77744b69c9e071 \
-                    sha256  4e4caf409bcafd9f2cc5f152a432f9c84d45e2f6460fafa7a667b29c380a86ec \
-                    size    11775586
+github.setup        drowe67 codec2 81ca4442c4d9469755bf02b84428e8955c543c82
+version             20191023-[string range ${github.version} 0 7]
+checksums           rmd160  8512524ae1b0f00606f6b60c37dc9a18c99b98cd \
+                    sha256  9b101a72fb64587a3d95a3ffa6244e682f23b62bbb0a65759c9aede131246591 \
+                    size    11775671
 revision            0
 
 depends_lib-append \


### PR DESCRIPTION


#### Description

- bump version to 81ca4442

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A602
Xcode 11.2 11B44

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
