### PR TITLE
py-qtconsole: update to 4.6.0, remove py34 subport

### DIFF
--- a/python/py-qtconsole/Portfile
+++ b/python/py-qtconsole/Portfile
@@ -4,14 +4,15 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-qtconsole
-version             4.5.5
-revision            1
+version             4.6.0
+revision            0
+
 categories-append   devel
 platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -23,9 +24,9 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  9657f52b200ef978df576f98b5305ed00000ab99 \
-                    sha256  b91e7412587e6cfe1644696538f73baf5611e837be5406633218443b2827c6d9 \
-                    size    426336
+checksums           rmd160  36b4a57f9a121e4b13ca36a00fa69e5965b7aa0e \
+                    sha256  654f423662e7dfe6a9b26fac8ec76aedcf742c339909ac49f1f0c1a1b744bcd1 \
+                    size    426936
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-setuptools \


### PR DESCRIPTION
#### Description
- update to latest version, needed for ```py-spyder-devel```
- remove py34 subport (no dependencies)

###### Tested on
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
