### PR TITLE
CubicSDR: fix version number and fix HighDpi wrong behaviour

### DIFF
--- a/science/CubicSDR/Portfile
+++ b/science/CubicSDR/Portfile
@@ -19,7 +19,7 @@ long_description    CubicSDR is the software portion of Software Defined \
 homepage            https://www.cubicsdr.com
 
 github.setup        cjcliffe CubicSDR 31323fe3c2f4ffc0d2f072f7e37ec26ebe2de609
-version             20190929-[string range ${github.version} 0 7]
+version             20191029-[string range ${github.version} 0 7]
 checksums           rmd160 b16465d1257b6b5af8e22f77fbc6706794445339 \
                     sha256 a71fc7f84bec7aa3b4cf2bbc171c4931867219cd38822cc06e78b455e1735da2 \
                     size   35463490
@@ -29,6 +29,13 @@ revision            0
 # by the wxWidgets PG -- which is what this provides. selecting 3.0
 # does not work.
 wxWidgets.use       wxWidgets-3.2
+
+# CHECK every version if upstream has fixed the behaviour
+# opengl widget doesn't work well with Redita display
+# therefore for user expiriance I disable it
+# see https://github.com/cjcliffe/CubicSDR/issues/758
+patchfiles-append \
+    disable-highdpi.patch
 
 depends_lib-append \
     port:liquid-dsp \

--- a/science/CubicSDR/files/disable-highdpi.patch
+++ b/science/CubicSDR/files/disable-highdpi.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/CubicSDRInfo.plist.in b/cmake/CubicSDRInfo.plist.in
+index c3658f4..f3fa8e9 100644
+--- cmake/CubicSDRInfo.plist.in
++++ cmake/CubicSDRInfo.plist.in
+@@ -33,7 +33,7 @@
+ 	<key>NSHumanReadableCopyright</key>
+ 	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
+     <key>NSHighResolutionCapable</key>
+-    <true/>
++    <false/>
+     <key>NSSupportsAutomaticGraphicsSwitching</key>
+     <true/>
+ </dict>


### PR DESCRIPTION


#### Description

- the version data was wrong
- OpenGL widget doesn't work well with HighDpi (working on patch) for
  the moment disable it

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.1 19B88
Xcode 11.1 11A1027

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
