### PR TITLE
google-cloud-sdk: update to 274.0.1

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             274.0.0
+version             274.0.1
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  974e11cad8ca9e4caedd4cec158748fd8b97c5b3 \
-                    sha256  6a2546806c67b186847c4aa296185100d9dc57a5521f3d46deae19575696a452 \
-                    size    23077531
+    checksums       rmd160  c483a99b811e0c70e3d733ff55280c1bcf61dfbf \
+                    sha256  523bf4c9f31007253165929a77a05c44d751f27ece8ae9573188cd79cfc5b915 \
+                    size    23085140
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  f070ddab0d5ae115977b8ea3a467b8329545b98f \
-                    sha256  1543e0c2efa1ab1b23c149e5dad3654e288f2b202f6382ef2141ee7922f24c84 \
-                    size    23082332
+    checksums       rmd160  439d21b65ebbf5a20098fda320155e8ea642abb9 \
+                    sha256  102023b8e90e240f46ed9b7fa6f2758c1a18cc8d71f7d2ab27b467074ee01e91 \
+                    size    23085813
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 274.0.1.

###### Tested on

macOS 10.15.2 19C57
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?