### PR TITLE
micronaut: update to 1.2.7

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -4,8 +4,8 @@ PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       java 1.0
 
-github.setup    micronaut-projects micronaut-core 1.2.6 v
-revision        1
+github.setup    micronaut-projects micronaut-core 1.2.7 v
+revision        0
 name            micronaut
 categories      java
 platforms       darwin
@@ -43,9 +43,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        ${name}-${version}
 
-checksums       rmd160  d10fc0c79c11dd279a9990085e66699b6dbf29fc \
-                sha256  7218e1e349df598db8a6a6c59a73eb4867b34caf91b2d9456bbdc7eac6476d28 \
-                size    12928603
+checksums       rmd160  259fedb56430a3ebfe4535924439b845a5c5b145 \
+                sha256  c48104b0519857a4b040eeeef0c371f832961c2bdfb4469ea80a44fbcd59b5e0 \
+                size    12928596
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 1.2.7.

###### Tested on

macOS 10.15.1 19B88
Xcode 11.2.1 11B500

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?