### PR TITLE
py-libxml2: add py38 subport

### DIFF
--- a/python/py-libxml2/Portfile
+++ b/python/py-libxml2/Portfile
@@ -27,7 +27,7 @@ checksums               rmd160  455f81e1f121c63dac96802de7f83ce4483f1afe \
                         sha256  aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f \
                         size    5624761
 
-python.versions         27 35 36 37
+python.versions         27 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_lib-append      port:libxml2


### PR DESCRIPTION
#### Description

Added subport for Python 3.8 to py-libxml2

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G10021
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
