### PR TITLE
lnav: update to 0.8.5

### DIFF
--- a/sysutils/lnav/Portfile
+++ b/sysutils/lnav/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           legacysupport 1.0
 
-github.setup        tstack lnav 0.8.1 v
-revision            6
+github.setup        tstack lnav 0.8.5 v
+revision            0
 
 maintainers         {g5pw @g5pw} openmaintainer
 categories          sysutils
@@ -28,8 +28,9 @@ depends_lib         port:curl \
                     port:bzip2 \
                     path:lib/libssl.dylib:openssl
 
-checksums           rmd160  9aa5556c9957f04f438ac33a65aaa0da897ae111 \
-                    sha256  80776cc4c79d6ae5d41c7fdec7385bd4fd340dadf0e919835d8a05d002930780
+checksums           rmd160  611d29fe11c79a8f253b6c775eb4c3ade01ee4dc \
+                    sha256  bb809bc8198d8f7395f3de76efdc1a08a5c2c97dc693040faee38802c38945de \
+                    size    908012
 
 configure.args      --disable-silent-rules \
                     --disable-static \
@@ -40,3 +41,5 @@ configure.args      --disable-silent-rules \
                     --with-sqlite3
 
 use_autoreconf      yes
+
+github.tarball_from releases


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.1 19B88
Xcode 11.2.1 11B500

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
