### PR TITLE
spring-boot-cli: update to 2.2.1

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name            spring-boot-cli
-version         2.2.0
+version         2.2.1
 revision        0
 
 categories      java
@@ -29,9 +29,9 @@ master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/
 
 distname        ${name}-${version}.RELEASE-bin
 
-checksums       rmd160  82f57dbbce76bdb570f384d8c1a651bac54450c9 \
-                sha256  d3be1dc619ef0cfb7f7fedb8e055dbaafa67ac16aecb14fd3b038d1a59241a9f \
-                size    11359147
+checksums       rmd160  83d48e9dae11e450d6898e8bed2430eec36e0e7a \
+                sha256  6ae3f96bfeb666321610d6ca4d81cc24356aef4ccf414ba04cdf1e183bdaf89d \
+                size    11365642
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
#### Description

Update to Spring Boot 2.2.1.RELEASE.

###### Tested on

macOS 10.15.1 19B88
Xcode 11.2 11B52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?