### PR TITLE
 hugo: update to 0.62.0, remove git dependency

### DIFF
--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gohugoio/hugo 0.61.0 v
+go.setup            github.com/gohugoio/hugo 0.62.0 v
 revision            0
-checksums           rmd160  21764e072520752afba6c0a3ca2b50a0925c2fe4 \
-                    sha256  fcb1da97e1fc2d994e4ff49d72e81f35dd8e7e7676b157719c254d1180a5770e \
-                    size    32242664
+checksums           rmd160  8f3299cc97c71e41b01e5520288f6019dd169109 \
+                    sha256  5eec15a53cf4d9b1eb2433899101ba0272cd26a60436f2d28c10f6ac0c0cd0e8 \
+                    size    32989052
 
 categories          www
 platforms           darwin
@@ -15,8 +15,6 @@ license             Apache-2
 maintainers         {isi.edu:calvin @cardi} openmaintainer
 description         A Fast and Flexible Static Site Generator built with love in GoLang
 long_description    ${description}
-
-depends_build-append port:git
 
 build.env-append    GO111MODULE=on
 


### PR DESCRIPTION
###### Tested on
macOS 10.13.6 17G8037
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?