### PR TITLE
py-scikit-learn: force OpenMP-capable compiler

### DIFF
--- a/python/py-scikit-learn/Portfile
+++ b/python/py-scikit-learn/Portfile
@@ -46,6 +46,7 @@ if {${name} ne ${subport}} {
                             sha256  c503802a81de18b8b4d40d069f5e363795ee44b1605f38bc104160ca3bfe2c41 \
                             size    11818490
     } else {
+        compiler.openmp_version 2.5
         depends_lib-append  port:libomp
         depends_run-append  port:py${python.version}-joblib
 


### PR DESCRIPTION
Use option introduced in MacPorts 2.6.0:
https://trac.macports.org/wiki/CompilerSelection

See: https://trac.macports.org/ticket/58515

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
~~macOS 10.x~~
~~Xcode 8.x~~

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
