### PR TITLE
mkcert: update to 1.4.1

### DIFF
--- a/security/mkcert/Portfile
+++ b/security/mkcert/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        FiloSottile mkcert 1.4.0 v
+github.setup        FiloSottile mkcert 1.4.1 v
 
 platforms           darwin
 categories          security devel
@@ -28,9 +28,9 @@ long_description    mkcert is a simple tool for making locally-trusted \
                     the system root store, and generates locally-trusted \
                     certificates.
 
-checksums           rmd160  f8b4c885be1ff0935765b7fd2d7f6f4a830219e1 \
-                    sha256  13fb21b151181203c8b33debf2f92791909787fa2d703ac7be341cb42a652537 \
-                    size    375907
+checksums           rmd160  b63c1168126cfcea0b091f25a37ffb89084d3f66 \
+                    sha256  933eb899893fd569448b68091a68726e1d521581ec684b1f80cf73e0e97396c8 \
+                    size    18110
 
 depends_build       port:go
 use_configure       no
@@ -38,6 +38,7 @@ use_configure       no
 build.cmd           ${prefix}/bin/go
 build.target        build
 build.env           GOPATH=${workpath}
+build.args          -ldflags '-X main.Version=${version}'
 
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.1 19B88
Xcode 11.2 11B52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
