### PR TITLE
wpa_passphrase: update to version 2.9

### DIFF
--- a/net/wpa_passphrase/Portfile
+++ b/net/wpa_passphrase/Portfile
@@ -3,8 +3,7 @@
 PortSystem      1.0
 
 name            wpa_passphrase
-version         2.8
-revision        1
+version         2.9
 
 platforms       darwin
 categories      net
@@ -23,9 +22,9 @@ depends_lib     port:openssl
 master_sites    https://w1.fi/releases/
 distname        wpa_supplicant-${version}
 
-checksums       rmd160  aad7b11821396dda36641a04aa51e20f006953d1 \
-                sha256  a689336a12a99151b9de5e25bfccadb88438f4f4438eb8db331cd94346fd3d96 \
-                size    3155904
+checksums       rmd160  0158e57d210df190dc1f7cce432762e7a91aea39 \
+                sha256  fcbdee7b4a64bea8177973299c8c824419c413ec2e3a95db63dd6a5dc3541f17 \
+                size    3231785
 
 patchfiles      patch-Makefile.diff
 
@@ -46,3 +45,7 @@ destroot {
     file copy ${build.dir}/doc/docbook/wpa_passphrase.8 \
         ${destroot}${prefix}/share/man/man8
 }
+
+livecheck.type  regex
+livecheck.url   ${homepage}
+livecheck.regex    wpa_supplicant-(\\d+(?:\\.\\d+)*)${extract.suffix}


### PR DESCRIPTION
#### Description

Update from version 2.8 to 2.9
Add livecheck support

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G103
Xcode 11.1 11A1027

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
