### PR TITLE
starship: update to 0.30.1

### DIFF
--- a/sysutils/starship/Portfile
+++ b/sysutils/starship/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        starship starship 0.27.0 v
+github.setup        starship starship 0.30.1 v
 categories          sysutils
 platforms           darwin
 maintainers         {l2dy @l2dy} openmaintainer
@@ -15,9 +15,9 @@ description         a minimal, blazing fast, and extremely customizable prompt f
 long_description    Starship is ${description}.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  25ed1538608b67a4fecefd43cd133d2df2856c46 \
-                    sha256  d9e70a2bb7e80f964a191a16581d7e6fc65344ce7de52fbb66ca82ee005eec57 \
-                    size    4354623
+                    rmd160  64f5e387709f5e856831df0ba6cf5c58e541292d \
+                    sha256  43c47f665b41bb2216a18a6ad83b7c5619becd272d51652c078bb4ff22faa827 \
+                    size    4371994
 
 # For crate:openssl-sys
 depends_build       port:pkgconfig
@@ -45,7 +45,7 @@ cargo.crates \
     byte-unit                        3.0.3  6894a79550807490d9f19a138a6da0f8830e70c83e83402dd23f16fd6c479056 \
     byteorder                        1.3.2  a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5 \
     c2-chacha                        0.2.3  214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb \
-    cc                              1.0.47  aa87058dce70a3ff5621797f1506cb837edd02ac4c0ae642b4542dce802908b8 \
+    cc                              1.0.48  f52a465a666ca3d838ebbf08b241383421412fe7ebb463527bba275526d89f76 \
     cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
     chrono                          0.4.10  31850b4a4d6bae316f7a09e691c944c28299298837edc0a03f755618c23cbc01 \
     clap                            2.33.0  5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9 \
@@ -77,21 +77,21 @@ cargo.crates \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
     lazycell                         1.2.1  b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f \
     lexical-core                     0.4.6  2304bccb228c4b020f3a4835d247df0a02a7c4686098d4167762cfbbe4c5cb14 \
-    libc                            0.2.65  1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8 \
+    libc                            0.2.66  d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558 \
     libgit2-sys                      0.9.2  4870c781f6063efb83150cd22c1ddf6ecf58531419e7570cdcced46970f64a16 \
     libz-sys                        1.0.25  2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe \
     linked-hash-map                  0.5.2  ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83 \
     log                              0.4.8  14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7 \
     mach                             0.2.3  86dd2487cdfea56def77b88438a2c915fb45113c5319bfe7e14306ca4cd0b0e1 \
     matches                          0.1.8  7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
-    maybe-uninit                     2.0.0  60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00 \
     memchr                           2.2.1  88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e \
     memoffset                        0.5.3  75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9 \
     nix                             0.15.0  3b2e0b4f3320ed72aaedb9a5ac838690a8047c7b275da22711fddff4f8a14229 \
     nodrop                          0.1.14  72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb \
     nom                              5.0.1  c618b63422da4401283884e6668d39f819a106ef51f5f59b81add00075da35ca \
+    ntapi                            0.3.3  f26e041cd983acbc087e30fcba770380cfa352d0e392e175b2344ebaf7ea0602 \
     num-integer                     0.1.41  b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09 \
-    num-traits                       0.2.9  443c53b3c3531dfcbfa499d8893944db78474ad7a1d87fa2d94d1a2231693ac6 \
+    num-traits                      0.2.10  d4c81ffc11c212fa327657cb19dd85eb7419e163b5b076bede2bdb5c974c07e4 \
     num_cpus                        1.11.1  76dac5ed2a876980778b8b85f75a71b6cbf0db0b1232ee12f826bccb00d09d72 \
     once_cell                        1.2.0  891f486f630e5c5a4916c7e16c4b24a53e78c860b646e9f8e005e4f16847bfed \
     path-slash                       0.1.1  a0858af4d9136275541f4eac7be1af70add84cf356d901799b065ac1b8ff6e2f \
@@ -124,14 +124,14 @@ cargo.crates \
     scopeguard                       1.0.0  b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d \
     semver                           0.9.0  1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403 \
     semver-parser                    0.7.0  388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
-    serde                          1.0.102  0c4b39bd9b0b087684013a792c59e3e07a46a01d2322518d8a1104641a0b1be0 \
-    serde_json                      1.0.42  1a3351dcbc1f067e2c92ab7c3c1f288ad1a4cffc470b5aaddb4c2e0a3ae80043 \
-    smallvec                        0.6.13  f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6 \
+    serde                          1.0.103  1217f97ab8e8904b57dd22eb61cde455fa7446a9c1cf43966066da047c1f3702 \
+    serde_json                      1.0.44  48c575e0cc52bdd09b47f330f646cf59afc586e9c4e3ccd6fc1f625b8ea1dad7 \
+    smallvec                         1.0.0  4ecf3b85f68e8abaa7555aa5abdb1153079387e60b718283d732f03897fcfc86 \
     static_assertions                0.3.4  7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3 \
     strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
-    syn                              1.0.8  661641ea2aa15845cddeb97dad000d22070bb5c1fb456b96c1cba883ec691e92 \
+    syn                             1.0.11  dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238 \
     synstructure                    0.12.3  67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545 \
-    sysinfo                          0.9.6  6f4b2468c629cffba39c0a4425849ab3cdb03d9dfacba69684609aea04d08ff9 \
+    sysinfo                         0.10.2  6a725d57055179635fad47ff8c4c70b255d92befd29a4f31a60f374052d7dc5c \
     tempfile                         3.1.0  7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9 \
     termcolor                        1.0.5  96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e \
     textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
@@ -140,13 +140,13 @@ cargo.crates \
     toml                             0.5.5  01d1404644c8b12b16bfcffa4322403a91a451584daaaa7c28d3152e6cbc98cf \
     typenum                         1.11.2  6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9 \
     unicode-bidi                     0.3.4  49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5 \
-    unicode-normalization            0.1.9  09c8070a9942f5e7cfccd93f490fdebd230ee3c3c9f107cb25bad5351ef671cf \
+    unicode-normalization           0.1.11  b561e267b2326bb4cebfc0ef9e68355c7abe6c6f522aeac2f5bf95d56c59bdcf \
     unicode-segmentation             1.6.0  e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0 \
-    unicode-width                    0.1.6  7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20 \
+    unicode-width                    0.1.7  caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479 \
     unicode-xid                      0.2.0  826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c \
     uom                             0.26.0  4cec796ec5f7ac557631709079168286056205c51c60aac33f51764bdc7b8dc4 \
     url                              2.1.0  75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61 \
-    vcpkg                            0.2.7  33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95 \
+    vcpkg                            0.2.8  3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168 \
     vec_map                          0.8.1  05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a \
     version_check                    0.1.5  914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd \
     void                             1.0.2  6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d \


### PR DESCRIPTION


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.1 19B88
Xcode 11.2.1 11B500

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
