### PR TITLE
trash: Fix build on Lion and older

### DIFF
--- a/sysutils/trash/Portfile
+++ b/sysutils/trash/Portfile
@@ -21,7 +21,8 @@ checksums           rmd160  b41da8fb4080842fc11e4e2b77d00f60c33894c6 \
 
 depends_build       bin:pod2man:perl5
 
-patchfiles          patch-Makefile.diff
+patchfiles          patch-Makefile.diff \
+                    patch-HGUtils.m-lion.diff
 
 configure.cmd       printenv
 configure.pre_args

--- a/sysutils/trash/files/patch-HGUtils.m-lion.diff
+++ b/sysutils/trash/files/patch-HGUtils.m-lion.diff
@@ -1,0 +1,27 @@
+--- HGUtils.m.orig
++++ HGUtils.m
+@@ -29,6 +29,10 @@
+ 
+ #import "HGUtils.h"
+ 
++#if __has_include(<Availability.h>)
++#include <Availability.h>
++#endif
++
+ 
+ NSString *stringFromFileSize(long long aSize)
+ {
+@@ -37,11 +41,13 @@ NSString *stringFromFileSize(long long aSize)
+     // Finder uses SI prefixes for file sizes and disk capacities
+     // (since Snow Leopard) so we'll do the same here.
+     //
++#if defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && defined(__MAC_10_8) && __MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_8
+     if (NSClassFromString(@"NSByteCountFormatter")) {
+         return [NSByteCountFormatter
+             stringFromByteCount: aSize
+             countStyle: NSByteCountFormatterCountStyleFile];
+     }
++#endif
+     
+     CGFloat kilo = 1000.0;
+     


### PR DESCRIPTION
The original code uses the `NSByteCountFormatter` class, which only exists in Mountain Lion and later. To allow running on older systems, the code checks at runtime whether the class exists, and uses a fallback implementation otherwise. However because this is purely a runtime check, *compiling* the code still requires the `NSByteCountFormatter` header, which breaks builds on Lion and older.

This change adds a compile-time version check for building with a pre-10.8 SDK, in which case the fallback implementation without `NSByteCountFormatter` is always used.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.7
Xcode 4.6.3

macOS 10.14
Xcode 11.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~ (n/a)
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] ~~tried existing tests with `sudo port test`?~~ (n/a)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
