### PR TITLE
tor-devel: update to 0.4.2.3-alpha

### DIFF
--- a/security/tor-devel/Portfile
+++ b/security/tor-devel/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                tor-devel
 conflicts           tor
-version             0.4.2.2-alpha
+version             0.4.2.3-alpha
 revision            0
 categories          security
 platforms           darwin
@@ -24,9 +24,9 @@ homepage            https://www.torproject.org/
 master_sites        https://dist.torproject.org/
 distname            tor-${version}
 
-checksums           rmd160  cf6ac26370a959004bb0479961a58e53aacc655f \
-                    sha256  81db998b9a81fd0900965e1196cf17b7f58abe07f8931f558a8d8b9afbd59284 \
-                    size    7532174
+checksums           rmd160  68d221a46664a776c6fc5c36ab4f86973b991de8 \
+                    sha256  ec3914be69ef3bf322a24d98ee8de6e194afa3327a4b92844b6b76af80f89d1e \
+                    size    7534968
 
 depends_lib         port:libevent \
                     path:lib/libssl.dylib:openssl \


### PR DESCRIPTION
#### Description

tor-devel: update to 0.4.2.3-alpha

###### Type(s)

- [X] bugfix
- [X] enhancement

###### Tested on

macOS 10.15.1 19B86a
Xcode 11.2 11B44 

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tested basic functionality of all binary files?