### PR TITLE
welle.io: update welle.io-devel to 20191124 & rearrange variants

### DIFF
--- a/multimedia/welle.io/Portfile
+++ b/multimedia/welle.io/Portfile
@@ -19,6 +19,7 @@ long_description        This is an open source DAB and DAB+ software defined rad
                         like Raspberry Pi 2/3 and 100€ China Windows 10 tablets.
 
 license                 GPL-2
+license_noconflict      openssl
 
 homepage                https://www.welle.io/
 
@@ -75,15 +76,15 @@ if {${subport} eq ${name}} {
                             458-fixFreezeWithRtlSdr.patch
 } else {
     # devel
-    github.setup            AlbrechtL welle.io c3dc6bec7a3494f669efbc0b0792e32fe73a69ab
+    github.setup            AlbrechtL welle.io 1aa8e2fe6319e95c1e1a2815d83f3bfcd41cd386
     set githash             [string range ${github.version} 0 6]
-    version                 20191113+git${githash}
+    version                 20191124+git${githash}
 
     conflicts               welle.io
 
-    checksums               rmd160  d769bdef25c7c193dca10463213a2f246de64874 \
-                            sha256  8acd45131a4dc9b0e0adadf1e528c215d59617cd1ca3e74643dcbf022d02181e \
-                            size    1634819
+    checksums               rmd160  d2b6df7232e1b1d883887d7851fa2610e3cf3f02 \
+                            sha256  4583db0be423de82f7cc2ebc0169ff4d8e8a5bf821b146f77a3d8bb6761e9177 \
+                            size    1636011
 
     configure.pre_args-append \
         -DGIT_COMMIT_HASH=${githash}


### PR DESCRIPTION
- Update welle.io-devel to 20191124
- Rearranage variants (invert them)
- Reenable licence_noconflict openssl (see https://github.com/AlbrechtL/welle.io/issues/469)

I didn't increase "revision" because there is no need that those having welle.io 'stable' update (rearrange of variants doesn't modify the default installation)

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G22010
Xcode 7.3.1 7D1014 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
