### PR TITLE
jrnl: move from Python 3.4 to 3.7

### DIFF
--- a/office/jrnl/Portfile
+++ b/office/jrnl/Portfile
@@ -1,11 +1,12 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8::et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
+# upon next update change GitHub location to jrnl-org
 github.setup        maebert jrnl 1.9.0 v
-revision            2
+revision            3
 maintainers         {g5pw @g5pw} openmaintainer
 categories          office
 description         ${name} is a simple journal application for your command line.
@@ -16,17 +17,18 @@ long_description    ${description} Journals are stored as human readable plain \
                     journal applications will long be forgotten.
 platforms           darwin
 license             MIT
-homepage            https://maebert.github.io/jrnl/
+homepage            https://jrnl.sh/
 
-python.default_version      34
+python.default_version 37
 
-depends_build       port:py${python.version}-setuptools
-depends_lib         port:py${python.version}-parsedatetime \
+depends_lib-append  port:py${python.version}-parsedatetime \
                     port:py${python.version}-tz \
                     port:py${python.version}-keyring \
                     port:py${python.version}-six \
                     port:py${python.version}-dateutil \
-                    port:py${python.version}-tzlocal
+                    port:py${python.version}-tzlocal \
+                    port:py${python.version}-setuptools
 
 checksums           rmd160  520411bcba201a228510bdb6f39d1f9d7a40c184 \
-                    sha256  ebc5f8c2efe39f90f82cbaf37b0e137576a39c966ebbaa9db3aa37278ab7462a
+                    sha256  ebc5f8c2efe39f90f82cbaf37b0e137576a39c966ebbaa9db3aa37278ab7462a \
+                    size    168064


### PR DESCRIPTION
#### Description
This PR changes the default Python version used by ```jrnl``` to 3.7 and replaces the ```python34``` variant in ```coccinelle``` with ```python37``` (other changes in the commit messages).

Please note: both ports are out-of-date, I'll leave it to the maintainer to update them. 

Additionally, ```coccinelle``` doesn't build but that is unrelated to this PR as it happens on the [buildbots as well](https://ports.macports.org/port/coccinelle/summary) - perhaps related to [Trac ticket 59446](https://trac.macports.org/ticket/59446)?

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
