### PR TITLE
cmake: allow universal build on macOS 10.13

### DIFF
--- a/devel/cmake/Portfile
+++ b/devel/cmake/Portfile
@@ -67,7 +67,8 @@ if {${subport} eq ${name}} {
         patch-CMakeFindFrameworks.cmake.release.diff \
         patch-Source_Modules_FindLibUV.cmake.release.diff \
         patch-fix_cxx14_17_checks.release.diff \
-        patch-fix-system-prefix-path.release.diff
+        patch-fix-system-prefix-path.release.diff \
+        patch-fix-feature-test.release.diff
 
     livecheck.type  regex
     livecheck.regex ${name}-(\[0-9.\]+)${extract.suffix}
@@ -100,7 +101,8 @@ if {${subport} eq ${name}} {
         patch-Source_Modules_FindLibUV.cmake.devel.diff \
         patch-fix_cxx14_17_checks.devel.diff \
         patch-fix-system-prefix-path.devel.diff \
-        patch-cmake-libuv.tiger.diff
+        patch-cmake-libuv.tiger.diff \
+        patch-fix-feature-test.devel.diff
 
     livecheck.type  regex
     livecheck.regex data-clipboard-text=\"(\[0-9a-g\]+)\"

--- a/devel/cmake/Portfile
+++ b/devel/cmake/Portfile
@@ -143,10 +143,8 @@ platform darwin {
     configure.env-append \
                     CMAKE_OSX_DEPLOYMENT_TARGET=${macosx_deployment_target}
 
-    if {${configure.sdkroot} != ""} {
-        configure.env-append CMAKE_OSX_SYSROOT=${configure.sdkroot}
-    } else {
-        configure.env-append CMAKE_OSX_SYSROOT=/
+    if {${configure.sdkroot} eq ""} {
+        configure.env-append SDKROOT=/
     }
 
     if {${os.arch} eq "i386" && ${os.major} <= 9} {

--- a/devel/cmake/files/patch-fix-feature-test.devel.diff
+++ b/devel/cmake/files/patch-fix-feature-test.devel.diff
@@ -1,0 +1,11 @@
+--- Source/Checks/cm_cxx_features.cmake.orig	2019-10-30 07:00:09.000000000 -0700
++++ Source/Checks/cm_cxx_features.cmake	2019-11-21 03:20:17.000000000 -0700
+@@ -26,6 +26,8 @@
+     string(REGEX REPLACE "[^\n]*warning:[^\n]*sprintf\\(\\) is often misused, please use snprintf[^\n]*" "" check_output "${check_output}")
+     # Filter out xcodebuild warnings.
+     string(REGEX REPLACE "[^\n]* xcodebuild\\[[0-9]*:[0-9]*\\] warning: [^\n]*" "" check_output "${check_output}")
++    # Filter out ld warnings.
++    string(REGEX REPLACE "[^\n]*ld: warning: [^\n]*" "" check_output "${check_output}")
+     # If using the feature causes warnings, treat it as broken/unavailable.
+     if(check_output MATCHES "(^|[ :])[Ww][Aa][Rr][Nn][Ii][Nn][Gg]")
+       set(CMake_HAVE_CXX_${FEATURE} OFF CACHE INTERNAL "TRY_COMPILE" FORCE)

--- a/devel/cmake/files/patch-fix-feature-test.release.diff
+++ b/devel/cmake/files/patch-fix-feature-test.release.diff
@@ -1,0 +1,11 @@
+--- Source/Checks/cm_cxx_features.cmake.orig	2019-10-30 07:00:09.000000000 -0700
++++ Source/Checks/cm_cxx_features.cmake	2019-11-21 03:20:17.000000000 -0700
+@@ -26,6 +26,8 @@
+     string(REGEX REPLACE "[^\n]*warning:[^\n]*sprintf\\(\\) is often misused, please use snprintf[^\n]*" "" check_output "${check_output}")
+     # Filter out xcodebuild warnings.
+     string(REGEX REPLACE "[^\n]* xcodebuild\\[[0-9]*:[0-9]*\\] warning: [^\n]*" "" check_output "${check_output}")
++    # Filter out ld warnings.
++    string(REGEX REPLACE "[^\n]*ld: warning: [^\n]*" "" check_output "${check_output}")
+     # If using the feature causes warnings, treat it as broken/unavailable.
+     if(check_output MATCHES "(^|[ :])[Ww][Aa][Rr][Nn][Ii][Nn][Gg]")
+       set(CMake_HAVE_CXX_${FEATURE} OFF CACHE INTERNAL "TRY_COMPILE" FORCE)


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13
Xcode 10.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
