### PR TITLE
python38: Disable posix._fcopyfile function on Tiger

### DIFF
--- a/lang/python38/Portfile
+++ b/lang/python38/Portfile
@@ -37,7 +37,8 @@ patchfiles          patch-setup.py.diff \
                     patch-Lib-ctypes-macholib-dyld.py.diff \
                     patch-libedit.diff \
                     patch-configure-xcode4bug.diff \
-                    patch-_osx_support.py.diff
+                    patch-_osx_support.py.diff \
+                    patch-Modules-posixmodule-tiger-copyfile.diff
 
 depends_build       port:pkgconfig
 depends_lib         port:bzip2 \

--- a/lang/python38/files/patch-Modules-posixmodule-tiger-copyfile.diff
+++ b/lang/python38/files/patch-Modules-posixmodule-tiger-copyfile.diff
@@ -1,3 +1,14 @@
+--- Lib/test/test_shutil.py.orig
++++ Lib/test/test_shutil.py
+@@ -2393,7 +2393,7 @@
+             shutil._USE_CP_SENDFILE = True
+ 
+ 
+-@unittest.skipIf(not MACOS, 'macOS only')
++@unittest.skipIf(not MACOS or not hasattr(posix, "_fcopyfile"), 'macOS with posix._fcopyfile only')
+ class TestZeroCopyMACOS(_ZeroCopyFileTest, unittest.TestCase):
+     PATCHPOINT = "posix._fcopyfile"
+ 
 --- Modules/clinic/posixmodule.c.h.orig
 +++ Modules/clinic/posixmodule.c.h
 @@ -4975,7 +4975,7 @@

--- a/lang/python38/files/patch-Modules-posixmodule-tiger-copyfile.diff
+++ b/lang/python38/files/patch-Modules-posixmodule-tiger-copyfile.diff
@@ -1,0 +1,40 @@
+--- Modules/clinic/posixmodule.c.h.orig
++++ Modules/clinic/posixmodule.c.h
+@@ -4975,7 +4975,7 @@
+     return return_value;
+ }
+ 
+-#if defined(__APPLE__)
++#if defined(__APPLE__) && MAC_OS_X_VERSION_MAX_ALLOWED >= 1050
+ 
+ PyDoc_STRVAR(os__fcopyfile__doc__,
+ "_fcopyfile($module, infd, outfd, flags, /)\n"
+--- Modules/posixmodule.c.orig
++++ Modules/posixmodule.c
+@@ -109,7 +109,7 @@
+ #include <sys/sendfile.h>
+ #endif
+ 
+-#if defined(__APPLE__)
++#if defined(__APPLE__) && MAC_OS_X_VERSION_MAX_ALLOWED >= 1050
+ #include <copyfile.h>
+ #endif
+ 
+@@ -9153,7 +9153,7 @@
+ #endif /* HAVE_SENDFILE */
+ 
+ 
+-#if defined(__APPLE__)
++#if defined(__APPLE__) && MAC_OS_X_VERSION_MAX_ALLOWED >= 1050
+ /*[clinic input]
+ os._fcopyfile
+ 
+@@ -14222,7 +14222,7 @@
+ #endif
+ #endif
+ 
+-#if defined(__APPLE__)
++#if defined(__APPLE__) && MAC_OS_X_VERSION_MAX_ALLOWED >= 1050
+     if (PyModule_AddIntConstant(m, "_COPYFILE_DATA", COPYFILE_DATA)) return -1;
+ #endif
+ 


### PR DESCRIPTION
#### Description

Python 3.8's `posix._fcopyfile` implementation unconditionally uses `<copyfile.h>`, which only exists on Leopard ane newer. This patch removes `posix._fcopyfile` on Tiger - this is okay because the rest of the stdlib uses `posix._fcopyfile` only conditionally after checking that the function exists (non-Apple systems don't have `posix._fcopyfile` either).

Fixes https://trac.macports.org/ticket/59827

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.4
Xcode 2.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

Note: I can't test this fully at the moment. The patch fixes the copyfile compile error, but the build still doesn't work for me because of another issue (https://trac.macports.org/ticket/59772).
