### PR TITLE
gmp: allow build on older systems

### DIFF
--- a/devel/gmp/Portfile
+++ b/devel/gmp/Portfile
@@ -132,6 +132,13 @@ if { ${auto_cpu} } {
 
 xcode_workaround.type append_to_compiler_name
 
+# see https://trac.macports.org/ticket/59493
+if {${os.platform} eq "darwin" && ${os.major} < 10 && [string match *clang* ${configure.compiler}]} {
+    depends_build-append port:cctools
+    configure.env-append NM=${prefix}/bin/nm
+    configure.args-append lt_cv_path_NM=${prefix}/bin/nm
+}
+
 if {![variant_isset universal]} {
     if {${build_arch} eq "x86_64"} {
         configure.env-append   ABI=64


### PR DESCRIPTION
Fixes https://trac.macports.org/ticket/59493

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6
Xcode 11.2 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
