### PR TITLE
py-gpilab-framework: remove 35

### DIFF
--- a/python/py-gpilab-framework/Portfile
+++ b/python/py-gpilab-framework/Portfile
@@ -8,7 +8,7 @@ PortGroup               select 1.0
 github.setup            gpilab framework 1.1.5 v
 name                    py-gpilab-framework
 revision                0
-python.versions         35 36 37
+python.versions         36 37
 python.default_version  37
 supported_archs         noarch
 platforms               darwin

--- a/python/py-gpilab-framework/files/gpilab-35
+++ b/python/py-gpilab-framework/files/gpilab-35
@@ -1,5 +1,0 @@
-bin/gpi-35
-bin/gpi_launch-35
-bin/gpi_make-35
-share/py35-gpilab-framework/include/PyFI
-share/py35-gpilab-framework/include/multiproc


### PR DESCRIPTION
Maintainer update. Addresses https://trac.macports.org/ticket/59955.