### PR TITLE
openjdk8: replace graalvm with openjdk*-graalvm subports

### DIFF
--- a/java/graalvm/Portfile
+++ b/java/graalvm/Portfile
@@ -1,53 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem       1.0
+PortGroup        obsolete 1.0
 
 name             graalvm
+replaced_by      openjdk8-graalvm
 version          19.3.0
-revision         0
-
+revision         1
 categories       java devel
-maintainers      {breun.nl:nils @breun} {@hcarvalhoalves gmail.com:hcarvalhoalves} openmaintainer
-platforms        darwin
-license          GPL-2
-supported_archs  x86_64
-
-description      GraalVM Community Edition
-
-long_description GraalVM is a universal virtual machine for running applications written in \
-                 JavaScript, Python, Ruby, R, JVM-based languages like Java, Scala, Clojure, \
-                 Kotlin, and LLVM-based languages such as C and C++.
-homepage         https://www.graalvm.org/
-
-master_sites     https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/
-    
-checksums        rmd160  0d6e88a4a9227ab7a515d84409b4f279d4a6a016 \
-                 sha256  6c43063148368dc537a58706fcbf332583371ebb32dfdb78017e6a80e139658b \
-                 size    356582812
-
-distname         ${name}-ce-java8-darwin-amd64-${version}
-worksrcdir       ${name}-ce-java8-${version}
-
-use_configure    no
-
-build {}
-
-# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
-destroot.violate_mtree yes
-
-configure.cxx_stdlib libstdc++
-
-set target /Library/Java/JavaVirtualMachines/${name}
-set destroot_target ${destroot}${target}
-
-destroot {
-    xinstall -m 755 -d ${destroot_target}
-    copy ${worksrcpath}/Contents ${destroot_target}
-}
-
-notes "
-If you have more than one JDK installed you can make GraalVM the default\
-by adding the following line to your Bash shell profile (~/.bash_profile):
-
-    export JAVA_HOME=${target}/Contents/Home
-"

--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -9,6 +9,13 @@ revision         0
 set build        09
 set major        8
 
+subport openjdk8-graalvm {
+    version      19.3.0
+    revision     0
+
+    set major    8
+}
+
 subport openjdk8-openj9 {
     version      8u232
     revision     1
@@ -40,6 +47,13 @@ subport openjdk11 {
     revision     0
 
     set build    10
+    set major    11
+}
+
+subport openjdk11-graalvm {
+    version      19.3.0
+    revision     0
+
     set major    11
 }
 
@@ -148,7 +162,21 @@ if {${subport} eq "openjdk8"} {
     worksrcdir   jdk${version}-b${build}
 
     configure.cxx_stdlib libstdc++
+} elseif {${subport} eq "openjdk8-graalvm"} {
+    master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/
+    distname     graalvm-ce-java${major}-darwin-amd64-${version}
+    worksrcdir   graalvm-ce-java${major}-${version}
 
+    checksums    rmd160  0d6e88a4a9227ab7a515d84409b4f279d4a6a016 \
+                 sha256  6c43063148368dc537a58706fcbf332583371ebb32dfdb78017e6a80e139658b \
+                 size    356582812
+
+    description  GraalVM Community Edition based on OpenJDK ${major}
+    long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, \
+                 Ruby, R, JVM-based languages like Java, Scala, Groovy, Kotlin, Clojure, and LLVM-based languages \
+                 such as C and C++.
+
+    homepage     https://www.graalvm.org
 } elseif {${subport} eq "openjdk8-openj9"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}.${revision}_openj9-${openj9_version}/
     # Temporary dist_subdir for stealth update: https://trac.macports.org/wiki/PortfileRecipes#stealth-updates
@@ -217,6 +245,21 @@ if {${subport} eq "openjdk8"} {
 
     distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}_${build}
     worksrcdir   jdk-${version}+${build}
+} elseif {${subport} eq "openjdk11-graalvm"} {
+    master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/
+    distname     graalvm-ce-java${major}-darwin-amd64-${version}
+    worksrcdir   graalvm-ce-java${major}-${version}
+
+    checksums    rmd160  7c00dcda9db1f595386a7acd580e2bdcc2382cd5 \
+                 sha256  5a7eaead66971e25bef2c21d94d0760b54bda13761908545be8c0323df17da4a \
+                 size    448564759
+
+    description  GraalVM Community Edition based on OpenJDK ${major}
+    long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, \
+                 Ruby, R, JVM-based languages like Java, Scala, Groovy, Kotlin, Clojure, and LLVM-based languages \
+                 such as C and C++.
+
+    homepage     https://www.graalvm.org
 } elseif {${subport} eq "openjdk11-openj9"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.${revision}_openj9-${openj9_version}/
     # Temporary dist_subdir for stealth update: https://trac.macports.org/wiki/PortfileRecipes#stealth-updates


### PR DESCRIPTION
#### Description

Since version 19.3.0 GraalVM is available with either OpenJDK 8 or 11 as its base. This pull request replaces `graalvm` (which was only available based on OpenJDK 8 before version 19.3.0) with `openjdk8-graalvm`, and introduces `openjdk11-graalvm` as a new port.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.1 19B88
Xcode 11.2.1 11B500

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?