### PR TITLE
cppunit: fix error with -Wdefaulted-function-deleted

### DIFF
--- a/devel/cppunit/Portfile
+++ b/devel/cppunit/Portfile
@@ -31,6 +31,9 @@ checksums           rmd160 36dcc92cadcde49c70f23d5340be6cdbe66b1c45 \
                     sha256 1c61dfdb430e04ebb411e4b80fbd49fe7e63a1be0209a76d7c07501f02834922 \
                     size   833961
 
+# see https://cgit.freedesktop.org/libreoffice/cppunit/commit/include/cppunit/extensions/TestSuiteBuilderContext.h?id=834f3a287387bd6230c98b0c5375aff568c75e02
+patchfiles-append   patch-fix_-Wdefaulted-function-deleted.diff
+
 configure.args      --disable-dot \
                     --disable-doxygen \
                     --disable-silent-rules

--- a/devel/cppunit/files/patch-fix_-Wdefaulted-function-deleted.diff
+++ b/devel/cppunit/files/patch-fix_-Wdefaulted-function-deleted.diff
@@ -1,0 +1,29 @@
+From 834f3a287387bd6230c98b0c5375aff568c75e02 Mon Sep 17 00:00:00 2001
+From: Markus Mohrhard <markus.mohrhard@googlemail.com>
+Date: Sat, 21 Dec 2019 02:44:08 +0800
+Subject: fix -Wdefaulted-function-deleted error
+
+---
+ include/cppunit/extensions/TestSuiteBuilderContext.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+(limited to 'include/cppunit/extensions/TestSuiteBuilderContext.h')
+
+diff --git a/include/cppunit/extensions/TestSuiteBuilderContext.h b/include/cppunit/extensions/TestSuiteBuilderContext.h
+index 12d157e..04f4b9b 100644
+--- include/cppunit/extensions/TestSuiteBuilderContext.h
++++ include/cppunit/extensions/TestSuiteBuilderContext.h
+@@ -42,8 +42,8 @@ public:
+ 
+   TestSuiteBuilderContextBase(TestSuiteBuilderContextBase const &) = default;
+   TestSuiteBuilderContextBase(TestSuiteBuilderContextBase &&) = default;
+-  TestSuiteBuilderContextBase & operator =(TestSuiteBuilderContextBase const &) = default;
+-  TestSuiteBuilderContextBase & operator =(TestSuiteBuilderContextBase &&) = default;
++  TestSuiteBuilderContextBase & operator =(TestSuiteBuilderContextBase const &) = delete;
++  TestSuiteBuilderContextBase & operator =(TestSuiteBuilderContextBase &&) = delete;
+ 
+   /*! \brief Adds a test to the fixture suite.
+    *
+-- 
+cgit v1.2.1
+


### PR DESCRIPTION
By default, cppunit uses -Werror.
See
https://cgit.freedesktop.org/libreoffice/cppunit/commit/include/cppunit/extensions/TestSuiteBuilderContext.h?id=834f3a287387bd6230c98b0c5375aff568c75e02
for upstream commit.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.2
Xcode 11.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
