### PR TITLE
k9s: update to 0.10.4

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.9.3
+go.setup            github.com/derailed/k9s 0.10.4
 
 categories          sysutils
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -15,14 +15,13 @@ long_description    K9s provides a curses based terminal UI to interact with \
                     Kubernetes for changes and offers subsequent commands to \
                     interact with observed Kubernetes resources.
 
-homepage            https://k9ss.io
 platforms           darwin
 supported_archs     x86_64
 license             Apache-2
 
-checksums           rmd160  a15b616b781fc1f99b30b4a3b9baf4b0a5b98578 \
-                    sha256  323d3b164e56040f14cea601ae6782dc0a84f06b2994e0ca9edbf308a7c216dc \
-                    size    760461
+checksums           rmd160  87dabfd9c37af055ca77a93a4f19f205dd80bd39 \
+                    sha256  43002d8bc6f42c577136ab9f22ab465956dcbdaa04806c72d80cc37bff9ab0a3 \
+                    size    786791
 
 # Reproduce the "build" target from the upstream Makefile
 set go_ldflags      "-w -X ${go.package}/cmd.version=${version} \


### PR DESCRIPTION
#### Description

Update to k9s 0.10.4. Also removed no longer existing homepage URL, falling back to GitHub page.

###### Tested on

macOS 10.15.2 19C57
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?