### PR TITLE
spdlog: update to version 1.4.2

### DIFF
--- a/devel/spdlog/Portfile
+++ b/devel/spdlog/Portfile
@@ -17,7 +17,7 @@ long_description    ${description}
 # only header files are installed, but C++11 is still required for build tests
 supported_archs     noarch
 compiler.cxx_standard   2011
-compiler.thread_local_storage yes
+compiler.blacklist-append {clang < 800}
 
 checksums           rmd160  ae10e5e58aee686ddcec0d55883005e7701e2b39 \
                     sha256  c571ebdf3c5bb6d25c8593d4fa402b94d7d10cc05e049855525f1ddd28c58d12 \

--- a/devel/spdlog/Portfile
+++ b/devel/spdlog/Portfile
@@ -17,6 +17,7 @@ long_description    ${description}
 # only header files are installed, but C++11 is still required for build tests
 supported_archs     noarch
 compiler.cxx_standard   2011
+compiler.thread_local_storage yes
 
 checksums           rmd160  ae10e5e58aee686ddcec0d55883005e7701e2b39 \
                     sha256  c571ebdf3c5bb6d25c8593d4fa402b94d7d10cc05e049855525f1ddd28c58d12 \

--- a/devel/spdlog/Portfile
+++ b/devel/spdlog/Portfile
@@ -18,6 +18,6 @@ long_description    ${description}
 supported_archs     noarch
 compiler.cxx_standard   2011
 
-checksums           rmd160  190ed785179ac24bd8a73cc25d094599aa916c79 \
-                    sha256  821c85b120ad15d87ca2bc44185fa9091409777c756029125a02f81354072157 \
-                    size    260262
+checksums           rmd160  ae10e5e58aee686ddcec0d55883005e7701e2b39 \
+                    sha256  c571ebdf3c5bb6d25c8593d4fa402b94d7d10cc05e049855525f1ddd28c58d12 \
+                    size    260286

--- a/devel/spdlog/Portfile
+++ b/devel/spdlog/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cmake  1.1
 
 github.setup        gabime spdlog 1.4.2 v
-#revision            0
+revision            0
 categories          devel
 platforms           darwin
 maintainers         {protomail.com:XNephila @XNephila} openmaintainer

--- a/devel/spdlog/Portfile
+++ b/devel/spdlog/Portfile
@@ -1,7 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
-PortGroup compiler_blacklist_versions 1.0
 
 PortSystem          1.0
+PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 PortGroup           cmake  1.1
 

--- a/devel/spdlog/Portfile
+++ b/devel/spdlog/Portfile
@@ -1,4 +1,5 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+PortGroup compiler_blacklist_versions 1.0
 
 PortSystem          1.0
 PortGroup           github 1.0
@@ -17,6 +18,8 @@ long_description    ${description}
 # only header files are installed, but C++11 is still required for build tests
 supported_archs     noarch
 compiler.cxx_standard   2011
+# setting "compiler.thread_local_storage yes" does not work, so for now just use blacklisting
+# See: https://lists.macports.org/pipermail/macports-dev/2019-November/041503.html
 compiler.blacklist-append {clang < 800}
 
 checksums           rmd160  ae10e5e58aee686ddcec0d55883005e7701e2b39 \

--- a/devel/spdlog/Portfile
+++ b/devel/spdlog/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake  1.1
 
-github.setup        gabime spdlog 0.16.3 v
+github.setup        gabime spdlog 1.4.2 v
 #revision            0
 categories          devel
 platforms           darwin
@@ -18,6 +18,6 @@ long_description    ${description}
 supported_archs     noarch
 compiler.cxx_standard   2011
 
-checksums           rmd160  9ab44bcae0ef239c77681df26f7df6b2324d6565 \
-                    sha256  c9c30f486de1bf06f10f1cfe0c8e528029e49d49fd324cb5accc5e8f3e31400c \
-                    size    163645
+checksums           rmd160  190ed785179ac24bd8a73cc25d094599aa916c79 \
+                    sha256  821c85b120ad15d87ca2bc44185fa9091409777c756029125a02f81354072157 \
+                    size    260262


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Update spdlog lib to 1.4.2

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.2
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
