### PR TITLE
tmux: fix server crash (during layout change)

### DIFF
--- a/sysutils/tmux/Portfile
+++ b/sysutils/tmux/Portfile
@@ -5,7 +5,7 @@ PortGroup       github 1.0
 
 github.setup    tmux tmux 3.0
 if {${subport} eq ${name}} {
-    revision        0
+    revision        1
     conflicts       tmux-devel
 }
 subport tmux-devel {
@@ -33,6 +33,10 @@ if {${subport} eq ${name}} {
     checksums               rmd160  dd7777c99f42060d709b24098acd4bda10ac49f8 \
                             sha256  9edcd78df80962ee2e6471a8f647602be5ded62bb41c574172bb3dc3d0b9b4b4 \
                             size    546099
+
+    patch.pre_args          -p1
+    patchfiles              fix-server-crash-layout.patch \
+                            fix-mem-leaks.patch
 }
 subport tmux-devel {
     checksums               rmd160  f95d6c3e6e9114503c248c9e2d52ff32250ca608 \

--- a/sysutils/tmux/files/fix-mem-leaks.patch
+++ b/sysutils/tmux/files/fix-mem-leaks.patch
@@ -1,0 +1,47 @@
+From 68d59a16cec91d2c2747c8c2862560e89f8f2d31 Mon Sep 17 00:00:00 2001
+From: nicm <nicm>
+Date: Mon, 14 Oct 2019 08:38:07 +0000
+Subject: [PATCH] Memory leaks, from Igor Wong in GitHub issue 1934.
+
+---
+ cmd-parse.y | 1 +
+ options.c   | 1 +
+ tmux.c      | 1 +
+ 3 files changed, 3 insertions(+)
+
+diff --git a/cmd-parse.y b/cmd-parse.y
+index 0cd7c6bf6..2c924010c 100644
+--- a/cmd-parse.y
++++ b/cmd-parse.y
+@@ -696,6 +696,7 @@ cmd_parse_build_commands(struct cmd_parse_commands *cmds,
+ 			pr.status = CMD_PARSE_ERROR;
+ 			pr.error = cmd_parse_get_error(pi->file, line, cause);
+ 			free(cause);
++			cmd_list_free(cmdlist);
+ 			goto out;
+ 		}
+ 		cmd_list_append(cmdlist, add);
+diff --git a/options.c b/options.c
+index 1be9f8cd7..f683c566e 100644
+--- a/options.c
++++ b/options.c
+@@ -296,6 +296,7 @@ options_remove(struct options_entry *o)
+ 	else
+ 		options_value_free(o, &o->value);
+ 	RB_REMOVE(options_tree, &oo->tree, o);
++	free((void *)o->name);
+ 	free(o);
+ }
+ 
+diff --git a/tmux.c b/tmux.c
+index c3fe3ee6f..fe2647f56 100644
+--- a/tmux.c
++++ b/tmux.c
+@@ -130,6 +130,7 @@ make_label(const char *label, char **cause)
+ 		free(base);
+ 		goto fail;
+ 	}
++	free(base);
+ 
+ 	if (mkdir(resolved, S_IRWXU) != 0 && errno != EEXIST)
+ 		goto fail;

--- a/sysutils/tmux/files/fix-server-crash-layout.patch
+++ b/sysutils/tmux/files/fix-server-crash-layout.patch
@@ -1,0 +1,23 @@
+From 2cb268d51b71d74cf32e9cd1f67892681a9563e1 Mon Sep 17 00:00:00 2001
+From: nicm <nicm>
+Date: Sat, 19 Oct 2019 12:40:42 +0000
+Subject: [PATCH] Do not crash trying to fix layout size if only one cell, from
+ Azat Khuzhin.
+
+---
+ layout-custom.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/layout-custom.c b/layout-custom.c
+index b049f482a..d73712928 100644
+--- a/layout-custom.c
++++ b/layout-custom.c
+@@ -210,7 +210,7 @@ layout_parse(struct window *w, const char *layout)
+ 		}
+ 		break;
+ 	}
+-	if (lc->sx != sx || lc->sy != sy) {
++	if (lc->type != LAYOUT_WINDOWPANE && (lc->sx != sx || lc->sy != sy)) {
+ 		log_debug("fix layout %u,%u to %u,%u", lc->sx, lc->sy, sx,sy);
+ 		layout_print_cell(lc, __func__, 0);
+ 		lc->sx = sx - 1; lc->sy = sy - 1;


### PR DESCRIPTION
During layout changes the server crashes, which makes using tmux-resurrect impossible.
see https://github.com/tmux-plugins/tmux-resurrect/issues/316

There's been an upstream fix, but it has never made it into 3.0.
see https://github.com/tmux/tmux/commit/2cb268d51b71d74cf32e9cd1f67892681a9563e1

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on

macOS 10.14.6 18G1012
Xcode 11.2.1 11B500

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
