### PR TITLE
mythtv.27: add patches to allow for building with Xcode 10 & 11

### DIFF
--- a/multimedia/mythtv.27/Portfile
+++ b/multimedia/mythtv.27/Portfile
@@ -125,6 +125,12 @@ subport mythtv-core${majorversion} {
 
 	# revert rpath linking stuff as it is non-functional in MacPorts
 	patchfiles-append   patch-rpath_linking.diff
+	patchfiles-append   patch-httpstatus_pointer_comparison_fix.diff
+	patchfiles-append   patch-lcdproclient_pointer_comparison_fix.diff
+	patchfiles-append   patch-libx264_bit_depth_fix.diff
+	patchfiles-append   patch-quicktime_framework_fix.diff
+	patchfiles-append   patch-tvplay_reference_lifespan_fix.diff
+	patchfiles-append   patch-videosource_pointer_comparison_fix.diff
 
 	post-extract {
 		file mkdir ${worksrcpath}/macports

--- a/multimedia/mythtv.27/files/patch-httpstatus_pointer_comparison_fix.diff
+++ b/multimedia/mythtv.27/files/patch-httpstatus_pointer_comparison_fix.diff
@@ -1,0 +1,13 @@
+--- mythtv/programs/mythbackend/httpstatus.cpp.orig	2018-02-01 05:20:06.000000000 -0700
++++ mythtv/programs/mythbackend/httpstatus.cpp	2019-11-25 18:12:44.000000000 -0700
+@@ -1478,8 +1478,8 @@
+ 
+             // Only include HTML line break if display value doesn't already
+             // contain breaks.
+-            if ((display.contains("<p>", Qt::CaseInsensitive) > 0) ||
+-                (display.contains("<br", Qt::CaseInsensitive) > 0))
++            if ((display.contains("<p>", Qt::CaseInsensitive) != 0) ||
++                (display.contains("<br", Qt::CaseInsensitive) != 0))
+             {
+                 // matches <BR> or <br /
+                 linebreak = "\r\n";

--- a/multimedia/mythtv.27/files/patch-lcdproclient_pointer_comparison_fix.diff
+++ b/multimedia/mythtv.27/files/patch-lcdproclient_pointer_comparison_fix.diff
@@ -1,0 +1,11 @@
+--- mythtv/programs/mythlcdserver/lcdprocclient.cpp.orig	2018-02-01 05:20:06.000000000 -0700
++++ mythtv/programs/mythlcdserver/lcdprocclient.cpp	2019-11-25 18:02:57.000000000 -0700
+@@ -2123,7 +2123,7 @@
+ 
+     for (int x = 0; x < text.length(); x++)
+     {
+-        if (separators.contains(text[x]) > 0)
++        if (separators.contains(text[x]) != 0)
+             lastSplit = line.length();
+ 
+         line += text[x];

--- a/multimedia/mythtv.27/files/patch-libx264_bit_depth_fix.diff
+++ b/multimedia/mythtv.27/files/patch-libx264_bit_depth_fix.diff
@@ -1,0 +1,60 @@
+--- mythtv/external/FFmpeg/libavcodec/libx264.c.orig	2018-02-01 05:20:06.000000000 -0700
++++ mythtv/external/FFmpeg/libavcodec/libx264.c	2019-11-25 16:24:38.000000000 -0700
+@@ -156,10 +156,16 @@
+     x264_nal_t *nal;
+     int nnal, i, ret;
+     x264_picture_t pic_out;
++    int bit_depth;
+ 
+     x264_picture_init( &x4->pic );
+     x4->pic.img.i_csp   = x4->params.i_csp;
+-    if (x264_bit_depth > 8)
++#if X264_BUILD >= 153
++    bit_depth = x4->params.i_bitdepth;
++#else
++    bit_depth = x264_bit_depth;
++#endif
++    if (bit_depth > 8)
+         x4->pic.img.i_csp |= X264_CSP_HIGH_DEPTH;
+     x4->pic.img.i_plane = avfmt2_num_planes(ctx->pix_fmt);
+ 
+@@ -599,6 +605,22 @@
+     AV_PIX_FMT_YUV444P10,
+     AV_PIX_FMT_NONE
+ };
++static const enum AVPixelFormat pix_fmts_all[] = {
++    AV_PIX_FMT_YUV420P,
++    AV_PIX_FMT_YUVJ420P,
++    AV_PIX_FMT_YUV422P,
++    AV_PIX_FMT_YUVJ422P,
++    AV_PIX_FMT_YUV444P,
++    AV_PIX_FMT_YUVJ444P,
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_YUV420P10,
++    AV_PIX_FMT_YUV422P10,
++    AV_PIX_FMT_YUV444P10,
++#ifdef X264_CSP_I400
++    AV_PIX_FMT_GRAY8,
++#endif
++    AV_PIX_FMT_NONE
++};
+ static const enum AVPixelFormat pix_fmts_8bit_rgb[] = {
+ #ifdef X264_CSP_BGR
+     AV_PIX_FMT_BGR24,
+@@ -609,12 +631,16 @@
+ 
+ static av_cold void X264_init_static(AVCodec *codec)
+ {
++#if X264_BUILD < 153
+     if (x264_bit_depth == 8)
+         codec->pix_fmts = pix_fmts_8bit;
+     else if (x264_bit_depth == 9)
+         codec->pix_fmts = pix_fmts_9bit;
+     else if (x264_bit_depth == 10)
+         codec->pix_fmts = pix_fmts_10bit;
++#else
++    codec->pix_fmts = pix_fmts_all;
++#endif
+ }
+ 
+ #define OFFSET(x) offsetof(X264Context, x)

--- a/multimedia/mythtv.27/files/patch-quicktime_framework_fix.diff
+++ b/multimedia/mythtv.27/files/patch-quicktime_framework_fix.diff
@@ -1,0 +1,11 @@
+--- mythtv/libs/libmythtv/libmythtv.pro.orig	2018-02-01 05:20:06.000000000 -0700
++++ mythtv/libs/libmythtv/libmythtv.pro	2019-11-25 17:50:40.000000000 -0700
+@@ -53,7 +53,7 @@
+ 
+ macx {
+     # Mac OS X Frameworks
+-    FWKS = AGL ApplicationServices Carbon Cocoa CoreServices CoreFoundation OpenGL QuickTime IOKit
++    FWKS = AGL ApplicationServices Carbon Cocoa CoreServices CoreFoundation OpenGL IOKit
+     using_quartz_video {
+         FWKS += QuartzCore
+     } else {

--- a/multimedia/mythtv.27/files/patch-tvplay_reference_lifespan_fix.diff
+++ b/multimedia/mythtv.27/files/patch-tvplay_reference_lifespan_fix.diff
@@ -1,0 +1,21 @@
+--- mythtv/libs/libmythtv/tv_play.cpp.orig	2018-02-01 05:20:06.000000000 -0700
++++ mythtv/libs/libmythtv/tv_play.cpp	2019-11-25 17:27:29.000000000 -0700
+@@ -196,12 +196,17 @@
+     QWaitCondition m_wait;
+ };
+ 
++static const MenuBase dummy_menubase;
++
+ class MenuNodeTuple
+ {
+ public:
+     MenuNodeTuple(const MenuBase &menu, const QDomNode &node) :
+         m_menu(menu), m_node(node) {}
+-    MenuNodeTuple(void) : m_menu(MenuBase()) {}
++    MenuNodeTuple(void) : m_menu(dummy_menubase)
++    {
++        assert("Should never be reached.");
++    }
+     const MenuBase &m_menu;
+     const QDomNode  m_node;
+ };

--- a/multimedia/mythtv.27/files/patch-videosource_pointer_comparison_fix.diff
+++ b/multimedia/mythtv.27/files/patch-videosource_pointer_comparison_fix.diff
@@ -1,0 +1,11 @@
+--- mythtv/libs/libmythtv/videosource.cpp.orig	2019-11-25 17:13:24.000000000 -0700
++++ mythtv/libs/libmythtv/videosource.cpp	2019-11-25 17:15:07.000000000 -0700
+@@ -396,7 +396,7 @@
+ void DataDirect_config::Load()
+ {
+     VerticalConfigurationGroup::Load();
+-    bool is_sd_userid = userid->getValue().contains('@') > 0;
++    bool is_sd_userid = userid->getValue().contains('@') != 0;
+     bool match = ((is_sd_userid  && (source == DD_SCHEDULES_DIRECT)) ||
+                   (!is_sd_userid && (source == DD_ZAP2IT)));
+     if (((userid->getValue() != lastloadeduserid) ||


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/58576

#### Description

A series of diff files that fix various compile time issues with newer Xcode. The changes mirror similar changer from newer versions of the related projects. Since this code is no longer supported, the diff is being used to fix it instead of proposing changes to the parent project. The Quicktime change will mean that the mythtv.27 now requires AVFoundation.

###### Type(s)

- [x] bugfix

###### Tested on

macOS 10.13.6 17G9016
Xcode 10.1 10B61 

macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`? All errors are pre-existing
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?