### PR TITLE
multiple ports: mkvtoolnix 38.0, libebml 1.3.9, libmatroska 1.5.2

### DIFF
--- a/multimedia/libmatroska/Portfile
+++ b/multimedia/libmatroska/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 
 name                libmatroska
-version             1.4.9
+version             1.5.2
 revision            0
-checksums           rmd160  ca85491dca0ac8e957b55c5c0db738784bc12af0 \
-                    sha256  38a61dd5d87c070928b5deb3922b63b2b83c09e2e4a10f9393eecb6afa9795c8 \
-                    size    64556
+checksums           rmd160  c601a4ba4e43eb7cf2ca8d41a54bbe10e9ce6905 \
+                    sha256  0ac6debfbf781d47f001b830aaf9be9dfbcefd13bcfb80ca5efc1c04b4a3c962 \
+                    size    64996
 
 categories          multimedia
 platforms           darwin

--- a/multimedia/mkvtoolnix/Portfile
+++ b/multimedia/mkvtoolnix/Portfile
@@ -6,11 +6,11 @@ PortGroup           github 1.0
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           muniversal 1.0
 
-github.setup        mbunkus mkvtoolnix 30.1.0 release-
-revision            1
-checksums           rmd160  7e60883259bdc72e1d39e171d92d9d82878999f1 \
-                    sha256  4628f40d62d359edb1441c52381b1f3a61aa227279133d7e01257f91e0d92591 \
-                    size    7274296
+github.setup        mbunkus mkvtoolnix 38.0.0 release-
+revision            0
+checksums           rmd160  f9b3f7e7a5bcef6778307db4f1ecc736f4c9e72f \
+                    sha256  0e1db5b5af6147dec245744a0d403120e53a44f6b81aad0d26c0f5c0e5515d00 \
+                    size    7348600
 
 categories          multimedia
 platforms           darwin
@@ -86,10 +86,6 @@ configure.args      --mandir=${prefix}/share/man \
                     --with-po4a=${prefix}/bin/po4a \
                     --with-po4a-translate=${prefix}/bin/po4a-translate \
                     --disable-qt
-
-# https://gitlab.com/mbunkus/mkvtoolnix/issues/2485
-configure.ldflags-append \
-                    -framework CoreFoundation
 
 configure.ldflags-append ${cxx_stdlibflags}
 

--- a/textproc/libebml/Portfile
+++ b/textproc/libebml/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 
 name                libebml
-version             1.3.6
+version             1.3.9
 revision            0
-checksums           rmd160  a5ec0996a02b59c3514586e1285072df13b71186 \
-                    sha256  1e5a7a7820c493aa62b0f35e15b4233c792cc03458c55ebdfa7a6521e4b43e9e \
-                    size    57764
+checksums           rmd160  dd174de83981608c69a66c849d871ab5c047ff61 \
+                    sha256  c6b6c6cd8b20a46203cb5dce636883aef68beb2846f1e4103b660a7da2c9c548 \
+                    size    69836
 
 categories          textproc
 platforms           darwin


### PR DESCRIPTION
#### Description
mkvtoolnix: Update to 38.0, fixes building against the latest boost.
libebml: Update to 1.3.9
libmatroska: Update to 1.5.2
Closes: https://trac.macports.org/ticket/58996
Closes: https://trac.macports.org/ticket/59041
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] update
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G1012
Xcode 11.2 11B52 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
