### PR TITLE
remove obsolete Python subports (maintainer: mcalhoun)

### DIFF
--- a/python/py-automat/Portfile
+++ b/python/py-automat/Portfile
@@ -2,10 +2,11 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
-PortGroup           github 1.0
 
-github.setup        glyph Automat 0.7.0 v
 name                py-automat
+python.rootname     Automat
+version             0.8.0
+revision            0
 
 categories-append   devel
 platforms           darwin
@@ -16,22 +17,23 @@ maintainers         {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
 description         A library for concise, idiomatic Python expression of finite-state automata
 long_description    Automat is a library for concise, idiomatic Python expression of finite-state automata (particularly deterministic finite-state transducers).
 
-checksums           rmd160  6d506f71e86c5d8b8de396c975347233d57377bd \
-                    sha256  cbd78b83fa2d81fe2a4d23d258e1661dd7493c9a50ee2f1a5b2cac61c1793b0e \
-                    size    61461
+homepage            https://github.com/glyph/automat
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
 
-master_sites        pypi:A/${github.project}
+checksums           rmd160  47ebcfc9c49f75aaa6dadc2eeb97d942e1dac0bc \
+                    sha256  269a09dfb063a3b078983f4976d83f0a0d3e6e7aaf8e27d8df1095e09dc4a484 \
+                    size    59687
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \
-                    port:py${python.version}-setuptools \
                     port:py${python.version}-setuptools_scm \
                     port:py${python.version}-m2r
 
     # uses from "pkg_resources import load_entry_point"
-    depends_run-append \
+    depends_lib-append \
                     port:py${python.version}-setuptools
 
     depends_run-append \
@@ -55,7 +57,13 @@ Please install py${python.version}-twisted and py${python.version}-graphviz manu
 "
     }
 
+    depends_run-append \
+                    port:py${python.version}-pytest
+
     test.run        yes
+    test.cmd        py.test-${python.branch}
+    test.target     automat/_test
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     livecheck.type  none
 }

--- a/python/py-automat/Portfile
+++ b/python/py-automat/Portfile
@@ -1,15 +1,18 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
-PortGroup  python 1.0
-PortGroup  github 1.0
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
 
 github.setup        glyph Automat 0.7.0 v
 name                py-automat
+
 categories-append   devel
-license             MIT
 platforms           darwin
+supported_archs     noarch
+license             MIT
 maintainers         {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
+
 description         A library for concise, idiomatic Python expression of finite-state automata
 long_description    Automat is a library for concise, idiomatic Python expression of finite-state automata (particularly deterministic finite-state transducers).
 
@@ -19,24 +22,21 @@ checksums           rmd160  6d506f71e86c5d8b8de396c975347233d57377bd \
 
 master_sites        pypi:A/${github.project}
 
-python.versions 27 34 35 36 37
+python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
-
-    supported_archs noarch
-
     depends_build-append \
-        port:py${python.version}-setuptools      \
-        port:py${python.version}-setuptools_scm  \
-        port:py${python.version}-m2r
+                    port:py${python.version}-setuptools \
+                    port:py${python.version}-setuptools_scm \
+                    port:py${python.version}-m2r
 
     # uses from "pkg_resources import load_entry_point"
     depends_run-append \
-        port:py${python.version}-setuptools
+                    port:py${python.version}-setuptools
 
     depends_run-append \
-        port:py${python.version}-attrs     \
-        port:py${python.version}-six
+                    port:py${python.version}-attrs \
+                    port:py${python.version}-six
 
     # see https://pypi.python.org/pypi/Automat/
     # see https://trac.macports.org/ticket/54627
@@ -55,7 +55,7 @@ Please install py${python.version}-twisted and py${python.version}-graphviz manu
 "
     }
 
-    test.run yes
+    test.run        yes
 
     livecheck.type  none
 }

--- a/python/py-constantly/Portfile
+++ b/python/py-constantly/Portfile
@@ -1,7 +1,7 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
-PortGroup  python 1.0
+PortSystem          1.0
+PortGroup           python 1.0
 
 name                py-constantly
 version             15.1.0
@@ -25,10 +25,9 @@ checksums           rmd160  7a9d1776bb3b44b1982ba01ce50f269d67c1e4a7 \
 
 worksrcdir          constantly-${version}
 
-python.versions 27 34 35 36 37
+python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
-
     depends_build-append \
         port:py${python.version}-setuptools
 

