### PR TITLE
luajit: use workaround for breakage in Xcode 11.2 as well

### DIFF
--- a/lang/luajit/Portfile
+++ b/lang/luajit/Portfile
@@ -33,8 +33,7 @@ compiler.blacklist  {clang < 700} macports-clang-3.3 macports-clang-3.4
 
 # Workaround for Xcode 11 issue
 # https://forums.developer.apple.com/thread/121887
-# Current information is that this should be fixed in Xcode 11.2
-if { ([vercmp ${os.major} 19] >= 0) && ([vercmp $xcodeversion 11.2] < 0) } {
+if { ([vercmp ${os.major} 19] >= 0) && ([vercmp $xcodeversion 11.3] < 0) } {
     if {[string match clang ${configure.compiler}]} {
         configure.cc-append -fno-stack-check
     }


### PR DESCRIPTION
#### Description

Hoping for the best in Xcode 11.3.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.1 19B88
Xcode 11.2 11B52 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
