### PR TITLE
starship: update to 0.25.2

### DIFF
--- a/sysutils/starship/Portfile
+++ b/sysutils/starship/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        starship starship 0.25.1 v
+github.setup        starship starship 0.25.2 v
 categories          sysutils
 platforms           darwin
 maintainers         {l2dy @l2dy} openmaintainer
@@ -15,9 +15,9 @@ description         a minimal, blazing fast, and extremely customizable prompt f
 long_description    Starship is ${description}.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  892ab0de2c43cb86b873dce1b3d29c00a7538f33 \
-                    sha256  9e60826dad38ef568fd432ac681f02b4cd9a4cf34ffb1df928bc5ed088f88387 \
-                    size    4331442
+                    rmd160  01abdfb3a567e6e1cb10a744d743d0dc5777e39c \
+                    sha256  b0d9f2b4d3c9a1b7842f31e8edbc0c8e1bc7c3c0c8e594698415c0057259ce21 \
+                    size    4340955
 
 # For crate:openssl-sys
 depends_build       port:pkgconfig
@@ -73,6 +73,7 @@ cargo.crates \
     jobserver                       0.1.17  f2b1d42ef453b30b7387e113da1c83ab1605d90c5b4e0eb8e96d016ed3b8c160 \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
     lazycell                         1.2.1  b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f \
+    lexical-core                     0.4.6  2304bccb228c4b020f3a4835d247df0a02a7c4686098d4167762cfbbe4c5cb14 \
     libc                            0.2.62  34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba \
     libgit2-sys                      0.9.1  a30f8637eb59616ee3b8a00f6adff781ee4ddd8343a615b8238de756060cc1b3 \
     libz-sys                        1.0.25  2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe \
@@ -84,6 +85,7 @@ cargo.crates \
     memoffset                        0.5.1  ce6075db033bbbb7ee5a0bbd3a3186bbae616f57fb001c485c7ff77955f8177f \
     nix                             0.14.1  6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce \
     nodrop                          0.1.13  2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945 \
+    nom                              5.0.1  c618b63422da4401283884e6668d39f819a106ef51f5f59b81add00075da35ca \
     num-integer                     0.1.41  b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09 \
     num-traits                       0.2.8  6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32 \
     num_cpus                        1.10.1  bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273 \
@@ -123,6 +125,7 @@ cargo.crates \
     serde                          1.0.101  9796c9b7ba2ffe7a9ce53c2287dfc48080f4b2b362fcc245a259b3a7201119dd \
     serde_json                      1.0.41  2f72eb2a68a7dc3f9a691bfda9305a1c017a6215e5a4545c258500d2099a37c2 \
     smallvec                        0.6.10  ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7 \
+    static_assertions                0.3.4  7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3 \
     strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
     syn                              1.0.5  66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf \
     syn                            0.15.44  9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5 \
@@ -145,6 +148,7 @@ cargo.crates \
     url                              2.1.0  75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61 \
     vcpkg                            0.2.7  33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95 \
     vec_map                          0.8.1  05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a \
+    version_check                    0.1.5  914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd \
     void                             1.0.2  6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d \
     wasi                             0.7.0  b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d \
     winapi                           0.3.8  8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6 \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15 19A602
Xcode 11.0 11A420a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
