### PR TITLE
micronaut: update to 1.2.8

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       java 1.0
 
-github.setup    micronaut-projects micronaut-core 1.2.7 v
+github.setup    micronaut-projects micronaut-core 1.2.8 v
 revision        0
 name            micronaut
 categories      java
@@ -43,9 +43,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        ${name}-${version}
 
-checksums       rmd160  259fedb56430a3ebfe4535924439b845a5c5b145 \
-                sha256  c48104b0519857a4b040eeeef0c371f832961c2bdfb4469ea80a44fbcd59b5e0 \
-                size    12928596
+checksums       rmd160  86485849a797a140035f1251736d889aee636780 \
+                sha256  d7087165930b8c8d07868d2e7e407e257cace98536767134c5b6e087e59345a5 \
+                size    12928672
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 1.2.8.

###### Tested on

macOS 10.15.2 19C57
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?