### PR TITLE
GPXLab: New port

### DIFF
--- a/gis/GPXLab/Portfile
+++ b/gis/GPXLab/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           qmake5 1.0
+
+github.setup        BourgeoisLab GPXLab 0.7.0 v
+categories          gis
+platforms           darwin
+license             GPL-3
+maintainers         {@sikmir gmail.com:sikmir} openmaintainer
+
+description         Program to show and manipulate GPS tracks
+long_description    GPXLab is an application to display and manage GPS tracks \
+                    previously recorded with a GPS tracker.
+
+checksums           rmd160  f9641281c8115c87916ecab57a02b6d6fc257d56 \
+                    sha256  850f3a581bf8448efce199c0e24f8609a4c92fa304e1da579b8e8cf063544e57 \
+                    size    1082125
+
+qt5.depends_build_component     qttools
+qt5.depends_runtime_component   qtimageformats qttranslations
+
+post-configure {
+    system -W ${worksrcpath} "${qt_lrelease_cmd} GPXLab/GPXLab.pro"
+}
+
+destroot {
+    copy ${worksrcpath}/GPXLab/GPXLab.app ${destroot}${applications_dir}
+}


### PR DESCRIPTION
#### Description

[GPXLab](https://github.com/BourgeoisLab/GPXLab) - program to show and manipulate GPS tracks.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
