### PR TITLE
ntpsec: update to 1.1.8

### DIFF
--- a/sysutils/ntpsec/Portfile
+++ b/sysutils/ntpsec/Portfile
@@ -6,6 +6,7 @@ PortGroup           python 1.0
 
 name                ntpsec
 version             1.1.7
+revision            1
 categories          sysutils net
 maintainers         {fwright.net:fw @fhgwright} openmaintainer
 description         A secure, hardened, and improved implementation of NTP
@@ -22,8 +23,19 @@ checksums           rmd160  4f88807fc4652d2bb0608ca82df5b7e6be18eb63 \
                     sha256  48eb3e0ed932fccc21373bc34a344b0c7164fda637f9b822b85b146f1aea398b \
                     size    2534524
 
-depends_build       port:bison
-depends_lib         path:lib/libssl.dylib:openssl port:python${python.version}
+# To avoid breaking any code that uses our Python package, keep the Python
+# version at 2.7 until we add variants for Python versions.  The upstream
+# code itself works with 2.6, 2.7, and 3.3+.
+python.versions     27
+
+# Note that the upstream --python option doesn't work correctly, so waf
+# must be run with the target Python version.  The waf PortGroup doesn't
+# currently allow selecting its Python version, but since it's hard-coded
+# for 2.7, we can ignore this for now.
+
+depends_build-append    port:bison
+depends_lib-append      path:lib/libssl.dylib:openssl \
+                        port:python${python.version}
 
 patchfiles          patch-PreHighSierra.diff
 

--- a/sysutils/ntpsec/Portfile
+++ b/sysutils/ntpsec/Portfile
@@ -5,8 +5,8 @@ PortGroup           waf 1.0
 PortGroup           python 1.0
 
 name                ntpsec
-version             1.1.7
-revision            1
+version             1.1.8
+revision            0
 categories          sysutils net
 maintainers         {fwright.net:fw @fhgwright} openmaintainer
 description         A secure, hardened, and improved implementation of NTP
@@ -19,9 +19,9 @@ homepage            https://www.ntpsec.org/
 conflicts           ntp openntpd
 
 master_sites        ftp://ftp.ntpsec.org/pub/releases/
-checksums           rmd160  4f88807fc4652d2bb0608ca82df5b7e6be18eb63 \
-                    sha256  48eb3e0ed932fccc21373bc34a344b0c7164fda637f9b822b85b146f1aea398b \
-                    size    2534524
+checksums           rmd160  50b7c2729118e23bf1b45fad5bc74430690c84c7 \
+                    sha256  8445827a4d5029da508a11e9c8e7958db839f73b39de612ab3909244f89a1340 \
+                    size    2589363
 
 # To avoid breaking any code that uses our Python package, keep the Python
 # version at 2.7 until we add variants for Python versions.  The upstream

--- a/sysutils/ntpsec/files/patch-PreHighSierra.diff
+++ b/sysutils/ntpsec/files/patch-PreHighSierra.diff
@@ -1,5 +1,5 @@
---- ./attic/backwards.c.orig	2019-09-02 19:17:36.000000000 -0700
-+++ ./attic/backwards.c	2019-09-03 22:22:14.000000000 -0700
+--- ./attic/backwards.c.orig	2019-11-17 14:18:12.000000000 -0800
++++ ./attic/backwards.c	2019-11-23 17:54:09.000000000 -0800
 @@ -7,6 +7,8 @@
  #include <stdlib.h>
  #include <time.h>
@@ -9,8 +9,8 @@
  #define UNUSED_ARG(arg)         ((void)(arg))
  
  static void ts_print(struct timespec *ts0, struct timespec *ts1);
---- ./attic/clocks.c.orig	2019-09-02 19:17:36.000000000 -0700
-+++ ./attic/clocks.c	2019-09-03 22:22:14.000000000 -0700
+--- ./attic/clocks.c.orig	2019-11-17 14:18:12.000000000 -0800
++++ ./attic/clocks.c	2019-11-23 17:54:09.000000000 -0800
 @@ -5,6 +5,8 @@
  #include <stdio.h>
  #include <time.h>
