### PR TITLE
json-modern-cpp: update version to 3.7.2

### DIFF
--- a/devel/json-modern-cpp/Portfile
+++ b/devel/json-modern-cpp/Portfile
@@ -1,24 +1,34 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem          1.0
-PortGroup           github 1.0
-PortGroup           cmake 1.1
-PortGroup           cxx11 1.1
+PortSystem             1.0
+PortGroup              github 1.0
+PortGroup              cmake 1.1
 
-name                json-modern-cpp
-platforms           darwin macosx
-categories          devel
-license             MIT
-maintainers         {@ra1nb0w irh.it:rainbow} openmaintainer
+name                   json-modern-cpp
+platforms              darwin macosx
+supported_archs        noarch
+categories             devel
+license                MIT
+maintainers            {@ra1nb0w irh.it:rainbow} openmaintainer
 
-description         JSON for Modern C++
-long_description    ${description}
+description            JSON for Modern C++
+long_description       ${description}
 
-github.setup        nlohmann json 3.7.0 v
-checksums           rmd160  de5bb385af6c16d14d4ba5632a4c728f7a492d8d \
-    sha256  fd6f4516a9122dc16dd0ad793a9d5f17fe59c12702f24502f70da9dab343eaa6 \
-    size    118869453
-revision            0
+github.setup           nlohmann json 3.7.2 v
+checksums              rmd160  fda813f674ae8aba2a3a1ebd4118f1529bba4fa7 \
+                       sha256  b22dcc77988665cfe9516383cc33d2d1bf64483130240f5475aa553a7e2146d6 \
+                       size    119013338
+revision               0
 
-configure.args-append \
-    -DJSON_BuildTests=OFF
+configure.ccache       no
+compiler.cxx_standard  2011
+configure.args-append  -DJSON_BuildTests=OFF
+
+pre-test {
+    configure.args-replace \
+        -DJSON_BuildTests=OFF -DJSON_BuildTests=ON
+    portconfigure::configure_main
+    portbuild::build_main
+}
+
+test.run yes


### PR DESCRIPTION


#### Description

- bump version to 3.7.2

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.1 19B88
Xcode 11.2 11B52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
