### PR TITLE
new port: kcov 37

### DIFF
--- a/devel/kcov/Portfile
+++ b/devel/kcov/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+
+github.setup        SimonKagstrom kcov 37 v
+github.tarball_from archive
+
+categories          devel
+license             GPL-2
+platforms           darwin
+maintainers         nomaintainer
+
+description         coverage report generator
+long_description    \
+    Kcov is a code coverage tester for compiled programs, Python scripts and \
+    shell scripts. It allows collecting code coverage information from \
+    executables without special command-line arguments, and continuously \
+    produces output from long-running applications.
+homepage            https://simonkagstrom.github.com/kcov/index.html
+
+checksums           rmd160  fd849129563ad2ea661b0185988376bf44006eea \
+                    sha256  a136e3dddf850a8b006509f49cc75383cd44662169e9fec996ec8cc616824dcc \
+                    size    305893
+
+depends_build-append port:pkgconfig port:python38
+depends_lib-append   port:zlib
+
+patch.pre_args      -p1
+patchfiles          bin-to-c-source.py.use-python38.patch

--- a/devel/kcov/files/bin-to-c-source.py.use-python38.patch
+++ b/devel/kcov/files/bin-to-c-source.py.use-python38.patch
@@ -1,0 +1,10 @@
+diff --git a/src/bin-to-c-source.py b/src/bin-to-c-source.py
+index f46cf1d..1d95b14 100755
+--- a/src/bin-to-c-source.py
++++ b/src/bin-to-c-source.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python3.8
+ 
+ import sys, struct
+ 


### PR DESCRIPTION
#### Description

kcov is a breakpoint-based profiler that I use with rust

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] submission
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G9016
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
