### PR TITLE
 remove obsolete Python subports (various maintainers)

### DIFF
--- a/python/py-appnope/Portfile
+++ b/python/py-appnope/Portfile
@@ -10,7 +10,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-argh/Portfile
+++ b/python/py-argh/Portfile
@@ -3,11 +3,10 @@
 PortSystem          1.0
 PortGroup           python 1.0
 
-set _name           argh
-set _n              [string index ${_name} 0]
-
-name                py-${_name}
+name                py-argh
 version             0.26.2
+revision            0
+
 platforms           darwin
 supported_archs     noarch
 license             LGPL-3+
@@ -17,21 +16,17 @@ description         A simple argparse wrapper
 long_description    ${description}
 
 homepage            https://github.com/neithere/${python.rootname}
-master_sites        pypi:${_n}/${_name}
-distname            ${_name}-${version}
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
 
-checksums           md5     edda25f3f0164a963dd89c0e3c619973 \
-                    rmd160  42da2aa1dfae654419acfc62db73d0fb27ecd23f \
-                    sha256  e9535b8c84dc9571a48999094fda7f33e63c3f1b74f3e5f3ac0105a58405bb65
+checksums           rmd160  42da2aa1dfae654419acfc62db73d0fb27ecd23f \
+                    sha256  e9535b8c84dc9571a48999094fda7f33e63c3f1b74f3e5f3ac0105a58405bb65 \
+                    size    32913
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 if {${name} ne ${subport}} {
     depends_build  port:py${python.version}-setuptools
 
     livecheck.type  none
-} else {
-    livecheck.type  regex
-    livecheck.url   https://pypi.python.org/pypi/${_name}/json
-    livecheck.regex "\"${_name}-(\[.\\d\]+)\\${extract.suffix}\""
 }

--- a/python/py-astroid/Portfile
+++ b/python/py-astroid/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             LGPL-2.1+
 supported_archs     noarch
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -38,18 +38,6 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-six \
                         port:py${python.version}-typed-ast \
                         port:py${python.version}-wrapt
-
-    if {${python.version} eq 34} {
-        version             2.2.5
-        revision            0
-        distname            ${python.rootname}-${version}
-        checksums           rmd160  c5a4e3ef953ac6852d0751473c62631b103940f5 \
-                            sha256  6560e1e1749f68c64a4b5dee4e091fce798d2f0d84ebe638cf0e0585a343acf4 \
-                            size    281829
-
-        depends_lib-append \
-                            port:py${python.version}-typing
-    }
 
     if {${python.version} eq 27} {
         version             1.6.5

--- a/python/py-atomicwrites/Portfile
+++ b/python/py-atomicwrites/Portfile
@@ -20,7 +20,7 @@ checksums           rmd160  4857ef73e7d5f8b96bcaff43f3a61002010c20dc \
                     sha256  75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6 \
                     size    11699
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -34,6 +34,4 @@ if {${name} ne ${subport}} {
     test.target
 
     livecheck.type      none
-} else {
-    livecheck.type      pypi
 }

--- a/python/py-backcall/Portfile
+++ b/python/py-backcall/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 platforms           darwin
 license             BSD
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-bcrypt/Portfile
+++ b/python/py-bcrypt/Portfile
@@ -11,7 +11,7 @@ categories-append   devel
 platforms           darwin
 license             Apache-2
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-blinker/Portfile
+++ b/python/py-blinker/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
 PortGroup           python 1.0
 
@@ -20,18 +22,15 @@ homepage            http://pythonhosted.org/blinker/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           md5     8b3722381f83c2813c52de3016b68d33 \
-                    sha256  471aee25f3992bd325afa3772f1063dbdbbca947a041b8b89466dc00d606f8b6 \
-                    rmd160  54a649ae37e54924ebfe75149c3d19b0d25aa1a4
+checksums           sha256  471aee25f3992bd325afa3772f1063dbdbbca947a041b8b89466dc00d606f8b6 \
+                    rmd160  54a649ae37e54924ebfe75149c3d19b0d25aa1a4 \
+                    size    111476
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
     livecheck.type  none
 
     depends_build-append \
                     port:py${python.version}-setuptools
-
-} else {
-    livecheck.type  pypi
 }

