### PR TITLE
auto-multiple-choice-devel: update to revision adb638a0

### DIFF
--- a/x11/auto-multiple-choice/Portfile
+++ b/x11/auto-multiple-choice/Portfile
@@ -40,13 +40,13 @@ if {${subport} eq ${name}} {
     conflicts               auto-multiple-choice-devel
 } else {
     # devel
-    set gitlab.commit       "b8e377a2926dfccd860a63414b5f51c7abac6dd9"
-    set amc_revision        "201910131933"
-    set amc_date            "201910131933"
+    set gitlab.commit       "adb638a014e0a1da2419ee092d1a19210b16d3c9"
+    set amc_revision        "201911160924"
+    set amc_date            "201911160924"
     version                 1.4.0-${amc_revision}
-    checksums               rmd160  5cb7dded388bd9b6acc329a0726f8acfd7cc8c36 \
-                            sha256  9e51ca3b79c2cb352ad01e8d49d992f924edd15c5c06f2eb7f19424571d40f17 \
-                            size    5768126
+    checksums               rmd160  0b48d68161f1bace705a2fa1508e3946dd5d6d36 \
+                            sha256  a2b0ac4b9599939e8c51d05ac7528bdab0cd91ccd67dd0c08b8b86373522fbff \
+                            size    5768018
     build.cmd               ${prefix}/bin/gmake
     conflicts               auto-multiple-choice
 }


### PR DESCRIPTION
* update to revision adb638a0
* correct printing bug

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.1
Xcode 11.2.1 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
