### PR TITLE
git: update version to 2.24.1 (security fixes)

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 name                git
-version             2.24.0
+version             2.24.1
 revision            0
 
 description         A fast version control system
@@ -22,14 +22,14 @@ use_xz              yes
 distfiles           git-${version}${extract.suffix} \
                     git-manpages-${version}${extract.suffix}
 
-checksums           git-2.24.0.tar.xz \
-                    rmd160  28b19ca928fcf8182f27031b3e2ec3e08a2b0584 \
-                    sha256  9f71d61973626d8b28c4cdf8e2484b4bf13870ed643fed982d68b2cfd754371b \
-                    size    5766056 \
-                    git-manpages-2.24.0.tar.xz \
-                    rmd160  3eb3ee81ff26b8536459e349eb43df173d1a7f6b \
-                    sha256  b0c872c16f22942c1cb6c90ec07f395a931f7c2f9fb920d2ec926674265c04a6 \
-                    size    453600
+checksums           git-2.24.1.tar.xz \
+                    rmd160  7e2f48ce850b1ee4d3dd459e08b28db15d87537a \
+                    sha256  723f24dce8fdd621a308b6187553fce7d5244205c065fe0a3aebd0b7c3f88562 \
+                    size    5772304 \
+                    git-manpages-2.24.1.tar.xz \
+                    rmd160  fcbd2fd839347d05f2f2942e3a02c26158c1f3d7 \
+                    sha256  27304ab2674d5ad623a0a72c22116cb47df4a611499a53aef5c7ec39a32cfefb \
+                    size    453752
 
 perl5.require_variant   yes
 perl5.conflict_variants yes
@@ -144,10 +144,10 @@ variant pcre {
 
 variant doc description {Install HTML and plaintext documentation} {
     distfiles-append        git-htmldocs-${version}${extract.suffix}
-    checksums-append        git-htmldocs-2.24.0.tar.xz \
-                            rmd160  3b406a15dfb06fa04baaf090f0e1698e80e44be8 \
-                            sha256  05b6ed0719d5e29d5c60dd7d0a5469f4a0514008a64f6084ac26335d1b37f73b \
-                            size    1306680
+    checksums-append        git-htmldocs-2.24.1.tar.xz \
+                            rmd160  85849497071ec4a7e79aeeb987e2840005a90a2f \
+                            sha256  8b4da79e7931c5156f3f994c6d8162c7ccb525ebd3f71e26ae8f8430db038403 \
+                            size    1307992
 
     patchfiles-append       git-subtree.html.diff
 


### PR DESCRIPTION


#### Description

addressing the security issues
CVE-2019-1348, CVE-2019-1349, CVE-2019-1350, CVE-2019-1351,
CVE-2019-1352, CVE-2019-1353, CVE-2019-1354, CVE-2019-1387, and
CVE-2019-19604

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
macOS 10.15.2 19C57
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