--- a/python/py-constantly/Portfile
+++ b/python/py-constantly/Portfile
@@ -2,9 +2,13 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
+PortGroup           github 1.0
 
+github.setup        twisted constantly 15.1.0
+github.tarball_from archive
 name                py-constantly
-version             15.1.0
+revision            0
+
 categories-append   devel
 license             MIT
 platforms           darwin
@@ -14,27 +18,15 @@ long_description    A library that provides symbolic constant support. \
     It includes collections and constants with text, numeric, and bit flag values. \
     Originally twisted.python.constants from the Twisted project.
 
-homepage            https://github.com/twisted/constantly
-
-master_sites        https://github.com/twisted/constantly/archive
-
-distname            ${version}
-
 checksums           rmd160  7a9d1776bb3b44b1982ba01ce50f269d67c1e4a7 \
-                    sha256  be63c40ef853ee785045a1d20327d8153db9291f9aaff552796bed5272f9dd60
+                    sha256  be63c40ef853ee785045a1d20327d8153db9291f9aaff552796bed5272f9dd60 \
+                    size    40635
 
-worksrcdir          constantly-${version}
-
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 if {${name} ne ${subport}} {
     depends_build-append \
         port:py${python.version}-setuptools
 
     livecheck.type  none
-} else {
-    livecheck.type   regex
-    livecheck.url    https://github.com/twisted/constantly/tags
-    livecheck.regex  "(\\d+(?:\\.\\d)*\[.a-z0-9\]*)${extract.suffix}"
-
 }

--- a/python/py-graphviz/Portfile
+++ b/python/py-graphviz/Portfile
@@ -1,4 +1,4 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
 PortGroup               python 1.0
@@ -19,7 +19,7 @@ checksums               rmd160  a95b770d327f9593ce2b4b57a3fbcdcecf696264 \
                         sha256  418279f94b5006751b3d78afcbd54ed353d9bbc5eb2c989663320e4cf58281b9 \
                         size    147674
 
