### PR TITLE
py-demjson:  add py36 and py37

### DIFF
--- a/python/py-demjson/Portfile
+++ b/python/py-demjson/Portfile
@@ -10,9 +10,9 @@ license             LGPL-3+
 platforms           darwin
 maintainers         nomaintainer
 
-python.versions     27
+python.versions     27 36 37
 
-description         encoder, decoder, and validator for JSON compliant with RFC 4627
+description         encoder, decoder, and lint/validator for JSON compliant with RFC 4627
 long_description    encoder, decoder, and lint/validator for JSON (JavaScript \
                     Object Notation) compliant with RFC 4627. This module \
                     provides classes and functions for encoding or decoding data \


### PR DESCRIPTION
* add subports for py36 and py37
* add "lint" keyword to description

#### Description
Tested with py36. 
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G1012
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac]? (no open tickets)
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
