### PR TITLE
rtl_433: update to version 19.08

### DIFF
--- a/science/rtl_433/Portfile
+++ b/science/rtl_433/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.0
 PortGroup           github 1.0
 
-github.setup        merbanan rtl_433 18.12
+github.setup        merbanan rtl_433 19.08
 epoch               1
 
 categories          science comms
@@ -15,8 +15,8 @@ maintainers         {@ducksauz duksta.org:john} openmaintainer
 description         RTL-SDR 433.92 MHz generic data receiver
 long_description    rtl_433 turns your Realtek RTL2832 based DVB dongle into a 433.92 MHz generic data receiver
 
-checksums           rmd160  bec2d508f80b79144a822de8b5ee9be10d96a690 \
-                    sha256  f79568bb5df6cf52b63e26ddb969eb5140c8c0bd26501722b7149218dce9b1ab \
-                    size    442044
+checksums           rmd160  bcfdfdc04e6b8837ff88692d1a95677d80555b8b \
+                    sha256  703a3b81e2b680ed820fc7acd475a14014e96a0592044cc4d4fab5bd59ccaf04 \
+                    size    743505
 
 depends_lib-append  port:rtl-sdr


### PR DESCRIPTION
#### Description
Update rtl_433 to latest tagged release on github (19.08)

* update to version 19.08

###### Type(s)
update

###### Tested on
macOS 10.14.6 18G2022
Xcode 11.3 11C29

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

