### PR TITLE
starship: update to 0.33.0

### DIFF
--- a/sysutils/starship/Portfile
+++ b/sysutils/starship/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        starship starship 0.32.2 v
+github.setup        starship starship 0.33.0 v
 categories          sysutils
 platforms           darwin
 maintainers         {l2dy @l2dy} \
@@ -17,9 +17,9 @@ description         a minimal, blazing fast, and extremely customizable prompt f
 long_description    Starship is ${description}.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  cc6c39f9f0abfbea25afaf93210050428e66a2d8 \
-                    sha256  f714c5a8cbbcfb658cb54a96257a645ab457e471d0444488a71f0bed90ca03a3 \
-                    size    5114475
+                    rmd160  90600c9b5c561e24ee8fcd69f0c384efba071a16 \
+                    sha256  b482531186ff1832bf38c730c91217ef5745b280468cf66e5e58ab15ac3aed61 \
+                    size    5112883
 
 # For crate:openssl-sys
 depends_build       port:pkgconfig
@@ -30,7 +30,6 @@ destroot {
 }
 
 cargo.crates \
-    adler32                          1.0.4  5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2 \
     aho-corasick                     0.7.6  58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d \
     ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
     ansi_term                       0.12.1  d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2 \
@@ -42,6 +41,7 @@ cargo.crates \
     autocfg                          0.1.7  1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2 \
     backtrace                       0.3.40  924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea \
     backtrace-sys                   0.1.32  5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491 \
+    base64                          0.11.0  b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7 \
     base64                          0.10.1  0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e \
     battery                          0.7.5  36a698e449024a5d18994a815998bf5e2e4bc1883e35a7d7ba95b6b69ee45907 \
     bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
@@ -49,7 +49,7 @@ cargo.crates \
     bumpalo                          2.6.0  ad807f2fc2bf185eeb98ff3a901bd46dc5ad58163d0fa4577ba0d25674d71708 \
     byte-unit                        3.0.3  6894a79550807490d9f19a138a6da0f8830e70c83e83402dd23f16fd6c479056 \
     byteorder                        1.3.2  a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5 \
-    bytes                           0.4.12  206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c \
+    bytes                            0.5.3  10004c15deb332055f7a4a208190aed362cf9a7c2f6ab70a305fba50e1105f38 \
     c2-chacha                        0.2.3  214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb \
     cc                              1.0.48  f52a465a666ca3d838ebbf08b241383421412fe7ebb463527bba275526d89f76 \
     cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
@@ -57,14 +57,10 @@ cargo.crates \
     clap                            2.33.0  5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9 \
     cloudabi                         0.0.3  ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
     constant_time_eq                 0.1.4  995a44c877f9212528ccc74b21a232f66ad69001e40ede5bcee2ac9ef2657120 \
-    cookie                          0.12.0  888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5 \
-    cookie_store                     0.7.0  46750b3f362965f197996c4448e4a0935e791bf7d6631bfce9ee0af3d24c919c \
     core-foundation                  0.6.4  25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d \
     core-foundation-sys              0.6.2  e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b \
-    crc32fast                        1.2.0  ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1 \
     crossbeam-deque                  0.7.2  c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca \
     crossbeam-epoch                  0.8.0  5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac \
-    crossbeam-queue                  0.1.2  7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b \
     crossbeam-queue                  0.2.0  dfd6515864a82d2f877b42813d4553292c6659498c9a2aa31bab5a15243c2700 \
     crossbeam-utils                  0.7.0  ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4 \
     crossbeam-utils                  0.6.6  04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6 \
@@ -76,29 +72,31 @@ cargo.crates \
     either                           1.5.3  bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3 \
     encoding_rs                     0.8.20  87240518927716f79692c2ed85bfe6e98196d18c6401ec75355760233a7e12e9 \
     env_logger                       0.6.2  aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3 \
-    error-chain                     0.12.1  3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9 \
     failure                          0.1.6  f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9 \
     failure_derive                   0.1.6  0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08 \
