### PR TITLE
castxml: allow binary to find libLLVM.dylib

### DIFF
--- a/lang/castxml/Portfile
+++ b/lang/castxml/Portfile
@@ -32,7 +32,7 @@ depends_lib-append  port:zlib \
 configure.args-append \
                     -DCastXML_INSTALL_DOC_DIR=share/doc/castxml
 
-variant clang60 conflicts clang70 clang80 description {Use clang 6.0 toolchain.} {
+variant clang60 conflicts clang70 clang80 clang90 description {Use clang 6.0 toolchain.} {
     depends_lib-append  port:llvm-6.0
     depends_build-append \
                         port:clang-6.0
@@ -40,7 +40,7 @@ variant clang60 conflicts clang70 clang80 description {Use clang 6.0 toolchain.}
                         -DLLVM_DIR=${prefix}/libexec/llvm-6.0/lib/cmake/llvm
 }
 
-variant clang70 conflicts clang60 clang80 description {Use clang 7.0 toolchain.} {
+variant clang70 conflicts clang60 clang80 clang90 description {Use clang 7.0 toolchain.} {
     depends_lib-append  port:llvm-7.0
     depends_build-append \
                         port:clang-7.0
@@ -48,7 +48,7 @@ variant clang70 conflicts clang60 clang80 description {Use clang 7.0 toolchain.}
                         -DLLVM_DIR=${prefix}/libexec/llvm-7.0/lib/cmake/llvm
 }
 
-variant clang80 conflicts clang60 clang70 description {Use clang 8.0 toolchain.} {
+variant clang80 conflicts clang60 clang70 clang90 description {Use clang 8.0 toolchain.} {
     depends_lib-append  port:llvm-8.0
     depends_build-append \
                         port:clang-8.0
@@ -56,6 +56,14 @@ variant clang80 conflicts clang60 clang70 description {Use clang 8.0 toolchain.}
                         -DLLVM_DIR=${prefix}/libexec/llvm-8.0/lib/cmake/llvm
 }
 
-if {![variant_isset clang60] && ![variant_isset clang70]} {
+variant clang90 conflicts clang60 clang70 clang80 description {Use clang 9.0 toolchain.} {
+    depends_lib-append  port:llvm-9.0
+    depends_build-append \
+                        port:clang-9.0
+    configure.args-append \
+                        -DLLVM_DIR=${prefix}/libexec/llvm-9.0/lib/cmake/llvm
+}
+
+if {![variant_isset clang60] && ![variant_isset clang70] && ![variant_isset clang90]} {
     default_variants +clang80
 }

--- a/lang/castxml/Portfile
+++ b/lang/castxml/Portfile
@@ -65,5 +65,5 @@ variant clang90 conflicts clang60 clang70 clang80 description {Use clang 9.0 too
 }
 
 if {![variant_isset clang60] && ![variant_isset clang70] && ![variant_isset clang90]} {
-    default_variants +clang80
+    default_variants +clang90
 }

--- a/lang/castxml/Portfile
+++ b/lang/castxml/Portfile
@@ -9,7 +9,7 @@ github.setup        CastXML CastXML 0.2.0 v
 
 name                castxml
 epoch               20190718
-revision            0
+revision            1
 categories          lang
 platforms           darwin
 license             Apache-2
@@ -40,6 +40,8 @@ variant clang60 conflicts clang70 clang80 clang90 description {Use clang 6.0 too
                         port:clang-6.0
     configure.args-append \
                         -DLLVM_DIR=${prefix}/libexec/llvm-6.0/lib/cmake/llvm
+    cmake.install_rpath-append \
+                        ${prefix}/libexec/llvm-6.0/lib
 }
 
 variant clang70 conflicts clang60 clang80 clang90 description {Use clang 7.0 toolchain.} {
@@ -48,6 +50,8 @@ variant clang70 conflicts clang60 clang80 clang90 description {Use clang 7.0 too
                         port:clang-7.0
     configure.args-append \
                         -DLLVM_DIR=${prefix}/libexec/llvm-7.0/lib/cmake/llvm
+    cmake.install_rpath-append \
+                        ${prefix}/libexec/llvm-7.0/lib
 }
 
 variant clang80 conflicts clang60 clang70 clang90 description {Use clang 8.0 toolchain.} {
@@ -56,6 +60,8 @@ variant clang80 conflicts clang60 clang70 clang90 description {Use clang 8.0 too
                         port:clang-8.0
     configure.args-append \
                         -DLLVM_DIR=${prefix}/libexec/llvm-8.0/lib/cmake/llvm
+    cmake.install_rpath-append \
+                        ${prefix}/libexec/llvm-8.0/lib
 }
 
 variant clang90 conflicts clang60 clang70 clang80 description {Use clang 9.0 toolchain.} {
@@ -64,6 +70,8 @@ variant clang90 conflicts clang60 clang70 clang80 description {Use clang 9.0 too
                         port:clang-9.0
     configure.args-append \
                         -DLLVM_DIR=${prefix}/libexec/llvm-9.0/lib/cmake/llvm
+    cmake.install_rpath-append \
+                        ${prefix}/libexec/llvm-9.0/lib
 }
 
 if {![variant_isset clang60] && ![variant_isset clang70] && ![variant_isset clang90]} {

--- a/lang/castxml/Portfile
+++ b/lang/castxml/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.1
-PortGroup           cxx11 1.1
 PortGroup           github 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
@@ -23,6 +22,9 @@ long_description    ${description}
 checksums           rmd160  32a444fcf649bbbd3757ff58ea16b605e158a261 \
                     sha256  669b2a06f04ed2fb3a3dc41eb8e68051d439e4e01a665153b8f424d084199725 \
                     size    94839
+
+compiler.cxx_standard \
+                    2011
 
 depends_lib-append  port:zlib \
                     port:libffi \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.2
Xcode 11.3 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
