### PR TITLE
yubico-authenticator: new port

### DIFF
--- a/aqua/yubico-authenticator/Portfile
+++ b/aqua/yubico-authenticator/Portfile
@@ -1,0 +1,55 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           qmake5 1.0
+PortGroup           github 1.0
+
+qt5.depends_component qtdeclarative qtquickcontrols2
+
+name                yubico-authenticator
+github.setup        Yubico yubioath-desktop 5.0.1 yubioath-desktop-
+revision            0
+categories          aqua security
+platforms           darwin
+license             BSD
+maintainers         {amake @amake} openmaintainer
+
+description         Tool for generating one-time password codes with YubiKey
+long_description \
+    Cross-platform application for generating Open Authentication (OATH) \
+    time-based TOTP and event-based HOTP one-time password codes, with the help \
+    of a YubiKey that protects the shared secrets.
+
+homepage            https://developers.yubico.com/yubioath-desktop/
+
+checksums           rmd160  a4a0d1d4a4f67ca940d02d398bae99e74d9f107a \
+                    sha256  97bcb5ef12559fa6122bd9ba1cc53ca2e4d932be8b73e1ba2366c77f718574ae \
+                    size    4847629
+
+# Python version must be synced with pyotherside and yubikey-manager ports
+set python.version  37
+set python.branch   [string range ${python.version} 0 end-1].[string index ${python.version} end]
+set python.prefix   ${frameworks_dir}/Python.framework/Versions/${python.branch}
+set python.pkgd     ${python.prefix}/lib/python${python.branch}/site-packages
+
+depends_lib-append  port:pyotherside
+
+depends_run-append  port:yubikey-manager
+
+patchfiles          0001-Remove-pip-installation-for-packaging-in-MacPorts.patch
+patch.pre_args      -p1
+
+destroot {
+    # Install bundled Python code
+    xinstall -d ${destroot}/${python.pkgd}
+    copy {*}[glob ${worksrcpath}/py/*] ${destroot}${python.pkgd}/
+
+    # Bundled Python is now a symlink to global site-packages
+    ln -s ${python.pkgd} ${worksrcpath}/yubioath-desktop.app/Contents/MacOS/pymodules
+
+    # The default install task insists on putting it in $(INSTALL_ROOT)/usr/bin
+    # so we do our own thing here.
+    system -W ${worksrcpath}/yubioath-desktop.app \
+           "strip Contents/MacOS/yubioath-desktop"
+    copy ${worksrcpath}/yubioath-desktop.app "${destroot}/${applications_dir}/Yubico Authenticator.app"
+}

--- a/aqua/yubico-authenticator/files/0001-Remove-pip-installation-for-packaging-in-MacPorts.patch
+++ b/aqua/yubico-authenticator/files/0001-Remove-pip-installation-for-packaging-in-MacPorts.patch
@@ -1,0 +1,42 @@
+From 563fa1b5cbbe6816f468ea922f381b0892a60265 Mon Sep 17 00:00:00 2001
+From: Aaron Madlon-Kay <aaron@madlon-kay.com>
+Date: Tue, 12 Nov 2019 16:44:11 +0900
+Subject: [PATCH] Remove pip installation for packaging in MacPorts
+
+MacPorts provides the Python modules globally
+---
+ yubioath-desktop.pro | 11 -----------
+ 1 file changed, 11 deletions(-)
+
+diff --git a/yubioath-desktop.pro b/yubioath-desktop.pro
+index f1aff3e..3978e9d 100644
+--- a/yubioath-desktop.pro
++++ b/yubioath-desktop.pro
+@@ -28,16 +28,6 @@ QRC_JSON = resources.json
+ # Generate first time
+ system(python build_qrc.py resources.json)
+ 
+-# Install python dependencies with pip on mac and win
+-win32|macx {
+-    pip.target = pymodules
+-    QMAKE_EXTRA_TARGETS += pip
+-    PRE_TARGETDEPS += pymodules
+-    QMAKE_CLEAN += -r pymodules
+-}
+-macx {
+-    pip.commands = python3 -m venv pymodules && source pymodules/bin/activate && pip3 install -r requirements.txt && deactivate
+-}
+ !macx {
+     pip.commands = pip3 install -r requirements.txt --target pymodules
+ }
+@@ -52,7 +42,6 @@ RC_ICONS = resources/icons/yubioath.ico
+ macx {
+     ICON = resources/icons/yubioath.icns
+     QMAKE_INFO_PLIST = resources/mac/Info.plist.in
+-    QMAKE_POST_LINK += cp -rnf pymodules/lib/python3*/site-packages/ yubioath-desktop.app/Contents/MacOS/pymodules/
+ }
+ 
+ # For generating a XML file with all strings.
+-- 
+2.24.0
+

--- a/devel/pyotherside/Portfile
+++ b/devel/pyotherside/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           qmake5 1.0
+PortGroup           github 1.0
+
+qt5.depends_component qtdeclarative
+
+github.setup        thp pyotherside 1.5.8
+revision            0
+categories          devel qt5
+platforms           darwin
+license             ISC
+maintainers         {amake @amake} openmaintainer
+
+description         Asynchronous Python 3 Bindings for Qt 5
+long_description    A Qt 5 QML Plugin that provides access to a Python 3 interpreter from QML.
+
+homepage            https://thp.io/2011/pyotherside/
+
+checksums           rmd160  eaa04100b96c551b2feecc6e34ae0037b642d809 \
+                    sha256  af27be92bba79e56b20d652c8eba35ac033c37e4b21a60da2654882026b8de09 \
+                    size    184827
+
+set python.version  37
+set python.branch   [string range ${python.version} 0 end-1].[string index ${python.version} end]
+
+depends_lib-append  port:python${python.version}
+
+configure.args-append \
+    PYTHON_CONFIG=${prefix}/bin/python${python.branch}-config

--- a/security/yubikey-manager/Portfile
+++ b/security/yubikey-manager/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 
 name                yubikey-manager
 github.setup        Yubico yubikey-manager 3.1.0 yubikey-manager-
-revision            1
+revision            2
 categories          security python
 platforms           darwin
 license             BSD
@@ -21,7 +21,10 @@ checksums           rmd160  4e50d02f66be22c2a3eecf7c8b7ae337d23a895e \
                     sha256  bc4a9a7c5e38b2549f3bbf171bafd153aae14fbd05c22ad2f83469bb26d02440 \
                     size    120950
 
-python.default_version 38
+# This must be bumped in step with the yubico-authenticator port's Python
+# version. The full, built app must be tested: Python 3.8 fails at runtime as of
+# 2019-11-12.
+python.default_version 37
 
 depends_build-append \
     port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

This PR adds [Yubico Authenticator](https://developers.yubico.com/yubioath-desktop/), which is like Google Authenticator but for YubiKeys.

I'm mostly looking for a sanity check as I've not worked with Qt ports before.

Also advice on how to handle pyotherside would be welcome: Right now it uses just Python 3.7 because that's what Yubico Authenticator needs. But hypothetically it should probably have variants for different Pythons, but I don't know how to make multiple variants live together in harmony, or how to instruct consuming ports to link to the right one.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.1 19B88
Xcode 11.2 11B52 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
