### PR TITLE
qt5*-qtbase: fix ICU test

### DIFF
--- a/aqua/qt53/Portfile
+++ b/aqua/qt53/Portfile
@@ -744,6 +744,10 @@ foreach {module module_info} [array get modules] {
             # see https://trac.macports.org/ticket/59364
             patchfiles-append patch-qtbase-intel_intrinsics.diff
 
+            # ICU now requires C++11
+            # see https://trac.macports.org/ticket/59434
+            patchfiles-append patch-qtbase-icu_test.diff
+
             # see https://trac.macports.org/ticket/59312
             use_xcode yes
 

--- a/aqua/qt53/files/patch-qtbase-icu_test.diff
+++ b/aqua/qt53/files/patch-qtbase-icu_test.diff
@@ -1,0 +1,9 @@
+--- config.tests/unix/icu/icu.pro.orig	2017-09-06 05:13:54.000000000 -0700
++++ config.tests/unix/icu/icu.pro	2019-11-13 10:09:23.000000000 -0700
+@@ -1,5 +1,6 @@
+ SOURCES = icu.cpp
+ CONFIG += console
+ CONFIG -= qt dylib
++CONFIG += c++11
+ 
+ include($$PWD/../../../src/3rdparty/icu_dependency.pri)

--- a/aqua/qt55/Portfile
+++ b/aqua/qt55/Portfile
@@ -764,6 +764,10 @@ foreach {module module_info} [array get modules] {
             # see https://trac.macports.org/ticket/59364
             patchfiles-append patch-qtbase-intel_intrinsics.diff
 
+            # ICU now requires C++11
+            # see https://trac.macports.org/ticket/59434
+            patchfiles-append patch-qtbase-icu_test.diff
+
             # see https://trac.macports.org/ticket/59312
             use_xcode yes
 

--- a/aqua/qt55/files/patch-qtbase-icu_test.diff
+++ b/aqua/qt55/files/patch-qtbase-icu_test.diff
@@ -1,0 +1,9 @@
+--- config.tests/unix/icu/icu.pro.orig	2017-09-06 05:13:54.000000000 -0700
++++ config.tests/unix/icu/icu.pro	2019-11-13 10:09:23.000000000 -0700
+@@ -1,5 +1,6 @@
+ SOURCES = icu.cpp
+ CONFIG += console
+ CONFIG -= qt dylib
++CONFIG += c++11
+ 
+ include($$PWD/../../../src/3rdparty/icu_dependency.pri)

--- a/aqua/qt56/Portfile
+++ b/aqua/qt56/Portfile
@@ -808,6 +808,10 @@ foreach {module module_info} [array get modules] {
             # see https://trac.macports.org/ticket/59364
             patchfiles-append patch-qtbase-intel_intrinsics.diff
 
+            # ICU now requires C++11
+            # see https://trac.macports.org/ticket/59434
+            patchfiles-append patch-qtbase-icu_test.diff
+
             # see https://trac.macports.org/ticket/59312
             use_xcode yes
 

--- a/aqua/qt56/files/patch-qtbase-icu_test.diff
+++ b/aqua/qt56/files/patch-qtbase-icu_test.diff
@@ -1,0 +1,9 @@
+--- config.tests/unix/icu/icu.pro.orig	2017-09-06 05:13:54.000000000 -0700
++++ config.tests/unix/icu/icu.pro	2019-11-13 10:09:23.000000000 -0700
+@@ -1,5 +1,6 @@
+ SOURCES = icu.cpp
+ CONFIG += console
+ CONFIG -= qt dylib
++CONFIG += c++11
+ 
+ include($$PWD/../../../src/3rdparty/icu_dependency.pri)

--- a/aqua/qt57/Portfile
+++ b/aqua/qt57/Portfile
@@ -879,6 +879,10 @@ foreach {module module_info} [array get modules] {
             # see https://trac.macports.org/ticket/59364
             patchfiles-append patch-qtbase-intel_intrinsics.diff
 
+            # ICU now requires C++11
+            # see https://trac.macports.org/ticket/59434
+            patchfiles-append patch-qtbase-icu_test.diff
+
             # see https://trac.macports.org/ticket/59312
             use_xcode yes
 

--- a/aqua/qt57/files/patch-qtbase-icu_test.diff
+++ b/aqua/qt57/files/patch-qtbase-icu_test.diff
@@ -1,0 +1,9 @@
+--- config.tests/unix/icu/icu.pro.orig	2017-09-06 05:13:54.000000000 -0700
++++ config.tests/unix/icu/icu.pro	2019-11-13 10:09:23.000000000 -0700
+@@ -1,5 +1,6 @@
+ SOURCES = icu.cpp
+ CONFIG += console
+ CONFIG -= qt dylib
++CONFIG += c++11
+ 
+ include($$PWD/../../../src/3rdparty/icu_dependency.pri)


### PR DESCRIPTION
ICU requires C++11.
QtBase uses -std=c++XYZ in the build but not the configure phase.

Fixes https://trac.macports.org/ticket/59434

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6
Xcode 11.2.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
