### PR TITLE
wireguard-tools: update to 0.0.20191127

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-tools
-version             0.0.20191012
+version             0.0.20191127
 revision            0
-checksums           rmd160  fce033d725580c606145735a2f2f9cd4341cfe7d \
-                    sha256  93573193c9c1c22fde31eb1729ad428ca39da77a603a3d81561a9816ccecfa8e \
-                    size    331812
+checksums           rmd160  542d7ab4d4d900e45ed21767fdffc7fdf1efbc6d \
+                    sha256  7d4e80a6f84564d4826dd05da2b59e8d17645072c0345d0fc0d197be176c3d06 \
+                    size    332368
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
###### Tested on
macOS 10.13.6 17G8037
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?