### PR TITLE
Webkit2-gtk fix clang-9 builds

### DIFF
--- a/www/webkit2-gtk-devel/Portfile
+++ b/www/webkit2-gtk-devel/Portfile
@@ -14,7 +14,7 @@ cmake.generator     Ninja
 name                webkit2-gtk-devel
 conflicts           webkit2-gtk
 version             2.27.2
-revision            0
+revision            1
 
 description         Apple's WebKit2 HTML rendering library for GTK+3
 long_description    ${description}
@@ -91,7 +91,6 @@ patchfiles-append    patch-enable-plugin-architecture-unix.diff
 # runs without this patch.
 patchfiles-append    patch-bundle-link-webcore.diff
 
-
 # it is preferred to use the WebKit built in bmalloc if it builds on a given os.
 # it has improved security features, but not all systems can build it at present.
 
@@ -153,12 +152,6 @@ variant minibrowser description {Build and install MiniBrowser (for testing)} {
 # the above code presently builds as-in on 10.13 and up
 if {${os.platform} eq "darwin" && ${os.major} <= 16} {
 
-    # the only compiler I know that works here is macports-clang-5.0
-    # macports-clang-9.0 does not work. There may be others in between that work.
-    # to be discovered as time allows. Input appreciated from interested parties.
-    # the first generated error is a name collision with MacTypes.h
-    compiler.whitelist      macports-clang-5.0
-
     # build of bmalloc fails up to 10.12 https://trac.macports.org/ticket/59447
     configure.args-replace -DUSE_SYSTEM_MALLOC=OFF -DUSE_SYSTEM_MALLOC=ON
     patchfiles-append       patch-ramsize.diff
@@ -193,9 +186,9 @@ if {${os.platform} eq "darwin" && ${os.major} <= 16} {
     # disable veclib on 10.7 and 10.8. There is a definition for
     # class complex<> in the vForce.h header that collides with libc++
     # if anyone has a more elegant fix for this, please volunteer it
-#    if {${os.major} == 11 || ${os.major} == 12} {
+    if {${os.major} == 11 || ${os.major} == 12} {
         patchfiles-append       patch-webcore-platform-audio-directconvolver-disable-veclib.diff
-#    }
+    }
 
     # add dep for newer ruby and spec this for build
     # https://trac.macports.org/ticket/52016

--- a/www/webkit2-gtk-devel/Portfile
+++ b/www/webkit2-gtk-devel/Portfile
@@ -213,4 +213,4 @@ if {${os.platform} eq "darwin" && ${os.major} <= 16} {
 
 livecheck.type      regex
 livecheck.url       http://webkitgtk.org/releases/
-livecheck.regex     "webkitgtk-(\\d+\\.\\d*\[13579\](?:\\.\\d+)*)"
+livecheck.regex     "webkitgtk-(\\d+(?:\\.\\d+)+)"

--- a/www/webkit2-gtk/Portfile
+++ b/www/webkit2-gtk/Portfile
@@ -79,6 +79,9 @@ depends_lib-append  port:atk \
 # 5. change some int64_t to gint64 to stop typedef errors in gstreamer
 patchfiles-append   patch-webkit2gtk-macports.diff
 
+# fix name collision that breaks build with clang-9.0
+patchfiles-append   patch-webkit2gtk-source-javascriptcore-tools-jsdollarvm-handle.diff
+
 # enable Netscape plugin architecture on macOS
 # or can be explicitly disabled with the following addition if preferred
 # configure.args-append -DENABLE_NETSCAPE_PLUGIN_API=OFF
@@ -151,12 +154,6 @@ variant minibrowser description {Build and install MiniBrowser (for testing)} {
 
 # the above code presently builds as-in on 10.13 and up
 if {${os.platform} eq "darwin" && ${os.major} <= 16} {
-
-    # the only compiler I know that works here is macports-clang-5.0
-    # macports-clang-9.0 does not work. There may be others in between that work.
-    # to be discovered as time allows. Input appreciated from interested parties.
-    # the first generated error is a name collision with MacTypes.h
-    compiler.whitelist      macports-clang-5.0
 
     # build of bmalloc fails up to 10.12 https://trac.macports.org/ticket/59447
     configure.args-replace -DUSE_SYSTEM_MALLOC=OFF -DUSE_SYSTEM_MALLOC=ON

--- a/www/webkit2-gtk/files/patch-webkit2gtk-source-javascriptcore-tools-jsdollarvm-handle.diff
+++ b/www/webkit2-gtk/files/patch-webkit2gtk-source-javascriptcore-tools-jsdollarvm-handle.diff
@@ -1,0 +1,13 @@
+diff --git Source/JavaScriptCore/tools/JSDollarVM.cpp Source/JavaScriptCore/tools/JSDollarVM.cpp
+index 92ffb85b..481763fa 100644
+--- Source/JavaScriptCore/tools/JSDollarVM.cpp
++++ Source/JavaScriptCore/tools/JSDollarVM.cpp
+@@ -179,7 +179,7 @@ private:
+ class ElementHandleOwner : public WeakHandleOwner {
+     WTF_MAKE_FAST_ALLOCATED;
+ public:
+-    bool isReachableFromOpaqueRoots(Handle<JSC::Unknown> handle, void*, SlotVisitor& visitor, const char** reason) override
++    bool isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, SlotVisitor& visitor, const char** reason) override
+     {
+         if (UNLIKELY(reason))
+             *reason = "JSC::Element is opaque root";


### PR DESCRIPTION
restore previous livecheck in webkit2-gtk-devel
remove an errant commented system guard
