### PR TITLE
libimobiledevice{,-devel}: loosen requirement for libusbmuxd

### DIFF
--- a/devel/libimobiledevice/Portfile
+++ b/devel/libimobiledevice/Portfile
@@ -40,7 +40,7 @@ depends_build-append \
 
 depends_lib         port:libplist \
                     path:lib/libssl.dylib:openssl \
-                    port:libusbmuxd
+                    path:lib/libusbmuxd.dylib:libusbmuxd
 
 configure.cmd       ./autogen.sh
 
@@ -56,8 +56,9 @@ subport libimobiledevice-devel {
                     sha256  b4299f250e391a1c493f78944eac1165170c76dedd95677ed181592989ed765b \
                     size    244977
 
-    depends_lib-delete port:libusbmuxd
-    depends_lib-append port:libusbmuxd-devel
+    # Prefer -devel port as these are often used together
+    depends_lib-delete path:lib/libusbmuxd.dylib:libusbmuxd
+    depends_lib-append path:lib/libusbmuxd.dylib:libusbmuxd-devel
 
     conflicts       libimobiledevice
 


### PR DESCRIPTION
#### Description

This PR loosens the dependency on libusbmuxd to allow either the regular or -devel version. I had an occasion to want to mix and match so I thought this would be nice.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.1 19B88
Xcode 11.2.1 11B500 

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
