### PR TITLE
scantailor-universal: Add new port

### DIFF
--- a/graphics/scantailor-universal/Portfile
+++ b/graphics/scantailor-universal/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                      1.0
+PortGroup                       github 1.0
+PortGroup                       cmake 1.0
+PortGroup                       qt5 1.0
+
+github.setup                    trufanov-nok scantailor 0.2.7
+github.tarball_from             archive
+name                            scantailor-universal
+conflicts                       scantailor
+platforms                       darwin
+maintainers                     {raphael @raphael-st} openmaintainer
+license                         GPL-3+
+categories                      graphics aqua
+description                     A fork of the original scantailor: an interactive post-processing tool for scanned pages. 
+homepage                        http://scantailor.org/
+long_description                Scan Tailor is an interactive post-processing tool for scanned \
+                                pages. It performs operations such as page splitting, deskewing, \
+                                adding/removing borders, and others. You give it raw scans, and \
+                                you get pages ready to be printed or assembled into a PDF or \
+                                DJVU file. Scanning, optical character recognition, and \
+                                assembling multi-page documents are out of scope of this project. \
+                                This fork merges the features of the ScanTailor Featured and \
+                                ScanTailor Enhanced versions, brings new ones and fixes.
+
+
+depends_lib-append              port:jpeg \
+                                port:zlib \
+                                port:libpng \
+                                port:tiff \
+                                port:boost \
+                                port:xrender
+
+checksums                       rmd160  7de5d9a14fe743535d4d56560c74c126f0b2cf30 \
+                                sha256  3e27647621d43638888a268902f8fa098b06a70a5da5d0623b1c11220a367910 \
+                                size    1307667
+                                
+                                # Enable High-DPI 
+patchfiles                      Info-plist.patch
+
+
+post-destroot {                 
+                                # create application bundle
+                                set appdir ${destroot}${applications_dir}/ScanTailorUniversal.app
+                                move ${destroot}${prefix}/scantailor.app ${appdir}
+                                move ${appdir}/Contents/MacOS/scantailor ${appdir}/Contents/MacOS/ScanTailorUniversal
+}

--- a/graphics/scantailor-universal/files/Info-plist.patch
+++ b/graphics/scantailor-universal/files/Info-plist.patch
@@ -1,0 +1,13 @@
+diff --git packaging/osx/Info.plist.in packaging/osx/Info.plist.in
+index 2aa1a238..de48e5e4 100644
+--- packaging/osx/Info.plist.in
++++ packaging/osx/Info.plist.in
+@@ -2,6 +2,8 @@
+ <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+ <plist version="1.0">
+ <dict>
++    <key>NSPrincipalClass</key>
++    <string>NSApplication</string>
+ 	<key>CFBundleDevelopmentRegion</key>
+ 	<string>English</string>
+ 	<key>CFBundleInfoDictionaryVersion</key>


### PR DESCRIPTION
#### Description
Adding a new fork of `scantailor`. It should be more up to date. It also features Qt5 instead of Qt4. It should have the same functionality as the base one, so I believe this could be a drop-in replacement with same functionalities. 

I kept the same maintainer as the core one. 

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
