### PR TITLE
gnome-internet-radio-locator: Update to 2.2.0

### DIFF
--- a/gnome/gnome-internet-radio-locator/Portfile
+++ b/gnome/gnome-internet-radio-locator/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                gnome-internet-radio-locator
-version             2.1.3
+version             2.2.0
 set branch          [join [lrange [split $version .] 0 1] .]
 
 categories          gnome
@@ -18,9 +18,9 @@ master_sites        gnome:sources/${name}/${branch}/
 
 use_xz              yes
 
-checksums           rmd160  6f269dfa275bb9d221cad79c5f973179599ea2bc \
-                    sha256  93dfa948069c1462f1defb34f06149dd85e883fcd89851bd07d09a475205a0a7 \
-                    size    558216
+checksums           rmd160  20626440092fe63abe3f18b9247b69f53034efb3 \
+                    sha256  bad897d51fa7d759341e8a0520ce8a0040c78de4893230b06c27d886ac11d5fe \
+                    size    559720
 
 depends_build       port:autoconf \
                     port:automake \


### PR DESCRIPTION
#### Description

GNOME Internet Radio Locator (gnome-internet-radio-locator) version 2.2.0 from https://download.gnome.org/sources/gnome-internet-radio-locator/2.2/gnome-internet-radio-locator-2.2.0.tar.xz

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.2 19C57
Xcode 11.2 11B52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
