### PR TITLE
libusbmuxd: update to 2.0.0

### DIFF
--- a/devel/libusbmuxd/Portfile
+++ b/devel/libusbmuxd/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        libimobiledevice libusbmuxd 1.0.10
+github.setup        libimobiledevice libusbmuxd 2.0.0
 
 categories          devel
 platforms           darwin
@@ -16,9 +16,9 @@ long_description    A client library to multiplex connections from and to iOS de
 
 license             LGPL-2.1
 
-checksums           rmd160  eb232798c31bca6d0259796b87922644a99d00fa \
-                    sha256  f7fe90e3613d20dd16967d8caa1df2edac5dacdaf32f5a826dc8e31d6d8b6b39 \
-                    size    28340
+checksums           rmd160  87eaeb1df29ccfbc17bce4ce8f13bd0eac1ce1bc \
+                    sha256  b7fe9a550fe7e3671f0a81d103b40fc220fa533cbadffbdaee9b6dbca02069b9 \
+                    size    42118
 
 depends_build-append \
                     port:autoconf \

--- a/textproc/libplist/Portfile
+++ b/textproc/libplist/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        libimobiledevice libplist 2.0.0
+github.setup        libimobiledevice libplist 2.1.0
 
 categories          textproc multimedia
 platforms           darwin
@@ -16,9 +16,9 @@ long_description    ${description}
 
 homepage            https://www.libimobiledevice.org/
 
-checksums           rmd160  3ed1e778e4bb429b243fc2724e1db1c2ff55c503 \
-                    sha256  47c9024e1f88033d05cf3f447af986b97b53589097b4a301c0d3bbe728cc41ab \
-                    size    161266
+checksums           rmd160  3dfed53811ad7281d4715242f8667f9135ea7a91 \
+                    sha256  5d47e7512e19e40ab835819f4090f266cd7db659e98d066a6be10e19e11e9000 \
+                    size    175985
 
 depends_build-append \
                     port:autoconf \


### PR DESCRIPTION
#### Description

libusbmuxd has its first new release in 5 years!

It now requires libplist 2.1.0, which I have also bumped.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.1 19B88
Xcode 11.2.1 11B500 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
