### PR TITLE
SDRangel: fix build on macos <= 10.11

### DIFF
--- a/science/SDRangel/files/leandsdr_dvbs2.h.patch
+++ b/science/SDRangel/files/leandsdr_dvbs2.h.patch
@@ -1,8 +1,37 @@
 diff --git a/plugins/channelrx/demoddatv/leansdr/dvbs2.h b/plugins/channelrx/demoddatv/leansdr/dvbs2.h
-index f9dcae651..6179173bc 100644
+index f9dcae651..c71a46b44 100644
 --- plugins/channelrx/demoddatv/leansdr/dvbs2.h
 +++ plugins/channelrx/demoddatv/leansdr/dvbs2.h
-@@ -1091,8 +1091,8 @@ struct s2_frame_receiver : runnable
+@@ -35,6 +35,10 @@
+ #include "ldpc.h"
+ #include "sdr.h"
+ 
++// avoid error: variable length array of non-POD element type 'complex'
++// on old clang; see https://trac.macports.org/ticket/59537
++#define PLSCODES_LENGTH 64
++
+ namespace leansdr
+ {
+ 
+@@ -77,7 +81,7 @@ struct s2_plscodes
+ {
+     // PLS index format MODCOD[4:0]|SHORTFRAME|PILOTS
+     static const int COUNT = 128;
+-    static const int LENGTH = 64;
++    static const int LENGTH = PLSCODES_LENGTH;
+     uint64_t codewords[COUNT];
+     complex<T> symbols[COUNT][LENGTH];
+     s2_plscodes()
+@@ -733,7 +737,7 @@ struct s2_frame_receiver : runnable
+         // Read PLSCODE
+ 
+         uint64_t plscode = 0;
+-        complex<float> pls_symbols[plscodes.LENGTH];
++        complex<float> pls_symbols[PLSCODES_LENGTH];
+         for (int s = 0; s < plscodes.LENGTH; ++s)
+         {
+             complex<float> p = interp_next(&ss) * agc_gain;
+@@ -1091,8 +1095,8 @@ struct s2_frame_receiver : runnable
          {
              float kph, kfw, kmu;
          } gains[2] = {
@@ -13,7 +42,7 @@ index f9dcae651..6179173bc 100644
          // Decision
          typename cstln_lut<SOFTSYMB, 256>::result *cr = c->lookup(p.re, p.im);
          // Carrier tracking
-@@ -2329,6 +2329,9 @@ struct s2_fecdec_helper : runnable
+@@ -2329,6 +2333,9 @@ struct s2_fecdec_helper : runnable
              fatal("pipe");
          // Size the pipes so that the helper never runs out of work to do.
          int pipesize = 64800 * batch_size;
@@ -23,7 +52,7 @@ index f9dcae651..6179173bc 100644
          if (fcntl(tx[0], F_SETPIPE_SZ, pipesize) < 0 ||
              fcntl(rx[0], F_SETPIPE_SZ, pipesize) < 0 ||
              fcntl(tx[1], F_SETPIPE_SZ, pipesize) < 0 ||
-@@ -2343,6 +2346,7 @@ struct s2_fecdec_helper : runnable
+@@ -2343,6 +2350,7 @@ struct s2_fecdec_helper : runnable
              else
                  fprintf(stderr, "*** Throughput will be suboptimal.\n");
          }


### PR DESCRIPTION
#### Description

quick and dirty fix for
error: variable length array of non-POD element type 'complex<float>'

should be fine since it is a DSP library (DVB-S2 implementation) and
therefore not changed frequently.

Closes: https://trac.macports.org/ticket/59537

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.1 19B88
Xcode 11.1 11A1027

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
