### PR TITLE
kubectx: update to 0.7.1

### DIFF
--- a/sysutils/kubectx/Portfile
+++ b/sysutils/kubectx/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        ahmetb kubectx 0.7.0 v
-revision            1
+github.setup        ahmetb kubectx 0.7.1 v
+revision            0
 categories          sysutils
 platforms           darwin
 supported_archs     noarch
@@ -15,28 +15,44 @@ description         Power tools for kubectl
 long_description    kubectx helps you switch between clusters back and forth. \
                     kubens helps you switch between Kubernetes namespaces smoothly.
 
-checksums           rmd160  f6f011e466317cc1323954ac9e5b4f3cc4bd78f7 \
-                    sha256  f944d5677d82e10bc8fbdd70a835ffb0aa522402e0b57331cdc4b80f6aefeee6 \
-                    size    484008
+checksums           rmd160  1febd41c44979de11f2847006c7388bbaf9f0e10 \
+                    sha256  e70c496af1aff89cddf3d11eaa6ac0197e8c4cb02c69216f63602d6bd2be7045 \
+                    size    484187
 
-depends_run         port:bash-completion path:${prefix}/bin/kubectl:kubectl-1.16
+depends_run         path:${prefix}/bin/kubectl:kubectl-1.16
 
 use_configure       no
 build {}
 
 destroot    {
-    xinstall -m 755 -d ${destroot}${prefix}/share/${name}
-    xinstall -m 644 ${worksrcpath}/CONTRIBUTING.md \
-        ${worksrcpath}/LICENSE \
-        ${worksrcpath}/README.md \
-        ${destroot}${prefix}/share/${name}
+    set doc_dir ${destroot}${prefix}/share/${name}
+    xinstall -d ${doc_dir}
+    xinstall -m 644 -W ${worksrcpath} \
+        CONTRIBUTING.md \
+        LICENSE \
+        README.md \
+        ${doc_dir}
 
-    xinstall -m 755 ${worksrcpath}/kubectx \
-        ${worksrcpath}/kubens \
-        ${destroot}${prefix}/bin
+    set bin_dir ${destroot}${prefix}/bin
+    xinstall -m 755 -W ${worksrcpath} \
+        kubectx \
+        kubens \
+        ${bin_dir}
 
-    xinstall -m 755 -d ${destroot}${prefix}/etc/bash_completion.d
-    xinstall -m 644 ${worksrcpath}/completion/kubectx.bash \
-        ${worksrcpath}/completion/kubens.bash \
-        ${destroot}${prefix}/etc/bash_completion.d
+    set src_completion_dir ${worksrcpath}/completion
+
+    set zsh_completion_dir ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -d ${zsh_completion_dir}
+    xinstall -m 644 ${src_completion_dir}/kubectx.zsh ${zsh_completion_dir}/_kubectx
+    xinstall -m 644 ${src_completion_dir}/kubens.zsh ${zsh_completion_dir}/_kubens
+
+    set bash_completion_dir ${destroot}${prefix}/etc/bash_completion.d
+    xinstall -d ${bash_completion_dir}
+    xinstall -m 644 ${src_completion_dir}/kubectx.bash ${bash_completion_dir}/kubectx
+    xinstall -m 644 ${src_completion_dir}/kubens.bash ${bash_completion_dir}/kubens
+
+    set fish_completion_dir ${destroot}${prefix}/share/fish/completions
+    xinstall -d ${fish_completion_dir}
+    xinstall -m 644 ${src_completion_dir}/kubectx.fish ${fish_completion_dir}/kubectx
+    xinstall -m 644 ${src_completion_dir}/kubens.fish ${fish_completion_dir}/kubens
 }


### PR DESCRIPTION
#### Description

Update to kubectx 0.7.1.

###### Tested on

macOS 10.15.1 19B88
Xcode 11.2 11B52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?