### PR TITLE
py-pyqt5: add new subport for py-pyqt5-chart

### DIFF
--- a/python/py-pyqt5/Portfile
+++ b/python/py-pyqt5/Portfile
@@ -50,27 +50,11 @@ if {${subport} eq "${name}-common"} {
         file copy ${worksrcpath}/sip/Enginio ${destroot}${prefix}/share/sip/PyQt5
     }
 
-} elseif {[string first "webengine" ${subport}] != -1} {
+} elseif {[string first "webengine" ${subport}] != -1 || [string first "chart" ${subport}] != -1} {
     PortGroup           qmake5 1.0
-
-    version             5.13.1
-    revision            0
-    description         PyQt5 Webengine bindings
-    long_description    ${description}
-    master_sites        https://www.riverbankcomputing.com/static/Downloads/PyQtWebEngine/${version}
-    distname            PyQtWebEngine_gpl-${version}
-    checksums           rmd160  88d23dacc583ca028b7444c3233d82901e2ad7da \
-                        sha256  8d8c1262005d8465653a848bf67327fb338e0d3c2d26090a6f7eb071dbb42092 \
-                        size    44883
-
-    livecheck.type      regex
-    livecheck.url       https://www.riverbankcomputing.com/software/pyqtwebengine/download
-    livecheck.regex     >PyQtWebEngine_gpl-(\[0-9.\]*).tar.gz<
 
     compiler.cxx_standard 2011
     depends_lib-append  port:py${python.version}-pyqt5
-    qt5.depends_component \
-                        qtwebengine
     use_configure       yes
     configure.pre_args
     configure.cmd       "${python.bin} configure.py"
@@ -87,42 +71,42 @@ if {${subport} eq "${name}-common"} {
     destroot.cmd        ${build.cmd}
     destroot.destdir    DESTDIR=${destroot}
 
-} elseif {[string first "chart" ${subport}] != -1} {
-    PortGroup           qmake5 1.0
+    if {[string first "webengine" ${subport}] != -1} {
+        version             5.13.1
+        revision            0
+        description         PyQt5 Webengine bindings
+        long_description    ${description}
+        master_sites        https://www.riverbankcomputing.com/static/Downloads/PyQtWebEngine/${version}
+        distname            PyQtWebEngine_gpl-${version}
+        checksums           rmd160  88d23dacc583ca028b7444c3233d82901e2ad7da \
+                            sha256  8d8c1262005d8465653a848bf67327fb338e0d3c2d26090a6f7eb071dbb42092 \
+                            size    44883
 
-    version             5.13.0
-    revision            0
-    description         PyQt5 Charts bindings
-    long_description    ${description}
-    master_sites        https://www.riverbankcomputing.com/static/Downloads/PyQtChart/${version}
-    distname            PyQtChart_gpl-${version}
-    checksums           rmd160  731013f88098d6236ebf4a7ac544ac58a1b2fb6f \
-                        sha256  21742b84343a3d598956f291cb971a734be849a47cd30ec74d1538e95c074a49 \
-                        size    64350
+        qt5.depends_component \
+                            qtwebengine
 
-    livecheck.type      regex
-    livecheck.url       https://www.riverbankcomputing.com/software/pyqtchart/download
-    livecheck.regex     >PyQtChart_gpl-(\[0-9.\]*).tar.gz<
+        livecheck.type      regex
+        livecheck.url       https://www.riverbankcomputing.com/software/pyqtwebengine/download
+        livecheck.regex     >PyQtWebEngine_gpl-(\[0-9.\]*).tar.gz<
 
-    compiler.cxx_standard 2011
-    depends_lib-append  port:py${python.version}-pyqt5
-    qt5.depends_component \
-                        qtcharts
-    use_configure       yes
-    configure.pre_args
-    configure.cmd       "${python.bin} configure.py"
-    qt5.spec_cmd        --spec=
-    configure.args-append \
-                        -q ${qt_qmake_cmd} \
-                        --verbose \
-                        --sip=${prefix}/bin/sip-${python.branch} \
-                        --no-qsci-api \
-                        --no-dist-info
+    } elseif {[string first "chart" ${subport}] != -1} {
+        version             5.13.0
+        revision            0
+        description         PyQt5 Charts bindings
+        long_description    ${description}
+        master_sites        https://www.riverbankcomputing.com/static/Downloads/PyQtChart/${version}
+        distname            PyQtChart_gpl-${version}
+        checksums           rmd160  731013f88098d6236ebf4a7ac544ac58a1b2fb6f \
+                            sha256  21742b84343a3d598956f291cb971a734be849a47cd30ec74d1538e95c074a49 \
+                            size    64350
 
-    build.cmd           make
-    build.target        all
-    destroot.cmd        ${build.cmd}
-    destroot.destdir    DESTDIR=${destroot}
+        qt5.depends_component \
+                            qtcharts
+
+        livecheck.type      regex
+        livecheck.url       https://www.riverbankcomputing.com/software/pyqtchart/download
+        livecheck.regex     >PyQtChart_gpl-(\[0-9.\]*).tar.gz<
+    }
 
 } elseif {${name} ne ${subport}} {
     PortGroup           qmake5 1.0
@@ -208,5 +192,4 @@ if {${subport} eq "${name}-common"} {
     variant graceful description {Don't abort (crash) on Python errors} {
         patchfiles-append       patch-no-abort-on-python-errors.diff
     }
-
 }

--- a/python/py-pyqt5/Portfile
+++ b/python/py-pyqt5/Portfile
@@ -30,6 +30,7 @@ subport "${name}-common" {}
 
 foreach py_ver ${python.versions} {
     subport "py${py_ver}-pyqt5-webengine" {}
+    subport "py${py_ver}-pyqt5-chart" {}
 }
 
 if {${subport} eq "${name}-common"} {
@@ -70,6 +71,43 @@ if {${subport} eq "${name}-common"} {
     depends_lib-append  port:py${python.version}-pyqt5
     qt5.depends_component \
                         qtwebengine
+    use_configure       yes
+    configure.pre_args
+    configure.cmd       "${python.bin} configure.py"
+    qt5.spec_cmd        --spec=
+    configure.args-append \
+                        -q ${qt_qmake_cmd} \
+                        --verbose \
+                        --sip=${prefix}/bin/sip-${python.branch} \
+                        --no-qsci-api \
+                        --no-dist-info
+
+    build.cmd           make
+    build.target        all
+    destroot.cmd        ${build.cmd}
+    destroot.destdir    DESTDIR=${destroot}
+
+} elseif {[string first "chart" ${subport}] != -1} {
+    PortGroup           qmake5 1.0
+
+    version             5.13.0
+    revision            0
+    description         PyQt5 Charts bindings
+    long_description    ${description}
+    master_sites        https://www.riverbankcomputing.com/static/Downloads/PyQtChart/${version}
+    distname            PyQtChart_gpl-${version}
+    checksums           rmd160  731013f88098d6236ebf4a7ac544ac58a1b2fb6f \
+                        sha256  21742b84343a3d598956f291cb971a734be849a47cd30ec74d1538e95c074a49 \
+                        size    64350
+
+    livecheck.type      regex
+    livecheck.url       https://www.riverbankcomputing.com/software/pyqtchart/download
+    livecheck.regex     >PyQtChart_gpl-(\[0-9.\]*).tar.gz<
+
+    compiler.cxx_standard 2011
+    depends_lib-append  port:py${python.version}-pyqt5
+    qt5.depends_component \
+                        qtcharts
     use_configure       yes
     configure.pre_args
     configure.cmd       "${python.bin} configure.py"


### PR DESCRIPTION
#### Description
This PR adds a subport for QtChart to ```py-pyqt5```, and refactors the Portfile as not to duplicate boilerplate code for the ```chart``` and ```webengine``` subports. It's a new dependency for ```py-eric-ide```.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
