### PR TITLE
update upt-related ports

### DIFF
--- a/python/py-colorlog/Portfile
+++ b/python/py-colorlog/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-colorlog
+version             4.0.2
+revision            0
+
+categories-append   devel
+platforms           darwin
+supported_archs     noarch
+license             MIT
+maintainers         {reneeotten @reneeotten} openmaintainer
+
+description         Log formatting with colors!
+long_description    ${description}
+
+homepage            https://github.com/borntyping/python-colorlog
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+
+checksums           rmd160  bd482e4c295559788b6e9ba4b2a5a909d473037e \
+                    sha256  3cf31b25cbc8f86ec01fef582ef3b840950dea414084ed19ab922c8b493f9b42 \
+                    size    26431
+
+python.versions     37
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    post-destroot {
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} LICENSE README.md ${destroot}${docdir}
+    }
+
+    depends_test-append \
+                    port:py${python.version}-pytest
+
+    test.run        yes
+    test.cmd        py.test-${python.branch}
+    test.target
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
+
+    livecheck.type  none
+}

--- a/python/py-upt-macports/Portfile
+++ b/python/py-upt-macports/Portfile
@@ -4,9 +4,9 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-set git_hash        216634f2cd168e2791bd3d5fb25546dcdb96eaf7
+set git_hash        0336f4045c39b6c04af22b2e4eb34c157ea1618f
 github.setup        macports upt-macports ${git_hash}
-version             0.1-20191024
+version             0.1-20191207
 name                py-${github.project}
 revision            0
 
@@ -18,9 +18,9 @@ maintainers         {@korusuke somaiya.edu:karan.sheth} openmaintainer
 description         MacPorts backend for upt.
 long_description    ${description}
 
-checksums           rmd160  38f4746a0e20d6d792b7a425456f805a19a4987e \
-                    sha256  79357276cd9b127fdb6bc4a1c174f159276174f92db24a0ff9b702b40e72495e \
-                    size    10184
+checksums           rmd160  fdd320ace08a732b667feb435b39b2ca92b040bd \
+                    sha256  a56cce90322fae482a84e56796320d3840772811499d77e418bb9558a358cedb \
+                    size    11524
 
 python.versions     37
 
@@ -30,6 +30,7 @@ if {${name} ne ${subport}} {
 
     depends_lib-append \
                     port:py${python.version}-jinja2 \
+                    port:py${python.version}-packaging \
                     port:py${python.version}-requests
 
     depends_test-append \

--- a/python/py-upt-rubygems/Portfile
+++ b/python/py-upt-rubygems/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-upt-rubygems
-version             0.3
+version             0.4
 revision            0
 
 platforms           darwin
@@ -19,9 +19,9 @@ homepage            https://framagit.org/upt/upt-rubygems
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           sha256  83ae82fef122a6351a882fbc5b49593b3bd2a1aac105896da4e28426a9f4422c \
-                    rmd160  e5eccca8256daf571cc50fdf952b758f2c3ca802 \
-                    size    5303
+checksums           sha256  85714a06a1de21cef2c7911f9d539ffa70e4a8b0bec70c7287a835c8882290b7 \
+                    rmd160  6d70308237f6ca2b8c4d22d148e7e57f9ad94ba9 \
+                    size    5523
 
 python.versions     37
 

--- a/sysutils/upt/Portfile
+++ b/sysutils/upt/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                upt
-version             0.10.3
-revision            1
+version             0.11
+revision            0
 
 categories-prepend  sysutils
 platforms           darwin
@@ -20,13 +20,14 @@ homepage            https://framagit.org/upt/upt
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  c7335c931d512f2d70da45961258c059415dfd8c \
-                    sha256  e08fcea114cf71ed98dd5f9085c40892301b22ebba9448d2940be77737596258 \
-                    size    28655
+checksums           rmd160  c0cfd7c4121eb87beef442957b471f589c7d224d \
+                    sha256  65ef84ec7d8ba5f563bd6e2d522f055b80b143063f7cd96663bf8ad2c424df79 \
+                    size    29366
 
 python.default_version  37
 
 depends_lib-append \
+                port:py${python.version}-colorlog \
                 port:py${python.version}-packaging \
                 port:py${python.version}-spdx-lookup \
                 port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description
This PR updates several ```upt```-related to their latest versions:
- ```upt``` to version 0.11
- ```py-upt-rubygems``` to 0.4
- ```py-upt-macports``` to latest commit (20191207)

I addition, a new port```py-colorlog``` (version 4.0.2) was added as it's a new dependency of ```upt```.


###### Tested on
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
