### PR TITLE
starship: update to 0.27.0

### DIFF
--- a/sysutils/starship/Portfile
+++ b/sysutils/starship/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        starship starship 0.26.4 v
+github.setup        starship starship 0.27.0 v
 categories          sysutils
 platforms           darwin
 maintainers         {l2dy @l2dy} openmaintainer
@@ -15,9 +15,9 @@ description         a minimal, blazing fast, and extremely customizable prompt f
 long_description    Starship is ${description}.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  e1f505a285b2b85607c7404d4a912968735391a4 \
-                    sha256  3fce013c9cf1258d3f8cd2716908cc63d02bb53bf4a659cde84c1e7fc6d7e706 \
-                    size    4347759
+                    rmd160  25ed1538608b67a4fecefd43cd133d2df2856c46 \
+                    sha256  d9e70a2bb7e80f964a191a16581d7e6fc65344ce7de52fbb66ca82ee005eec57 \
+                    size    4354623
 
 # For crate:openssl-sys
 depends_build       port:pkgconfig
@@ -39,7 +39,7 @@ cargo.crates \
     backtrace                       0.3.40  924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea \
     backtrace-sys                   0.1.32  5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491 \
     base64                          0.10.1  0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e \
-    battery                          0.7.4  7a6d6fe5630049e900227cd89afce4c1204b88ec8e61a2581bb96fcce26f047b \
+    battery                          0.7.5  36a698e449024a5d18994a815998bf5e2e4bc1883e35a7d7ba95b6b69ee45907 \
     bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
     blake2b_simd                     0.5.9  b83b7baab1e671718d78204225800d6b170e648188ac7dc992e9d6bddf87d0c0 \
     byte-unit                        3.0.3  6894a79550807490d9f19a138a6da0f8830e70c83e83402dd23f16fd6c479056 \
@@ -47,7 +47,7 @@ cargo.crates \
     c2-chacha                        0.2.3  214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb \
     cc                              1.0.47  aa87058dce70a3ff5621797f1506cb837edd02ac4c0ae642b4542dce802908b8 \
     cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
-    chrono                           0.4.9  e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68 \
+    chrono                          0.4.10  31850b4a4d6bae316f7a09e691c944c28299298837edc0a03f755618c23cbc01 \
     clap                            2.33.0  5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9 \
     cloudabi                         0.0.3  ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
     constant_time_eq                 0.1.4  995a44c877f9212528ccc74b21a232f66ad69001e40ede5bcee2ac9ef2657120 \
@@ -55,7 +55,7 @@ cargo.crates \
     core-foundation-sys              0.6.2  e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b \
     crossbeam-deque                  0.7.2  c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca \
     crossbeam-epoch                  0.8.0  5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac \
-    crossbeam-queue                  0.1.2  7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b \
+    crossbeam-queue                  0.2.0  dfd6515864a82d2f877b42813d4553292c6659498c9a2aa31bab5a15243c2700 \
     crossbeam-utils                  0.7.0  ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4 \
     crossbeam-utils                  0.6.6  04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6 \
     dirs                             2.0.2  13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3 \
@@ -68,7 +68,7 @@ cargo.crates \
     fuchsia-cprng                    0.1.1  a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba \
     gethostname                      0.2.0  d4ab273ca2a31eb6ca40b15837ccf1aa59a43c5db69ac10c542be342fae2e01d \
     getrandom                       0.1.13  e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407 \
-    git2                            0.10.1  39f27186fbb5ec67ece9a56990292bc5aed3c3fc51b9b07b0b52446b1dfb4a82 \
+    git2                            0.10.2  7c1af51ea8a906616af45a4ce78eacf25860f7a13ae7bf8a814693f0f4037a26 \
     hermit-abi                       0.1.3  307c3c9f937f38e3534b1d6447ecf090cafcc9744e4a6360e8b037b2cf5af120 \
     humantime                        1.3.0  df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f \
     idna                             0.2.0  02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9 \
@@ -78,7 +78,7 @@ cargo.crates \
     lazycell                         1.2.1  b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f \
     lexical-core                     0.4.6  2304bccb228c4b020f3a4835d247df0a02a7c4686098d4167762cfbbe4c5cb14 \
     libc                            0.2.65  1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8 \
-    libgit2-sys                      0.9.1  a30f8637eb59616ee3b8a00f6adff781ee4ddd8343a615b8238de756060cc1b3 \
+    libgit2-sys                      0.9.2  4870c781f6063efb83150cd22c1ddf6ecf58531419e7570cdcced46970f64a16 \
     libz-sys                        1.0.25  2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe \
     linked-hash-map                  0.5.2  ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83 \
     log                              0.4.8  14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7 \
@@ -87,7 +87,7 @@ cargo.crates \
     maybe-uninit                     2.0.0  60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00 \
     memchr                           2.2.1  88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e \
     memoffset                        0.5.3  75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9 \
-    nix                             0.14.1  6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce \
+    nix                             0.15.0  3b2e0b4f3320ed72aaedb9a5ac838690a8047c7b275da22711fddff4f8a14229 \
     nodrop                          0.1.14  72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb \
     nom                              5.0.1  c618b63422da4401283884e6668d39f819a106ef51f5f59b81add00075da35ca \
     num-integer                     0.1.41  b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09 \
@@ -109,8 +109,8 @@ cargo.crates \
     rand_core                        0.3.1  7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b \
     rand_hc                          0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
     rand_os                          0.1.3  7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071 \
-    rayon                            1.2.0  83a27732a533a1be0a0035a111fe76db89ad312f6f0347004c220c57f209a123 \
-    rayon-core                       1.6.0  98dcf634205083b17d0861252431eb2acbfb698ab7478a2d20de07954f47ec7b \
+    rayon                            1.2.1  43739f8831493b276363637423d3622d4bd6394ab6f0a9c4a552e208aeb7fddd \
+    rayon-core                       1.6.1  f8bf17de6f23b05473c437eb958b9c850bfc8af0961fe17b4cc92d5a627b4791 \
     rdrand                           0.4.0  678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2 \
     redox_syscall                   0.1.56  2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84 \
     redox_users                      0.3.1  4ecedbca3bf205f8d8f5c2b44d83cd0690e39ee84b951ed649e9f1841132b66d \
@@ -125,7 +125,7 @@ cargo.crates \
     semver                           0.9.0  1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403 \
     semver-parser                    0.7.0  388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
     serde                          1.0.102  0c4b39bd9b0b087684013a792c59e3e07a46a01d2322518d8a1104641a0b1be0 \
-    serde_json                      1.0.41  2f72eb2a68a7dc3f9a691bfda9305a1c017a6215e5a4545c258500d2099a37c2 \
+    serde_json                      1.0.42  1a3351dcbc1f067e2c92ab7c3c1f288ad1a4cffc470b5aaddb4c2e0a3ae80043 \
     smallvec                        0.6.13  f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6 \
     static_assertions                0.3.4  7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3 \
     strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
@@ -144,7 +144,7 @@ cargo.crates \
     unicode-segmentation             1.6.0  e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0 \
     unicode-width                    0.1.6  7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20 \
     unicode-xid                      0.2.0  826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c \
-    uom                             0.23.1  3ef5bbe8385736e498dbb0033361f764ab43a435192513861447b9f7714b3fec \
+    uom                             0.26.0  4cec796ec5f7ac557631709079168286056205c51c60aac33f51764bdc7b8dc4 \
     url                              2.1.0  75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61 \
     vcpkg                            0.2.7  33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95 \
     vec_map                          0.8.1  05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.1 19B88
Xcode 11.2.1 11B500

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
