### PR TITLE
New port: MooseFS - FUSE based network FS.

### DIFF
--- a/fuse/moosefs/Portfile
+++ b/fuse/moosefs/Portfile
@@ -1,0 +1,109 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                moosefs
+version             3.0.108
+distname            ${name}-${version}-1
+categories          fuse
+platforms           darwin
+license             GPL-2
+maintainers         {@chogata moosefs.com:chogata} openmaintainer
+description         Moose File System
+long_description    MooseFS is a distributed, fault-tolerant, highly efficient network file system, FUSE based.
+homepage            https://moosefs.com/
+master_sites        http://ppa.moosefs.com/src
+
+checksums           rmd160  0492e611f8de1e4c59313d84787a50851c3c5657 \
+                    sha256  eb7f89ec5fc24c44d90e99cf0ad0f587012782b400a03295acd6f400a3bc83d0 \
+                    size    1193904
+
+depends_build       port:pkgconfig
+
+depends_lib         port:libpcap \
+                    port:zlib
+ 
+default_variants    +servers +client
+set mfs_cliconfs    {mfsmount.cfg}
+set mfs_servconfs   {mfschunkserver.cfg mfsexports.cfg mfshdd.cfg mfsmaster.cfg mfsmetalogger.cfg mfstopology.cfg}
+set mfs_masterfiles {metadata.mfs}
+configure.args      --disable-all
+notes               ""
+
+livecheck.type      regex
+livecheck.url       http://ppa.moosefs.com/moosefs-3/version
+livecheck.regex     {^(.*)$}
+
+variant servers description {All server-side needed binaries} {
+    add_users               _mfs group=_mfs realname=MooseFS\ User home=${prefix}/var/mfs
+    configure.args-append   --enable-mfscgi \
+                            --enable-mfscgiserv \
+                            --enable-mfschunkserver \
+                            --enable-mfscli \
+                            --enable-mfsmaster \
+                            --enable-mfsmetalogger \
+                            --enable-mfsnetdump \
+                            --with-default-user=_mfs \
+                            --with-default-group=_mfs
+    startupitem.create      yes
+    startupitems            name mfsmaster \
+                            location LaunchDaemons \
+                            start "${prefix}/sbin/mfsmaster start" \
+                            stop "${prefix}/sbin/mfsmaster stop" \
+                            restart "${prefix}/sbin/mfsmaster restart" \
+                            name mfschunkserver \
+                            location LaunchDaemons \
+                            start "${prefix}/sbin/mfschunkserver start" \
+                            stop "${prefix}/sbin/mfschunkserver stop" \
+                            restart "${prefix}/sbin/mfschunkserver restart" \
+                            name mfsmetalogger \
+                            location LaunchDaemons \
+                            start "${prefix}/sbin/mfsmetalogger start" \
+                            stop "${prefix}/sbin/mfsmetalogger stop" \
+                            restart "${prefix}/sbin/mfsmetalogger restart"
+    notes-append            "
+You have just installed MooseFS Master, Chunkserver and Metalogger binaries. To run them automatically during system startup,\
+you need to activate them. Use these commands:
+sudo launchctl load -w /Library/LaunchDaemons/org.macports.mfsmaster.plist
+sudo launchctl load -w /Library/LaunchDaemons/org.macports.mfschunkserver.plist
+sudo launchctl load -w /Library/LaunchDaemons/org.macports.mfsmetalogger.plist
+to activate Master, Chunkserver and Metalogger daemons respectively. The command suggested to you by macports will activate\
+ALL daemons at the same time, so don't use it if you'd rather activate just one of them.
+Chunkserver and Metalogger will not run if they cannot resolve the hostname 'mfsmaster' (unless you changed the default\
+setting for MASTER_HOST in mfschunkserver.cfg or mfsmetalogger.cfg respectively).
+
+"
+}
+
+variant client description {Client binaries only} {
+    configure.args-append   --enable-mfsmount
+    depends_lib-append      port:osxfuse
+    notes-append            "
+You have just installed MooseFS Client (mfsmount). To run it, type 'mfsmount /path/to/mountpoint'. The Client process will try to resolve\
+the hostname 'mfsmaster' to find an instance of MooseFS to connect to. If you need to set\
+specific mfsmaster host and/or port or change other settings, refer to 'man 8 mfsmount' for further information.
+
+"
+}
+
+post-activate {
+    if {[variant_isset client]} {
+        foreach conf ${mfs_cliconfs} {
+            if {![file exists ${prefix}/etc/mfs/${conf}] && [file exists ${prefix}/etc/mfs/${conf}.sample]} {
+                copy ${prefix}/etc/mfs/${conf}.sample ${prefix}/etc/mfs/${conf}
+            }
+        }
+    }
+    if {[variant_isset servers]} {
+        foreach conf ${mfs_servconfs} {
+            if {![file exists ${prefix}/etc/mfs/${conf}] && [file exists ${prefix}/etc/mfs/${conf}.sample]} {
+                copy ${prefix}/etc/mfs/${conf}.sample ${prefix}/etc/mfs/${conf}
+            }
+        }
+        foreach mfsfile ${mfs_masterfiles} {
+            if {![file exists ${prefix}/var/mfs/${mfsfile}] && [file exists ${prefix}/var/mfs/${mfsfile}.empty]} {
+                copy ${prefix}/var/mfs/${mfsfile}.empty ${prefix}/var/mfs/${mfsfile}
+            }
+        }
+    }
+}


### PR DESCRIPTION
Port was tested on MacOS 10.13.6.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
