### PR TITLE
terraform: update to 0.12.15

### DIFF
--- a/sysutils/terraform/Portfile
+++ b/sysutils/terraform/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                terraform
-version             0.12.14
+version             0.12.15
 
 categories          sysutils
 license             MPL-2
@@ -25,9 +25,9 @@ homepage            https://www.terraform.io/downloads.html
 master_sites        https://releases.hashicorp.com/${name}/${version}
 distname            ${name}_${version}_darwin_amd64
 
-checksums           rmd160  0b862d81eb7148bf3cc196568e3c6f8d6293ba75 \
-                    sha256  2a4538ccf212865cb2c275dc079926f409b3809cb589638f560d5ab389babe00 \
-                    size    17092356
+checksums           rmd160  11ea8e1d17810ca15c229b12c0d3fbc3950ac6da \
+                    sha256  c1ec56b36e8395a454b7d0ba421aa42c54d2f91c913893447d20aecf1437623f \
+                    size    17098855
 
 use_configure       no
 use_zip             yes


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.1 19B88
Xcode 11.2.1 11B500

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
