### PR TITLE
wireguard-tools: update to 0.0.20191205

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-tools
-version             0.0.20191127
+version             0.0.20191205
 revision            0
-checksums           rmd160  542d7ab4d4d900e45ed21767fdffc7fdf1efbc6d \
-                    sha256  7d4e80a6f84564d4826dd05da2b59e8d17645072c0345d0fc0d197be176c3d06 \
-                    size    332368
+checksums           rmd160  05c9a9204b2427bd9992ef50ef6e48e97375b42c \
+                    sha256  4de4c0efa35f8eb170c27a0bc8977e5c0634b8e19c03915d03218cc88bb0adbe \
+                    size    332092
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
###### Tested on
macOS 10.13.6 17G8037
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?