### PR TITLE
Gildas: update to 201912a

### DIFF
--- a/science/gildas/Portfile
+++ b/science/gildas/Portfile
@@ -5,7 +5,7 @@ PortGroup           compilers 1.0
 PortGroup           active_variants 1.1 
 
 name                gildas
-version             201911a
+version             201912a
 set my_version      [string tolower [clock format [clock scan 2000-[string range ${version} 4 5]-10] -format %b]][string range ${version} 2 3][string range ${version} 6 end]
 categories          science
 platforms           darwin
@@ -30,9 +30,9 @@ master_sites        http://www.iram.fr/~gildas/dist/ \
 distname            ${name}-src-${my_version}
 use_xz              yes
 
-checksums           rmd160  0916fd97c9af1ab69ea6fa5d8a77cee738892582 \
-                    sha256  09e0044104b9ce5bf530c63a813bc7431232f1000ab9363b2d7f6543f3af3a86 \
-                    size    41909684
+checksums           rmd160  31676d9fd1ddd2f207ddf8b75a16dd8d85b09f9a \
+                    sha256  611974b126b03f4a172b3380a245251f5f5492e0796dbed49ab0f4fffe2b984f \
+                    size    41920212
 
 patch.pre_args      -p1
 patchfiles          patch-admin-Makefile.def.diff \


### PR DESCRIPTION
Can someone please merge this PR for Gildas monthly release?

Note: Travis build is expected to fail because of timeout. On the other hand, following [this discussion](https://github.com/macports/macports-ports/pull/5698#issuecomment-549559593), it seems that @cjones051073 has done the necessary changes to ensure Azure build won't fail (I am not able to confirm this).