-    flate2                          1.0.13  6bd6d6f4752952feb71363cffc9ebac9411b75b87c6ab6058c40c8900cf43c0f \
     fnv                              1.0.6  2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3 \
     fuchsia-cprng                    0.1.1  a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba \
     fuchsia-zircon                   0.3.3  2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
     fuchsia-zircon-sys               0.3.3  3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
-    futures                         0.1.29  1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef \
-    futures-cpupool                  0.1.8  ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4 \
+    futures-channel                  0.3.1  fcae98ca17d102fd8a3603727b9259fcf7fa4239b603d2142926189bc8999b86 \
+    futures-core                     0.3.1  79564c427afefab1dfb3298535b21eda083ef7935b4f0ecbfcb121f0aec10866 \
+    futures-io                       0.3.1  e676577d229e70952ab25f3945795ba5b16d63ca794ca9d2c860e5595d20b5ff \
+    futures-macro                    0.3.1  52e7c56c15537adb4f76d0b7a76ad131cb4d2f4f32d3b0bcabcbe1c7c5e87764 \
+    futures-sink                     0.3.1  171be33efae63c2d59e6dbba34186fe0d6394fb378069a76dfd80fdcffd43c16 \
+    futures-task                     0.3.1  0bae52d6b29cf440e298856fec3965ee6fa71b06aa7495178615953fd669e5f9 \
+    futures-util                     0.3.1  c0d66274fb76985d3c62c886d1da7ac4c0903a8c9f754e8fe0f35a6a6cc39e76 \
     gethostname                      0.2.1  e692e296bfac1d2533ef168d0b60ff5897b8b70a4009276834014dd8924cc028 \
     getrandom                       0.1.13  e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407 \
     git2                            0.11.0  77519ef7c5beee314d0804d4534f01e0f9e8d9acdee2b7a48627e590b27e0ec4 \
-    h2                              0.1.26  a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462 \
+    h2                               0.2.1  b9433d71e471c1736fd5a61b671fc0b148d7a2992f666c958d03cd8feb3b88d1 \
     heck                             0.3.1  20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205 \
     hermit-abi                       0.1.5  f629dc602392d3ec14bfc8a09b5e644d7ffd725102b48b81e59f90f2633621d7 \
-    http                            0.1.21  d6ccf5ede3a895d8856620237b2f02972c1bbc78d2965ad7fe8838d4a0ed41f0 \
-    http-body                        0.1.0  6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d \
+    http                             0.2.0  b708cc7f06493459026f53b9a61a7a121a5d1ec6238dee58ea4941132b30156b \
+    http-body                        0.3.1  13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b \
     httparse                         1.3.4  cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9 \
     humantime                        1.3.0  df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f \
-    hyper                          0.12.35  9dbe6ed1438e1f8ad955a4701e9a944938e9519f6888d12d8558b645e247d5f6 \
-    hyper-rustls                    0.17.1  719d85c7df4a7f309a77d145340a063ea929dcb2e025bae46a80345cffec2952 \
-    idna                             0.1.5  38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e \
+    hyper                           0.13.1  8bf49cfb32edee45d890537d9057d1b02ed55f53b7b6a30bae83a38c9231749e \
+    hyper-rustls                    0.19.0  b89109920197f2c90d75e82addbb96bf424570790d310cc2b18f0b33f4a9cc43 \
     idna                             0.2.0  02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9 \
     indexmap                         1.3.0  712d7b3ea5827fcb9d4fda14bf4da5f136f0db2ae9c8f4bd4e2d1c6fde4e6db2 \
     iovec                            0.1.4  b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e \
@@ -113,16 +111,13 @@ cargo.crates \
     libgit2-sys                     0.10.0  d9ec6bca50549d34a392611dde775123086acbd994e3fff64954777ce2dc2e51 \
     libz-sys                        1.0.25  2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe \
     linked-hash-map                  0.5.2  ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83 \
