### PR TITLE
sbt: use Java portgroup

### DIFF
--- a/devel/sbt/Portfile
+++ b/devel/sbt/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
+PortGroup       java 1.0
 
 name            sbt
 version         0.13.18
@@ -18,7 +19,7 @@ long_description \
     extension are done in Scala.  Sbt supports continuous compilation \
     and testing with triggered execution in mixed Scala/Java projects.
 
-homepage        http://www.scala-sbt.org/
+homepage        https://www.scala-sbt.org/
 master_sites    https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/${version}
 distname        ${name}-launch
 dist_subdir     ${name}/${version}
@@ -29,7 +30,8 @@ checksums       md5     c660658ea9b1300d31aaa713f214b1b4 \
                 sha256  add170a6e07d3ecf2a5add54565a0b5f729524083f0b05f9e1d4df90adb9257b \
                 size    1210278
 
-depends_build   bin:java:kaffe
+java.version    1.6+
+java.fallback   openjdk8
 
 # Name the wrapper shell script.
 set wrapper     sbt.sh


### PR DESCRIPTION
Replace fallback dependency on `kaffe` with Java LTS

Use HTTPS homepage

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
