### PR TITLE
x264: Update snapshot and fix sigsev on Catalina

### DIFF
--- a/multimedia/x264/Portfile
+++ b/multimedia/x264/Portfile
@@ -6,7 +6,7 @@ PortGroup           xcodeversion 1.0
 PortGroup           xcode_workaround 1.0
 
 name                x264
-version             20190313
+version             20191217
 categories          multimedia
 license             GPL-2+
 platforms           darwin
@@ -25,9 +25,9 @@ distname            ${name}-snapshot-${version}-2245-stable
 
 use_bzip2           yes
 
-checksums           rmd160  324cd6e0260b8f4da92910350e7b91f9040e5c92 \
-                    sha256  3e59522696a20ab54e85990dbfecc6c01fc9f623afab8d23d48c2a62b1906dac \
-                    size    770593
+checksums           rmd160  6a204dfd1d56faf2d9c0ff2b90642507112f291d \
+                    sha256  b2495c8f2930167d470994b1ce02b0f4bfb24b3317ba36ba7f112e9809264160 \
+                    size    770169
 
 minimum_xcodeversions {9 3.1}
 


### PR DESCRIPTION
This fixes a segmentation fault on Catalina

#### Description

I was experiencing segmentation faults with `ffmpeg`encoding `libx264` video files. Updating the library (and self compiling) fixes the problem for me.

This is probably related: https://trac.macports.org/ticket/59750 so i think this should fix that.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
