### PR TITLE
git-lfs: switch to Ronn-NG for building docs

### DIFF
--- a/devel/git-lfs/Portfile
+++ b/devel/git-lfs/Portfile
@@ -4,6 +4,7 @@ PortSystem              1.0
 PortGroup               golang 1.0
 
 go.setup                github.com/git-lfs/git-lfs 2.9.0 v
+revision                1
 maintainers             {raimue @raimue} \
                         openmaintainer
 platforms               darwin
@@ -19,14 +20,14 @@ checksums               rmd160  9374f0b32fa30d16aec69448813647cf0192fb38 \
                         sha256  cdf2fe82aaf57a094df26c4240fd42f0c00fa1f6c8260deb02d0d69e42584eb9 \
                         size    2493649
 
-depends_build-append    port:rb19-ronn
+depends_build-append    port:rb24-ronn-ng
 depends_run             port:git
 
 use_configure no
 
 build.cmd               make
 build.target            bin/git-lfs man
-build.args              RONN=${prefix}/bin/ronn-1.9
+build.args              RONN=${prefix}/bin/ronn-2.4
 
 destroot {
     set bindir ${destroot}${prefix}/bin


### PR DESCRIPTION
#### Description
`rb19-ronn` depends on Ruby 1.9, which has been unmaintained for a long time. This PR updates this dependency to Ronn-NG which is [adopted by Debian](https://packages.debian.org/buster/ronn).
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
