### PR TITLE
orc: Fix OrcTargetPowerPCFlags enum typedef

### DIFF
--- a/devel/orc/Portfile
+++ b/devel/orc/Portfile
@@ -5,6 +5,7 @@ PortGroup           meson 1.0
 
 name                orc
 version             0.4.30
+revision            1
 description         Orc - The Oil Runtime Compiler
 long_description    Orc is a library and set of tools for compiling \
     and executing very simple programs that operate on arrays of data.
@@ -20,5 +21,7 @@ use_xz              yes
 checksums           rmd160  322c384aee5b158d1592d6f65b28c044e3277282 \
                     sha256  ba41b92146a5691cd102eb79c026757d39e9d3b81a65810d2946a1786a1c4972 \
                     size    176340
+
+patchfiles          patch-fix-OrcTargetPowerPCFlags-enum-typedef.diff
 
 test.run            yes

--- a/devel/orc/files/patch-fix-OrcTargetPowerPCFlags-enum-typedef.diff
+++ b/devel/orc/files/patch-fix-OrcTargetPowerPCFlags-enum-typedef.diff
@@ -1,0 +1,14 @@
+--- orc/orctarget.h
++++ orc/orctarget.h
+@@ -19,7 +19,7 @@ enum {
+   ORC_TARGET_FAST_DENORMAL = (1<<31)
+ };
+ 
+-enum {
++typedef enum {
+   ORC_TARGET_POWERPC_64BIT = (1<<0),
+   ORC_TARGET_POWERPC_LE = (1<<1),
+   ORC_TARGET_POWERPC_ALTIVEC = (1<<2),
+-- 
+2.22.0
+


### PR DESCRIPTION
orc produces duplicated symbols;
https://gitlab.freedesktop.org/gstreamer/orc/merge_requests/32

This resolves https://trac.macports.org/ticket/59426
And anything else that recently broken with the orc update

#### Description

orc produces duplicated symbols causing anything built with it to fail;
https://gitlab.freedesktop.org/gstreamer/orc/merge_requests/32

This resolves https://trac.macports.org/ticket/59426
And anything else that recently broken with the orc update

With this change I'm able to build `gstreamer1-gst-plugins-base` without the patch it's not possible, other Ports may also be affected by the breakage introduced in `orc` 0.4.30

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G103
Xcode 10.3 10G8 

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
