### PR TITLE
qri: new port

### DIFF
--- a/devel/qri/Portfile
+++ b/devel/qri/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        qri-io qri 0.9.3 v
+
+categories          devel net
+license             GPL-3
+platforms           darwin
+
+maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
+
+checksums           rmd160  33f399e9856177d43dc7f10d8b24295b13b09389 \
+                    sha256  9207e22b5a47e1f258e591d81d403d983d028d81dac6d7120c545022346a1302 \
+                    size    4465272
+
+description         A global dataset version control system (GDVCS) built on \
+                    the distributed web.
+
+long_description    Qri is a global dataset version control system (GDVCS) \
+                    built on the distributed web. Qri is global, specific to \
+                    datasets, provides version control and runs on the \
+                    distributed web, seeking to  solve common data problems \
+                    around discovery, trust, friction & synchronization.
+
+homepage            https://qri.io/
+
+depends_build       port:go
+build.env           GO111MODULE=on
+build.target        build
+
+installs_libs       no
+use_configure       no
+use_parallel_build  no
+
+destroot {
+    set gopath [exec go env GOPATH]
+    copy "${gopath}/bin/qri" ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

New port for [Qri](https://qri.io/)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.2 19C57
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
