### PR TITLE
x264: -fno-stack-check to avoid segfault on macOS 10.15

### DIFF
--- a/multimedia/x264/Portfile
+++ b/multimedia/x264/Portfile
@@ -32,9 +32,12 @@ minimum_xcodeversions {9 3.1}
 
 depends_build       port:nasm
 
+
 # as of 20190313 the PPC assembly uses VSX, which is Power7+ only. We could disable asm, but
 # instead we can use the previous ppc assembly,  which does compile and provides the same functions
-patchfiles-append   patch-x264-older-ppc-code.diff
+
+# -- this seems to not be available from the distfiles mirrors anymore and is PPC only?
+#patchfiles-append   patch-x264-older-ppc-code.diff
 
 configure.args      --enable-pic \
                     --enable-shared \
@@ -86,6 +89,9 @@ platform darwin 8 {
 # sets its own optflags
 configure.optflags
 configure.cflags-append -I. -fno-common -read_only_relocs suppress
+
+# avoid issues with Xcode 12.x on macOS 10.15 where x264 will segfault
+configure.cflags-append -fno-stack-check
 
 destroot.args       DIR_INSTALL=${destroot}${prefix}
 


### PR DESCRIPTION
#### Description

x264 will segfault on macOS 10.15 in what appears to be a similar issue to https://trac.macports.org/ticket/59246. Use `-fno-stack-check` in `cflags` to avoid this.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.1 19B88
Xcode 11.2.1 11B53 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
