### PR TITLE
gnuplot: allow build with MacPorts compilers

### DIFF
--- a/math/gnuplot/Portfile
+++ b/math/gnuplot/Portfile
@@ -53,6 +53,10 @@ minimum_xcodeversions \
 
 patchfiles          patch-configure.diff
 
+# If the compiler defaults to C++20, a header file `version` exists.
+# `-I$(top_builddir)` will find the local file VERSION instead.
+patchfiles-append   patch-cxx20.diff
+
 configure.args      --with-caca=${prefix} \
                     --with-gd=${prefix} \
                     --with-readline=${prefix} \

--- a/math/gnuplot/files/patch-cxx20.diff
+++ b/math/gnuplot/files/patch-cxx20.diff
@@ -1,0 +1,11 @@
+--- src/Makefile.in.orig	2019-05-28 20:35:53.000000000 -0700
++++ src/Makefile.in	2019-11-01 18:21:23.000000000 -0700
+@@ -206,7 +206,7 @@
+ am__v_at_ = $(am__v_at_@AM_DEFAULT_V@)
+ am__v_at_0 = @
+ am__v_at_1 = 
+-DEFAULT_INCLUDES = -I.@am__isrc@ -I$(top_builddir)
++DEFAULT_INCLUDES = -I.@am__isrc@ -idirafter$(top_builddir)
+ depcomp = $(SHELL) $(top_srcdir)/depcomp
+ am__depfiles_maybe = depfiles
+ am__mv = mv -f


### PR DESCRIPTION
As of C++20, version is a standard header file.
Gnuplot has a file VERSION which is found first.
As a workaround, replace -I with -idirafter.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6
Xcode 11.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
