### PR TITLE
jtc: patch 1.75c for older compilers

### DIFF
--- a/textproc/jtc/Portfile
+++ b/textproc/jtc/Portfile
@@ -6,6 +6,7 @@ PortGroup           github 1.0
 
 github.setup        ldn-softdev jtc 1.75c
 github.tarball_from archive
+revision            1
 
 platforms           darwin
 categories          textproc
@@ -26,6 +27,8 @@ long_description    jtc stand for: JSON test console, but it's a legacy name, \
 checksums           rmd160  2a1d972c62c3e7ac8555a9c8becfac5285d62d35 \
                     sha256  cce715ec3c1234f51d05197b0cb5f69e5a7eead73775027f3f915df162153c67 \
                     size    198105
+
+patchfiles          patch-signal-hpp.diff
 
 compiler.cxx_standard 2014
 

--- a/textproc/jtc/files/patch-signal-hpp.diff
+++ b/textproc/jtc/files/patch-signal-hpp.diff
@@ -1,0 +1,11 @@
+--- lib/signals.hpp.orig	2020-01-09 04:38:11.000000000 -0500
++++ lib/signals.hpp	2020-01-09 04:38:28.000000000 -0500
+@@ -281,7 +281,7 @@
+   for(size_t i = 0; i < offset; ++i) {                          // extract all symbolic parts
+    auto next_prt = strchr(prtptr, ' ');                         // skip to end of part
+    if(next_prt == nullptr) break;                               // unexpected
+-   std::string part(prtptr, next_prt);
++   std::string part(prtptr, next_prt - prtptr);
+ 
+    while(*next_prt == ' ') ++next_prt;                          // find a a next part
+    if(next_prt == nullptr) break;                               // unexpected


### PR DESCRIPTION
Attempt to fix build failures for older XCode versions for `jtc` 1.75c

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.2 19C57
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
