### PR TITLE
minikube: update to 1.5.2

### DIFF
--- a/sysutils/minikube/Portfile
+++ b/sysutils/minikube/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        kubernetes minikube 1.5.1 v
+github.setup        kubernetes minikube 1.5.2 v
 categories          sysutils
 platforms           darwin
 supported_archs     x86_64
@@ -19,12 +19,12 @@ long_description    Minikube runs a single-node Kubernetes cluster inside a VM \
 github.tarball_from releases
 distfiles           minikube-darwin-amd64
 checksums           minikube-darwin-amd64 \
-                    rmd160  d05a0cc7330be58ad9b3de03505be01080763222 \
-                    sha256  7ba345034e176566930d873acd0f38366dd14fdafd038febe600ea38c24c4208 \
-                    size    58626528
+                    rmd160  0c56d0debd9271b35b77676a63f148b5a1c15ef1 \
+                    sha256  734306019f837a6aee9cb7a0245839f98ea7688ee2cde387099334cb9356c2c4 \
+                    size    49407152
 dist_subdir         ${name}/${version}
 
-depends_lib         path:${prefix}/bin/kubectl:kubectl-1.15
+depends_lib         path:${prefix}/bin/kubectl:kubectl-1.16
 use_configure       no
 
 default_variants    +hyperkit
@@ -32,8 +32,8 @@ default_variants    +hyperkit
 variant hyperkit description {Install Hyperkit driver} {
     distfiles-append    docker-machine-driver-hyperkit
     checksums-append    docker-machine-driver-hyperkit \
-                        rmd160  40e251f9a4a88d7e7b1fd3e44414e3c8f2c2bb2b \
-                        sha256  75a515f71711ab806525f00d2b218a29aaf62a63e3e0d51e56c1bfc9c6ec77ed \
+                        rmd160  fdf0c51c2a391dc26ff1095ff16848eb44a029f0 \
+                        sha256  892466b58a52612b1c9085078e6de2df85f0f24f9b4810d4fd3af035c5fc8d29 \
                         size    11314532
 }
 


### PR DESCRIPTION
#### Description

minikube implements a local Kubernetes cluster on macOS, Linux, and Windows. minikube's primary goals are to be the best tool for local Kubernetes application development and to support all Kubernetes features that fit.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G95
Xcode 11.2 11B52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
