### PR TITLE
google-cloud-sdk: update to 271.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             270.0.0
+version             271.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  8dff7684914b8cfddbd112fa06f211b9f949b4b5 \
-                    sha256  d618f7b37a29168ecadd5e1b6bf70887d95d3c055e42b98f259e7c9f0dbea686 \
-                    size    22508521
+    checksums       rmd160  14637ac02834eed067f9f38e3a2757b03684d731 \
+                    sha256  33b116b4a8c110206150c08ca5b42b580aabdde6a41c0e123493bb88503f7dd4 \
+                    size    22599070
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  60e24b879c568ddc01297bc947375e00f34c43f7 \
-                    sha256  96f202d6d4c15c5c93ee3f034e91b98b97d79c00d1be051afecdb5a0bbf190d8 \
-                    size    22508692
+    checksums       rmd160  bf2f514a5593eaf4f7be1e46e95ab7736632737b \
+                    sha256  842ab3866eaf323eb9268f8f761c8b98a00d93c3d280b702b7c42b11db9ac8fc \
+                    size    22597533
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 271.0.0.

###### Tested on

macOS 10.15.1 19B88
Xcode 11.2 11B52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?