### PR TITLE
gtk-osx-application: Update to 2.1.3, fix bindings

### DIFF
--- a/devel/gtk-osx-application/Portfile
+++ b/devel/gtk-osx-application/Portfile
@@ -10,7 +10,7 @@ version         2.1.3
 license         LGPL-2.1
 set branch      [join [lrange [split ${version} .] 0 1] .]
 categories      devel
-maintainers     {elelay @elelay} openmaintainer
+maintainers     {gmail.com:g.litenstein @Lord-Kamina} openmaintainer
 
 description Mac OS X menu bar integration library for GTK quartz
 
@@ -155,28 +155,20 @@ pre-fetch {
 }
 
 subport gtk-osx-application-gtk3 {
-    PortGroup active_variants 1.1
-    
     depends_lib port:gtk-osx-application
     require_active_variants gtk-osx-application "gtk3 python37"
 }
 
 subport gtk-osx-application-common-gtk3 {
-  PortGroup           obsolete 1.0
-  
   replaced_by         gtk-osx-application
 }
 
 subport gtk-osx-application-gtk2 {
-    PortGroup active_variants 1.1
-    
     depends_lib port:gtk-osx-application
     require_active_variants gtk-osx-application "gtk2 no_introspection"
 }
 
 subport gtk-osx-application-common-gtk2 {
-  PortGroup           obsolete 1.0
-  
   replaced_by         gtk-osx-application
 }
 

--- a/devel/gtk-osx-application/Portfile
+++ b/devel/gtk-osx-application/Portfile
@@ -2,22 +2,23 @@
 
 PortSystem 1.0
 PortGroup       active_variants 1.1
+PortGroup       conflicts_build 1.0
 
 name            gtk-osx-application
 conflicts       ige-mac-integration
-version         2.0.8
+version         2.1.3
 license         LGPL-2.1
 set branch      [join [lrange [split ${version} .] 0 1] .]
 categories      devel
-maintainers     nomaintainer
+maintainers     {elelay @elelay} openmaintainer
 
-description	Mac OS X menu bar integration library for GTK2 quartz
+description Mac OS X menu bar integration library for GTK quartz
 
 long_description \
-		A simple library whose purpose is to \
-		allow GTK quartz applications to integrate with \
-		the Mac OS X menu bar. Requires gtk2 or gtk3 and its \
-		dependencies to be built with variant +quartz
+        A simple library whose purpose is to \
+        allow GTK quartz applications to integrate with \
+        the Mac OS X menu bar. Requires gtk2 or gtk3 and its \
+        dependencies to be built with variant +quartz
 
 homepage        https://wiki.gnome.org/Projects/GTK%2B/OSX/Integration
 
@@ -29,26 +30,13 @@ distname        ${myname}-${version}
 use_xz          yes
 
 # sha256 from upstream, rmd160 computed locally
-checksums       sha256    74fce9dbc5efe4e3d07a20b24796be1b1d6c3ac10a0ee6b1f1d685c809071b79 \
-                rmd160    53fd44172a3fa076e4401b6aac1adb10b76a5b7c
-
+checksums           sha256  d5f72302daad1f517932194d72967a32e72ed8177cfa38aaf64f0a80564ce454 \
+                    rmd160  3ec9e5e1063d1b4407b10bfca5389841f49bc069 \
+                    size    368108
 
 depends_build   port:pkgconfig
 
-set gtk_version gtk2
-
 pre-configure {
-
-  if {${name} eq ${subport}} {
-    ui_error "
-The gtk-osx-application port has been replaced by 'gtk-osx-application-gtk2'
-and 'gtk-osx-application-gtk3'.
-Please `sudo port deactivate gtk-osx-application`
-followed by `sudo port upgrade -u outdated` or another command to update.
-Then if all works as intended `sudo port uninstall gtk-osx-application`
-"
-    return -code error
-  }
 
   if {![active_variants $gtk_version quartz ""]} {
     ui_error "
@@ -61,116 +49,143 @@ dependencies are built with variants +quartz and try again.
   }
 }
 
-# py27-gtk-osx-application-gtk3 is not needed (only gir matters).
-# If a python gtk3 program requires gtk-osx-application, add
-#    depends_lib-append port:gtk-osx-application-gtk3 \
-#                       port:py27-gobject3
+set python_version          3.7
 
