### PR TITLE
comply: new port

### DIFF
--- a/security/comply/Portfile
+++ b/security/comply/Portfile
@@ -1,0 +1,57 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        strongdm comply 1.4.1 v
+
+description         Compliance automation framework, focused on SOC2
+
+long_description    Comply is a SOC2-focused compliance automation tool. It \
+                    includes: a Policy Generator: a markdown-powered document \
+                    pipeline for publishing auditor-friendly policy documents, \
+                    Ticketing Integration: to automate compliance throughout \
+                    the year via your existing ticketing system, and SOC2 \
+                    Templates: open source policy and procedure templates \
+                    suitable for satisfying a SOC2 audit.
+
+categories          security
+license             Apache-2
+platforms           darwin
+
+maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
+
+checksums           rmd160  3cd4410085580544fde44990362b3d6d477d3945 \
+                    sha256  83b659fc77f6be5ead4f8355216bff74aef5b7e607ad72d3b7633e6052a128df \
+                    size    2826455
+
+depends_build       port:go
+
+installs_libs       no
+use_configure       no
+use_parallel_build  no
+
+set comply_example_dir  "${prefix}/share/${name}/example"
+set gopath              "${workpath}/go"
+
+build.env               PATH=$env(PATH):${gopath}/bin GOPATH=${gopath}
+build.pre_args          VERSION=${version}
+build.target
+
+pre-build {
+    file mkdir  ${gopath}/src/github.com/strongdm
+    file link   ${gopath}/src/github.com/strongdm/${name} ${worksrcpath}
+}
+
+destroot {
+    xinstall -d ${destroot}${comply_example_dir}
+
+    copy "${worksrcpath}/${name}" "${destroot}${prefix}/bin/${name}"
+    copy {*}[glob ${worksrcpath}/example/*] ${destroot}${comply_example_dir}
+}
+
+notes "
+    Example configuration for ${name} can be found in:
+
+        ${comply_example_dir}
+"


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.2 19C57
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
