### PR TITLE
nebula: new port

### DIFF
--- a/net/nebula/Portfile
+++ b/net/nebula/Portfile
@@ -1,0 +1,65 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        slackhq nebula 1.0.0 v
+
+categories          net
+license             MIT
+platforms           darwin
+
+maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
+
+checksums           rmd160  8d33d443ee8a5d7ebe121fb378807d4d0b211b41 \
+                    sha256  fa5d0afa58f93bf115143f65f26dfa4025dff4797b8708b8e56b672c58d48dea \
+                    size    104683
+
+description         A scalable overlay networking tool with a focus on \
+                    performance, simplicity and security.
+
+long_description    Nebula is a scalable overlay networking tool with a focus \
+                    on performance, simplicity and security. It lets you \
+                    seamlessly connect computers anywhere in the world. \
+                    Nebula is portable, and runs on Linux, OSX, and Windows. \
+                    It can be used to connect a small number of computers, \
+                    but is also able to connect tens of thousands of computers.
+
+depends_build       port:go
+
+build.env           BUILD_NUMBER="${version}"
+build.target        bin-darwin
+
+use_configure       no
+use_parallel_build  no
+installs_libs       no
+
+set neb_share_dir   ${prefix}/share/${name}
+set neb_conf_dir    ${prefix}/etc/${name}
+set neb_example_dir ${neb_share_dir}/examples
+
+set neb_sample_config   ${neb_example_dir}/config.yaml
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/build/darwin/nebula \
+      ${destroot}${prefix}/bin/
+
+    xinstall -m 755 ${worksrcpath}/build/darwin/nebula-cert \
+      ${destroot}${prefix}/bin/
+
+    xinstall -d ${destroot}${neb_conf_dir}
+    xinstall -d ${destroot}${neb_example_dir}
+
+    copy {*}[glob ${worksrcpath}/examples/*] ${destroot}${neb_example_dir}
+
+    reinplace "s|/etc/nebula|${prefix}/etc/nebula|g" \
+      ${destroot}${neb_sample_config}
+}
+
+destroot.keepdirs   ${destroot}${neb_conf_dir}
+
+notes "
+  Example configuration for Nebula can be found in:
+
+    ${neb_example_dir}
+"


### PR DESCRIPTION
#### Description

New port for Slack's [Nebula](https://github.com/slackhq/nebula)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.2 19C57
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
