### PR TITLE
remove obsolete Python subports (maintainer: eborisch)

### DIFF
--- a/lang/py-htmldocs/Portfile
+++ b/lang/py-htmldocs/Portfile
@@ -1,9 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-name                py-htmldocs
 PortGroup           python 1.0
-python.versions     27 34 35 36 37
+
+name                py-htmldocs
+python.versions     27 35 36 37
 python.default_version 27
 version             1.0
 set base_rev        2
@@ -12,7 +13,6 @@ license             {PSF}
 
 if {$subport != $name} {
     if {${python.version} == 27} { version 2.7.16 }
-    if {${python.version} == 34} { version 3.4.10 }
     if {${python.version} == 35} { version 3.5.7 }
     if {${python.version} == 36} { version 3.6.9 }
     if {${python.version} == 37} { version 3.7.4 }
@@ -49,12 +49,6 @@ if {${name} != ${subport}} {
         rmd160  7ed880a8601cf35df1d6dd16f7c2ed22567b0504 \
         sha256  02d488e908ceaa793662c3ea17ee9b9259f32782d74705633151c19f5fd05fe5
     }
-    
-    if {${python.version} == 34} {
-      checksums \
-        rmd160  750b3d62ad9cc4bdd772dcfe9040131a7c1681b4 \
-        sha256  5c96de4476bf9ed7cee06822cf111262e6b46787aede8d8783eb5a803538bf2f
-    }
 
     if {${python.version} == 35} {
       checksums \
@@ -85,14 +79,12 @@ if {${name} != ${subport}} {
             ${destroot}${prefix}/share/doc/python${python.version}-doc
         file mkdir ${destroot}${prefix}/share/doc
         file copy ${workpath}/${extractname} ${destdocdir}
-        system "chmod -R a+rX ${destdocdir}" 
+        system "chmod -R a+rX ${destdocdir}"
     }
-    
+
     livecheck.url       https://www.python.org/ftp/python/doc/
     livecheck.type      regex
     livecheck.regex     ([string map {. \\.} ${python.branch}.\[0-9ap\]+])
 } else {
     livecheck.type      none
 }
-
-

--- a/python/py-XlsxWriter/Portfile
+++ b/python/py-XlsxWriter/Portfile
@@ -4,9 +4,10 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        jmcnamara XlsxWriter 1.1.1 RELEASE_
+github.setup        jmcnamara XlsxWriter 1.2.5 RELEASE_
 name                py-XlsxWriter
-python.versions     27 34 35 36 37
+
+python.versions     27 35 36 37
 python.default_version 27
 platforms           darwin
 license             BSD
@@ -20,9 +21,9 @@ long_description    XlsxWriter can be used to write text, numbers, formulas \
                     and hyperlinks to multiple worksheets and it supports \
                     features such as formatting and many more.
 
-checksums \
-    rmd160  76f9dc49dce59ec671f8c76621639f87693025be \
-    sha256  253c0b92c5ed4de625f17a5e2aa22d1abc9b99535292b4e0bbb565125b173df1
+checksums           rmd160  e6d401986ced10da7042d7ebf6583f8a4608cb08 \
+                    sha256  e8b0b94c30773e18cf880a4b71d7ee025585631a519153325e294a4814cc125a \
+                    size    28675086
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
@@ -30,7 +31,7 @@ if {${name} ne ${subport}} {
     post-destroot {
         set DOCDIR ${destroot}${prefix}/share/doc/${subport}
         xinstall -d ${DOCDIR}
-        file copy ${worksrcpath}/LICENSE.txt ${DOCDIR}
+        xinstall -m 0644 -W ${worksrcpath} LICENSE.txt ${DOCDIR}
     }
 
     livecheck.type  none

--- a/python/py-clang/Portfile
+++ b/python/py-clang/Portfile
@@ -8,7 +8,7 @@ version                 3
 # Needed for change to meta-versioning
 epoch                   1
 name                    py-clang
-python.versions         27 34 35 36 37
+python.versions         27 35 36 37
 python.default_version  27
 platforms               darwin
 license                 NCSA
@@ -81,12 +81,12 @@ if {${name} ne ${subport}} {
         "
     }
 
-    if {![variant_isset clang37] && 
-        ![variant_isset clang39] && 
-        ![variant_isset clang40] && 
-        ![variant_isset clang50] && 
-        ![variant_isset clang60] && 
-        ![variant_isset clang70] && 
+    if {![variant_isset clang37] &&
+        ![variant_isset clang39] &&
+        ![variant_isset clang40] &&
+        ![variant_isset clang50] &&
+        ![variant_isset clang60] &&
+        ![variant_isset clang70] &&
         ![variant_isset clang80]} {
         default_variants +clang50
     }
@@ -94,18 +94,18 @@ if {${name} ne ${subport}} {
     pre-extract {
         # Will never hit this when installing from packages, which is OK, as
         # they will have the default variant set above.
-        if {![variant_isset clang37] && 
-            ![variant_isset clang39] && 
-            ![variant_isset clang40] && 
-            ![variant_isset clang50] && 
-            ![variant_isset clang60] && 
-            ![variant_isset clang70] && 
+        if {![variant_isset clang37] &&
+            ![variant_isset clang39] &&
+            ![variant_isset clang40] &&
+            ![variant_isset clang50] &&
+            ![variant_isset clang60] &&
+            ![variant_isset clang70] &&
             ![variant_isset clang80]} {
             ui_error "At least one of the clangNN variants must be active."
             return -code error "Unsupported (no) variants selected."
         }
     }
-    
+
     post-extract {
         file copy ${filespath}/setup.py ${worksrcpath}/
     }

--- a/python/py-h5py/Portfile
+++ b/python/py-h5py/Portfile
@@ -28,7 +28,7 @@ long_description  \
 
 homepage                https://www.h5py.org
 
-python.versions         27 34 35 36 37 38
+python.versions         27 35 36 37 38
 python.default_version  37
 
 checksums \

--- a/python/py-pptx/Portfile
+++ b/python/py-pptx/Portfile
@@ -4,9 +4,11 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        scanny python-pptx 0.6.17 v
+github.setup        scanny python-pptx 0.6.18 v
 name                py-pptx
-python.versions     27 34 35 36
+revision            0
+
+python.versions     27 35 36
 python.default_version 27
 platforms           darwin
 license             MIT
@@ -27,10 +29,9 @@ long_description    A typical use would be generating a customized PowerPoint \
                     would be tedious to get right by hand.
 
 
-checksums \
-    rmd160  b357d0347792031fec49d02277c7a70f2f2104da \
-    sha256  ae373ac4f3a13052483780092891c19a08675df3d173451a52f9a3d7a2f79453 \
-    size    49037894
+checksums           rmd160  af8536421ae8c147fb327144760d72ac47264eb0 \
+                    sha256  56668f654f424f97792d22e666358effbb6f7c95d8c80112e64f6bbc18b2cc4e \
+                    size    49027278
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
@@ -41,7 +42,8 @@ if {${name} ne ${subport}} {
     post-destroot {
         set DOCDIR ${destroot}${prefix}/share/doc/${subport}
         xinstall -d ${DOCDIR}
-        file copy ${worksrcpath}/LICENSE ${DOCDIR}
+        xinstall -m 0644 -W ${worksrcpath} HISTORY.rst \
+            LICENSE README.rst ${DOCDIR}
     }
 
     livecheck.type  none

--- a/python/py-pydicom/Portfile
+++ b/python/py-pydicom/Portfile
@@ -3,9 +3,10 @@
 PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
+
 github.setup        pydicom pydicom 1.3.0 v
 name                py-pydicom
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 platforms           darwin
 license             MIT BSD
 maintainers         {eborisch @eborisch} \
@@ -58,7 +59,7 @@ if {${name} ne ${subport}} {
                 "env PYTHONPATH='${worksrcpath}/build/lib' make html"
         }
     }
-    
+
     post-destroot {
         set DOCDIR ${destroot}${prefix}/share/doc/${subport}
         xinstall -d ${DOCDIR}


### PR DESCRIPTION
#### Description
This PR removes obsolete Python subports for ports maintained by @eborisch  that have no dependencies. I have update ```py-pptx``` and ```py-XlsxWriter``` to their latest version.

###### Tested on
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`? Yes, but only for ports that I updated
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
