### PR TITLE
libfilezilla: change C++ compiler standard to 2017

### DIFF
--- a/devel/libfilezilla/Portfile
+++ b/devel/libfilezilla/Portfile
@@ -33,7 +33,7 @@ depends_lib         port:libiconv \
 
 use_bzip2           yes
 
-compiler.cxx_standard   2014
+compiler.cxx_standard   2017
 # libfilezilla uses thread_local, which is not supported in Xcode < 8
 compiler.thread_local_storage   yes
 


### PR DESCRIPTION
###### Tested on

macOS 10.14.6 18G1012
Xcode 11.2.1 11B500

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?