### PR TITLE
remove obsolete Python subports (maintainer: stromnov)

### DIFF
--- a/python/py-DAWG/Portfile
+++ b/python/py-DAWG/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 platforms           darwin
 license             MIT
 
-python.versions     27 34 35 36
+python.versions     27 35 36
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -23,15 +23,12 @@ master_sites        pypi:D/DAWG/
 distname            DAWG-${version}
 
 checksums           rmd160  5bf0ce20bc7624bdfd1c4cdeff5d2aaee9e66637 \
-                    sha256  30d5da3e48b8cbe5ec94c5a202d2962780d3895ba0883123e6788565f71b2953
+                    sha256  30d5da3e48b8cbe5ec94c5a202d2962780d3895ba0883123e6788565f71b2953 \
+                    size    255839
 
 if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
 
     livecheck.type      none
-} else {
-    livecheck.type      regex
-    livecheck.url       https://pypi.python.org/pypi/DAWG/json
-    livecheck.regex     {DAWG-(\d+(?:\.\d+)*)\.[tz]}
 }

--- a/python/py-acora/Portfile
+++ b/python/py-acora/Portfile
@@ -10,7 +10,7 @@ categories-append   textproc devel
 platforms           darwin
 license             BSD
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-actdiag/Portfile
+++ b/python/py-actdiag/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             Apache-2
 supported_archs     noarch
 
-python.versions     27 34 35 36
+python.versions     27 35 36
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -24,15 +24,12 @@ master_sites        pypi:a/actdiag/
 distname            actdiag-${version}
 
 checksums           rmd160  f9137bae326346a1e86b02212075b687942cd082 \
-                    sha256  983071777d9941093aaef3be1f67c198a8ac8d2bba264cdd1f337ca415ab46af
+                    sha256  983071777d9941093aaef3be1f67c198a8ac8d2bba264cdd1f337ca415ab46af \
+                    size    2577258
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-setuptools \
                         port:py${python.version}-blockdiag
 
     livecheck.type      none
-} else {
-    livecheck.type      regex
-    livecheck.url       https://pypi.python.org/pypi/actdiag/json
-    livecheck.regex     {actdiag-(\d+(?:\.\d+)*)\.[tz]}
 }

--- a/python/py-amqp/Portfile
+++ b/python/py-amqp/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -31,15 +31,6 @@ if {${name} ne ${subport}} {
     depends_build-append \
                         port:py${python.version}-setuptools
     depends_lib-append  port:py${python.version}-vine
-
-    if {${python.version} eq 34} {
-        version             2.4.2
-        revision            0
-        distname            ${python.rootname}-${version}
-        checksums           rmd160  78514e5604eff9220a051bf6eb55ee91b4c5e39e \
-                            sha256  043beb485774ca69718a35602089e524f87168268f0d1ae115f28b88d27f92d7 \
-                            size    116265
-    }
 
     livecheck.type      none
 }

--- a/python/py-backports-ssl_match_hostname/Portfile
+++ b/python/py-backports-ssl_match_hostname/Portfile
@@ -12,7 +12,7 @@ license             PSF
 supported_archs     noarch
 
 # do not add subports for python > 3.4
-python.versions     27 34
+python.versions     27
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-backports/Portfile
+++ b/python/py-backports/Portfile
@@ -11,7 +11,7 @@ license             PSF
 supported_archs     noarch
 
 # do not add subports for python > 3.4
-python.versions     27 34
+python.versions     27
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-billiard/Portfile
+++ b/python/py-billiard/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 platforms           darwin
 license             BSD
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-blist/Portfile
+++ b/python/py-blist/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 platforms           darwin
 license             BSD
 
-python.versions     27 34 35 36
+python.versions     27 35 36
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -24,7 +24,8 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
 checksums           rmd160  d94195d48b44bba1009ad7e27e6c2e431bef4559 \
-                    sha256  3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3
+                    sha256  3a12c450b001bdf895b30ae818d4d6d3f1552096b8c995f0fe0c74bef04d1fc3 \
+                    size    122442
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -49,6 +50,4 @@ if {${name} ne ${subport}} {
     }
 
     livecheck.type      none
-} else {
-    livecheck.type      pypi
 }

