### PR TITLE
ImageMagick: add support for HEIC images

### DIFF
--- a/graphics/ImageMagick/Portfile
+++ b/graphics/ImageMagick/Portfile
@@ -10,7 +10,7 @@ PortGroup                   conflicts_build 1.0
 
 name                        ImageMagick
 version                     6.9.10-78
-revision                    0
+revision                    1
 checksums                   rmd160  de36eb0634ca80f8ded6cbf50dbc9a1858a59cc0 \
                             sha256  1801df8a4f64ef040ba9d8040ad4128c26d72b6245e818c0e65070904f541a9d \
                             size    9063344
@@ -64,7 +64,8 @@ depends_lib                 port:bzip2 \
                             port:openjpeg \
                             port:openexr \
                             port:expat \
-                            port:libxml2
+                            port:libxml2 \
+                            port:libheif
 
 # Magick-config etc. use pkg-config
 depends_lib-append          port:pkgconfig
@@ -97,6 +98,7 @@ configure.args              --enable-shared \
                             --with-zlib \
                             --with-modules \
                             --with-xml \
+                            --with-heic \
                             --without-gcc-arch \
                             --without-perl \
                             --without-fpx \


### PR DESCRIPTION
#### Description

Uses the newly-added libheif port to enable working with HEIC images (as produced by default by e.g. modern iOS devices).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.2 19C57
Xcode 11.3 11C29 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
