### PR TITLE
kotlin: use java PortGroup

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -2,8 +2,10 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           java 1.0
 
 github.setup        JetBrains kotlin 1.3.60 v
+revision            1
 github.tarball_from releases
 distname            ${name}-compiler-${version}
 categories          lang java
@@ -25,7 +27,8 @@ checksums           rmd160  382ed423cd191187824073867433b96cd4a78d9b \
                     sha256  12f97cff23ff8116904cb97a7ef4e3af5c3b8e5df9d9e63baa251d9a73b42fbb \
                     size    53111648
 
-depends_run         bin:java:kaffe
+java.version        1.8+
+java.fallback       openjdk8
 
 worksrcdir          kotlinc
 


### PR DESCRIPTION
#### Description

Use MacPorts' [java PortGroup](https://guide.macports.org/chunked/reference.portgroup.html#reference.portgroup.java) for Kotlin's dependency on OpenJDK.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.1 19B88
Xcode 11.2.1 11B500

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?