### PR TITLE
remove obsolete Python versions in variants

### DIFF
--- a/devel/qscintilla/Portfile
+++ b/devel/qscintilla/Portfile
@@ -109,7 +109,7 @@ foreach qt_major {4 5} {
         }
     }
 
-    set python_versions {27 34 35 36 37}
+    set python_versions {27 35 36 37}
 
     foreach pver ${python_versions} {
         subport py${pver}-${name}-qt${qt_major} {

--- a/devel/quickfix/Portfile
+++ b/devel/quickfix/Portfile
@@ -21,7 +21,8 @@ master_sites        sourceforge:project/quickfix/quickfix/${version}
 worksrcdir          ${name}
 
 checksums           rmd160  369d5bf7044fa4c90d2d74e4470e50c0ad82951b \
-                    sha256  f6e8bdb004eaf45e50f63005b8c2611cb0afd42cf70f110f600c852aa572342d
+                    sha256  f6e8bdb004eaf45e50f63005b8c2611cb0afd42cf70f110f600c852aa572342d \
+                    size    21803784
 
 depends_lib         port:libxml2
 
@@ -54,20 +55,20 @@ variant postgresql90 conflicts postgresql84 description {Include PostgreSQL 9.0 
     configure.args-replace  --without-postgresql --with-postgresql=${prefix}/lib/postgresql90/bin/pg_config
 }
 
-variant python27 conflicts python34 python35 description {Include Python 2.7 support} {
+variant python27 conflicts python35 python37 description {Include Python 2.7 support} {
     depends_lib-append      port:python27
     configure.python        ${prefix}/bin/python2.7
     configure.args-replace  --without-python --with-python
 }
 
-variant python34 conflicts python27 python35 description {Include Python 3.4 support} {
-    depends_lib-append      port:python34
-    configure.python        ${prefix}/bin/python3.4
+variant python35 conflicts python27 python37 description {Include Python 3.5 support} {
+    depends_lib-append      port:python35
+    configure.python        ${prefix}/bin/python3.5
     configure.args-replace  --without-python --with-python
 }
 
-variant python35 conflicts python27 python34 description {Include Python 3.5 support} {
-    depends_lib-append      port:python35
-    configure.python        ${prefix}/bin/python3.5
+variant python37 conflicts python27 python35 description {Include Python 3.7 support} {
+    depends_lib-append      port:python37
+    configure.python        ${prefix}/bin/python3.7
     configure.args-replace  --without-python --with-python
 }

--- a/graphics/inkscape-textext/Portfile
+++ b/graphics/inkscape-textext/Portfile
@@ -9,7 +9,7 @@ categories              graphics tex
 maintainers             {gmail.com:jjstickel @jjstickel}
 license                 BSD
 platforms               darwin
-homepage                http://pav.iki.fi/software/textext/
+homepage                https://pav.iki.fi/software/textext/
 master_sites            ${homepage}
 distname                textext-${version}
 worksrcdir              ${name}
@@ -23,23 +23,14 @@ long_description        Textext provides re-editable LaTeX objects to Inkscapeâ€
                         repertoire.
 
 checksums               sha256  4d3d262efc8b199dff407b6d153c8822ac9b30d46357e0cdc191c2c0f5fea077 \
-                        rmd160  fcaf932207a5477562135b00be29445fc92e1caa
-                    
+                        rmd160  fcaf932207a5477562135b00be29445fc92e1caa \
+                        size    9475
+
 depends_run             path:bin/inkscape:inkscape \
                         port:pdf2svg \
                         bin:pdflatex:texlive-latex
 
-variant python26 conflicts python27 description {Configure to use Python version 2.6} {}
-variant python27 conflicts python26 description {Configure to use Python version 2.7} {}
-
-if { ![variant_isset python26] } {
-	default_variants      +python27
-}
-if {[variant_isset python26]} {
-    set python.version 26
-} elseif {[variant_isset python27]} {
-    set python.version 27
-}
+set python.version 27
 
 variant tkinter description {use py-tkinter backend} {
     depends_run-append  port:py${python.version}-tkinter

--- a/graphics/openexr/Portfile
+++ b/graphics/openexr/Portfile
@@ -14,7 +14,7 @@ description     OpenEXR Graphics Library
 long_description \
     OpenEXR is a high dynamic-range (HDR) image file format developed \
     by Industrial Light & Magic for use in computer imaging applications.
-homepage        http://www.openexr.com
+homepage        https://www.openexr.com
 platforms       darwin
 github.tarball_from releases
 
@@ -79,11 +79,12 @@ subport ilmbase {
     patchfiles-append patch-configure.diff
 }
 
-set python_versions {27 34 35 36 37}
+set python_versions {27 35 36 37}
 
 foreach pver ${python_versions} {
     subport py${pver}-pyilmbase {
         PortGroup   active_variants 1.1
+
         revision    3
         distname    pyilmbase-${version}
         checksums   rmd160  127329978f2fd5793a267d1c7c46d5514d1d46b7 \

--- a/graphics/vigra/Portfile
+++ b/graphics/vigra/Portfile
@@ -26,7 +26,8 @@ long_description    VIGRA stands for \"Vision with Generic Algorithms\". \
 homepage            https://ukoethe.github.io/vigra/
 
 checksums           rmd160  21378c72a0702cbdd4de4d79c59f0587f6bcde8d \
-                    sha256  b0cdf67e283d2b52e35a45cdcff44453b5b73a9b7d7a1ca84d6508107e49832f
+                    sha256  b0cdf67e283d2b52e35a45cdcff44453b5b73a9b7d7a1ca84d6508107e49832f \
+                    size    34212258
 
 depends_lib         port:jpeg \
                     port:tiff \
@@ -93,7 +94,7 @@ if {[variant_isset valgrind]} {
     configure.args-append -DWITH_VALGRIND=NO
 }
 
-variant python27 conflicts python34 python35 python36 python37 description "Also build vigranumpy python27 bindings" {
+variant python27 conflicts python35 python36 python37 description "Also build vigranumpy python27 bindings" {
     configure.args-append   -DPYTHON_EXECUTABLE=${prefix}/bin/python2.7 \
                             -DPYTHON_SPHINX=${prefix}/bin/sphinx-build-2.7
     depends_lib-append  port:boost \
@@ -103,17 +104,7 @@ variant python27 conflicts python34 python35 python36 python37 description "Also
     require_active_variants boost python27
 }
 
-variant python34 conflicts python27 python35 python36 python37 description "Also build vigranumpy python34 bindings" {
-    configure.args-append   -DPYTHON_EXECUTABLE=${prefix}/bin/python3.4 \
-                            -DPYTHON_SPHINX=${prefix}/bin/sphinx-build-3.4
-    depends_lib-append  port:boost \
-                        port:python34 \
-                        port:py34-numpy \
-                        port:py34-sphinx
-    require_active_variants boost python34
-}
-
-variant python35 conflicts python27 python34 python36 python37 description "Also build vigranumpy python35 bindings" {
+variant python35 conflicts python27 python36 python37 description "Also build vigranumpy python35 bindings" {
     configure.args-append   -DPYTHON_EXECUTABLE=${prefix}/bin/python3.5 \
                             -DPYTHON_SPHINX=${prefix}/bin/sphinx-build-3.5
     depends_lib-append  port:boost \
@@ -123,7 +114,7 @@ variant python35 conflicts python27 python34 python36 python37 description "Also
     require_active_variants boost python35
 }
 
-variant python36 conflicts python27 python34 python35 python37 description "Also build vigranumpy python36 bindings" {
+variant python36 conflicts python27 python35 python37 description "Also build vigranumpy python36 bindings" {
     configure.args-append   -DPYTHON_EXECUTABLE=${prefix}/bin/python3.6 \
                             -DPYTHON_SPHINX=${prefix}/bin/sphinx-build-3.6
     depends_lib-append  port:boost \
@@ -133,7 +124,7 @@ variant python36 conflicts python27 python34 python35 python37 description "Also
     require_active_variants boost python36
 }
 
-variant python37 conflicts python27 python34 python35 python36 description "Also build vigranumpy python37 bindings" {
+variant python37 conflicts python27 python35 python36 description "Also build vigranumpy python37 bindings" {
     configure.args-append   -DPYTHON_EXECUTABLE=${prefix}/bin/python3.7 \
                             -DPYTHON_SPHINX=${prefix}/bin/sphinx-build-3.7
     depends_lib-append  port:boost \
@@ -143,11 +134,11 @@ variant python37 conflicts python27 python34 python35 python36 description "Also
     require_active_variants boost python37
 }
 
-if {![variant_isset python34] && ![variant_isset python35] && ![variant_isset python36] && ![variant_isset python37]} {
+if {![variant_isset python35] && ![variant_isset python36] && ![variant_isset python37]} {
     default_variants +python27
 }
 
-if {![variant_isset python27] && ![variant_isset python34] && ![variant_isset python35] && ![variant_isset python36] && ![variant_isset python37]} {
+if {![variant_isset python27] && ![variant_isset python35] && ![variant_isset python36] && ![variant_isset python37]} {
     configure.args-append -DWITH_VIGRANUMPY=NO
 }
 


### PR DESCRIPTION
#### Description
This PR removes variants and/or subports that use obsolete Python versions for ports that have no dependencies. In ```quickfix``` the ```python34``` variant was replaced with a ```python37``` variant if not yet present.

Please note that the development of ```inkscape-text``` has moved to https://github.com/textext/textext and there are newer versions available. A newer version is also available for ```quickfix``` (```quickfix seems to have been updated (port version: 1.14.3, new version: 1.15.1)```) - I encourage the maintainers to update these ports.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`? Only, if subports were added.
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
