### PR TITLE
kerberos5: add support for libressl 2.9

### DIFF
--- a/net/kerberos5/files/libressl.patch
+++ b/net/kerberos5/files/libressl.patch
@@ -31,23 +31,14 @@
  
  /* 1.1 standardizes constructor and destructor names, renaming
   * EVP_MD_CTX_{create,destroy} and deprecating ASN1_STRING_data. */
-@@ -3040,7 +3040,7 @@
-     return retval;
- }
+@@ -3076,6 +3076,10 @@
+     int_dhvparams *vparams;
+ } int_dhx942_dh;
  
--#if OPENSSL_VERSION_NUMBER >= 0x10100000L
-+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
- 
- /*
-  * We need to decode DomainParameters from RFC 3279 section 2.3.3.  We would
---- plugins/preauth/pkinit/pkinit_crypto_openssl.h.orig	2017-12-05 11:36:22.000000000 -0600
-+++ plugins/preauth/pkinit/pkinit_crypto_openssl.h	2017-12-19 06:06:40.000000000 -0600
-@@ -46,7 +46,7 @@
- #include <openssl/asn1.h>
- #include <openssl/pem.h>
- 
--#if OPENSSL_VERSION_NUMBER >= 0x10100000L
-+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
- #include <openssl/asn1t.h>
- #else
- #include <openssl/asn1_mac.h>
++#if defined(LIBRESSL_VERSION_NUMBER) && !defined(static_ASN1_SEQUENCE_END_name)
++#define static_ASN1_SEQUENCE_END_name ASN1_SEQUENCE_END_name
++#endif
++
+ ASN1_SEQUENCE(DHvparams) = {
+     ASN1_SIMPLE(int_dhvparams, seed, ASN1_BIT_STRING),
+     ASN1_SIMPLE(int_dhvparams, counter, BIGNUM)


### PR DESCRIPTION
re: https://trac.macports.org/ticket/58124

The patch is cherry picked from FreeBSD.

https://github.com/freebsd/freebsd-ports/blob/master/security/krb5-117/files/patch-plugins_preauth_pkinit_pkinit__crypto__openssl.c

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.9

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