-    lock_api                         0.3.2  e57b3997725d2b60dbec1297f6c2e2957cc383db1cebd6be812163f969c7d586 \
     log                              0.4.8  14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7 \
     mach                             0.2.3  86dd2487cdfea56def77b88438a2c915fb45113c5319bfe7e14306ca4cd0b0e1 \
     matches                          0.1.8  7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
-    maybe-uninit                     2.0.0  60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00 \
     memchr                           2.2.1  88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e \
     memoffset                        0.5.3  75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9 \
     mime                            0.3.14  dd1d63acd1b78403cc0c325605908475dd9b9a3acbf65ed8bcab97e27014afcf \
     mime_guess                       2.0.1  1a0ed03949aef72dbdf3116a383d7b38b4768e6f960528cd6a6044aa9ed68599 \
-    miniz_oxide                      0.3.5  6f3f74f726ae935c3f514300cc6773a0c9492abc5e972d42ba0c0ebb88757625 \
     mio                             0.6.21  302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f \
     miow                             0.2.1  8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919 \
     net2                            0.2.33  42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88 \
@@ -136,33 +131,29 @@ cargo.crates \
     num_cpus                        1.11.1  76dac5ed2a876980778b8b85f75a71b6cbf0db0b1232ee12f826bccb00d09d72 \
     once_cell                        1.2.0  891f486f630e5c5a4916c7e16c4b24a53e78c860b646e9f8e005e4f16847bfed \
     open                             1.3.2  94b424e1086328b0df10235c6ff47be63708071881bead9e76997d9291c0134b \
+    openssl-probe                    0.1.2  77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de \
     os_info                          1.2.0  0d46cac13d062d40f1284a3927cb86edf3a4d7b6df38dad4124c510819166695 \
-    parking_lot                      0.9.0  f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252 \
-    parking_lot_core                 0.6.2  b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b \
     path-slash                       0.1.1  a0858af4d9136275541f4eac7be1af70add84cf356d901799b065ac1b8ff6e2f \
-    percent-encoding                 1.0.1  31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831 \
     percent-encoding                 2.1.0  d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
+    pin-project                      0.4.6  94b90146c7216e4cb534069fb91366de4ea0ea353105ee45ed297e2d1619e469 \
+    pin-project-internal             0.4.6  44ca92f893f0656d3cba8158dd0f2b99b94de256a4a54e870bd6922fcc6c8355 \
+    pin-project-lite                 0.1.2  e8822eb8bb72452f038ebf6048efa02c3fe22bf83f76519c9583e47fc194a422 \
+    pin-utils                     0.1.0-alpha.4  5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587 \
     pkg-config                      0.3.17  05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677 \
     ppv-lite86                       0.2.6  74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b \
     pretty_env_logger                0.3.1  717ee476b1690853d222af4634056d830b5197ffd747726a9a1eee6da9f49074 \
+    proc-macro-hack                 0.5.11  ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5 \
+    proc-macro-nested                0.1.3  369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e \
     proc-macro2                      1.0.6  9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27 \
-    publicsuffix                     1.5.4  3bbaa49075179162b49acac1c6aa45fb4dafb5f13cf6794276d77bc7fd95757b \
     quick-error                      1.2.2  9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0 \
     quote                            1.0.2  053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe \
-    rand                             0.6.5  6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca \
     rand                             0.7.2  3ae1b169243eaf61759b8475a998f0a385e42042370f3a7dbaf35246eacc8412 \
-    rand_chacha                      0.1.1  556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef \
     rand_chacha                      0.2.1  03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853 \
     rand_core                        0.3.1  7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b \
     rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
     rand_core                        0.4.2  9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc \
     rand_hc                          0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
-    rand_hc                          0.1.0  7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4 \
-    rand_isaac                       0.1.1  ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08 \
-    rand_jitter                      0.1.4  1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b \
     rand_os                          0.1.3  7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071 \
