### PR TITLE
macos-fortress: Bugfix bump revision

### DIFF
--- a/net/macos-fortress/Portfile
+++ b/net/macos-fortress/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                macos-fortress
 version             2019.10.27
-revision            0
+revision            1
 
 categories          net security
 platforms           darwin


### PR DESCRIPTION
macos-fortress: Bugfix bump revision

* Mirrors are still serving old hosts.orig file, not hosts-orig

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

@mf2k I believe that a revision bump is necessary because the file `hosts.orig.macports` is still being created upon install. Local installs work, but not MacPorts installs.
