### PR TITLE
vault: update to 1.3.0

### DIFF
--- a/security/vault/Portfile
+++ b/security/vault/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        hashicorp vault 1.2.4 v
+github.setup        hashicorp vault 1.3.0 v
 homepage            https://www.vaultproject.io/
 
 platforms           darwin
@@ -43,6 +43,9 @@ use_configure       no
 use_parallel_build  no
 
 post-extract {
+    # Patch go.mod to remove the replace command for Thrift
+    exec patch -d "${worksrcpath}" -p0 < "${filespath}/remove-replace-thrift-gomod.patch"
+
     file mkdir [file dirname ${proj_dir}]
     move ${worksrcpath} ${proj_dir}
 }

--- a/security/vault/files/remove-replace-thrift-gomod.patch
+++ b/security/vault/files/remove-replace-thrift-gomod.patch
@@ -1,0 +1,11 @@
+--- go.mod      2019-11-15 01:19:35.000000000 -0500
++++ go.mod      2019-11-15 01:19:41.000000000 -0500
+@@ -2,7 +2,7 @@
+ 
+ go 1.12
+ 
+-replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0
++//replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0
+ 
+ replace github.com/hashicorp/vault/api => ./api
+ 


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.1 19B88
Xcode 11.2.1 11B500

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
