### PR TITLE
yarn: update to 1.19.2

### DIFF
--- a/devel/yarn/Portfile
+++ b/devel/yarn/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        yarnpkg yarn 1.19.1 v
+github.setup        yarnpkg yarn 1.19.2 v
 revision            0
 
 categories          devel
@@ -28,9 +28,9 @@ homepage            https://yarnpkg.com/
 github.tarball_from releases
 distname            ${name}-${git.branch}
 
-checksums           rmd160  43769e50b1142891d51a08675b78e088f86deed1 \
-                    sha256  34293da6266f2aae9690d59c2d764056053ff7eebc56b80b8df05010c3da9343 \
-                    size    1243585
+checksums           rmd160  b46b99d1b6684e4cba86bf0472f2670736f0bbf5 \
+                    sha256  2ed90e6aaf3988df5c75b6829b7c523754453a0b7134a9d0bf11161f927eae25 \
+                    size    1244018
 
 depends_run         path:bin/node:nodejs10
 


### PR DESCRIPTION
#### Description

Update yarn to version 1.19.2

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.1 19B2106
Xcode 11.2.1 11B500 

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
