### PR TITLE
lazygit: update to 0.11.2

### DIFF
--- a/devel/lazygit/Portfile
+++ b/devel/lazygit/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/jesseduffield/lazygit 0.10.6 v
+go.setup            github.com/jesseduffield/lazygit 0.11.2 v
 categories          devel
 license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
@@ -11,9 +11,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
 description         A simple terminal UI for git commands, written in Go
 long_description    $description
 
-checksums           rmd160  f93d94570e506960f4dd6391324ba87988c31f48 \
-                    sha256  585c368436ddee949a981db786a2f8da859567f6ae78129af952541af002b1c0 \
-                    size    7105787
+checksums           rmd160  fd7018778136b156318b195a52fd9172b4f93e69 \
+                    sha256  af93d8cf1ed170458c50a580c7386064efd7b9b74cc1205b0d38682aff9b6dbe \
+                    size    7113870
 
 build.args          -ldflags \
                       '-X main.version=${version} -X main.buildSource=macports'


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.1 19B88
Xcode 11.2.1 11B500

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
