### PR TITLE
py-pyopencl: Update to 2019.1.2 and add py37

### DIFF
--- a/python/py-pyopencl/Portfile
+++ b/python/py-pyopencl/Portfile
@@ -8,7 +8,7 @@ set _name           pyopencl
 set _n              [string index ${_name} 0]
 
 name                py-${_name}
-version             2017.2.2
+version             2019.1.2
 categories-append   science parallel
 license             MIT
 platforms           darwin
@@ -23,17 +23,18 @@ homepage            http://mathema.tician.de/software/${_name}
 master_sites        pypi:${_n}/${_name}/
 distname            ${_name}-${version}
 
-checksums           md5     bfd56711959bd4ca120a6f3fd8fc6aef \
-                    rmd160  df2ad4923eec06fea0b3055e1654ab173e99d7b3 \
-                    sha256  d2f7b04d2e819c6e90d6366b7712a7452a39fba218e51b11b02c85ab07fd2983
+checksums           md5     3cefdc1566100ef60b122686e003788f \
+                    rmd160  e848810e5f8911bd3a3b4620ea7c3330cf5d872a \
+                    sha256  7803f3128dbd28ae6f5b851a80ef586a35b9575406ea7bb068b8e1516f8043f0
 
-python.versions     27 35 36
+python.versions     27 35 36 37
 
 if {${name} ne ${subport}} {
     depends_build-append \
                         port:py${python.version}-setuptools \
                         port:py${python.version}-numpy \
-                        port:py${python.version}-mako
+                        port:py${python.version}-mako \
+                        port:py${python.version}-pybind11
 
     depends_lib-append \
                         port:py${python.version}-cffi

--- a/python/py-pyopencl/Portfile
+++ b/python/py-pyopencl/Portfile
@@ -23,9 +23,9 @@ homepage            http://mathema.tician.de/software/${_name}
 master_sites        pypi:${_n}/${_name}/
 distname            ${_name}-${version}
 
-checksums           md5     3cefdc1566100ef60b122686e003788f \
-                    rmd160  e848810e5f8911bd3a3b4620ea7c3330cf5d872a \
-                    sha256  7803f3128dbd28ae6f5b851a80ef586a35b9575406ea7bb068b8e1516f8043f0
+checksums           rmd160  e848810e5f8911bd3a3b4620ea7c3330cf5d872a \
+                    sha256  7803f3128dbd28ae6f5b851a80ef586a35b9575406ea7bb068b8e1516f8043f0 \
+                    size 343805
 
 python.versions     27 35 36 37
 


### PR DESCRIPTION
#### Description

Update [pyopencl](https://github.com/inducer/pyopencl) to the latest version, 2019.1.2, and add Python 3.7 support. This closes https://trac.macports.org/ticket/57518, which requested an update to 2018.2.1.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G1012
Xcode 11.2.1 11B500 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
