### PR TITLE
wireguard-go: Remove git dependency

### DIFF
--- a/net/wireguard-go/Portfile
+++ b/net/wireguard-go/Portfile
@@ -28,8 +28,7 @@ homepage            https://www.wireguard.com/
 master_sites        https://git.zx2c4.com/wireguard-go/snapshot/
 use_xz              yes
 
-depends_build       port:git \
-                    port:go
+depends_build       port:go
 
 use_configure       no
 


### PR DESCRIPTION
#### Description

`git` is preinstalled on macOS and the MacPorts version of `git` is not required.

###### Type(s)

- [X] enhancement

###### Tested on

macOS 10.15.2 19C57
Xcode 11.3 11C29

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tested basic functionality of all binary files?