### PR TITLE
dcmtk: Simplify variants, add -static sub-port

### DIFF
--- a/graphics/dcmtk/Portfile
+++ b/graphics/dcmtk/Portfile
@@ -48,7 +48,6 @@ configure.cppflags-replace -I${prefix}/include -isystem${prefix}/include
 depends_lib             port:jpeg \
                         port:libiconv \
                         port:libxml2 \
-                        port:openjpeg \
                         port:libpng \
                         port:tcp_wrappers \
                         port:tiff \
@@ -57,7 +56,7 @@ depends_lib             port:jpeg \
 depends_build-append    port:pkgconfig
 
 configure.args-append   -DDCMTK_WITH_TIFF=ON \
-                        -DDCMTK_WITH_OPENJPEG=ON \
+                        -DDCMTK_WITH_OPENJPEG=OFF \
                         -DDCMTK_WITH_PNG=ON \
                         -DDCMTK_WITH_OPENSSL=OFF \
                         -DDCMTK_WITH_XML=ON \

--- a/graphics/dcmtk/Portfile
+++ b/graphics/dcmtk/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem              1.0
 PortGroup               compiler_blacklist_versions 1.0
+PortGroup               active_variants 1.1
 PortGroup               muniversal 1.0
 PortGroup               conflicts_build 1.0
 PortGroup               cmake 1.1
@@ -10,7 +11,7 @@ PortGroup               cxx11 1.1
 
 github.setup            DCMTK dcmtk 3.6.5 DCMTK-
 
-revision                0
+revision                1
 set unpatched_version   [lindex [split ${version} _] 0]
 set stripped_version    [string map {. ""} ${unpatched_version}]
 categories              graphics
@@ -38,55 +39,106 @@ checksums \
     sha256  074a4c423718cdef3c14c108cea6fa2b08a456c2c03b19984d07a27370c71235 \
     size    6279048
 
-compiler.blacklist      *gcc* {clang < 137}
+compiler.cxx_standard   2011
 
 # avoid self-conflict
 configure.cppflags-replace -I${prefix}/include -isystem${prefix}/include
 
 
-depends_lib             port:zlib \
+depends_lib             port:jpeg \
                         port:libiconv \
+                        port:libxml2 \
+                        port:openjpeg \
+                        port:libpng \
                         port:tcp_wrappers \
-                        port:jpeg
+                        port:tiff \
+                        port:zlib
 
-configure.args-append   -DDCMTK_WITH_TIFF=OFF \
-                        -DDCMTK_WITH_PNG=OFF \
+depends_build-append    port:pkgconfig
+
+configure.args-append   -DDCMTK_WITH_TIFF=ON \
+                        -DDCMTK_WITH_OPENJPEG=ON \
+                        -DDCMTK_WITH_PNG=ON \
                         -DDCMTK_WITH_OPENSSL=OFF \
-                        -DDCMTK_WITH_XML=OFF \
+                        -DDCMTK_WITH_XML=ON \
                         -DDCMTK_WITH_ICONV=ON \
                         -DDCMTK_ENABLE_PRIVATE_TAGS=OFF \
                         -DDCMTK_WITH_DOXYGEN=OFF \
-                        -DBUILD_SHARED_LIBS=ON \
                         -DDCMTK_WITH_SNDFILE=OFF \
                         -DDCMTK_WITH_WRAP=ON \
                         -DCMAKE_CXX_STANDARD=11 \
                         -DDCMTK_ENABLE_STL=ON
 
-post-configure {
-    # 7921b2e in base creates symlinks, bypassing the github portgroup's move
-    # which would be OK, except Doxygen doesn't seem to like being pointed to a
-    # symlink as the base of the directories to search for sources. However,
-    # adding a '/.' to the end of the INPUT line makes it happy again, so...
-    # https://github.com/doxygen/doxygen/issues/3518
-    reinplace -E "s|^(INPUT .*)\"|\\1/.\"|" doxygen/htmldocs.cfg
-}
+subport                 dcmtk-static {}
 
