### PR TITLE
volk-gnss-sdr: add Python variants and update volk-gnss-sdr-next subport

### DIFF
--- a/science/gnss-sdr/Portfile
+++ b/science/gnss-sdr/Portfile
@@ -39,7 +39,7 @@ if {${subport} eq "gnss-sdr"} {
     checksums           rmd160 c280bf809e1e99187a1d060684f06d9b2f6aeb7f \
                         sha256 0c55b5cd971f308d734b00c7d68e3c43fc25fcf787b40b330b04ca624d3583d1 \
                         size   3716114
-    revision            2
+    revision            3
 
     conflicts           gnss-sdr-devel gnss-sdr-next
 
@@ -60,7 +60,7 @@ subport gnss-sdr-devel {
     checksums           rmd160 c280bf809e1e99187a1d060684f06d9b2f6aeb7f \
                         sha256 0c55b5cd971f308d734b00c7d68e3c43fc25fcf787b40b330b04ca624d3583d1 \
                         size   3716114
-    revision            2
+    revision            3
 
     conflicts           gnss-sdr gnss-sdr-next
 
@@ -75,11 +75,11 @@ subport gnss-sdr-next {
         This port is kept up with the GNSS-SDR GIT next branch, which is typically updated daily to weekly.  This version of GNSS-SDR generally contains fixes and new features that will be incorporated in an upcoming release, and compiles against the gnuradio-next subport. This port may or not compile or function correctly, as it represents a work in progress.  If it does not work, check back in a few days.  Or try deactivating the currently active gnss-sdr and gnuradio ports, cleaning any current builds, and trying again.
 
     name      gnss-sdr-next
-    github.setup gnss-sdr gnss-sdr 124531ba39f5f280bb984a4b3fe11863d639a385
-    version   20191027-[string range ${github.version} 0 7]
-    checksums rmd160  f53b95bfe66e479218176a17cadc64f8eb81aac0 \
-              sha256  d07dbbd90551e85ddc15d0a0c01ca608f1de875f50df381e4cd64458358abb3b \
-              size    3754796
+    github.setup gnss-sdr gnss-sdr 39234295d71b33a4e01b44147e837ff2aa0edd11
+    version   20191201-[string range ${github.version} 0 7]
+    checksums rmd160  682fe7a087e6a5cca2e15537f49b2cefea4dd4c9 \
+              sha256  1afd38c63bd2df2dd744344da41162f9586d3b65b2be2cd2f019f311d47fba0f \
+              size    3761297
     revision  0
 
     conflicts gnss-sdr gnss-sdr-devel

--- a/science/volk-gnss-sdr/Portfile
+++ b/science/volk-gnss-sdr/Portfile
@@ -36,7 +36,7 @@ if {${subport} eq "volk-gnss-sdr"} {
         This port is kept up with the VOLK-GNSS-SDR release, which is typically updated every few months. This version compiles against the gnss-sdr and gnuradio ports.
 
     github.setup        gnss-sdr gnss-sdr 0.0.11 v
-    revision            1
+    revision            2
     checksums           rmd160 c280bf809e1e99187a1d060684f06d9b2f6aeb7f \
                         sha256 0c55b5cd971f308d734b00c7d68e3c43fc25fcf787b40b330b04ca624d3583d1 \
                         size   3716114
@@ -56,7 +56,7 @@ subport volk-gnss-sdr-devel {
     checksums           rmd160 c280bf809e1e99187a1d060684f06d9b2f6aeb7f \
                         sha256 0c55b5cd971f308d734b00c7d68e3c43fc25fcf787b40b330b04ca624d3583d1 \
                         size   3716114
-    revision            1
+    revision            2
 
     conflicts           volk-gnss-sdr volk-gnss-sdr-next
 
@@ -67,11 +67,11 @@ subport volk-gnss-sdr-next {
         This port is kept up with the VOLK-GNSS-SDR GIT next branch, which is typically updated daily to weekly.  This version of VOLK-GNSS-SDR generally contains fixes and new features that will be incorporated in an upcoming release, and compiles against the gnss-sdr-next and gnuradio-next ports.  This port may or not compile or function correctly, as it represents a work in progress.  If it does not work, check back in a few days.  Or try deactivating the currently active gnss-sdr and gnuradio ports, cleaning any current builds, and trying again.
 
     name      volk-gnss-sdr-next
-    github.setup gnss-sdr gnss-sdr 124531ba39f5f280bb984a4b3fe11863d639a385
-    version   20191027-[string range ${github.version} 0 7]
-    checksums rmd160  f53b95bfe66e479218176a17cadc64f8eb81aac0 \
-              sha256  d07dbbd90551e85ddc15d0a0c01ca608f1de875f50df381e4cd64458358abb3b \
-              size    3754796
+    github.setup gnss-sdr gnss-sdr 39234295d71b33a4e01b44147e837ff2aa0edd11
+    version   20191201-[string range ${github.version} 0 7]
+    checksums rmd160  682fe7a087e6a5cca2e15537f49b2cefea4dd4c9 \
+              sha256  1afd38c63bd2df2dd744344da41162f9586d3b65b2be2cd2f019f311d47fba0f \
+              size    3761297
     revision  0
 
     conflicts volk-gnss-sdr volk-gnss-sdr-devel
@@ -94,10 +94,58 @@ depends_build-append port:pkgconfig
 depends_lib-append \
     path:lib/libvolk.dylib:volk \
     port:orc \
-    port:python27 \
-    port:py27-mako \
-    port:py27-six \
     port:boost
+
+# specify the Python dependencies; these are checked for at configure,
+# then used for building, but not at runtime.
+
+set pythons_suffixes {27 36 37 38}
+
+set pythons_ports {}
+foreach s ${pythons_suffixes} {
+    lappend pythons_ports python${s}
+}
+
+proc python_dir {} {
+    global pythons_suffixes
+    foreach s ${pythons_suffixes} {
+        if {[variant_isset python${s}]} {
+            set p python[string index ${s} 0].[string index ${s} 1]
+            return [file normalize [exec ${p} -c "import sys; print(sys.prefix)"]/lib/${p}/site-packages]
+        }
+    }
+    error "Python support not enabled."
+}
+
+foreach s ${pythons_suffixes} {
+    set p python${s}
+    set v [string index ${s} 0].[string index ${s} 1]
+    set i [lsearch -exact ${pythons_ports} ${p}]
+    set c [lreplace ${pythons_ports} ${i} ${i}]
+    variant ${p} description "Build Volk using Python ${v}" conflicts {*}${c} "
+    # required Python
+    depends_lib-append \
+        port:${p}
+    depends_build-append \
+        port:py${s}-six \
+        port:py${s}-mako
+    # specify the Python version to use
+    configure.args-append \
+        -DPYTHON_EXECUTABLE=${frameworks_dir}/Python.framework/Versions/${v}/bin/python${v} \
+        -DVOLK_PYTHON_DIR=${frameworks_dir}/Python.framework/Versions/${v}/lib/python${v}/site-packages
+    "
+}
+
+if {![variant_isset debug]} {
+    set selected_python python37
+    foreach s ${pythons_suffixes} {
+        if {[variant_isset python${s}]} {
+            set selected_python python${s}
+        }
+    }
+    default_variants +${selected_python}
+}
+
 
 # do VPATH (out of source tree) build
 


### PR DESCRIPTION
#### Description

Add variants +python27, +python34, +python35, +python36, +python37 and +python38, as done in the volk port. Variant +python37  is choosen by default.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.1
Xcode 11.2.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
