### PR TITLE
restic: update to 0.9.6

### DIFF
--- a/sysutils/restic/Portfile
+++ b/sysutils/restic/Portfile
@@ -38,6 +38,23 @@ post-build {
     }
 }
 
+test.run            yes
+
+test {
+    set repository_path ${workpath}/repo
+    set restore_path    ${workpath}/restore
+    set file_name       build.go
+
+    system -W ${worksrcpath} \
+        "RESTIC_PASSWORD=\"foo\" ./restic -r ${repository_path} init"
+    system -W ${worksrcpath} \
+        "RESTIC_PASSWORD=\"foo\" ./restic -r ${repository_path} backup ${file_name}"
+    system -W ${worksrcpath} \
+        "RESTIC_PASSWORD=\"foo\" ./restic -r ${repository_path} restore latest -t ${restore_path}"
+    system -W ${worksrcpath} \
+        "diff -q ${file_name} ${restore_path}/${file_name}"
+}
+
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
 

--- a/sysutils/restic/Portfile
+++ b/sysutils/restic/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/restic/restic 0.9.5 v
+go.setup            github.com/restic/restic 0.9.6 v
 categories          sysutils
 
 license             BSD
@@ -14,9 +14,9 @@ long_description    Restic is a program that does backups right. Its design goal
 
 homepage            https://restic.net/
 
-checksums           rmd160  7297c7dc01980c0ece228ad492bbc7d06fae6d37 \
-                    sha256  f818778b135d3b0ca9710992e13b7e06458fcde3aa914b60907aeca7ac84bb5e \
-                    size    26934307
+checksums           rmd160  24d2329c034e69d2a0eef477ef78bc9875a7a8af \
+                    sha256  2f46c381b4f2964068e256f85f11cacdda75601cf0ef5069e08b3ed91c2f7c9c \
+                    size    27009000
 
 set pyver           3.7
 


### PR DESCRIPTION
Also added a basic Test phase that goes through a backup-restore-compare operation. Disregard this commit if there is a better way.

closes: https://trac.macports.org/ticket/59595

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G2022
Xcode 11.3 11C29 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
