### PR TITLE
prometheus: update to 2.15.1

### DIFF
--- a/net/prometheus/Portfile
+++ b/net/prometheus/Portfile
@@ -1,7 +1,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        prometheus prometheus 2.14.0 v
+github.setup        prometheus prometheus 2.15.1 v
 github.tarball_from archive
 
 description         The Prometheus monitoring system and time series database
@@ -42,9 +42,9 @@ set prom_share_dir  ${prefix}/share/${name}
 set prom_log_dir    ${prefix}/var/log/${name}
 set prom_log_file   ${prom_log_dir}/${name}.log
 
-checksums   rmd160  22f7a8eff328b7ac6c1788fb0662f5b67c241b12 \
-            sha256  5c40de1961997996ef5b59561a78116a9548235bc77305c05f214b6319a0284d \
-            size    12755125
+checksums   rmd160  a3edd47f85fe304469572616cb253b8c3b5b6cba \
+            sha256  67590a51ad26ee6135d40b8df90f8b58d85ce890fc67e66d08bb8207db289a1e \
+            size    12852863
 
 add_users           ${prom_user} \
                     group=${prom_user} \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.2 19C57
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
