### PR TITLE
ddclient: Add MacPorts sendmail, switch to GitHub repo

### DIFF
--- a/net/ddclient/Portfile
+++ b/net/ddclient/Portfile
@@ -2,19 +2,22 @@
 
 PortSystem          1.0
 PortGroup           perl5 1.0
+PortGroup           github 1.0
 
-name                ddclient
-version             3.9.1
+github.setup        ddclient ddclient 3.9.1 v
+revision            3
+
 platforms           darwin
 categories          net
 license             GPL
 maintainers         {snc @nerdling} openmaintainer
+
 description         Update dynamic DNS entries
+
 long_description    ddclient is a Perl client used to update dynamic \
                     DNS entries for accounts on many dynamic DNS services.
-homepage            http://ddclient.sourceforge.net/
 
-master_sites        sourceforge
+homepage            https://ddclient.net/
 
 checksums           rmd160  4b879422b6462241725d62e4a7d247dcd79e4942 \
                     sha256  e4969e15cc491fc52bdcd649d4c2b0e4b1bf0c9f9dba23471c634871acc52470 \
@@ -23,12 +26,25 @@ checksums           rmd160  4b879422b6462241725d62e4a7d247dcd79e4942 \
 depends_lib         port:p${perl5.major}-io-socket-ssl
 depends_run         port:perl${perl5.major} \
                     port:p${perl5.major}-data-validate-ip \
+                    port:postfix \
                     path:share/curl/curl-ca-bundle.crt:curl-ca-bundle
 
+# diff -NaurdB --label ddclient ddclient.orig ddclient > patch-ddclient.diff
 patchfiles          patch-ddclient.diff
+
+set sendmail        ${prefix}/sbin/sendmail
+
+variant system_sendmail \
+    description {Use the system sendmail.} {
+    depends_run-delete \
+                    port:postfix
+    set sendmail    sendmail
+}
+
 post-patch {
-    reinplace "s|@@PREFIX@@|${prefix}|g"        ${worksrcpath}/${name}
     reinplace "s|^#!.*/perl.*$|#!${perl5.bin}|" ${worksrcpath}/${name}
+    reinplace "s|@PREFIX@|${prefix}|g"          ${worksrcpath}/${name}
+    reinplace "s|@SENDMAIL@|${sendmail}|g"      ${worksrcpath}/${name}
 }
 
 use_configure       no
@@ -62,5 +78,3 @@ post-activate {
 startupitem.create  yes
 startupitem.start   ${prefix}/sbin/${name}
 startupitem.stop    "/bin/kill \$(cat ${prefix}/var/run/${name}.pid)"
-
-livecheck.regex     "${name}-(\\d+\\.\\d+\\.\\d+)"

--- a/net/ddclient/files/patch-ddclient.diff
+++ b/net/ddclient/files/patch-ddclient.diff
@@ -1,13 +1,29 @@
---- ddclient.orig	2012-10-16 09:50:53.000000000 -0400
-+++ ddclient	2012-10-16 09:51:43.000000000 -0400
-@@ -35,8 +35,8 @@
+--- ddclient
++++ ddclient	2019-12-14 16:44:52.000000000 -0500
+@@ -1,5 +1,4 @@
+-#!/usr/bin/perl -w
+-#!/usr/local/bin/perl -w
++#!@PREFIX@/bin/perl@PERL5_MAJOR_VERSION@
+ ######################################################################
+ #
+ # DDCLIENT - a Perl client for updating DynDNS information
+@@ -33,8 +32,8 @@
  $program  =~ s/d$//;
  my $now       = time;
  my $hostname  = hostname();
 -my $etc       = ($program =~ /test/i) ? './'   : '/etc/ddclient/';
 -my $cachedir  = ($program =~ /test/i) ? './'   : '/var/cache/ddclient/';
-+my $etc       = ($program =~ /test/i) ? './'   : '@@PREFIX@@/etc/ddclient/';
-+my $cachedir  = ($program =~ /test/i) ? './'   : '@@PREFIX@@/var/cache/ddclient/';
++my $etc       = ($program =~ /test/i) ? './'   : '@PREFIX@/etc/ddclient/';
++my $cachedir  = ($program =~ /test/i) ? './'   : '@PREFIX@/var/cache/ddclient/';
  my $savedir   = ($program =~ /test/i) ? 'URL/' : '/tmp/';
  my $msgs      = '';
  my $last_msgs = '';
+@@ -1627,7 +1626,7 @@
+ 	$recipients = opt('mail-failure');
+     }
+     if ($msgs && $recipients && $msgs ne $last_msgs) {
+-	pipecmd("sendmail -oi $recipients",
++	pipecmd("@SENDMAIL@ -oi $recipients",
+ 		"To: $recipients",
+ 		"Subject: status report from $program\@$hostname",
+ 		"\r\n",


### PR DESCRIPTION
ddclient: Add MacPorts sendmail, switch to GitHub repo

* Use the MacPorts sendmail binary; avoid conflict with native sendmail
* Add variant to use native sendmail
* Use the ddclient GitHub repo

#### Description

The current `ddclient` uses macOS-native `sendmail`, which isn't necessarily configured to send mail on most systems, and poses a conflict with MacPorts `postfix` port. This commit addresses this issue.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
