### PR TITLE
git-secret: Adding new port

### DIFF
--- a/devel/git-secret/Portfile
+++ b/devel/git-secret/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+
+github.setup            sobolevn git-secret 0.3.2 v
+revision                0
+homepage                https://git-secret.io/
+categories              devel
+platforms               darwin
+
+maintainers             @pedrohdz \
+                        openmaintainer
+
+license                 MIT
+checksums               rmd160  13f41a485bb0f5b1c7f4ea2174f2b4f3b1a6b1e8 \
+                        sha256  b7e95ed46339b3a04869ac5e82e3b225fcdaf0138000c0b25a078a6303ce5087
+
+description             Bash tool to store private data inside a git repo.
+long_description        A bash tool to store your private data inside a git \
+                        repo. How’s that? Basically, it just encrypts, using \
+                        gpg, the tracked files with the public keys of all \
+                        the users that you trust. So everyone of them can \
+                        decrypt these files using only their personal secret \
+                        key. Why deal with all this private-public keys \
+                        stuff?  Well, to make it easier for everyone to \
+                        manage access rights.  There are no passwords that \
+                        change. When someone is out - just delete their \
+                        public key, reencrypt the files, and they won’t be \
+                        able to decrypt secrets anymore.
+
+depends_run             bin:bash:bash \
+                        bin:git:git \
+                        bin:gpg:gnupg2
+
+destroot.args-append    PREFIX="${prefix}"
+use_configure           no


### PR DESCRIPTION
git-secret is a bash tool to store private data inside a git repo.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Adding a port for https://git-secret.io/


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G103
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
