### PR TITLE
sdrangel: new port

### DIFF
--- a/science/SDRangel/Portfile
+++ b/science/SDRangel/Portfile
@@ -1,0 +1,150 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem            1.0
+PortGroup             github 1.0
+PortGroup             cmake 1.1
+PortGroup             qt5 1.0
+PortGroup             app 1.0
+
+name                  SDRangel
+platforms             darwin macosx
+categories            science
+license               GPL-3.0
+maintainers           {@ra1nb0w irh.it:rainbow} openmaintainer
+
+description           SDRangel is an Open Source Qt5 / OpenGL 3.0+ SDR \
+    and signal analyzer frontend to various hardware.
+long_description    ${description}
+
+github.setup          f4exb sdrangel 4.11.11 v
+checksums             rmd160  5364bb8f90fb7d4c47e6f946ab59f67618451d1c \
+                      sha256  20046e245a7199b1254bea064a3e1da95bd2ef11c68d176b15f7836fd57b3544 \
+                      size    24138069
+revision              0
+
+compiler.c_standard   2011
+compiler.cxx_standard 2011
+
+patchfiles-append \
+    leandsdr_dvbs2.h.patch
+
+depends_lib-append \
+    port:boost \
+    port:codec2 \
+    port:cm256cc \
+    port:dsdcc \
+    port:ffmpeg \
+    port:fftw-3-single \
+    path:lib/libusb.dylib:libusb \
+    port:libiconv \
+    port:libopus \
+    port:opencv \
+    port:serialDV
+
+qt5.depends_component \
+    qtmultimedia \
+    qttools \
+    qtwebsockets
+
+configure.args-append \
+    -DBUILD_GUI=OFF \
+    -DBUILD_SERVER=OFF \
+    -DBUNDLE=OFF \
+    -DENABLE_AIRSPY=OFF \
+    -DENABLE_AIRSPYHF=OFF \
+    -DENABLE_BLADERF=OFF \
+    -DENABLE_FUNCUBE=OFF \
+    -DENABLE_HACKRF=OFF \
+    -DENABLE_IIO=OFF \
+    -DENABLE_LIMESUITE=OFF \
+    -DENABLE_MIRISDR=OFF \
+    -DENABLE_PERSEUS=OFF \
+    -DENABLE_RTLSDR=OFF \
+    -DENABLE_SOAPYSDR=OFF \
+    -DENABLE_XTRX=OFF \
+    -DFORCE_SSE41=ON \
+    -DIconv_LIBRARY=${prefix}/lib/libiconv.dylib \
+    -DIconv_INCLUDE_DIR=${prefix}/include \
+    -DRX_SAMPLE_24BIT=ON
+
+variant debug description {Enable debug messages} {
+    configure.args-append   \
+        -DCMAKE_BUILD_TYPE=Debug \
+        -DDEBUG_OUTPUT=ON
+}
+
+variant gui description {Enable Gui} {
+    configure.args-replace  -DBUILD_GUI=OFF -DBUILD_GUI=ON
+
+    app.create yes
+    app.name SDRangel
+    app.executable sdrangel
+    app.icon cmake/cpack/sdrangel_icon.icns
+    app.retina yes
+}
+
+variant native description {Enable native cpu flags (recommended)} {
+    configure.args-replace  -DFORCE_SSE41=ON -DFORCE_SSE41=OFF
+}
+
+variant server description {Enable server binary} {
+    configure.args-replace  -DBUILD_SERVER=OFF -DBUILD_SERVER=ON
+}
+
+variant airspy description {Enable Airspy hardware} {
+    depends_lib-append      port:airspy
+    configure.args-replace  -DENABLE_AIRSPY=OFF -DENABLE_AIRSPY=ON
+}
+
+variant airspyhf description {Enable AirspyHF hardware} {
+    depends_lib-append      port:airspyhf
+    configure.args-replace  -DENABLE_AIRSPYHF=OFF -DENABLE_AIRSPYHF=ON
+}
+
+variant bladerf description {Enable bladeRF hardware} {
+    depends_lib-append      port:bladeRF
+    configure.args-replace  -DENABLE_BLADERF=OFF -DENABLE_BLADERF=ON
+}
+
+variant funcube description {Enable funcube hardware} {
+    configure.args-replace  -DENABLE_FUNCUBE=OFF -DENABLE_FUNCUBE=ON
+}
+
+variant hackrf description {Enable HackRF hardware} {
+    depends_lib-append      path:lib/libhackrf.dylib:hackrf
+    configure.args-replace  -DENABLE_HACKRF=OFF -DENABLE_HACKRF=ON
+}
+
+variant libiio description {Enable libiio support, like PlutoSDR hardware} {
+    depends_lib-append      port:libiio
+    configure.args-replace  -DENABLE_IIO=OFF -DENABLE_IIO=ON
+}
+
+variant limesuite description {Enable limesuite hardware} {
+    depends_lib-append      path:lib/libLimeSuite.dylib:limesuite
+    configure.args-replace  -DENABLE_LIMESUITE=OFF -DENABLE_LIMESUITE=ON
+}
+
+variant perseus description {Enable perseus sdr device} {
+    depends_lib-append      port:perseus-sdr
+    configure.args-replace  -DENABLE_PERSEUS=OFF -DENABLE_PERSEUS=ON
+}
+
+variant rtlsdr description {Enable rtl-sdr hardware} {
+    depends_lib-append      port:rtl-sdr
+    configure.args-replace  -DENABLE_RTLSDR=OFF -DENABLE_RTLSDR=ON
+}
+
+variant xtrx description {Enable xtrx hardware} {
+    configure.args-replace  -DENABLE_XTRX=OFF -DENABLE_XTRX=ON
+}
+
+variant soapysdr description {Enable SoapySDR support} {
+    depends_lib-append      port:SoapySDR
+    configure.args-replace  -DENABLE_SOAPYSDR=OFF -DENABLE_SOAPYSDR=ON
+}
+
+default_variants +soapysdr +airspy +airspyhf +limesuite +rtlsdr +funcube +server +gui
+
+test.run     yes
+test.cmd     ./sdrangelbench

