### PR TITLE
uriparser: create test variant to avoid gtest

### DIFF
--- a/devel/uriparser/Portfile
+++ b/devel/uriparser/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 
 github.setup        uriparser uriparser 0.9.3 uriparser-
-revision            0
+revision            1
 checksums           rmd160  8fce419da21d3e5081d6eaa35eb3a3a84c8f6287 \
                     sha256  28af4adb05e811192ab5f04566bebc5ebf1c30d9ec19138f944963d52419e28f \
                     size    173073
@@ -24,12 +24,20 @@ homepage            https://uriparser.github.io
 github.tarball_from releases
 use_bzip2           yes
 
-# Only used by tests but detected at configure time.
-depends_build-append    port:gtest
-
 patchfiles          testrunner.patch
 
-configure.args      -DURIPARSER_BUILD_DOCS=OFF
+configure.args      -DURIPARSER_BUILD_DOCS=OFF \
+                    -DURIPARSER_BUILD_TESTS=OFF
 
-test.run            yes
-test.target         check
+variant tests description {Enable tests} {
+    configure.args-delete   -DURIPARSER_BUILD_TESTS=OFF
+    depends_build-append    port:gtest
+
+    # duplicate settings from gtest CMakeLists.txt file
+    compiler.cxx_standard   2011
+    configure.args-append   -DCMAKE_CXX_STANDARD=11 \
+                            -DCMAKE_CXX_STANDARD_REQUIRED=ON
+
+    test.run                yes
+    test.target             check
+}


### PR DESCRIPTION
Recent versions of gtest require C++11.
Building the tests requires uriparser to use C++11 as well.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.1
Xcode 11.2.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
