### PR TITLE
submission port:samurai

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -585,7 +585,7 @@ array set modules {
             adcf56b5de6f34744bba2307b696fc75611884f4270e87dfa760d6e99dd711bb
             255593964
         }
-        "port:python27 port:py27-ply port:ninja port:gperf port:bison port:flex"
+        "port:python27 port:py27-ply path:bin/ninja:samurai port:gperf port:bison port:flex"
         "port:fontconfig port:dbus port:harfbuzz path:lib/pkgconfig/glib-2.0.pc:glib2 port:zlib port:minizip port:libevent port:libxml2 port:jsoncpp port:protobuf3-cpp port:poppler port:pulseaudio port:icu path:lib/libavcodec.dylib:ffmpeg port:libopus port:webp port:libpng port:lcms2 port:freetype port:re2 port:snappy"
         "qtdeclarative qtquickcontrols qtquickcontrols2 qtlocation qtwebchannel qttools"
         {"Qt WebEngine"}
@@ -1473,6 +1473,7 @@ foreach {module module_info} [array get modules] {
                 # UsingTheRightCompiler (https://trac.macports.org/wiki/UsingTheRightCompiler)
                 build.env-append      CXX=${configure.cxx}
                 build.env-append      CC=${configure.cc}
+                build.env-append      SAMUFLAGS=-j${build.jobs}
                 configure.args-append QMAKE_LINK=${configure.cxx}
 
                 # avoid

--- a/aqua/qt511/Portfile
+++ b/aqua/qt511/Portfile
@@ -593,7 +593,7 @@ array set modules {
             5bb49ead71b851db4dc56f8fd97e0db72a268b22104129a06bac201d55d3b8fe
             233678844
         }
-        "port:python27 port:py27-ply port:ninja"
+        "port:python27 port:py27-ply path:bin/ninja:samurai"
         ""
         "qtquickcontrols qtwebchannel qtlocation qttools"
         {"Qt WebEngine"}
@@ -1461,6 +1461,7 @@ foreach {module module_info} [array get modules] {
                 # UsingTheRightCompiler (https://trac.macports.org/wiki/UsingTheRightCompiler)
                 build.env-append      CXX=${configure.cxx}
                 build.env-append      CC=${configure.cc}
+                build.env-append      SAMUFLAGS=-j${build.jobs}
                 configure.args-append QMAKE_LINK=${configure.cxx}
 
                 # see https://chromium.googlesource.com/chromium/src/+/cd7154e0bb5f3ca9c72586da79f87d13afb5361a%5E%21/

--- a/aqua/qt59/Portfile
+++ b/aqua/qt59/Portfile
@@ -591,7 +591,7 @@ array set modules {
             74d3c3430a294faac2c6048ac5224f82fe98247a86cac13b386aa5a1c22db27c
             215346584
         }
-        "port:python27 port:py27-ply port:ninja"
+        "port:python27 port:py27-ply path:bin/ninja:samurai"
         ""
         "qtquickcontrols qtwebchannel qtlocation qttools"
         {"Qt WebEngine"}
@@ -1442,6 +1442,7 @@ foreach {module module_info} [array get modules] {
                 # UsingTheRightCompiler (https://trac.macports.org/wiki/UsingTheRightCompiler)
                 build.env-append      CXX=${configure.cxx}
                 build.env-append      CC=${configure.cc}
+                build.env-append      SAMUFLAGS=-j${build.jobs}
                 configure.args-append QMAKE_LINK=${configure.cxx}
 
                 # see https://trac.macports.org/ticket/59294

--- a/devel/ninja/Portfile
+++ b/devel/ninja/Portfile
@@ -12,6 +12,7 @@ platforms           darwin
 maintainers         {ryandesign @ryandesign} openmaintainer
 license             Apache-2
 installs_libs       no
+conflicts           samurai
 
 description         Small build system with a focus on speed.
 

--- a/devel/samurai/Portfile
+++ b/devel/samurai/Portfile
@@ -1,0 +1,42 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        michaelforney samurai 0.7
+categories          devel
+platforms           darwin
+maintainers         nomaintainer
+license             Apache-2
+installs_libs       no
+
+description         ninja-compatible build tool written in C.
+
+long_description    samurai (samu) is a compatible replacement ninja build tool written in C99 with \
+                    a focus on simplicity, speed, and portability. \
+                    samurai implements the ninja build language through version 1.9.0 except \
+                    for MSVC dependency handling (deps = msvc). It uses the same format for \
+                    .ninja_log and .ninja_deps as ninja, currently version 5 and 4 respectively. \
+                    It is feature-complete and supports most of the same options as ninja. \
+                    The port provides the native `samu` command and a symlink so it can be called \
+                    as `ninja` by standard build systems.
+conflicts           ninja
+
+checksums           rmd160  dd72603a03490a50f378ef228d1d86f3238ca0b1 \
+                    sha256  41ca07134e0ee1dc5f0f8f83a432f8c285cb1615508cb9dc2b47290c6e0c3943 \
+                    size    28217
+
+installs_libs       no
+use_configure       no
+
+build.pre_args-delete all
+build.env-append    CC=${configure.cc} \
+                    "CFLAGS=${configure.cflags}" \
+                    "LDFLAGS=${configure.ldflags}"
+destroot.post_args-append \
+                    PREFIX=${prefix}
+
+post-destroot {
+    ln -s samu ${destroot}${prefix}/bin/ninja
+    ln -s samu.1.gz ${destroot}${prefix}/share/man/man1/ninja.1.gz
+}


### PR DESCRIPTION
Samurai is a lean-and-mean drop-in alternative for ninja. It reduces
the resource overhead required for building large projects and allows
certain options to be set via the SAMUFLAGS env. variable. This can
have huge benefits for building a huge project like QtWebEngine which
calls ninja somewhere deep in its build system bowels, with providing
control over the options to pass to the command. Since multiple ninja
commands can end up running concurrently which all launch as many compile
jobs as they see fit, even powerful systems can be stressed to the max.
This PR contains changes to port:qt5*-qtwebengine that force each samu
job the launch at most $build.jobs jobs.


#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.9.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->