### PR TITLE
meson: apply upstream patch to fix 32bit macs

### DIFF
--- a/devel/meson/Portfile
+++ b/devel/meson/Portfile
@@ -4,7 +4,9 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        mesonbuild meson 0.52.0
+github.setup        mesonbuild meson 0.52.1
+revision            0
+
 github.tarball_from releases
 license             Apache-2
 categories          devel python
@@ -21,9 +23,9 @@ long_description    Meson is a build system designed to optimize programmer prod
                     Valgrind, CCache and the like. It is both extremely fast, and, even more importantly, \
                     as user friendly as possible.
 
-checksums           rmd160  56bb1bb93794c5715dfdfac41a88363351514f14 \
-                    sha256  d60f75f0dedcc4fd249dbc7519d6f3ce6df490033d276ef1cf27453ef4938d32 \
-                    size    1507110
+checksums           rmd160  23a70a0fdcfc66d060ac8f8b413fa160aae8287b \
+                    sha256  0c277472e49950a5537e3de3e60c57b80dbf425788470a1a8ed27446128fc035 \
+                    size    1507726
 
 # as of verison 0.45.0,requires python 3.5 or better
 
@@ -44,6 +46,9 @@ if {${os.platform} eq "darwin" && ${os.major} <= 9} {
                     port:cctools
 
 }
+
+# https://github.com/mesonbuild/meson/issues/6187
+patchfiles-append   patch-meson-32bit-apple.diff
 
 post-destroot {
     set python_prefix ${frameworks_dir}/Python.framework/Versions/${python.branch}

--- a/devel/meson/files/patch-meson-32bit-apple.diff
+++ b/devel/meson/files/patch-meson-32bit-apple.diff
@@ -1,0 +1,53 @@
+https://github.com/mesonbuild/meson/issues/6187
+
+From c8bfa6b7485316505e294c42eccb691630c85d3d Mon Sep 17 00:00:00 2001
+From: "Michael Hirsch, Ph.D" <scivision@users.noreply.github.com>
+Date: Sun, 17 Nov 2019 11:33:58 -0500
+Subject: [PATCH] macos: detect old OS/cpu 64-bit CPU in 32-bit MacOS kernel
+
+intended to fix #6187 pending user verification
+---
+ mesonbuild/environment.py | 23 ++++++++++++++++++++++-
+ 1 file changed, 22 insertions(+), 1 deletion(-)
+
+diff --git mesonbuild/environment.py mesonbuild/environment.py
+index f53f17fffe..247ab1f6ef 100644
+--- mesonbuild/environment.py
++++ mesonbuild/environment.py
+@@ -293,6 +293,23 @@ def detect_windows_arch(compilers: CompilersDict) -> str:
+             return 'x86'
+     return os_arch
+ 
++
++def detect_osx_arch() -> str:
++    """
++    per #6187, handle early Mac 64-bit Intel CPU with 64-bit OSX using a **32-bit kernel**
++    testing this requires old MacOS and hardware, not easily available for cloud CI,
++    so users needing this functionality may kindly need to help with debugging info.
++    """
++    try:
++        ret = subprocess.run(['sysctl', '-n', 'hw.cpu64bit_capable'],
++                             universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL).stdout
++        trial = 'x86_64' if ret.strip() == '1' else 'x86'
++    except Exception:
++        # very old MacOS version with implicit 32-bit CPU due to calling if-elif stack
++        trial = 'x86'
++    return trial
++
++
+ def any_compiler_has_define(compilers: CompilersDict, define):
+     for c in compilers.values():
+         try:
+@@ -317,7 +334,11 @@ def detect_cpu_family(compilers: CompilersDict) -> str:
+     else:
+         trial = platform.machine().lower()
+     if trial.startswith('i') and trial.endswith('86'):
+-        trial = 'x86'
++        if mesonlib.is_osx():
++            # handle corner case with early Mac 64-bit CPU and older OSX
++            trial = detect_osx_arch()
++        else:
++            trial = 'x86'
+     elif trial == 'bepc':
+         trial = 'x86'
+     elif trial.startswith('arm') or trial.startswith('earm'):


### PR DESCRIPTION
this patch is a WIP upstream, but appears to fix meson for
32bit macs, at least in the general use case of targeting the
build machine

https://github.com/mesonbuild/meson/issues/6187

needs more testing here, and then once in MacPorts, more broad testing prior to being incorporated into meson permanently

This patch does not fix the meson cross-compiling issue (eg building software +universal). This will have to be handled separately.

@rmottola -- please install this version and report back

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix
