### PR TITLE
msodbcsql{,17}: Fix ids of installed library

### DIFF
--- a/databases/msodbcsql/Portfile
+++ b/databases/msodbcsql/Portfile
@@ -32,6 +32,7 @@ build {
     system "install_name_tool -change /usr/local/lib/libodbcinst.2.dylib ${prefix}/lib/libodbcinst.2.dylib ${worksrcpath}/lib/libmsodbcsql.13.dylib"
     system "install_name_tool -change /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib ${prefix}/lib/openssl-1.0/libcrypto.1.0.0.dylib ${worksrcpath}/lib/libmsodbcsql.13.dylib"
     system "install_name_tool -change /usr/local/opt/openssl/lib/libssl.1.0.0.dylib ${prefix}/lib/openssl-1.0/libssl.1.0.0.dylib ${worksrcpath}/lib/libmsodbcsql.13.dylib"
+    system "install_name_tool -id ${prefix}/lib/libmsodbcsql.13.dylib ${worksrcpath}/lib/libmsodbcsql.13.dylib"
 }
 
 destroot {

--- a/databases/msodbcsql/Portfile
+++ b/databases/msodbcsql/Portfile
@@ -2,6 +2,7 @@ PortSystem          1.0
 
 name                msodbcsql
 version             13.1.9.2
+revision            1
 epoch               1
 categories          databases
 platforms           darwin

--- a/databases/msodbcsql17/Portfile
+++ b/databases/msodbcsql17/Portfile
@@ -29,6 +29,7 @@ patch {
                     
 build {
     system "install_name_tool -change /usr/local/lib/libodbcinst.2.dylib ${prefix}/lib/libodbcinst.2.dylib ${worksrcpath}/lib/libmsodbcsql.17.dylib"
+    system "install_name_tool -id ${prefix}/lib/libmsodbcsql.17.dylib ${worksrcpath}/lib/libmsodbcsql.17.dylib"
 }
 
 destroot {

--- a/databases/msodbcsql17/Portfile
+++ b/databases/msodbcsql17/Portfile
@@ -2,6 +2,7 @@ PortSystem          1.0
 
 name                msodbcsql17
 version             17.4.1.1
+revision            1
 categories          databases
 platforms           darwin
 supported_archs     x86_64


### PR DESCRIPTION
Fix IDs of installed libraries; without out this, applications linked against the (17) library fail with:

```
dyld: Library not loaded: /Users/bamboo/bamboo-agent-home/xml-data/build-dir/LO-MBT-BR/msodbcsql.build/retail/Darwin/amd64/Sql/Ntdbms/sqlncli/libmsodbcsql.dylib
  Referenced from:<application path>
  Reason: image not found
Abort trap: 6
```

since (again, without patch) the libraries IDs point into what (I'm guessing) is MS's build/staging path:
```
> otool -L /opt/local/lib/libmsodbcsql.1{3,7}.dylib
/opt/local/lib/libmsodbcsql.13.dylib:
	/Users/bamboo/bamboo-agent-home/xml-data/build-dir/OD-MBT1-BR/13.1.9.2.build/retail/Darwin/amd64/Sql/Ntdbms/sqlncli/libmsodbcsql.dylib (compatibility version 1.5.0, current version 1.9.2)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1259.11.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1226.10.1)
	/opt/local/lib/libodbcinst.2.dylib (compatibility version 3.0.0, current version 3.0.0)
	/opt/local/lib/openssl-1.0/libcrypto.1.0.0.dylib (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/Kerberos.framework/Versions/A/Kerberos (compatibility version 5.0.0, current version 6.0.0)
	/usr/lib/libcurl.4.dylib (compatibility version 7.0.0, current version 8.0.0)
	/opt/local/lib/openssl-1.0/libssl.1.0.0.dylib (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 120.1.0)
/opt/local/lib/libmsodbcsql.17.dylib:
	/Users/bamboo/bamboo-agent-home/xml-data/build-dir/LO-MBT-BR/msodbcsql.build/retail/Darwin/amd64/Sql/Ntdbms/sqlncli/libmsodbcsql.dylib (compatibility version 0.0.1, current version 4.1.1)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1259.11.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1226.10.1)
	/opt/local/lib/libodbcinst.2.dylib (compatibility version 3.0.0, current version 3.0.0)
	/System/Library/Frameworks/Kerberos.framework/Versions/A/Kerberos (compatibility version 5.0.0, current version 6.0.0)
	/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 120.1.0)
```

With this patch:
```
> otool -L /opt/local/lib/libmsodbcsql.{13,17}.dylib
/opt/local/lib/libmsodbcsql.13.dylib:
	/opt/local/lib/libmsodbcsql.13.dylib (compatibility version 1.5.0, current version 1.9.2)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1259.11.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1226.10.1)
	/opt/local/lib/libodbcinst.2.dylib (compatibility version 3.0.0, current version 3.0.0)
	/opt/local/lib/openssl-1.0/libcrypto.1.0.0.dylib (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/Kerberos.framework/Versions/A/Kerberos (compatibility version 5.0.0, current version 6.0.0)
	/usr/lib/libcurl.4.dylib (compatibility version 7.0.0, current version 8.0.0)
	/opt/local/lib/openssl-1.0/libssl.1.0.0.dylib (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 120.1.0)
/opt/local/lib/libmsodbcsql.17.dylib:
	/opt/local/lib/libmsodbcsql.17.dylib (compatibility version 0.0.1, current version 4.1.1)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1259.11.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1226.10.1)
	/opt/local/lib/libodbcinst.2.dylib (compatibility version 3.0.0, current version 3.0.0)
	/System/Library/Frameworks/Kerberos.framework/Versions/A/Kerberos (compatibility version 5.0.0, current version 6.0.0)
	/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 120.1.0)
```