-variant doc description "Install documentation" {
-    depends_build-append    port:doxygen
-    build.target-append     DOXYGEN
-    configure.args-delete   -DDCMTK_WITH_DOXYGEN=OFF
-    configure.args-append   -DDCMTK_WITH_DOXYGEN=ON
+if {${name} ne ${subport}} {
+    depends_run-append      port:dcmtk
+    configure.args-append   -DBUILD_SHARED_LIBS=OFF
+    long_description        Libraries to enable static-linking to dcmtk.
+
+    set actvar              ""
+    set inactvar            ""
+
+    pre-configure {
+        foreach variant {private sound ssl universal} {
+            if {[variant_isset ${variant}]} {
+                append actvar " " ${variant}
+            } else {
+                append inactvar " " ${variant}
+            }
+        }
+
+        if {![active_variants port:dcmtk "${actvar}" "${inactvar}"]} {
+            ui_error {dcmtk and dcmtk-static must have matching variants!}
+            return -code error
+        }
+    }
+
+    destroot {
+        xinstall -m 644 {*}[glob -directory ${cmake.build_dir}/lib/ *.a] \
+            ${destroot}${prefix}/lib/
+    }
+} else {
+    configure.args-append   -DBUILD_SHARED_LIBS=ON
+
+    post-configure {
+        # 7921b2e in base creates symlinks, bypassing the github portgroup's move
+        # which would be OK, except Doxygen doesn't seem to like being pointed to a
+        # symlink as the base of the directories to search for sources. However,
+        # adding a '/.' to the end of the INPUT line makes it happy again, so...
+        # https://github.com/doxygen/doxygen/issues/3518
+        reinplace -E "s|^(INPUT .*)\"|\\1/.\"|" doxygen/htmldocs.cfg
+    }
+
+    variant doc description "Install documentation" {
+        depends_build-append    port:doxygen
+        build.target-append     DOXYGEN
+        configure.args-delete   -DDCMTK_WITH_DOXYGEN=OFF
+        configure.args-append   -DDCMTK_WITH_DOXYGEN=ON
+    }
+
+    if {[variant_isset doc]} {
+        post-destroot {
+            # Don't really want these man pages.
+            system -W ${destroot}${prefix}/share/man/man1 "rm -f *_${distname}_*"
+        }
+        set DOCDIR          file://${prefix}/share/doc/dcmtk/html/index.html
+        notes               "DCMTK documentation available at:\n  ${DOCDIR}"
+    }
+
+    destroot.args           docdir=${prefix}/share/doc/${name}
+
+    post-destroot {
+        # avoid conflict with other MacPorts libraries
+        foreach lib {charls} {
+            delete ${destroot}${prefix}/lib/lib${lib}.dylib
+        }
+    }
 }
 
 variant private description "Install private tags dictionary" {
     configure.args-delete   -DDCMTK_ENABLE_PRIVATE_TAGS=OFF
     configure.args-append   -DDCMTK_ENABLE_PRIVATE_TAGS=ON
-}
-
-variant png description "Enable png support" {
-    depends_lib-append      port:libpng
-    configure.args-delete   -DDCMTK_WITH_PNG=OFF
-    configure.args-append   -DDCMTK_WITH_PNG=ON
 }
 
 variant sound description "Enable sndfile support" {
@@ -101,37 +153,7 @@ variant ssl description "Enable openssl support" {
     configure.args-append   -DDCMTK_WITH_OPENSSL=ON
 }
 
-variant tiff description "Enable tiff support" {
-    depends_lib-append      port:tiff
-    configure.args-delete   -DDCMTK_WITH_TIFF=OFF
-    configure.args-append   -DDCMTK_WITH_TIFF=ON
-}
-
-variant xml description "Enable xml support" {
-    depends_lib-append      port:libxml2
-    configure.args-delete   -DDCMTK_WITH_XML=OFF
-    configure.args-append   -DDCMTK_WITH_XML=ON
-}
-
-default_variants        +png +ssl +tiff +xml
-
-if {[variant_isset doc]} {
-    post-destroot {
-        # Don't really want these man pages.
-        system -W ${destroot}${prefix}/share/man/man1 "rm -f *_${distname}_*"
-    }
-    set DOCDIR          file://${prefix}/share/doc/dcmtk/html/index.html
-    notes               "DCMTK documentation available at:\n  ${DOCDIR}"
-}
-
-destroot.args           docdir=${prefix}/share/doc/${name}
-
-post-destroot {
-    # avoid conflict with other MacPorts libraries
-    foreach lib {charls} {
-        delete ${destroot}${prefix}/lib/lib${lib}.dylib
-    }
-}
+default_variants        +ssl
 
 test.run                yes
 test.cmd                env DYLD_LIBRARY_PATH=${cmake.build_dir}/lib make


### PR DESCRIPTION
Maintainer update.

Remove (make mandatory) optional (previously default-on) dependency variants. Most of these libs will be installed by users already (xml2, jpeg, png, zlib ...) with the possible exception of openjpeg (which was being opportunistically ~linked to~ detected but not linked against previously.)

Add dcmtk-static sub-port (depends_run on port:dcmtk) which only includes static libraries. This enables building binaries statically-linked against dcmtk. (This is a user request, not a typical use-case, to be sure.)

Added `-DDCMTK_WITH_OPENJPEG=OFF` to prevent detection of openjpeg (even though it doesn't currently try to link to it.