### PR TITLE
poppler: add variant "pdfsig"

### DIFF
--- a/graphics/poppler/Portfile
+++ b/graphics/poppler/Portfile
@@ -10,7 +10,6 @@ PortGroup           legacysupport 1.0
 name                poppler
 conflicts           xpdf-tools
 version             0.83.0
-revision            1
 license             GPL-2+
 maintainers         {devans @dbevans} openmaintainer
 categories          graphics
@@ -128,9 +127,7 @@ if {${subport} ne ${name}} {
 
 # build pdfsig
 variant pdfsig description {Build pdfsig binary} {
-	configure.args-delete -DWITH_NSS3=OFF
-	configure.args-append -DWITH_NSS3=ON
-	depends_build-append port:nss
+	configure.args-replace -DWITH_NSS3=OFF -DWITH_NSS3=ON
 	depends_lib-append port:nss
 }
 

--- a/graphics/poppler/Portfile
+++ b/graphics/poppler/Portfile
@@ -10,6 +10,7 @@ PortGroup           legacysupport 1.0
 name                poppler
 conflicts           xpdf-tools
 version             0.83.0
+revision            1
 license             GPL-2+
 maintainers         {devans @dbevans} openmaintainer
 categories          graphics
@@ -123,6 +124,14 @@ if {${subport} ne ${name}} {
     # generation of Poppler-0.18.gir fails if previous version of poppler is active
     # and new symbols are introduced, appropriate for main poppler port only
     conflicts_build ${name}
+}
+
+# build pdfsig
+variant pdfsig description {Build pdfsig binary} {
+	configure.args-delete -DWITH_NSS3=OFF
+	configure.args-append -DWITH_NSS3=ON
+	depends_build-append port:nss
+	depends_lib-append port:nss
 }
 
 livecheck.type      regex


### PR DESCRIPTION
pdfsig is poppler's utility to check digital signatures. This patch
allows to choose whether pdfsig will be built.

#### Description

This patch adds functionality to verify digital signatures from commandline.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6
Xcode 11

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
