### PR TITLE
wireguard-tools: update to 0.0.20191206

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-tools
-version             0.0.20191205
+version             0.0.20191206
 revision            0
-checksums           rmd160  05c9a9204b2427bd9992ef50ef6e48e97375b42c \
-                    sha256  4de4c0efa35f8eb170c27a0bc8977e5c0634b8e19c03915d03218cc88bb0adbe \
-                    size    332092
+checksums           rmd160  e96cf99d59c669a7863bc18fc4362488aa19dff9 \
+                    sha256  75e4e8f2971257339ef45af1be67f0a21435235f25277e3e0e4d6f867714ece5 \
+                    size    332584
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
###### Tested on
macOS 10.13.6 17G8037
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?