### PR TITLE
just: Update to v0.4.4

### DIFF
--- a/sysutils/just/Portfile
+++ b/sysutils/just/Portfile
@@ -2,28 +2,93 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           cargo 1.0
 
-github.setup        casey just 0.2.0
-github.tarball_from releases
+github.setup        casey just 0.4.4 v
 
 categories          sysutils
 platforms           darwin
+maintainers         {@casey rodarmor.com:casey} openmaintainer
 license             permissive
 
-maintainers         rodarmor.com:casey
 description         A handy way to store and run project-specific commands
 long_description    just is a simple tool which allows you to easily save \
                     and run project specific commands.
 
-checksums           rmd160 d57a533c7386740f653c6653983ae7b123cf7d99 \
-                    sha256 7e36c5a8ea3bb4d1f2d8e22ec2df19ff6e61da27edaae56265905e1c26f8dcda
+cargo.crates \
+    aho-corasick                     0.7.3  e6f484ae0c99fec2e858eb6134949117399f222608d84cadb3f58c1f97c2364c \
+    ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
+    assert_matches                   1.3.0  7deb0a829ca7bcfaf5da70b073a8d128619259a7be8216a355e23f00763059e5 \
+    atty                            0.2.11  9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652 \
+    autocfg                          0.1.4  0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf \
+    backtrace                       0.3.26  1a13fc43f04daf08ab4f71e3d27e1fc27fc437d3e95ac0063a796d92fb40f39b \
+    backtrace-sys                   0.1.28  797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6 \
+    bitflags                         1.0.4  228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12 \
+    brev                            0.1.14  423c06240bda0044486c500264dd450b24eb25d1223103a6b8b817ed7fc0be7a \
+    cc                              1.0.37  39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d \
+    cfg-if                           0.1.9  b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33 \
+    clap                            2.33.0  5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9 \
+    ctor                             0.1.9  3b4c17619643c1252b5f690084b82639dd7fac141c57c8e77a00e0148132092c \
+    ctrlc                            3.1.2  5531b7f0698d9220b4729f8811931dbe0e91a05be2f7b3245fdc50dd856bae26 \
+    difference                       2.0.0  524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198 \
+    dotenv                          0.13.0  c0d0a1279c96732bc6800ce6337b6a614697b0e74ae058dc03c62ebeb78b4d86 \
+    edit-distance                    2.1.0  bbbaaaf38131deb9ca518a274a45bfdb8771f139517b073b16c2d3d32ae5037b \
+    either                           1.5.2  5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b \
+    env_logger                       0.6.1  b61fa891024a945da30a9581546e8cfaf5602c7b3f4c137a2805cf388f92075a \
+    executable-path                  1.0.0  3ebc5a6d89e3c90b84e8f33c8737933dda8f1c106b5415900b38b9d433841478 \
+    failure                          0.1.5  795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2 \
+    failure_derive                   0.1.5  ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1 \
+    fuchsia-cprng                    0.1.1  a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba \
+    glob                            0.2.11  8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb \
+    humantime                        1.2.0  3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114 \
+    itertools                        0.8.0  5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358 \
+    lazy_static                      1.3.0  bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14 \
+    libc                            0.2.58  6281b86796ba5e4366000be6e9e18bf35580adf9e63fbe2294aadb587613a319 \
+    log                              0.4.6  c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6 \
+    memchr                           2.2.0  2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39 \
+    nix                             0.13.0  46f0f3210768d796e8fa79ec70ee6af172dacbe7147f5e69be5240a47778302b \
+    numtoa                           0.1.0  b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef \
+    output_vt100                     0.1.2  53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9 \
+    pretty_assertions                0.6.1  3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427 \
+    proc-macro2                     0.4.30  cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759 \
+    quick-error                      1.2.2  9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0 \
+    quote                           0.6.12  faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db \
+    rand                             0.4.6  552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293 \
+    rand_core                        0.3.1  7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b \
+    rand_core                        0.4.0  d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0 \
+    rdrand                           0.4.0  678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2 \
+    redox_syscall                   0.1.54  12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252 \
+    redox_termios                    0.1.1  7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76 \
+    regex                            1.1.6  8f0a0bcab2fd7d1d7c54fa9eae6f43eddeb9ce2e7352f8518a814a4f65d60c58 \
+    regex-syntax                     0.6.6  dcfd8681eebe297b81d98498869d4aae052137651ad7b96822f09ceb690d0a96 \
+    remove_dir_all                   0.5.1  3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5 \
+    rustc-demangle                  0.1.15  a7f4dccf6f4891ebcc0c39f9b6eb1a83b9bf5d747cb439ec6fba4f3b977038af \
+    strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
+    syn                            0.15.34  a1393e4a97a19c01e900df2aec855a29f71cf02c402e2f443b8d2747c25c5dbe \
+    synstructure                    0.10.2  02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f \
+    target                           1.0.0  10000465bb0cc031c87a44668991b284fd84c0e6bd945f62d4af04e9e52a222a \
+    tempdir                          0.3.7  15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8 \
+    termcolor                        1.0.4  4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f \
+    termion                          1.5.2  dde0593aeb8d47accea5392b39350015b5eccb12c0d98044d856983d89548dea \
+    textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
+    thread_local                     0.3.6  c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b \
+    ucd-util                         0.1.3  535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86 \
+    unicode-width                    0.1.5  882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526 \
+    unicode-xid                      0.1.0  fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc \
+    utf8-ranges                      1.0.2  796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737 \
+    vec_map                          0.8.1  05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a \
+    void                             1.0.2  6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d \
+    winapi                           0.3.7  f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770 \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                      0.1.2  7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    wincolor                         1.0.1  561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba
 
-homepage            https://github.com/casey/just
-depends_run         port:gmake
-supported_archs     noarch
-use_configure       no
-build               {}
+checksums-append    ${distname}${extract.suffix} \
+                    rmd160 a90622fcbb6e8046c032617141824e043e0a97c7 \
+                    sha256 f3c051c54e77fc5c915ae54a6a5549d668603ad27e8c83b44cda585bc4abb8b6 \
+                    size   79697
 
 destroot {
-  file copy ${worksrcpath}/just ${destroot}${prefix}/bin/just
+    xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/just ${destroot}${prefix}/bin/
 }


### PR DESCRIPTION
#### Description

Updates `sysutils/just` from 0.2.0 to v0.4.4. The new version is now a rust program, instead of a shell script, so the portfile is substantially different.

This is my first rust portfile, so please let me know if I messed anything up! The hashes were generated by `cargo2port` from `macports-contrib`.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G103
Xcode 11.1 11A1027

###### Verification

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
