### PR TITLE
php-xdebug: Downgrade to v2.7.2 only for PHP 7.0

### DIFF
--- a/php/php-xdebug/Portfile
+++ b/php/php-xdebug/Portfile
@@ -15,12 +15,19 @@ master_sites            ${homepage}/files/
 php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
 php.extensions.zend     xdebug
 
-if {[vercmp ${php.branch} 7.0] >= 0} {
+if {[vercmp ${php.branch} 7.1] >= 0} {
     version             2.8.0
     revision            0
     checksums           rmd160  0fc3a106fa03cbc3b6b2384cf7f1ed89f975b31b \
                         sha256  cb1d117ecbec7409a408cf24e59d92f7e3816fe8e2331dd0ffc3dce60228c264 \
                         size    238122
+} elseif {[vercmp ${php.branch} 7.0] >= 0} {
+    version             2.7.2
+    epoch               1
+    revision            0
+    checksums           rmd160  dd7784825909ac35288fdfda631f5318c768e688 \
+                        sha256  b0f3283aa185c23fcd0137c3aaa58554d330995ef7a3421e983e8d018b05a4a6 \
+                        size    230987
 } elseif {[vercmp ${php.branch} 5.5] >= 0} {
     version             2.5.5
     revision            0


### PR DESCRIPTION
Although not mentioned in the [release notes](https://xdebug.org/updates#x_2_8_0) or [announcement](https://xdebug.org/announcements/2019-10-31) of v2.8.0, the [version compatibility table](https://xdebug.org/docs/compat) shows support for PHP 7.0 was dropped.

Latest version to support PHP 7.0 is 2.7.2, so reinstate the previous version info in a logic block for PHP 7.0

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G1012
Xcode 11.2.1 11B500

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
