### PR TITLE
wireguard-tools: update to version 1.0.20191226

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-tools
-version             0.0.20191212
+version             1.0.20191226
 revision            0
-checksums           rmd160  47174730d7b270ac576bfb3f0847fc327d8406ff \
-                    sha256  b0d718380f7a8822b2f12d75e462fa4eafa3a77871002981f367cd4fe2a1b071 \
-                    size    333024
+checksums           rmd160  6f8354c6e1494aab5eca77df86aa997c4185dcc5 \
+                    sha256  aa8af0fdc9872d369d8c890a84dbc2a2466b55795dccd5b47721b2d97644b04f \
+                    size    90720
 
 categories          net
 platforms           darwin
@@ -15,15 +15,15 @@ license             GPL-2
 maintainers         {isi.edu:calvin @cardi} openmaintainer
 description         Tools for the WireGuard VPN
 long_description    \
-    WireGuard-tools contains command-line tools to interact with \
+    wireguard-tools contains command-line tools to interact with \
     the userspace Go implementation of WireGuard. Currently there \
     are two tools: wg, to set and retrieve configuration of \
     WireGuard interfaces, and wg-quick, set up a WireGuard interface \
     simply.
 
 homepage            https://www.wireguard.com/
-master_sites        https://git.zx2c4.com/WireGuard/snapshot/
-distname            WireGuard-${version}
+master_sites        https://git.zx2c4.com/wireguard-tools/snapshot/
+distname            wireguard-tools-${version}
 use_xz              yes
 
 depends_run         port:bash \
@@ -31,11 +31,10 @@ depends_run         port:bash \
 
 use_configure       no
 
-# only build and install the tools for macOS
-build.pre_args      -C src/tools
+build.pre_args      -C src
 build.target
 
-destroot.pre_args   -C src/tools
+destroot.pre_args   -C src
 destroot.args       install
 destroot.post_args-append PREFIX=${prefix} \
                     SYSCONFDIR=${prefix}/etc \
@@ -50,5 +49,5 @@ post-destroot {
     reinplace -E "s|\(search_paths\\+=.*\)\(/usr/local/etc\)|\\1${sysconfdir}|" ${destroot}${completions_path}/wg-quick
 }
 
-livecheck.name      WireGuard
-livecheck.url       https://git.zx2c4.com/WireGuard/refs/
+livecheck.name      wireguard-tools
+livecheck.url       https://git.zx2c4.com/wireguard-tools/refs/


### PR DESCRIPTION
Upstream changed tarball locations, but nothing else has changed:
https://lists.zx2c4.com/pipermail/wireguard/2019-December/004787.html