--- a/python/py-blockdiag/Portfile
+++ b/python/py-blockdiag/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             Apache-2
 supported_archs     noarch
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-click/Portfile
+++ b/python/py-click/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-cloudpickle/Portfile
+++ b/python/py-cloudpickle/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -28,14 +28,5 @@ checksums           rmd160  ac0a73471a6e2b8e56002110435e7bf2c570bcc5 \
                     size    43576
 
 if {${name} ne ${subport}} {
-    if {${python.version} eq 34} {
-        version             0.8.1
-        revision            0
-        distname            ${python.rootname}-${version}
-        checksums           rmd160  15f1a75a76e2b0fc3bb6607e0efce4bb14fd5c39 \
-                            sha256  3ea6fd33b7521855a97819b3d645f92d51c8763d3ab5df35197cd8e96c19ba6f \
-                            size    30832
-    }
-
     livecheck.type      none
 }

--- a/python/py-cryptography/Portfile
+++ b/python/py-cryptography/Portfile
@@ -11,7 +11,7 @@ categories-append   devel
 platforms           darwin
 license             BSD
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -40,7 +40,7 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-cffi \
                         path:lib/libssl.dylib:openssl
 
-    if {${python.version} < 34} {
+    if {${python.version} eq 27} {
         depends_lib-append  port:py${python.version}-enum34 \
                             port:py${python.version}-ipaddress
     }

--- a/python/py-datashape/Portfile
+++ b/python/py-datashape/Portfile
@@ -12,7 +12,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-flake8-mccabe/Portfile
+++ b/python/py-flake8-mccabe/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  a0df4f8d27f457b929f91c870961afcf50f51c9f \
                     sha256  dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f \
                     size    8612
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-heapdict/Portfile
+++ b/python/py-heapdict/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-imageio/Portfile
+++ b/python/py-imageio/Portfile
@@ -10,14 +10,14 @@ categories-append   graphics
 platforms           darwin
 license             BSD
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 
 description         Easy interface to read and write a wide range of image data.
 long_description    ${description}
 
-homepage            http://imageio.github.io/
+homepage            https://imageio.github.io/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}

--- a/python/py-isort/Portfile
+++ b/python/py-isort/Portfile
@@ -28,25 +28,23 @@ checksums           rmd160  f3905a2005ed7df9127161d1561f786addcde7fc \
                     sha256  54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1 \
                     size    69546
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
-    if {${python.version} in "27 34"} {
+    if {${python.version} eq 27} {
         version     4.3.15
         revision    0
         distname    isort-${version}
         checksums   rmd160  746484d1524c2a318f18170175e48e72d018d90d \
                     sha256  96151fca2c6e736503981896495d344781b60d18bfda78dc11b290c6125ebdb6 \
                     size    67949
+
+        depends_lib-append \
+                    port:py${python.version}-futures
     }
 
     depends_lib-append \
                     port:py${python.version}-setuptools
-
-    if {${python.version} eq 27} {
-        depends_lib-append \
-                    port:py${python.version}-futures
-    }
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}

--- a/python/py-jedi/Portfile
+++ b/python/py-jedi/Portfile
@@ -10,7 +10,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-jwt/Portfile
+++ b/python/py-jwt/Portfile
@@ -3,11 +3,10 @@
 PortSystem          1.0
 PortGroup           python 1.0
 
-set _name           PyJWT
-set _n              [string index ${_name} 0]
-
 name                py-jwt
+python.rootname     PyJWT
 version             1.7.1
+
 categories-append   security
 platforms           darwin
 supported_archs     noarch
@@ -18,23 +17,18 @@ description         JSON Web Token implementation in Python
 long_description    ${description}
 
 homepage            https://github.com/jpadilla/pyjwt
-master_sites        pypi:${_n}/${_name}/
-distname            ${_name}-${version}
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
 
 checksums           rmd160  bfe7a0ea07327593b728ba82766d809ae4c1be75 \
                     sha256  8d59a976fb773f3e6a39c85636357c4f0e242707394cadadd9814f5cbaa20e96 \
                     size    41979
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools \
                             port:py${python.version}-pytest-runner
 
-
     livecheck.type  none
-} else {
-    livecheck.type  regex
-    livecheck.url   https://pypi.python.org/pypi/${_name}/json
-    livecheck.regex "\"${_name}-(\[.\\d\]+)\\.tar\\.gz\""
 }

