### PR TITLE
delve: new port

### DIFF
--- a/devel/delve/Portfile
+++ b/devel/delve/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/go-delve/delve 1.3.2 v
+
+categories          devel
+license             MIT
+installs_libs       no
+
+build.target        github.com/go-delve/delve/cmd/dlv
+
+maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
+
+checksums           rmd160  5d483435c60f35cd3d8fc06bcd0acc0135722e42 \
+                    sha256  832936b9ddb9f32eecc0a41d3e590ec861638c8eb7d8b689ea2550a6f2d2f711 \
+                    size    7733210
+
+description         Delve is a debugger for the Go programming language.
+long_description    Delve is a debugger for the Go programming language. \
+                    The goal of the project is to provide a simple, full \
+                    featured debugging tool for Go. Delve should be easy \
+                    to invoke and easy to use. Chances are if you're using a \
+                    debugger, things aren't going your way. With that in mind,\
+                    Delve should stay out of your way as much as possible.
+
+notes               "delve is installed as dlv"
+
+set delve_doc_dir   ${prefix}/share/doc/${name}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/dlv ${destroot}${prefix}/bin/
+    xinstall -d ${destroot}${delve_doc_dir}
+    copy {*}[glob ${worksrcpath}/Documentation/*] ${destroot}${delve_doc_dir}/
+}


### PR DESCRIPTION
New port for [Delve](https://github.com/go-delve/delve), a debugger for Golang

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.1 19B88
Xcode 11.0 11A420a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
