### PR TITLE
json-modern-cpp: replaced by nlohmann-json

### DIFF
--- a/devel/json-modern-cpp/Portfile
+++ b/devel/json-modern-cpp/Portfile
@@ -1,24 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
-PortGroup           cmake 1.1
-PortGroup           cxx11 1.1
+PortGroup           obsolete 1.0
 
 name                json-modern-cpp
+replaced_by         nlohmann-json
 platforms           darwin macosx
 categories          devel
-license             MIT
-maintainers         {@ra1nb0w irh.it:rainbow} openmaintainer
+version             3.7.0
+revision            1
 
-description         JSON for Modern C++
-long_description    ${description}
-
-github.setup        nlohmann json 3.7.0 v
-checksums           rmd160  de5bb385af6c16d14d4ba5632a4c728f7a492d8d \
-    sha256  fd6f4516a9122dc16dd0ad793a9d5f17fe59c12702f24502f70da9dab343eaa6 \
-    size    118869453
-revision            0
-
-configure.args-append \
-    -DJSON_BuildTests=OFF
+# Remove after November 2020

--- a/science/PothosAudio/Portfile
+++ b/science/PothosAudio/Portfile
@@ -17,10 +17,10 @@ github.setup        pothosware PothosAudio 0.3.1 pothos-audio-
 checksums           rmd160  9c9de97682c38d2c5cfb93c5603dd8c537add99f \
                     sha256  e697b361ad900668d3d84a22326893473408042a556c0060ea55e301af5848e4 \
                     size    9017
-revision            0
+revision            1
 
 depends_lib-append \
     port:PothosCore \
     port:poco \
-    port:json-modern-cpp \
+    port:nlohmann-json \
     port:portaudio

--- a/science/PothosBlocks/Portfile
+++ b/science/PothosBlocks/Portfile
@@ -19,9 +19,9 @@ github.setup        pothosware PothosBlocks 0.5.1 pothos-blocks-
 checksums           rmd160  c060a24f60c6297ee8fcef324172bd8595b8873e \
                     sha256  57bd57eb4559f4f537b91f900fd026d06b056b260bca95750148f94624fd4b1d \
                     size    50438
-revision            0
+revision            1
 
 depends_lib-append \
     port:PothosCore \
     port:poco \
-    port:json-modern-cpp
+    port:nlohmann-json

--- a/science/PothosComms/Portfile
+++ b/science/PothosComms/Portfile
@@ -20,10 +20,10 @@ github.setup        pothosware PothosComms 0.3.3 pothos-comms-
 checksums           rmd160 7faf51fd293717da52d193f848aa4034e57c182a \
                     sha256 77a33db29c41b6c9c35543ba633d1494c9b28846ebfa3290f1420046d752172c \
                     size   87729
-revision            0
+revision            1
 
 depends_lib-append \
     port:PothosCore \
     port:poco \
-    port:json-modern-cpp \
+    port:nlohmann-json \
     port:spuce

--- a/science/PothosCore/Portfile
+++ b/science/PothosCore/Portfile
@@ -17,7 +17,7 @@ github.setup        pothosware PothosCore 0.6.1 pothos-
 checksums           rmd160  da4d2a054f3e6731cc67841fe28083ada806b874 \
                     sha256  3ccb1e1f7774cf40d58bab22a3ee93aae5d8341df6ae30acd7750e794264bd57 \
                     size    258129
-revision            0
+revision            1
 
 depends_build-append \
     port:pkgconfig
@@ -25,7 +25,7 @@ depends_build-append \
 depends_lib-append \
     port:poco \
     port:muparserx \
-    port:json-modern-cpp
+    port:nlohmann-json
 
 configure.args-append \
     -DPOTHOS_EXTVER=release \

--- a/science/PothosSoapy/Portfile
+++ b/science/PothosSoapy/Portfile
@@ -17,10 +17,10 @@ github.setup        pothosware PothosSoapy 0.5.0 pothos-soapy-
 checksums           rmd160  78f453bdfb55f55b110e151994311ea787449dc2 \
                     sha256  a2feba392c8e90f4b783cd63615375d0df31078236a78543c46c433e9577475b \
                     size    27479
-revision            0
+revision            1
 
 depends_lib-append \
     port:PothosCore \
     port:poco \
-    port:json-modern-cpp \
+    port:nlohmann-json \
     port:SoapySDR


### PR DESCRIPTION


#### Description

- replaced by nlohmann-json because it is a duplicate
  see https://github.com/macports/macports-ports/pull/5760#issuecomment-552906911
- changed depends_lib on Pothos*

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.1 19B88
Xcode 11.2 11B52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
