### PR TITLE
frescobaldi: fix empty conflicts variable

### DIFF
--- a/editors/frescobaldi/Portfile
+++ b/editors/frescobaldi/Portfile
@@ -63,7 +63,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
     if {"${name}2" eq ${subport}} {
         # don't conflict with frescobaldi and frescobaldi-devel,
         # allowing replaced_by to act as expected
-        conflicts   {}
+        conflicts
     }
 }
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.6.8 10K549
Xcode 3.2.6 DevToolsSupport-1806.0 10M2518

and

macOS 10.13.6 17G10021
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
