### PR TITLE
unbound: update version to 1.9.5 and fix CVE-2019-18934

### DIFF
--- a/net/unbound/Portfile
+++ b/net/unbound/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 name                unbound
-version             1.9.4
+version             1.9.5
 categories          net
 license             BSD
 maintainers         {snc @nerdling} openmaintainer
@@ -31,9 +31,9 @@ long_description    Unbound is a validating, recursive, and caching DNS \
 
 master_sites        http://unbound.net/downloads/
 
-checksums           rmd160  b566322d636513c89940b8ab18b787d739586ff6 \
-                    sha256  3d3e25fb224025f0e732c7970e5676f53fd1764c16d6a01be073a13e42954bb0 \
-                    size    5686242
+checksums           rmd160  a49319ccc743709687792a57f1796acfa22e791e \
+                    sha256  8a8d400f697c61d73d109c250743a1b6b79848297848026d82b43e831045db57 \
+                    size    5686689
 
 configure.args-append   --with-pidfile=${prefix}/var/run/${name}/${name}.pid \
                         --with-ssl=${prefix} \


### PR DESCRIPTION


#### Description

- bump version to 1.9.5
- fix CVE-2019-18934
  Shell code execution after a specially crafted answer
  see https://nlnetlabs.nl/downloads/unbound/CVE-2019-18934.txt

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
macOS 10.15.1 19B88
Xcode 11.2 11B52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
