### PR TITLE
google-cloud-sdk: update to 274.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             273.0.0
+version             274.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  dec83593ec4500293418c158ada622fd6d6c6ffc \
-                    sha256  8e3e94b207025181dde5ee12304d46af880ba6f82579da40347ac856def048bc \
-                    size    22880794
+    checksums       rmd160  974e11cad8ca9e4caedd4cec158748fd8b97c5b3 \
+                    sha256  6a2546806c67b186847c4aa296185100d9dc57a5521f3d46deae19575696a452 \
+                    size    23077531
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  61001c7f92d4f0dd2e9a0cc47a5fe70ca0d93a59 \
-                    sha256  bf5057707b971f48edef4262123d6012e138e840990ff873ed83494b293f3409 \
-                    size    22881157
+    checksums       rmd160  f070ddab0d5ae115977b8ea3a467b8329545b98f \
+                    sha256  1543e0c2efa1ab1b23c149e5dad3654e288f2b202f6382ef2141ee7922f24c84 \
+                    size    23082332
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 274.0.0.

###### Tested on

macOS 10.15.2 19C57
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?