### PR TITLE
kubectl: Updating 1.15.5 and 1.14.8

### DIFF
--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -26,17 +26,17 @@ subport kubectl-1.16 {
 }
 
 subport kubectl-1.15 {
-    set patchNumber     4
-    checksums           rmd160  e769db0689e797c826d879a035a0202588a0df82 \
-                        sha256  45737d73d16a82a7855deb0cf1d7c9bae1315ea59b4364b95482a03cbcc965d2 \
-                        size    48591088
+    set patchNumber     5
+    checksums           rmd160  2492d019a762096a2211b7fc38d0a0a493060d82 \
+                        sha256  6bc71aa53567ad6dda92d0cc733adce67251434851847dbae6216a1f254336f3 \
+                        size    48596112
 }
 
 subport kubectl-1.14 {
-    set patchNumber     4
-    checksums           rmd160  92a520f847e959e04cf5d7602d8c419fa6c26d1d \
-                        sha256  de3a28b0245d67b81b75f731b74a17def673ae4a87c98071421394888b5495d8 \
-                        size    48702920
+    set patchNumber     8
+    checksums           rmd160  8611eb77c1969da0819e2059139300034c28a076 \
+                        sha256  f8bf94a564bad769efa08a4bb05c5b6d10f2fffd2cee47377690d12b04c87644 \
+                        size    48707608
 }
 
 subport kubectl-1.13 {


### PR DESCRIPTION
- kubectl-1.15.5
- kubectl-1.14.8

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G1012
Xcode 11.2 11B52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
