### PR TITLE
llvm/clang-9.0: fix build on Leopard

### DIFF
--- a/lang/llvm-9.0/Portfile
+++ b/lang/llvm-9.0/Portfile
@@ -168,6 +168,9 @@ patchfiles-append \
     5001-patch-machoreader-strnlen.diff \
     5002-patch-objdumper-strnlen.diff
 
+# fix build on leopard
+patchfiles-append 5000-patch-llvm8-tools-dsymutil-symbolmap-use-older-cfname-and-fix-uuid-on-leopard.diff
+
 if {${subport} eq "clang-${llvm_version}"} {
     patchfiles-append \
         1001-MacPorts-Only-Prepare-clang-format-for-replacement-w.patch \
@@ -182,7 +185,11 @@ if {${subport} eq "clang-${llvm_version}"} {
         3001-Fix-missing-long-long-math-prototypes-when-using-the.patch \
         3002-implement-atomic-using-mutex-lock_guard-for-64b-ops-.patch \
         openmp-locations.patch
-        
+
+    # fix build on leopard
+    patchfiles-append \
+        5001-patch-libcxx-src-new-posix-memalign-leopard.diff \
+        5002-patch-toolchains-darwin-add-back-pre-10.6-link-libs.diff
 
     # https://llvm.org/bugs/show_bug.cgi?id=25681
     if {${worksrcdir} eq "trunk" || ${worksrcdir} eq "release_${llvm_version_no_dot}"} {

--- a/lang/llvm-9.0/files/5000-patch-llvm8-tools-dsymutil-symbolmap-use-older-cfname-and-fix-uuid-on-leopard.diff
+++ b/lang/llvm-9.0/files/5000-patch-llvm8-tools-dsymutil-symbolmap-use-older-cfname-and-fix-uuid-on-leopard.diff
@@ -1,0 +1,23 @@
+diff --git a/tools/dsymutil/SymbolMap.cpp b/tools/dsymutil/SymbolMap.cpp
+index cab9374a..5c2377e4 100644
+--- a/tools/dsymutil/SymbolMap.cpp
++++ b/tools/dsymutil/SymbolMap.cpp
+@@ -18,8 +18,18 @@
+ #ifdef __APPLE__
+ #include <CoreFoundation/CoreFoundation.h>
+ #include <uuid/uuid.h>
++
++#if MAC_OS_X_VERSION_MAX_ALLOWED < 1060
++/* declare a missing reference not found in SDK < 10.6 for function called below */
++typedef char * uuid_string_t;
++typedef struct __CFError * CFErrorRef;
++#define CFPropertyListCreateWithStream(A,B,C,D,E,F) CFPropertyListCreateFromStream(A,B,C,D,E,F)
++#endif
++
+ #endif
+ 
++
++
+ namespace llvm {
+ namespace dsymutil {
+ 

--- a/lang/llvm-9.0/files/5001-patch-libcxx-src-new-posix-memalign-leopard.diff
+++ b/lang/llvm-9.0/files/5001-patch-libcxx-src-new-posix-memalign-leopard.diff
@@ -1,0 +1,53 @@
+diff --git a/projects/libcxx/src/new.cpp b/projects/libcxx/src/new.cpp
+index cc8383d..ff09580 100644
+--- a/projects/libcxx/src/new.cpp
++++ b/projects/libcxx/src/new.cpp
+@@ -31,6 +31,48 @@
+ # endif
+ #endif
+ 
++
++# if defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED < 1060)
++#include <stdlib.h>
++#include <errno.h>
++
++int posix_memalign(void** pp, size_t alignment, size_t bytes) {
++
++  /* if alignment is 0 or not a power of 2 return bad value */
++  if (alignment < sizeof( void *) ||            // excludes 0 == alignment
++      0 != (alignment & (alignment - 1))) {     // relies on sizeof(void *) being a power of two.
++    return EINVAL;
++  }
++
++  void* mem = 0;
++
++  if (alignment <= 16) {
++
++    /* MacOSX always returns memory aligned on
++     * a 16 byte alignment
++     */
++    mem = malloc(bytes);
++
++  } else {
++
++   /* if the caller wants a larger alignment than 16
++    * we give them a page-aligned allotment. This is not as efficient
++    * as an optimized aligned memory implementation, but much
++    * simpler, effective, and requires no changes to the rest of the
++    * underlying memory management system.
++    */
++    mem = valloc(bytes);
++  }
++  if (mem == 0)
++    return ENOMEM;
++  else {
++    *pp = mem;
++    return 0;
++  }
++}
++#endif
++
++
+ namespace std
+ {
+ 

--- a/lang/llvm-9.0/files/5002-patch-toolchains-darwin-add-back-pre-10.6-link-libs.diff
+++ b/lang/llvm-9.0/files/5002-patch-toolchains-darwin-add-back-pre-10.6-link-libs.diff
@@ -1,0 +1,30 @@
+kencu@macports.org - add back runtime libraries used on 10.4 and 10.5
+removed in https://github.com/llvm/llvm-project/commit/3434ade2b7ca351b61522f7da4b55070d811b83f
+
+related, the following code used to add libclang_rt_10.4.a to Tiger, but this library
+is no longer built in the runtime library collections. If building for Tiger, it
+may be required to replace this library at some point.
+The line below this, adding "builtins" adds libclang_rt.osx.a, does the second part of this.
+it may be easiest to just add Tiger functions to libclang_rt.osx.a directly
+   // if (isMacosxVersionLT(10, 5))
+   //   AddLinkRuntimeLib(Args, CmdArgs, "libclang_rt.10.4.a");
+   // else
+   //   AddLinkRuntimeLib(Args, CmdArgs, "libclang_rt.osx.a");
+
+diff --git a/tools/clang/lib/Driver/ToolChains/Darwin.cpp b/tools/clang/lib/Driver/ToolChains/Darwin.cpp
+index bea877ae9..26f1ad714 100644
+--- a/tools/clang/lib/Driver/ToolChains/Darwin.cpp
++++ b/tools/clang/lib/Driver/ToolChains/Darwin.cpp
+@@ -1140,6 +1140,12 @@ void DarwinClang::AddLinkRuntimeLibArgs(const ArgList &Args,
+         getTriple().getArch() != llvm::Triple::aarch64)
+       CmdArgs.push_back("-lgcc_s.1");
+   }
++  if (isTargetMacOS()) {
++    if (isMacosxVersionLT(10, 5))
++      CmdArgs.push_back("-lgcc_s.10.4");
++    else if (isMacosxVersionLT(10, 6))
++      CmdArgs.push_back("-lgcc_s.10.5");
++  }
+   AddLinkRuntimeLib(Args, CmdArgs, "builtins");
+ }
+ 


### PR DESCRIPTION
identical fixes to llvm/clang-8.0
```
$ port -v installed llvm-9.0 clang-9.0
The following ports are currently installed:
  clang-9.0 @9.0.0_0+analyzer+defaultlibcxx+emulated_tls+libstdcxx (active) platform='darwin 9' archs='i386' date='2019-10-31T14:13:17-0700'
  llvm-9.0 @9.0.0_0+emulated_tls (active) platform='darwin 9' archs='i386' date='2019-10-31T11:45:46-0700'
```
and works.