### PR TITLE
cdo: update to 1.9.8

### DIFF
--- a/science/cdo/Portfile
+++ b/science/cdo/Portfile
@@ -5,18 +5,18 @@ PortGroup                   mpi 1.0
 PortGroup                   cxx11 1.1
 
 name                        cdo
-version                     1.9.6
-revision                    3
+version                     1.9.8
+revision                    0
 platforms                   darwin
 maintainers                 {takeshi @tenomoto} openmaintainer
 license                     GPL-2
 categories                  science
 description                 Climate Data Operators
 homepage                    https://code.mpimet.mpg.de/projects/cdo
-master_sites                https://code.mpimet.mpg.de/attachments/download/19299
-checksums           rmd160  82a66d99bbe026254f8dea15ca078e3acaed29f0 \
-                    sha256  b31474c94548d21393758caa33f35cf7f423d5dfc84562ad80a2bdcb725b5585 \
-                    size    10463349
+master_sites                https://code.mpimet.mpg.de/attachments/download/20826
+checksums           rmd160  c26192d80274a193556f924ddbb767e3e9283024 \
+                    sha256  f2660ac6f8bf3fa071cf2a3a196b3ec75ad007deb3a782455e80f28680c5252a \
+                    size    10793380
 
 long_description \
     CDO is a collection of command line Operators               \
@@ -37,6 +37,8 @@ depends_lib                 port:netcdf \
                             port:proj \
                             port:fftw-3
 
+patchfiles                  patch-skip-nc4-test.diff
+
 configure.args              --with-netcdf=${prefix} \
                             --disable-dependency-tracking \
                             --disable-openmp \
@@ -48,6 +50,11 @@ configure.args              --with-netcdf=${prefix} \
                             --with-zlib=${prefix}
 configure.cppflags-append   -I${prefix}/include/udunits2
 configure.ldflags-append    -lhdf5
+
+test.run                    yes
+test.dir                    ${worksrcpath}/test
+test.args                   -j1
+test.target                 check
 
 # Setting configure.cc h5pcc has been removed because it causes error
 # because -Wl,-headerpad_max_install_names does not work with -pthread.
@@ -80,8 +87,7 @@ variant grib_api description {obsoleted by eccodes variant} {
 
 variant eccodes description {enable grib2 support} {
     depends_lib-append      port:ecCodes
-    configure.args-append   --with-jasper=${prefix} \
-                            --with-eccodes=${prefix} \
+    configure.args-append   --with-eccodes=${prefix} \
                             --disable-cgribex
     configure.ldflags-append    -lpng -lopenjpeg
 }

--- a/science/cdo/files/patch-skip-nc4-test.diff
+++ b/science/cdo/files/patch-skip-nc4-test.diff
@@ -1,0 +1,10 @@
+--- test/tsformat.test.in.orig	2019-10-22 13:06:02.000000000 +0200
++++ test/tsformat.test.in	2019-11-08 00:45:00.000000000 +0100
+@@ -24,6 +24,7 @@
+     if [ "${FORMAT}" = nc4  ] ; then  FILEFORMAT=netCDF4;  fi
+ 
+     HAS_FORMAT=`${CDO} --config has-${FORMAT}`
++    if [ "${FORMAT}" = nc4  ] ; then  HAS_FORMAT=no;  fi
+ }
+ #
+ function testfunc()


### PR DESCRIPTION
#### Description
This provides the following updates:
* Update to upstream v1.9.8
* Removed stale --with-jasper configuration (no longer needed or suppored)
* Added test suite (skipping one test that is known to fail)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
MacOS 10.15.1
Command Line Tools 11.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
