### PR TITLE
Stack/cabal version number fixes in binaries

### DIFF
--- a/devel/alex/Portfile
+++ b/devel/alex/Portfile
@@ -5,6 +5,7 @@ PortGroup           haskell_stack 1.0
 
 name                alex
 version             3.2.5
+revision            1
 categories          devel haskell
 maintainers         nomaintainer
 license             GPL-3
@@ -12,11 +13,12 @@ platforms           macosx
 homepage            https://www.haskell.org/alex/
 
 description         A tool for generating lexical analysers in Haskell
-long_description    \
-            Alex is a tool for generating lexical analysers in Haskell. \
-            It takes a description of tokens based on regular expressions \
-            and generates a Haskell module containing code for scanning \
-            text efficiently. It is similar to the tool lex or flex for C/C++.
+long_description    Alex is a tool for generating lexical analysers in\
+                    Haskell.  It takes a description of tokens based\
+                    on regular expressions and generates a Haskell\
+                    module containing code for scanning text\
+                    efficiently. It is similar to the tool lex or flex\
+                    for C/C++.
 
 master_sites        https://hackage.haskell.org/package/${name}-${version}
 
@@ -30,9 +32,15 @@ checksums           rmd160  d1ba9a2e529ec162c9c9a9c45b4dc1babc05a1f6 \
 set alex_datadir    share/${name}
 
 post-extract {
-    xinstall -o macports -m 0755 -d \
-        "[option haskell_stack.stack_root]" \
-        ${destroot}${prefix}/${alex_datadir}
+    if {[geteuid] == 0} {
+        xinstall -o ${macportsuser} -d \
+            "[option haskell_stack.stack_root]" \
+            ${destroot}${prefix}/${alex_datadir}
+    } else {
+        xinstall -d \
+            "[option haskell_stack.stack_root]" \
+            ${destroot}${prefix}/${alex_datadir}
+    }
 
     # Fix for cabal data-files hardcoded path in binary
     # See:
@@ -46,6 +54,8 @@ post-extract {
     reinplace "s|@PREFIX@|${prefix}|g" \
         ${worksrcpath}/src/Paths_${name}.hs
     reinplace "s|@NAME@|${name}|g" \
+        ${worksrcpath}/src/Paths_${name}.hs
+    reinplace -E "s|(Version\[\[:space:\]\]+)\\\[\[\[:digit:\]\]+(,\[\[:digit:\]\]+){1,4}\\\]|\\1\[[join [split ${version} .] ,]\]|" \
         ${worksrcpath}/src/Paths_${name}.hs
 }
 

--- a/devel/happy/Portfile
+++ b/devel/happy/Portfile
@@ -5,6 +5,7 @@ PortGroup           haskell_stack 1.0
 
 name                happy
 version             1.19.12
+revision            1
 categories          devel haskell
 maintainers         nomaintainer
 license             GPL-3
@@ -12,10 +13,10 @@ platforms           macosx
 homepage            https://github.com/simonmar/happy
 
 description         A parser generator for Haskell
-long_description    \
-            Happy is a parser generator for Haskell. Given a grammar \
-            specification in BNF, Happy generates Haskell code to parse \
-            the grammar. Happy works in a similar way to the yacc tool for C.
+long_description    Happy is a parser generator for Haskell. Given a\
+                    grammar specification in BNF, Happy generates\
+                    Haskell code to parse the grammar. Happy works in\
+                    a similar way to the yacc tool for C.
 
 master_sites        https://hackage.haskell.org/package/${name}-${version}
 
@@ -45,6 +46,8 @@ post-extract {
     reinplace "s|@PREFIX@|${prefix}|g" \
         ${worksrcpath}/src/Paths_${name}.hs
     reinplace "s|@NAME@|${name}|g" \
+        ${worksrcpath}/src/Paths_${name}.hs
+    reinplace -E "s|(Version\[\[:space:\]\]+)\\\[\[\[:digit:\]\]+(,\[\[:digit:\]\]+){1,4}\\\]|\\1\[[join [split ${version} .] ,]\]|" \
         ${worksrcpath}/src/Paths_${name}.hs
 }
 

--- a/devel/hlint/Portfile
+++ b/devel/hlint/Portfile
@@ -5,17 +5,18 @@ PortGroup           haskell_cabal 1.0
 
 name                hlint
 version             2.2.2
+revision            1
 categories          devel haskell
 maintainers         nomaintainer
 license             GPL-3
 platforms           macosx
 homepage            https://www.haskell.org/alex/
 
-description         A a tool for suggesting possible improvements to Haskell code.
-long_description    \
-    HLint is a tool for suggesting possible improvements to Haskell code. \
-    These suggestions include ideas such as using alternative functions, \
-    simplifying code and spotting redundancies.
+description         A tool for suggesting possible improvements to Haskell code.
+long_description    HLint is a tool for suggesting possible\
+                    improvements to Haskell code.  These suggestions\
+                    include ideas such as using alternative functions,\
+                    simplifying code and spotting redundancies.
 
 master_sites        https://hackage.haskell.org/package/${name}-${version}
 
@@ -27,8 +28,13 @@ checksums           rmd160  d2e7ae8bc0a53976ed1906b3649c8388911ed655 \
 set hlint_datadir    share/${name}
 
 post-extract {
-    xinstall -o macports -m 0755 -d \
-        ${destroot}${prefix}/${hlint_datadir}
+    if {[geteuid] == 0} {
+        xinstall -o ${macportsuser} -d \
+            ${destroot}${prefix}/${hlint_datadir}
+    } else {
+        xinstall -d \
+            ${destroot}${prefix}/${hlint_datadir}
+    }
 
     # Fix for cabal data-files hardcoded path in binary
     # See:
@@ -42,6 +48,8 @@ post-extract {
     reinplace "s|@PREFIX@|${prefix}|g" \
         ${worksrcpath}/src/Paths_${name}.hs
     reinplace "s|@NAME@|${name}|g" \
+        ${worksrcpath}/src/Paths_${name}.hs
+    reinplace -E "s|(Version\[\[:space:\]\]+)\\\[\[\[:digit:\]\]+(,\[\[:digit:\]\]+){1,4}\\\]|\\1\[[join [split ${version} .] ,]\]|" \
         ${worksrcpath}/src/Paths_${name}.hs
 }
 

--- a/devel/ihaskell/Portfile
+++ b/devel/ihaskell/Portfile
@@ -4,10 +4,10 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           haskell_stack 1.0
 
-github.setup        gibiansky IHaskell ac0882d
-name                ihaskell
-version             2019.08.30
-revision            1
+github.setup        gibiansky IHaskell 2318ee2
+name                [string tolower ${github.project}]
+version             2019.12.16
+revision            0
 
 categories          devel haskell
 platforms           darwin
@@ -15,19 +15,20 @@ license             MIT
 maintainers         nomaintainer
 
 description         A Haskell kernel for IPython.
-long_description    \
-    IHaskell is a kernel for the Jupyter project, which allows you to \
-    use Haskell inside Jupyter frontends (including the console and \
-    notebook). For a tour of some IHaskell features, check out the \
-    demo Notebook at \
-    http://nbviewer.ipython.org/github/gibiansky/IHaskell/blob/master/notebooks/IHaskell.ipynb. More \
-    example notebooks are available on the wiki at \
-    https://github.com/gibiansky/IHaskell/wiki. The wiki also has more \
-    extensive documentation of IHaskell features.
+long_description    IHaskell is a kernel for the Jupyter project,\
+                    which allows you to use Haskell inside Jupyter\
+                    frontends (including the console and\
+                    notebook). For a tour of some IHaskell features,\
+                    check out the demo Notebook at\
+                    http://nbviewer.ipython.org/github/gibiansky/IHaskell/blob/master/notebooks/IHaskell.ipynb. More\
+                    example notebooks are available on the wiki at\
+                    https://github.com/gibiansky/IHaskell/wiki. The\
+                    wiki also has more extensive documentation of\
+                    IHaskell features.
 
-checksums           rmd160  47cf8fed7674b0e2421019ff4c813ee4eea93882 \
-                    sha256  c6e6c9a7d71ba6349027f1fb818608f8355acafe6fa7cbe57265ec9951a5ddb4 \
-                    size    753553
+checksums           rmd160  2764a538d21901b55aa31d3b3234fc1cdaa576ca \
+                    sha256  feb4aceba2d38cb91d2c82255067fb6e716d28d34e7f5a48d70cbe55dd1cd173 \
+                    size    774326
 
 # use these to specify python versions, python3 required 
 set python3_version 3.7
@@ -39,6 +40,7 @@ set python3_version_nickname \
 depends_lib-append  \
                     path:lib/pkgconfig/pango.pc:pango \
                     port:ghc \
+                    port:libmagic \
                     port:python${python3_version_nickname} \
                     port:py${python3_version_nickname}-cairo \
                     port:py${python3_version_nickname}-ipykernel \
@@ -75,6 +77,9 @@ post-extract {
 # See https://github.com/commercialhaskell/stack/issues/825\\
 extra-lib-dirs:\\
 \\ \\ - /usr/lib\\
+\\ \\ - ${prefix}/lib\\
+extra-include-dirs:\\
+\\ \\ - ${prefix}/include\\
 " \
         stack.yaml
 
@@ -91,6 +96,8 @@ extra-lib-dirs:\\
         ${worksrcpath}/src/Paths_${name}.hs
     reinplace "s|@NAME@|${name}|g" \
         ${worksrcpath}/src/Paths_${name}.hs
+    reinplace -E "s|(Version\[\[:space:\]\]+)\\\[\[\[:digit:\]\]+(,\[\[:digit:\]\]+){1,4}\\\]|\\1\[[join [split ${version} .] ,]\]|" \
+        ${worksrcpath}/src/Paths_${name}.hs
 }
 
 # no jupyter_select yet, so hack PATH to find `which jupyter`: 
@@ -98,7 +105,7 @@ extra-lib-dirs:\\
 # note: this command does not change the destroot PATH environment, so export
 # PATH explicitly in the necessary system command below
 destroot.env-append \
-    PATH=$env(PATH):${frameworks_dir}/Python.framework/Versions/${python3_version}/bin \
+    "PATH=$env(PATH):${frameworks_dir}/Python.framework/Versions/${python3_version}/bin" \
     ${name}_datadir=${destroot}${prefix}/${ihaskell_datadir}
 
 post-destroot {
@@ -118,14 +125,10 @@ post-destroot {
     }
     
     # run ihaskell to install the IPython files into destroot
-    system -W ${worksrcpath} "\
-        export \
-            PATH=$env(PATH):${frameworks_dir}/Python.framework/Versions/${python3_version}/bin \
-            ${name}_datadir=${destroot}${prefix}/${ihaskell_datadir} \
-            ; \
+    system -W ${worksrcpath} \
+        "export ${destroot.env} ; \
         ${destroot}${prefix}/bin/ihaskell install \
-            --prefix=${destroot}${prefix} \
-        "
+            --prefix=${destroot}${prefix}"
 
     # delete any destroot path appearing in text files
     fs-traverse f ${destroot}${prefix} {

--- a/www/adblock2privoxy/Portfile
+++ b/www/adblock2privoxy/Portfile
@@ -13,22 +13,25 @@ platforms           macosx
 homepage            https://github.com/essandess/adblock2privoxy
 
 description         Convert adblock config files to privoxy format
-long_description    ${description}. \
-            AdBlock Plus browser plugin has great block list files\
-            provided by big community, but it is client software and\
-            cannot work on a server as proxy.  Privoxy proxy has good\
-            potential to block ads at server side, but it experiences\
-            acute shortage of updated block lists.  This software\
-            converts adblock lists to privoxy config files format.\
-            Almost all adblock features are supported including\
-            block/unblock requests (on privoxy) all syntax features\
-            are supported except for regex templates matching host\
-            name hide/unhide page elements (via CSS) all syntax\
-            features are supported all block request options except\
-            for outdated ones: Supported: script, image, stylesheet,\
-            object, xmlhttprequest, object-subrequest, subdocument,\
-            document, elemhide, other, popup, third-party, domain=...,\
-            match-case, donottrack.
+long_description    ${description}.\
+                    AdBlock Plus browser plugin has great block list\
+                    files provided by big community, but it is client\
+                    software and cannot work on a server as proxy.\
+                    Privoxy proxy has good potential to block ads at\
+                    server side, but it experiences acute shortage of\
+                    updated block lists.  This software converts\
+                    adblock lists to privoxy config files format.\
+                    Almost all adblock features are supported\
+                    including block/unblock requests (on privoxy) all\
+                    syntax features are supported except for regex\
+                    templates matching host name hide/unhide page\
+                    elements (via CSS) all syntax features are\
+                    supported all block request options except for\
+                    outdated ones: Supported: script, image,\
+                    stylesheet, object, xmlhttprequest,\
+                    object-subrequest, subdocument, document,\
+                    elemhide, other, popup, third-party, domain=...,\
+                    match-case, donottrack.
 
 master_sites        https://hackage.haskell.org/package/${name}-${version}
 
@@ -57,17 +60,21 @@ variant initialize_always \
 # relative paths to ${prefix}
 set ab2p_datadir    share/${name}
 
-# Fix for cabal data-files hardcoded path in binary
-# See:
-# https://github.com/commercialhaskell/stack/issues/848
-# https://github.com/commercialhaskell/stack/issues/4857
-# https://github.com/haskell/cabal/issues/462
-# https://github.com/haskell/cabal/issues/3586
 post-extract {
+    # Fix for cabal data-files hardcoded path in binary
+    # See:
+    # https://github.com/commercialhaskell/stack/issues/848
+    # https://github.com/commercialhaskell/stack/issues/4857
+    # https://github.com/haskell/cabal/issues/462
+    # https://github.com/haskell/cabal/issues/3586
     xinstall -m 0644 -W ${worksrcpath} \
-        ${filespath}/Paths_${name}.hs ./src
+        ${filespath}/Paths_NAME.hs ./src/Paths_${name}.hs
 
     reinplace "s|@PREFIX@|${prefix}|g" \
+        ${worksrcpath}/src/Paths_${name}.hs
+    reinplace "s|@NAME@|${name}|g" \
+        ${worksrcpath}/src/Paths_${name}.hs
+    reinplace -E "s|(Version\[\[:space:\]\]+)\\\[\[\[:digit:\]\]+(,\[\[:digit:\]\]+){1,4}\\\]|\\1\[[join [split ${version} .] ,]\]|" \
         ${worksrcpath}/src/Paths_${name}.hs
 }
 

--- a/www/adblock2privoxy/files/Paths_NAME.hs
+++ b/www/adblock2privoxy/files/Paths_NAME.hs
@@ -13,7 +13,7 @@ See:
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE NoRebindableSyntax #-}
 {-# OPTIONS_GHC -fno-warn-missing-import-lists #-}
-module Paths_adblock2privoxy (
+module Paths_@NAME@ (
     version,
     getBinDir, getLibDir, getDynLibDir, getDataDir, getLibexecDir,
     getDataFileName, getSysconfDir
@@ -42,19 +42,19 @@ version = Version [2,0,1] []
 bindir, libdir, dynlibdir, datadir, libexecdir, sysconfdir :: FilePath
 
 bindir     = "@PREFIX@/bin"
-libdir     = "@PREFIX@/lib/adblock2privoxy"
-dynlibdir  = "@PREFIX@/lib/adblock2privoxy"
-datadir    = "@PREFIX@/share/adblock2privoxy"
-libexecdir = "@PREFIX@/lib/adblock2privoxy"
+libdir     = "@PREFIX@/lib/@NAME@"
+dynlibdir  = "@PREFIX@/lib/@NAME@"
+datadir    = "@PREFIX@/share/@NAME@"
+libexecdir = "@PREFIX@/lib/@NAME@"
 sysconfdir = "@PREFIX@/etc"
 
 getBinDir, getLibDir, getDynLibDir, getDataDir, getLibexecDir, getSysconfDir :: IO FilePath
-getBinDir = catchIO (getEnv "adblock2privoxy_bindir") (\_ -> return bindir)
-getLibDir = catchIO (getEnv "adblock2privoxy_libdir") (\_ -> return libdir)
-getDynLibDir = catchIO (getEnv "adblock2privoxy_dynlibdir") (\_ -> return dynlibdir)
-getDataDir = catchIO (getEnv "adblock2privoxy_datadir") (\_ -> return datadir)
-getLibexecDir = catchIO (getEnv "adblock2privoxy_libexecdir") (\_ -> return libexecdir)
-getSysconfDir = catchIO (getEnv "adblock2privoxy_sysconfdir") (\_ -> return sysconfdir)
+getBinDir = catchIO (getEnv "@NAME@_bindir") (\_ -> return bindir)
+getLibDir = catchIO (getEnv "@NAME@_libdir") (\_ -> return libdir)
+getDynLibDir = catchIO (getEnv "@NAME@_dynlibdir") (\_ -> return dynlibdir)
+getDataDir = catchIO (getEnv "@NAME@_datadir") (\_ -> return datadir)
+getLibexecDir = catchIO (getEnv "@NAME@_libexecdir") (\_ -> return libexecdir)
+getSysconfDir = catchIO (getEnv "@NAME@_sysconfdir") (\_ -> return sysconfdir)
 
 getDataFileName :: FilePath -> IO FilePath
 getDataFileName name = do


### PR DESCRIPTION
Stack/cabal version number fixes in binaries

* Fix the version number comp[iled into the binaries of stack/cabal-compiled binaries that use `Paths_NAME.hs`.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
