### PR TITLE
libfmt: update to 6.0.0

### DIFF
--- a/devel/libfmt/Portfile
+++ b/devel/libfmt/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake  1.1
+PortGroup           compiler_blacklist_versions 1.0
 
-github.setup        fmtlib fmt 5.3.0
+github.setup        fmtlib fmt 6.0.0
 name                libfmt
 homepage            http://fmtlib.net
 categories          devel
@@ -17,11 +18,12 @@ long_description    \
     fmt (formerly cppformat) is an open-source formatting library. \
     It can be used as a safe alternative to printf or as a fast alternative to C++ IOStreams.
 
-checksums           rmd160  7ab5001c8144d8d3d25b1726295e1447d065d694 \
-                    sha256  7b40e266c16cbcc16a9d8743713d012be3188872c4bce5dde3556cdf3b5846d2 \
-                    size 662560
+checksums           rmd160  f93a5790bd795411ec6956a3470693cc3ad1e5e0 \
+                    sha256  9a6bb7dad07ad385d52597593f3cbc0d7180bfae87f2f2ede00b9ca6b801f48f \
+                    size 708513
 
 compiler.cxx_standard   2011
+compiler.blacklist-append {clang < 800}
 
 configure.args-append \
     -DBUILD_SHARED_LIBS=ON


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
This PR updates libfmt to v6.0.0.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.1 19B88
Xcode 11.2.1 11B500

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
