### PR TITLE
wireguard-tools: update to 0.0.20191219

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-tools
-version             0.0.20191212
+version             0.0.20191219
 revision            0
-checksums           rmd160  47174730d7b270ac576bfb3f0847fc327d8406ff \
-                    sha256  b0d718380f7a8822b2f12d75e462fa4eafa3a77871002981f367cd4fe2a1b071 \
-                    size    333024
+checksums           rmd160  7cb2d054fb56c88360276150b77e4bd787d264dd \
+                    sha256  5aba6f0c38e97faa0b155623ba594bb0e4bd5e29deacd8d5ed8bda8d8283b0e7 \
+                    size    332596
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
###### Tested on
macOS 10.13.6 17G8037
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?