### PR TITLE
qt4-mac: link .pc files into $prefix/lib/pkgconfig ...

### DIFF
--- a/aqua/qt4-mac/Portfile
+++ b/aqua/qt4-mac/Portfile
@@ -11,7 +11,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                qt4-mac
 version             4.8.7
-revision            9
+revision            10
 set branch          [join [lrange [split ${version} .] 0 1] .]
 
 categories          aqua
@@ -1121,6 +1121,17 @@ post-destroot {
     ln -s ${qt_frameworks_dir}/QtGui.framework/Resources \
         ${dr_qt_libs_dir}
 
+    # link pkg-config files to where they will be found automatically
+    if {${qt_libs_dir} ne "${prefix}/lib"} {
+
+        set qt_pc_dir ${qt_libs_dir}/pkgconfig
+        set dr_lib_pc_dir ${destroot}${prefix}/lib/pkgconfig
+        xinstall -d -m 0755 ${destroot}${qt_pc_dir}
+        foreach pcfile [glob -nocomplain -tails -directory ${destroot}${qt_pc_dir} *.pc] {
+            ln -s ${qt_pc_dir}/${pcfile} ${dr_lib_pc_dir}
+        }
+
+    }
 }
 
 variant odbc description {Enable iODBC SQL Driver} {


### PR DESCRIPTION
... to be accessible by default.

Closes: https://trac.macports.org/ticket/50347