@@ -20,8 +20,8 @@
  struct table {
    const int type;
    const char* name;
---- ./attic/digest-timing.c.orig	2019-09-02 19:17:36.000000000 -0700
-+++ ./attic/digest-timing.c	2019-09-03 22:22:14.000000000 -0700
+--- ./attic/digest-timing.c.orig	2019-11-17 14:18:12.000000000 -0800
++++ ./attic/digest-timing.c	2019-11-23 17:54:09.000000000 -0800
 @@ -34,6 +34,8 @@
  #include <openssl/rand.h>
  #include <openssl/objects.h>
@@ -31,8 +31,8 @@
  #define UNUSED_ARG(arg)         ((void)(arg))
  
  #ifndef EVP_MD_CTX_reset
---- ./include/ntp_machine.h.orig	2019-09-02 19:17:36.000000000 -0700
-+++ ./include/ntp_machine.h	2019-09-03 22:22:14.000000000 -0700
+--- ./include/ntp_machine.h.orig	2019-11-17 14:18:12.000000000 -0800
++++ ./include/ntp_machine.h	2019-11-23 17:54:09.000000000 -0800
 @@ -13,14 +13,145 @@
  
  #ifndef CLOCK_REALTIME
@@ -185,9 +185,9 @@
  
  int ntp_set_tod (struct timespec *tvs);
  
---- ./include/ntp_stdlib.h.orig	2019-09-02 19:17:36.000000000 -0700
-+++ ./include/ntp_stdlib.h	2019-09-03 22:22:14.000000000 -0700
-@@ -96,7 +96,9 @@ extern	const char * eventstr	(int);
+--- ./include/ntp_stdlib.h.orig	2019-11-17 14:18:12.000000000 -0800
++++ ./include/ntp_stdlib.h	2019-11-23 17:54:09.000000000 -0800
+@@ -95,7 +95,9 @@ extern	const char * eventstr	(int);
  extern	const char * ceventstr	(int);
  extern	const char * res_match_flags(unsigned short);
  extern	const char * res_access_flags(unsigned short);
@@ -195,10 +195,10 @@
  extern	const char * k_st_flags	(uint32_t);
 +#endif
  extern	char *	statustoa	(int, int);
- extern	sockaddr_u * netof6	(sockaddr_u *);
  extern	const char * socktoa	(const sockaddr_u *);
---- ./include/ntp_syscall.h.orig	2019-09-02 19:17:36.000000000 -0700
-+++ ./include/ntp_syscall.h	2019-09-03 22:22:14.000000000 -0700
+ extern	const char * socktoa_r	(const sockaddr_u *sock, char *buf, size_t buflen);
+--- ./include/ntp_syscall.h.orig	2019-11-17 14:18:12.000000000 -0800
++++ ./include/ntp_syscall.h	2019-11-23 17:54:09.000000000 -0800
 @@ -9,9 +9,11 @@
  #ifndef GUARD_NTP_SYSCALL_H
  #define GUARD_NTP_SYSCALL_H
@@ -211,8 +211,8 @@
  
  /*
   * The units of the maxerror and esterror fields vary by platform.  If
---- ./libntp/clockwork.c.orig	2019-09-02 19:17:36.000000000 -0700
-+++ ./libntp/clockwork.c	2019-09-03 22:22:14.000000000 -0700
+--- ./libntp/clockwork.c.orig	2019-11-17 14:18:12.000000000 -0800
++++ ./libntp/clockwork.c	2019-11-23 17:54:09.000000000 -0800
 @@ -5,8 +5,10 @@
  #include "config.h"
  
@@ -226,8 +226,8 @@
  
  #include "ntp.h"
  #include "ntp_machine.h"
---- ./libntp/statestr.c.orig	2019-09-02 19:17:36.000000000 -0700
-+++ ./libntp/statestr.c	2019-09-03 22:22:14.000000000 -0700
+--- ./libntp/statestr.c.orig	2019-11-17 14:18:12.000000000 -0800
++++ ./libntp/statestr.c	2019-11-23 17:54:09.000000000 -0800
 @@ -12,7 +12,9 @@
  #include "lib_strbuf.h"
  #include "ntp_refclock.h"
@@ -328,8 +328,8 @@
  
  /*
   * statustoa - return a descriptive string for a peer status
---- ./ntpd/ntp_control.c.orig	2019-09-02 19:17:36.000000000 -0700
-+++ ./ntpd/ntp_control.c	2019-09-03 22:22:14.000000000 -0700
+--- ./ntpd/ntp_control.c.orig	2019-11-17 14:18:12.000000000 -0800
++++ ./ntpd/ntp_control.c	2019-11-23 17:54:09.000000000 -0800
 @@ -1359,6 +1359,7 @@ ctl_putsys(
  	char str[256];
  	double dtemp;
@@ -452,8 +452,8 @@
  		break;
  
  	case CS_K_PPS_FREQ:
---- ./ntpd/ntp_loopfilter.c.orig	2019-09-02 19:17:36.000000000 -0700
-+++ ./ntpd/ntp_loopfilter.c	2019-09-03 22:22:14.000000000 -0700
+--- ./ntpd/ntp_loopfilter.c.orig	2019-11-17 14:18:12.000000000 -0800
++++ ./ntpd/ntp_loopfilter.c	2019-11-23 17:54:09.000000000 -0800
 @@ -23,8 +23,10 @@
  
  #define NTP_MAXFREQ	500e-6
@@ -689,8 +689,8 @@
  }
 -#endif /* SIGSYS */
 +#endif /* HAVE_KERNEL_PLL && SIGSYS */
---- ./ntpd/ntp_timer.c.orig	2019-09-02 19:17:36.000000000 -0700
-+++ ./ntpd/ntp_timer.c	2019-09-03 22:22:14.000000000 -0700
+--- ./ntpd/ntp_timer.c.orig	2019-11-17 14:18:12.000000000 -0800
++++ ./ntpd/ntp_timer.c	2019-11-23 17:54:09.000000000 -0800
 @@ -13,7 +13,9 @@
  #include <signal.h>
  #include <unistd.h>
@@ -713,8 +713,8 @@
  #ifdef ENABLE_LEAP_SMEAR
  	leap_smear.enabled = (leap_smear_intv != 0);
  #endif
---- ./ntpd/refclock_local.c.orig	2019-09-02 19:17:36.000000000 -0700
-+++ ./ntpd/refclock_local.c	2019-09-03 22:22:14.000000000 -0700
+--- ./ntpd/refclock_local.c.orig	2019-11-17 14:18:12.000000000 -0800
++++ ./ntpd/refclock_local.c	2019-11-23 17:54:09.000000000 -0800
 @@ -158,6 +158,7 @@ local_poll(
  	 * If another process is disciplining the system clock, we set
  	 * the leap bits and quality indicators from the kernel.
@@ -737,8 +737,8 @@
  	pp->lastref = pp->lastrec;
  	refclock_receive(peer);
  }
---- ./ntpfrob/precision.c.orig	2019-09-02 19:17:36.000000000 -0700
-+++ ./ntpfrob/precision.c	2019-09-03 22:22:14.000000000 -0700
+--- ./ntpfrob/precision.c.orig	2019-11-17 14:18:12.000000000 -0800
++++ ./ntpfrob/precision.c	2019-11-23 17:54:09.000000000 -0800
 @@ -11,6 +11,7 @@
  #include "ntp_types.h"
  #include "ntp_calendar.h"
@@ -747,8 +747,8 @@
  
  #define	DEFAULT_SYS_PRECISION	-99
  
---- ./tests/libntp/statestr.c.orig	2019-09-02 19:17:36.000000000 -0700
-+++ ./tests/libntp/statestr.c	2019-09-03 22:22:14.000000000 -0700
+--- ./tests/libntp/statestr.c.orig	2019-11-17 14:18:12.000000000 -0800
++++ ./tests/libntp/statestr.c	2019-11-23 17:54:09.000000000 -0800
 @@ -4,7 +4,9 @@
  #include "unity.h"
  #include "unity_fixture.h"
@@ -769,11 +769,11 @@
  }
  
  // statustoa
