### PR TITLE
starship: update to 0.32.2

### DIFF
--- a/sysutils/starship/Portfile
+++ b/sysutils/starship/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        starship starship 0.31.0 v
+github.setup        starship starship 0.32.2 v
 categories          sysutils
 platforms           darwin
 maintainers         {l2dy @l2dy} \
@@ -17,9 +17,9 @@ description         a minimal, blazing fast, and extremely customizable prompt f
 long_description    Starship is ${description}.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  011df2097d63a88161fd67cacf7d5ab07b377854 \
-                    sha256  237cd922e5adaba0f68b7f113b371186050581f2c43561a3a798c7c24efe995d \
-                    size    4384104
+                    rmd160  cc6c39f9f0abfbea25afaf93210050428e66a2d8 \
+                    sha256  f714c5a8cbbcfb658cb54a96257a645ab457e471d0444488a71f0bed90ca03a3 \
+                    size    5114475
 
 # For crate:openssl-sys
 depends_build       port:pkgconfig
@@ -34,6 +34,7 @@ cargo.crates \
     aho-corasick                     0.7.6  58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d \
     ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
     ansi_term                       0.12.1  d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2 \
+    anyhow                          1.0.25  9267dff192e68f3399525901e709a48c1d3982c9c072fa32f2127a0cb0babf14 \
     arrayref                         0.3.5  0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee \
     arrayvec                         0.5.1  cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8 \
     arrayvec                        0.4.12  cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9 \
@@ -45,6 +46,7 @@ cargo.crates \
     battery                          0.7.5  36a698e449024a5d18994a815998bf5e2e4bc1883e35a7d7ba95b6b69ee45907 \
     bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
     blake2b_simd                     0.5.9  b83b7baab1e671718d78204225800d6b170e648188ac7dc992e9d6bddf87d0c0 \
+    bumpalo                          2.6.0  ad807f2fc2bf185eeb98ff3a901bd46dc5ad58163d0fa4577ba0d25674d71708 \
     byte-unit                        3.0.3  6894a79550807490d9f19a138a6da0f8830e70c83e83402dd23f16fd6c479056 \
     byteorder                        1.3.2  a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5 \
     bytes                           0.4.12  206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c \
@@ -66,6 +68,7 @@ cargo.crates \
     crossbeam-queue                  0.2.0  dfd6515864a82d2f877b42813d4553292c6659498c9a2aa31bab5a15243c2700 \
     crossbeam-utils                  0.7.0  ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4 \
     crossbeam-utils                  0.6.6  04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6 \
+    ct-logs                          0.6.0  4d3686f5fa27dbc1d76c751300376e167c5a43387f44bb451fd1c24776e49113 \
     dirs                             2.0.2  13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3 \
     dirs-sys                         0.3.4  afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b \
     doc-comment                      0.3.1  923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97 \
@@ -78,8 +81,6 @@ cargo.crates \
     failure_derive                   0.1.6  0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08 \
     flate2                          1.0.13  6bd6d6f4752952feb71363cffc9ebac9411b75b87c6ab6058c40c8900cf43c0f \
     fnv                              1.0.6  2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3 \
-    foreign-types                    0.3.2  f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1 \
-    foreign-types-shared             0.1.1  00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b \
     fuchsia-cprng                    0.1.1  a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba \
     fuchsia-zircon                   0.3.3  2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
     fuchsia-zircon-sys               0.3.3  3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
@@ -89,19 +90,21 @@ cargo.crates \
     getrandom                       0.1.13  e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407 \
     git2                            0.11.0  77519ef7c5beee314d0804d4534f01e0f9e8d9acdee2b7a48627e590b27e0ec4 \
     h2                              0.1.26  a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462 \
+    heck                             0.3.1  20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205 \
     hermit-abi                       0.1.5  f629dc602392d3ec14bfc8a09b5e644d7ffd725102b48b81e59f90f2633621d7 \
     http                            0.1.21  d6ccf5ede3a895d8856620237b2f02972c1bbc78d2965ad7fe8838d4a0ed41f0 \
     http-body                        0.1.0  6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d \
     httparse                         1.3.4  cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9 \
     humantime                        1.3.0  df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f \
     hyper                          0.12.35  9dbe6ed1438e1f8ad955a4701e9a944938e9519f6888d12d8558b645e247d5f6 \
