### PR TITLE
bmon-4.0: fix for undeclared identifier

### DIFF
--- a/net/bmon/Portfile
+++ b/net/bmon/Portfile
@@ -2,7 +2,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 
 github.setup            tgraf bmon 4.0 v
-revision                2
+revision                3
 categories              net
 platforms               darwin
 maintainers             {l2dy @l2dy} openmaintainer
@@ -16,7 +16,15 @@ long_description        bmon is a bandwidth monitor with multiple modes and \
 github.tarball_from     releases
 
 checksums               rmd160  9f8639ef55c77f1085169d40c02f5702ac30cfc4 \
-                        sha256  02fdc312b8ceeb5786b28bf905f54328f414040ff42f45c83007f24b76cc9f7a
+                        sha256  02fdc312b8ceeb5786b28bf905f54328f414040ff42f45c83007f24b76cc9f7a \
+                        size    202241
+
+# Trac: #59334, PR: #5636
+if {([vercmp ${os.major} 11] <=  0) ||
+    ([vercmp ${os.major} 19] >=  0) &&
+    ([vercmp ${xcodeversion} 11.3] < 0)} {
+    patchfiles          patch-fix__unused.diff
+}
 
 depends_build           port:pkgconfig
 

--- a/net/bmon/files/patch-fix__unused.diff
+++ b/net/bmon/files/patch-fix__unused.diff
@@ -1,0 +1,17 @@
+Fix for #59334
+  - error: use of undeclared identifier 'unused'
+
+--- include/bmon/bmon.h.orig
++++ include/bmon/bmon.h
+@@ -67,6 +67,11 @@ enum {
+ #define __unused__
+ #endif
+
++/* #59334 */
++#ifdef __APPLE__
++#define __unused __attribute__ ((unused))
++#endif
++
+ #ifdef DEBUG
+ #define DBG(FMT, ARG...)					\
+ 	do {							\


### PR DESCRIPTION
bmon-4.0: fix for undeclared identifier

  - Closes: https://trac.macports.org/ticket/59334
  - Add: size in Portfile

###### Type(s)

- [x] bugfix

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?