--- a/python/py-blosc/Portfile
+++ b/python/py-blosc/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 platforms           darwin
 license             MIT
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -28,7 +28,7 @@ long_description    Blosc (http://blosc.pytables.org) is a high performance \
                     \
                     This is a Python package that wraps it.
 
-homepage            http://blosc.pytables.org/
+homepage            http://python-blosc.blosc.org/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
@@ -46,6 +46,15 @@ if {${name} ne ${subport}} {
     depends_lib-append  port:blosc
 
     build.args-append   --blosc=${prefix}
+
+    pre-test {
+        test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
+    }
+
+    test.run            yes
+    test.dir            ${build.dir}/blosc
+    test.cmd            ${python.bin} test.py
+    test.target
 
     livecheck.type      none
 }

--- a/python/py-celery/Portfile
+++ b/python/py-celery/Portfile
@@ -12,7 +12,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-celery/files/py34-celery
+++ b/python/py-celery/files/py34-celery
@@ -1,7 +1,0 @@
--
--
--
--
--
--
-${frameworks_dir}/Python.framework/Versions/3.4/bin/celery

--- a/python/py-colander/Portfile
+++ b/python/py-colander/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-contextlib2/Portfile
+++ b/python/py-contextlib2/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             PSF
 supported_archs     noarch
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-cubes/Portfile
+++ b/python/py-cubes/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 platforms           darwin
 license             BSD
 
-python.versions     27 34 35 36
+python.versions     27 35 36
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -23,7 +23,8 @@ master_sites        pypi:c/cubes/
 distname            cubes-${version}
 
 checksums           rmd160  a01cf288ba56341abae7aba1e61810a686e6ec0b \
-                    sha256  adb34a7d81f8bc30f03933f0f0906e9179cf9415cc2dcebcb9e8aa653442e085
+                    sha256  adb34a7d81f8bc30f03933f0f0906e9179cf9415cc2dcebcb9e8aa653442e085 \
+                    size    128742
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-setuptools \
@@ -35,13 +36,12 @@ if {${name} ne ${subport}} {
         revision            0
         distname            cubes-${version}
         checksums           rmd160  56afb93f9384df3629f7c6d4a59c67b8833b9789 \
-                            sha256  702381127f0baf8c7c67ac777087671b47c04fea56d4b468ac58efa5fd641002
+                            sha256  702381127f0baf8c7c67ac777087671b47c04fea56d4b468ac58efa5fd641002 \
+                            size    158003
         depends_lib-append  port:py${python.version}-tz
     } else {
         depends_lib-append  port:py${python.version}-expressions
     }
 
     livecheck.type      none
-} else {
-    livecheck.type      pypi
 }

--- a/python/py-cytoolz/Portfile
+++ b/python/py-cytoolz/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 platforms           darwin
 license             BSD
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-datrie/Portfile
+++ b/python/py-datrie/Portfile
@@ -5,12 +5,12 @@ PortGroup           python 1.0
 
 name                py-datrie
 version             0.8
-revision            0
+revision            1
 categories-append   devel
 platforms           darwin
-license             LGPL
+license             LGPL-2+
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -27,10 +27,31 @@ checksums           rmd160  9eb01a22060a6845cf03780dadd38c3c285ebda2 \
                     size    226077
 
 if {${name} ne ${subport}} {
+    # Cythonize the C-code since it doesn't work otherwise with Python 3.8
+    # this can likely be removed when upstream realeses a new version
+    if {${python.version} eq 38} {
+        pre-build {
+            system -W ${worksrcpath} "cython-${python.branch} src/datrie.pyx src/cdatrie.pxd src/stdio_ext.pxd -a"
+        }
+
+        depends_build-append \
+                    port:py${python.version}-cython
+    }
+
     depends_build-append \
-                        port:py${python.version}-setuptools
+                    port:py${python.version}-setuptools
 
-    depends_lib-append  port:py${python.version}-pytest-runner
+    depends_test-append \
+                    port:py${python.version}-hypothesis \
+                    port:py${python.version}-pytest
 
-    livecheck.type      none
+    pre-test {
+        test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
+    }
+
+    test.run        yes
+    test.cmd        py.test-${python.branch}
+    test.target
+
+    livecheck.type  none
 }

--- a/python/py-descartes/Portfile
+++ b/python/py-descartes/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
-PortGroup           select 1.0
 
 name                py-descartes
 version             1.1.0
@@ -12,20 +11,21 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 
 description         Use geometric objects as matplotlib paths and patches
 long_description    ${description}
 
-homepage            http://bitbucket.org/sgillies/descartes/
+homepage            https://bitbucket.org/sgillies/descartes/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
 checksums           rmd160  98f8ab1bbe095dced35e650a114e3ffbc8994a10 \
