### PR TITLE
starship: update to 0.26.4

### DIFF
--- a/sysutils/starship/Portfile
+++ b/sysutils/starship/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        starship starship 0.26.2 v
+github.setup        starship starship 0.26.4 v
 categories          sysutils
 platforms           darwin
 maintainers         {l2dy @l2dy} openmaintainer
@@ -15,9 +15,9 @@ description         a minimal, blazing fast, and extremely customizable prompt f
 long_description    Starship is ${description}.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  d9932e81859e024780f07f782abf4973a9ffeb3e \
-                    sha256  f2de2005ee22d7ff5874690c0c08aa1a284366f92a9ed445674b0d0ab63ca5cc \
-                    size    4347533
+                    rmd160  e1f505a285b2b85607c7404d4a912968735391a4 \
+                    sha256  3fce013c9cf1258d3f8cd2716908cc63d02bb53bf4a659cde84c1e7fc6d7e706 \
+                    size    4347759
 
 # For crate:openssl-sys
 depends_build       port:pkgconfig
@@ -32,6 +32,7 @@ cargo.crates \
     ansi_term                       0.12.1  d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2 \
     ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
     arrayref                         0.3.5  0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee \
+    arrayvec                         0.5.1  cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8 \
     arrayvec                        0.4.12  cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9 \
     atty                            0.2.13  1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90 \
     autocfg                          0.1.7  1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2 \
@@ -40,11 +41,11 @@ cargo.crates \
     base64                          0.10.1  0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e \
     battery                          0.7.4  7a6d6fe5630049e900227cd89afce4c1204b88ec8e61a2581bb96fcce26f047b \
     bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
-    blake2b_simd                     0.5.8  5850aeee1552f495dd0250014cf64b82b7c8879a89d83b33bbdace2cc4f63182 \
+    blake2b_simd                     0.5.9  b83b7baab1e671718d78204225800d6b170e648188ac7dc992e9d6bddf87d0c0 \
     byte-unit                        3.0.3  6894a79550807490d9f19a138a6da0f8830e70c83e83402dd23f16fd6c479056 \
     byteorder                        1.3.2  a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5 \
     c2-chacha                        0.2.3  214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb \
-    cc                              1.0.46  0213d356d3c4ea2c18c40b037c3be23cd639825c18f25ee670ac7813beeef99c \
+    cc                              1.0.47  aa87058dce70a3ff5621797f1506cb837edd02ac4c0ae642b4542dce802908b8 \
     cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
     chrono                           0.4.9  e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68 \
     clap                            2.33.0  5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9 \
@@ -52,9 +53,10 @@ cargo.crates \
     constant_time_eq                 0.1.4  995a44c877f9212528ccc74b21a232f66ad69001e40ede5bcee2ac9ef2657120 \
     core-foundation                  0.6.4  25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d \
     core-foundation-sys              0.6.2  e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b \
-    crossbeam-deque                  0.7.1  b18cd2e169ad86297e6bc0ad9aa679aee9daa4f19e8163860faf7c164e4f5a71 \
-    crossbeam-epoch                  0.7.2  fedcd6772e37f3da2a9af9bf12ebe046c0dfe657992377b4df982a2b54cd37a9 \
+    crossbeam-deque                  0.7.2  c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca \
+    crossbeam-epoch                  0.8.0  5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac \
     crossbeam-queue                  0.1.2  7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b \
+    crossbeam-utils                  0.7.0  ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4 \
     crossbeam-utils                  0.6.6  04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6 \
     dirs                             2.0.2  13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3 \
     dirs-sys                         0.3.4  afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b \
@@ -82,14 +84,15 @@ cargo.crates \
     log                              0.4.8  14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7 \
     mach                             0.2.3  86dd2487cdfea56def77b88438a2c915fb45113c5319bfe7e14306ca4cd0b0e1 \
     matches                          0.1.8  7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
