### PR TITLE
dvisvgm: use compiler.cxx_standard

### DIFF
--- a/graphics/dvisvgm/Portfile
+++ b/graphics/dvisvgm/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem       1.0
-PortGroup        cxx11 1.1
 PortGroup        github 1.0
 
 name             dvisvgm
@@ -16,6 +15,7 @@ long_description DVI to SVG converter. The command-line utility dvisvgm is a too
     vector graphics format SVG.
 
 subport dvisvgm-devel {}
+compiler.cxx_standard 2011
 
 if {${subport} eq ${name}} {
 


### PR DESCRIPTION
this is the current recommendation
and fixes the build with gcc as well

closes: https://trac.macports.org/ticket/59551

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
10.5 PPC
10.14 