### PR TITLE
polyml: fix build on systems without Mach-O PPC header files

### DIFF
--- a/lang/polyml/Portfile
+++ b/lang/polyml/Portfile
@@ -25,6 +25,9 @@ depends_lib         port:gmp port:libffi
 configure.args      --mandir=${prefix}/share/man --build=${build_arch}-apple-darwin${os.major} \
                     --enable-shared --with-system-libffi
 
+patchfiles          patch-no-ppc-reloc-header.diff
+patch.pre_args -p1
+
 post-destroot {
     xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}
     xinstall -m 644 -W ${worksrcpath} COPYING \

--- a/lang/polyml/files/patch-no-ppc-reloc-header.diff
+++ b/lang/polyml/files/patch-no-ppc-reloc-header.diff
@@ -1,0 +1,12 @@
+diff --git a/libpolyml/machoexport.cpp b/libpolyml/machoexport.cpp
+index f5b1aa3..93e126e 100644
+--- a/libpolyml/machoexport.cpp
++++ b/libpolyml/machoexport.cpp
+@@ -55,7 +55,6 @@
+ #include <mach-o/loader.h>
+ #include <mach-o/reloc.h>
+ #include <mach-o/nlist.h>
+-#include <mach-o/ppc/reloc.h>
+ #include <mach-o/x86_64/reloc.h>
+ 
+ #ifdef HAVE_STRING_H


### PR DESCRIPTION
#### Description

This is to fix the build failure reported by a build bot on Mac OS X 10.15.  **I have not been able to test the fix under Mac OS X 10.15 so there may still be other issues.**

The fix has already been [merged upstream in Poly/ML](https://github.com/polyml/polyml/commit/44efa473da58f37c8961f56c9893ca496c871a33) but is not yet in any release.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.10.5 14F2511
Xcode 6.2 6C131e 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
