### PR TITLE
rxvt-unicode: fix build failure

### DIFF
--- a/x11/rxvt-unicode/Portfile
+++ b/x11/rxvt-unicode/Portfile
@@ -46,6 +46,7 @@ configure.perl  ${prefix}/bin/perl5.28
 
 patchfiles      patch-Makefile.in.diff \
                 patch-perl-5.28-compat.diff \
+                patch-perl-embed-args.diff \
                 CVE-2017-7483.patch
 
 if {[string match *clang* ${configure.cxx}]} {

--- a/x11/rxvt-unicode/files/patch-perl-embed-args.diff
+++ b/x11/rxvt-unicode/files/patch-perl-embed-args.diff
@@ -1,0 +1,29 @@
+--- src/Makefile.in
++++ src/Makefile.in
+@@ -23,7 +23,7 @@ DEFS = @DEFS@
+ LIBS = @LIBS@
+ XINC = @X_CFLAGS@ @PIXBUF_CFLAGS@ @STARTUP_NOTIFICATION_CFLAGS@
+ XLIB = @X_LIBS@ -lX11 @X_EXTRA_LIBS@ @PIXBUF_LIBS@ @STARTUP_NOTIFICATION_LIBS@
+-COMPILE = $(CXX) -I.. -I$(srcdir) -I. -I$(srcdir)/../libev -I$(srcdir)/../libptytty/src $(DEFS) $(CPPFLAGS) $(CXXFLAGS) $(XINC)
++COMPILE = $(CXX) -I.. -I$(srcdir) -I. -I$(srcdir)/../libev -I$(srcdir)/../libptytty/src $(DEFS) $(CPPFLAGS) $(XINC)
+ LINK = @LINKER@ $(LDFLAGS)
+ EXEEXT = @EXEEXT@
+ PERLFLAGS = @PERLFLAGS@
+@@ -57,7 +57,7 @@ RXVTD_BINNAME=$(DESTDIR)$(bindir)/$(RXVTNAME)d$(EXEEXT)
+ #-------------------------------------------------------------------------
+ # inference rules
+ .C.o:
+-	$(COMPILE) -c $<
++	$(COMPILE) $(CXXFLAGS) -c $<
+ 
+ #-------------------------------------------------------------------------
+ 
+@@ -139,7 +139,7 @@ rxvtperl.C: rxvtperl.xs iom_perl.h iom_perl.xs typemap typemap.iom
+ 	PERL="$(PERL)" $(PERL) @PERLPRIVLIBEXP@/ExtUtils/xsubpp -C++ -typemap @PERLPRIVLIBEXP@/ExtUtils/typemap -typemap 'typemap.iom' -typemap 'typemap' -prototypes $(srcdir)/rxvtperl.xs >$@
+ 
+ rxvtperl.o: rxvtperl.C perlxsi.c
+-	$(COMPILE) $(PERLFLAGS) -DLIBDIR="\"$(libdir)/urxvt\"" -c $<
++	$(COMPILE) $(PERLFLAGS) $(CXXFLAGS) -DLIBDIR="\"$(libdir)/urxvt\"" -c $<
+ 
+ depend:
+ 	makedepend -f Makefile.in -I. -I.. -I../libptytty/src -I../libev -Y *.C *.xs >/dev/null 2>&1


### PR DESCRIPTION
urxvt fails to build If the sdk used to build perl is missing, because
the compiler arguments provided by the ExtUtils::Embed perl module
include the corresponding -isysroot option.

Closes: https://trac.macports.org/ticket/59648
