### PR TITLE
gpsd: Fix build failures on 10.6, then update to v3.20.

### DIFF
--- a/net/gpsd/Portfile
+++ b/net/gpsd/Portfile
@@ -64,6 +64,7 @@ if {${subport} eq ${name}} {
 
 # GPSD requires Python 2.6, 2.7, or 3.2+; don't use 2.6, 3.2, or
 # 3.3, since we're weaning MP off of them.
+# Some programs currently have issues with Python 3.8, so omit that for now.
 
 set pythons_suffixes {27 34 35 36 37}
 
@@ -103,9 +104,47 @@ return -code error "Invalid Python variant selection"
 
 set pyver_dotted [join [split ${pyver_no_dot} ""] .]
 
+# KLUDGE: GPSD currently expects the Python extensions to build with the same
+# C compiler as was used to build Python itself.  This causes build failures
+# when the "Python C compiler" and the compiler chosen for GPSD have
+# configuration incompatibilities (or if the "Python C compiler" is absent).
+# Until this is fixed in GPSD upstream, some fiddling with compiler selection
+# is needed here.  This is especially kludgy since it requires knowledge of
+# how the Python port chooses the compiler.
+#
+# At the moment, the known failing case is when building with +python27
+# (the default) on 10.6, but here we just copy the condition from the python27
+# Portfile.  However, unlike the latter, we don't include the clang_dependency
+# portgroup outside the conditional, since it's not known to be needed in such
+# cases, and its mere presence alters the compiler selection.
+#
+# The upstream code will not have this fixed in the (imminent) new release.
+
+if {[variant_isset python27]} {
+    # Code copied (approximately) from python27 Portfile
+    if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {
+        PortGroup           clang_dependency 1.0
+
+        clang_dependency.extra_versions 3.7
+    }
+}
+
+# KLUDGE: Another problem is that the hack to avoid the daemon() deprecation
+# warning causes clang-9.0++ to choke when targeting 10.6.  The relevant code
+# shouldn't really be built as C++ at all, but until that's fixed, we avoid
+# the problem by blacklisting clang-9.0 with +qt on OSX <10.7.
+#
+# The upstream code will not have this fixed in the (imminent) new release.
+
+if {[variant_isset qt]} {
+    if {${os.platform} eq "darwin" && ${os.major} < 11} {
+        compiler.blacklist-append macports-clang-9.0
+    }
+}
+
 # NOTE:  All Python dependencies which are conceptually depends_run actually
 # need to be depends_lib, since the build procedure references them, usually
-# just to verify theire existence.
+# just to verify their existence.
 
 depends_lib-append      port:python${pyver_no_dot} \
                         port:py${pyver_no_dot}-serial

--- a/net/gpsd/Portfile
+++ b/net/gpsd/Portfile
@@ -3,9 +3,10 @@
 PortSystem              1.0
 
 name                    gpsd
-
-license                 BSD
+version                 3.20
+revision                0
 categories              net
+license                 BSD
 maintainers             {michaelld @michaelld} \
                         {fwright.net:fw @fhgwright} openmaintainer
 platforms               darwin
@@ -21,46 +22,15 @@ long_description        GPSD is a service daemon that handles GPSes and other \
 
 homepage                https://gpsd.io
 
-subport gpsd-devel {}
+master_sites            savannah
+checksums               rmd160  a87ed286b4a42092de54986889f0253990163d7e \
+                        sha256  172a7805068eacb815a3c5225436fcb0be46e7e49a5001a94034eac43df85e50 \
+                        size    3600835
 
-if {${subport} eq ${name}} {
+livecheck.type          regex
+livecheck.url           https://download.savannah.gnu.org/releases/gpsd/
+livecheck.regex         "${name}-(\\d+(?:\\.\\d+)*)${extract.suffix}"
 
-    # release
-    conflicts           gpsd-devel
-
-    version             3.19
-    checksums           rmd160  b9f41521519f6887585eb4cafa85a058ad1385b0 \
-                        sha256  27dd24d45b2ac69baab7933da2bf6ae5fb0be90130f67e753c110a3477155f39 \
-                        size    10581777
-    revision            0
-
-    master_sites        savannah
-
-    livecheck.type          regex
-    livecheck.url           https://download.savannah.gnu.org/releases/gpsd/
-    livecheck.regex         "${name}-(\\d+(?:\\.\\d+)*)${extract.suffix}"
-
-} else {
-
-    # devel
-    conflicts           gpsd
-
-    revision            0
-    git.branch          a4ecde71556018f6d7a70831165169fffd0cc3a1
-    version             20190817-[string range ${git.branch} 0 7]
-    checksums           rmd160  9c365e553ebd80b173b0ddbbadb317d1103ff776 \
-                        sha256  16318c956793aa78f269dc5274d737da69c616c35746dd18b569eba6ca3d1048 \
-                        size    8698196
-
-    master_sites        https://gitlab.com/gpsd/gpsd/-/archive/${git.branch}/
-    distname            ${name}-${git.branch}
-    use_bzip2           yes
-
-    livecheck.type      regexm
-    livecheck.version   ${git.branch}
-    livecheck.url       https://gitlab.com/gpsd/gpsd/commits/master?format=atom
-    livecheck.regex     {gpsd/gpsd/commit/([0-9a-f]{40}).*}
-}
 
 # GPSD requires Python 2.6, 2.7, or 3.2+; don't use 2.6, 3.2, or
 # 3.3, since we're weaning MP off of them.
@@ -117,8 +87,6 @@ set pyver_dotted [join [split ${pyver_no_dot} ""] .]
 # Portfile.  However, unlike the latter, we don't include the clang_dependency
 # portgroup outside the conditional, since it's not known to be needed in such
 # cases, and its mere presence alters the compiler selection.
-#
-# The upstream code will not have this fixed in the (imminent) new release.
 
 if {[variant_isset python27]} {
     # Code copied (approximately) from python27 Portfile
@@ -133,8 +101,6 @@ if {[variant_isset python27]} {
 # warning causes clang-9.0++ to choke when targeting 10.6.  The relevant code
 # shouldn't really be built as C++ at all, but until that's fixed, we avoid
 # the problem by blacklisting clang-9.0 with +qt on OSX <10.7.
-#
-# The upstream code will not have this fixed in the (imminent) new release.
 
 if {[variant_isset qt]} {
     if {${os.platform} eq "darwin" && ${os.major} < 11} {
@@ -265,4 +231,21 @@ description {Include xgps/xgpsspeed X11 clients (dependency-intensive)} {
 
 if {![variant_isset xgps]} {
     notes "The xgps variant is now needed to get the xgps and xgpsspeed programs."
+}
+
+
+# The gpsd-devel subport is obsolete as of 04-Jan-2020.
+# Handle it last so that it can override the dependencies.
+
+subport gpsd-devel {
+
+    PortGroup           obsolete 1.0
+
+    # Copy last pre-obsolete version, with revbump
+    git.branch          a4ecde71556018f6d7a70831165169fffd0cc3a1
+    version             20190817-[string range ${git.branch} 0 7]
+    revision            1
+
+    replaced_by         gpsd
+
 }


### PR DESCRIPTION
This tweaks the compiler selection when building for OSX <10.7.
See the comments in the Portfile for more details.

Since this is only fixing build failures, there is no revbump.

TESTED:
Used "port test" and "port install" as the primary test, with the
default variants, all binary variants with the default python27, each
single binary variant with the default python27, and the xgps variant
(except on 10.5) with each non-default python.  Ran this on a
MacPro/10.9, a MacPro/10.14, a MacPro 10.15, a MacBook Pro/10.9, a
PowerBook G4/10.5, and VMs for all 10.5-10.13 versions.  This was all
done for both the normal and -devel ports.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
