### PR TITLE
gitlab-runner: update to 12.6.0

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 12.5.0 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 12.6.0 v
 
 categories          devel
 platforms           darwin
@@ -23,9 +23,9 @@ homepage            https://docs.gitlab.com/runner/
 master_sites        https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v${version}/
 distname            gitlab-runner-v${version}
 
-checksums           rmd160  1d315f843401966b4c975dacded3ddd49393c9b5 \
-                    sha256  541a8f4f1fc03b216a3f390e844ebe486db32f42ede0f3e4ac6524b0d1bd8f8c \
-                    size    27481502
+checksums           rmd160  e17e0aae2e55f20bd873bf17583d34797b988316 \
+                    sha256  592239134fda12905d2b2f3e6419e14269f14225b4c849acf7d19ef2a9ab63bd \
+                    size    6951134
 
 # Reproduce the "build_simple" target from the upstream Makefile
 set go_ldflags      "-X ${go.package}/common.NAME=${go.package} \


### PR DESCRIPTION
#### Description

Update to GitLab Runner 12.6.0.

###### Tested on

macOS 10.15.2 19C57
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?