### PR TITLE
prometheus: update to 2.14.0; Prometheus now requires Yarn at build-t…

### DIFF
--- a/net/prometheus/Portfile
+++ b/net/prometheus/Portfile
@@ -1,7 +1,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        prometheus prometheus 2.13.1 v
+github.setup        prometheus prometheus 2.14.0 v
 github.tarball_from archive
 
 description         The Prometheus monitoring system and time series database
@@ -21,7 +21,8 @@ license             Apache-2
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
 
 depends_build       port:go \
-                    port:promu
+                    port:promu \
+                    port:yarn
 
 build.env           GOPATH=${workpath} \
                     PATH=${workpath}/bin:$env(PATH)
@@ -41,9 +42,9 @@ set prom_share_dir  ${prefix}/share/${name}
 set prom_log_dir    ${prefix}/var/log/${name}
 set prom_log_file   ${prom_log_dir}/${name}.log
 
-checksums   rmd160  1226d0bf75f7db7366ac24099dd53286f149c471 \
-            sha256  5624c16728679362cfa46b76ec1d247018106989f2260d35583c42c49c5142b5 \
-            size    15249891
+checksums   rmd160  22f7a8eff328b7ac6c1788fb0662f5b67c241b12 \
+            sha256  5c40de1961997996ef5b59561a78116a9548235bc77305c05f214b6319a0284d \
+            size    12755125
 
 add_users           ${prom_user} \
                     group=${prom_user} \


### PR DESCRIPTION
…ime to build its React Web UI

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.1 19B88
Xcode 11.2 11B52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
