### PR TITLE
proguard: update to 6.2.0

### DIFF
--- a/java/proguard/Portfile
+++ b/java/proguard/Portfile
@@ -1,7 +1,7 @@
 PortSystem 1.0
 
 name            proguard
-version         5.3.2
+version         6.2.0
 categories      java
 platforms       darwin
 license         GPL-2
@@ -21,8 +21,10 @@ homepage        http://proguard.sourceforge.net/
 
 master_sites    sourceforge
 distname        ${name}${version}
-checksums           rmd160  5e4dea659fa4376ce9029f51063b3f3542957786 \
-                    sha256  b7e4e63bd7e232d2b00a962f39da04e504502f0853b69161948de24caf401364
+
+checksums       rmd160  733100f8442d28d43dadc1cf855e2d1ab1213ced \
+                sha256  7f64bd1db37c3b2eae69803135e0e59f438b759bd00a5ef18ee7319657916575 \
+                size    2180476
 
 depends_lib     bin:java:kaffe
 
@@ -40,7 +42,7 @@ destroot {
     foreach f [glob -directory ${worksrcpath}/lib *.jar] {
         file copy ${f} ${javadir}/
     }
-    foreach f {README docs examples} {
+    foreach f {README.md LICENSE.md examples} {
         file copy ${worksrcpath}/${f} ${docdir}/
     }
 }


### PR DESCRIPTION
###### Tested on

macOS 10.14.6 18G1012
Xcode 11.2 11B52

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?