### PR TITLE
several ports: remove variants with obsolete Python versions

### DIFF
--- a/devel/xapian-core/Portfile
+++ b/devel/xapian-core/Portfile
@@ -177,7 +177,7 @@ foreach v {5.5 5.6 7.0 7.1 7.2 7.3} {
 }
 
 # Python
-foreach v {2.7 3.4 3.5 3.6 3.7} {
+foreach v {2.7 3.5 3.6 3.7} {
     set v_no_dot [string map {. {}} ${v}]
     if {[vercmp ${v} 3] >= 0} {
         set suffix 3

--- a/science/htcondor/Portfile
+++ b/science/htcondor/Portfile
@@ -23,7 +23,7 @@ long_description \
   HTCondor, HTCondor places them into a queue, chooses when and where to run \
   the jobs based upon a policy, carefully monitors their progress, and \
   ultimately informs the user upon completion.
-homepage                http://research.cs.wisc.edu/htcondor
+homepage                https://research.cs.wisc.edu/htcondor
 
 default_variants        +personal +kerberos
 
@@ -38,9 +38,9 @@ variant personal \
     startupitem.stop    "${prefix}/sbin/condor_off -all -master"
 }
 
-set pythons_suffixes {27 34 35 36}
+set pythons_suffixes {27 35 36}
 
-if {!([variant_isset python34] || [variant_isset python35] || [variant_isset python36])} {
+if {!([variant_isset python35] || [variant_isset python36])} {
     default_variants +python27
 }
 

--- a/science/libsbml/Portfile
+++ b/science/libsbml/Portfile
@@ -89,25 +89,19 @@ variant multi description {Enable libSBML support for the SBML Level 3 Multistat
     configure.args-append   -DENABLE_MULTI:BOOL=ON
 }
 
-variant python27 conflicts python34 description {Configure to use Python version 2.7} {
+variant python27 conflicts python35 python36 description {Configure to use Python version 2.7} {
     depends_build-append  port:swig port:swig-python
     depends_lib-append      port:python27
     configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python2.7 -DPYTHON_USE_DYNAMIC_LOOKUP:BOOL=ON
 }
 
-variant python34 conflicts python27 python35 python36 description {Configure to use Python version 3.4} {
-    depends_build-append  port:swig port:swig-python
-    depends_lib-append      port:python34
-    configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python3.4 -DPYTHON_USE_DYNAMIC_LOOKUP:BOOL=ON
-}
-
-variant python35 conflicts python27 python34 python36 description {Configure to use Python version 3.5} {
+variant python35 conflicts python27 python36 description {Configure to use Python version 3.5} {
     depends_build-append  port:swig port:swig-python
     depends_lib-append      port:python35
     configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python3.5 -DPYTHON_USE_DYNAMIC_LOOKUP:BOOL=ON
 }
 
-variant python36 conflicts python27 python34 python35 description {Configure to use Python version 3.6} {
+variant python36 conflicts python27 python35 description {Configure to use Python version 3.6} {
     depends_build-append  port:swig port:swig-python
     depends_lib-append      port:python36
     configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python3.6 -DPYTHON_USE_DYNAMIC_LOOKUP:BOOL=ON

--- a/science/plplot/Portfile
+++ b/science/plplot/Portfile
@@ -53,10 +53,7 @@ cmake.out_of_source yes
 post-patch {
     reinplace "s|-ObjC|-ObjC -framework AquaTerm|" ${worksrcpath}/cmake/modules/aqt.cmake
     reinplace "s|-framework AquaTerm|-F${frameworks_dir} -framework AquaTerm|" ${worksrcpath}/cmake/modules/aqt.cmake
-    if {[variant_isset python26]} {
-        reinplace "s|\${CMAKE_INSTALL_EXEC_PREFIX}|${frameworks_dir}/Python.framework/Versions/2.6|" \
-                            ${worksrcpath}/cmake/modules/python.cmake
-    } elseif {[variant_isset python27]} {
+    if {[variant_isset python27]} {
         reinplace "s|\${CMAKE_INSTALL_EXEC_PREFIX}|${frameworks_dir}/Python.framework/Versions/2.7|" \
                             ${worksrcpath}/cmake/modules/python.cmake
     }
@@ -217,16 +214,7 @@ variant ocaml description {Add support for OCaml} {
                             -DOCAML_HAS_GTK=OFF
 }
 
-variant python26 conflicts python27 description {Add support for python26} {
-    depends_lib-append      port:python26 \
-                            port:py26-numpy \
-                            port:swig-python
-    configure.args-delete   -DENABLE_python=OFF
-    configure.args-append   -DENABLE_python=ON \
-                            -DHAVE_NUMPY:BOOL=ON \
-                            -DPYTHON_INCLUDE_PATH=${frameworks_dir}/Python.framework/Versions/2.6/Headers
-}
-variant python27 conflicts python26 description {Add support for python27} {
+variant python27 description {Add support for python27} {
     depends_lib-append      port:python27 \
                             port:py27-numpy \
                             port:swig-python

--- a/science/plplot510/Portfile
+++ b/science/plplot510/Portfile
@@ -15,7 +15,8 @@ license         LGPL
 description     Scientific plotting package, double precision version
 master_sites    sourceforge:plplot
 checksums       rmd160  16e353cf410232da700d5f2edd1533006f2dc4c4 \
-                sha256  d4e930b8b9d43cd1663408986218d61f166de7cbc9ef5bed111b0bdea934f9d5
+                sha256  d4e930b8b9d43cd1663408986218d61f166de7cbc9ef5bed111b0bdea934f9d5 \
+                size    14766687
 homepage        http://plplot.sourceforge.net/
 set description_base "PLplot is a cross-platform software package for \
 creating scientific plots. To help accomplish that task it is organized as a \
@@ -49,10 +50,7 @@ patchfiles      patch-CMakeLists.txt.diff \
 post-patch {
     reinplace "s|-ObjC|-ObjC -framework AquaTerm|" ${worksrcpath}/cmake/modules/aqt.cmake
     reinplace "s|-framework AquaTerm|-F${frameworks_dir} -framework AquaTerm|" ${worksrcpath}/cmake/modules/aqt.cmake
-    if {[variant_isset python26]} {
-        reinplace "s|\${CMAKE_INSTALL_EXEC_PREFIX}|${frameworks_dir}/Python.framework/Versions/2.6|" \
-                            ${worksrcpath}/cmake/modules/python.cmake
-    } elseif {[variant_isset python27]} {
+    if {[variant_isset python27]} {
         reinplace "s|\${CMAKE_INSTALL_EXEC_PREFIX}|${frameworks_dir}/Python.framework/Versions/2.7|" \
                             ${worksrcpath}/cmake/modules/python.cmake
     }
@@ -214,16 +212,7 @@ variant java description {Add support for Java} {
     configure.args-append   -DENABLE_java=ON
 }
 
-variant python26 conflicts python27 description {Add support for python26} {
-    depends_lib-append      port:python26 \
-                            port:py26-numpy \
-                            port:swig-python
-    configure.args-delete   -DENABLE_python=OFF
-    configure.args-append   -DENABLE_python=ON \
-                            -DHAVE_NUMPY:BOOL=ON \
-                            -DPYTHON_INCLUDE_PATH=${frameworks_dir}/Python.framework/Versions/2.6/Headers
-}
-variant python27 conflicts python26 description {Add support for python27} {
+variant python27 description {Add support for python27} {
     depends_lib-append      port:python27 \
                             port:py27-numpy \
                             port:swig-python
@@ -237,12 +226,6 @@ variant py27_pyqt4 requires python27 description {Add support for pyQT4 using py
     depends_lib-append      port:py27-pyqt4
     configure.args-delete   -DENABLE_pyqt4=OFF
     configure.args-append   -DENABLE_pyqt4=ON
-}
-
-variant gdc description {Add support for D} {
-    depends_lib-append      port:gdc
-    configure.args-delete   -DENABLE_d=OFF
-    configure.args-append   -DENABLE_d=ON
 }
 
 variant aquaterm description {Add support for Aquaterm} {

--- a/shells/xonsh/Portfile
+++ b/shells/xonsh/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  f2bc6f32f4c02a030cfce935178dd87bb7ae96b1 \
                     sha256  ad469eccc0b53638af772babffc44450b0d5a89ea9f40fff13d2666377eeb699 \
                     size    2432219
 
-python.versions     34 35 36 37 38
+python.versions     36 37 38
 
 depends_lib-append  port:py${python.version}-prompt_toolkit \
                     port:py${python.version}-pygments \
@@ -43,6 +43,6 @@ variant python38 conflicts python36 python37 description {Use Python 3.8} {
     python.default_version 38
 }
 
-if {![variant_isset python34] && ![variant_isset python35] && ![variant_isset python36] && ![variant_isset python38]} {
+if {![variant_isset python36] && ![variant_isset python38]} {
     default_variants +python37
 }

--- a/sysutils/salt/Portfile
+++ b/sysutils/salt/Portfile
@@ -14,7 +14,7 @@ description        Salt is a Python-based remote execution, automation, \
 long_description    SaltStack is fast, scalable and flexible software for data \
                     center automation, from infrastructure and any cloud, \
                     to the entire application stack.
-homepage            http://saltstack.com/
+homepage            https://saltstack.com/
 
 if {$subport eq $name} {
     PortGroup               github 1.0
@@ -23,7 +23,7 @@ if {$subport eq $name} {
     github.setup            saltstack salt ${version} v
     revision                1
 
-    python.versions         27 34 35 36
+    python.versions         27 35 36
     categories              sysutils python
 
     checksums       rmd160  47b77490e40fdc2ec4c5d262003afecdb0b8e94a \
@@ -32,11 +32,11 @@ if {$subport eq $name} {
 
     notes    "Salt startupitems are installed by subports salt-minion, salt-master, salt-syndic, salt-api."
 
-    if {![variant_isset python34] && ![variant_isset python35] && ![variant_isset python36]} {
+    if {![variant_isset python35] && ![variant_isset python36]} {
         default_variants +python27
     }
 
-    variant python27 conflicts python34 python35 python36 description {python-2.7 support} {
+    variant python27 conflicts python35 python36 description {python-2.7 support} {
         python.default_version 27
         depends_build       port:py${python.version}-setuptools
 
@@ -51,20 +51,7 @@ if {$subport eq $name} {
         notes    "Salt startupitems are installed by subports salt-minion, salt-master, salt-syndic, salt-api."
     }
 
-    variant python34 conflicts python27 python35 python36 description {python-3.4 support} {
-        python.default_version 34
-        depends_build       port:py${python.version}-setuptools
-
-        depends_lib-append  port:py${python.version}-yaml \
-                            port:py${python.version}-jinja2 \
-                            port:py${python.version}-msgpack \
-              port:py${python.version}-tornado \
-              port:py${python.version}-zmq
-
-        destroot.cmd-append --with-salt-version=${version}
-    }
-
-    variant python35 conflicts python27 python34 python36 description {python-3.5 support} {
+    variant python35 conflicts python27 python36 description {python-3.5 support} {
         python.default_version 35
         depends_build       port:py${python.version}-setuptools
 
@@ -77,7 +64,7 @@ if {$subport eq $name} {
         destroot.cmd-append --with-salt-version=${version}
     }
 
-    variant python36 conflicts python27 python34 python35 description {python-3.6 support} {
+    variant python36 conflicts python27 python35 description {python-3.6 support} {
         python.default_version 36
         depends_build       port:py${python.version}-setuptools
 

--- a/textproc/unicode/Portfile
+++ b/textproc/unicode/Portfile
@@ -21,9 +21,9 @@ checksums           rmd160  d0c19391989c6afa845377232d3e54483c8fbcc3 \
 
 worksrcdir          ${name}
 
-depends_run         port:python34
+depends_run         port:python37
 
-configure.python    ${prefix}/bin/python3.4
+configure.python    ${prefix}/bin/python3.7
 
 use_configure       no
 
@@ -40,7 +40,7 @@ destroot {
 }
 
 if {${name} eq ${subport}} {
-    revision            0
+    revision            1
 
     description         displays properties for a given Unicode character \
                         or searches for a given character name
@@ -56,7 +56,7 @@ if {${name} eq ${subport}} {
 }
 
 subport paracode {
-    revision            0
+    revision            1
 
     description         converts UTF-8 input to use different codepoints
 


### PR DESCRIPTION
#### Description
This PR removes variants for obsolete Python versions from several ports or switches to Python 3.7 as the default Python version.

Please note that several of these ports are out-of-date, it would be good if the maintainers do update them.
```
htcondor seems to have been updated (port version: 8_8_1, new version: 8_8_6)
libsbml seems to have been updated (port version: 5.17.0, new version: 5.18.0)
plplot510 seems to have been updated (port version: 5.10.0, new version: 5.15.0)
salt seems to have been updated (port version: 2019.2.0, new version: 2019.8)
```

###### Tested on
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? 
- [ ] tried a full install with `sudo port -vst install`? 
- [ ] tested basic functionality of all binary files? 

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
