### PR TITLE
gmic: require Xcode if SDKs not provided by CLT

### DIFF
--- a/science/gmic/Portfile
+++ b/science/gmic/Portfile
@@ -77,5 +77,11 @@ build.dir           ${worksrcpath}/src
 build.args-append   CC=${configure.cc} \
                     CXX=${configure.cxx}
 
+#see https://trac.macports.org/ticket/59677
+#see https://trac.macports.org/ticket/58779
+if { !${use_xcode} && ![file exists ${configure.developer_dir}/SDKs] } {
+    use_xcode yes
+}
+
 livecheck.url       http://gmic.eu/files/source/
 livecheck.regex     ${name}_(\[0-9.\]+)${extract.suffix}


### PR DESCRIPTION
Fixes https://trac.macports.org/ticket/59677
See https://trac.macports.org/ticket/58779

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.10
Xcode 7.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
