### PR TITLE
gmt5: update gmt6 sub-port to version 6.0.0

### DIFF
--- a/science/gmt5/Portfile
+++ b/science/gmt5/Portfile
@@ -8,8 +8,9 @@ version             5.4.5
 revision            1
 conflicts           gmt6
 subport gmt6 {
-    version         6.0.0rc5
-    revision        1
+    version         6.0.0
+    revision        0
+    epoch           1
     conflicts       gmt5
 }
 categories          science
@@ -25,13 +26,12 @@ long_description GMT is an open source collection of ~120 tools \
 
 homepage            https://www.generic-mapping-tools.org/
 master_sites        ftp://ftp.soest.hawaii.edu/gmt          \
-                    ftp://ibis.grdl.noaa.gov/pub/gmt        \
+                    ftp://ftp.star.nesdis.noaa.gov/pub/sod/lsa/gmt \
                     ftp://ftp.iris.washington.edu/pub/gmt   \
                     ftp://ftp.iag.usp.br/pub/gmt            \
-                    ftp://ftp.geologi.uio.no/pub/gmt        \
-                    ftp://gd.tuwien.ac.at/pub/gmt           \
-                    ftp://ftp.scc.u-tokai.ac.jp/pub/gmt     \
-                    ftp://gmt.mirror.ac.za/pub/gmt
+                    ftp://gmt.mirror.ac.za/gmt              \
+                    http://mirrors.ustc.edu.cn/gmt          \
+                    http://www.scc.u-tokai.ac.jp/gmt
 use_xz              yes
 distname            gmt-${version}
 distfiles           ${distname}-src${extract.suffix}
@@ -41,12 +41,13 @@ if {${subport} eq "gmt5"} {
                         sha256  078d4997507cb15344c74a874568985e45bdbd6d3a72d330c74c47f4c0359bb1 \
                         size    59175704
 } else {
-    checksums           rmd160  2392d55baadcf02b5c5766fa95264a039a248a8f \
-                        sha256  176f19b2890db52cd811820ca87a3c27149d5a4dde239d49c2f0da34c218b61a \
-                        size    66926028
+    checksums           rmd160  a53d2bd50a960dd31893ca377d36a188c5e07f88 \
+                        sha256  8b91af18775a90968cdf369b659c289ded5b6cb2719c8c58294499ba2799b650 \
+                        size    66892468
 }
 
-depends_lib         port:dcw-gmt \
+depends_lib         port:curl \
+                    port:dcw-gmt \
                     port:ghostscript \
                     port:gshhg-gmt \
                     port:netcdf
@@ -73,6 +74,7 @@ configure.cflags-append     -fstrict-aliasing
 configure.args-append       -DDCW_ROOT=${prefix}/share/gmt/dcw \
                             -DGSHHG_ROOT=${prefix}/share/gmt/gshhg \
                             -DNETCDF_ROOT=${prefix} \
+                            -DCURL_ROOT=${prefix} \
                             -DFFTW3_ROOT=off \
                             -DGDAL_ROOT=off \
                             -DPCRE_ROOT=off \
@@ -80,6 +82,10 @@ configure.args-append       -DDCW_ROOT=${prefix}/share/gmt/dcw \
                             -DGMT_INSTALL_MODULE_LINKS=off \
                             -DGMT_INSTALL_TRADITIONAL_FOLDERNAMES=off \
                             -DLICENSE_RESTRICTED=GPL
+
+if {${subport} eq "gmt6"} {
+	configure.args-append   -DGS_ROOT=${prefix}
+}
 
 variant fftw3 description {Optional support for FFTW-3 library} {
     depends_lib-append      port:fftw-3-single


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