--- a/python/py-mpmath/Portfile
+++ b/python/py-mpmath/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-networkx/Portfile
+++ b/python/py-networkx/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -21,7 +21,7 @@ long_description    NetworkX is a Python package for the creation, \
                     manipulation, and study of the structure, dynamics, \
                     and functions of complex networks.
 
-homepage            http://networkx.github.io
+homepage            https://networkx.github.io
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            networkx-${version}
@@ -35,7 +35,7 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-setuptools
     depends_lib-append  port:py${python.version}-decorator
 
-    if {${python.version} < 35} {
+    if {${python.version} eq 27} {
         version             2.2
         revision            0
         distname            ${python.rootname}-${version}

--- a/python/py-nibabel/Portfile
+++ b/python/py-nibabel/Portfile
@@ -1,42 +1,43 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem              1.0
-PortGroup               python 1.0
+PortSystem          1.0
+PortGroup           python 1.0
 
-name                    py-nibabel
-version                 2.5.1
-revision                0
-platforms               darwin
-license                 MIT
-maintainers             nomaintainer
-description             Access a cacophony of neuro-imaging file formats
+name                py-nibabel
+version             2.5.1
+revision            0
 
-long_description        Nibabel provides read and write access to some \
-                        common medical and neuroimaging file formats, \
-                        including: ANALYZE (plain, SPM99, SPM2), GIFTI, \
-                        NIfTI1, MINC, MGH and ECAT as well as PAR/REC. We \
-                        can read and write Freesurfer geometry, and read \
-                        Freesurfer morphometry and annotation files. There \
-                        is some very limited support for DICOM. NiBabel is \
-                        the successor of PyNIfTI.
+platforms           darwin
+supported_archs     noarch
+license             MIT
+maintainers         nomaintainer
 
-homepage                https://nipy.org/nibabel
-master_sites            pypi:n/nibabel/
-distname                nibabel-${version}
+description         Access a cacophony of neuro-imaging file formats
+long_description    Nibabel provides read and write access to some \
+                    common medical and neuroimaging file formats, \
+                    including: ANALYZE (plain, SPM99, SPM2), GIFTI, \
+                    NIfTI1, MINC, MGH and ECAT as well as PAR/REC. We \
+                    can read and write Freesurfer geometry, and read \
+                    Freesurfer morphometry and annotation files. There \
+                    is some very limited support for DICOM. NiBabel is \
+                    the successor of PyNIfTI.
 
-supported_archs         noarch
+homepage            https://nipy.org/nibabel
+master_sites        pypi:n/nibabel/
+distname            nibabel-${version}
 
-checksums               rmd160  ec1f734ec80852e1941a47faa35e81fb2ec55804 \
-                        sha256  83ecac4773ece02c49c364d99b465644c17cc66f1719560117e74991d9eb566b \
-                        size    4598466
+checksums           rmd160  ec1f734ec80852e1941a47faa35e81fb2ec55804 \
+                    sha256  83ecac4773ece02c49c364d99b465644c17cc66f1719560117e74991d9eb566b \
+                    size    4598466
 
-python.versions         27 35 36 37
+python.versions     27 35 36 37
 
 if {${name} ne ${subport}} {
-    depends_lib-append  port:py${python.version}-bz2file \
-                        port:py${python.version}-numpy \
-                        port:py${python.version}-setuptools \
-                        port:py${python.version}-six
+    depends_lib-append \
+                    port:py${python.version}-bz2file \
+                    port:py${python.version}-numpy \
+                    port:py${python.version}-setuptools \
+                    port:py${python.version}-six
 
     post-patch {
         reinplace "s|@@PREFIX@@|${prefix}|g" ${worksrcpath}/setup.py
@@ -49,5 +50,5 @@ if {${name} ne ${subport}} {
             Changelog ${destroot}${docdir}
     }
 
-    livecheck.type      none
+    livecheck.type  none
 }

--- a/python/py-nibabel/Portfile
+++ b/python/py-nibabel/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    py-nibabel
-version                 2.4.0
+version                 2.5.1
 revision                0
 platforms               darwin
 license                 MIT
@@ -26,28 +26,16 @@ distname                nibabel-${version}
 
 supported_archs         noarch
 
-checksums \
-    rmd160  a479afa81c5b79752ef0f39dcde0304e53a26f3a \
-    sha256  dd0c41715d0391c724e2828bba2c16690dbd6aafbca8e920ee8448ed0086e4c1 \
-    size    4589348
+checksums               rmd160  ec1f734ec80852e1941a47faa35e81fb2ec55804 \
+                        sha256  83ecac4773ece02c49c364d99b465644c17cc66f1719560117e74991d9eb566b \
+                        size    4598466
 
-python.versions         27 34 35 36 37
+python.versions         27 35 36 37
 
 if {${name} ne ${subport}} {
-    # Revisit when tests are fixed upstream
-    #depends_test-append     port:py${python.version}-nose \
-    #                        port:py${python.version}-mock \
-    #                        port:py${python.version}-sphinx \
-    #                        port:py${python.version}-pytest
-    #test.run    yes
-    #test.cmd    ${python.bin} setup.py
-    #test.target test
-
-    depends_build-append \
-                        port:py${python.version}-setuptools
-
-    depends_lib-append  port:py${python.version}-numpy \
-                        port:py${python.version}-bz2file \
+    depends_lib-append  port:py${python.version}-bz2file \
+                        port:py${python.version}-numpy \
+                        port:py${python.version}-setuptools \
                         port:py${python.version}-six
 
     post-patch {

--- a/python/py-pandas/Portfile
+++ b/python/py-pandas/Portfile
@@ -10,7 +10,7 @@ categories-append   science
 license             BSD
 platforms           darwin
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -18,7 +18,7 @@ description         Powerful data structures for data analysis and statistics
 
 long_description    ${description}
 
-homepage            http://pandas.pydata.org
+homepage            https://pandas.pydata.org
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
@@ -28,7 +28,7 @@ checksums           rmd160  cb526595c8b38bd4973a49ebebb61c165421628b \
                     size    12632585
 
 if {${name} ne ${subport}} {
-    if {${python.version} < 35} {
+    if {${python.version} eq 27} {
         version             0.24.2
         revision            0
         distname            ${python.rootname}-${version}

--- a/python/py-pathlib2/Portfile
+++ b/python/py-pathlib2/Portfile
@@ -10,7 +10,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -31,7 +31,7 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-setuptools
     depends_lib-append  port:py${python.version}-six
 
-    if {${python.version} < 35} {
+    if {${python.version} eq 27} {
         depends_lib-append  port:py${python.version}-scandir
     }
 

--- a/python/py-pathtools/Portfile
+++ b/python/py-pathtools/Portfile
@@ -14,18 +14,19 @@ maintainers         {petr @petrrr} openmaintainer
 description         File system general utilities
 long_description    ${description}
 
-homepage            http://pythonhosted.org/pathtools/
+homepage            https://pythonhosted.org/pathtools
 master_sites        pypi:p/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           md5     9a1af5c605768ea5804b03b734ff0f82 \
-                    rmd160  cdc2001f64f953bcff70e1dd85d2527665a12272 \
-                    sha256  7c35c5421a39bb82e58018febd90e3b6e5db34c5443aaaf742b3f33d4655f1c0
+checksums           rmd160  cdc2001f64f953bcff70e1dd85d2527665a12272 \
+                    sha256  7c35c5421a39bb82e58018febd90e3b6e5db34c5443aaaf742b3f33d4655f1c0 \
+                    size    11006
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 if { ${name} ne ${subport} } {
-    depends_build-append       port:py${python.version}-setuptools
+    depends_build-append \
+                    port:py${python.version}-setuptools
 
     livecheck.type  none
 }

--- a/python/py-pexpect/Portfile
+++ b/python/py-pexpect/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             ISC
 supported_archs     noarch
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -23,7 +23,7 @@ long_description    Pexpect is a pure Python module for spawning child \
                     your script to spawn a child application and control \
                     it as if a human were typing commands.
 
-homepage            http://pexpect.readthedocs.org/
+homepage            https://pexpect.readthedocs.org/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}

--- a/python/py-pickleshare/Portfile
+++ b/python/py-pickleshare/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -31,7 +31,7 @@ if {${name} ne ${subport}} {
     depends_build-append \
                         port:py${python.version}-setuptools
 
-    if {${python.version} < 34} {
+    if {${python.version} eq 27} {
         depends_lib-append  port:py${python.version}-pathlib2
     }
 

--- a/python/py-pluggy/Portfile
+++ b/python/py-pluggy/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  98db928a51f7eacceb43aa7fe08bfeafb137abc6 \
                     sha256  15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0 \
                     size    57962
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-prompt_toolkit/Portfile
+++ b/python/py-prompt_toolkit/Portfile
@@ -13,7 +13,7 @@ maintainers         {@xeron gmail.com:xeron.oskom} openmaintainer
 description         Library for building powerful interactive command lines in Python
 long_description    ${description}
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 homepage            https://github.com/prompt-toolkit/python-prompt-toolkit
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
@@ -23,7 +23,7 @@ checksums           rmd160  7fef3cdd4d9c419124244191777ff0767bb6cb8f \
                     size    347981
 
 if {${name} ne ${subport}} {
-    if {${python.version} in "27 34"} {
+    if {${python.version} eq 27} {
         version     1.0.18
         revision    0
         checksums   rmd160  c0907914130f16c24cd543ef3bbcea655bca8968 \

--- a/python/py-pynacl/Portfile
+++ b/python/py-pynacl/Portfile
@@ -11,7 +11,7 @@ categories-append   devel
 platforms           darwin
 license             Apache-2
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-pywavelets/Portfile
+++ b/python/py-pywavelets/Portfile
@@ -10,7 +10,7 @@ categories-append   science math
 platforms           darwin
 license             MIT
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-repoze.lru/Portfile
+++ b/python/py-repoze.lru/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35 36
+python.versions     27 35 36
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -24,7 +24,8 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
 checksums           rmd160  7ddad7fdbcf013e9c6d1b30583ab386d8bd6d4f8 \
-                    sha256  0429a75e19380e4ed50c0694e26ac8819b4ea7851ee1fc7583c8572db80aff77
+                    sha256  0429a75e19380e4ed50c0694e26ac8819b4ea7851ee1fc7583c8572db80aff77 \
+                    size    19591
 
 if {$subport ne $name} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-toolz/Portfile
+++ b/python/py-toolz/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-widgetsnbextension/Portfile
+++ b/python/py-widgetsnbextension/Portfile
@@ -10,14 +10,14 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 
 description         Interactive HTML widgets for Jupyter notebooks.
 long_description    ${description}
 
-homepage            http://ipython.org
+homepage            https://ipython.org
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
@@ -31,7 +31,7 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-setuptools
     depends_lib-append  port:py${python.version}-notebook
 
-    if {${python.version} in {27 34 35}} {
+    if {${python.version} in {27 35}} {
         version             3.5.0
         revision            0
         distname            ${python.rootname}-${version}

--- a/python/py-yaml/Portfile
+++ b/python/py-yaml/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 platforms           darwin
 license             MIT
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-zipp/Portfile
+++ b/python/py-zipp/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 platforms           darwin
 license             MIT
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 


### PR DESCRIPTION
#### Description
This PR removes obsolete Python subports for various maintained ports that have no dependencies.

###### Tested on
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? Yes, in the case of updates or added subports.
- [x] tried a full install with `sudo port -vst install`? Yes, in the case of updates or added subports.
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
