### PR TITLE
alertmanager: update to 0.20.0

### DIFF
--- a/net/alertmanager/Portfile
+++ b/net/alertmanager/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        prometheus alertmanager 0.19.0 v
+github.setup        prometheus alertmanager 0.20.0 v
 github.tarball_from archive
 
 description         The Alertmanager handles alerts sent by client \
@@ -20,7 +20,7 @@ platforms           darwin
 categories          net
 license             Apache-2
 
-maintainers         {gmail.com:herbygillot @herbygillot} openmaintainer
+maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
 
 depends_build       port:go \
                     port:promu
@@ -36,9 +36,9 @@ use_parallel_build  no
 
 distfiles           alertmanager-${version}${extract.suffix}:main
 
-checksums   rmd160  c19ed98763ca6ff3e6ed131a3f2d2fb0c4c653e6 \
-            sha256  4730664f746173f89804df43b3f608cac030e79baae165d6d99df472eb52d36a \
-            size    5862442
+checksums   rmd160  8c108540f1460557f9f44e2579c19c7febbd96bc \
+            sha256  4789ef95b09ba86a66a2923c3535d1bfe30a566390770784c52052c7c83ee1bc \
+            size    5837531
 
 set svc_name        prometheus-alertmanager
 set prom_user       prometheus


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.2 19C57
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