-python.versions         27 34 35 36 37
+python.versions         27 35 36 37
 
 if {${name} ne ${subport}} {
 

--- a/python/py-hyperlink/Portfile
+++ b/python/py-hyperlink/Portfile
@@ -1,4 +1,4 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
 PortGroup           python 1.0
@@ -20,7 +20,7 @@ checksums           rmd160  d6372062ea8a7721c96a9f519d2bdff587b8ec26 \
                     sha256  658cba1f39b2802ab80a394c582e420aab1ff5ece8e83804a4790c6f5cf835a3 \
                     size    101141
 
-python.versions 27 34 35 36 37
+python.versions 27 35 36 37 38
 
 if {${name} ne ${subport}} {
 

--- a/python/py-incremental/Portfile
+++ b/python/py-incremental/Portfile
@@ -2,9 +2,13 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
+PortGroup           github 1.0
 
+github.setup        twisted incremental 17.5.0
+github.tarball_from archive
 name                py-incremental
-version             17.5.0
+revision            0
+
 categories-append   devel
 license             MIT
 platforms           darwin
@@ -12,21 +16,13 @@ maintainers         {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
 description         A small library that versions your Python projects
 long_description    Incremental is a small library that versions your Python projects.
 
-homepage            https://github.com/twisted/incremental
-
-master_sites        https://github.com/twisted/incremental/archive
-
-distname            incremental-${version}
-
 checksums           rmd160  d43e1e373acf42abcaaef8ffde8f77bf5a48abb5 \
-                    sha256  7be9a13ebb2ad1dd1ed3ecf547c3fa6e1154bb793418c6cc504b9b6039b0045a
+                    sha256  7be9a13ebb2ad1dd1ed3ecf547c3fa6e1154bb793418c6cc504b9b6039b0045a \
+                    size    14674
 
-worksrcdir          incremental-incremental-${version}
-
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 if {${name} ne ${subport}} {
-
     # see https://pypi.python.org/pypi/incremental/
     #depends_lib-append port:py${python.version}-twisted
     if {[catch {set installed [lindex [registry_active py${python.version}-twisted] 0]}]} {
@@ -43,8 +39,4 @@ Please install py${python.version}-twisted manually for correct functionality.
         port:py${python.version}-click
 
     livecheck.type  none
-} else {
-    livecheck.type   regex
-    livecheck.url    https://github.com/twisted/incremental/tags
-    livecheck.regex  "(\\d+(?:\\.\\d)*\[.a-z0-9\]*)${extract.suffix}"
 }

--- a/python/py-incremental/Portfile
+++ b/python/py-incremental/Portfile
@@ -1,7 +1,7 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
-PortGroup  python 1.0
+PortSystem          1.0
+PortGroup           python 1.0
 
 name                py-incremental
 version             17.5.0
@@ -23,7 +23,7 @@ checksums           rmd160  d43e1e373acf42abcaaef8ffde8f77bf5a48abb5 \
 
 worksrcdir          incremental-incremental-${version}
 
-python.versions 27 34 35 36 37
+python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
 

--- a/python/py-libxml2/Portfile
+++ b/python/py-libxml2/Portfile
@@ -1,4 +1,4 @@
-# -*- Mode: Tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
 PortGroup python 1.0
@@ -27,7 +27,7 @@ checksums               rmd160  455f81e1f121c63dac96802de7f83ce4483f1afe \
                         sha256  aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f \
                         size    5624761
 
-python.versions         27 34 35 36 37
+python.versions         27 35 36 37
 
 if {${name} ne ${subport}} {
     depends_lib-append      port:libxml2

--- a/python/py-m2r/Portfile
+++ b/python/py-m2r/Portfile
@@ -1,4 +1,4 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
 PortGroup           python 1.0
@@ -19,7 +19,7 @@ checksums           rmd160  a71cedf33366b78544c1f5488d57d879e16b87cd \
                     sha256  5864619db80a3470f2f535bd374d6bdf025806815b203e7e0c809b544106f249 \
                     size    24466
 
-python.versions 27 34 35 36 37
+python.versions 27 35 36 37 38
 
 if {${name} ne ${subport}} {
 

--- a/python/py-openssl/Portfile
+++ b/python/py-openssl/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  a80df25bfa8d302f3cbebd36b72cb8f1ca8e6054 \
                     sha256  ce78b34790ff870676559c07c204d6ba485479f43b68e3c4520557140ebebc06 \
                     size    173512
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-simpy/Portfile
+++ b/python/py-simpy/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  b4dbd2b2e62feac1948a1dd0d0471819511b3669 \
                     sha256  6806ab46fd0df5ad7c998a87dc990227dee9486e6d3698ef8fbcd3e0e158a904 \
                     size    399980
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append\
@@ -42,6 +42,15 @@ if {${name} ne ${subport}} {
             system -W ${worksrcpath}/docs "make SPHINXBUILD=${prefix}/bin/sphinx-build-${python.branch} html man"
         }
     }
+
+    depends_test-append \
+                    port:py${python.version}-pytest
+
+    test.run        yes
+    test.cmd        py.test-${python.branch}
+    test.args       -o addopts="-m 'not benchmark'"
+    test.target
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     post-destroot {
         if {[variant_isset docs]} {

--- a/python/py-simpy/Portfile
+++ b/python/py-simpy/Portfile
@@ -1,35 +1,40 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
-PortGroup python 1.0
-PortGroup bitbucket 1.0
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           bitbucket 1.0
 
-bitbucket.setup simpy simpy 3.0.11
-name            py-${name}
-license         MIT
-maintainers     {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
-platforms       darwin freebsd
-supported_archs noarch
-installs_libs   no
-description     python based simulation language
-long_description \
-    SimPy is an object-oriented, process-based \
-    discrete-event simulation language based on standard Python.
+bitbucket.setup     simpy simpy 3.0.11
+name                py-${name}
+revision            0
 
-homepage        https://simpy.readthedocs.io
+platforms           darwin freebsd
+supported_archs     noarch
+license             MIT
+maintainers         {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
 
-python.versions 27 34 35 36 37
+installs_libs       no
 
-if {${name} ne ${subport}} {
-    depends_build-append       port:py${python.version}-setuptools
+description         python based simulation language
+long_description    SimPy is an object-oriented, process-based \
+                    discrete-event simulation language based on standard Python.
 
-    checksums       rmd160  b4dbd2b2e62feac1948a1dd0d0471819511b3669 \
+homepage            https://simpy.readthedocs.io
+
+checksums           rmd160  b4dbd2b2e62feac1948a1dd0d0471819511b3669 \
                     sha256  6806ab46fd0df5ad7c998a87dc990227dee9486e6d3698ef8fbcd3e0e158a904 \
                     size    399980
 
+python.versions     27 34 35 36 37 38
+
+if {${name} ne ${subport}} {
+    depends_build-append\
+                    port:py${python.version}-setuptools
+
     variant docs description {Install Sphinx-generated docs} {
-        depends_build-append       port:py${python.version}-sphinx \
-                                   port:py${python.version}-sphinx_rtd_theme
+        depends_build-append \
+                    port:py${python.version}-sphinx \
+                    port:py${python.version}-sphinx_rtd_theme
     }
 
     post-build {
@@ -52,5 +57,6 @@ if {${name} ne ${subport}} {
                     ${destroot}${python.prefix}
         }
     }
+
     livecheck.type  none
 }

--- a/python/py-sphinxcontrib-applehelp/Portfile
+++ b/python/py-sphinxcontrib-applehelp/Portfile
@@ -22,12 +22,10 @@ checksums           rmd160  c4afa2e1711623167a2d880c849fc91b59ba035b \
                     sha256  edaa0ab2b2bc74403149cb0209d6775c96de797dfd5b5e2a71981309efab3897 \
                     size    22086
 
-python.versions     34 35 36 37 38
+python.versions     35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \
                         port:py${python.version}-setuptools
     livecheck.type      none
-} else {
-    livecheck.type      pypi
 }

--- a/python/py-sphinxcontrib-devhelp/Portfile
+++ b/python/py-sphinxcontrib-devhelp/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  7a48f3d21aaee9f5405b7c3a778a697c5f3231cd \
                     sha256  6c64b077937330a9128a4da74586e8c2130262f014689b4b89e2d08ee7294a34 \
                     size    14016
 
-python.versions     34 35 36 37 38
+python.versions     35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -30,6 +30,4 @@ if {${name} ne ${subport}} {
     depends_run-append \
                         port:py${python.version}-docutils
     livecheck.type      none
-} else {
-    livecheck.type      pypi
 }

--- a/python/py-sphinxcontrib-htmlhelp/Portfile
+++ b/python/py-sphinxcontrib-htmlhelp/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  d33e25e6b107f4a58064b6fea6219b51866fc766 \
                     sha256  4670f99f8951bd78cd4ad2ab962f798f5618b17675c35c5ac3b2132a14ea8422 \
                     size    25417
 
-python.versions     34 35 36 37 38
+python.versions     35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -31,6 +31,4 @@ if {${name} ne ${subport}} {
     depends_run-append \
                         port:py${python.version}-docutils
     livecheck.type      none
-} else {
-    livecheck.type      pypi
 }

--- a/python/py-sphinxcontrib-jsmath/Portfile
+++ b/python/py-sphinxcontrib-jsmath/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  9ff064c88f8f121bd7876ae3f79b4c31f5a9264f \
                     sha256  a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8 \
                     size    5787
 
-python.versions     34 35 36 37 38
+python.versions     35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -30,6 +30,4 @@ if {${name} ne ${subport}} {
     depends_run-append \
                         port:py${python.version}-docutils
     livecheck.type      none
-} else {
-    livecheck.type      pypi
 }

--- a/python/py-sphinxcontrib-qthelp/Portfile
+++ b/python/py-sphinxcontrib-qthelp/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  6aa1ee00851bf48b612bb4197387ee9f096595a3 \
                     sha256  79465ce11ae5694ff165becda529a600c754f4bc459778778c7017374d4d406f \
                     size    17804
 
-python.versions     34 35 36 37 38
+python.versions     35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -30,6 +30,4 @@ if {${name} ne ${subport}} {
     depends_run-append \
                         port:py${python.version}-docutils
     livecheck.type      none
-} else {
-    livecheck.type      pypi
 }

--- a/python/py-sphinxcontrib-serializinghtml/Portfile
+++ b/python/py-sphinxcontrib-serializinghtml/Portfile
@@ -22,12 +22,10 @@ checksums           rmd160  62ad36be05e2dbccc0a0c1493fd7fd5bec5461b4 \
                     sha256  c0efb33f8052c04fd7a26c0a07f1678e8512e0faec19f4aa8f2473a8b81d5227 \
                     size    15799
 
-python.versions     34 35 36 37 38
+python.versions     35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \
                         port:py${python.version}-setuptools
     livecheck.type      none
-} else {
-    livecheck.type      pypi
 }


### PR DESCRIPTION
#### Description
This PR removes obsolete Python subports for ports maintained by @MarcusCalhoun-Lopez  that have no dependencies. Subports for newer Python versions were added if the test-suite passes and for a few ports could make use of the github PG.

###### Tested on
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
