### PR TITLE
web-ext: update to 3.2.1

### DIFF
--- a/devel/web-ext/Portfile
+++ b/devel/web-ext/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                web-ext
-version             3.2.0
+version             3.2.1
 revision            0
-checksums           rmd160  ba13c7d3bd0382dc232336945fde09af559ed462 \
-                    sha256  ad9fe38259f02aed73f021d2487858e1c7f5e1efe04026ff6c7515e132bf5f43 \
-                    size    201953
+checksums           rmd160  f46bc7d0c3afae609937dfce19da5797cf1212ab \
+                    sha256  3c64d04944a4faac3045dfbfe5ea4f93df82bd1f53ca9540ce1c83b1edf0dba3 \
+                    size    204468
 
 categories          devel
 maintainers         nomaintainer


### PR DESCRIPTION
###### Tested on
macOS 10.13.6 17G8030
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?