### PR TITLE
ecCodes-2.14.1: Update to latest upstream version

### DIFF
--- a/science/ecCodes/Portfile
+++ b/science/ecCodes/Portfile
@@ -5,7 +5,7 @@ PortGroup cmake     1.0
 PortGroup compilers 1.0
 
 name                ecCodes
-version             2.12.5
+version             2.14.1
 platforms           darwin
 maintainers         {takeshi @tenomoto}
 license             Apache-2
@@ -14,15 +14,17 @@ description         API and tools for decoding and encoding GRIB, BUFR and GTS f
 homepage            https://confluence.ecmwf.int/display/ECC
 master_sites        https://confluence.ecmwf.int/download/attachments/45757960
 distname            eccodes-${version}-Source
-checksums           rmd160  f3f6a34fdc521676d6e1069e4741e894d6db174f \
-                    sha256  0c14cb222f18a0357fd996f0802867c54500765836a8fa0aaedb92671973e614 \
-                    size    10968231
+checksums           rmd160  f62da706eb064bc22951b040af7d04306a1f8b80 \
+                    sha256  16da742691c0ac81ccc378ae3f97311ef0dfdc82505aa4c652eb773e911cc9d6 \
+                    size    11014537
 long_description \
     ecCodes is a package developed by ECMWF which provides an application programming interface and \
     a set of tools for decoding and encoding messages in the following formats: \
         \n* WMO FM-92 GRIB edition 1 and edition 2 \
         \n* WMO FM-94 BUFR edition 3 and edition 4 \
         \n* WMO GTS abbreviated header (only decoding).
+
+patchfiles          patch-no-jasper-deps.diff
 
 if [fortran_variant_isset] {
     compilers.choose    cc fc f77 f90
@@ -33,9 +35,8 @@ depends_build-append \
                     bin:bison:bison \
                     bin:flex:flex \
                     port:perl5
-depends_lib         port:jasper \
-                    port:hdf5 \
-                    port:openjpeg15 \
+depends_lib         port:openjpeg15 \
+                    port:ld64 \
                     port:libpng \
                     port:libaec \
                     port:netcdf \
@@ -52,8 +53,6 @@ configure.args-append \
                     -DAEC_PATH=${prefix}/lib/libaec \
                     -DENABLE_PYTHON=OFF \
                     -DENABLE_TESTS=OFF \
-                    -DJASPER_INCLUDE_DIR=${prefix}/include \
-                    -DJASPER_LIBRARY_RELEASE=${prefix}/lib/libjasper.dylib \
                     -DNETCDF_CONFIG_EXECUTABLE=${prefix}/bin/nc-config \
                     -DOPENJPEG_INCLUDE_DIR=${prefix}/include/openjpeg-1.5 \
                     -DOPENJPEG_LIBRARY=${prefix}/lib/libopenjpeg.dylib \

--- a/science/ecCodes/files/patch-no-jasper-deps.diff
+++ b/science/ecCodes/files/patch-no-jasper-deps.diff
@@ -1,0 +1,17 @@
+Removed section that finds jasper.
+It is not needed since we use openjpeg instead, but the CMakeLists.txt inadvertently forces looking for jasper.
+
+--- CMakeLists.txt	2019-07-08 14:06:44.000000000 +0200
++++ CMakeLists.txt	2019-07-19 13:27:24.158310812 +0200
+@@ -196,11 +196,6 @@
+     #       which can affect future package discovery if not undone by the caller.
+     #       The current CMAKE_PREFIX_PATH is backed up as _CMAKE_PREFIX_PATH
+     #
+-    set(CMAKE_WARN_DEPRECATED OFF) # Suppress deprecation message
+-    ecbuild_add_extra_search_paths( jasper )
+-    find_package( Jasper )
+-    set(CMAKE_PREFIX_PATH ${_CMAKE_PREFIX_PATH})    # Restore CMAKE_PREFIX_PATH
+-    set(CMAKE_WARN_DEPRECATED ON)  # Remove suppression
+ 
+     find_package( OpenJPEG )
+ 


### PR DESCRIPTION
#### Description

This also removes the dependency on jasper, as its support is deprecated by the developer. The functionalities are covered by openjpeg.
Unfortunately an error in the CMake setup makes the configuration look for jasper first, then openjpeg.
The patchfile avoids this.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.1
Xcode Command Line Tools 11

###### Verification

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? Yes, but there is no test sequence.
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
