### PR TITLE
openjdk8: update openjdk*-graalvm to 19.3.0.2

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -10,7 +10,7 @@ set build        09
 set major        8
 
 subport openjdk8-graalvm {
-    version      19.3.0
+    version      19.3.0.2
     revision     0
 
     set major    8
@@ -51,7 +51,7 @@ subport openjdk11 {
 }
 
 subport openjdk11-graalvm {
-    version      19.3.0
+    version      19.3.0.2
     revision     0
 
     set major    11
@@ -167,9 +167,9 @@ if {${subport} eq "openjdk8"} {
     distname     graalvm-ce-java${major}-darwin-amd64-${version}
     worksrcdir   graalvm-ce-java${major}-${version}
 
-    checksums    rmd160  0d6e88a4a9227ab7a515d84409b4f279d4a6a016 \
-                 sha256  6c43063148368dc537a58706fcbf332583371ebb32dfdb78017e6a80e139658b \
-                 size    356582812
+    checksums    rmd160  fcbd472848afb06702746a1445ab2fe02c5e4d21 \
+                 sha256  39b2e4d456335694a595cbdd0602fe2b4c685ca3f822f9b1c01339ba007c2c1f \
+                 size    356588464
 
     description  GraalVM Community Edition based on OpenJDK ${major}
     long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, \
@@ -250,9 +250,9 @@ if {${subport} eq "openjdk8"} {
     distname     graalvm-ce-java${major}-darwin-amd64-${version}
     worksrcdir   graalvm-ce-java${major}-${version}
 
-    checksums    rmd160  7c00dcda9db1f595386a7acd580e2bdcc2382cd5 \
-                 sha256  5a7eaead66971e25bef2c21d94d0760b54bda13761908545be8c0323df17da4a \
-                 size    448564759
+    checksums    rmd160  be0ca48f91ed3bb684b8a47918124b958804e895 \
+                 sha256  1c123aef2f18f5d71a80298260a703f634e3f8e3fd5c3aa91614949f8f238301 \
+                 size    448511231
 
     description  GraalVM Community Edition based on OpenJDK ${major}
     long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, \


### PR DESCRIPTION
#### Description

Update to GraalVM Community Edition 19.3.0.2.

###### Tested on

macOS 10.15.2 19C57
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?