### PR TITLE
zig: Fix build failure

### DIFF
--- a/lang/zig/Portfile
+++ b/lang/zig/Portfile
@@ -34,3 +34,8 @@ compiler.blacklist-append *gcc* clang
 compiler.fallback   macports-clang-${llvm_version}
 compiler.whitelist  macports-clang-${llvm_version}
 cmake.module_path   [list ${prefix}/libexec/llvm-${llvm_version}]
+
+# This build system is unusual in that it wants to install files to the
+# destroot at build time. This may get fixed in the future.
+# https://github.com/ziglang/zig/issues/2928
+build.args-append   DESTDIR=${destroot}


### PR DESCRIPTION
### Description

Fix build failure

The build system is unusual in that it wants to install files to the destroot at build time, so we need to tell it where the destroot is at build time. This may get fixed in the future.

See: https://github.com/ziglang/zig/issues/2928
See: #5691
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G8037
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
