### PR TITLE
bulk_extractor: fix "incomplete type 'EVP_MD_CTX'"

### DIFF
--- a/security/bulk_extractor/Portfile
+++ b/security/bulk_extractor/Portfile
@@ -2,9 +2,10 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           old_openssl 1.0
 
 github.setup        simsong bulk_extractor 1.5.5
-revision            5
+revision            6
 categories          security sysutils
 platforms           darwin
 maintainers         nomaintainer
@@ -33,6 +34,9 @@ depends_lib         port:afflib \
                     port:sqlite3 \
                     port:tre \
                     port:zlib
+
+openssl.branch      1.0
+openssl.configure   build_flags
 
 # libewf is not universal
 universal_variant   no

--- a/security/bulk_extractor/Portfile
+++ b/security/bulk_extractor/Portfile
@@ -51,7 +51,7 @@ use_autoreconf      yes
 post-destroot {
     set docdir ${prefix}/share/doc/${subport}
     xinstall -d ${destroot}${docdir}
-    xinstall -m 644 -W ${worksrcpath} \
+    xinstall -m 0644 -W ${worksrcpath} \
         AUTHORS COPYING ChangeLog NEWS README \
         ${destroot}${docdir}
 }


### PR DESCRIPTION
I found a workaround for this error in another Portfile: https://github.com/macports/macports-ports/commit/fb9b14b429de03e4f7e54acff7280b2292a2833d

Worked for me on 10.14.6

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G1012
Xcode 11.2.1 11B500

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
