### PR TITLE
libcxx: Avoid hardcoded list of clang compiler versions

### DIFF
--- a/lang/libcxx/Portfile
+++ b/lang/libcxx/Portfile
@@ -1,7 +1,8 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem              1.0
 PortGroup               compiler_blacklist_versions 1.0
 PortGroup               active_variants 1.1
-
 
 name                    libcxx
 epoch                   1
@@ -89,11 +90,18 @@ if {${os.major} < 11 || [variant_isset replacemnt_libcxx]} {
 
         # only selected clang versions support emulated_tls, and the emulated_tls variant
         # needs to be enabled to build libcxx with emulated_tls support
-        foreach ver {5.0 6.0 7.0 8.0 9.0} {
-            if {[file exists ${prefix}/bin/clang-mp-${ver}]} {
-                if {[active_variants clang-${ver} emulated_tls]} {
-                  default_variants-append +emulated_tls
-                  compiler.whitelist-prepend macports-clang-${ver}
+        foreach clang_c ${compiler.fallback} {
+            if {[string match macports-clang-* $clang_c]} {
+                # Extract version number from macports clang compiler name
+                set clang_v [lindex [split $clang_c -] 2]
+                if { ${clang_v} >= 5.0 } {
+                    if {[file exists ${prefix}/bin/clang-mp-${clang_v}]} {
+                        if {[active_variants clang-${clang_v} emulated_tls]} {
+                            ui_debug "Adding ${clang_c} to compiler whitelist"
+                            default_variants-append +emulated_tls
+                            compiler.whitelist-prepend ${clang_c}
+                        }
+                    }
                 }
             }
         }
@@ -102,9 +110,16 @@ if {${os.major} < 11 || [variant_isset replacemnt_libcxx]} {
     compiler.blacklist *gcc* {clang < 500}
 
     # clang 3.5 and newer are conditionally blacklisted to prevent dependency cycles
-    foreach ver {3.5 3.6 3.7 3.8 3.9 4.0 5.0 6.0 7.0 8.0 9.0 devel} {
-        if {![file exists ${prefix}/bin/clang-mp-${ver}]} {
-            compiler.blacklist-append macports-clang-${ver}
+    foreach clang_c ${compiler.fallback} {
+        if {[string match macports-clang-* $clang_c]} {
+            # Extract version number from macports clang compiler name
+            set clang_v [lindex [split $clang_c -] 2]
+            if { ${clang_v} >= 3.5 } {
+                if {![file exists ${prefix}/bin/clang-mp-${clang_v}]} {
+                    ui_debug "Adding ${clang_c} to compiler blacklist"
+                    compiler.blacklist-append ${clang_c}
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Replaces hardcoded clang version lists, which have to updated each time a change is made to the supported versions, to dynamical deduce the versions via ${compiler.fallback} list of possible valid versions.