### PR TITLE
msmtp: update version to 1.8.7

### DIFF
--- a/mail/msmtp/Portfile
+++ b/mail/msmtp/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                msmtp
-version             1.8.6
+version             1.8.7
 revision            0
 categories          mail
 platforms           darwin
@@ -21,9 +21,9 @@ homepage            https://marlam.de/msmtp/
 master_sites        ${homepage}releases/
 use_xz              yes
 
-checksums           rmd160  3c9b157bdaf6a2d116cf2c081076aa8e09cc45a4 \
-                    sha256  6625f147430c65ba8527f52c4fe5d4d33552d3c0fb6d793ba7df819a3b3042e1 \
-                    size    339732
+checksums           rmd160  f5b7ce9a5433ec61fed976f659a8755302f4e6a9 \
+                    sha256  9a53bcdc244ec5b1a806934ecc7746d9d09db581f587bedf597e9da2f48c51f1 \
+                    size    340908
 
 depends_build       port:pkgconfig
 depends_lib         port:gettext \


### PR DESCRIPTION


#### Description

- bump version to 1.8.7

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.2 19C57
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
