### PR TITLE
openjdk8: update OpenJ9 subports to OpenSSL 1.1.1d

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -11,7 +11,7 @@ set major        8
 
 subport openjdk8-openj9 {
     version      8u232
-    revision     0
+    revision     1
 
     set build    09
     set major    8
@@ -20,7 +20,7 @@ subport openjdk8-openj9 {
 
 subport openjdk8-openj9-large-heap {
     version      8u232
-    revision     0
+    revision     1
 
     set build    09
     set major    8
@@ -45,7 +45,7 @@ subport openjdk11 {
 
 subport openjdk11-openj9 {
     version      11.0.5
-    revision     0
+    revision     1
 
     set build    10
     set major    11
@@ -54,7 +54,7 @@ subport openjdk11-openj9 {
 
 subport openjdk11-openj9-large-heap {
     version      11.0.5
-    revision     0
+    revision     1
 
     set build    10
     set major    11
@@ -97,7 +97,7 @@ subport openjdk13 {
 
 subport openjdk13-openj9 {
     version      13.0.1
-    revision     0
+    revision     1
 
     set build    9
     set major    13
@@ -106,7 +106,7 @@ subport openjdk13-openj9 {
 
 subport openjdk13-openj9-large-heap {
     version      13.0.1
-    revision     0
+    revision     1
 
     set build    9
     set major    13
@@ -150,11 +150,13 @@ if {${subport} eq "openjdk8"} {
     configure.cxx_stdlib libstdc++
 
 } elseif {${subport} eq "openjdk8-openj9"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}.${revision}_openj9-${openj9_version}/
+    # Temporary dist_subdir for stealth update: https://trac.macports.org/wiki/PortfileRecipes#stealth-updates
+    dist_subdir  ${name}/${version}_${revision}
 
-    checksums    rmd160  339903ae88b6fc5c0ce96b17f1c4d9dd154465d6 \
-                 sha256  c689b6dd149daa33663d9a6821fe7536f4448744d8a1df18b4790cbe96f52d21 \
-                 size    114223649
+    checksums    rmd160  d90d77e1ee0d2752f992ba8a53dbcad9602e191d \
+                 sha256  168079dcc20f62ac4409800c78d23a63ba7c665e58cd7ac8bde21ebbbb2b6d48 \
+                 size    114222397
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}b${build}_openj9-${openj9_version}
     worksrcdir   jdk${version}-b${build}
@@ -167,11 +169,13 @@ if {${subport} eq "openjdk8"} {
                  VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
                  suitable for running all workloads.
 } elseif {${subport} eq "openjdk8-openj9-large-heap"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}.${revision}_openj9-${openj9_version}/
+    # Temporary dist_subdir for stealth update: https://trac.macports.org/wiki/PortfileRecipes#stealth-updates
+    dist_subdir  ${name}/${version}_${revision}
 
-    checksums    rmd160  6cba2677ee4ff78b69b12e008b14db0b778925b1 \
-                 sha256  13f91afd57facafd2fd196b83a6e3e3859e4aa46ad17eea7938bbff241b5150f \
-                 size    114212803
+    checksums    rmd160  5b541680f690a2eb353c764dba8c5ddf62f8f366 \
+                 sha256  e28e308321886fe98caada4148a6ee768b22e97486696220ffde6c174fe75fa9 \
+                 size    114212346
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}b${build}_openj9-${openj9_version}
     worksrcdir   jdk${version}-b${build}
@@ -214,11 +218,13 @@ if {${subport} eq "openjdk8"} {
     distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}_${build}
     worksrcdir   jdk-${version}+${build}
 } elseif {${subport} eq "openjdk11-openj9"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.${revision}_openj9-${openj9_version}/
+    # Temporary dist_subdir for stealth update: https://trac.macports.org/wiki/PortfileRecipes#stealth-updates
+    dist_subdir  ${name}/${version}_${revision}
 
-    checksums    rmd160  ce3acca7195363e60c507edec299dec4ed0fe3f8 \
-                 sha256  c3b8d7de2e063e8066ca0dfcb2e1c12a2c0a11b81ba2f2af0d6bd25388d34dc8 \
-                 size    196975017
+    checksums    rmd160  1915fac0403ce775419dcccaafe74de9a8432cac \
+                 sha256  97dc8234b73e233316b5dfdca75af9a0d54aa23b1309b1a68fd0a5d2fa928e05 \
+                 size    196981668
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
     worksrcdir   jdk-${version}+${build}
@@ -231,11 +237,13 @@ if {${subport} eq "openjdk8"} {
                  VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
                  suitable for running all workloads.
 } elseif {${subport} eq "openjdk11-openj9-large-heap"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.${revision}_openj9-${openj9_version}/
+    # Temporary dist_subdir for stealth update: https://trac.macports.org/wiki/PortfileRecipes#stealth-updates
+    dist_subdir  ${name}/${version}_${revision}
 
-    checksums    rmd160  0d79bb5164d12552683b555f8b36c080908e8b86 \
-                 sha256  f6d6daeae903197230cb77a7cd0fb803f174b934811b29b9ef8511e59c8f43d0 \
-                 size    196982387
+    checksums    rmd160  5d0f9d8f81dec18bd5d2a57fcf2684759e87b9d3 \
+                 sha256  5bfc4ad3b3568303091e3863c4c9baff279929a35326dd48fb26d8e95e8e3174 \
+                 size    196984646
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
     worksrcdir   jdk-${version}+${build}
@@ -304,12 +312,14 @@ if {${subport} eq "openjdk8"} {
 
     worksrcdir   jdk-${version}+${build}
 } elseif {${subport} eq "openjdk13-openj9"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.${revision}_openj9-${openj9_version}/
+    # Temporary dist_subdir for stealth update: https://trac.macports.org/wiki/PortfileRecipes#stealth-updates
+    dist_subdir  ${name}/${version}_${revision}
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
 
-    checksums    rmd160  232648314bf0d1ef4bb613cacbc0b3cee832be98 \
-                 sha256  fe658dfb15ebcf05d5f222062f1a067b88780a190baae7b7e9488cb2cb58e15e \
-                 size    201711210
+    checksums    rmd160  8bd31c96ae660af6af81be78dd50b2103424bfa5 \
+                 sha256  ea578286d726c0cc9660625f4cd93f67fe1ca89d47584bc4d14bda71f9cb2d5d \
+                 size    201722075
 
     worksrcdir   jdk-${version}+${build}
 
@@ -321,12 +331,14 @@ if {${subport} eq "openjdk8"} {
                  VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
                  suitable for running all workloads.
 } elseif {${subport} eq "openjdk13-openj9-large-heap"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.${revision}_openj9-${openj9_version}/
+    # Temporary dist_subdir for stealth update: https://trac.macports.org/wiki/PortfileRecipes#stealth-updates
+    dist_subdir  ${name}/${version}_${revision}
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
 
-    checksums    rmd160  1ca48c87226d33b829946481de6fe48206c51842 \
-                 sha256  66176195bd5f77056204371a46a3b6a91f194efc4c67433c6628322d75fddb07 \
-                 size    201739900
+    checksums    rmd160  401a9beec2f300b0739d7757aa1bc3aacd676b44 \
+                 sha256  0f8b8b11faa2d128adba469429d5fbfd524bc9948e9b16bb78ab8efb43b4018c \
+                 size    201721778
 
     worksrcdir   jdk-${version}+${build}
 


### PR DESCRIPTION
#### Description

Update OpenJ9-based AdoptOpenJDK subports to OpenSSL 1.1.1d.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on

macOS 10.15.1 19B88
Xcode 11.2 11B52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?