### PR TITLE
SourceKitten: Update to 0.26.0

### DIFF
--- a/devel/SourceKitten/Portfile
+++ b/devel/SourceKitten/Portfile
@@ -3,9 +3,9 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           xcodeversion 1.0
-use_xcode           yes
 
-github.setup        jpsim SourceKitten 0.23.2
+use_xcode           yes
+github.setup        jpsim SourceKitten 0.26.0
 categories          devel
 platforms           darwin
 


### PR DESCRIPTION
#### Description

I'm running through `port livecheck installed` and trying to update things that have an open maintainer or no maintainer.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.1 19B86a
Xcode 11.2 11B41 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
