### PR TITLE
maven3: update to 3.6.3

### DIFF
--- a/java/maven3/Portfile
+++ b/java/maven3/Portfile
@@ -5,7 +5,8 @@ PortGroup select 1.0
 PortGroup java 1.0
 
 name            maven3
-version         3.6.2
+version         3.6.3
+revision        0
 
 categories      java devel
 license         Apache-2
@@ -34,9 +35,9 @@ master_sites    apache:maven/maven-3/${version}/binaries
 distname        apache-maven-${version}-bin
 worksrcdir      apache-maven-${version}
 
-checksums       rmd160  7fc2ef3a72aa4b082730ee962b19d2c52a1be579 \
-                sha256  3fbc92d1961482d6fbd57fbf3dd6d27a4de70778528ee3fb44aa7d27eb32dfdc \
-                size    9142315
+checksums       rmd160  825e2cca16a72da4bb0a4b5add615e155623c05e \
+                sha256  26ad91d751b3a9a53087aefa743f4e16a17741d3915b219cf74112bf87a438c5 \
+                size    9506321
 
 java.version    1.7+
 java.fallback   openjdk11


### PR DESCRIPTION
#### Description

Update to Apache Maven 3.6.3.

###### Tested on

macOS 10.15.1 19B88
Xcode 11.2.1 11B500

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?