### PR TITLE
libmypaint: requires C11

### DIFF
--- a/graphics/libmypaint/Portfile
+++ b/graphics/libmypaint/Portfile
@@ -30,6 +30,9 @@ depends_build       port:pkgconfig \
 depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     port:json-c
 
+# include/glib-2.0/glib/gtypes.h:46: error: redefinition of typedef ‘gchar’
+compiler.c_standard 2011
+
 # reconfigure with our intltool.m4 using upstream autogen.sh
 post-extract {
     xinstall ${filespath}/autogen.sh ${worksrcpath}


### PR DESCRIPTION
/opt/local/include/glib-2.0/glib/gtypes.h:46: error: redefinition of
typedef ‘gchar’

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.5.8 9L31a
Xcode 3.1.4 DevToolsSupport-1186.0 9M2809 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
