### PR TITLE
jtc: update to 1.75c

### DIFF
--- a/textproc/jtc/Portfile
+++ b/textproc/jtc/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 
-github.setup        ldn-softdev jtc 1.75b
+github.setup        ldn-softdev jtc 1.75c
 github.tarball_from archive
 
 platforms           darwin
@@ -23,9 +23,9 @@ long_description    jtc stand for: JSON test console, but it's a legacy name, \
                     insert new elements, remove, copy, move, compare, \
                     transform and swap around).
 
-checksums           rmd160  3226c0deb0fd2d5b44f0e7474f151e53a4b01e2d \
-                    sha256  602cc3ff02734f32e17d4abd66a071ea22d72bd08ad59450792452626f2467aa \
-                    size    195789
+checksums           rmd160  2a1d972c62c3e7ac8555a9c8becfac5285d62d35 \
+                    sha256  cce715ec3c1234f51d05197b0cb5f69e5a7eead73775027f3f915df162153c67 \
+                    size    198105
 
 compiler.cxx_standard 2014
 


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15.2 19C57
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
