### PR TITLE
py-virtualenvwrapper: add Python 3.8

### DIFF
--- a/python/py-stevedore/Portfile
+++ b/python/py-stevedore/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  de1f8e7334aeb7daaf887f8f08441c0050369bc4 \
                     sha256  e0739f9739a681c7a1fda76a102b65295e96a144ccdb552f2ae03c5f0abe8a14 \
                     size    505482
 
-python.versions     27 35 36 37
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-setuptools \

--- a/python/py-virtualenv-clone/Portfile
+++ b/python/py-virtualenv-clone/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  b7c61d8f0fdf36d297577266cb896d4ca95fee7a \
                     sha256  c88ae171a11b087ea2513f260cdac9232461d8e9369bcd1dc143fc399d220557 \
                     size    6226
 
-python.versions     27 35 36 37
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_lib-append \

--- a/python/py-virtualenvwrapper/Portfile
+++ b/python/py-virtualenvwrapper/Portfile
@@ -28,7 +28,7 @@ checksums           rmd160  1d7791e2df3689b44e3293757825bd89405c2af1 \
                     sha256  51a1a934e7ed0ff221bdd91bf9d3b604d875afbb3aa2367133503fee168f5bfa \
                     size    334920
 
-python.versions     27 35 36 37
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-pbr \


### PR DESCRIPTION
#### Description

* Add Python 3.8 support to virtualenvwrapper's dependencies (separate commits): stevedore and virtualenv-clone
* Add Python 3.8 support to virtualenvwrapper

Have not had any issues with this change so far.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.1 19B88
Xcode 11.1 11A1027

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
