### PR TITLE
terraform: update to 0.12.19

### DIFF
--- a/sysutils/terraform/Portfile
+++ b/sysutils/terraform/Portfile
@@ -17,10 +17,10 @@ maintainers             {emcrisostomo @emcrisostomo} \
 # *NOTE* Remember to update `latestVersion` on a version upgrade.
 set latestVersion       terraform-0.12
 subport terraform-0.12 {
-    set patchNumber     18
-    checksums           rmd160  96a09c613a4e6a669cd62792de3bdc1762679d8a \
-                        sha256  dd6983cfe0d0922de51e019a80db2a270e8a2636b9f05b49bf7dcbfe7bd90ea9 \
-                        size    17965753
+    set patchNumber     19
+    checksums           rmd160  b641ca4137b81f0ff75d65d3f324773df1033710 \
+                        sha256  5238fe45d051cac90f0fc0701796c5244ef88218d0fe4eceec31cee43899a434 \
+                        size    17975674
 }
 
 subport terraform-0.11 {
@@ -34,9 +34,10 @@ subport terraform_select {}
 
 if {${subport} eq ${name}} {
     PortGroup           obsolete 1.0
+
     replaced_by         ${latestVersion}
-    version             0.12.18
-    revision            1
+    version             0.12.19
+    revision            0
 
 } elseif {${subport} eq "terraform_select"} {
     version             0.0.0


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.2 19C57
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
