### PR TITLE
Patch for import cast_unicode_py2 in py-jupyter_console

### DIFF
--- a/python/py-jupyter_console/Portfile
+++ b/python/py-jupyter_console/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-jupyter_console
 version             6.0.0
-revision            0
+revision            1
 categories-append   devel
 platforms           darwin
 license             BSD
@@ -26,6 +26,8 @@ distname            ${python.rootname}-${version}
 checksums           rmd160  49e131bc49f75029856ef101883119e02f1951ea \
                     sha256  308ce876354924fb6c540b41d5d6d08acfc946984bf0c97777c1ddcb42e0b2f5 \
                     size    27780
+
+patchfiles          import_cast_unicode_py2.patch
 
 if {${name} ne ${subport}} {
 

--- a/python/py-jupyter_console/files/import_cast_unicode_py2.patch
+++ b/python/py-jupyter_console/files/import_cast_unicode_py2.patch
@@ -1,0 +1,18 @@
+diff -u /opt/local/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages/jupyter_console/ptshell.py.\~1\~ /opt/local/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages/jupyter_console/ptshell.py
+--- jupyter_console/ptshell.py.~1~	2018-10-03 02:28:05.000000000 +0200
++++ jupyter_console/ptshell.py	2020-01-12 17:28:07.000000000 +0100
+@@ -19,7 +19,11 @@
+ 
+ from zmq import ZMQError
+ from IPython.core import page
+-from IPython.utils.py3compat import cast_unicode_py2, input
++try:
++    from IPython.utils.py3compat import cast_unicode_py2, input
++except ImportError:
++    from IPython.utils.py3compat import input
++    from ipython_genutils.py3compat import cast_unicode_py2
+ from ipython_genutils.tempdir import NamedFileInTemporaryDirectory
+ from traitlets import (Bool, Integer, Float, Unicode, List, Dict, Enum,
+                        Instance, Any)
+
+Diff finished.  Sun Jan 12 17:28:29 2020


### PR DESCRIPTION
This is a temporary patch until upstream jupyter-console is updated.
See https://stackoverflow.com/questions/59631663/jupyter-console-fails-to-start-but-jupyter-notebook-is-fine

#### Description

IPython.utils.py3compat recently changed. Now jupyter-console doesn't work anymore, because it hasn't been updated to take this change into account. This is a patch to cope with that situation until jupiter-console has been updated.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G10021
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [ x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ x] tried a full install with `sudo port -vst install`?
- [ x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
