### PR TITLE
pdf2djvu: apply upstream patches for poppler 0.83.0 compatibility

### DIFF
--- a/graphics/pdf2djvu/Portfile
+++ b/graphics/pdf2djvu/Portfile
@@ -5,6 +5,7 @@ PortGroup           github 1.0
 PortGroup           cxx11 1.1
 
 github.setup        jwilk pdf2djvu 0.9.14
+revision            1
 categories          graphics textproc
 platforms           darwin
 license             GPL-2
@@ -34,7 +35,9 @@ depends_lib         port:djvulibre \
                     port:libxslt
 
 patchfiles          patch-i18n.hh.diff \
-                    patch-sys-uuid.diff 
+                    patch-sys-uuid.diff \
+                    patch-poppler-0.83-001.diff \
+                    patch-poppler-0.83-002.diff
  
 #Openmp is anyway not detected with llvm-gcc or clang, and breaks compilation with
 #gcc42 on SL (ticket #38184)

--- a/graphics/pdf2djvu/files/patch-poppler-0.83-001.diff
+++ b/graphics/pdf2djvu/files/patch-poppler-0.83-001.diff
@@ -1,0 +1,46 @@
+From 0aa17bb79dbcdfc249e4841f5b5398e27cfdfd41 Mon Sep 17 00:00:00 2001
+From: Jakub Wilk <jwilk@jwilk.net>
+Date: Fri, 15 Nov 2019 11:47:47 +0100
+Subject: [PATCH] =?UTF-8?q?pdf-backend:=20fix=20global=20params=20init=20f?=
+ =?UTF-8?q?or=20Poppler=20=E2=89=A5=200.83.?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fixes:
+
+    pdf-backend.cc: In constructor ‘pdf::Environment::Environment()’:
+    pdf-backend.cc:106:35: error: no match for ‘operator=’ (operand types are ‘std::unique_ptr<GlobalParams>’ and ‘GlobalParams*’)
+---
+ pdf-backend.cc | 16 +++++++++++++++-
+ 1 file changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/pdf-backend.cc b/pdf-backend.cc
+index a94383e..085cd9e 100644
+--- pdf-backend.cc
++++ pdf-backend.cc
+@@ -101,9 +101,23 @@ static void poppler_error_handler(void *data, ErrorCategory category, pdf::Offse
+ }
+ #endif
+ 
++template <typename T> T new_global_params();
++
++// POPPLER_VERSION >= 8300
++template <> std::unique_ptr<GlobalParams> new_global_params<std::unique_ptr<GlobalParams>>()
++{
++  return std::unique_ptr<GlobalParams>(new GlobalParams);
++}
++
++// POPPLER_VERSION < 8300
++template <> GlobalParams* new_global_params<GlobalParams*>()
++{
++  return new GlobalParams;
++}
++
+ pdf::Environment::Environment()
+ {
+-  globalParams = new GlobalParams();
++  globalParams = new_global_params<decltype(globalParams)>();
+   setErrorCallback(poppler_error_handler, nullptr);
+ }
+ 

--- a/graphics/pdf2djvu/files/patch-poppler-0.83-002.diff
+++ b/graphics/pdf2djvu/files/patch-poppler-0.83-002.diff
@@ -1,0 +1,36 @@
+From 27b9e028091a2f370367e9eaf37b4bb1cde87b62 Mon Sep 17 00:00:00 2001
+From: Jakub Wilk <jwilk@jwilk.net>
+Date: Mon, 25 Nov 2019 07:27:12 +0100
+Subject: [PATCH] =?UTF-8?q?pdf-backend:=20fix=20const=20issues=20with=20Po?=
+ =?UTF-8?q?ppler=20=E2=89=A5=200.83.?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fixes:
+
+    pdf-backend.cc: In static member function ‘static void pdf::Renderer::convert_path(pdf::gfx::State*, pdf::splash::Path&)’:
+    pdf-backend.cc:517:40: error: invalid conversion from ‘const GfxPath*’ to ‘pdf::gfx::Path*’ {aka ‘GfxPath*’} [-fpermissive]
+---
+ pdf-backend.cc | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/pdf-backend.cc b/pdf-backend.cc
+index 085cd9e..8a95e95 100644
+--- pdf-backend.cc
++++ pdf-backend.cc
+@@ -513,12 +513,11 @@ bool pdf::get_glyph(splash::Splash *splash, splash::Font *font,
+ void pdf::Renderer::convert_path(pdf::gfx::State *state, splash::Path &splash_path)
+ {
+   /* Source was copied from <poppler/SplashOutputDev.c>. */
+-  pdf::gfx::Subpath *subpath;
+-  pdf::gfx::Path *path = state->getPath();
++  auto path = state->getPath();
+   int n_subpaths = path->getNumSubpaths();
+   for (int i = 0; i < n_subpaths; i++)
+   {
+-    subpath = path->getSubpath(i);
++    auto subpath = path->getSubpath(i);
+     if (subpath->getNumPoints() > 0)
+     {
+       double x1, y1, x2, y2, x3, y3;


### PR DESCRIPTION
Should be included in upcoming 0.9.15 release.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G1012
Xcode 10.3 10G8 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
