### PR TITLE
gcc8: add support for environment variable SDKROOT

### DIFF
--- a/lang/gcc8/Portfile
+++ b/lang/gcc8/Portfile
@@ -9,7 +9,7 @@ PortGroup conflicts_build              1.0
 epoch               4
 name                gcc8
 version             8.3.0
-revision            4
+revision            5
 subport             libgcc8 { revision 5 }
 platforms           darwin
 categories          lang
@@ -74,6 +74,11 @@ if {[vercmp ${xcodeversion} 10.2] >= 0} {
     # This should be removed in the next release of GCC
     patchfiles-append   xcode-bug-_Atomic-fix.patch 
 }
+
+# Support Xcode SDKROOT / xcrun.
+# Based on master branch patch discussed in :-
+# https://gcc.gnu.org/ml/gcc-patches/2019-10/msg00251.html
+patchfiles-append use-SDKROOT.patch
 
 configure.dir       ${workpath}/build
 configure.cmd       ${worksrcpath}/configure

--- a/lang/gcc8/files/use-SDKROOT.patch
+++ b/lang/gcc8/files/use-SDKROOT.patch
@@ -1,0 +1,73 @@
+--- gcc/config/darwin-driver.c.orig	2019-10-13 15:43:49.000000000 +0100
++++ gcc/config/darwin-driver.c	2019-10-13 15:49:57.000000000 +0100
+@@ -124,6 +124,27 @@
+   return new_flag;
+ }
+ 
++/* See if we can find the sysroot from the SDKROOT environment variable.  */
++static const char *
++maybe_get_sysroot_from_sdkroot ()
++{
++  const char *maybe_sysroot = getenv ("SDKROOT");
++
++  /* We'll use the same rules as the clang driver, for compatibility.
++     1) The path must be absolute
++     2) Ignore "/", that is the default anyway and we do not want the
++       sysroot semantics to be applied to it.
++     3) It must exist (actually, we'll check it's readable too).  */
++
++   if (maybe_sysroot  == NULL
++       || *maybe_sysroot != '/'
++       || strlen (maybe_sysroot) == 1
++       || access (maybe_sysroot, R_OK) == -1)
++    return NULL;
++
++  return xstrndup (maybe_sysroot, strlen (maybe_sysroot));
++}
++
+ /* Translate -filelist and -framework options in *DECODED_OPTIONS
+    (size *DECODED_OPTIONS_COUNT) to use -Xlinker so that they are
+    considered to be linker inputs in the case that no other inputs are
+@@ -148,6 +169,7 @@
+   bool appendM64 = false;
+   const char *vers_string = NULL;
+   bool seen_version_min = false;
++  bool seen_sysroot_p = false;
+ 
+   for (i = 1; i < *decoded_options_count; i++)
+     {
+@@ -211,6 +233,11 @@
+ 	  seen_version_min = true;
+ 	  vers_string = xstrndup ((*decoded_options)[i].arg, 32);
+ 
++        case OPT__sysroot_:
++        case OPT_isysroot:
++          seen_sysroot_p = true;
++          break;
++
+ 	default:
+ 	  break;
+ 	}
+@@ -272,6 +299,22 @@
+ 		       &(*decoded_options)[*decoded_options_count - 1]);
+     }
+ 
++  if (! seen_sysroot_p)
++  {
++    /* We will pick up an SDKROOT if we didn't specify a sysroot and treat
++       it as overriding any configure-time --with-sysroot.  */
++    const char *sdkroot = maybe_get_sysroot_from_sdkroot ();
++    if (sdkroot)
++    {
++      ++*decoded_options_count;
++      *decoded_options = XRESIZEVEC (struct cl_decoded_option,
++                                     *decoded_options,
++                                     *decoded_options_count);
++      generate_option (OPT__sysroot_, sdkroot, 1, CL_DRIVER,
++                       &(*decoded_options)[*decoded_options_count - 1]);
++    }
++  }
++  
+   /* We will need to know the OS X version we're trying to build for here
+      so that we can figure out the mechanism and source for the sysroot to
+      be used.  */


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.2
Xcode 11.3 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
