### PR TITLE
remove obsolete Python subports (maintainer: jmroot)

### DIFF
--- a/python/py-SDL2/Portfile
+++ b/python/py-SDL2/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
@@ -16,12 +18,13 @@ long_description \
    discontinued PySDL project. In contrast to PySDL, it has no licensing \
    restrictions, nor does it rely on C code, but uses ctypes instead.
 
-checksums           rmd160 875770a7d077736c6fedb1554a39ea7f04822db1 \
-                    sha256 57a1e9ae229b21a22fd5cef96a97328bdcc4b16d1ca53ec805b1fab734ba523c
+checksums           rmd160  875770a7d077736c6fedb1554a39ea7f04822db1 \
+                    sha256  57a1e9ae229b21a22fd5cef96a97328bdcc4b16d1ca53ec805b1fab734ba523c \
+                    size    716421
 
-python.versions     27 33 34 35 36
+python.versions     27 35 36
 
-if {$subport ne $name} {
+if {${subport} ne ${name}} {
     depends_lib-append  port:libsdl2 \
                         port:libsdl2_image \
                         port:libsdl2_mixer \

--- a/python/py-bdist_mpkg/Portfile
+++ b/python/py-bdist_mpkg/Portfile
@@ -23,17 +23,14 @@ homepage            https://pypi.python.org/pypi/bdist_mpkg/
 master_sites        pypi:b/bdist_mpkg/
 distname            bdist_mpkg-${version}
 
-checksums           md5 81f5f8601331acda2926efeb97a0804d \
-                    rmd160 a5550e7d420fde8b7425a273286c5f02b056c8cf \
-                    sha256 1b460cc4ea834f0be9e787759fac542cb2414463a1f7f1aedb5870e90f6beb9d
+checksums           rmd160  a5550e7d420fde8b7425a273286c5f02b056c8cf \
+                    sha256  1b460cc4ea834f0be9e787759fac542cb2414463a1f7f1aedb5870e90f6beb9d \
+                    size    19004
 
-python.versions     26 27 33 34 35 36
+python.versions     27 35 36
 
-if {$subport ne $name} {
-    depends_lib     port:py${python.version}-setuptools
+if {${subport} ne ${name}} {
+    depends_lib-append \
+                    port:py${python.version}-setuptools
     livecheck.type  none
-} else {
-    livecheck.type  regex
-    livecheck.url   https://pypi.python.org/pypi/bdist_mpkg/
-    livecheck.regex bdist_mpkg (0\.\[0-9\]+\.\[0-9\]+)
 }

--- a/python/py-dice3ds/Portfile
+++ b/python/py-dice3ds/Portfile
@@ -18,11 +18,11 @@ homepage            http://www.aerojockey.com/software/dice3ds/
 
 master_sites        ${homepage}
 distname            Dice3DS-${version}
-checksums           md5 b4e5a26a2f8fd9c0ee539ea37d1ffb8e \
-                    sha1 a890588b6e041c9888aa33664a5302adbc9a8dbc \
-                    rmd160 9b22c55045044027b02f13b946d024bf68113f63
+checksums           rmd160  9b22c55045044027b02f13b946d024bf68113f63 \
+                    sha256  633936de36cac68f806797c1a24f33ad0a0516a102f389c2019f5ba0da463fbf \
+                    size    39430
 
-python.versions     26 27
+python.versions     27
 
 if {$subport ne $name} {
     depends_lib     port:py${python.version}-numpy

--- a/python/py-opengl-accelerate/Portfile
+++ b/python/py-opengl-accelerate/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
 PortGroup           python 1.0
 
@@ -16,15 +18,17 @@ homepage            http://pyopengl.sourceforge.net/
 master_sites        pypi:P/PyOpenGL-accelerate/
 distname            PyOpenGL-accelerate-${version}
 
-checksums           md5 489338a4818fa63ea54ff3de1b48995c \
-                    rmd160 7d353f43a341fbc34ed580076b8555bae60cc4d5 \
-                    sha256 927f4670b893d46e2f6273ae938bf0a1db27ffae3336eba94813ccef6260c410
+checksums           rmd160  7d353f43a341fbc34ed580076b8555bae60cc4d5 \
+                    sha256  927f4670b893d46e2f6273ae938bf0a1db27ffae3336eba94813ccef6260c410 \
+                    size    323541
 
-python.versions     26 27 33 34 35 36 37
+python.versions     27 35 36 37
 
-if {$subport ne $name} {
-    depends_lib     port:py${python.version}-numpy
-    depends_build-append port:py${python.version}-cython
+if {${subport} ne ${name}} {
+    depends_lib-append \
+                    port:py${python.version}-numpy
+    depends_build-append \
+                    port:py${python.version}-cython
     patchfiles      patch-use-cython.diff
     post-patch {
         delete {*}[glob ${worksrcpath}/src/*.c]

--- a/python/py-opengl/Portfile
+++ b/python/py-opengl/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
 PortGroup           python 1.0
 
@@ -20,15 +22,17 @@ homepage            http://pyopengl.sourceforge.net/
 master_sites        pypi:P/PyOpenGL/
 distname            PyOpenGL-${version}
 
-checksums           md5    0de021941018d46d91e5a8c11c071693 \
-                    rmd160 75728a3b53e62a41e634037c4f00efd4ba1ee67b \
-                    sha256 9b47c5c3a094fa518ca88aeed35ae75834d53e4285512c61879f67a48c94ddaf
+checksums           rmd160  75728a3b53e62a41e634037c4f00efd4ba1ee67b \
+                    sha256  9b47c5c3a094fa518ca88aeed35ae75834d53e4285512c61879f67a48c94ddaf \
+                    size    1172688
 
-python.versions     26 27 33 34 35 36 37
+python.versions     27 35 36 37
 
-if {$subport ne $name} {
-    depends_build   port:py${python.version}-setuptools
-    depends_lib     port:py${python.version}-opengl-accelerate \
+if {${subport} ne ${name}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+    depends_lib-append \
+                    port:py${python.version}-opengl-accelerate \
                     port:py${python.version}-tkinter
     if {${python.version} >= 30} {
         depends_lib-append port:py${python.version}-Pillow

--- a/python/py-pil/Portfile
+++ b/python/py-pil/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem      1.0
 PortGroup       python 1.0
 
@@ -11,19 +13,20 @@ long_description    The Python Imaging Library (PIL) adds image \
                     processing capabilities to your Python interpreter. \
                     This library supports many file formats, and \
                     provides powerful image processing and graphics \
-                    capabilities. 
+                    capabilities.
 categories-append   graphics
 platforms       darwin freebsd
 homepage        http://www.pythonware.com/products/pil/
 master_sites    http://effbot.org/downloads/
 distname        Imaging-${version}
-checksums       md5 fc14a54e1ce02a0225be8854bfba478e \
-                sha1 76c37504251171fda8da8e63ecb8bc42a69a5c81 \
-                rmd160 9af570fe100e250a4860314341fe3e6d695d7fde
 
-python.versions 26 27
+checksums       rmd160  9af570fe100e250a4860314341fe3e6d695d7fde \
+                sha256  895bc7c2498c8e1f9b99938f1a40dc86b3f149741f105cf7c7bd2e0725405211 \
+                size    498749
 
-if {$subport ne $name} {
+python.versions 27
+
+if {${subport} ne ${name}} {
     conflicts       py${python.version}-Pillow
 
     patchfiles      patch-setup.py pil-2009-raclette-fb7ce579f5f9.diff \
@@ -33,11 +36,11 @@ if {$subport ne $name} {
     depends_lib-append  port:freetype \
                         port:lcms \
                         port:py${python.version}-tkinter
-    
+
     post-patch {
         reinplace s,__PREFIX__,${prefix},g ${worksrcpath}/setup.py
     }
-    
+
     post-destroot {
         xinstall -d -m 0755 ${destroot}${prefix}/share/doc/${subport}
         xinstall -m 0644 -W ${worksrcpath} BUILDME CHANGES CONTENTS README \


### PR DESCRIPTION
#### Description
This PR removes obsolete Python subports for ports maintained by @jmroot that have no dependencies (keeping ```py-psyco``` [as requested](https://trac.macports.org/ticket/56853)).

###### Tested on
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
