### PR TITLE
chromedriver: Update to version 78.0.3904.70

### DIFF
--- a/www/chromedriver/Portfile
+++ b/www/chromedriver/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                chromedriver
-version             76.0.3809.68
+version             78.0.3904.70
 categories          www
 platforms           darwin
 maintainers         nomaintainer
@@ -23,9 +23,9 @@ master_sites        https://chromedriver.storage.googleapis.com/${version}/
 distname            ${name}_mac64
 use_zip             yes
 
-checksums           rmd160  cb4959f35c015faa509118a468f204181c09573e \
-                    sha256  093ce5480be24520c1b5c0d265cc20a3b28527877d0bb02fe24ab5ac503d1239 \
-                    size    7216033
+checksums           rmd160  0be0c41da777153ea7859be8dd0fb33b0d85ceb4 \
+                    sha256  f04501f36af92ab869111137a66c84612e69ec729caa29b25fa4c305614cfe37 \
+                    size    7488025
 
 extract.mkdir       yes
 


### PR DESCRIPTION
chromedriver: Update to version 78.0.3904.70

* Update to version 78.0.3904.70
* Previous versions are incompatible with the latest Chrome versions

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] update
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G1012
Xcode 11.1 11A1027

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
