### PR TITLE
Gildas: update to 201911a

### DIFF
--- a/science/gildas/Portfile
+++ b/science/gildas/Portfile
@@ -5,7 +5,7 @@ PortGroup           compilers 1.0
 PortGroup           active_variants 1.1 
 
 name                gildas
-version             201910b
+version             201911a
 set my_version      [string tolower [clock format [clock scan 2000-[string range ${version} 4 5]-10] -format %b]][string range ${version} 2 3][string range ${version} 6 end]
 categories          science
 platforms           darwin
@@ -30,9 +30,9 @@ master_sites        http://www.iram.fr/~gildas/dist/ \
 distname            ${name}-src-${my_version}
 use_xz              yes
 
-checksums           rmd160  e3af7407cb69de975bfdf144661b59a1a9c1406d \
-                    sha256  342691a9ef1bf45941d86f21d14305cbfc962104fef652ec1f5ac7b797346f92 \
-                    size    40930832
+checksums           rmd160  0916fd97c9af1ab69ea6fa5d8a77cee738892582 \
+                    sha256  09e0044104b9ce5bf530c63a813bc7431232f1000ab9363b2d7f6543f3af3a86 \
+                    size    41909684
 
 patch.pre_args      -p1
 patchfiles          patch-admin-Makefile.def.diff \


### PR DESCRIPTION
Hi, can someone please merge this PR for update 201911?

Nota: Travis build is expected to fail because of timeout. Azure build is expected to fail because of missing dependency (cfitsio variant).