### PR TITLE
py-selenium: Update Portfile to use Python 3

### DIFF
--- a/python/py-selenium/Portfile
+++ b/python/py-selenium/Portfile
@@ -1,30 +1,34 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem      1.0
-PortGroup       python 1.0
+PortSystem          1.0
+PortGroup           python 1.0
 
-name            py-selenium
-set real_name   selenium
-version         3.141.0
-python.versions 27
-license         Apache-2
-maintainers     {dstrubbe @dstrubbe} openmaintainer
-platforms       darwin
-description     Python language binding for Selenium Remote Control
+name                py-selenium
+version             3.141.0
+license             Apache-2
+maintainers         {dstrubbe @dstrubbe} openmaintainer
+platforms           darwin
 
+description         Python language bindings for Selenium WebDriver
 long_description \
-    Selenium Python Client Driver is a Python language binding for \
-    Selenium Remote Control (version 1.0 and 2.0). Currently the remote protocol, \
-    Firefox and Chrome for Selenium 2.0 are supported, as well as the \
-    Selenium 1.0 bindings. As work will progresses we'll add more "native" drivers.
+    The selenium package is used to automate web browser interaction \
+    from Python. Several browsers/drivers are supported (Firefox, \
+    Chrome, Internet Explorer), as well as the Remote protocol.
 
-homepage            https://code.google.com/p/selenium/
-master_sites        pypi:s/${real_name}/
-distname            ${real_name}-${version}
+homepage            https://www.seleniumhq.org/
+master_sites        pypi:s/${python.rootname}/
+distname            ${python.rootname}-${version}
+
+python.versions     27 37 38
+
 checksums           rmd160  6175bf1db6e8de270d0c34b9c58649ab1b118bc7 \
                     sha256  deaf32b60ad91a4611b98d8002757f29e6f2c2d5fcaf202e1c9ad06d6772300d \
                     size    854669
 
 if {${name} ne ${subport}} {
-    depends_build-append port:py${python.version}-setuptools
+    depends_build-append \
+                    port:py${python.version}-setuptools
+    depends_run-append \
+                    port:py${python.version}-urllib3
+    livecheck.type none
 }


### PR DESCRIPTION
py-selenium: Update Portfile to use Python 3

* Add Python version 3.7 and 3.8
* Update documentation to modern webdriver API version

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G103
Xcode 11.1 11A1027

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
