### PR TITLE
openjdk8: update openjdk13 subport to 13.0.1

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -88,10 +88,10 @@ subport openjdk12-openj9-large-heap {
 }
 
 subport openjdk13 {
-    version      13
+    version      13.0.1
     revision     0
 
-    set build    33
+    set build    9
     set major    13
 }
 
@@ -298,9 +298,9 @@ if {${subport} eq "openjdk8"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}/
     distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}_${build}
 
-    checksums    rmd160  542642959d04f0d43e7bc34e4d4f1615b68283fa \
-                 sha256  f948be96daba250b6695e22cb51372d2ba3060e4d778dd09c89548889783099f \
-                 size    198189530
+    checksums    rmd160  1c7fef6b601c262f245a3b40fab279abfa5fec6c \
+                 sha256  9c82de98ce9bc2353bcf314d85366c9a2c572db034e10a71aa47e804e13748c1 \
+                 size    198205689
 
     worksrcdir   jdk-${version}+${build}
 } elseif {${subport} eq "openjdk13-openj9"} {


### PR DESCRIPTION
#### Description

Update to AdoptOpenJDK HotSpot 13.0.1.

###### Tested on

macOS 10.15 19A602
Xcode 11.1 11A1027

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?