### PR TITLE
rhyme: Fix build failure without /usr/include

### DIFF
--- a/editors/vis/Portfile
+++ b/editors/vis/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 github.setup        martanne vis 0.5 v
 categories          editors
 platforms           darwin
-maintainers         gmail.com:israelchauca openmaintainer
+maintainers         {en.sent.com:macports @Raimondi} openmaintainer
 license             ISC
 description         a highly efficient text editor
 long_description    vis is a highly efficient screen-oriented text editor \

--- a/security/lastpass-cli/Portfile
+++ b/security/lastpass-cli/Portfile
@@ -9,7 +9,7 @@ revision            1
 
 categories          security
 platforms           darwin
-maintainers         gmail.com:israelchauca oaf.dk:mni {khindenburg @kurthindenburg} openmaintainer
+maintainers         {en.sent.com:macports @Raimondi} oaf.dk:mni {khindenburg @kurthindenburg} openmaintainer
 license             GPL-2
 supported_archs     noarch
 

--- a/textproc/rhyme/Portfile
+++ b/textproc/rhyme/Portfile
@@ -26,6 +26,8 @@ depends_lib           port:gdbm \
 patchfiles            patch-Makefile.diff
 
 use_configure         no
+configure.cppflags-append \
+                        -I${prefix}/include/readline
 
 if {[vercmp [macports_version] 2.5.99] >= 0} {
 build.env-append      "FLAGS=${configure.cflags} [get_canonical_archflags]"
@@ -35,7 +37,8 @@ build.env-append      FLAGS="${configure.cflags} [get_canonical_archflags]"
 
 use_parallel_build    no
 build.args-append     PREFIX=${prefix}   \
-                      CC=${configure.cc}
+                        CC=${configure.cc} \
+                        INCLUDES="${configure.cppflags}"
 
 destroot.args-append  DESTDIR=${destroot} \
                       PREFIX=${prefix}

--- a/textproc/rhyme/Portfile
+++ b/textproc/rhyme/Portfile
@@ -12,7 +12,7 @@ checksums               rmd160  5049ee3f2ad6d56d03fd28a7399129213f4ca808 \
 categories              textproc
 platforms               darwin
 license                 GPL-2
-maintainers             gmail.com:israelchauca
+maintainers             {en.sent.com:macports @Raimondi}
 
 description             Rhyming dictionary
 

--- a/textproc/rhyme/Portfile
+++ b/textproc/rhyme/Portfile
@@ -1,44 +1,47 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem            1.0
+PortSystem              1.0
 
-name                  rhyme
-version               0.9
+name                    rhyme
+version                 0.9
 revision                6
 checksums               rmd160  5049ee3f2ad6d56d03fd28a7399129213f4ca808 \
                         sha256  11d4862cc3adfc18ea83ca233854c562fcebdc838fa7fb62de6ef3f63f992bd4 \
                         size    896013
 
-categories            textproc
-platforms             darwin
-license               GPL-2
-maintainers           gmail.com:israelchauca
-description           Rhyming dictionary.
-long_description      Command-line program that takes a word and returns to you \
-                      a formatted list of all words that rhyme with it.
-homepage              http://rhyme.sourceforge.net/
-master_sites          sourceforge:project/rhyme/rhyme/${version}
+categories              textproc
+platforms               darwin
+license                 GPL-2
+maintainers             gmail.com:israelchauca
 
-depends_lib           port:gdbm \
-                      port:readline \
-                      port:ncurses
+description             Rhyming dictionary
 
-patchfiles            patch-Makefile.diff
+long_description        Command-line program that takes a word and returns to \
+                        you a formatted list of all words that rhyme with it.
 
-use_configure         no
+homepage                http://rhyme.sourceforge.net/
+master_sites            sourceforge:project/rhyme/rhyme/${version}
+
+depends_lib             port:gdbm \
+                        port:ncurses \
+                        port:readline
+
+patchfiles              patch-Makefile.diff
+
+use_configure           no
 variant universal {}
 
 configure.cppflags-append \
                         -I${prefix}/include/readline
 
-use_parallel_build    no
-build.args-append     PREFIX=${prefix}   \
+use_parallel_build      no
+build.args-append       PREFIX=${prefix}   \
                         CC=${configure.cc} \
                         FLAGS="${configure.cflags} [get_canonical_archflags cc]" \
                         INCLUDES="${configure.cppflags}"
 
 destroot.args-append    PREFIX=${prefix}
 
-livecheck.type        regex
-livecheck.url         http://sourceforge.net/projects/$name/files/$name/
-livecheck.regex       /${name}/(\[0-9.\]+)/
+livecheck.type          regex
+livecheck.url           http://sourceforge.net/projects/$name/files/$name/
+livecheck.regex         /${name}/(\[0-9.\]+)/

--- a/textproc/rhyme/Portfile
+++ b/textproc/rhyme/Portfile
@@ -5,6 +5,10 @@ PortSystem            1.0
 name                  rhyme
 version               0.9
 revision              5
+checksums               rmd160  5049ee3f2ad6d56d03fd28a7399129213f4ca808 \
+                        sha256  11d4862cc3adfc18ea83ca233854c562fcebdc838fa7fb62de6ef3f63f992bd4 \
+                        size    896013
+
 categories            textproc
 platforms             darwin
 license               GPL-2
@@ -14,8 +18,6 @@ long_description      Command-line program that takes a word and returns to you 
                       a formatted list of all words that rhyme with it.
 homepage              http://rhyme.sourceforge.net/
 master_sites          sourceforge:project/rhyme/rhyme/${version}
-checksums             rmd160 5049ee3f2ad6d56d03fd28a7399129213f4ca808 \
-                      sha256 11d4862cc3adfc18ea83ca233854c562fcebdc838fa7fb62de6ef3f63f992bd4
 
 depends_lib           port:gdbm \
                       port:readline \

--- a/textproc/rhyme/Portfile
+++ b/textproc/rhyme/Portfile
@@ -4,7 +4,7 @@ PortSystem            1.0
 
 name                  rhyme
 version               0.9
-revision              5
+revision                6
 checksums               rmd160  5049ee3f2ad6d56d03fd28a7399129213f4ca808 \
                         sha256  11d4862cc3adfc18ea83ca233854c562fcebdc838fa7fb62de6ef3f63f992bd4 \
                         size    896013
@@ -26,18 +26,15 @@ depends_lib           port:gdbm \
 patchfiles            patch-Makefile.diff
 
 use_configure         no
+variant universal {}
+
 configure.cppflags-append \
                         -I${prefix}/include/readline
-
-if {[vercmp [macports_version] 2.5.99] >= 0} {
-build.env-append      "FLAGS=${configure.cflags} [get_canonical_archflags]"
-} else {
-build.env-append      FLAGS="${configure.cflags} [get_canonical_archflags]"
-}
 
 use_parallel_build    no
 build.args-append     PREFIX=${prefix}   \
                         CC=${configure.cc} \
+                        FLAGS="${configure.cflags} [get_canonical_archflags cc]" \
                         INCLUDES="${configure.cppflags}"
 
 destroot.args-append  DESTDIR=${destroot} \

--- a/textproc/rhyme/Portfile
+++ b/textproc/rhyme/Portfile
@@ -37,8 +37,7 @@ build.args-append     PREFIX=${prefix}   \
                         FLAGS="${configure.cflags} [get_canonical_archflags cc]" \
                         INCLUDES="${configure.cppflags}"
 
-destroot.args-append  DESTDIR=${destroot} \
-                      PREFIX=${prefix}
+destroot.args-append    PREFIX=${prefix}
 
 livecheck.type        regex
 livecheck.url         http://sourceforge.net/projects/$name/files/$name/


### PR DESCRIPTION
#### Description

This PR cleans up the rhyme portfile in several ways, but the most important fixes are that it now actually uses the right `-arch` flags (the portfile's previous attempts to do so were ineffective), and it should now build on systems that don't have /usr/include, such as Mojave and later.

I don't know the maintainer's GitHub handle. I'll notify them about this PR by email.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G8037
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
