### PR TITLE
google-cloud-sdk: update to 269.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             268.0.0
+version             269.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  644da047b85ffd01a35d119b562d65ef9a8950c5 \
-                    sha256  881bf8ecf8abeb3effefe80d20f6aa68f1596a48bd95f0abe7c133437da9dc1d \
-                    size    22278903
+    checksums       rmd160  8837b1b2c3f29da8ddb2740b323b99d6fcfdfeed \
+                    sha256  f258237e3b074a17005be8b3964992f1d528cc0685584f0c7271b82de84e2938 \
+                    size    22430521
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  bd788a4a2954ed1fd92b874c575037a51514e24c \
-                    sha256  759a9ecf9406b2a8758e8e1cedd6d461ad6f0834e80f785c91425e8b209c0082 \
-                    size    22279718
+    checksums       rmd160  fc4c55ec11ebf43218f86ba19383392ba17ff041 \
+                    sha256  cb0f4d98e03184831c507f0864c279782ab11a382a3e6e3ff37e37765393604e \
+                    size    22430647
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 269.0.0.

###### Tested on

macOS 10.15 19A602
Xcode 11.1 11A1027

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?