### PR TITLE
recode: move to python 3

### DIFF
--- a/textproc/recode/Portfile
+++ b/textproc/recode/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        rrthomas recode 3.7.6 v
-revision            0
+revision            1
 checksums           rmd160  f5e475da14cd2a49f61e6e5b17ad4479c78b8c99 \
                     sha256  46c5828ac6f5fb759ecf98b16a674188d901b84675b0dbbc0afc03c542d3a954 \
                     size    2210564
@@ -24,15 +24,26 @@ long_description    This recode program has the purpose of converting files \
 
 github.tarball_from releases
 
-depends_test        port:py27-cython
+set python.branch   3.7
+set python.version  [join [split ${python.branch} "."] ""]
+set python.prefix   ${frameworks_dir}/Python.framework/Versions/${python.branch}
+set python.bin      ${python.prefix}/bin/python${python.branch}
+set cython.bin      ${python.prefix}/bin/cython
+
+depends_build       port:python${python.version}
 
 depends_lib         port:gettext \
                     port:libiconv
+
+depends_test        port:py${python.version}-cython
 
 if {[string match *gcc* ${configure.compiler}]} {
     patchfiles-append \
                     pragma.patch
 }
+
+configure.env-append \
+                    PYTHON=${python.bin}
 
 post-destroot {
     delete ${destroot}${prefix}/lib/charset.alias
@@ -46,7 +57,6 @@ post-destroot {
 
 test.run            yes
 test.target         check
-test.env            CC=${configure.cc} \
-                    DYLD_LIBRARY_PATH=${worksrcpath}/src/.libs \
-                    PATH=${frameworks_dir}/Python.framework/Versions/2.7/bin:$env(PATH)
-test.args           PYTHON=${prefix}/bin/python2.7
+test.env            CC=${configure.cc}
+test.args           PYTHON=${python.bin} \
+                    CYTHON=${cython.bin}


### PR DESCRIPTION


#### Description

In macOS 10.15 there is no problem because it has python3 therefore I can't test if it works correctly. test, please.

Closes: https://trac.macports.org/ticket/59254

@ryandesign I bumped revision to force rebuild and because depends changed but the packaged files are the same; is it right?

###### Type(s)

<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.1 19B88
Xcode 11.2 11B52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
