### PR TITLE
FreeRDP : fix +codecs variant

### DIFF
--- a/net/FreeRDP/Portfile
+++ b/net/FreeRDP/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake   1.1
 
 epoch               2
 github.setup        FreeRDP FreeRDP 2.0.0-rc4
-revision            2
+revision            3
 categories          net
 platforms           darwin
 license             Apache
@@ -24,8 +24,7 @@ checksums           rmd160  8c492959eca7d8621dbb243a94cd1b12d14529f8 \
 depends_build-append \
                     port:pkgconfig
 
-depends_lib-append  \
-                    port:xorg-libX11 \
+depends_lib-append  port:xorg-libX11 \
                     port:xorg-libXcursor \
                     port:xorg-libXext \
                     port:xorg-libXi \
@@ -35,7 +34,7 @@ depends_lib-append  \
                     port:xorg-libXv \
                     port:xrender \
                     port:zlib \
-                    path:lib/libjpeg.dylib:jpeg \
+                    path:lib/libjpeg.dylib:libjpeg-turbo \
                     path:lib/libssl.dylib:openssl \
                     port:kerberos5
 
@@ -100,12 +99,12 @@ variant codecs description {support MP3, FAAD2, FAAC and SOXR codecs} {
                     port:soxr
     configure.args-replace \
                     -DWITH_LAME=OFF \
-                    -DWITH_FAAD2=OFF \
-                    -DWITH_FAAC=OFF \
-                    -DWITH_SOXR=OFF \
                     -DWITH_LAME=ON \
+                    -DWITH_FAAD2=OFF \
                     -DWITH_FAAD2=ON \
+                    -DWITH_FAAC=OFF \
                     -DWITH_FAAC=ON \
+                    -DWITH_SOXR=OFF \
                     -DWITH_SOXR=ON
 }
 


### PR DESCRIPTION
and restore preference for port:libjpeg-turbo

The `-replace` feature takes pairs of before/after pattern*s*, and of course not something composite as I threw together with too much haste and no time for even a quick test.
It is not required to have multiple `configure.args-replace` statements, something I never really liked when I still thought that was a requirement.