### PR TITLE
wireshark2: update to 2.6.13

### DIFF
--- a/net/wireshark2/Portfile
+++ b/net/wireshark2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.0
 
 name                wireshark2
-version             2.6.11
+version             2.6.13
 revision            0
 categories          net
 license             {GPL-2 GPL-3}
@@ -27,10 +27,10 @@ distfiles           wireshark-${version}${extract.suffix}
 
 worksrcdir          wireshark-${version}
 
-checksums           sha256  29751581c8549562957940e68f0b9410a499616c91c1768195bc02def13f5a85 \
-                    rmd160  a94e93c8222acd36ed320365d3fbd0cd36b40b3d \
-                    sha1    60549213e862dde2245f9b8d8187227723671f17 \
-                    size    28480628
+checksums           sha256  9dba6d71bca77192f101c706bcb1545c4dea88d964fe63daa101bc9631a0e2cb \
+                    rmd160  1d4452f8fb5e0434857bcaa625bf49a096c7bf8f \
+                    sha1    04a8fa5cbd28215d020902884580666e5cf9ee5f \
+                    size    28496240
 
 conflicts           wireshark-devel wireshark wireshark22 wireshark24 wireshark3
 
@@ -155,6 +155,7 @@ post-destroot {
     xinstall -d ${destroot}${prefix}/include/wireshark/epan/dissectors/
     xinstall -d ${destroot}${prefix}/include/wireshark/epan/ftypes/
     xinstall -d ${destroot}${prefix}/include/wireshark/wiretap/
+    xinstall -d ${destroot}${prefix}/include/wireshark/wsutil/
     xinstall -m 644 -W ${worksrcpath}/ config.h ${destroot}${prefix}/include/wireshark/
     xinstall -m 644 {*}[glob ${worksrcpath}/epan/*.h] ${destroot}${prefix}/include/wireshark/epan/
     xinstall -m 644 {*}[glob ${worksrcpath}/epan/crypt/*.h] ${destroot}${prefix}/include/wireshark/epan/crypt/
@@ -162,6 +163,7 @@ post-destroot {
     xinstall -m 644 {*}[glob ${worksrcpath}/epan/dissectors/*.h] ${destroot}${prefix}/include/wireshark/epan/dissectors/
     xinstall -m 644 {*}[glob ${worksrcpath}/epan/ftypes/*.h] ${destroot}${prefix}/include/wireshark/epan/ftypes/
     xinstall -m 644 {*}[glob ${worksrcpath}/wiretap/*.h] ${destroot}${prefix}/include/wireshark/wiretap/
+    xinstall -m 644 {*}[glob ${worksrcpath}/wsutil/*.h] ${destroot}${prefix}/include/wireshark/wsutil/
 }
 
 livecheck.type      regex


### PR DESCRIPTION
#### Description

Update wireshark2 from 2.6.11 to 2.6.13

Also include headers from "wsutil".

Simple changes.

##### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G1012
Xcode 11.2.1 11B500

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
