### PR TITLE
py-awscli: update to 1.16.292

### DIFF
--- a/python/py-awscli/Portfile
+++ b/python/py-awscli/Portfile
@@ -6,7 +6,7 @@ PortGroup           select 1.0
 
 
 name                py-awscli
-version             1.16.266
+version             1.16.292
 revision            0
 platforms           darwin
 supported_archs     noarch
@@ -20,9 +20,9 @@ homepage            https://aws.amazon.com/cli/
 master_sites        pypi:a/awscli
 distname            awscli-${version}
 
-checksums           rmd160  ec4467e0fbbc6af3e0cb978de2ab1bf7a61a3b61 \
-                    sha256  9c59a5ca805f467669d471b29550ecafafb9b380a4a6926a9f8866f71cd4f7be \
-                    size    986685
+checksums           rmd160  05f7dac0ff97244a7fec3a0ffea3afa4bfa66860 \
+                    sha256  a54f254a52198475a263518ad0960943e423ca0e1128d4c61434fb7b72f08a5c \
+                    size    1026263
 
 python.versions     27 35 36 37
 


### PR DESCRIPTION
#### Description

Update awscli to version 1.16.292.

Please not that this is my first time updating the awscli port. 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.1 19B88
Xcode 11.2.1 11B500 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
