### PR TITLE
gpscorrelate: new port

### DIFF
--- a/gis/gpscorrelate/Portfile
+++ b/gis/gpscorrelate/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem           1.0
+PortGroup            active_variants 1.1
+PortGroup            github 1.0
+
+github.setup         dfandrich gpscorrelate 2.0
+categories           gis graphics
+platforms            darwin
+license              GPL-2
+maintainers          {@sikmir gmail.com:sikmir} openmaintainer
+description          GPS Photo Correlation
+long_description     Writes location data to EXIF tags using GPX files.
+homepage             https://dfandrich.github.io/gpscorrelate/
+
+checksums            rmd160  0c5c7eeeacb6d22dc6cf24e2935eb9e405089440 \
+                     sha256  ae768f00b4f3d7cac91809c6e3f80903bd6406c45cca77afae7ad12eba15d5af \
+                     size    270590
+
+depends_build-append bin:xsltproc:libxslt \
+                     port:docbook-xml-4.2 \
+                     port:docbook-xsl-nons \
+                     port:pkgconfig
+
+depends_lib-append   port:exiv2 \
+                     port:gettext \
+                     port:gtk3 \
+                     port:libxml2
+
+require_active_variants gtk3 x11
+
+use_configure          no
+
+build.args-append      prefix=${prefix} \
+                       CFLAGS="-Wall -O2 -DENABLE_NLS" \
+                       LDFLAGS="-Wall -O2 -lm -lintl" \
+                       XSLTPROC="--nonet"
+
+destroot.args-append   prefix=${prefix}
+destroot.target-append install-po


### PR DESCRIPTION
#### Description

https://dfandrich.github.io/gpscorrelate/

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
