### PR TITLE
ext4fuse: add +external variant to build against upstream osxfuse

### DIFF
--- a/fuse/ext4fuse/Portfile
+++ b/fuse/ext4fuse/Portfile
@@ -34,3 +34,9 @@ build.target
 destroot            {
     xinstall -m 755 ${worksrcpath}/ext4fuse ${destroot}${prefix}/bin/
 }
+
+variant external description {Build against an external installation of osxfuse} {
+    depends_lib-delete  path:lib/libfuse.dylib:osxfuse
+
+    build.env-append    PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+}


### PR DESCRIPTION
#### Description

There is a bit of a [situation](https://github.com/macports/macports-ports/commit/e3205bcb316f8159267330af142db0c1557bbd40#diff-2c53e35181b251d8ade09454ceffc346R7-R10) going on with osxfuse preventing upgrading of the port to a version that will work on Catalina.

I needed to install ext4fuse, and came up with this as a way to get it done. If people aren't comfortable with this, I'm happy to keep it to myself.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.2 19C57
Xcode 11.3 11C29 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