+    maybe-uninit                     2.0.0  60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00 \
     memchr                           2.2.1  88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e \
-    memoffset                        0.5.2  4a85c1a8c329f11437034d7313dca647c79096523533a1c79e86f1d0f657c7cc \
+    memoffset                        0.5.3  75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9 \
     nix                             0.14.1  6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce \
     nodrop                          0.1.14  72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb \
     nom                              5.0.1  c618b63422da4401283884e6668d39f819a106ef51f5f59b81add00075da35ca \
     num-integer                     0.1.41  b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09 \
-    num-traits                       0.2.8  6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32 \
-    num_cpus                        1.11.0  155394f924cdddf08149da25bfb932d226b4a593ca7468b08191ff6335941af5 \
+    num-traits                       0.2.9  443c53b3c3531dfcbfa499d8893944db78474ad7a1d87fa2d94d1a2231693ac6 \
+    num_cpus                        1.11.1  76dac5ed2a876980778b8b85f75a71b6cbf0db0b1232ee12f826bccb00d09d72 \
     once_cell                        1.2.0  891f486f630e5c5a4916c7e16c4b24a53e78c860b646e9f8e005e4f16847bfed \
     path-slash                       0.1.1  a0858af4d9136275541f4eac7be1af70add84cf356d901799b065ac1b8ff6e2f \
     percent-encoding                 2.1.0  d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
@@ -123,12 +126,12 @@ cargo.crates \
     semver-parser                    0.7.0  388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
     serde                          1.0.102  0c4b39bd9b0b087684013a792c59e3e07a46a01d2322518d8a1104641a0b1be0 \
     serde_json                      1.0.41  2f72eb2a68a7dc3f9a691bfda9305a1c017a6215e5a4545c258500d2099a37c2 \
-    smallvec                        0.6.12  533e29e15d0748f28afbaf4ff7cab44d73e483a8e50b38c40bd13b7f3d48f542 \
+    smallvec                        0.6.13  f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6 \
     static_assertions                0.3.4  7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3 \
     strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
-    syn                              1.0.7  0e7bedb3320d0f3035594b0b723c8a28d7d336a3eda3881db79e61d676fb644c \
-    synstructure                    0.12.1  3f085a5855930c0441ca1288cf044ea4aecf4f43a91668abdb870b4ba546a203 \
-    sysinfo                          0.9.5  d5bd3b813d94552a8033c650691645f8dd5a63d614dddd62428a95d3931ef7b6 \
+    syn                              1.0.8  661641ea2aa15845cddeb97dad000d22070bb5c1fb456b96c1cba883ec691e92 \
+    synstructure                    0.12.3  67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545 \
+    sysinfo                          0.9.6  6f4b2468c629cffba39c0a4425849ab3cdb03d9dfacba69684609aea04d08ff9 \
     tempfile                         3.1.0  7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9 \
     termcolor                        1.0.5  96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e \
     textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
@@ -137,8 +140,8 @@ cargo.crates \
     toml                             0.5.5  01d1404644c8b12b16bfcffa4322403a91a451584daaaa7c28d3152e6cbc98cf \
     typenum                         1.11.2  6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9 \
     unicode-bidi                     0.3.4  49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5 \
-    unicode-normalization            0.1.8  141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426 \
-    unicode-segmentation             1.5.0  49f5526225fd8b77342d5986ab5f6055552e9c0776193b5b63fd53b46debfad7 \
+    unicode-normalization            0.1.9  09c8070a9942f5e7cfccd93f490fdebd230ee3c3c9f107cb25bad5351ef671cf \
+    unicode-segmentation             1.6.0  e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0 \
     unicode-width                    0.1.6  7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20 \
     unicode-xid                      0.2.0  826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c \
     uom                             0.23.1  3ef5bbe8385736e498dbb0033361f764ab43a435192513861447b9f7714b3fec \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.1 19B88
Xcode 11.2 11B52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
