### PR TITLE
gitlab-runner: update to 12.5.0

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 12.4.1 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 12.5.0 v
 
 categories          devel
 platforms           darwin
@@ -23,9 +23,9 @@ homepage            https://docs.gitlab.com/runner/
 master_sites        https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v${version}/
 distname            gitlab-runner-v${version}
 
-checksums           rmd160  c4b5c21dcc9afb86d43e1ca101a549de05a2a460 \
-                    sha256  ff716083e9eb4fbd065f2e5dec59d2a4b3e6463ec8e9a40c534223a16bcf9e83 \
-                    size    27480873
+checksums           rmd160  1d315f843401966b4c975dacded3ddd49393c9b5 \
+                    sha256  541a8f4f1fc03b216a3f390e844ebe486db32f42ede0f3e4ac6524b0d1bd8f8c \
+                    size    27481502
 
 # Reproduce the "build_simple" target from the upstream Makefile
 set go_ldflags      "-X ${go.package}/common.NAME=${go.package} \


### PR DESCRIPTION
#### Description

Update to GitLab Runner 12.5.0.

###### Tested on

macOS 10.15.1 19B88
Xcode 11.2.1 11B500

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?