### PR TITLE
helm: add subports (2.16.0, 2.15.2), co-maintainer

### DIFF
--- a/sysutils/helm/Portfile
+++ b/sysutils/helm/Portfile
@@ -7,12 +7,31 @@ name                    helm
 categories              sysutils
 platforms               darwin
 license                 Apache-2
-maintainers             {ogsite.net:sirn @sirn} @pedrohdz openmaintainer
+maintainers             {ogsite.net:sirn @sirn} @pedrohdz {lbschenkel @lbschenkel} \
+                        openmaintainer
 
 subport helm_select {}
 
 # *NOTE* Remember to update `latestVersion` on a version upgrade.
-set latestVersion       helm-2.14
+set latestVersion       helm-2.16
+subport helm-2.16 {
+    set baseVersion     2.16
+    set patchNumber     0
+    revision            0
+    checksums           rmd160  8081c0edb02e047ee8db15d6cc4e47acb0f059ec \
+                        sha256  4544c03e044ad19424136fb66267f21b620eeee46dee9ec7735288081ca8d12a \
+                        size    26558615
+}
+
+subport helm-2.15 {
+    set baseVersion     2.15
+    set patchNumber     2
+    revision            0
+    checksums           rmd160  2f0790dbe10ccebd724f43d5e0f3533b0c389ee1 \
+                        sha256  0815dc44f9f1c5bcee1c130268bfca2ddf6425b60cf042d3b3c907c35ef11e31 \
+                        size    25747450
+}
+
 subport helm-2.14 {
     set baseVersion     2.14
     set patchNumber     2

--- a/sysutils/helm/files/helm2.15
+++ b/sysutils/helm/files/helm2.15
@@ -1,0 +1,2 @@
+bin/helm2.15
+bin/tiller2.15

--- a/sysutils/helm/files/helm2.16
+++ b/sysutils/helm/files/helm2.16
@@ -1,0 +1,2 @@
+bin/helm2.16
+bin/tiller2.16


### PR DESCRIPTION
#### Description

- Added new subports for 2.16.0 and 2.15.2.
- Added myself as co-maintainer, I hope you don't mind (I'm also maintaining `kubectl` and `minikube`)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G1012
Xcode 11.0 11A420a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
