### PR TITLE
weechat: refactor python variants

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -58,6 +58,7 @@ platforms           darwin
 depends_build-append \
                     port:asciidoctor \
                     port:libxslt \
+                    port:pkgconfig \
                     port:docbook-xsl-nons
 
 depends_lib-append  \
@@ -92,29 +93,22 @@ variant python requires python27 description {Compatibility variant, requires +p
 variant python27 description "Bindings for python 2.7 plugins" conflicts python36 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
     configure.args-replace  -DENABLE_PYTHON2=OFF -DENABLE_PYTHON2=ON
-    configure.args-append   -DPYTHON_EXECUTABLE=${prefix}/bin/python2.7
-    configure.args-append   -DPYTHON_INCLUDE_PATH=${frameworks_dir}/Python.framework/Versions/2.7/Headers
-    configure.args-append   -DPYTHON_LIBRARY=${frameworks_dir}/Python.framework/Versions/2.7/Python
     depends_lib-append      port:python27
 }
 
 variant python36 description "Bindings for python 3.6 plugins" conflicts python27 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
-    configure.args-append   -DPYTHON_EXECUTABLE=${prefix}/bin/python3.6
-    configure.args-append   -DPYTHON_INCLUDE_PATH=${frameworks_dir}/Python.framework/Versions/3.6/Headers
-    configure.args-append   -DPYTHON_LIBRARY=${frameworks_dir}/Python.framework/Versions/3.6/Python
     depends_lib-append      port:python36
 }
 
-post-configure {
-    if {[variant_isset python27] || [variant_isset python36]} {
-        set patchfile ${configure.dir}/src/plugins/python/CMakeFiles/python.dir/link.txt
+post-patch {
+    set patchfile ${worksrcpath}/cmake/FindPython.cmake
 
-        reinplace -E "s| \(Python.framework\)| ${frameworks_dir}/\\1|g" ${patchfile}
-
-        if {[variant_isset python36]} {
-            reinplace -E "s|-Wl,-stack_size,1000000||" ${patchfile}
-        }
+    if {[variant_isset python27]} {
+        reinplace -E "s|PYTHON python2|PYTHON python-2.7|g" ${patchfile}
+    }
+    if {[variant_isset python36]} {
+        reinplace -E "s|PYTHON python3|PYTHON python-3.6|g" ${patchfile}
     }
 }
 


### PR DESCRIPTION
#### Description
Python variants won't build without this commit, so no revbump is needed.

Fixes: https://trac.macports.org/ticket/59819

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G1012
Xcode 11.2.1 11B500

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
