### PR TITLE
kotlin: update to 1.3.61

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           java 1.0
 
-github.setup        JetBrains kotlin 1.3.60 v
-revision            1
+github.setup        JetBrains kotlin 1.3.61 v
+revision            0
 github.tarball_from releases
 distname            ${name}-compiler-${version}
 categories          lang java
@@ -23,9 +23,9 @@ long_description    Kotlin is a pragmatic programming language for JVM \
 
 homepage            https://kotlinlang.org/
 
-checksums           rmd160  382ed423cd191187824073867433b96cd4a78d9b \
-                    sha256  12f97cff23ff8116904cb97a7ef4e3af5c3b8e5df9d9e63baa251d9a73b42fbb \
-                    size    53111648
+checksums           rmd160  3fc7f1ad53a0c8b7efd0bdbeded3d61700896880 \
+                    sha256  3901151ad5d94798a268d1771c6c0b7e305a608c2889fc98a674802500597b1c \
+                    size    53125546
 
 java.version        1.8+
 java.fallback       openjdk8


### PR DESCRIPTION
#### Description

Update to Kotlin 1.3.61.

###### Tested on

macOS 10.15.1 19B88
Xcode 11.2.1 11B500

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?