### PR TITLE
google-cloud-sdk: update to 273.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             272.0.0
+version             273.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  42ffb5b050b7933c569776f7fad6bbf0584a4c1d \
-                    sha256  90d368e827c8496597c60d34c2b256e6931d5dcab4a035ce7013fa90c89241b8 \
-                    size    22741887
+    checksums       rmd160  dec83593ec4500293418c158ada622fd6d6c6ffc \
+                    sha256  8e3e94b207025181dde5ee12304d46af880ba6f82579da40347ac856def048bc \
+                    size    22880794
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  c1052a8cdd1203c3051c9c0bc9fb8cf803edceab \
-                    sha256  63079aab3bd6714a1d819fdde798f30e2ac306d13b541516ac2b5b660f69cc9f \
-                    size    22743076
+    checksums       rmd160  61001c7f92d4f0dd2e9a0cc47a5fe70ca0d93a59 \
+                    sha256  bf5057707b971f48edef4262123d6012e138e840990ff873ed83494b293f3409 \
+                    size    22881157
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 273.0.0.

###### Tested on

macOS 10.15.1 19B88
Xcode 11.2.1 11B500

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?