### PR TITLE
welle.io: add welle.io-devel subport

### DIFF
--- a/multimedia/welle.io/Portfile
+++ b/multimedia/welle.io/Portfile
@@ -5,9 +5,8 @@ PortGroup               qt5 1.0
 PortGroup               github 1.0
 PortGroup               cmake 1.1
 
-github.setup            AlbrechtL welle.io 2.0 v
-github.tarball_from     archive
-epoch                   1
+name                    welle.io
+subport welle.io-devel  {}
 
 categories              multimedia
 platforms               darwin
@@ -22,10 +21,6 @@ long_description        This is an open source DAB and DAB+ software defined rad
 license                 GPL-2
 
 homepage                https://www.welle.io/
-
-checksums               rmd160  354a3ad5313f11a441a75f4d3852d73c9a4dd76c \
-                        sha256  abfe999b6788ae57dfaaebea5e1db912565d60cc287c9eec4636b0e10eab4f9d \
-                        size    1621571
 
 qt5.depends_component   qtcharts \
                         qtdeclarative \
@@ -60,15 +55,47 @@ variant airspy description {Add Airspy support} {
     depends_lib-append port:airspy
 }
 
+if {${subport} eq ${name}} {
+    # stable
+    github.setup            AlbrechtL welle.io 2.0 v
+    github.tarball_from     archive
+    epoch                   1
+
+    conflicts               welle.io-devel
+
+    checksums               rmd160  354a3ad5313f11a441a75f4d3852d73c9a4dd76c \
+                            sha256  abfe999b6788ae57dfaaebea5e1db912565d60cc287c9eec4636b0e10eab4f9d \
+                            size    1621571
+
+    configure.pre_args-append \
+        -DGIT_COMMIT_HASH=${version}
+
+    patch.pre_args          -p1
+    patchfiles-append       CMakeLists.txt.patch \
+                            458-fixFreezeWithRtlSdr.patch
+} else {
+    # devel
+    github.setup            AlbrechtL welle.io 4b9ab6d00046927309c84ea4aa31df679ce40c59
+    set githash             [string range ${github.version} 0 6]
+    version                 20191029+git${githash}
+
+    conflicts               welle.io
+
+    checksums               rmd160  1998043b2a1daacbd97abd661b0e9ac6035e209d \
+                            sha256  42b22c2dd8f71e1359c882314b1f3230d22ca580a86c29c075459860c4c4040b \
+                            size    1630258
+
+    configure.pre_args-append \
+        -DGIT_COMMIT_HASH=${githash}
+
+    patch.pre_args          -p1
+    patchfiles-append       458-fixFreezeWithRtlSdr.patch
+}
+
 configure.pre_args-append \
     -DBUNDLE_INSTALL_DIR=${applications_dir} \
-    -DGIT_COMMIT_HASH=${version} \
     -DGIT_DESCRIBE=${version} \
     -DWELLE-IO_VERSION=${version}
-
-patch.pre_args      -p1
-patchfiles          CMakeLists.txt.patch \
-                    458-fixFreezeWithRtlSdr.patch
 
 post-patch {
     reinplace "s/\$(PRODUCT_BUNDLE_IDENTIFIER)/@PRODUCT_BUNDLE_IDENTIFIER@/" ${worksrcpath}/welle-io.plist


### PR DESCRIPTION
#### Description

add welle.io-devel subport

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
