### PR TITLE
aspell-dict-{da,de,el,pt_BR,pt_PT} - update to latest version

### DIFF
--- a/textproc/aspell-dict-da/Portfile
+++ b/textproc/aspell-dict-da/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 
 set langcode        da
 name		        aspell-dict-${langcode}
-version		        1.4.42-1
+version		        1.6.36-11-0
 categories	        textproc
 license		        GPL-2+
 maintainers	        nomaintainer
@@ -16,10 +16,10 @@ supported_archs     noarch
 
 master_sites	    gnu:aspell/dict/${langcode}
 
-distname	        aspell5-${langcode}-${version}
-checksums           md5     d14c03dca23b572606279d7317b022d0 \
-                    sha1    8cc990c195707e2b4db4ed0969aa10117a3b6bb2 \
-                    rmd160  e9278ec5665d54066ff1808176e08af280501b9c
+distname	        aspell6-${langcode}-${version}
+checksums           rmd160  83e6b10abc0378661ebd0778fa24b0d662b14a9e \
+                    sha256  dbc6cbceaa7a4528f3756f0b5cce5c3d0615c2103d3899b47e9df2ed9582e2f7 \
+                    size    295300
 
 use_bzip2	        yes
 

--- a/textproc/aspell-dict-de/Portfile
+++ b/textproc/aspell-dict-de/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 
 set langcode        de
 name		        aspell-dict-${langcode}
-version		        20030222-1
+version		        20161207-7-0
 categories	        textproc
 license		        GPL-2
 maintainers	        nomaintainer
@@ -20,7 +20,9 @@ homepage            http://aspell.net
 master_sites	    gnu:aspell/dict/${langcode}
 
 distname	        aspell6-${langcode}-${version}
-checksums	        md5 5950c5c8a36fc93d4d7616591bace6a6
+checksums           rmd160  df152d724af872fda49fc0165b2c144be4bebb69 \
+                    sha256  c2125d1fafb1d4effbe6c88d4e9127db59da9ed92639c7cbaeae1b7337655571 \
+                    size    294974
 
 use_bzip2	        yes
 

--- a/textproc/aspell-dict-el/Portfile
+++ b/textproc/aspell-dict-el/Portfile
@@ -4,7 +4,8 @@ PortSystem 1.0
 
 set langcode        el
 name                aspell-dict-${langcode}
-version             0.50-3
+version             0.08-0
+epoch               1
 categories          textproc
 license             GPL-2+
 maintainers         nomaintainer
@@ -15,10 +16,10 @@ platforms	        darwin
 supported_archs     noarch
 
 master_sites	    gnu:aspell/dict/${langcode}
-distname	        aspell-${langcode}-${version}
-checksums	        md5     0ea2c42ceb9b91f7f5de2c017234ad37 \
-                    sha1    f0242d02e45956f8fe5d8321d737ee4dc5d18931 \
-                    rmd160  df6b86825ad3b3b448287c07cf4eaee986aa1320
+distname	        aspell6-${langcode}-${version}
+checksums           rmd160  307f297f25fc065f04b11d219769c1eb3b36c416 \
+                    sha256  4af60f1a8adf8b1899680deefdf49288d7406a2c591658f880628bf7c1604cd2 \
+                    size    358493
 
 use_bzip2           yes
 
@@ -31,4 +32,4 @@ configure.args      --vars \
 
 livecheck.type      regex
 livecheck.url       https://ftp.gnu.org/gnu/aspell/dict/0index.html
-livecheck.regex     >aspell6\?-${langcode}-(.*?)\\.tar\\.
+livecheck.regex     >aspell6-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-pt_BR/Portfile
+++ b/textproc/aspell-dict-pt_BR/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 
 set langcode        pt_BR
 name                aspell-dict-${langcode}
-version             20090702-0
+version             20131030-12-0
 categories          textproc
 license             LGPL-2.1+
 maintainers         nomaintainer
@@ -16,9 +16,9 @@ supported_archs     noarch
 
 master_sites	    gnu:aspell/dict/${langcode}
 distname	        aspell6-${langcode}-${version}
-checksums           md5     e082a8956882eb94a67c12e1b8c4a324 \
-                    sha1    add1db9a6a908dccaad13a7fd85c3b202299ff26 \
-                    rmd160  ba4015f19ed703c800ee9aab450fc3f481d00ad7
+checksums           rmd160  37ea34282d7c8ed9d5cc79fec28a4ef3fcd25787 \
+                    sha256  eb0d99db0b5d5c442133a88bddfe96dd252c0c3df3da36e9326c241dc4bc14f7 \
+                    size    894604
 
 use_bzip2           yes
 

--- a/textproc/aspell-dict-pt_PT/Portfile
+++ b/textproc/aspell-dict-pt_PT/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 
 set langcode        pt_PT
 name                aspell-dict-${langcode}
-version             20070510-0
+version             20190329-1-0
 categories          textproc
 license             GPL-2
 maintainers         nomaintainer
@@ -16,9 +16,9 @@ supported_archs     noarch
 
 master_sites	    gnu:aspell/dict/${langcode}
 distname	        aspell6-${langcode}-${version}
-checksums	        md5     a54267ce8f91de6e6a1baf1e8048cba0 \
-                    sha1    e136c2f411b582897437b06b9068c98ee333be41 \
-                    rmd160  ea4364131c2696054e529143193bc50a561d9d72
+checksums           rmd160  6a2eab8718cf05d772a1cc1be9455e9eee9b6ea0 \
+                    sha256  e5708b890c2afff51276a6cc276af5e6b3b8a026db75eda48b58124f2368a051 \
+                    size    87497
 
 use_bzip2           yes
 


### PR DESCRIPTION
#### Description

I went through `aspell-dict-*` and updated the ones under `nomaintainer`. I only verified these ports successfully build.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G1012
Xcode 11.2.1 11B500 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
