### PR TITLE
graalvm: update to 19.3.0

### DIFF
--- a/java/graalvm/Portfile
+++ b/java/graalvm/Portfile
@@ -3,7 +3,7 @@
 PortSystem       1.0
 
 name             graalvm
-version          19.2.1
+version          19.3.0
 revision         0
 
 categories       java devel
@@ -19,14 +19,14 @@ long_description GraalVM is a universal virtual machine for running applications
                  Kotlin, and LLVM-based languages such as C and C++.
 homepage         https://www.graalvm.org/
 
-master_sites     https://github.com/oracle/graal/releases/download/vm-${version}/
+master_sites     https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/
     
-checksums        rmd160  03818ed6399ee665904d8fa933814a2503385ab8 \
-                 sha256  988b943bf956f88079123c2d6225d188050c1f34b3ff47449be7c7ed241dc00f \
-                 size    349548861
+checksums        rmd160  0d6e88a4a9227ab7a515d84409b4f279d4a6a016 \
+                 sha256  6c43063148368dc537a58706fcbf332583371ebb32dfdb78017e6a80e139658b \
+                 size    356582812
 
-distname         ${name}-ce-darwin-amd64-${version}
-worksrcdir       ${name}-ce-${version}
+distname         ${name}-ce-java8-darwin-amd64-${version}
+worksrcdir       ${name}-ce-java8-${version}
 
 use_configure    no
 


### PR DESCRIPTION
#### Description

Update to GraalVM Community Edition 19.3.0.

###### Tested on

macOS 10.15.1 19B88
Xcode 11.2.1 11B500

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?