-    hyper-tls                        0.3.2  3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f \
+    hyper-rustls                    0.17.1  719d85c7df4a7f309a77d145340a063ea929dcb2e025bae46a80345cffec2952 \
     idna                             0.1.5  38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e \
     idna                             0.2.0  02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9 \
     indexmap                         1.3.0  712d7b3ea5827fcb9d4fda14bf4da5f136f0db2ae9c8f4bd4e2d1c6fde4e6db2 \
     iovec                            0.1.4  b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e \
     itoa                             0.4.4  501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f \
     jobserver                       0.1.17  f2b1d42ef453b30b7387e113da1c83ab1605d90c5b4e0eb8e96d016ed3b8c160 \
+    js-sys                          0.3.33  367647c532db6f1555d7151e619540ec5f713328235b8c062c6b4f63e84adfe3 \
     kernel32-sys                     0.2.2  7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
     lazycell                         1.2.1  b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f \
@@ -122,10 +125,10 @@ cargo.crates \
     miniz_oxide                      0.3.5  6f3f74f726ae935c3f514300cc6773a0c9492abc5e972d42ba0c0ebb88757625 \
     mio                             0.6.21  302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f \
     miow                             0.2.1  8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919 \
-    native-tls                       0.2.3  4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e \
     net2                            0.2.33  42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88 \
     nix                             0.15.0  3b2e0b4f3320ed72aaedb9a5ac838690a8047c7b275da22711fddff4f8a14229 \
     nodrop                          0.1.14  72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb \
+    nom                              4.2.3  2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6 \
     nom                              5.0.1  c618b63422da4401283884e6668d39f819a106ef51f5f59b81add00075da35ca \
     ntapi                            0.3.3  f26e041cd983acbc087e30fcba770380cfa352d0e392e175b2344ebaf7ea0602 \
     num-integer                     0.1.41  b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09 \
@@ -133,9 +136,6 @@ cargo.crates \
     num_cpus                        1.11.1  76dac5ed2a876980778b8b85f75a71b6cbf0db0b1232ee12f826bccb00d09d72 \
     once_cell                        1.2.0  891f486f630e5c5a4916c7e16c4b24a53e78c860b646e9f8e005e4f16847bfed \
     open                             1.3.2  94b424e1086328b0df10235c6ff47be63708071881bead9e76997d9291c0134b \
-    openssl                        0.10.26  3a3cc5799d98e1088141b8e01ff760112bbd9f19d850c124500566ca6901a585 \
-    openssl-probe                    0.1.2  77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de \
-    openssl-sys                     0.9.53  465d16ae7fc0e313318f7de5cecf57b2fbe7511fd213978b457e1c96ff46736f \
     os_info                          1.2.0  0d46cac13d062d40f1284a3927cb86edf3a4d7b6df38dad4124c510819166695 \
     parking_lot                      0.9.0  f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252 \
     parking_lot_core                 0.6.2  b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b \
@@ -163,8 +163,8 @@ cargo.crates \
     rand_os                          0.1.3  7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071 \
     rand_pcg                         0.1.2  abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44 \
     rand_xorshift                    0.1.1  cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c \
-    rayon                            1.2.1  43739f8831493b276363637423d3622d4bd6394ab6f0a9c4a552e208aeb7fddd \
-    rayon-core                       1.6.1  f8bf17de6f23b05473c437eb958b9c850bfc8af0961fe17b4cc92d5a627b4791 \
+    rayon                            1.3.0  db6ce3297f9c85e16621bb8cca38a06779ffc31bb8184e1be4bed2be4678a098 \
+    rayon-core                       1.7.0  08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9 \
     rdrand                           0.4.0  678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2 \
     redox_syscall                   0.1.56  2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84 \
     redox_users                      0.3.1  4ecedbca3bf205f8d8f5c2b44d83cd0690e39ee84b951ed649e9f1841132b66d \
@@ -172,14 +172,14 @@ cargo.crates \
     regex-syntax                    0.6.12  11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716 \
     remove_dir_all                   0.5.2  4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e \
     reqwest                         0.9.24  f88643aea3c1343c804950d7bf983bd2067f5ab59db6d613a08e05572f2714ab \
+    ring                            0.16.9  6747f8da1f2b1fabbee1aaa4eb8a11abf9adef0bf58a41cee45db5d59cecdfac \
     rust-argon2                      0.5.1  4ca4eaef519b494d1f2848fc602d18816fed808a981aedf4f1f00ceb7c9d32cf \
     rustc-demangle                  0.1.16  4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783 \
     rustc_version                    0.2.3  138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a \
+    rustls                          0.16.0  b25a18b1bf7387f0145e7f8324e700805aade3842dd3db2e74e4cdeb4677c09e \
     ryu                              1.0.2  bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8 \
