### PR TITLE
py-pykde4, py-pyqt4: remove subports for Python 3.4

### DIFF
--- a/kde/py-pykde4/Portfile
+++ b/kde/py-pykde4/Portfile
@@ -38,7 +38,7 @@ distname            pykde4-${version}
 checksums           rmd160  3ea2492cd31704e559456cb78dd85660fae7e74c \
                     sha256  7fb9d7b5ed03d531243ebd67939baf30933452dafbdfca866e6653e9a77d80fc
 
-set python.versions         {{27 2.7} {34 3.4}}
+set python.versions         {{27 2.7}}
 set python.default_version  27
 
 foreach py ${python.versions} {

--- a/python/py-pyqt4/Portfile
+++ b/python/py-pyqt4/Portfile
@@ -24,7 +24,7 @@ set patch       [lindex [split ${version} .] 2]
 
 # pre-declare provided subports
 
-python.versions 27 34 35 36 37 38
+python.versions 27 35 36 37 38
 python.default_version 27
 
 foreach py_ver ${python.versions} {


### PR DESCRIPTION
py34-pykde4 and py34-pyqt4 depend on nonexistent port dbus-python34.

Do not use replaced_by.
See https://trac.macports.org/ticket/59051 for discussion.

Fixes https://trac.macports.org/ticket/59891

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.2
Xcode 11.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
