### PR TITLE
uni: new port

### DIFF
--- a/textproc/uni/Portfile
+++ b/textproc/uni/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/arp242/uni 1.0.0 v
+
+categories          textproc
+license             MIT
+installs_libs       no
+
+maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
+
+checksums           rmd160  e0e5b5808aaaf83d1dac90d73921f79451b3fc90 \
+                    sha256  2afd697b9291ce8fa60725f26164fe37ba754e9b2e3a611a98ea4d9dd51a8b9f \
+                    size    395367
+
+description         uni queries the Unicode database from the commandline.
+long_description    Query the Unicode database from the commandline, with \
+                    good support for emojis. Includes full support for \
+                    Unicode 12.1 (May 2019) with full Emoji support (a \
+                    surprisingly large amount of emoji pickers don't deal \
+                    with emoji sequences very well).
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
New port for [uni](https://github.com/arp242/uni), a command-line Unicode and emoji query tool.

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.2 19C57
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
