### PR TITLE
nco: update to 4.9.0

### DIFF
--- a/science/nco/Portfile
+++ b/science/nco/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           compilers 1.0
 PortGroup           github 1.0
 
-github.setup        nco nco 4.8.1
+github.setup        nco nco 4.9.0
 revision            0
 platforms           darwin
 maintainers         {takeshi @tenomoto}
@@ -15,9 +15,9 @@ description         The netCDF Operators
 compilers.choose    cc cxx
 compilers.setup     -clang33 -clang34
 
-checksums           rmd160  e156726051368ccfa61b61636db903c3b8f5c151 \
-                    sha256  671d73b5b0fc02282db8fa40cdd82e3d903ae178154297092c474445fa96b186 \
-                    size    5240496
+checksums           rmd160  e21db8d44767a7480657b894138fdb87f07ca5d5 \
+                    sha256  34eb83936b0bd09e2d99eed7b26c326c4e67db6caa2416571c2ca82841a0f3e6 \
+                    size    5274427
 
 homepage            http://nco.sourceforge.net/
 long_description \


### PR DESCRIPTION
#### Description

Upstream update to version 4.9.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.1
Xcode Command Line Tools 11.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