--- a/science/SDRangel/files/leandsdr_dvbs2.h.patch
+++ b/science/SDRangel/files/leandsdr_dvbs2.h.patch
@@ -1,0 +1,33 @@
+diff --git a/plugins/channelrx/demoddatv/leansdr/dvbs2.h b/plugins/channelrx/demoddatv/leansdr/dvbs2.h
+index f9dcae651..6179173bc 100644
+--- plugins/channelrx/demoddatv/leansdr/dvbs2.h
++++ plugins/channelrx/demoddatv/leansdr/dvbs2.h
+@@ -1091,8 +1091,8 @@ struct s2_frame_receiver : runnable
+         {
+             float kph, kfw, kmu;
+         } gains[2] = {
+-            {4e-2, 1e-4, 0.001 / (cstln_amp * cstln_amp)},
+-            {4e-2, 1e-4, 0.001 / (cstln_amp * cstln_amp)}};
++            {4e-2, 1e-4, (float) 0.001 / (cstln_amp * cstln_amp)},
++            {4e-2, 1e-4, (float) 0.001 / (cstln_amp * cstln_amp)}};
+         // Decision
+         typename cstln_lut<SOFTSYMB, 256>::result *cr = c->lookup(p.re, p.im);
+         // Carrier tracking
+@@ -2329,6 +2329,9 @@ struct s2_fecdec_helper : runnable
+             fatal("pipe");
+         // Size the pipes so that the helper never runs out of work to do.
+         int pipesize = 64800 * batch_size;
++// macOS does not have F_SETPIPE_SZ and there
++// is no way to change the buffer size
++#ifndef __APPLE__
+         if (fcntl(tx[0], F_SETPIPE_SZ, pipesize) < 0 ||
+             fcntl(rx[0], F_SETPIPE_SZ, pipesize) < 0 ||
+             fcntl(tx[1], F_SETPIPE_SZ, pipesize) < 0 ||
+@@ -2343,6 +2346,7 @@ struct s2_fecdec_helper : runnable
+             else
+                 fprintf(stderr, "*** Throughput will be suboptimal.\n");
+         }
++#endif
+         int child = vfork();
+         if (!child)
+         {

--- a/science/serialDV/Portfile
+++ b/science/serialDV/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem            1.0
+PortGroup             cmake 1.1
+PortGroup             github 1.0
+
+categories            science comms
+platforms             darwin macosx
+license               GPL-3
+maintainers           {@ra1nb0w irh.it:rainbow} openmaintainer
+description           C++ Minimal interface to encode and decode audio with AMBE3000 \
+    based devices in packet mode over a serial link.
+long_description      ${description}
+
+github.setup          f4exb serialDV 1.1.4 v
+checksums             rmd160  30fcb2b18a28565772435b5e4c048dd13cee4a88 \
+                      sha256  b13851a1ef743cf683f80ecb788cc3050fdc01307e52b0656a2d788d92bf5ee1 \
+                      size    297844
+revision              0
+
+compiler.cxx_standard 2011
+
+test.run yes
+test.cmd dvtest -h


### PR DESCRIPTION
#### Description

SDRangel is an Open Source Qt5 / OpenGL 3.0+ SDR and signal analyzer frontend to various hardware.

Also include serialDV as dependency.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A602
Xcode 11.1 11A1027

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
