### PR TITLE
weechat: Change build option from aspell to spell

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -81,7 +81,7 @@ configure.args-append \
                     -DENABLE_PYTHON=OFF \
                     -DENABLE_PYTHON3=OFF \
                     -DENABLE_RUBY=OFF \
-                    -DENABLE_ASPELL=OFF \
+                    -DENABLE_SPELL=OFF \
                     -DENABLE_TCL=OFF \
                     -DENABLE_MAN=ON
 
@@ -123,8 +123,8 @@ variant tcl description {Support for tcl} {
 }
 
 variant aspell description {Support for aspell} {
-    configure.args-delete   -DENABLE_ASPELL=OFF
-    configure.args-append   -DENABLE_ASPELL=ON
+    configure.args-delete   -DENABLE_SPELL=OFF
+    configure.args-append   -DENABLE_SPELL=ON
     depends_lib-append      port:aspell
 }
 


### PR DESCRIPTION
#### Description

https://github.com/weechat/weechat/issues/1299
weechat updated spellcheck option from aspell to spell to add enchant support

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.1 19B88
Xcode 11.2.1 11B500

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
