### PR TITLE
kubectx: update default kubectl dependency from 1.15 to 1.16

### DIFF
--- a/sysutils/kubectx/Portfile
+++ b/sysutils/kubectx/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        ahmetb kubectx 0.7.0 v
-revision            0
+revision            1
 categories          sysutils
 platforms           darwin
 supported_archs     noarch
@@ -19,7 +19,7 @@ checksums           rmd160  f6f011e466317cc1323954ac9e5b4f3cc4bd78f7 \
                     sha256  f944d5677d82e10bc8fbdd70a835ffb0aa522402e0b57331cdc4b80f6aefeee6 \
                     size    484008
 
-depends_run         port:bash-completion path:${prefix}/bin/kubectl:kubectl-1.15
+depends_run         port:bash-completion path:${prefix}/bin/kubectl:kubectl-1.16
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

Update default kubectl runtime dependency from 1.15 to 1.16.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.1 19B88
Xcode 11.2 11B52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?