### PR TITLE
py35-astropy: version 3.2.3 is the last that supports Python 3.5

### DIFF
--- a/python/py-astropy/Portfile
+++ b/python/py-astropy/Portfile
@@ -37,6 +37,12 @@ if {${name} ne ${subport}} {
         checksums           rmd160  52888f36460ed39d2bd6e3da2bdc63782569f21f \
                             sha256  9c067764f4119dd7bce3228b0b508d48ddad5d726c580b70215ee78baa2eb512 \
                             size    8357877
+    } elseif {${python.version} < 36} {
+        version             3.2.3
+        revision            1
+        checksums           rmd160  1aa7495e0939513768b33d447fc2a7ceaa55683c \
+                            sha256  47f00816c2978fdd10f448c8f0337d6dca7b8cbeaab4bf272b5fd37cb4b890d3 \
+                            size    7964789
     }
 
     depends_lib-append  port:cfitsio \


### PR DESCRIPTION
#### Description

Fixes this error message:

```
--->  Building py35-astropy
Executing:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_python_py-astropy/py35-astropy/work/astropy-4.0" && /opt/local/Library/Frameworks/Python.framework/Versions/3.5/bin/python3.5 setup.py --no-user-cfg --offline --no-git build --use-system-cfitsio --use-system-expat --use-system-wcslib --use-system-erfa
ERROR: Python >=3.6 is required by astropy
Command failed:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_python_py-astropy/py35-astropy/work/astropy-4.0" && /opt/local/Library/Frameworks/Python.framework/Versions/3.5/bin/python3.5 setup.py --no-user-cfg --offline --no-git build --use-system-cfitsio --use-system-expat --use-system-wcslib --use-system-erfa
Exit code: 1
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix