### PR TITLE
lpcnetfreedv: update version to 0.1

### DIFF
--- a/audio/lpcnetfreedv/Portfile
+++ b/audio/lpcnetfreedv/Portfile
@@ -3,7 +3,6 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
-PortGroup           cxx11 1.1
 
 name                lpcnetfreedv
 platforms           darwin macosx
@@ -15,12 +14,13 @@ description         Experimental Neural Net speech coding for FreeDV
 long_description    Experimental version of LPCNet being developed \
     for over the air Digital Voice experiments with FreeDV.
 
-github.setup        drowe67 LPCNet 34049f83170aaf1e6e3595f5ac086ef565f8b6b3
-version             20191102-[string range ${github.version} 0 7]
+github.setup        drowe67 LPCNet 0.1 v
 checksums           rmd160  8528279ddda440ef85fcc7096ed27d5d10a85ce9 \
                     sha256  8709610cfa418b3f3d45a166ec14e06b9dc9af478849754cda3b87f2fad3f9fd \
                     size    33011015
 revision            0
+
+epoch               1
 
 depends_lib-append \
     port:codec2
@@ -33,8 +33,7 @@ pre-configure {
     # enable optimization (SSSE3) on all Intel hardwares
     if {${build_arch} eq "i386" || ${build_arch} eq "x86_64"} {
         configure.args-append \
-            -DCMAKE_C_FLAGS="-mssse3" \
-            -DCMAKE_CXX_FLAGS="-mssse3"
+            -DCMAKE_C_FLAGS="-mssse3 -msse4.1"
     }
 }
 
@@ -42,6 +41,9 @@ pre-configure {
 variant native description {Enable auto selection of cpu flags like avx/avx2/neon} {
     configure.args-delete -DDISABLE_CPU_OPTIMIZATION=ON
 }
+
+# linux only scripts
+test.run            off
 
 notes "To enable lpcnet on codec2 you need to rebuild it manually with\
 the respective variant enabled. Aka, circular dependency.\


### PR DESCRIPTION


#### Description
- move from commit to version 0.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.1 19B88
Xcode 11.2 11B52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
