### PR TITLE
libtasn1: Add -std=c99

### DIFF
--- a/devel/libtasn1/Portfile
+++ b/devel/libtasn1/Portfile
@@ -28,6 +28,9 @@ checksums       rmd160  2bd63ef37c5656f5bb1860a481f0f360bcf636a1 \
 configure.args  --disable-gcc-warnings \
                 --disable-silent-rules
 
+# gcc-4 on OS X 10.5 defaults to gnu89 which is "ISO C90 plus GNU extensions". We need C99.
+configure.cflags-append  -std=c99
+
 test.run        yes
 test.target     check
 


### PR DESCRIPTION
gcc-4 on OS X 10.5 defaults to gnu89

Closes: https://trac.macports.org/ticket/59809

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.5.8 9L31a
Xcode 3.1.4 DevToolsSupport-1186.0 9M2809 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