-    rand_pcg                         0.1.2  abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44 \
-    rand_xorshift                    0.1.1  cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c \
     rayon                            1.3.0  db6ce3297f9c85e16621bb8cca38a06779ffc31bb8184e1be4bed2be4678a098 \
     rayon-core                       1.7.0  08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9 \
     rdrand                           0.4.0  678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2 \
@@ -171,51 +162,46 @@ cargo.crates \
     regex                            1.3.1  dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd \
     regex-syntax                    0.6.12  11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716 \
     remove_dir_all                   0.5.2  4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e \
-    reqwest                         0.9.24  f88643aea3c1343c804950d7bf983bd2067f5ab59db6d613a08e05572f2714ab \
+    reqwest                         0.10.0  03c6cbd2bc1c1cb7052dbe30f4a70cf65811967c800f2dfbb2e6036dc9ee2553 \
     ring                            0.16.9  6747f8da1f2b1fabbee1aaa4eb8a11abf9adef0bf58a41cee45db5d59cecdfac \
     rust-argon2                      0.5.1  4ca4eaef519b494d1f2848fc602d18816fed808a981aedf4f1f00ceb7c9d32cf \
     rustc-demangle                  0.1.16  4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783 \
     rustc_version                    0.2.3  138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a \
     rustls                          0.16.0  b25a18b1bf7387f0145e7f8324e700805aade3842dd3db2e74e4cdeb4677c09e \
+    rustls-native-certs              0.1.0  51ffebdbb48c14f84eba0b715197d673aff1dd22cc1007ca647e28483bbcc307 \
     ryu                              1.0.2  bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8 \
+    schannel                        0.1.16  87f550b06b6cba9c8b8be3ee73f391990116bf527450d2556e9b9ce263b9a021 \
     scopeguard                       1.0.0  b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d \
     sct                              0.6.0  e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c \
+    security-framework               0.3.4  8ef2429d7cefe5fd28bd1d2ed41c944547d4ff84776f5935b456da44593a16df \
+    security-framework-sys           0.3.3  e31493fc37615debb8c5090a7aeb4a9730bc61e77ab10b9af59f1a202284f895 \
     semver                           0.9.0  1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403 \
     semver-parser                    0.7.0  388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
     serde                          1.0.104  414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449 \
     serde_derive                   1.0.104  128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64 \
     serde_json                      1.0.44  48c575e0cc52bdd09b47f330f646cf59afc586e9c4e3ccd6fc1f625b8ea1dad7 \
-    serde_urlencoded                 0.5.5  642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a \
+    serde_urlencoded                 0.6.1  9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97 \
     slab                             0.4.2  c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8 \
     smallvec                         1.0.0  4ecf3b85f68e8abaa7555aa5abdb1153079387e60b718283d732f03897fcfc86 \
-    smallvec                        0.6.13  f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6 \
     sourcefile                       0.1.4  4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3 \
     spin                             0.5.2  6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d \
     static_assertions                0.3.4  7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3 \
-    string                           0.2.1  d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d \
     strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
     syn                             1.0.11  dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238 \
     synstructure                    0.12.3  67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545 \
-    sysinfo                         0.10.3  02067c0c215cbc50176ad0c8718183c5e6bfd3d97c6913c26abeae3bfa8ed2ae \
+    sysinfo                         0.10.4  99474859bbf2710ae8f09912a047cfe24d2c1076af9eb86661eb906ca7d1e994 \
     tempfile                         3.1.0  7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9 \
+    term_size                        0.3.1  9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327 \
     termcolor                        1.0.5  96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e \
     textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
     thread_local                     0.3.6  c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b \
     time                            0.1.42  db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f \
