### PR TITLE
adblock2privoxy: Portfile enhancements

### DIFF
--- a/www/adblock2privoxy/Portfile
+++ b/www/adblock2privoxy/Portfile
@@ -14,20 +14,20 @@ homepage            https://github.com/essandess/adblock2privoxy
 
 description         Convert adblock config files to privoxy format
 long_description    ${description}. \
-            AdBlock Plus browser plugin has great block list files \
-            provided by big community, but it is client software and \
-            cannot work on a server as proxy.  Privoxy proxy has good \
-            potential to block ads at server side, but it experiences \
-            acute shortage of updated block lists.  This software \
-            converts adblock lists to privoxy config files format. \
-            Almost all adblock features are supported including \
-            block/unblock requests (on privoxy) all syntax features \
-            are supported except for regex templates matching host \
-            name hide/unhide page elements (via CSS) all syntax \
-            features are supported all block request options except \
-            for outdated ones: Supported: script, image, stylesheet, \
-            object, xmlhttprequest, object-subrequest, subdocument, \
-            document, elemhide, other, popup, third-party, domain=..., \
+            AdBlock Plus browser plugin has great block list files\
+            provided by big community, but it is client software and\
+            cannot work on a server as proxy.  Privoxy proxy has good\
+            potential to block ads at server side, but it experiences\
+            acute shortage of updated block lists.  This software\
+            converts adblock lists to privoxy config files format.\
+            Almost all adblock features are supported including\
+            block/unblock requests (on privoxy) all syntax features\
+            are supported except for regex templates matching host\
+            name hide/unhide page elements (via CSS) all syntax\
+            features are supported all block request options except\
+            for outdated ones: Supported: script, image, stylesheet,\
+            object, xmlhttprequest, object-subrequest, subdocument,\
+            document, elemhide, other, popup, third-party, domain=...,\
             match-case, donottrack.
 
 master_sites        https://hackage.haskell.org/package/${name}-${version}
@@ -40,9 +40,19 @@ depends_run-append \
                     port:nginx \
                     port:privoxy
 
-variant initialize \
-    description {Initialize all configuration files. Existing
-        configurations files are not overwritten by default.} {}
+variant initialize_always \
+    description {Always initialize all configuration files. Intended\
+        for development and troubleshooting only. Working deployments\
+        must disable this variant to prevent configuration files\
+        being overwritten at the next upgrade. Existing configuration\
+        files are not overwritten by default.} {
+    ui_warn \
+        "
+\tAll configuration files will be initialized because
+\tthe variant +initialize_always is set. Please disable
+\tthis variant for working deployments.
+"
+}
 
 # relative paths to ${prefix}
 set ab2p_datadir    share/${name}
@@ -142,7 +152,7 @@ post-activate {
         ${prefix}/etc/${name}/nginx.conf \
         ${prefix}/etc/${name}/css/default.html \
         ] {
-        if { [variant_isset "initialize"]
+        if { [variant_isset "initialize_always"]
              && [file exists ${f}]
             } {
             delete ${f}.previous
@@ -150,7 +160,7 @@ post-activate {
                 ${f} \
                 ${f}.previous
         }
-        if { [variant_isset "initialize"]
+        if { [variant_isset "initialize_always"]
              || ![file exists ${f}]
             } {
             if { [file isfile ${f}.macports] } {
@@ -177,5 +187,15 @@ adblock2privoxy -p ${prefix}/etc/adblock2privoxy/privoxy -w ${prefix}/etc/adbloc
 
 Update run:
 
-adblock2privoxy -t ${prefix}/etc/adblock2privoxy/privoxy/ab2p.task
-"
+adblock2privoxy -t ${prefix}/etc/adblock2privoxy/privoxy/ab2p.task"
+
+if { [variant_isset "initialize_always"] } {
+    if {[exists notes]} {
+        # leave a blank line after the existing notes
+        notes-append ""
+    }
+    notes-append \
+        "The variant +initialize_always is set, which initializes\
+        all configuration files. Please disable this variant for\
+        working deployments."
+}


### PR DESCRIPTION
adblock2privoxy: Portfile enhancements

* Fix initialize_always variant per comments at https://github.com/macports/macports-ports/pull/4978
* Fix spaces

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G1012
Xcode 11.2 11B52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