-    schannel                        0.1.16  87f550b06b6cba9c8b8be3ee73f391990116bf527450d2556e9b9ce263b9a021 \
     scopeguard                       1.0.0  b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d \
-    security-framework               0.3.4  8ef2429d7cefe5fd28bd1d2ed41c944547d4ff84776f5935b456da44593a16df \
-    security-framework-sys           0.3.3  e31493fc37615debb8c5090a7aeb4a9730bc61e77ab10b9af59f1a202284f895 \
+    sct                              0.6.0  e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c \
     semver                           0.9.0  1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403 \
     semver-parser                    0.7.0  388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
     serde                          1.0.104  414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449 \
@@ -189,6 +189,8 @@ cargo.crates \
     slab                             0.4.2  c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8 \
     smallvec                         1.0.0  4ecf3b85f68e8abaa7555aa5abdb1153079387e60b718283d732f03897fcfc86 \
     smallvec                        0.6.13  f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6 \
+    sourcefile                       0.1.4  4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3 \
+    spin                             0.5.2  6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d \
     static_assertions                0.3.4  7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3 \
     string                           0.2.1  d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d \
     strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
@@ -206,6 +208,7 @@ cargo.crates \
     tokio-executor                   0.1.9  ca6df436c42b0c3330a82d855d2ef017cd793090ad550a6bc2184f4b933532ab \
     tokio-io                        0.1.12  5090db468dad16e1a7a54c8c67280c5e4b544f3d3e018f0b913b400261f85926 \
     tokio-reactor                   0.1.11  6732fe6b53c8d11178dcb77ac6d9682af27fc6d4cb87789449152e5377377146 \
+    tokio-rustls                    0.10.2  1df2fa53ac211c136832f530ccb081af9af891af22d685a9493e232c7a359bc2 \
     tokio-sync                       0.1.7  d06554cce1ae4a50f42fba8023918afa931413aded705b560e29600ccf7c6d76 \
     tokio-tcp                        0.1.3  1d14b10654be682ac43efee27401d792507e30fd8d26389e1da3b185de2e4119 \
     tokio-threadpool                0.1.17  f0c32ffea4827978e9aa392d2f743d973c1dfa3730a2ed3f22ce1e6984da848c \
@@ -220,6 +223,7 @@ cargo.crates \
     unicode-segmentation             1.6.0  e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0 \
     unicode-width                    0.1.7  caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479 \
     unicode-xid                      0.2.0  826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c \
+    untrusted                        0.7.0  60369ef7a31de49bcb3f6ca728d4ba7300d9a1658f94c727d4cab8c8d9f4aece \
     uom                             0.26.0  4cec796ec5f7ac557631709079168286056205c51c60aac33f51764bdc7b8dc4 \
     url                              1.7.2  dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a \
     url                              2.1.0  75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61 \
@@ -233,6 +237,16 @@ cargo.crates \
     void                             1.0.2  6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d \
     want                             0.2.0  b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230 \
     wasi                             0.7.0  b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d \
+    wasm-bindgen                    0.2.56  99de4b68939a880d530aed51289a7c7baee154e3ea8ac234b542c49da7134aaf \
+    wasm-bindgen-backend            0.2.56  b58e66a093a7b7571cb76409763c495b8741ac4319ac20acc2b798f6766d92ee \
+    wasm-bindgen-macro              0.2.56  a80f89daea7b0a67b11f6e9f911422ed039de9963dce00048a653b63d51194bf \
+    wasm-bindgen-macro-support      0.2.56  4f9dbc3734ad6cff6b76b75b7df98c06982becd0055f651465a08f769bca5c61 \
+    wasm-bindgen-shared             0.2.56  d907984f8506b3554eab48b8efff723e764ddbf76d4cd4a3fe4196bc00c49a70 \
+    wasm-bindgen-webidl             0.2.56  f85a3825a459cf6a929d03bacb54dca37a614d43032ad1343ef2d4822972947d \
+    web-sys                         0.3.33  2fb60433d0dc12c803b9b017b3902d80c9451bab78d27bc3210bf2a7b96593f1 \
+    webpki                          0.21.0  d7e664e770ac0110e2384769bcc59ed19e329d81f555916a6e072714957b81b4 \
+    webpki-roots                    0.17.0  a262ae37dd9d60f60dd473d1158f9fbebf110ba7b6a5051c8160460f6043718b \
+    weedle                          0.10.0  3bb43f70885151e629e2a19ce9e50bd730fd436cfd4b666894c9ce4de9141164 \
     winapi                           0.3.8  8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6 \
     winapi                           0.2.8  167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
     winapi-build                     0.1.1  2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.2 19C57
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
