### PR TITLE
gpg_verify-1.0: Bugfix MacPorts user and exit

### DIFF
--- a/_resources/port1.0/group/gpg_verify-1.0.tcl
+++ b/_resources/port1.0/group/gpg_verify-1.0.tcl
@@ -45,7 +45,11 @@ options gpg_verify.gpg_homedir
 default gpg_verify.gpg_homedir {${workpath}/.gnupg}
 
 pre-checksum {
-     xinstall -o macports -m 0755 -d "[option gpg_verify.gpg_homedir]"
+    if {[geteuid] == 0} {
+        xinstall -o ${macportsuser} -d [option gpg_verify.gpg_homedir]
+    } else {
+        xinstall -d [option gpg_verify.gpg_homedir]
+    }
 }
 
 proc gpg_verify.verify_gpg_signature {pubkey_file signature_file test_file} {
@@ -60,7 +64,6 @@ proc gpg_verify.verify_gpg_signature {pubkey_file signature_file test_file} {
             --verify ${signature_file} ${test_file} 2>/dev/null; \
             then echo 'VERIFIED'; else echo 'UNVERIFIED'; fi"]
     if {[string trim ${gpg_verification}] != "VERIFIED"} {
-        ui_error "GPG signature verification failed on ${test_file} with pubkey file ${pubkey_file}."
-        exit 1
+        error "GPG signature verification failed on ${test_file} with pubkey file ${pubkey_file}."
     }
 }


### PR DESCRIPTION
gpg_verify-1.0: Bugfix MacPorts user and exit

* See https://trac.macports.org/ticket/59899
* See #5124

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
