### PR TITLE
splash: update to 2.9.1

### DIFF
--- a/science/splash/Portfile
+++ b/science/splash/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup compilers 1.0
 
 name                splash
-version             2.9.0
+version             2.9.1
 revision            0
 categories          science graphics
 platforms           darwin
@@ -19,9 +19,9 @@ license             GPL-2+
 
 worksrcdir          ${name}
 
-checksums           rmd160  fd91759042a5522f911a709cd2345ca0f2f3be9c \
-                    sha256  a3fa807ce2322421af3719fdc87d9214e6937c5ba004e7d8767d32f9e74d8cf9 \
-                    size    2171502
+checksums           rmd160  86e3585d601d5a65e2b0b81a14a3f212414eb12f \
+                    sha256  212bbe16c56d1a009acbd263689ef6a30052d5bb4878aad345d97927fbdd1996 \
+                    size    2186770
 
 default_variants    +giza
 
@@ -55,7 +55,7 @@ pre-build {
 }
 
 variant hdf5 description {compiles data reads that depend on HDF5} {
-   build.args-append       gadgethdf5 amuse_hdf5 HDF5ROOT=${prefix}
+   build.args-append       gadgethdf5 amuse_hdf5 cactus_hdf5 HDF5ROOT=${prefix}
    depends_lib-append      port:hdf5
 }
 


### PR DESCRIPTION
#### Description

* update to version 2.9.1
* added cactus_hdf5 to hdf5 variant

###### Type(s)

- [ ] bugfix
- [x ] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.1 19B88
Version 11.2 (11B52)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
