### PR TITLE
webkit2-gtk: fix quartz build

### DIFF
--- a/www/webkit2-gtk/Portfile
+++ b/www/webkit2-gtk/Portfile
@@ -82,6 +82,11 @@ patchfiles-append   patch-webkit2gtk-macports.diff
 # fix name collision that breaks build with clang-9.0
 patchfiles-append   patch-webkit2gtk-source-javascriptcore-tools-jsdollarvm-handle.diff
 
+# remove a definition from a header that was accidentally left behind in 2.26.2
+# this can be removed in 2.27.x
+# see: https://trac.macports.org/ticket/59704#comment:10
+patchfiles-append   patch-layertreehost-remove-invalidate.diff
+
 # enable Netscape plugin architecture on macOS
 # or can be explicitly disabled with the following addition if preferred
 # configure.args-append -DENABLE_NETSCAPE_PLUGIN_API=OFF

--- a/www/webkit2-gtk/files/patch-layertreehost-remove-invalidate.diff
+++ b/www/webkit2-gtk/files/patch-layertreehost-remove-invalidate.diff
@@ -1,0 +1,15 @@
+This definition from the header was subsequently removed in 2.27.1 but was left behind
+in this header for 2.26.2. This causes an error building +quartz.
+see: https://trac.macports.org/ticket/59704#comment:10
+kencu@macports.org
+
+--- Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h.orig	2019-11-19 23:19:08.000000000 -0800
++++ Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h	2019-11-19 23:19:22.000000000 -0800
+@@ -212,7 +212,6 @@
+ inline void LayerTreeHost::cancelPendingLayerFlush() { }
+ inline void LayerTreeHost::setRootCompositingLayer(WebCore::GraphicsLayer*) { }
+ inline void LayerTreeHost::setViewOverlayRootLayer(WebCore::GraphicsLayer*) { }
+-inline void LayerTreeHost::invalidate() { }
+ inline void LayerTreeHost::scrollNonCompositedContents(const WebCore::IntRect&) { }
+ inline void LayerTreeHost::forceRepaint() { }
+ inline bool LayerTreeHost::forceRepaintAsync(CallbackID) { return false; }


### PR DESCRIPTION
see: https://trac.macports.org/ticket/59704#comment:10

This fixes the build of webkit2-gtk +quartz

running it past the CI system to ensure it does not break any of the non-quartz builds.