### PR TITLE
qsynth: use original icns file

### DIFF
--- a/audio/qsynth/Portfile
+++ b/audio/qsynth/Portfile
@@ -45,14 +45,6 @@ configure.args-append \
                     -DBUNDLE_INSTALL_DIR=${qt_apps_dir}
 
 if {${os.platform} eq "darwin"} {
-    # https://sourceforge.net/p/qsynth/tickets/19/
-    depends_build-append \
-                    port:makeicns
-
-    post-extract {
-        system -W ${worksrcpath}/src/images "${prefix}/bin/makeicns -in qsynth.png -out qsynth.icns"
-    }
-
     post-destroot {
         if {[info procs qt5.add_app_wrapper] ne ""} {
            qt5.add_app_wrapper qsynth


### PR DESCRIPTION
qsynth.icns is now present in the source package.
(Moreover, the build previously failed in trace mode,
since makeicns was hidden from the extract phase.)

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G9016
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
