### PR TITLE
xorg-encodings: add xorg-font-util build dep to fix install

### DIFF
--- a/x11/xorg-encodings/Portfile
+++ b/x11/xorg-encodings/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                xorg-encodings
 set my_name         encodings
 version             1.0.5
-revision            0
+revision            1
 categories          x11 x11-font graphics
 license             public-domain
 maintainers         nomaintainer
@@ -25,7 +25,10 @@ checksums           rmd160  ac69411cd9a8bec97138c6184f32732d13faa62e \
                     size    713817
 
 depends_build       bin:gzip:gzip \
-                    port:mkfontscale
+                    port:mkfontscale \
+                    port:pkgconfig \
+                    port:xorg-util-macros \
+                    port:xorg-font-util
 
 livecheck.type      regex
 livecheck.regex     ${my_name}-(\[\\d.\]+)${extract.suffix}


### PR DESCRIPTION
Without fontutil.pc pkgconfig, configure defaults fontdir to
{prefix}/share/fonts/X11.  Adding xorg-font-util correctly configures
fontdir to {prefix}/share/fonts, fixing the install location.

#### Description

Current version (1.0.5) uses pkgconfig in configure to discover the x11 fontdir, but if xorg-font-util isn't installed, then it uses an internal default -- which is different than macports fontdir.

The incorrect location for the encodings breaks other utilities such as font_cache.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G103
Xcode 11.1 11A1027

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
