### PR TITLE
[WIP] libcxx: Add support for (Intel) Tiger

### DIFF
--- a/lang/libcxx/Portfile
+++ b/lang/libcxx/Portfile
@@ -59,18 +59,18 @@ set libcxxabi_worksrcpath   [file join ${workpath} ${libcxxabi_distname}]
 set libcxx_worksrcpath      [file join ${workpath} ${libcxx_distname}]
 
 platform darwin {
-    if {${os.major} < 9} {
-        pre-fetch {
-            ui_error "${name} is not supported on Tiger or earlier."
-            error "unsupported platform"
-        }
-    }
-
     if {${os.major} < 11} {
         post-activate {
             set dirs /
             if {${os.subplatform} eq "macosx"} {
-                lappend dirs ${developer_dir}/SDKs/MacOSX[join [lrange [split ${macosx_version} .] 0 1] .].sdk
+                if {${os.major} == 8} {
+                    # The Tiger SDK has an u after the version number,
+                    # unlike all other versions.
+                    set sdk_name MacOSX10.4u.sdk
+                } else {
+                    set sdk_name MacOSX[join [lrange [split ${macosx_version} .] 0 1] .].sdk
+                }
+                lappend dirs ${developer_dir}/SDKs/${sdk_name}
             }
             foreach d ${dirs} {
                 system -W ${d} "tar xzf ${roots_path}/${root_name}.tgz"

--- a/lang/libcxx/Portfile
+++ b/lang/libcxx/Portfile
@@ -129,6 +129,7 @@ if {${os.major} < 11 || [variant_isset replacemnt_libcxx]} {
         # http://trac.macports.org/wiki/LibcxxOnOlderSystems#Leopardppc
         # older clang compilers produce unreliable ppc code
         compiler.blacklist-append macports-clang-3.4
+        compiler.blacklist-append macports-clang-3.3
     }
 
     post-extract {

--- a/lang/libcxx/files/1002-libcxx-buildit-build-fix-for-Leopard.patch
+++ b/lang/libcxx/files/1002-libcxx-buildit-build-fix-for-Leopard.patch
@@ -18,7 +18,7 @@ index c18de042e..0a585022a 100755
      fi
      SOEXT=dylib
 -    if [ "$MACOSX_DEPLOYMENT_TARGET" = "10.6" ]
-+    if [ "$MACOSX_DEPLOYMENT_TARGET" = "10.5" ] || [ "$MACOSX_DEPLOYMENT_TARGET" = "10.6" ]
++    if [[ "$MACOSX_DEPLOYMENT_TARGET" == 10.[456] ]]
      then
          EXTRA_FLAGS="-nostdinc++ -std=c++11 -U__STRICT_ANSI__"
          LDSHARED_FLAGS="-o libc++.1.dylib \

--- a/lang/libcxx/files/1004-libcxx-MacPorts-Use-LIBCXXABI_PATH-for-path-to-build-time-l.patch
+++ b/lang/libcxx/files/1004-libcxx-MacPorts-Use-LIBCXXABI_PATH-for-path-to-build-time-l.patch
@@ -24,7 +24,7 @@ index 4fd356420..c10f876a7 100755
 +        LIBCXXABI_DYLIB_PATH=/usr/lib/libc++abi.dylib
 +    fi
 +
-     if [ "$MACOSX_DEPLOYMENT_TARGET" = "10.5" ] || [ "$MACOSX_DEPLOYMENT_TARGET" = "10.6" ]
+     if [[ "$MACOSX_DEPLOYMENT_TARGET" == 10.[456] ]]
      then
          EXTRA_FLAGS="-nostdinc++ -std=c++11 -U__STRICT_ANSI__"
 @@ -63,31 +69,10 @@ case $TRIPLE in

--- a/lang/libcxx/files/1005-libcxx-buildit-Fix-CFLAGS-for-Leopard-and-Snow-Leopard-to-i.patch
+++ b/lang/libcxx/files/1005-libcxx-buildit-Fix-CFLAGS-for-Leopard-and-Snow-Leopard-to-i.patch
@@ -15,7 +15,7 @@ index c10f876a7..e1ef3381e 100755
 +++ libcxx-5.0.1.src/lib/buildit
 @@ -63,7 +63,7 @@ case $TRIPLE in
  
-     if [ "$MACOSX_DEPLOYMENT_TARGET" = "10.5" ] || [ "$MACOSX_DEPLOYMENT_TARGET" = "10.6" ]
+     if [[ "$MACOSX_DEPLOYMENT_TARGET" == 10.[456] ]]
      then
 -        EXTRA_FLAGS="-nostdinc++ -std=c++11 -U__STRICT_ANSI__"
 +        EXTRA_FLAGS="${EXTRA_FLAGS} -U__STRICT_ANSI__"

--- a/lang/libcxx/files/2001-Fix-local-and-iterator-when-building-with-Lion-and-n.patch
+++ b/lang/libcxx/files/2001-Fix-local-and-iterator-when-building-with-Lion-and-n.patch
@@ -14,6 +14,15 @@ diff --git libcxx-5.0.1.src/include/iterator libcxx-5.0.1.src/include/iterator
 index d163ab1b0..a44890712 100644
 --- libcxx-5.0.1.src/include/iterator
 +++ libcxx-5.0.1.src/include/iterator
+@@ -428,7 +428,7 @@
+ #include <type_traits>
+ #include <cstddef>
+ #include <initializer_list>
+-#ifdef __APPLE__
++#if defined(__APPLE__) && __has_include(<Availability.h>)
+ #include <Availability.h>
+ #endif
+ 
 @@ -1044,8 +1044,8 @@ public:
      _LIBCPP_INLINE_VISIBILITY bool failed() const _NOEXCEPT {return __sbuf_ == 0;}
  
@@ -29,6 +38,15 @@ diff --git libcxx-5.0.1.src/include/locale libcxx-5.0.1.src/include/locale
 index d30d950c7..cd2869561 100644
 --- libcxx-5.0.1.src/include/locale
 +++ libcxx-5.0.1.src/include/locale
+@@ -197,7 +197,7 @@
+ #include <nl_types.h>
+ #endif
+ 
+-#ifdef __APPLE__
++#if defined(__APPLE__) && __has_include(<Availability.h>)
+ #include <Availability.h>
+ #endif
+ 
 @@ -1372,8 +1372,8 @@ __pad_and_output(_OutputIterator __s,
  }
  


### PR DESCRIPTION
#### Description

A few small modifications to enable building libcxx on Intel Tiger.

So far I've only been able to test the build with `-universal`, because compiling for PowerPC requires a newer clang than I currently have working on my Tiger system (see [LibcxxOnOlderSystems](https://trac.macports.org/wiki/LibcxxOnOlderSystems#Leopardppc)). I also haven't been able to test if the built libc++ actually works - the libraries that need it currently don't build for me (for unrelated reasons).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.4
Xcode 2.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
