### PR TITLE
lazygit: update to 0.10.4

### DIFF
--- a/devel/lazygit/Portfile
+++ b/devel/lazygit/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/jesseduffield/lazygit 0.9 v
+go.setup            github.com/jesseduffield/lazygit 0.10.4 v
 categories          devel
 license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
@@ -11,9 +11,12 @@ maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
 description         A simple terminal UI for git commands, written in Go
 long_description    $description
 
-checksums           rmd160  7a7d5009dd6c001906fbf142baba52e1d1aad0b0 \
-                    sha256  a3e2437ba241562984eed282cf856b3efc9b7b3688eef56393e2e5b5bc14bd76 \
-                    size    7249510
+checksums           rmd160  cb4db079c9056f467e4495a8bfe6ce95c77dedbc \
+                    sha256  97c79fd93b8c7028da80899d7f02f4ddab8785e898709e5e0134378a02d348bd \
+                    size    7486637
+
+build.args          -ldflags \
+                      '-X main.version=${version} -X main.buildSource=macports'
 
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.1 19B88
Xcode 11.2 11B52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
