### PR TITLE
welle.io: update to 20191113 (welle.io-devel subport)

### DIFF
--- a/multimedia/welle.io/Portfile
+++ b/multimedia/welle.io/Portfile
@@ -75,21 +75,18 @@ if {${subport} eq ${name}} {
                             458-fixFreezeWithRtlSdr.patch
 } else {
     # devel
-    github.setup            AlbrechtL welle.io 4b9ab6d00046927309c84ea4aa31df679ce40c59
+    github.setup            AlbrechtL welle.io c3dc6bec7a3494f669efbc0b0792e32fe73a69ab
     set githash             [string range ${github.version} 0 6]
-    version                 20191029+git${githash}
+    version                 20191113+git${githash}
 
     conflicts               welle.io
 
-    checksums               rmd160  1998043b2a1daacbd97abd661b0e9ac6035e209d \
-                            sha256  42b22c2dd8f71e1359c882314b1f3230d22ca580a86c29c075459860c4c4040b \
-                            size    1630258
+    checksums               rmd160  d769bdef25c7c193dca10463213a2f246de64874 \
+                            sha256  8acd45131a4dc9b0e0adadf1e528c215d59617cd1ca3e74643dcbf022d02181e \
+                            size    1634819
 
     configure.pre_args-append \
         -DGIT_COMMIT_HASH=${githash}
-
-    patch.pre_args          -p1
-    patchfiles-append       458-fixFreezeWithRtlSdr.patch
 }
 
 configure.pre_args-append \


### PR DESCRIPTION
#### Description
welle.io: update to 20191113 (welle.io-devel subport)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
