### PR TITLE
micronaut: use java PortGroup

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -1,9 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
+PortSystem      1.0
 PortGroup       github 1.0
+PortGroup       java 1.0
 
 github.setup    micronaut-projects micronaut-core 1.2.6 v
+revision        1
 name            micronaut
 categories      java
 platforms       darwin
@@ -47,6 +49,9 @@ checksums       rmd160  d10fc0c79c11dd279a9990085e66699b6dbf29fc \
 
 use_zip         yes
 use_configure   no
+
+java.version    1.8+
+java.fallback   openjdk8
 
 build {}
 


### PR DESCRIPTION
#### Description

Use MacPorts' [java PortGroup](https://guide.macports.org/chunked/reference.portgroup.html#reference.portgroup.java) for Micronaut's dependency on OpenJDK.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.1 19B88
Xcode 11.2.1 11B500

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?