### PR TITLE
freedv-gui: update version to 7aa0b4d6

### DIFF
--- a/science/freedv-gui/Portfile
+++ b/science/freedv-gui/Portfile
@@ -14,11 +14,11 @@ description         GUI Application for FreeDV – an open source digital \
     voice protocol that integrates the modems, codecs, and FEC
 long_description    ${description}
 
-github.setup        drowe67 freedv-gui 17671ccd348f906df3b9fca33cc99098f77d48d3
-version             20191031-[string range ${github.version} 0 7]
-checksums           rmd160  641496dad364c373c73e901ef6dc2cc0d71a13c3 \
-                    sha256  cde260fde00729bb1039f8c08499a76b740eab45d47925d38cdd05ead5e3cf11 \
-                    size    5795519
+github.setup        drowe67 freedv-gui 7aa0b4d6277622aef0b3d8600bfa3c2e71990242
+version             20191103-[string range ${github.version} 0 7]
+checksums           rmd160  78bb79074fac582aeb212dd75f8f75cb3e295302 \
+                    sha256  f0249cbcc917555fad9d359f8dca0810dd65fccfc0f37d93e0c8db64c53500d0 \
+                    size    5795466
 revision            0
 
 depends_build-append \


### PR DESCRIPTION


#### Description

- bump version to 7aa0b4d6

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.1 19B88
Xcode 11.2 11B52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
