### PR TITLE
wireguard-tools: update to 1.0.20200102

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-tools
-version             1.0.20191226
+version             1.0.20200102
 revision            0
-checksums           rmd160  6f8354c6e1494aab5eca77df86aa997c4185dcc5 \
-                    sha256  aa8af0fdc9872d369d8c890a84dbc2a2466b55795dccd5b47721b2d97644b04f \
-                    size    90720
+checksums           rmd160  7c5acb869c76f8c160b646f1709fe89038e33e63 \
+                    sha256  547cd1c2f8dca904faac9e8d3964f1ef956c24bb12e3498da88dde95243c7f08 \
+                    size    91496
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
###### Tested on
macOS 10.13.6 17G8037
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?