### PR TITLE
lpcnetfreedv: update version to 34049f83

### DIFF
--- a/audio/lpcnetfreedv/Portfile
+++ b/audio/lpcnetfreedv/Portfile
@@ -15,11 +15,11 @@ description         Experimental Neural Net speech coding for FreeDV
 long_description    Experimental version of LPCNet being developed \
     for over the air Digital Voice experiments with FreeDV.
 
-github.setup        drowe67 LPCNet 1443da9221a041b4569e5d66f78f65a081320b05
-version             20191011-[string range ${github.version} 0 7]
-checksums           rmd160  a1de0f8c615a180ead03f0e0cee765cc921bf9bb \
-                    sha256  347febf6f8ac110fedee16036dc729bceb05d3500ffc05650720d753308b75c7 \
-                    size    33010957
+github.setup        drowe67 LPCNet 34049f83170aaf1e6e3595f5ac086ef565f8b6b3
+version             20191102-[string range ${github.version} 0 7]
+checksums           rmd160  8528279ddda440ef85fcc7096ed27d5d10a85ce9 \
+                    sha256  8709610cfa418b3f3d45a166ec14e06b9dc9af478849754cda3b87f2fad3f9fd \
+                    size    33011015
 revision            0
 
 depends_lib-append \


### PR DESCRIPTION


#### Description

- bump version to 34049f83

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.1 19B88
Xcode 11.2 11B52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
