### PR TITLE
fribidi: fix CVE-2019-18397 - Stack buffer overflow

### DIFF
--- a/textproc/fribidi/Portfile
+++ b/textproc/fribidi/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 
 PortGroup       github 1.0
 github.setup    fribidi fribidi 1.0.7 v
-revision        0
+revision        1
 
 categories      textproc
 license         LGPL-2.1+
@@ -28,7 +28,11 @@ depends_build   port:pkgconfig
 use_autoreconf  yes
 autoreconf.args -fvi
 
-patchfiles      gen.tab_Makefile.am.patch
+# remove CVE-2019-18397.patch with the next release
+patchfiles \
+     gen.tab_Makefile.am.patch \
+     CVE-2019-18397.patch
+
 post-patch {
     # git.mk seems to trigger a ./config.status --recheck, which is unnecessary
     # and additionally fails due to quoting

--- a/textproc/fribidi/files/CVE-2019-18397.patch
+++ b/textproc/fribidi/files/CVE-2019-18397.patch
@@ -1,0 +1,24 @@
+From 034c6e9a1d296286305f4cfd1e0072b879f52568 Mon Sep 17 00:00:00 2001
+From: Dov Grobgeld <dov.grobgeld@gmail.com>
+Date: Thu, 24 Oct 2019 09:37:29 +0300
+Subject: [PATCH] Truncate isolate_level to FRIBIDI_BIDI_MAX_EXPLICIT_LEVEL
+
+---
+ lib/fribidi-bidi.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/lib/fribidi-bidi.c b/lib/fribidi-bidi.c
+index 6c84392..d384878 100644
+--- lib/fribidi-bidi.c
++++ lib/fribidi-bidi.c
+@@ -747,7 +747,9 @@ fribidi_get_par_embedding_levels_ex (
+             }
+ 
+ 	  RL_LEVEL (pp) = level;
+-          RL_ISOLATE_LEVEL (pp) = isolate_level++;
++          RL_ISOLATE_LEVEL (pp) = isolate_level;
++          if (isolate_level < FRIBIDI_BIDI_MAX_EXPLICIT_LEVEL-1)
++              isolate_level++;
+           base_level_per_iso_level[isolate_level] = new_level;
+ 
+ 	  if (!FRIBIDI_IS_NEUTRAL (override))


### PR DESCRIPTION


#### Description
see https://seclists.org/oss-sec/2019/q4/59

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
macOS 10.15.1 19B88
Xcode 11.2 11B52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
