### PR TITLE
Dovecot2 pandocfix

### DIFF
--- a/mail/dovecot2/Portfile
+++ b/mail/dovecot2/Portfile
@@ -31,7 +31,6 @@ set perl5_major_version \
 
 depends_build-append \
                     port:gettext \
-                    port:pandoc \
                     port:pkgconfig \
                     port:wget
 
@@ -81,6 +80,7 @@ configure.args      --sysconfdir=${prefix}/etc \
                     --with-pam
 
 configure.cppflags  -I${prefix}/include/openssl
+configure.env-append       PANDOC=false
 
 variant gssapi \
     description "Enable GSSAPI authentication" {


### PR DESCRIPTION
#### Description
Removes pointless pandoc dependency. 

The pandoc 'dependency' is only relevant to the maintainer. Disabling it changes nothing in what the port installs, but does eliminate ate a tree of dependencies that blocks 32-bit builds. 

Fixes:
   https://trac.macports.org/ticket/58890

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.6.8, 10.14.6
Xcode 3.2.6, 11.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [ x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
