### PR TITLE
libkml: create test variant to avoid gtest

### DIFF
--- a/gis/libkml/Portfile
+++ b/gis/libkml/Portfile
@@ -5,7 +5,7 @@ PortGroup               cmake 1.1
 PortGroup               github 1.0
 
 github.setup            libkml libkml 1.3.0
-revision                1
+revision                2
 checksums               rmd160  b13c1c8d072098f365ac315cc1588ef3eba4ad1d \
                         sha256  5ac678ec9b3f737749712206fc199acb27bbdb74ca8656607fc809cbc951a482 \
                         size    6640063
@@ -23,9 +23,6 @@ long_description        ${name} is a library for parsing, generating and \
 
 depends_build-append    port:boost
 
-# Only used by tests but detected at configure time.
-depends_build-append    port:gtest
-
 depends_lib-append      port:expat \
                         port:minizip \
                         port:uriparser \
@@ -35,7 +32,7 @@ patchfiles              DYLD_LIBRARY_PATH.patch
 
 configure.args-append   -DBoost_INCLUDE_DIR=${prefix}/include \
                         -DBUILD_EXAMPLES=OFF \
-                        -DBUILD_TESTING=ON \
+                        -DBUILD_TESTING=OFF \
                         -DEXPAT_LIBRARY=${prefix}/lib/libexpat.dylib \
                         -DMINIZIP_LIBRARY=${prefix}/lib/libminizip.dylib \
                         -DURIPARSER_LIBRARY=${prefix}/lib/liburiparser.dylib \
@@ -44,8 +41,20 @@ configure.args-append   -DBoost_INCLUDE_DIR=${prefix}/include \
                         -DWITH_SWIG=OFF \
                         -DZLIB_LIBRARY_RELEASE=${prefix}/lib/libz.dylib
 
-test.run                yes
-test.target             test
+variant tests description {Enable tests} {
+    configure.args-replace  -DBUILD_TESTING=OFF \
+                            -DBUILD_TESTING=ON
+
+    depends_build-append    port:gtest
+
+    # duplicate settings from gtest CMakeLists.txt file
+    compiler.cxx_standard   2011
+    configure.args-append   -DCMAKE_CXX_STANDARD=11 \
+                            -DCMAKE_CXX_STANDARD_REQUIRED=ON
+
+    test.run                yes
+    test.target             test
+}
 
 post-destroot {
     set docdir ${prefix}/share/doc/${subport}


### PR DESCRIPTION
Recent versions of gtest require C++11.
Building the tests requires uriparser to use C++11 as well.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.1
Xcode 11.2.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
