### PR TITLE
wireguard-tools: update to 0.0.20191212

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-tools
-version             0.0.20191206
+version             0.0.20191212
 revision            0
-checksums           rmd160  e96cf99d59c669a7863bc18fc4362488aa19dff9 \
-                    sha256  75e4e8f2971257339ef45af1be67f0a21435235f25277e3e0e4d6f867714ece5 \
-                    size    332584
+checksums           rmd160  47174730d7b270ac576bfb3f0847fc327d8406ff \
+                    sha256  b0d718380f7a8822b2f12d75e462fa4eafa3a77871002981f367cd4fe2a1b071 \
+                    size    333024
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
###### Tested on
macOS 10.13.6 17G8037
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?