### PR TITLE
py-pyaudio: fix example folder; add python 3.8; remove python 3.4

### DIFF
--- a/python/py-pyaudio/Portfile
+++ b/python/py-pyaudio/Portfile
@@ -26,10 +26,11 @@ distname                ${my_name}-${version}
 checksums               rmd160  7a6bb88f56622555e77eb799e4ee74ff970b6e92 \
                         sha256  93bfde30e0b64e63a46f2fd77e85c41fd51182a4a3413d9edfaf9ffaa26efb74 \
                         size    37428
+revision                1
 
 worksrcdir              PyAudio-${version}
 
-python.versions         27 34 35 36 37
+python.versions         27 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -46,12 +47,11 @@ if {${name} ne ${subport}} {
     python.link_binaries no
 
     post-destroot {
-        xinstall -d ${destroot}${prefix}/share/doc/py${python.version}-pyaudio
-        xinstall -m 640 {*}[glob ${worksrcpath}/examples/*] \
+        xinstall -d ${destroot}${prefix}/share/doc/py${python.version}-pyaudio/examples
+        xinstall -m 0644 -W ${worksrcpath} README CHANGELOG \
             ${destroot}${prefix}/share/doc/py${python.version}-pyaudio
-        xinstall -d ${destroot}${prefix}/share/examples/py-pyaudio
-        xinstall -m 640 {*}[glob ${worksrcpath}/examples/*] \
-            ${destroot}${prefix}/share/examples/py-pyaudio
+        xinstall -m 0644 {*}[glob ${worksrcpath}/examples/*] \
+            ${destroot}${prefix}/share/doc/py${python.version}-pyaudio/examples
     }
 
     livecheck.type      none


### PR DESCRIPTION
#### Description

    - example folder must be versioned otherwise collision happens
    - add python 3.8 support
    - remove python 3.4 EOL

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.1 19B88
Xcode 11.2 11B52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
