### PR TITLE
remove obsolete Python subports (maintainer: lpsinger)

### DIFF
--- a/python/py-acor/Portfile
+++ b/python/py-acor/Portfile
@@ -12,22 +12,20 @@ description         estimate the autocorrelation time of time-series data quickl
 long_description    This is a direct port of a C++ routine by Jonathan Goodman \
                     (NYU) called ACOR that estimates the autocorrelation time \
                     of time series data very quickly.
-homepage            https://pypi.python.org/pypi/${python.rootname}/
+homepage            https://github.com/dfm/acor
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
 platforms           darwin
 license             MIT
 
-checksums           md5     8681b949f50e0f9a02bfbd15f7a3d56c \
-                    rmd160  d6e0c55e4db74b45e2ed632a0a553851ef6fe017 \
-                    sha256  4c647d30326004cfcfbcf630e97586ce574954e36bebf75b657d33d5d79e94e3
+checksums           rmd160  d6e0c55e4db74b45e2ed632a0a553851ef6fe017 \
+                    sha256  4c647d30326004cfcfbcf630e97586ce574954e36bebf75b657d33d5d79e94e3 \
+                    size    6122
 
-python.versions     27 34 35 36
+python.versions     27 35 36
 
-if {${name} eq ${subport}} {
-    livecheck.type  pypi
-} else {
+if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
 

--- a/python/py-astlib/Portfile
+++ b/python/py-astlib/Portfile
@@ -1,10 +1,12 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; truncate-lines: t; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
 PortGroup               python 1.0
 
 name                    py-astlib
-version                 0.10.0
+version                 0.10.1
+revision                0
+
 categories              python science
 platforms               darwin
 maintainers             {aronnax @lpsinger} openmaintainer
@@ -19,14 +21,14 @@ long_description \
 homepage                http://astlib.sourceforge.net
 master_sites            sourceforge:astlib
 distname                astLib-${version}
-checksums               rmd160  8cc62b175f7ad3a194279164de6a6c2efc13384c \
-                        sha256  8231da3294d8ac7b40292e9be0a0a7ab515f29401a148088464a0c2dcd8e6610 \
-                        size    742005
 
-python.versions         27 34 35 36 37
+checksums               rmd160  34e1f8148992cbd40fe224c8afa2130358b6fc5f \
+                        sha256  080a015f025623451d9429cc82ed33e7930099429064282027b5663438903982 \
+                        size    742043
+
+python.versions         27 35 36 37
 
 if {${name} ne ${subport}} {
-
     depends_lib-append  port:py${python.version}-setuptools \
                         port:py${python.version}-astropy \
                         port:py${python.version}-numpy \
@@ -34,11 +36,8 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-matplotlib \
                         path:${python.pkgd}/PIL:py${python.version}-Pillow
 
-}
-
-if {${name} eq ${subport}} {
+    livecheck.type      none
+} else {
     # Some version numbers were assigned out of order
     livecheck.regex     {/astlib/0.15/|/astlib/0.17/|/astlib/0.17.1/|/astlib/([a-zA-Z0-9.]+\.[a-zA-Z0-9.]+)/}
-} else {
-    livecheck.type      none
 }

--- a/python/py-astroML/Portfile
+++ b/python/py-astroML/Portfile
@@ -4,18 +4,17 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           select 1.0
 
-set realname        astroML
+name                py-astroML
+version             0.4.1
+revision            0
 
-name                py-${realname}
-version             0.3
-revision            1
 categories-append   science
 license             BSD
 platforms           darwin
 supported_archs     noarch
 maintainers         {aronnax @lpsinger} openmaintainer
 
-python.versions     27 34 35 36
+python.versions     27 35 36
 
 description         tools for machine learning and data mining in astronomy
 
@@ -29,14 +28,28 @@ long_description    AstroML is a Python module for machine learning and data \
                     astronomical datasets.
 
 homepage            https://www.astroml.org
-master_sites        pypi:[string index ${realname} 0]/${realname}
-distname            ${realname}-${version}
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
 
-checksums           rmd160  2a029523b0fcc768acb4e2a3efe1050e24a32cc8 \
-                    sha256  ea6d0119593aed0e0dadc79c613ac0bddad95e6f12151237562a4fd67552b2b8 \
-                    size    242925
+checksums           rmd160  3953350b06d20c22ea7a4d27b90b7db94968ffe4 \
+                    sha256  a4efa8acee889c92088ff2433d24793d24cfe7aba15d523e2e0cc12d81e4b899 \
+                    size    105183
 
 if {${name} ne ${subport}} {
+    # fix permissions
+    post-extract {
+        fs-traverse item ${worksrcpath} {
+            if {[file isdirectory ${item}]} {
+                file attributes ${item} -permissions a+rx
+            } elseif {[file isfile ${item}]} {
+                file attributes ${item} -permissions a+r
+            }
+        }
+    }
+
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
     depends_lib-append \
                     port:py${python.version}-numpy \
                     port:py${python.version}-scipy \
@@ -44,17 +57,19 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-scikit-learn \
                     port:py${python.version}-astropy
 
-    variant addons description "Install optional package py${python.version}-${realname}_addons for faster C implementations of some algorithms" {
+    variant addons description "Install optional package py${python.version}-${python.rootname}_addons for faster C implementations of some algorithms" {
         depends_run-append \
-                    port:py${python.version}-${realname}_addons
+                    port:py${python.version}-${python.rootname}_addons
     }
     default_variants +addons
 
     depends_test-append \
-                    port:py${python.version}-nose
+                    port:py${python.version}-pytest
     test.run        yes
-    test.cmd        nosetests-${python.branch}
+    test.cmd        py.test-${python.branch}
+    test.args       -o addopts=''
     test.target
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     livecheck.type  none
 }

--- a/python/py-astroML_addons/Portfile
+++ b/python/py-astroML_addons/Portfile
@@ -4,16 +4,16 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           select 1.0
 
-set realname        astroML_addons
-
-name                py-${realname}
+name                py-astroML_addons
 version             0.2.2
+revision            0
+
 categories-append   science
 license             BSD
 platforms           darwin
 maintainers         {aronnax @lpsinger} openmaintainer
 
-python.versions     27 34 35 36
+python.versions     27 35 36
 
 description         performance add-ons for the astroML package
 
@@ -28,8 +28,8 @@ long_description    AstroML is a Python module for machine learning and data \
                     implementations of some algorithms in astroML.
 
 homepage            https://www.astroml.org
-master_sites        pypi:[string index ${realname} 0]/${realname}
-distname            ${realname}-${version}
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
 
 checksums           rmd160  b4d642a073c846bd66c902ada33079afd2abdd70 \
                     sha256  c4b6e9d9f86550e1a59b54ddedf6666c7293bd7ad7b99549170e3053e57cb0cb \

--- a/python/py-bpython/Portfile
+++ b/python/py-bpython/Portfile
@@ -5,8 +5,10 @@ PortGroup               python 1.0
 PortGroup               select 1.0
 PortGroup               github 1.0
 
-github.setup            bpython bpython 0.17.1 "" -release
+github.setup            bpython bpython 0.18 "" -release
 name                    py-${name}
+revision                0
+
 platforms               darwin
 supported_archs         noarch
 maintainers             {aronnax @lpsinger} openmaintainer
@@ -16,11 +18,11 @@ long_description        a fancy interface to the Python interpreter for \
                         Unix-like operating systems
 
 homepage                https://www.bpython-interpreter.org
-checksums               rmd160  d375318faa9a5a5af7b6a5223aa29e854ab89532 \
-                        sha256  2e2c0d94986aed8b04fc6be652d7a89632d425e77e808e891a59993e48c5a394 \
-                        size    204362
+checksums               rmd160  acf93ffbe983cb522fac59eb23861c81bf0acb6e \
+                        sha256  eae3fd5c722cecfa002edfa27374a96004a1b6efa8015c991da995c0a3595da2 \
+                        size    204788
 
-python.versions         27 34 35 36
+python.versions         27 35 36 37
 
 if {${name} ne ${subport}} {
     livecheck.type          none
@@ -43,7 +45,7 @@ if {${name} ne ${subport}} {
 
     select.group            bpython
     select.file             ${filespath}/bpython${python.version}
-    
+
     post-destroot {
         set themedir ${destroot}${python.prefix}/share/themes
         xinstall -d ${themedir}

--- a/python/py-bpython/files/bpython34
+++ b/python/py-bpython/files/bpython34
@@ -1,8 +1,0 @@
-bin/bpdb-3.4
-bin/bpython-3.4
-bin/bpython-curses-3.4
-bin/bpython-urwid-3.4
-${frameworks_dir}/Python.framework/Versions/3.4/share/man/man1/bpython.1
-${frameworks_dir}/Python.framework/Versions/3.4/share/man/man5/bpython-config.5
-${frameworks_dir}/Python.framework/Versions/3.4/share/themes/light.theme
-${frameworks_dir}/Python.framework/Versions/3.4/share/themes/sample.theme

--- a/python/py-bpython/files/bpython37
+++ b/python/py-bpython/files/bpython37
@@ -1,0 +1,8 @@
+bin/bpdb-3.7
+bin/bpython-3.7
+bin/bpython-curses-3.7
+bin/bpython-urwid-3.7
+${frameworks_dir}/Python.framework/Versions/3.7/share/man/man1/bpython.1
+${frameworks_dir}/Python.framework/Versions/3.7/share/man/man5/bpython-config.5
+${frameworks_dir}/Python.framework/Versions/3.7/share/themes/light.theme
+${frameworks_dir}/Python.framework/Versions/3.7/share/themes/sample.theme

--- a/python/py-colormath/Portfile
+++ b/python/py-colormath/Portfile
@@ -1,9 +1,13 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
 github.setup        gtaylor python-colormath 3.0.0
 name                py-colormath
+revision            1
+
 categories-append   math
 license             BSD
 maintainers         {aronnax @lpsinger} openmaintainer
@@ -15,13 +19,13 @@ long_description \
 platforms           darwin
 supported_archs     noarch
 
-homepage            http://python-colormath.readthedocs.org/
+homepage            https://python-colormath.readthedocs.org/
 
 checksums           rmd160  9967dd7e3011c93d5b73565f905f740e6d6e285f \
                     sha256  e497f89469e9b532d84c0355c9dd8098b2c0f999712e5b7a8a5e9c53ef2cf9e7 \
                     size    74973
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -29,8 +33,15 @@ if {${name} ne ${subport}} {
 
     depends_lib-append \
                     port:py${python.version}-networkx \
-                    port:py${python.version}-nose \
                     port:py${python.version}-numpy
+
+    depends_test-append \
+                    port:py${python.version}-nose
+
+    test.run        yes
+    test.cmd        nosetests-${python.branch}
+    test.target
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     post-destroot {
        xinstall -m 755 -d ${destroot}${prefix}/share/doc/${subport}

--- a/python/py-curtsies/Portfile
+++ b/python/py-curtsies/Portfile
@@ -5,6 +5,8 @@ PortGroup               python 1.0
 
 name                    py-curtsies
 version                 0.3.0
+revision                1
+
 platforms               darwin
 supported_archs         noarch
 maintainers             {aronnax @lpsinger} openmaintainer
@@ -12,15 +14,14 @@ license                 MIT
 description             Curses-like terminal wrapper, with colored strings
 long_description        ${description}
 
-homepage                http://curtsies.readthedocs.io
+homepage                https://curtsies.readthedocs.io
 master_sites            pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname                ${python.rootname}-${version}
-checksums               md5     20e7295c9592b4101915131a685725f0 \
-                        rmd160  39fd8eb76f8e38fec3a7803659e3ae1a7cbfce2a \
+checksums               rmd160  39fd8eb76f8e38fec3a7803659e3ae1a7cbfce2a \
                         sha256  89c802ec051d01dec6fc983e9856a3706e4ea8265d2940b1f6d504a9e26ed3a9 \
                         size    47120
 
-python.versions         27 34 35 36
+python.versions         27 35 36 37
 
 if {${name} ne ${subport}} {
     livecheck.type          none
@@ -30,6 +31,7 @@ if {${name} ne ${subport}} {
     depends_lib-append      port:py${python.version}-blessings \
                             port:py${python.version}-wcwidth
 
-} else {
-    livecheck.type      pypi
+    if {${python.version} eq 27} {
+        depends_lib-append  port:py${python.version}-typing
+    }
 }

--- a/python/py-emcee/Portfile
+++ b/python/py-emcee/Portfile
@@ -4,9 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-set realname        emcee
-github.setup        dfm ${realname} 2.2.1 v
-name                py-${realname}
+github.setup        dfm emcee 2.2.1 v
+name                py-emcee
 
 maintainers         {aronnax @lpsinger} openmaintainer
 
@@ -17,17 +16,18 @@ long_description    emcee is a stable, well tested Python implementation of \
                     Monte Carlo (MCMC) proposed by Goodman & Weare (2010). The \
                     code is open source and has already been used in several \
                     published projects in the astrophysics literature.
-homepage            http://dan.iel.fm/emcee/
-distname            ${realname}-${version}
+homepage            https://github.com/dfm/emcee
+distname            ${python.rootname}-${version}
 
 platforms           darwin
 supported_archs     noarch
 license             MIT
 
 checksums           rmd160  9d877a80ce5a19b8c442d225a27a57fe548a14f0 \
-                    sha256  afb252b304051ca7a936e81adfa69c92b37fdafd8d3be95e920059f08dcf2d00
+                    sha256  afb252b304051ca7a936e81adfa69c92b37fdafd8d3be95e920059f08dcf2d00 \
+                    size    769439
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-ephem/Portfile
+++ b/python/py-ephem/Portfile
@@ -4,7 +4,9 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-ephem
-version             3.7.6.0
+version             3.7.7.0
+revision            0
+
 categories-append   science
 platforms           darwin
 maintainers         {aronnax @lpsinger} openmaintainer
@@ -23,13 +25,24 @@ homepage            http://rhodesmill.org/pyephem/
 distname            ephem-${version}
 master_sites        pypi:e/ephem/
 
-checksums           rmd160  32e5fcb0e74936706b68bd811a9dcdf55b97b1f8 \
-                    sha256  7a4c82b1def2893e02aec0394f108d24adb17bd7b0ca6f4bc78eb7120c0212ac \
-                    size    739442
+checksums           rmd160  ffd3edcf7b9c87e88b96b8c598526036c890ae42 \
+                    sha256  607148429f85412915e32265779c0cf6d09f73aa97cf1ff0d101ac22c69c4436 \
+                    size    745041
 
-python.versions     27 34 35 36
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
+    # fix permissions
+    post-extract {
+        fs-traverse item ${worksrcpath} {
+            if {[file isdirectory ${item}]} {
+                file attributes ${item} -permissions a+rx
+            } elseif {[file isfile ${item}]} {
+                file attributes ${item} -permissions a+r
+            }
+        }
+    }
+
     livecheck.type  none
 
     test.dir        "${worksrcpath}/build/lib.macosx-${macosx_deployment_target}-${configure.build_arch}-${python.branch}"

--- a/python/py-erf/Portfile
+++ b/python/py-erf/Portfile
@@ -1,4 +1,4 @@
-# -*- coding: utf-8; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
 PortGroup           python 1.0
@@ -16,9 +16,10 @@ long_description    Algorithms for SciPy to calculate bootstrap confidence \
                     intervals for statistics functions applied to data.
 
 checksums           rmd160  94b59ce15968f47c67c50fb8509750827f9539f0 \
-                    sha256  f06451e9777ca915e5813937e92235cbe9a60ea2a72d50dd6a0d4697932c6ed4
+                    sha256  f06451e9777ca915e5813937e92235cbe9a60ea2a72d50dd6a0d4697932c6ed4 \
+                    size    25506
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-flask-login/Portfile
+++ b/python/py-flask-login/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 
 github.setup        maxcountryman flask-login 0.4.1
 name                py-${name}
-python.versions     27 34 35 36
+python.versions     27 35 36
 license             MIT
 platforms           darwin
 supported_archs     noarch
@@ -18,7 +18,8 @@ long_description    Flask-Login provides user session management for Flask. It \
 homepage            https://flask-login.readthedocs.org/
 
 checksums           rmd160  894e04b4360905f00442d6e37c5906f4efc1d372 \
-                    sha256  5d48a082b1d2cfd82a2d4e367b38696f7bb050855bf43a0be24fbd236ba3eace
+                    sha256  5d48a082b1d2cfd82a2d4e367b38696f7bb050855bf43a0be24fbd236ba3eace \
+                    size    43668
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-flask-mail/Portfile
+++ b/python/py-flask-mail/Portfile
@@ -8,7 +8,7 @@ github.setup        mattupstate flask-mail 0.9.1
 name                py-flask-mail
 version             0.9.1
 revision            2
-python.versions     27 34 35 36
+python.versions     27 35 36
 categories-append   www
 maintainers         {aronnax @lpsinger} openmaintainer
 description         Flask Mail extension
@@ -18,10 +18,11 @@ long_description    \
 license             BSD
 platforms           darwin
 supported_archs     noarch
-homepage            http://pythonhosted.org/Flask-Mail/
+homepage            https://pythonhosted.org/Flask-Mail/
 
 checksums           rmd160  4428a70c792d942f41ea2fdef3f515444f473705 \
-                    sha256  3f5c2a7218bca5328a70c8cc4f1da2c09a14e6fc9a375485303dd92bf5883938
+                    sha256  3f5c2a7218bca5328a70c8cc4f1da2c09a14e6fc9a375485303dd92bf5883938 \
+                    size    44018
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools \

--- a/python/py-flask-script/Portfile
+++ b/python/py-flask-script/Portfile
@@ -33,6 +33,7 @@ if {${name} ne ${subport}} {
     test.run        yes
     test.cmd        py.test-${python.branch}
     test.target     tests.py
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     livecheck.type  none
 }

--- a/python/py-flask-script/Portfile
+++ b/python/py-flask-script/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 name                py-flask-script
 set realname        Flask-Script
 version             2.0.6
-python.versions     27 34 35 36
+python.versions     27 35 36
 license             BSD
 platforms           darwin
 supported_archs     noarch

--- a/python/py-flask-sqlalchemy/Portfile
+++ b/python/py-flask-sqlalchemy/Portfile
@@ -21,10 +21,14 @@ long_description    \
     helpers that make it easier to accomplish common tasks.
 
 homepage            https://pythonhosted.org/Flask-SQLAlchemy/
-checksums           rmd160  98461a11f7460a4f7fe2e3b0d6dcee9286f32499 \
-                    sha256  d3fe0ae672b0d1e34348482adf781e7af36b60e005347154fbe7594199e33457
+checksums           rmd160  6ab62d75641c202203681e6bf10d8a097aed7b10 \
+                    sha256  379f26af26c7a69a4ea12dea369832d991056d478553b40edcd104a021e453fa \
+                    size    154232
 
-python.versions     27 34 35 36
+# there seems to be a stealth update, remove on next update
+dist_subdir     ${name}/${version}_1
+
+python.versions     27 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-gcn/Portfile
+++ b/python/py-gcn/Portfile
@@ -1,12 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
-PortGroup python 1.0
-PortGroup github 1.0
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
 
 github.setup        lpsinger pygcn 0.1.19 v
 name                py-gcn
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 categories-append   science
 license             GPL-2+
 platforms           darwin

--- a/python/py-healpy/Portfile
+++ b/python/py-healpy/Portfile
@@ -1,4 +1,4 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; truncate-lines: t; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
 PortGroup               python 1.0
@@ -23,7 +23,7 @@ checksums               rmd160  15482bf7e135a8c9910f43f7cf286d5f24bbeeea \
                         sha256  3d797aee3501a810d4f210c1f89af4540e7873eaf196d01a0187bb19d5bfab91 \
                         size    4182138
 
-python.versions         27 34 35 36 37
+python.versions         27 35 36 37
 
 if {${name} ne ${subport}} {
 
@@ -60,11 +60,4 @@ if {${name} ne ${subport}} {
     }
 
     livecheck.type      none
-
-} else {
-
-    livecheck.type      regex
-    livecheck.url       ${homepage}
-    livecheck.regex     {healpy-([0-9]+(\.[0-9]+)*)}
-
 }

--- a/python/py-ipympl/Portfile
+++ b/python/py-ipympl/Portfile
@@ -10,7 +10,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 maintainers         {aronnax @lpsinger} openmaintainer
 

--- a/python/py-itsdangerous/Portfile
+++ b/python/py-itsdangerous/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-itsdangerous
 version             0.24
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 license             BSD
 platforms           darwin
 supported_archs     noarch

--- a/python/py-mlpy/Portfile
+++ b/python/py-mlpy/Portfile
@@ -29,9 +29,12 @@ master_sites.mirror_subdir \
                     "/mlpy%20${version}"
 distname            mlpy-${version}
 
-checksums           sha1    32f986f7f0f7cce5c773d2909d34705eab39df16
+checksums           rmd160  9dfb6387214859993d66db9108d07340aacb35c6 \
+                    sha256  344fa75fbf9f76af72f6a346d5309613defc4d244bac13c218e509a51d68bf6a \
+                    size    1961206 \
+                    sha1    32f986f7f0f7cce5c773d2909d34705eab39df16
 
-python.versions     27 34 35 36
+python.versions     27 35 36
 
 if {${name} ne ${subport}} {
     depends_build   port:py${python.version}-setuptools

--- a/python/py-novas/Portfile
+++ b/python/py-novas/Portfile
@@ -1,4 +1,4 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; truncate-lines: t; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
 PortGroup               python 1.0
@@ -20,9 +20,10 @@ license                 public-domain
 homepage                https://pypi.python.org/pypi/novas/
 
 checksums               rmd160  7eda716bb72102f2a4d7e39fc7e52313af53482a \
-                        sha256  c0e55db139f7e33ed9cb213bf2c803aed6c0cbc582f491f69144a8edd9f900ed
+                        sha256  c0e55db139f7e33ed9cb213bf2c803aed6c0cbc582f491f69144a8edd9f900ed \
+                        size    2745745
 
-python.versions         27 34 35 36
+python.versions         27 35 36
 
 if {${name} ne ${subport}} {
 

--- a/python/py-novas_de405/Portfile
+++ b/python/py-novas_de405/Portfile
@@ -1,4 +1,4 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; truncate-lines: t; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
 PortGroup               python 1.0
@@ -17,9 +17,11 @@ long_description \
 homepage                https://pypi.python.org/pypi/novas_de405/
 master_sites            http://jplephem.s3.amazonaws.com/
 distname                novas_de405-${version}
-checksums               sha256  b63583a7cf7711e5ffb02a09c4ff840f0424cc9a374214f5c6dc2d5d70f6dd7a
+checksums               rmd160  fa04b8820e7e0b66c47c2cc96e469bca9071a6c2 \
+                        sha256  b63583a7cf7711e5ffb02a09c4ff840f0424cc9a374214f5c6dc2d5d70f6dd7a \
+                        size    54898450
 
-python.versions         27 34 35 36
+python.versions         27 35 36
 
 livecheck.url           http://jplephem.s3.amazonaws.com/packages.html
 livecheck.regex         novas_de405-((\[0-9\]+)(\.\[0-9\]+)\*)[quotemeta ${extract.suffix}]

--- a/python/py-phonenumbers/Portfile
+++ b/python/py-phonenumbers/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 
 github.setup        daviddrysdale python-phonenumbers 8.9.12 v
 name                py-phonenumbers
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 categories-append   textproc
 license             apache
 platforms           darwin

--- a/python/py-pyfftw/Portfile
+++ b/python/py-pyfftw/Portfile
@@ -1,4 +1,4 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; truncate-lines: t; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
 PortGroup               python 1.0
@@ -15,10 +15,11 @@ long_description \
     A pythonic wrapper around FFTW, the FFT library, presenting a unified \
     interface for all the supported transforms.
 
-checksums           rmd160  356eee0df579b256d81c9f1222503ad3d811eec4 \
-                    sha256  c8644ccdf3ca222efa941e781adf1f21a488d8edb70c476d8df37ff6b0699d9d
+checksums               rmd160  356eee0df579b256d81c9f1222503ad3d811eec4 \
+                        sha256  c8644ccdf3ca222efa941e781adf1f21a488d8edb70c476d8df37ff6b0699d9d \
+                        size    97745
 
-python.versions         27 34 35 36
+python.versions         27 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-pytest-mpl/Portfile
+++ b/python/py-pytest-mpl/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
@@ -18,10 +20,11 @@ long_description    This is a plugin to faciliate image comparison for \
                     easy to compare figures produced by tests to reference \
                     images when using pytest.
 
-python.versions     27 34 35 36
+python.versions     27 35 36
 
 checksums           rmd160  6b135b3a08453376c88e23f434a1fc901d54bc9d \
-                    sha256  960d02c75d6b3b75043060c0b1fcdf98099ce1b6e72d3b3bd508bc13f074a152
+                    sha256  960d02c75d6b3b75043060c0b1fcdf98099ce1b6e72d3b3bd508bc13f074a152 \
+                    size    193158
 
 if {${name} ne ${subport}} {
   depends_build-append \

--- a/python/py-scikits-bootstrap/Portfile
+++ b/python/py-scikits-bootstrap/Portfile
@@ -1,4 +1,4 @@
-# -*- coding: utf-8; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
 PortGroup           python 1.0
@@ -16,9 +16,10 @@ long_description    Algorithms for SciPy to calculate bootstrap confidence \
                     intervals for statistics functions applied to data.
 
 checksums           rmd160  6663c5bee399df8c4c158d5294251f59be2ee67c \
-                    sha256  ff421c4eed1651d4f49b0b8e12182f943d4dd1b2d44045c9da2c6ef185775773
+                    sha256  ff421c4eed1651d4f49b0b8e12182f943d4dd1b2d44045c9da2c6ef185775773 \
+                    size    9192
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-socks/Portfile
+++ b/python/py-socks/Portfile
@@ -15,10 +15,11 @@ description         python SOCKS client module
 long_description    PySOCKS is a SOCKS client module, branched off several \
                     earlier abandoned projects
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 checksums           rmd160  0722a43bee0e650c9c23e7bb4f5d62ef5ae7cc2c \
-                    sha256  f42d36ea146ead64274206945683d182114a9f2a326b4702ae2cc784b667ad02
+                    sha256  f42d36ea146ead64274206945683d182114a9f2a326b4702ae2cc784b667ad02 \
+                    size    287022
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-twilio/Portfile
+++ b/python/py-twilio/Portfile
@@ -1,13 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
-PortGroup python 1.0
-PortGroup github 1.0
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
 
 github.setup        twilio twilio-python 6.18.1
 name                py-twilio
 categories-append   devel net
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 license             MIT
 platforms           darwin
 supported_archs     noarch

--- a/python/py-xdg/Portfile
+++ b/python/py-xdg/Portfile
@@ -1,4 +1,4 @@
-# -*- Mode: Tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
 PortGroup       python 1.0
@@ -24,7 +24,7 @@ long_description    \
     *   Recent File Spec 0.2 \
     *   Shared-MIME-Database Specification 0.13
 
-homepage        http://freedesktop.org/wiki/Software/pyxdg
+homepage        https://freedesktop.org/wiki/Software/pyxdg
 master_sites    pypi:p/pyxdg/
 distname        pyxdg-${version}
 
@@ -32,7 +32,7 @@ checksums       sha256  fe2928d3f532ed32b39c32a482b54136fe766d19936afc96c8f00645
                 rmd160  be6da6e5f7552c41c8590e59bf6deca95948a510 \
                 size    57879
 
-python.versions 27 34 35 36 37
+python.versions 27 35 36 37
 
 
 if {${name} ne ${subport}} {


### PR DESCRIPTION
#### Description
This PR removes obsolete Python subports for ports maintained by @lpsinger  that have no dependencies. Subports for newer Python versions were added for a few ports if the test-suite passes and, additionally, I updated a few ports to their latest version. 

Please note that there are many more outdated ports (i.e., py-emcee, py-flask-sqlalchemy, py-gcn, py-itsdangerous, py-phonenumbers, py-pyfftw, py-pytest-mpl, py-scikits-bootstrap, py-socks, py-twilio); I will leave it to the maintainer to take care of this.

###### Tested on
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
