### PR TITLE
olm: update to v3.1.4

### DIFF
--- a/devel/olm/Portfile
+++ b/devel/olm/Portfile
@@ -1,10 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cxx11 1.1
+PortGroup           cmake 1.1
 
 name                olm
-version             2.3.0
+version             3.1.4
 categories          devel security
 platforms           darwin
 maintainers         {@scarface-one disroot.org:scarface} openmaintainer
@@ -14,19 +14,17 @@ long_description    An implementation of the Double Ratchet cryptographic ratche
                     and C++11 and exposed as a C API.
 
 license             Apache-2
-homepage            http://git.matrix.org/git/olm/about/
+homepage            https://gitlab.matrix.org/matrix-org/olm/
 
-master_sites        http://git.matrix.org/git/olm/snapshot
+master_sites        https://gitlab.matrix.org/matrix-org/olm/-/archive/${version}
 
-checksums           rmd160  f848e0fe13866943c0af07a2cbbfc16aee6de229 \
-                    sha256  533714fb84860e04c185790d16ef9085f15e902c2105db941d5c7e92b0565ef8 \
-                    size    480801
+checksums           rmd160  04922bc2e9571698cbfb6c8f11be33e764e46dcf \
+                    sha256  1ca9926ce71d778fb7352d1ee77513194db8c7f49c0d69d38ac49ec3bafcea38 \
+                    size    521495
 
-use_configure       no
-
-build.target        static
-
-destroot {
-    copy ${worksrcpath}/build/libolm.a ${destroot}${prefix}/lib/libolm.a
-    copy ${worksrcpath}/include/olm ${destroot}${prefix}/include
+variant static description {Make static library} {
+	configure.args-append \
+		-DBUILD_SHARED_LIBS=NO
 }
+
+compiler.cxx_standard 2011


### PR DESCRIPTION
#### Description

* update to 3.1.4
* use cmake for build system, as make is now deprecated
* added variant static for any ports which need static lib
* fixed build failure

Closes: https://trac.macports.org/ticket/59760

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.1 19B88
Xcode 11.0 11A420a 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
