### PR TITLE
sbt-0.7: port abandoned

### DIFF
--- a/devel/sbt-0.7/Portfile
+++ b/devel/sbt-0.7/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                sbt-0.7
 version             0.7.7
 categories          devel java
-maintainers         jon.buffington.name:me
+maintainers         nomaintainer
 platforms           darwin
 
 description         Simple build tool (sbt) is designed to simplify building Scala projects.


### PR DESCRIPTION
Maintainer was removed from the original `sbt` port several years ago (in 0cfc3070ad3b6828ed3abbae309a5624f58a9d2f).
See: https://trac.macports.org/ticket/33721

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
