### PR TITLE
cmake: fix build with clang-3.4

### DIFF
--- a/devel/cmake/Portfile
+++ b/devel/cmake/Portfile
@@ -122,6 +122,13 @@ depends_lib-append  port:curl \
 # system libuv is the default as of 20160830 (g320f5)
 depends_lib-append  path:lib/pkgconfig/libuv.pc:libuv
 
+# configure is just a shell script that passes directly to bootstrap
+configure.cmd       ./bootstrap
+
+# bootstrap takes cmake-style args for the build of the cmake to be installed
+# the args are passed as usual for cmake, after "--", so we pass them as post_args
+configure.post_args --
+
 configure.env-append \
                     CMAKE_PREFIX_PATH=${prefix} \
                     CMAKE_INCLUDE_PATH=${prefix}/include/ncurses \
@@ -140,6 +147,13 @@ if {${os.platform} eq "darwin" && ${os.major} <= 10 && ${cxx_stdlib} eq "libc++"
 if {${os.platform} eq "darwin" && ${os.major} == 11 && ${configure.cxx_stdlib} eq "libc++"} {
     compiler.whitelist macports-clang-3.4
 }
+
+# clang 3.4 can't build certain parts of the cmake self-testing infrastructure
+# https://trac.macports.org/ticket/59782
+if {${configure.compiler} eq "macports-clang-3.4"} {
+    configure.post_args-append -DBUILD_TESTING=OFF
+}
+
 
 platform darwin {
     configure.env-append \
@@ -173,7 +187,6 @@ configure.args-append --docdir=share/doc/cmake \
                     --no-system-librhash
 
 configure.universal_args
-configure.post_args
 
 # CMake's configure script doesn't recognize `--host`.
 array set merger_host {i386 {} x86_64 {} ppc {} ppc64 {}}


### PR DESCRIPTION
enable existing mechanism to pass -DCMAKE arg to cmake during build
disable certain cmake self-tests which currently don't build with clang-3.4
allows bootstrapping with clang-3.4 -> cmake -> clang-3.7
closes: https://trac.macports.org/ticket/59782

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.7.5, 10.14
Xcode 4.5, 11.2.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