-subport py27-gtk-osx-application-gtk2 {
-    set gtk_version gtk2
+variant gtk2 requires python27 conflicts gtk3 description {Build with support for GTK+-2.0} {
+    global gtk_version
+    set gtk_version             gtk2
+    depends_lib-append          port:gtk2 \
+                                port:py27-pygtk \
+                                port:py27-gobject
+    require_active_variants     py27-gobject quartz
+    require_active_variants     py27-cairo quartz
+    require_active_variants     py27-pygtk quartz
+    require_active_variants     libglade2 quartz
+    configure.args-append       --with-gtk2 --without-gtk3 --enable-introspection=yes
+}
 
-    depends_lib-append port:py27-pygtk \
-                       port:gtk-osx-application-gtk2
-    
-    set python_prefix           ${frameworks_dir}/Python.framework/Versions/2.7
+variant gtk3 conflicts gtk2 description {Build with support for GTK+-3.0} {
+    global gtk_version
+    set gtk_version             gtk3
+    depends_lib-append          port:gtk3
+    configure.args-append       --with-gtk3 --without-gtk2 --enable-introspection=yes
+}
 
-    configure.python            ${python_prefix}/bin/python2.7
-    configure.env-append        PYGTK_CODEGEN=${python_prefix}/bin/pygtk-codegen-2.0
-    configure.env-append        PYGOBJECT_CODEGEN=${python_prefix}/bin/pygobject-codegen-2.0
-    configure.pkg_config_path   ${python_prefix}/lib/pkgconfig/
-    configure.pre_args          --prefix=${python_prefix}
+variant python27 conflicts python35 python36 python37 python38 description {Build bindings for Python 2.7} {
+    depends_lib-append          port:python27
+    require_active_variants     py27-cairo quartz
+}
 
+variant python35 requires gtk3 conflicts python27 python36 python37 python38 description {Build bindings for Python 3.5} {
+    depends_lib-append          port:python35
+}
 
-    configure.args-append --with-gtk2 --without-gtk3 --disable-introspection
+variant python36 requires gtk3 conflicts python27 python35 python37 python38 description {Build bindings for Python 3.6} {
+    depends_lib-append          port:python36
+}
 
-    # enable-python defaults to all, but it must be set to
-    # 'yes' otherwise pygtk bindings are not built.
-    # By the way, I had no success configuring with --python=all
-    # as per README (configure rejected the option).
-    # So no gir for gtk2 variant
-    configure.args-append --enable-python=yes
-    
-    post-destroot {
-        delete ${destroot}${prefix}/include
-        delete ${destroot}${prefix}/lib
-        delete ${destroot}${prefix}/share
+variant python37 requires gtk3 conflicts python27 python35 python36 python38 description {Build bindings for Python 3.7} {
+    depends_lib-append          port:python37
+}
+
+variant python38 requires gtk3 conflicts python27 python35 python36 python37 description {Build bindings for Python 3.8} {
+    depends_lib-append          port:python38
+}
+
+if {[variant_isset python27]} {
+    global python_version
+    set python_version          2.7
+} elseif {[variant_isset python35]} {
+    global python_version
+    set python_version          3.5
+} elseif {[variant_isset python36]} {
+    global python_version
+    set python_version          3.6
+} elseif {[variant_isset python37]} {
+    global python_version
+    set python_version          3.7
+} elseif {[variant_isset python38]} {
+    global python_version
+    set python_version          3.8
+}
+
+if {![variant_isset gtk2] && ![variant_isset python27]} {
+    global python_version
+    if {![variant_isset python35] && \
+        ![variant_isset python36] && \
+        ![variant_isset python37] && \
+        ![variant_isset python38] && \
+        ![variant_isset no_introspection]} {
+            default_variants-append +python37
+        }
+    if {![variant_isset no_introspection]} {
+            default_variants-append +gtk3
     }
+    depends_lib-append [string map {. ""} port:py${python_version}-gobject3]
+    if {![variant_isset python38]} {
+            conflicts_build [string map {. ""} py${python_version}-gobject]
+    }
+} \
+elseif {[variant_isset gtk2]} {
+            default_variants-append +python27 +no_introspection
+        } \
+elseif {![variant_isset gtk2] && \
+        [variant_isset python27]} {
+            default_variants-append +gtk3
+            depends_lib-append port:py27-gobject3
+}
+
+
+set python_prefix           ${frameworks_dir}/Python.framework/Versions/${python_version}
+configure.args-append           --enable-python=yes --with-pkgconfigdir="${python_prefix}/lib/pkgconfig" --datarootdir="${prefix}/share"
+
+variant no_introspection requires gtk2 python27 conflicts gtk3 description {Disable gobject-introspection support} {
+    depends_lib-delete          port:py27-gobject
+    configure.env-append        PYGOBJECT_CODEGEN=${python_prefix}/bin/pygobject-codegen-2.0
+    configure.env-append        PYGTK_CODEGEN=${python_prefix}/bin/pygtk-codegen-2.0
+    configure.args-replace      --enable-introspection=yes --enable-introspection=no
+    configure.args-append       --disable-introspection
+}
+
+pre-fetch {
+    global python_prefix, python_version
+    set python_prefix           ${frameworks_dir}/Python.framework/Versions/${python_version}
+    configure.python            ${python_prefix}/bin/python${python_version}
+    configure.pkg_config_path   ${python_prefix}/lib/pkgconfig
 }
 
 subport gtk-osx-application-gtk3 {
-    set gtk_version gtk3
+    PortGroup active_variants 1.1
     
-    depends_lib-append port:gtk3 \
-                       path:include/gtkmacintegration/gtk-mac-bundle.h:gtk-osx-application-common-gtk3
-
-    
-    # force gtk version
-    configure.args-append --with-gtk3 --without-gtk2
-
-    configure.args-append --enable-python=no
-
-    post-destroot {
-        delete ${destroot}${prefix}/include
-        delete ${destroot}${prefix}/lib/pkgconfig/gtk-mac-integration.pc
-        delete ${destroot}${prefix}/share/strings
-    }
+    depends_lib port:gtk-osx-application
+    require_active_variants gtk-osx-application "gtk3 python37"
 }
 
 subport gtk-osx-application-common-gtk3 {
-    set gtk_version gtk3
-    
-    depends_lib-append port:gtk3
-
-    
-    # force gtk version
-    configure.args-append --with-gtk3 --without-gtk2
-
-    configure.args-append --enable-python=no
-
-    post-destroot {
-        delete ${destroot}${prefix}/lib
-        delete ${destroot}${prefix}/share/gir-1.0
-    }
+  PortGroup           obsolete 1.0
+  
+  replaced_by         gtk-osx-application
 }
 
 subport gtk-osx-application-gtk2 {
-    set gtk_version gtk2
-
-    depends_lib-append port:gtk2 \
-                       path:include/gtkmacintegration/gtk-mac-bundle.h:gtk-osx-application-common-gtk2
-
-    # force gtk version to 2.0
-    configure.args-append --with-gtk2 --without-gtk3  --disable-introspection
-
-    configure.args-append --enable-python=no
-
-    post-destroot {
-        delete ${destroot}${prefix}/include
-        delete ${destroot}${prefix}/lib/pkgconfig/gtk-mac-integration.pc
-        delete ${destroot}${prefix}/share/strings
-    }
+    PortGroup active_variants 1.1
+    
+    depends_lib port:gtk-osx-application
+    require_active_variants gtk-osx-application "gtk2 no_introspection"
 }
 
 subport gtk-osx-application-common-gtk2 {
-    set gtk_version gtk2
-
-    depends_lib-append port:gtk2
-
-    # force gtk version to 2.0
-    configure.args-append --with-gtk2 --without-gtk3 --disable-introspection
-
-    configure.args-append --enable-python=no
-
-    post-destroot {
-        delete ${destroot}${prefix}/lib
-    }
+  PortGroup           obsolete 1.0
+  
+  replaced_by         gtk-osx-application
 }
 
 configure.ccache        no
 configure.cmd-append    --libdir=${prefix}/lib --includedir=${prefix}/include
 
 patchfiles-append       patch-bindings-python-gtkmacintegration-Makefile-in.diff \
-                        patch-bindings-python-gtk_osxapplication-Makefile-in.diff
+                        patch-bindings-python-gtk_osxapplication-Makefile-in.diff \
+                        patch-configure-python-syntax.diff
 
 livecheck.type          gnome
 livecheck.name          ${myname}

--- a/devel/gtk-osx-application/files/patch-configure-python-syntax.diff
+++ b/devel/gtk-osx-application/files/patch-configure-python-syntax.diff
@@ -1,0 +1,28 @@
+--- configure.orig	2019-11-26 18:12:22.000000000 -0300
++++ configure	2019-11-26 18:13:42.000000000 -0300
+@@ -16780,12 +16780,12 @@
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for headers required to compile python extensions" >&5
+ $as_echo_n "checking for headers required to compile python extensions... " >&6; }
+ 
+-    py_prefix=`$PYTHON -c "import sys; print sys.prefix"`
+-  py_exec_prefix=`$PYTHON -c "import sys; print sys.exec_prefix"`
+-  PYTHON_INCLUDES="-I${py_prefix}/include/python${PYTHON_VERSION}"
++    py_prefix=`$PYTHON -c "import sys; print(sys.prefix)"`
++  py_exec_prefix=`$PYTHON -c "import sys; print(sys.exec_prefix)"`
++  PYTHON_INCLUDES="-I${py_prefix}/include/python${PYTHON_VERSION} -I${py_prefix}/include/python${PYTHON_VERSION}m"
+ 
+   if test "$py_prefix" != "$py_exec_prefix"; then
+-    PYTHON_INCLUDES="$PYTHON_INCLUDES -I${py_exec_prefix}/include/python${PYTHON_VERSION}"
++    PYTHON_INCLUDES="$PYTHON_INCLUDES -I${py_exec_prefix}/include/python${PYTHON_VERSION} -I${py_prefix}/include/python${PYTHON_VERSION}m"
+   fi
+ 
+ 
+@@ -17316,7 +17316,7 @@
+ fi
+ 	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking Gtk GIR" >&5
+ $as_echo_n "checking Gtk GIR... " >&6; }
+-	GIR_PATH="$PREFIX/share/gir-1.0/Gtk-3.0.gir"
++	GIR_PATH="$prefix/share/gir-1.0/Gtk-3.0.gir"
+ 	as_ac_File=`$as_echo "ac_cv_file_$GIR_PATH" | $as_tr_sh`
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $GIR_PATH" >&5
+ $as_echo_n "checking for $GIR_PATH... " >&6; }


### PR DESCRIPTION
This shouldn’t break anything for the like, whole two ports who depended on this, while also updating it and fixing python bindings and gobject-introspection support in a less roundabout-way.

Do note though that these changes depend partly on #5759 being merged.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6
Xcode 11.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files? --> I built and ran Deluge 2.0.3 as an app-bundle on top of this.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
