### PR TITLE
gitlab-runner: update to 12.4.1

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 12.4.0 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 12.4.1 v
 
 categories          devel
 platforms           darwin
@@ -23,9 +23,9 @@ homepage            https://docs.gitlab.com/runner/
 master_sites        https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v${version}/
 distname            gitlab-runner-v${version}
 
-checksums           rmd160  ef25a7b203d059e6ac9c7309b0753d39b7df9fb9 \
-                    sha256  99c31339c1eaf140dbe24556ae6d8a139b629e6b5d4a381efcf173b893e88796 \
-                    size    27477491
+checksums           rmd160  c4b5c21dcc9afb86d43e1ca101a549de05a2a460 \
+                    sha256  ff716083e9eb4fbd065f2e5dec59d2a4b3e6463ec8e9a40c534223a16bcf9e83 \
+                    size    27480873
 
 # Reproduce the "build_simple" target from the upstream Makefile
 set go_ldflags      "-X ${go.package}/common.NAME=${go.package} \


### PR DESCRIPTION
#### Description

Update to GitLab Runner 12.4.1.

###### Tested on

macOS 10.15.1 19B88
Xcode 11.1 11A1027

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?