### PR TITLE
py-arpeggio: update to 1.9.2 to fix checksum and permit use of tests

### DIFF
--- a/python/py-arpeggio/Portfile
+++ b/python/py-arpeggio/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  2fa93422ba02dade8a4abc89c53316308b4a4863 \
                     sha256  948ce06163a48a72c97f4fe79ad3d1c1330b6fec4f22ece182fb60ef60bd022b \
                     size    37145
 
-python.versions     27 36 37
+python.versions     27 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-arpeggio/Portfile
+++ b/python/py-arpeggio/Portfile
@@ -1,11 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        igordejanovic Arpeggio 1.9.0 v
 name                py-arpeggio
+version             1.9.2
 platforms           darwin
 license             MIT
 maintainers         nomaintainer
@@ -14,24 +13,25 @@ description         Packrat parser interpreter
 long_description    Arpeggio is a recursive descent parser with memoization \
                     based on PEG grammars (aka Packrat parser).
 
-checksums           rmd160  2e9823273ad9a382aaa42dbc6553e3892f7f25d5 \
-                    sha256  fc6e1bd37fd1c5620f86c338cfad3bfd73217e46d79af831a62c22c3fc0b184a \
-                    size    758169
+homepage            https://github.com/igordejanovic/Arpeggio
+master_sites        pypi:A/Arpeggio
+distname            Arpeggio-${version}
+
+checksums           rmd160  2fa93422ba02dade8a4abc89c53316308b4a4863 \
+                    sha256  948ce06163a48a72c97f4fe79ad3d1c1330b6fec4f22ece182fb60ef60bd022b \
+                    size    37145
 
 python.versions     27 36 37
 
 if {${name} ne ${subport}} {
     depends_build-append \
-                        port:py${python.version}-setuptools
+                        port:py${python.version}-setuptools \
+                        port:py${python.version}-pytest-runner
 
     depends_test-append \
                         port:py${python.version}-pytest
 
     test.run            yes
-    test.cmd            py.test-${python.branch}
-    test.target         tests/unit
 
     livecheck.type      none
-} else {
-    livecheck.type      pypi
 }


### PR DESCRIPTION
#### Description

Previous checksums did not match the tarball of 1.9.0 on github. Upstream maintainer reports that PyPI tarball didn't have the tests that this port uses until 1.9.1. Previous maintainer of py-arpeggio intended to run the tests, so in order to run tests against a tarball that has them, we
have to update the version. See also https://github.com/textX/Arpeggio/issues/67

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.15 19A583
Xcode 11.1 11A1027 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
