### PR TITLE
netcdf and netcdf-fortran: updates to 4.7.0 and 4.5.2, resp.

### DIFF
--- a/science/netcdf-fortran/Portfile
+++ b/science/netcdf-fortran/Portfile
@@ -4,15 +4,15 @@ PortSystem                  1.0
 PortGroup                   muniversal 1.0
 PortGroup                   mpi 1.0
 PortGroup                   github 1.0
-# Although CMakeLists.txt is provided nf-config is not yet ported.
+# Still using configure/make system because CMakeLists.txt does not install nf-config.
 
 # netcdf-fortran does not require the fortran interface of hdf5.
 # enforcing hdf5 variant does not allow installation of
 # hdf5+cxx (w/o a fortran variant) and netcdf-fortran.
 #mpi.enforce_variant         hdf5
 
-github.setup                Unidata netcdf-fortran 4.4.5 v
-revision                    5
+github.setup                Unidata netcdf-fortran 4.5.2 v
+revision                    0
 maintainers                 {takeshi @tenomoto} openmaintainer
 platforms                   darwin
 categories                  science
@@ -29,9 +29,9 @@ long_description \
     This software package provides Fortran application interfaces \
     for accessing netCDF data.
 
-checksums           rmd160  5ba175668f5a6806ab44fc08f92b80a6caa0ced8 \
-                    sha256  a34f6f69eabdee9e7bcaca80c1e532b5e8afabf936bd511538d7e09e972949e8 \
-                    size    1344715
+checksums           rmd160  f2660e976135b5db239a93aca167b96e28806765 \
+                    sha256  f39f7c902d4db4d6a5ecdf6d13e400b23d67619fcea9af6313fb0f351d25cfe9 \
+                    size    1796651
 
 compilers.choose    f77 f90 fc
 mpi.setup           require_fortran

--- a/science/netcdf/Portfile
+++ b/science/netcdf/Portfile
@@ -6,8 +6,8 @@ PortGroup                   github 1.0
 PortGroup                   cmake 1.0
 PortGroup                   muniversal 1.0
 
-github.setup                Unidata netcdf-c 4.7.0 v
-revision                    1
+github.setup                Unidata netcdf-c 4.7.2 v
+revision                    0
 epoch                       3
 name                        netcdf
 maintainers                 {takeshi @tenomoto} openmaintainer
@@ -23,9 +23,9 @@ long_description \
 
 homepage                    http://www.unidata.ucar.edu/software/netcdf/
 
-checksums           rmd160  216b165165dde6aa2566c45afe2fe809571c73b2 \
-                    sha256  d325865067532624940f9fc2193423507f47ce9d30113d395c6762f64198f551 \
-                    size    18359142
+checksums           rmd160  4d3792bb72e537673d1202f47ec10d0cd176f462 \
+                    sha256  bc9995d84ace1a68688345536abc299f31ceb12ce00309c06d117ab5c81b1e26 \
+                    size    18403859
 
 compilers.choose            cc cpp
 mpi.setup


### PR DESCRIPTION
#### Description

These are simple upstream updates for the netcdf and netcdf-fortran packages.
Please note that this is a replacement for the (closed) PR #5729 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.1
Command Line Tools 11.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
