### PR TITLE
py-healpy: use OpenMP option from MacPorts 2.6.0

### DIFF
--- a/python/py-healpy/Portfile
+++ b/python/py-healpy/Portfile
@@ -31,8 +31,7 @@ if {${name} ne ${subport}} {
 
     variant openmp description "enable OpenMP parallel acceleration" {
         # Pick a compiler that supports openmp
-        compiler.whitelist macports-clang-6.0 macports-clang-5.0 macports-clang-3.7 macports-gcc-7 macports-gcc-6 macports-gcc-5 macports-gcc-4.8 macports-gcc-4.7 macports-gcc-4.6 macports-gcc-4.5 macports-gcc-4.4 macports-gcc-4.3
-        compiler.fallback macports-clang-6.0
+        compiler.openmp_version 2.5
     }
 
     if {[variant_isset openmp]} {


### PR DESCRIPTION
…instead of a compiler whitelist/fallback
See https://trac.macports.org/wiki/CompilerSelection#Parallelism

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
~~macOS 10.x~~
~~Xcode 8.x~~

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
