### PR TITLE
frescobaldi: update to 3.1

### DIFF
--- a/editors/frescobaldi/Portfile
+++ b/editors/frescobaldi/Portfile
@@ -4,8 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        wbsoft frescobaldi 2.20.0 v
-revision            1
+github.setup        wbsoft frescobaldi 3.1 v
 conflicts           ${name}-devel ${name}2
 categories          editors python
 maintainers         {gmail.com:davide.liessi @dliessi} openmaintainer
@@ -18,38 +17,42 @@ homepage            http://www.frescobaldi.org/
 platforms           darwin
 license             GPL-2+
 
-# frescobaldi-devel points to a specific commit and not to a release
-if {"${name}-devel" ne ${subport}} {
-    github.tarball_from releases
-}
+github.tarball_from releases
 
-checksums           rmd160  27f121545cc7efe6a2b10fa69490a5714655f729 \
-                    sha256  c3d7faab7b21ddbab98749751a94d0a848138a800b0ae744f0ec94000b459ae4 \
-                    size    4478977
+checksums           rmd160  e68c671a2baa179c19549c325cb376d329ebb33e \
+                    sha256  1a37ab60aaed848e66ef8e5b0ccc963d794bf05994fc36defbc761a65fd3506b \
+                    size    6243866
 
 subport ${name}-devel {
-    PortGroup           active_variants 1.1
-
-    github.setup        wbsoft ${name} 8e43f2f01cf56803a8c10b98d8787f97015895a0
-    revision            0
     conflicts           ${name} ${name}2
-    version             20180806
-    set devel_version   3.0.0
-
-    checksums           rmd160  e79fb399116910fe15df5f449b495e7f0ab39165 \
-                        sha256  38e9f0f003316b70a1d11623087bd903d4f600e46930c757cedbf572979434f5 \
-                        size    8501726
+    version             20191227
+    set devel_version   ${github.version}
 }
 
 subport ${name}2 {
+    github.setup        wbsoft frescobaldi 2.20.0 v
+    revision            1
     conflicts           ${name} ${name}-devel
+
+    checksums           rmd160  27f121545cc7efe6a2b10fa69490a5714655f729 \
+                        sha256  c3d7faab7b21ddbab98749751a94d0a848138a800b0ae744f0ec94000b459ae4 \
+                        size    4478977
 }
 
-# remove this block after 8 August 2019
+# keep this block until 27 December 2020
+# then add block to prevent installation of frescobaldi and
+# frescobaldi-devel prior to 10.7 (QtWebEngine appeared after
+# Qt 5.3, which is the latest version available on 10.6)
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    if {${name} eq ${subport}} {
+        version     2.20.0
+        revision    2
+    }
     if {"${name}-devel" eq ${subport}} {
-        version 20170217
-        revision 2
+        version     20170217
+        revision    2
+    }
+    if {${name} eq ${subport} || "${name}-devel" eq ${subport}} {
         replaced_by ${name}2
         long_description    ${long_description} \
                             \n\nFrescobaldi 3 requires Qt 5, \
@@ -58,33 +61,26 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
                             (i.e., the port ${name}2) instead.
     }
     if {"${name}2" eq ${subport}} {
-        # don't conflict with frescobaldi-devel,
+        # don't conflict with frescobaldi and frescobaldi-devel,
         # allowing replaced_by to act as expected
-        conflicts   ${name}
+        conflicts   {}
     }
 }
 
 depends_run-append  port:portmidi
 
-# keep Python 3.5 for frescobaldi until next version update
-# to avoid unnecessary building of py37-pyqt4 on user machine
-# (the next version of frescobaldi will depend on py37-pyqt5)
-if {${name} eq ${subport}} {
-    python.default_version  35
-} else {
-    python.default_version  37
-}
+python.default_version  37
 
 depends_build-append    port:py${python.version}-setuptools
 depends_lib-append      port:py${python.version}-ly
 
-if {"${name}-devel" eq ${subport}} {
-    depends_run-append      port:py${python.version}-pyqt5 \
-                            port:py${python.version}-poppler-qt5
-    require_active_variants py${python.version}-pyqt5 webkit
-} else {
+if {"${name}2" eq ${subport}} {
     depends_run-append      port:py${python.version}-pyqt4 \
                             port:py${python.version}-poppler-qt4
+} else {
+    depends_run-append      port:py${python.version}-pyqt5 \
+                            port:py${python.version}-pyqt5-webengine \
+                            port:py${python.version}-poppler-qt5
 }
 
 variant app description {Make application bundle} {


### PR DESCRIPTION
- update both frescobaldi and frescobaldi-devel to latest version,
  requiring PyQt5 (including QtWebEngine)
- replace frescobaldi and frescobaldi-devel with frescobaldi2
  prior to Mac OS X 10.7 (QtWebEngine appeared after Qt 5.3,
  which is the latest version available on Mac OS X 10.6)
- use Python 3.7 for all

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G10021
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