-                    sha256  135a502146af5ed6ff359975e2ebc5fa4b71b5432c355c2cafdc6dea1337035b
+                    sha256  135a502146af5ed6ff359975e2ebc5fa4b71b5432c355c2cafdc6dea1337035b \
+                    size    3525
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-distributed/Portfile
+++ b/python/py-distributed/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -20,7 +20,7 @@ long_description    Dask.distributed is a lightweight library for distributed \
                     computing in Python. It extends both the concurrent.futures \
                     and dask APIs to moderate sized clusters.
 
-homepage            http://distributed.readthedocs.io/en/latest/
+homepage            https://distributed.readthedocs.io/en/latest/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}

--- a/python/py-dynd/Portfile
+++ b/python/py-dynd/Portfile
@@ -13,7 +13,7 @@ categories-append   devel
 platforms           darwin
 license             BSD
 
-python.versions     27 34 35 36
+python.versions     27 35 36
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -24,7 +24,8 @@ long_description    DyND-Python, a component of the Blaze project, is the \
                     array library.
 
 checksums           rmd160  dc0c24136b8b295ab85046489b6a3b05146ce8b2 \
-                    sha256  0ef58192fa66e9401dce91bc8a5602e16397529464e2bb027af62ed6f19d7a2c
+                    sha256  0ef58192fa66e9401dce91bc8a5602e16397529464e2bb027af62ed6f19d7a2c \
+                    size    184984
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-ecdsa/Portfile
+++ b/python/py-ecdsa/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-editor/Portfile
+++ b/python/py-editor/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             Apache
 supported_archs     noarch
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-funcsigs/Portfile
+++ b/python/py-funcsigs/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             Apache-2
 supported_archs     noarch
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-genshi/Portfile
+++ b/python/py-genshi/Portfile
@@ -10,7 +10,7 @@ categories-append   textproc www
 platforms           darwin
 license             BSD
 
-python.versions     27 34 35 36
+python.versions     27 35 36
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -27,7 +27,8 @@ master_sites        http://ftp.edgewall.com/pub/genshi/
 distname            Genshi-${version}
 
 checksums           rmd160  3c8d8dfd8cb55b30e38af0039e2c42d56669c913 \