-    tokio                           0.1.22  5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6 \
-    tokio-buf                        0.1.1  8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46 \
-    tokio-current-thread             0.1.6  d16217cad7f1b840c5a97dfb3c43b0c871fef423a6e8d2118c604e843662a443 \
-    tokio-executor                   0.1.9  ca6df436c42b0c3330a82d855d2ef017cd793090ad550a6bc2184f4b933532ab \
-    tokio-io                        0.1.12  5090db468dad16e1a7a54c8c67280c5e4b544f3d3e018f0b913b400261f85926 \
-    tokio-reactor                   0.1.11  6732fe6b53c8d11178dcb77ac6d9682af27fc6d4cb87789449152e5377377146 \
-    tokio-rustls                    0.10.2  1df2fa53ac211c136832f530ccb081af9af891af22d685a9493e232c7a359bc2 \
-    tokio-sync                       0.1.7  d06554cce1ae4a50f42fba8023918afa931413aded705b560e29600ccf7c6d76 \
-    tokio-tcp                        0.1.3  1d14b10654be682ac43efee27401d792507e30fd8d26389e1da3b185de2e4119 \
-    tokio-threadpool                0.1.17  f0c32ffea4827978e9aa392d2f743d973c1dfa3730a2ed3f22ce1e6984da848c \
-    tokio-timer                     0.2.12  1739638e364e558128461fc1ad84d997702c8e31c2e6b18fb99842268199e827 \
+    tokio                            0.2.6  0e1bef565a52394086ecac0a6fa3b8ace4cb3a138ee1d96bd2b93283b56824e3 \
+    tokio-rustls                    0.12.1  ea2ce8e6bc7ce619b4fc05761a550c8a750f6bf551f2e9b1efaec93124e13d51 \
+    tokio-util                       0.2.0  571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930 \
     toml                             0.5.5  01d1404644c8b12b16bfcffa4322403a91a451584daaaa7c28d3152e6cbc98cf \
+    tower-service                    0.3.0  e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860 \
     try-lock                         0.2.2  e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382 \
-    try_from                         0.3.2  283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b \
     typenum                         1.11.2  6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9 \
     unicase                          2.6.0  50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6 \
     unicode-bidi                     0.3.4  49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5 \
@@ -225,20 +211,19 @@ cargo.crates \
     unicode-xid                      0.2.0  826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c \
     untrusted                        0.7.0  60369ef7a31de49bcb3f6ca728d4ba7300d9a1658f94c727d4cab8c8d9f4aece \
     uom                             0.26.0  4cec796ec5f7ac557631709079168286056205c51c60aac33f51764bdc7b8dc4 \
-    url                              1.7.2  dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a \
     url                              2.1.0  75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61 \
     urlencoding                      1.0.0  3df3561629a8bb4c57e5a2e4c43348d9e29c7c29d9b1c4c1f47166deca8f37ed \
     user32-sys                       0.2.0  4ef4711d107b21b410a3a974b1204d9accc8b10dad75d8324b5d755de1617d47 \
-    uuid                             0.7.4  90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a \
     vcpkg                            0.2.8  3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168 \
     vec_map                          0.8.1  05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a \
     version_check                    0.9.1  078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce \
     version_check                    0.1.5  914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd \
     void                             1.0.2  6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d \
-    want                             0.2.0  b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230 \
+    want                             0.3.0  1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0 \
     wasi                             0.7.0  b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d \
     wasm-bindgen                    0.2.56  99de4b68939a880d530aed51289a7c7baee154e3ea8ac234b542c49da7134aaf \
     wasm-bindgen-backend            0.2.56  b58e66a093a7b7571cb76409763c495b8741ac4319ac20acc2b798f6766d92ee \
+    wasm-bindgen-futures             0.4.6  3bf1b55e0dc85085cfab2c0c520b977afcf16ac5801ee0de8dde42a4f5649b2a \
     wasm-bindgen-macro              0.2.56  a80f89daea7b0a67b11f6e9f911422ed039de9963dce00048a653b63d51194bf \
     wasm-bindgen-macro-support      0.2.56  4f9dbc3734ad6cff6b76b75b7df98c06982becd0055f651465a08f769bca5c61 \
     wasm-bindgen-shared             0.2.56  d907984f8506b3554eab48b8efff723e764ddbf76d4cd4a3fe4196bc00c49a70 \


### PR DESCRIPTION

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.2 19C57
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
