### PR TITLE
tor-devel: update to 0.4.2.4-rc

### DIFF
--- a/security/tor-devel/Portfile
+++ b/security/tor-devel/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                tor-devel
 conflicts           tor
-version             0.4.2.3-alpha
+version             0.4.2.4-rc
 revision            0
 categories          security
 platforms           darwin
@@ -24,9 +24,9 @@ homepage            https://www.torproject.org/
 master_sites        https://dist.torproject.org/
 distname            tor-${version}
 
-checksums           rmd160  68d221a46664a776c6fc5c36ab4f86973b991de8 \
-                    sha256  ec3914be69ef3bf322a24d98ee8de6e194afa3327a4b92844b6b76af80f89d1e \
-                    size    7534968
+checksums           rmd160  b679d71f265ea4ad76fda27ffcf2a20a7a3163e5 \
+                    sha256  a09530838c5e6316a4ad55cf9c0ae0c76f147b419c69da2f129666a8666849dc \
+                    size    7567877
 
 depends_lib         port:libevent \
                     path:lib/libssl.dylib:openssl \


### PR DESCRIPTION
#### Description
tor-devel: update to 0.4.2.4-rc

###### Type(s)

- [X] bugfix
- [X] enhancement

###### Tested on
macOS 10.15.2 19C39d
Xcode 11.3 11C24b 

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tested basic functionality of all binary files?