### PR TITLE
redis: update to 5.0.7

### DIFF
--- a/databases/redis/Portfile
+++ b/databases/redis/Portfile
@@ -5,13 +5,12 @@ PortGroup           muniversal 1.0
 PortGroup           xcode_workaround 1.0
 
 name                redis
-version             5.0.6
-revision            2
+version             5.0.7
 categories          databases
 platforms           darwin
 license             BSD
 
-maintainers         nomaintainer
+maintainers         {gmail.com:davidgilman1 @dgilman} openmaintainer
 
 description         Redis is an open source, advanced key-value store.
 long_description    ${description}
@@ -19,9 +18,9 @@ long_description    ${description}
 homepage            https://redis.io/
 master_sites        http://download.redis.io/releases/
 
-checksums           rmd160  ecbfc9e1ae11baa0c4cb2bfb6099082df053f84a \
-                    sha256  6624841267e142c5d5d5be292d705f8fb6070677687c5aad1645421a936d22b3 \
-                    size    1979873
+checksums           rmd160  0490b980daaba10d5697af8b8b719c6ab54a821c \
+                    sha256  61db74eabf6801f057fd24b590232f2f337d422280fd19486eca03be87d3a82b \
+                    size    1984203
 
 patchfiles          patch-redis.conf.diff
 
@@ -90,8 +89,6 @@ post-activate {
 
 startupitem.create  yes
 startupitem.executable  ${prefix}/bin/redis-server ${prefix}/etc/redis.conf
-
-test.run yes
 
 notes "
 If you prefer to start a redis server manually, rather than using 'port load', then use this command:


### PR DESCRIPTION
#### Description

I disabled the tests because I can't get them to pass successfully, and even worse when they fail they clutter your system with almost a hundred orphaned redis servers.

###### Type(s)

- [x] enhancement

###### Tested on
macOS 10.13.6 17G9016
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
