### PR TITLE
gr-sdrplay: new port

### DIFF
--- a/science/gr-sdrplay/Portfile
+++ b/science/gr-sdrplay/Portfile
@@ -1,0 +1,82 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem            1.0
+PortGroup             cmake 1.1
+
+name                  gr-sdrplay
+categories            science comms
+platforms             darwin macosx
+license               GPL-3+
+maintainers           {@ra1nb0w irh.it:rainbow} {michaelld @michaelld} openmaintainer
+description           GNU Radio block for SDRPlay boards
+long_description      ${description}
+homepage              https://gitlab.com/HB9FXQ/gr-sdrplay
+
+fetch.type            git
+git.url               ${homepage}
+git.branch            d28ae3d3a61d154bec51940ecc2f637ffed2e8a4
+version               20180717-[string range ${git.branch} 0 7]
+
+compiler.c_standard   2011
+compiler.cxx_standard 2011
+
+patchfiles-append \
+    cmakelists.txt.patch
+
+depends_build-append \
+    port:cppunit \
+    port:pkgconfig \
+    port:swig-python
+
+depends_lib-append \
+    port:boost \
+    path:lib/libgnuradio-runtime.dylib:gnuradio \
+    port:SDRplay
+
+# remove top-level library path, such that internal libraries are used
+# instead of any already-installed ones.
+configure.ldflags-delete -L${prefix}/lib
+
+# specify the Python dependencies
+depends_lib-append port:python27
+# specify that Python version to use
+configure.args-append \
+    -DPYTHON_EXECUTABLE=${frameworks_dir}/Python.framework/Versions/2.7/bin/python2.7 \
+    -DPYTHON_INCLUDE_DIR=${frameworks_dir}/Python.framework/Versions/2.7/Headers \
+    -DPYTHON_LIBRARY=${frameworks_dir}/Python.framework/Versions/2.7/Python \
+    -DGR_PYTHON_DIR=${frameworks_dir}/Python.framework/Versions/2.7/lib/python2.7/site-packages
+
+configure.args-append \
+    -DCMAKE_MODULES_DIR=share/cmake \
+    -DDOXYGEN_DOT_EXECUTABLE= \
+    -DDOXYGEN_EXECUTABLE=
+
+variant docs description "Install ${name} documentation" {
+
+    depends_build-append \
+        port:doxygen \
+        path:bin/dot:graphviz
+
+    configure.args-delete \
+        -DDOXYGEN_DOT_EXECUTABLE= \
+        -DDOXYGEN_EXECUTABLE=
+
+    configure.args-append \
+        -DDOXYGEN_DOT_EXECUTABLE=${prefix}/bin/dot \
+        -DDOXYGEN_EXECUTABLE=${prefix}/bin/doxygen
+
+}
+
+default_variants +docs
+
+post-destroot {
+    # copy GNU Radio examples
+    xinstall -m 755 -d ${destroot}${prefix}/share/gnuradio/examples/sdrplay
+    file copy {*}[glob ${worksrcpath}/examples/*] \
+        ${destroot}${prefix}/share/gnuradio/examples/sdrplay
+}
+
+livecheck.type          regexm
+livecheck.version       ${git.branch}
+livecheck.url           ${homepage}/commits/master
+livecheck.regex         {/HB9FXQ/gr-sdrplay/commit/([0-9a-z]*)}

--- a/science/gr-sdrplay/files/cmakelists.txt.patch
+++ b/science/gr-sdrplay/files/cmakelists.txt.patch
@@ -1,0 +1,54 @@
+From 746e78d01e1642788c2287b92c4352df5f4558c7 Mon Sep 17 00:00:00 2001
+From: Davide Gerhard <rainbow@irh.it>
+Date: Mon, 4 Nov 2019 08:18:26 +0100
+Subject: [PATCH] fix boost component and c++11 usage
+
+---
+ CMakeLists.txt     | 9 ++++++---
+ lib/CMakeLists.txt | 2 --
+ 2 files changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9267e43..24d853f 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -86,8 +86,8 @@ set(Boost_ADDITIONAL_VERSIONS
+     "1.55.0" "1.55" "1.56.0" "1.56" "1.57.0" "1.57" "1.58.0" "1.58" "1.59.0" "1.59"
+     "1.60.0" "1.60" "1.61.0" "1.61" "1.62.0" "1.62" "1.63.0" "1.63" "1.64.0" "1.64"
+     "1.65.0" "1.65" "1.66.0" "1.66" "1.67.0" "1.67" "1.68.0" "1.68" "1.69.0" "1.69"
+-)
+-find_package(Boost "1.35" COMPONENTS filesystem system)
++ )
++find_package(Boost "1.35" COMPONENTS chrono filesystem system thread)
+ 
+ if(NOT Boost_FOUND)
+     message(FATAL_ERROR "Boost required to compile sdrplay")
+@@ -145,7 +145,10 @@ find_package(Gnuradio "3.7.2" REQUIRED)
+ list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_SOURCE_DIR}/cmake/Modules)
+ include(GrVersion)
+ 
+-add_definitions(-std=c++11)
++set(CMAKE_CXX_STANDARD 11)
++if(${CMAKE_VERSION} VERSION_LESS "3.1")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++${CMAKE_CXX_STANDARD}")
++endif()
+ 
+ if(NOT CPPUNIT_FOUND)
+     message(FATAL_ERROR "CppUnit required to compile sdrplay")
+diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
+index e8be177..d977246 100644
+--- lib/CMakeLists.txt
++++ lib/CMakeLists.txt
+@@ -22,9 +22,7 @@
+ # Setup library
+ ########################################################################
+ include(GrPlatform) #define LIB_SUFFIX
+-include(GrBoost)
+ 
+-add_definitions(-std=c++11)
+ include_directories(${Boost_INCLUDE_DIR})
+ link_directories(${Boost_LIBRARY_DIRS})
+ 
+-- 
+2.22.0
+


### PR DESCRIPTION
#### Description

GNU Radio block for SDRPlay boards

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.1 19B88
Xcode 11.2 11B52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
