### PR TITLE
nco: update to 4.8.1

### DIFF
--- a/science/nco/Portfile
+++ b/science/nco/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           compilers 1.0
 PortGroup           github 1.0
 
-github.setup        nco nco 4.8.0
-revision            1
+github.setup        nco nco 4.8.1
+revision            0
 platforms           darwin
 maintainers         {takeshi @tenomoto}
 license             GPL-3
@@ -15,9 +15,9 @@ description         The netCDF Operators
 compilers.choose    cc cxx
 compilers.setup     -clang33 -clang34
 
-checksums           rmd160  12272e2a538246ad77de16168aa769d94f781a20 \
-                    sha256  6b2e74dbc14514f55700fcec9fe9c156ca5c59515ea2e2df4535a01345c73e80 \
-                    size    5224429
+checksums           rmd160  e156726051368ccfa61b61636db903c3b8f5c151 \
+                    sha256  671d73b5b0fc02282db8fa40cdd82e3d903ae178154297092c474445fa96b186 \
+                    size    5240496
 
 homepage            http://nco.sourceforge.net/
 long_description \


### PR DESCRIPTION
#### Description
Upstream update to 4.8.1

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
MacOS 10.15.1
Command Line Tools 11.2

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
