### PR TITLE
clang-3.4: Fix bootstrap issues on Tiger

### DIFF
--- a/lang/llvm-3.4/Portfile
+++ b/lang/llvm-3.4/Portfile
@@ -63,8 +63,8 @@ if {${subport} eq "llvm-${llvm_version}"} {
     }
 }
 
-if {${os.platform} eq "darwin" && ${os.major} < 12 && ${cxx_stdlib} eq "libc++"} {
-    if {${os.major} < 11} {
+if {${os.platform} eq "darwin" && ${os.major} < 12} {
+    if {${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {
         configure.cxx_stdlib    libstdc++
         # Have to also use bootstrap versions of deps that use libstdc++ in
         # order to be able to build libc++.


### PR DESCRIPTION
#### Description

Previously the special case for bootstrapping on old systems would only run if the cxx_stdlib is libc++. On Tiger this is not the case, but the libxml2/icu bootstrapping is still needed (otherwise there is a circular dependency clang-3.4 -> libxml2 -> icu -> clang-3.4).

I've only tested this on Intel, but according to [LibcxxOnOlderSystems](https://trac.macports.org/wiki/LibcxxOnOlderSystems#Leopardppc) it's not possible to bootstrap clang on PowerPC anyway, so I don't think it makes a difference.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.4
Xcode 2.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