---- ./wafhelpers/bin_test.py.orig	2019-09-02 19:17:36.000000000 -0700
-+++ ./wafhelpers/bin_test.py	2019-09-03 22:22:14.000000000 -0700
-@@ -91,6 +91,12 @@ def cmd_bin_test(ctx, config):
-         for cmd in cmd_map3:
-             cmd_map2[cmd] = cmd_map3[cmd]
+--- ./wafhelpers/bin_test.py.orig	2019-11-17 14:18:12.000000000 -0800
++++ ./wafhelpers/bin_test.py	2019-11-23 17:54:09.000000000 -0800
+@@ -97,6 +97,12 @@ def cmd_bin_test(ctx, config):
+     if ctx.env['PYTHON_CURSES']:
+         cmd_map_python.update(cmd_map_python_curses)
  
 +    # Kludge to remove ntptime if it didn't get built
 +    if not ctx.env.HEADER_SYS_TIMEX_H:
@@ -784,8 +784,8 @@
      for cmd in sorted(cmd_map):
          if not run(cmd, cmd_map[cmd], False):
              fails += 1
---- ./wafhelpers/options.py.orig	2019-09-02 19:17:36.000000000 -0700
-+++ ./wafhelpers/options.py	2019-09-03 22:22:14.000000000 -0700
+--- ./wafhelpers/options.py.orig	2019-11-17 14:18:12.000000000 -0800
++++ ./wafhelpers/options.py	2019-11-23 17:54:09.000000000 -0800
 @@ -19,6 +19,8 @@ def options_cmd(ctx, config):
                     help="Droproot earlier (breaks SHM and NetBSD).")
      grp.add_option('--enable-seccomp', action='store_true',
@@ -795,9 +795,9 @@
      grp.add_option('--disable-mdns-registration', action='store_true',
                     default=False, help="Disable MDNS registration.")
      grp.add_option(
---- ./wscript.orig	2019-09-02 19:17:36.000000000 -0700
-+++ ./wscript	2019-09-03 22:22:14.000000000 -0700
-@@ -593,7 +593,7 @@ int main(int argc, char **argv) {
+--- ./wscript.orig	2019-11-17 14:18:12.000000000 -0800
++++ ./wscript	2019-11-23 17:54:09.000000000 -0800
+@@ -592,7 +592,7 @@ int main(int argc, char **argv) {
      structures = (
          ("struct if_laddrconf", ["sys/types.h", "net/if6.h"], False),
          ("struct if_laddrreq", ["sys/types.h", "net/if6.h"], False),
@@ -806,7 +806,7 @@
          ("struct ntptimeval", ["sys/time.h", "sys/timex.h"], False),
      )
      for (s, h, r) in structures:
-@@ -798,6 +798,21 @@ int main(int argc, char **argv) {
+@@ -797,6 +797,21 @@ int main(int argc, char **argv) {
      ctx.define("HAVE_WORKING_FORK", 1,
                 comment="Whether a working fork() exists")
  


### PR DESCRIPTION
#### Description

This PR has two commits - one to repair the damage to the 1.1.7 port caused by the change to the default Python version, and one to update to the new upstream version.  See the individual commit messages for more details.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.5-10.15
Xcode 3.1.4-11.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
