### PR TITLE
cloc: Update to 1.84

### DIFF
--- a/textproc/cloc/Portfile
+++ b/textproc/cloc/Portfile
@@ -4,8 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           perl5 1.0
 
-github.setup        AlDanial cloc 1.82
-revision            0
+github.setup        AlDanial cloc 1.84
 perl5.branches      5.28
 categories          textproc devel
 license             GPL-2 Artistic-1
@@ -18,9 +17,9 @@ long_description    cloc counts blank lines, comment lines, and physical \
                     Given two versions of a code base, cloc can compute \
                     differences in blank, comment, and source lines.
 
-checksums           rmd160  788490e80659fc10a2339cb02a0e8f1200e2804f \
-                    sha256  b71bed1b153275c7ea3fc03e60a92332ea3137232ff9a7d6f12f631ad2bd0d18 \
-                    size    494413
+checksums           rmd160  5538b760db2c1bc0aa06e6fb2094820c1a35a143 \
+                    sha256  66246ca354414f78528e8e412828f04915517546587253312e68dcb660e5a29f \
+                    size    514902
 
 depends_run-append  port:perl${perl5.major} \
                     port:p${perl5.major}-algorithm-diff \


### PR DESCRIPTION
#### Description

I'm running through `port livecheck installed` and trying to update things that have an open maintainer or no maintainer.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.1 19B86a
Xcode 11.2 11B41 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
