### PR TITLE
Update emacs-devel and emacs-app-devel to 20191120

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -88,11 +88,11 @@ if {$subport eq $name || $subport eq "emacs-app"} {
 
 if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
     epoch           1
-    version         20190829
+    version         20191120
 
     fetch.type      git
     git.url         http://git.savannah.gnu.org/r/emacs.git
-    git.branch      9df285250bc30b5ba86a19c817eea0c56164e022
+    git.branch      c928f41330ece779127a0c4c9b6ca0fdde8a1046
 
     pre-configure {
         system -W ${worksrcpath} "sh ./autogen.sh"
@@ -133,6 +133,10 @@ if {$subport eq $name || $subport eq "emacs-devel"} {
             port:libpng \
             port:lcms2 \
             port:Xft2
+
+        if {$subport eq "emacs-devel"} {
+            depends_lib-append port:harfbuzz
+        }
 
         # autoconf appears to be dropping linker flags for freetype &
         # fontconfig; work around this. See #28083
@@ -182,6 +186,10 @@ if {$subport eq $name || $subport eq "emacs-devel"} {
     }
 }
 
+if {$subport eq "emacs-app-devel"} {
+    configure.args-append --without-harfbuzz
+}
+
 if {$subport eq "emacs-app" || $subport eq "emacs-app-devel"} {
     categories-append   aqua
 
@@ -207,12 +215,11 @@ if {$subport eq "emacs-app" || $subport eq "emacs-app-devel"} {
 
     if {$subport eq "emacs-app"} {
         revision 4
-    }
-
-    variant multicolor_font description {Apply multicolor font patch} {
-        # Revert "Disable multicolor fonts on OS X..."
-        # This reverts commit 9344612d3cd164317170b6189ec43175757e4231.
-        patchfiles-append   patch-enable-multicolor-fonts.diff
+        variant multicolor_font description {Apply multicolor font patch} {
+            # Revert "Disable multicolor fonts on OS X..."
+            # This reverts commit 9344612d3cd164317170b6189ec43175757e4231.
+            patchfiles-append patch-enable-multicolor-fonts.diff
+        }
     }
 
     variant imagemagick description {Use ImageMagick} {


### PR DESCRIPTION
#### Description

emacs-devel: update emacs-devel and emacs-app-devel to 20191120
    
    * add harfbuzz port dependency to emac-devel
    * blacklist harfbuzz for emacs-app-devel
    * fix multicolor_font variant for emacs-app-devel

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G1012
Xcode 11.2.1 11B500 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