-                    sha256  1d154402e68bc444a55bcac101f96cb4e59373100cc7a2da07fbf3e5cc5d7352
+                    sha256  1d154402e68bc444a55bcac101f96cb4e59373100cc7a2da07fbf3e5cc5d7352 \
+                    size    491579
 
 if {${name} ne ${subport}} {
     livecheck.type      none

--- a/python/py-geohash/Portfile
+++ b/python/py-geohash/Portfile
@@ -4,13 +4,14 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-geohash
+python.rootname     python-geohash
 version             0.8.5
 revision            0
 categories-append   devel math
 platforms           darwin
-license             Apache MIT BSD
+license             Apache-2 MIT BSD
 
-python.versions     27 34 35 36
+python.versions     27 35 36
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -23,12 +24,9 @@ master_sites        pypi:p/python-geohash/
 distname            python-geohash-${version}
 
 checksums           rmd160  e490fb2bc77ad5160a642d54d69555eb9bfbfd6f \
-                    sha256  05a21fcf4eda1a5eddbd291890ade23fc5ddaa6bb98f2ee23d2d384ed14f086d
+                    sha256  05a21fcf4eda1a5eddbd291890ade23fc5ddaa6bb98f2ee23d2d384ed14f086d \
+                    size    17636
 
 if {${name} ne ${subport}} {
     livecheck.type      none
-} else {
-    livecheck.type      regex
-    livecheck.url       https://pypi.python.org/pypi/python-geohash/json
-    livecheck.regex     {python-geohash-(\d+(?:\.\d+)*)\.[tz]}
 }

--- a/python/py-gevent-websocket/Portfile
+++ b/python/py-gevent-websocket/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 34 35 36
+python.versions     27 35 36
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -24,7 +24,8 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
 checksums           rmd160  99ea547011169d06b03e3bcc9ccac6726567c8bb \
-                    sha256  7eaef32968290c9121f7c35b973e2cc302ffb076d018c9068d2f5ca8b2d85fb0
+                    sha256  7eaef32968290c9121f7c35b973e2cc302ffb076d018c9068d2f5ca8b2d85fb0 \
+                    size    18366
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-gevent/Portfile
+++ b/python/py-gevent/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     i386 x86_64
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-hat-trie/Portfile
+++ b/python/py-hat-trie/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 platforms           darwin
 license             MIT
 
-python.versions     27 34 35 36
+python.versions     27 35 36
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -23,13 +23,12 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
 checksums           rmd160  4345c329d1ccf29198f76dd441a55ef17bad0e3a \
-                    sha256  403643764538a3692de2664894d9a0567fe6449465d0a623aed514593e74a1f6
+                    sha256  403643764538a3692de2664894d9a0567fe6449465d0a623aed514593e74a1f6 \
+                    size    79886
 
 if {${name} ne ${subport}} {
     depends_build-append \
                         port:py${python.version}-setuptools
 
     livecheck.type      none
-} else {
-    livecheck.type      pypi
 }

--- a/python/py-hiredis/Portfile
+++ b/python/py-hiredis/Portfile
@@ -10,7 +10,7 @@ categories-append   devel databases
 platforms           darwin
 license             BSD
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -27,5 +27,13 @@ checksums           rmd160  8cb06c2dd5de9ac1ac77759c8bb3890cc67f69be \
                     size    54407
 
 if {${name} ne ${subport}} {
-    livecheck.type      none
+    pre-test {
+        test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
+    }
+
+    test.run        yes
+    test.cmd        ${python.bin} test.py
+    test.target
+
+    livecheck.type  none
 }

--- a/python/py-imread/Portfile
+++ b/python/py-imread/Portfile
@@ -10,7 +10,7 @@ categories-append   graphics
 platforms           darwin
 license             MIT
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-ipaddress/Portfile
+++ b/python/py-ipaddress/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             PSF
 supported_archs     noarch
 
-python.versions     27 34 35 36
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -29,7 +29,12 @@ checksums           rmd160  500a7b9a17545ff9d9d27e653c11bce238a08f9c \
 
 if {${name} ne ${subport}} {
     depends_build-append \
-                        port:py${python.version}-setuptools
+                    port:py${python.version}-setuptools
 
-    livecheck.type      none
+    test.run        yes
+    test.cmd        ${python.bin} test_ipaddress.py
+    test.target
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
+
+    livecheck.type  none
 }

--- a/python/py-ipyparallel/Portfile
+++ b/python/py-ipyparallel/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-iso8601/Portfile
+++ b/python/py-iso8601/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -24,11 +24,20 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
 checksums           rmd160  ae52894b339afe833b31371931c0250dfc5992b8 \
-                    sha256  49c4b20e1f38aa5cf109ddcd39647ac419f928512c869dc01d5c7098eddede82
+                    sha256  49c4b20e1f38aa5cf109ddcd39647ac419f928512c869dc01d5c7098eddede82 \
+                    size    8868
 
 if {${name} ne ${subport}} {
     depends_build-append \
-                        port:py${python.version}-setuptools
+                    port:py${python.version}-setuptools
 
-    livecheck.type      none
+    depends_test-append \
+                    port:py${python.version}-pytest
+
+    test.run        yes
+    test.cmd        py.test-${python.branch}
+    test.target
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
+
+    livecheck.type  none
 }

--- a/python/py-joblib/Portfile
+++ b/python/py-joblib/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-jug/Portfile
+++ b/python/py-jug/Portfile
@@ -9,7 +9,7 @@ revision            0
 platforms           darwin
 license             MIT
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-jupyter/Portfile
+++ b/python/py-jupyter/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -24,7 +24,8 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
 checksums           rmd160  60b8fbadf895ad211192356af59314d0812568e2 \
-                    sha256  d9dc4b3318f310e34c82951ea5d6683f67bed7def4b259fafbfe4f1beb1d8e5f
+                    sha256  d9dc4b3318f310e34c82951ea5d6683f67bed7def4b259fafbfe4f1beb1d8e5f \
+                    size    12916
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-notebook \

--- a/python/py-jupyter_console/Portfile
+++ b/python/py-jupyter_console/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -29,7 +29,7 @@ checksums           rmd160  49e131bc49f75029856ef101883119e02f1951ea \
 
 if {${name} ne ${subport}} {
 
-    if {${python.version} in "27 34"} {
+    if {${python.version} eq 27} {
         version             5.2.0
         revision            0
         distname            ${python.rootname}-${version}

--- a/python/py-jupyterlab_launcher/Portfile
+++ b/python/py-jupyterlab_launcher/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-kombu/Portfile
+++ b/python/py-kombu/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-lepl/Portfile
+++ b/python/py-lepl/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-lepl
+python.rootname     LEPL
 version             5.1.3
 revision            0
 categories-append   devel
@@ -24,15 +25,14 @@ master_sites        pypi:L/LEPL/
 distname            LEPL-${version}
 
 checksums           rmd160  dc5bb15465e38d7748a440e644adbc3a2984a929 \
-                    sha256  a8715c709308350ce4afed5d525682656886d38141387ec87d44421da8d41397
+                    sha256  a8715c709308350ce4afed5d525682656886d38141387ec87d44421da8d41397 \
+                    size    203680
 
-python.default_version  27
-python.versions     27 34 35 36
+python.versions     27 35 36
 
 if {${name} ne ${subport}} {
-    depends_build-append    port:py${python.version}-setuptools
-}
+    depends_build-append \
+                    port:py${python.version}-setuptools
 
-livecheck.type      regex
-livecheck.url       https://pypi.python.org/pypi/lepl/json
-livecheck.regex     "LEPL-(\\d+(?:\\.\\d+)*)${extract.suffix}"
+    livecheck.type  none
+}

--- a/python/py-levenshtein/Portfile
+++ b/python/py-levenshtein/Portfile
@@ -10,7 +10,7 @@ categories-append   textproc
 platforms           darwin freebsd
 license             GPL-2+
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -29,7 +29,8 @@ master_sites        pypi:p/python-Levenshtein/
 distname            python-Levenshtein-${version}
 
 checksums           rmd160  710a87493ceef19ae046195c2d561f2d4d64cf6e \
-                    sha256  033a11de5e3d19ea25c9302d11224e1a1898fe5abd23c61c7c360c25195e3eb1
+                    sha256  033a11de5e3d19ea25c9302d11224e1a1898fe5abd23c61c7c360c25195e3eb1 \
+                    size    48617
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -38,5 +39,4 @@ if {${name} ne ${subport}} {
     livecheck.type      none
 } else {
     livecheck.name      python-Levenshtein
-    livecheck.type      pypi
 }

--- a/python/py-llvmlite/Portfile
+++ b/python/py-llvmlite/Portfile
@@ -11,7 +11,7 @@ categories-append   devel science
 platforms           darwin
 license             BSD
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-llvmmath/Portfile
+++ b/python/py-llvmmath/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 platforms           darwin
 license             BSD
 
-python.versions     27 34 35 36
+python.versions     27 35 36
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -23,7 +23,8 @@ master_sites        pypi:l/llvmmath/
 distname            llvmmath-${version}
 
 checksums           rmd160  83122b865efffc88de2a3bcd6a22d1d803d68069 \
-                    sha256  383a380ee0f7984f50201dc6b0e25ccd291a952ca1afacb850d50dae85810b75
+                    sha256  383a380ee0f7984f50201dc6b0e25ccd291a952ca1afacb850d50dae85810b75 \
+                    size    58145
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-llvmpy/Portfile
+++ b/python/py-llvmpy/Portfile
@@ -15,7 +15,7 @@ license             BSD
 # Stealth update
 dist_subdir         ${name}/${version}_1
 
-python.versions     27 34 35 36
+python.versions     27 35 36
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -27,7 +27,8 @@ long_description    llvmpy is a Python wrapper around the llvm C++ library \
 homepage            http://www.llvmpy.org/
 
 checksums           rmd160  a75da7b2e2d04f8cf2ffb1f5ccd94ebe97d7cfe8 \
-                    sha256  89c705170e372f42bc509b1f197d44a0029f76253bb2b3057ecd666735b42a74
+                    sha256  89c705170e372f42bc509b1f197d44a0029f76253bb2b3057ecd666735b42a74 \
+                    size    573360
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:llvm-3.3

--- a/python/py-logbook/Portfile
+++ b/python/py-logbook/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 platforms           darwin
 license             BSD
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-logilab-common/Portfile
+++ b/python/py-logilab-common/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             LGPL-2.1+
 supported_archs     noarch
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-macfsevents/Portfile
+++ b/python/py-macfsevents/Portfile
@@ -9,7 +9,7 @@ revision            0
 platforms           darwin
 license             BSD
 
-python.versions     27 34 35 36
+python.versions     27 35 36
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -25,7 +25,8 @@ master_sites        pypi:M/MacFSEvents
 distname            MacFSEvents-${version}
 
 checksums           rmd160  4173250047586f3a48b2ff3c88347cac087304bf \
-                    sha256  1324b66b356051de662ba87d84f73ada062acd42b047ed1246e60a449f833e10
+                    sha256  1324b66b356051de662ba87d84f73ada062acd42b047ed1246e60a449f833e10 \
+                    size    13772
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-magic/Portfile
+++ b/python/py-magic/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -27,7 +27,8 @@ master_sites        pypi:p/python-magic
 distname            python-magic-${version}
 
 checksums           rmd160  ad4925d65a20c56ff8696070ac7afdd824989c29 \
-                    sha256  f3765c0f582d2dfc72c15f3b5a82aecfae9498bd29ca840d72f37d7bd38bfcd5
+                    sha256  f3765c0f582d2dfc72c15f3b5a82aecfae9498bd29ca840d72f37d7bd38bfcd5 \
+                    size    73194
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-mahotas/Portfile
+++ b/python/py-mahotas/Portfile
@@ -9,7 +9,7 @@ revision            0
 platforms           darwin
 license             MIT
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-mako/Portfile
+++ b/python/py-mako/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-marisa-trie/Portfile
+++ b/python/py-marisa-trie/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 platforms           darwin
 license             LGPL
 
-python.versions     27 34 35 36
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -23,7 +23,8 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            marisa-trie-${version}
 
 checksums           rmd160  f0c254b37abf122c0b397d3a8954011eac2c5b51 \
-                    sha256  c73bc25d868e8c4ea7aa7f1e19892db07bba2463351269b05340ccfa06eb2baf
+                    sha256  c73bc25d868e8c4ea7aa7f1e19892db07bba2463351269b05340ccfa06eb2baf \
+                    size    270581
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -32,6 +33,17 @@ if {${name} ne ${subport}} {
     post-patch {
         reinplace "s|setup_requires=\\\[\"pytest-runner\"\\\]|setup_requires=\\\[\\\]|" ${worksrcpath}/setup.py
     }
+
+    depends_test-append \
+                    port:py${python.version}-pytest
+
+    pre-test {
+        test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
+    }
+
+    test.run        yes
+    test.cmd        py.test-${python.branch}
+    test.target
 
     livecheck.type      none
 }

--- a/python/py-markdown/Portfile
+++ b/python/py-markdown/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-mdp-toolkit/Portfile
+++ b/python/py-mdp-toolkit/Portfile
@@ -5,13 +5,13 @@ PortGroup           python 1.0
 
 name                py-mdp-toolkit
 version             3.5
-revision            0
+revision            1
 categories-append   science
 platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35 36
+python.versions     27 35 36
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -24,19 +24,21 @@ master_sites        sourceforge:mdp-toolkit
 distname            MDP-${version}
 
 checksums           rmd160  143a23cfc22225a39ca8bee79a2975ad3dd8506e \
-                    sha256  33f13804d32a2430caeef04f5cf3a11209a854ab78f5686b75cff4ed6bff812b
+                    sha256  33f13804d32a2430caeef04f5cf3a11209a854ab78f5686b75cff4ed6bff812b \
+                    size    335420
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-                    port:py${python.version}-py \
-                    port:py${python.version}-pytest
-
     depends_lib-append \
+                    port:py${python.version}-future \
                     port:py${python.version}-numpy
+
+    depends_test-append \
+                    port:py${python.version}-pytest
 
     test.run        yes
     test.cmd        py.test-${python.branch}
     test.target     mdp/test
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     livecheck.type  none
 }

--- a/python/py-meta-devel/Portfile
+++ b/python/py-meta-devel/Portfile
@@ -13,7 +13,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35 36
+python.versions     27 35 36
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -25,7 +25,8 @@ long_description    ${description}
 homepage            http://srossross.github.com/Meta
 
 checksums           rmd160  f61823d29d06a8b7ef80df9acb7f2d019915bc2b \
-                    sha256  7b688d67304bd6e5e64f3bc0ed2d14a8a490cb29ee50a118aa94ab8524e252f0
+                    sha256  7b688d67304bd6e5e64f3bc0ed2d14a8a490cb29ee50a118aa94ab8524e252f0 \
+                    size    47954
 
 if {${name} ne ${subport}} {
     conflicts           py${python.version}-meta

--- a/python/py-monotonic/Portfile
+++ b/python/py-monotonic/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             Apache
 supported_archs     noarch
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-munch/Portfile
+++ b/python/py-munch/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 


### PR DESCRIPTION
#### Description
This PR removes obsolete Python subports for an initial subset of ports maintained by @stromnov that have no dependencies. Subports for newer Python versions were added if the test-suite passes. 

###### Tested on
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? Yes, but only for ports where I added new subports
- [x] tried a full install with `sudo port -vst install`? Yes, but only for ports where I added new subports
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
