### PR TITLE
libomp 9.0.0: fix build with Leopard

### DIFF
--- a/lang/libomp/Portfile
+++ b/lang/libomp/Portfile
@@ -47,6 +47,7 @@ if { ${subport} eq "libomp-devel" } {
         livecheck.version       ${version}
         livecheck.regex         revision=(\[0-9\]+)
         set rtpath              "runtime/"
+        patchfiles-append       patch-libomp-use-gettid-on-Leopard.diff
     }
 } else {
     PortGroup               github 1.0
@@ -70,6 +71,7 @@ if { ${subport} eq "libomp-devel" } {
 
         worksrcdir              ${distname}
         set rtpath              "runtime/"
+        patchfiles-append       patch-libomp-use-gettid-on-Leopard.diff
     } else {
         # Last version working on libstdc++
         github.setup            llvm-mirror openmp 381 svn-tags/RELEASE_

--- a/lang/libomp/files/patch-libomp-use-gettid-on-Leopard.diff
+++ b/lang/libomp/files/patch-libomp-use-gettid-on-Leopard.diff
@@ -1,0 +1,14 @@
+--- runtime/src/kmp_wrapper_getpid.h.orig	2019-10-11 17:25:02.000000000 -0700
++++ runtime/src/kmp_wrapper_getpid.h	2019-10-11 17:28:49.000000000 -0700
+@@ -22,7 +22,11 @@
+ #include <unistd.h>
+ #if KMP_OS_DARWIN
+ // OS X
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+ #define __kmp_gettid() syscall(SYS_thread_selfid)
++#else
++#define __kmp_gettid() syscall(SYS_gettid)
++#endif
+ #elif KMP_OS_FREEBSD
+ #include <pthread_np.h>
+ #define __kmp_gettid() pthread_getthreadid_np()


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.5.8 9L34
Xcode 3.1.4 DevToolsSupport-1186.0 9M2809 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
