### PR TITLE
dovecot2: Portfile bugfix for apns variant

### DIFF
--- a/mail/dovecot2/Portfile
+++ b/mail/dovecot2/Portfile
@@ -22,6 +22,9 @@ long_description    Dovecot is an IMAP and POP3 server for Linux/UNIX-like \
                     it is written in C, it uses several coding techniques to \
                     avoid most of the common pitfalls.
 
+set perl5_major_version \
+                    5.28
+
 depends_build-append \
                     port:gettext \
                     port:pandoc \
@@ -115,8 +118,6 @@ variant apns \
             ${worksrcpath}/src/imap/cmd-x-apple-push-service.c \
             ${worksrcpath}/src/plugins/push-notify/push-notify-plugin.c
     }
-    set perl5_major_version
-                    5.28
     depends_run-append \
                     port:perl${perl5_major_version} \
                     port:p${perl5_major_version}-net-apns-persistent \


### PR DESCRIPTION
dovecot2: Portfile bugfix for apns variant
* Fix `perl5_major_version` variable

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G1012
Xcode 11.2 11B52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
