### PR TITLE
FAudio: Update to 19.12

### DIFF
--- a/audio/FAudio/Portfile
+++ b/audio/FAudio/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cmake 1.1
 
-github.setup            FNA-XNA FAudio 19.11
+github.setup            FNA-XNA FAudio 19.12
 revision                0
 
 license                 zlib
@@ -18,9 +18,9 @@ long_description        an XAudio reimplementation that focuses solely on develo
 
 depends_lib-append      port:libsdl2
 
-checksums               rmd160  ed8502e2bb32506198a147d50e0ccf4ed1c14a20 \
-                        sha256  a073743e24510b4003a2988480eeb16f8e122ab7cd5356258ae160aad4d6d30b \
-                        size    901795
+checksums               rmd160  250d8bda48138250105b3a5a18d208c2f7000478 \
+                        sha256  bee3fd89afd79dd310303fd1b90ca657b012902408b00895f9a67abc9444ed1d \
+                        size    901837
 
 # remove set deployment target
 patchfiles              patch-faudio-remove-deployment-target.diff


### PR DESCRIPTION
#### Description

Updates FAudio to 19.12
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G1012
Xcode 10.3 10G8 

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
