### PR TITLE
google-cloud-sdk: update to 275.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             274.0.1
+version             275.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  c483a99b811e0c70e3d733ff55280c1bcf61dfbf \
-                    sha256  523bf4c9f31007253165929a77a05c44d751f27ece8ae9573188cd79cfc5b915 \
-                    size    23085140
+    checksums       rmd160  13087e1cc2d8c1389d664167dcae8db0b4d02d48 \
+                    sha256  e07f3232a1e5e16e80cc5ab7882a0b1d2641f0a32551a8db6b01322ff755c2fb \
+                    size    23152261
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  439d21b65ebbf5a20098fda320155e8ea642abb9 \
-                    sha256  102023b8e90e240f46ed9b7fa6f2758c1a18cc8d71f7d2ab27b467074ee01e91 \
-                    size    23085813
+    checksums       rmd160  fd74e4752f1eaa4d76123d3551892649477b385f \
+                    sha256  eec3b8aeb29c49d60f2a001a7ba342548c5afdb2188c6495efe6d82514c7799b \
+                    size    23155113
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 275.0.0.

###### Tested on

macOS 10.15.2 19C57
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?