### PR TITLE
k9s: update to 0.11.2

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.11.0
+go.setup            github.com/derailed/k9s 0.11.2
 
 categories          sysutils
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -19,9 +19,9 @@ platforms           darwin
 supported_archs     x86_64
 license             Apache-2
 
-checksums           rmd160  e082ea6f2598b635c470d413055e01ea3df8c2b0 \
-                    sha256  f86788080f4273e06fd826e7e8b9f96a022be5f0d503eb90b1983f283cf11f6d \
-                    size    837943
+checksums           rmd160  e1f399d519390466cf523f546578561e729ecebf \
+                    sha256  4007fcfb6957b12b756294aacbdf596b987daa0c1aac096de9288c2de3ed796e \
+                    size    838273
 
 # Reproduce the "build" target from the upstream Makefile
 set go_ldflags      "-w -X ${go.package}/cmd.version=${version} \


### PR DESCRIPTION
#### Description

Update to k9s 0.11.2.

###### Tested on

macOS 10.15.2 19C57
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?