### PR TITLE
py-language-server + dependencies: add py38 subport

### DIFF
--- a/python/py-language-server/Portfile
+++ b/python/py-language-server/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  83526f28f2129375a8729be06037455c08f56949 \
                     sha256  9cb24edfdd64d210d1b08b60134b7007895352dc38420e8e17692e7369647b4c \
                     size    447863
 
-python.versions     27 35 36 37
+python.versions     27 35 36 37 38
 
 if {${subport} ne ${name}} {
     depends_lib-append \

--- a/python/py-language-server/files/py38-pyls
+++ b/python/py-language-server/files/py38-pyls
@@ -1,0 +1,1 @@
+${frameworks_dir}/Python.framework/Versions/3.8/bin/pyls

--- a/python/py-pylint/Portfile
+++ b/python/py-pylint/Portfile
@@ -12,7 +12,7 @@ platforms           darwin
 license             GPL-2+
 supported_archs     noarch
 
-python.versions     27 34 35 36 37
+python.versions     27 34 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-pylint/files/pylint38
+++ b/python/py-pylint/files/pylint38
@@ -1,0 +1,4 @@
+${frameworks_dir}/Python.framework/Versions/3.8/bin/epylint
+${frameworks_dir}/Python.framework/Versions/3.8/bin/pylint
+${frameworks_dir}/Python.framework/Versions/3.8/bin/pyreverse
+${frameworks_dir}/Python.framework/Versions/3.8/bin/symilar

--- a/python/py-python-jsonrpc-server/Portfile
+++ b/python/py-python-jsonrpc-server/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  629c82aab44ae2d0843b2a99596c640ec050afe7 \
                     sha256  59ce9c9523c14c493a327b3a27ee37464a36dc2b9d8ab485ecbcedd38840380a \
                     size    25797
 
-python.versions     27 35 36 37
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-rope/Portfile
+++ b/python/py-rope/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  3352e635c6c40703c44b812f3e7c6b0bc16cc4b4 \
                     sha256  408cd9b1e75e1b95a646d0abe5aa0ba78903c9ae78c431a728f2a6d6b08628a6 \
                     size    243907
 
-python.versions     27 35 36 37
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description
Add py38 subport for py-language-server and its dependencies py-pylint, py-python-jsonrpc-server and py-rope.
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.1 19B88
Xcode 11.2 11B52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
