### PR TITLE
ds9: replace outdated tcltls sources

### DIFF
--- a/science/ds9/Portfile
+++ b/science/ds9/Portfile
@@ -23,11 +23,20 @@ long_description \
 license_noconflict      openssl
 
 homepage                http://ds9.si.edu/
-master_sites            ${homepage}/download/source
+master_sites            ${homepage}/download/source \
+                        https://core.tcl-lang.org/tcltls/uv:tcltls
 distname                ${name}.${version}
-checksums               sha256  07c7396e220d9763d4a9edd18f5ba0edf8030a1bddbf1c65b33b962d37a97677 \
+distfiles               ${distname}${extract.suffix} \
+                        tcltls-1.7.19.tar.gz:tcltls
+
+checksums               ds9.7.6.tar.gz \
                         rmd160  0c80027a4d5c5c42e0a50c996063d5e4509beee6 \
-                        size    84727405
+                        sha256  07c7396e220d9763d4a9edd18f5ba0edf8030a1bddbf1c65b33b962d37a97677 \
+                        size    84727405 \
+                        tcltls-1.7.19.tar.gz \
+                        rmd160  53cb55a0e9d1c2465773addbf57284cff338bc4d \
+                        sha256  498cd118b5e128678f26d259a497bac3dfb8323442b6abeb821ccccd1a910a86 \
+                        size    164750
 
 depends_build-append    port:autoconf
 
@@ -53,6 +62,11 @@ post-patch {
         ${worksrcpath}/ds9/unix/ds9.C \
         ${worksrcpath}/ds9/library/ds9.tcl \
         ${worksrcpath}/tksao/configure
+
+    # The bundled version of tcltls is too old to build against recent versions
+    # of OpenSSL. Substitute a more recent version, tcltls-1.7.19.
+    file delete -force ${worksrcpath}/tls
+    file rename ${workpath}/tcltls-1.7.19 ${worksrcpath}/tls
 }
 
 variant x11 conflicts aqua description {Enable X11 GUI} {


### PR DESCRIPTION
The ds9 source tarball includes an outdated copy of tcltls that
does not build against openssl 1.1.0 or newer. Replace the outdated
tcltls source with a more recent version.

Fixes: https://trac.macports.org/ticket/59692