### PR TITLE
remove obsolete Python subports (maintainer: mojca)

### DIFF
--- a/python/py-numpydoc/Portfile
+++ b/python/py-numpydoc/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  14a0bddfb0cf0d9810b92055d7b3c680830132e3 \
                     sha256  e08f8ee92933e324ff347771da15e498dbf0bc6295ed15003872b34654a0a627 \
                     size    27583
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -32,11 +32,11 @@ if {${name} ne ${subport}} {
 
     depends_test-append  \
                         port:py${python.version}-nose
+
     test.run            yes
     test.cmd            nosetests-${python.branch}
     test.target
+    test.env            PYTHONPATH=${worksrcpath}/build/lib
 
     livecheck.type      none
-} else {
-    livecheck.type      pypi
 }

--- a/python/py-paho-mqtt/Portfile
+++ b/python/py-paho-mqtt/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-paho-mqtt
-set internal_name   paho-mqtt
-version             1.4.0
+version             1.5.0
+revision            0
 platforms           darwin
 # Eclipse Public License v1.0 / Eclipse Distribution License v1.0
 license             unknown
@@ -14,23 +14,19 @@ maintainers         {mojca @mojca} openmaintainer
 description         MQTT version 3.1/3.1.1 client class
 long_description    Eclipse Paho MQTT Python client library
 
-homepage            http://eclipse.org/paho
-master_sites        pypi:p/${internal_name}
-distname            ${internal_name}-${version}
+homepage            https://eclipse.org/paho
+master_sites        pypi:p/${python.rootname}
+distname            ${python.rootname}-${version}
 
-checksums           rmd160  32e05e56cec24bb3e065270f6d12cead68b9b5d8 \
-                    sha256  e440a052b46d222e184be3be38676378722072fcd4dfd2c8f509fb861a7b0b79 \
-                    size    88626
+checksums           rmd160  d1edc86d593af29a2bc6cf6ca269140ac082fa42 \
+                    sha256  e3d286198baaea195c8b3bc221941d25a3ab0e1507fc1779bdb7473806394be4 \
+                    size    99525
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 if {${name} ne ${subport}} {
     depends_build-append \
-                        port:py${python.version}-setuptools
+                    port:py${python.version}-setuptools
 
-    livecheck.type      none
-} else {
-    livecheck.type      regex
-    livecheck.url       https://pypi.python.org/pypi/${internal_name}
-    livecheck.regex     ${internal_name}-(\[0-9.\]+)\\.tar\\.gz
+    livecheck.type  none
 }

--- a/python/py-pypeg2/Portfile
+++ b/python/py-pypeg2/Portfile
@@ -4,24 +4,36 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pypeg2
+python.rootname     pyPEG2
 version             2.15.2
+revision            0
+
 categories          python lang
 platforms           darwin
 license             GPL-2
 maintainers         {mojca @mojca} openmaintainer
+
 description         An intrinsic PEG Parser-Interpreter for Python
 long_description    ${description}
+
 homepage            https://fdik.org/pyPEG/
 master_sites        pypi:p/pyPEG2
 distname            pyPEG2-${version}
 
 checksums           rmd160  594103ba8a33086a306a172f27c6d29cf0c1435a \
-                    sha256  2b2d4f80d8e1a9370b2a91f4a25f4abf7f69b85c8da84cd23ec36451958a1f6d
+                    sha256  2b2d4f80d8e1a9370b2a91f4a25f4abf7f69b85c8da84cd23ec36451958a1f6d \
+                    size    40334
 
-python.versions     27 34 35 36
+python.versions     27 35 36 37 38
 
 if { ${name} ne ${subport} } {
     depends_run     port:py${python.version}-lxml
-    # TODO: enable testing (test suite exists)
+
+    test.run        yes
+    test.dir        ${build.dir}/pypeg2/test
+    test.cmd        ${python.bin} test_pyPEG2.py && ${python.bin} test_xmlast.py
+    test.target
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
+
     livecheck.type  none
 }

--- a/python/py-spacepy/Portfile
+++ b/python/py-spacepy/Portfile
@@ -1,11 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 PortGroup           python 1.0
 
+github.setup        spacepy spacepy 0.2.1 release-
 name                py-spacepy
-python.rootname     spacepy
-version             0.1.6
+github.tarball_from releases
 platforms           darwin
 license             PSF
 maintainers         {mojca @mojca} openmaintainer
@@ -13,14 +14,13 @@ maintainers         {mojca @mojca} openmaintainer
 description         SpacePy Tools for Space Science Applications
 long_description    ${description}
 
-homepage            http://spacepy.lanl.gov
-master_sites        sourceforge:project/${python.rootname}/${python.rootname}/${python.rootname}-${version}
-distname            ${python.rootname}-${version}
+homepage            https://spacepy.github.io
 
-checksums           rmd160  729328bb82ee15f377390465d90e62222c5d5f45 \
-                    sha256  61bc67d638313d264a29450fe59c3d272fa8a1dc80eb44eff3ded9ed9820177c
+checksums           rmd160  b8ed170a52f00a103c519714530aadbace4a33d3 \
+                    sha256  2a3f1b84fb80bfbd1366c3721645d876388254bbd8056d710562a1e0634b03bc \
+                    size    8858235
 
-python.versions     27 34 35 36
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
     # TODO: figure out which ones are build dependencies and which ones are runtime
@@ -38,13 +38,13 @@ if {${name} ne ${subport}} {
     # TODO: use the compilers portgroup
     if {${os.major} > 9} {
         depends_build-append \
-                    port:gcc6
+                    port:gcc9
         configure.env-append \
-                    F77=${prefix}/bin/gfortran-mp-6 \
-                    F90=${prefix}/bin/gfortran-mp-6
+                    F77=${prefix}/bin/gfortran-mp-9 \
+                    F90=${prefix}/bin/gfortran-mp-9
         build.env-append \
-                    F77=${prefix}/bin/gfortran-mp-6 \
-                    F90=${prefix}/bin/gfortran-mp-6
+                    F77=${prefix}/bin/gfortran-mp-9 \
+                    F90=${prefix}/bin/gfortran-mp-9
     } else {
         # https://trac.macports.org/ticket/51388
         depends_build-append \
@@ -73,6 +73,4 @@ if {${name} ne ${subport}} {
     }
 
     livecheck.type  none
-} else {
-    livecheck.regex "${python.rootname}-(\[a-zA-Z0-9.\]+)\/${python.rootname}-"
 }


### PR DESCRIPTION
#### Description
This PR removes obsolete Python subports for ports maintained by @mojca that have no dependencies. Subports for newer Python versions were added if the test-suite passes. 
I have update ```py-paho-mqtt``` to its latest version; please note that development of ``` py-spacepy``` has continued at [GitHub](https://github.com/spacepy/spacepy) (now at version 0.2.1, I did not attempt an update).

###### Tested on
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? Yes, but only for ports where I added new subports
- [x] tried a full install with `sudo port -vst install`? Yes, but only for ports where I added new subports
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
