### PR TITLE
Update sysutils/blueutil to v2.5.1

### DIFF
--- a/sysutils/blueutil/Portfile
+++ b/sysutils/blueutil/Portfile
@@ -3,7 +3,7 @@
 PortSystem                  1.0
 PortGroup                   github 1.0
 
-github.setup                toy blueutil 2.4.0 v
+github.setup                toy blueutil 2.5.1 v
 categories                  sysutils
 platforms                   darwin
 maintainers                 {dons.net.au:darius @DanielO}
@@ -16,10 +16,10 @@ long_description            Command line interface for Bluetooth on OSX, \
                             devices, pair new devices, connect and disconnect \
                             devices, and check if a device is connected.
 
-checksums                   sha1    de57e6a1783a89523b0aec96b1bbbac2b1dd3a0e \
-                            rmd160  e342c7a6b8112b93abccfc86fe177cd2b1db1a5d \
-                            sha256  3ddbd876885f9b79d7da8dc2f6a19b263b4c7708c6f7f1172a5320a89464066b \
-                            size    9727
+checksums                   sha1    6507cd58bbc22632350dd903ed453a024ead46f9 \
+                            rmd160  d661423901f4b5b922be87658a55a94c542c389b \
+                            sha256  b207ea049a748fa949a9532ae2691e9e800ea7ac6f29f3cbffa7efb2bbd27055 \
+                            size    10831
 
 if { ${os.platform} eq "darwin" && ${os.major} <= 12} {
     pre-fetch {


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G2022
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
