### PR TITLE
gate: update Geant4 version

### DIFF
--- a/science/gate/Portfile
+++ b/science/gate/Portfile
@@ -12,7 +12,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        OpenGATE Gate 8.2 v
 name                gate
-revision            1
+revision            2
 
 categories          science
 maintainers         {mojca @mojca} openmaintainer
@@ -109,7 +109,7 @@ post-destroot {
 
 variant geant4105 description {Use Geant4 10.5} {
     set geant.version       10.5
-    set geant.revision      0
+    set geant.revision      1
     set geant.port_name     geant4.${geant.version}
     set geant.data_versions ${geant.data_versions_10.5}
     set geant.datadir       ${prefix}/share/Geant4/Data/Geant4.${geant.version}


### PR DESCRIPTION
I'm struggling with some troubles when configuring without trace mode and building under trace mode, I'm not sure what the reason is. The resulting binary seems to launch correctly at least.

Closes: https://trac.macports.org/ticket/59792

@Vajiheh123 @ttazegul97

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.13.6 17G9016
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
