### PR TITLE
llvm/clang/lldb-9.0: bump to 9.0.1

### DIFF
--- a/lang/llvm-9.0/Portfile
+++ b/lang/llvm-9.0/Portfile
@@ -102,9 +102,9 @@ if {${subport} eq "llvm-${llvm_version}"} {
 #default_variants-append +assertions
 #default_variants-append +debug
 
-version                 ${llvm_version}.0
+version                 ${llvm_version}.1
 epoch                   1
-master_sites            https://releases.llvm.org/${version}
+master_sites            https://github.com/llvm/llvm-project/releases/download/llvmorg-${version}
 #master_sites            https://prereleases.llvm.org/${llvm_version}.0/rc2
 use_xz                  yes
 extract.suffix          .tar.xz
@@ -117,41 +117,40 @@ if {${distfiles} ne ""} {
             distfiles-append     polly-${version}.src${extract.suffix}
         }
     } elseif {${subport} eq "clang-${llvm_version}"} {
-        distfiles-append     cfe-${version}.src${extract.suffix} compiler-rt-${version}.src${extract.suffix} libcxx-${version}.src${extract.suffix} clang-tools-extra-${version}.src${extract.suffix}
+        distfiles-append     clang-${version}.src${extract.suffix} compiler-rt-${version}.src${extract.suffix} libcxx-${version}.src${extract.suffix} clang-tools-extra-${version}.src${extract.suffix}
     } elseif {${subport} eq "lldb-${llvm_version}"} {
-        distfiles-append     cfe-${version}.src${extract.suffix} lldb-${version}.src${extract.suffix}
+        distfiles-append     clang-${version}.src${extract.suffix} lldb-${version}.src${extract.suffix}
     }
 }
 
-checksums           llvm-9.0.0.src.tar.xz \
-                    rmd160  fb47d140555cd728006f07d7ad12ae9cb3f8ace6 \
-                    sha256  d6a0565cf21f22e9b4353b2eb92622e8365000a9e90a16b09b56f8157eabfe84 \
-                    size    32994768 \
-                    cfe-9.0.0.src.tar.xz \
-                    rmd160  43a9fde0f388fe6d021357bb4382bef6d445f279 \
-                    sha256  7ba81eef7c22ca5da688fdf9d88c20934d2d6b40bfe150ffd338900890aa4610 \
-                    size    13533024 \
-                    compiler-rt-9.0.0.src.tar.xz \
-                    rmd160  0b80105106d7c19f806b82508b5f4af771a95ae1 \
-                    sha256  56e4cd96dd1d8c346b07b4d6b255f976570c6f2389697347a6c3dcb9e820d10e \
-                    size    1993084 \
-                    libcxx-9.0.0.src.tar.xz \
-                    rmd160  e92b03ab660c8bb598dae2893e01b57a449b29fe \
-                    sha256  3c4162972b5d3204ba47ac384aa456855a17b5e97422723d4758251acf1ed28c \
-                    size    1814388 \
-                    clang-tools-extra-9.0.0.src.tar.xz \
-                    rmd160  284072baa8c9771de7e35cb1e9ad4ed813ff20c9 \
-                    sha256  ea1c86ce352992d7b6f6649bc622f6a2707b9f8b7153e9f9181a35c76aa3ac10 \
-                    size    2183436 \
-                    lldb-9.0.0.src.tar.xz \
-                    rmd160  ec312e0ef133e8a649a833ce7ca7338d5fdae377 \
-                    sha256  1e4c2f6a1f153f4b8afa2470d2e99dab493034c1ba8b7ffbbd7600de016d0794 \
-                    size    9846624 \
-                    polly-9.0.0.src.tar.xz \
-                    rmd160  9cce54e805f090f3c5e82f1f659e3a2f8c20cd23 \
-                    sha256  a4fa92283de725399323d07f18995911158c1c5838703f37862db815f513d433 \
-                    size    8719928
-
+checksums           llvm-9.0.1.src.tar.xz \
+                    rmd160  151c137ac3a514b6d32aaee5bb77dd32eb7d1f19 \
+                    sha256  00a1ee1f389f81e9979f3a640a01c431b3021de0d42278f6508391a2f0b81c9a \
+                    size    33035112 \
+                    clang-9.0.1.src.tar.xz \
+                    rmd160  424b98b3b6252f119fc06c8dfbc8fb1344531e88 \
+                    sha256  5778512b2e065c204010f88777d44b95250671103e434f9dc7363ab2e3804253 \
+                    size    13452780 \
+                    compiler-rt-9.0.1.src.tar.xz \
+                    rmd160  0a2bcf2ae22362a3c6743e3a63d3943a3f284946 \
+                    sha256  c2bfab95c9986318318363d7f371a85a95e333bc0b34fbfa52edbd3f5e3a9077 \
+                    size    1983828 \
+                    libcxx-9.0.1.src.tar.xz \
+                    rmd160  b85b557e1fa372f2f3eb854c13ca103abb671d66 \
+                    sha256  0981ff11b862f4f179a13576ab0a2f5530f46bd3b6b4a90f568ccc6a62914b34 \
+                    size    1813356 \
+                    clang-tools-extra-9.0.1.src.tar.xz \
+                    rmd160  f05643036eb0b394fe0cabb1e88fc8bc0c759837 \
+                    sha256  b26fd72a78bd7db998a26270ec9ec6a01346651d88fa87b4b323e13049fb6f07 \
+                    size    2175728 \
+                    lldb-9.0.1.src.tar.xz \
+                    rmd160  f0507a476d6ac832478dbcd72385ab4be9c8e9ce \
+                    sha256  8a7b9fd795c31a3e3cba6ce1377a2ae5c67376d92888702ce27e26f0971beb09 \
+                    size    9837400 \
+                    polly-9.0.1.src.tar.xz \
+                    rmd160  c5415f90f51ab3e3e6fbcab672bfcd52a9cc788c \
+                    sha256  9a4ac69df923230d13eb6cd0d03f605499f6a854b1dc96a9b72c4eb075040fcf \
+                    size    8768196
 
 patch.pre_args  -p1
 patchfiles \
@@ -485,7 +484,7 @@ post-extract {
             system -W ${worksrcpath}/projects "svn ${proxy_args} co -r ${libcxx_rev} https://llvm.org/svn/llvm-project/libcxx/branches/release_${llvm_version_no_dot} libcxx"
             system -W ${worksrcpath}/tools/clang/tools "svn ${proxy_args} co -r ${clang-modernize_rev} https://llvm.org/svn/llvm-project/clang-tools-extra/branches/release_${llvm_version_no_dot} extra"
         } else {
-            file rename ${workpath}/cfe-${version}.src ${worksrcpath}/tools/clang
+            file rename ${workpath}/clang-${version}.src ${worksrcpath}/tools/clang
             file rename ${workpath}/compiler-rt-${version}.src ${worksrcpath}/projects/compiler-rt
             file rename ${workpath}/libcxx-${version}.src ${worksrcpath}/projects/libcxx
             file rename ${workpath}/clang-tools-extra-${version}.src ${worksrcpath}/tools/clang/tools/extra
@@ -498,7 +497,7 @@ post-extract {
             system -W ${worksrcpath}/tools "svn ${proxy_args} co -r ${svn.revision} https://llvm.org/svn/llvm-project/cfe/branches/release_${llvm_version_no_dot} clang"
             system -W ${worksrcpath}/tools "svn ${proxy_args} co -r ${svn.revision} https://llvm.org/svn/llvm-project/lldb/branches/release_${llvm_version_no_dot} lldb"
         } else {
-            file rename ${workpath}/cfe-${version}.src ${worksrcpath}/tools/clang
+            file rename ${workpath}/clang-${version}.src ${worksrcpath}/tools/clang
             file rename ${workpath}/lldb-${version}.src ${worksrcpath}/tools/lldb
         }
     }


### PR DESCRIPTION
distfiles are back at github again this time
otherwise minor changes only
cfe has been renamed to clang


llvm-9.0.1 builds on 10.13
running this past the buildbot farm
has not yet been tested on 10.5 - 10.10