### PR TITLE
mysql8: update to 8.0.18

### DIFF
--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -3,8 +3,8 @@
 PortSystem              1.0
 
 name                    mysql8
-version                 8.0.17
-set boost_version       1.69.0
+version                 8.0.18
+set boost_version       1.70.0
 categories              databases
 platforms               darwin
 license                 GPL-2
@@ -12,7 +12,7 @@ maintainers             {gmail.com:herby.gillot @herbygillot} openmaintainer
 homepage                https://www.mysql.com/
 
 # Set revision_client and revision_server to 0 on version bump.
-set revision_client 2
+set revision_client 0
 set revision_server 0
 
 set name_mysql          ${name}
@@ -44,18 +44,19 @@ if {$subport eq $name} {
                         ${boost_distname}${extract.suffix}:boost
 
     checksums           ${distname}${extract.suffix} \
-                        rmd160  aa6f5fe3a890e8e4a7fef8a6c3a30701d925a79f \
-                        sha256  c6e3f38199a77bfd8a4925ca00b252d3b6159b90e4980c7232f1c58d6ca759d6 \
-                        size    190203398 \
+                        rmd160  cc43f36cf917ad60361a47eef7ee86a2791710aa \
+                        sha256  4cb39a315298eb243c25c53c184b3682b49c2a907a1d8432ba0620534806ade8 \
+                        size    197457483 \
                         ${boost_distname}${extract.suffix} \
-                        rmd160  ad6cd576a5229a11601986908ff03261582c9f81 \
-                        sha256  9a2c2819310839ea373f42d69e733c339b4e9a19deab6bfec448281554aa4dbb \
-                        size    111710205
+                        rmd160  1c39413060dca46a02ea2143788d6ee061b79d03 \
+                        sha256  882b48708d211a5f48e60b0124cf5863c1534cd544ecd0664bb534a4b5d506e9 \
+                        size    116000903
 
     depends_lib-append  path:lib/libssl.dylib:openssl \
                         port:cyrus-sasl2 \
                         port:icu \
-                        port:zlib
+                        port:zlib \
+                        port:zstd
 
     depends_run-append  port:mysql_select
 
@@ -117,9 +118,11 @@ if {$subport eq $name} {
         -DWITH_BOOST:PATH="${worksrcpath}/../${boost_distname}" \
         -DWITH_ICU:PATH="${prefix}" \
         -DWITH_INNODB_MEMCACHED=1 \
+        -DWITH_PROTOBUF=bundled \
         -DWITH_SASL:PATH="${prefix}" \
         -DWITH_SSL:PATH="${prefix}" \
-        -DWITH_ZLIB:PATH="${prefix}"
+        -DWITH_ZLIB:PATH="${prefix}" \
+        -DWITH_ZSTD=system
 
     # FIXME: Disable building MySQL Router until we resolve link issues
     configure.args-append \
@@ -129,9 +132,9 @@ if {$subport eq $name} {
 
     patch.pre_args  -p1
     patchfiles      patch-cmake-install_layout.cmake.diff \
-                    patch-router-cmake-set_rpath.diff \
                     patch-sql-local-boost.diff \
-                    patch-mysql8-workaround-no-SC_PHYS_PAGES.diff
+                    patch-mysql8-workaround-no-SC_PHYS_PAGES.diff \
+                    patch-cmake-install_macros.cmake.diff
 
     post-extract {
         file mkdir ${cmake.build_dir}/macports

--- a/databases/mysql8/files/patch-cmake-install_layout.cmake.diff
+++ b/databases/mysql8/files/patch-cmake-install_layout.cmake.diff
@@ -1,27 +1,28 @@
---- a/cmake/install_layout.cmake.orig	2016-02-08 20:35:02.000000000 -0430
-+++ b/cmake/install_layout.cmake	2016-02-08 20:53:31.000000000 -0430
-@@ -82,7 +82,7 @@
+--- a/cmake/install_layout.cmake        2019-10-24 09:35:40.000000000 -0500
++++ b/cmake/install_layout.cmake	2019-10-24 09:40:23.000000000 -0500
+@@ -85,7 +85,7 @@
  ENDIF()
-
+ 
  SET(INSTALL_LAYOUT "${DEFAULT_INSTALL_LAYOUT}"
--CACHE STRING "Installation directory layout. Options are: TARGZ (as in tar.gz installer), WIN (as in zip installer), STANDALONE, RPM, DEB, SVR4, FREEBSD, GLIBC, OSX, SLES")
-+CACHE STRING "Installation directory layout. Options are: TARGZ (as in tar.gz installer), WIN (as in zip installer), STANDALONE, RPM, DEB, SVR4, FREEBSD, GLIBC, OSX, MACPORTS, SLES")
-
+-CACHE STRING "Installation directory layout. Options are: TARGZ (as in tar.gz installer), STANDALONE, RPM, DEB, SVR4, FREEBSD, GLIBC, OSX")
++CACHE STRING "Installation directory layout. Options are: TARGZ (as in tar.gz installer), STANDALONE, RPM, DEB, SVR4, FREEBSD, GLIBC, OSX, MACPORTS")
+ 
  IF(UNIX)
-   IF(INSTALL_LAYOUT MATCHES "RPM" OR
-@@ -101,7 +101,7 @@
-     SET(CMAKE_INSTALL_PREFIX ${default_prefix}
+   IF(INSTALL_LAYOUT MATCHES "RPM")
+@@ -102,7 +102,7 @@
        CACHE PATH "install prefix" FORCE)
    ENDIF()
--  SET(VALID_INSTALL_LAYOUTS "RPM" "DEB" "SVR4" "FREEBSD" "GLIBC" "OSX" "TARGZ" "SLES" "STANDALONE")
-+  SET(VALID_INSTALL_LAYOUTS "RPM" "DEB" "SVR4" "FREEBSD" "GLIBC" "OSX" "MACPORTS" "TARGZ" "SLES" "STANDALONE")
+   SET(VALID_INSTALL_LAYOUTS
+-    "RPM" "DEB" "SVR4" "FREEBSD" "GLIBC" "OSX" "TARGZ" "STANDALONE")
++    "RPM" "DEB" "SVR4" "FREEBSD" "GLIBC" "OSX" "TARGZ" "STANDALONE" "MACPORTS")
    LIST(FIND VALID_INSTALL_LAYOUTS "${INSTALL_LAYOUT}" ind)
    IF(ind EQUAL -1)
      MESSAGE(FATAL_ERROR "Invalid INSTALL_LAYOUT parameter:${INSTALL_LAYOUT}."
-@@ -291,6 +291,39 @@
- SET(INSTALL_SECURE_FILE_PRIV_EMBEDDEDDIR_OSX ${secure_file_priv_embedded_path})
-
- #
+@@ -306,6 +306,37 @@
+ SET(INSTALL_MYSQLKEYRINGDIR_RPM         "/var/lib/mysql-keyring")
+ SET(INSTALL_SECURE_FILE_PRIVDIR_RPM     ${secure_file_priv_path})
+ 
++
 +# MACPORTS layout
 +#
 +SET(INSTALL_BINDIR_MACPORTS                       "lib/@NAME@/bin")
@@ -29,6 +30,7 @@
 +SET(INSTALL_SCRIPTDIR_MACPORTS                    "lib/@NAME@/bin")
 +#
 +SET(INSTALL_LIBDIR_MACPORTS                       "lib/@NAME@/mysql")
++SET(INSTALL_PRIV_LIBDIR_MACPORTS                  "lib/@NAME@/mysql")
 +SET(INSTALL_PLUGINDIR_MACPORTS                    "lib/@NAME@/plugin")
 +#
 +SET(INSTALL_INCLUDEDIR_MACPORTS                   "include/@NAME@/mysql")
@@ -49,12 +51,8 @@
 +SET(INSTALL_SECURE_FILE_PRIVDIR_MACPORTS          "${CMAKE_INSTALL_PREFIX}/var/db/@NAME@-files")
 +SET(INSTALL_SECURE_FILE_PRIV_EMBEDDEDDIR_MACPORTS "${CMAKE_INSTALL_PREFIX}/var/db/@NAME@-files")
 +SET(INSTALL_PLUGINTESTDIR_MACPORTS                ${plugin_tests})
-+#
-+# SUID /bin/ps is not in MacPorts sandbox causing scripts/CMakeLists.txt tests to fail so we set FIND_PROC here.
-+#
-+SET(FIND_PROC "ps -ef | grep -v mysqld_safe | grep -- $MYSQLD | grep $PID > /dev/null")
 +
-+#
- # TARGZ layout
++
  #
- SET(INSTALL_BINDIR_TARGZ           "bin")
+ # DEB layout
+ #

--- a/databases/mysql8/files/patch-cmake-install_macros.cmake.diff
+++ b/databases/mysql8/files/patch-cmake-install_macros.cmake.diff
@@ -1,0 +1,16 @@
+--- a/cmake/install_macros.cmake	2019-12-10 15:50:53.000000000 -0500
++++ b/cmake/install_macros.cmake	2019-12-10 16:43:28.000000000 -0500
+@@ -324,11 +324,11 @@
+     ADD_CUSTOM_COMMAND(TARGET ${TARGET} POST_BUILD
+       COMMAND install_name_tool -change
+       "@rpath/$<TARGET_FILE_NAME:libprotobuf-lite>"
+-      "@loader_path/../lib/$<TARGET_FILE_NAME:libprotobuf-lite>"
++      "@loader_path/../mysql/$<TARGET_FILE_NAME:libprotobuf-lite>"
+       "$<TARGET_FILE:${TARGET}>"
+       COMMAND install_name_tool -change
+       "@rpath/$<TARGET_FILE_NAME:libprotobuf>"
+-      "@loader_path/../lib/$<TARGET_FILE_NAME:libprotobuf>"
++      "@loader_path/../mysql/$<TARGET_FILE_NAME:libprotobuf>"
+       "$<TARGET_FILE:${TARGET}>"
+       )
+   ELSEIF(UNIX)

--- a/databases/mysql8/files/patch-sql-local-boost.diff
+++ b/databases/mysql8/files/patch-sql-local-boost.diff
@@ -1,11 +1,10 @@
---- a/sql/CMakeLists.txt.orig	2019-04-13 07:46:31.000000000 -0400
-+++ b/sql/CMakeLists.txt	2019-06-09 04:02:17.000000000 -0400
-@@ -24,7 +24,15 @@
- INCLUDE_DIRECTORIES(
-   ${CMAKE_SOURCE_DIR}/libbinlogevents/include
- )
+--- a/sql/CMakeLists.txt        2019-10-24 09:46:10.000000000 -0500
++++ b/sql/CMakeLists.txt	2019-10-24 09:46:42.000000000 -0500
+@@ -20,7 +20,14 @@
+ # along with this program; if not, write to the Free Software
+ # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+ 
 -INCLUDE_DIRECTORIES(SYSTEM ${BOOST_PATCHES_DIR} ${BOOST_INCLUDE_DIR})
-+
 +# Prevent Boost from including external precompiled Boost libraries
 +IF(USING_LOCAL_BOOST)
 +  ADD_DEFINITIONS(


### PR DESCRIPTION
- add patch to fix library path for protobuf
- add zstd dependency

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.1 19B2106
Xcode 11.2.1 11B500

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
