### PR TITLE
php: Add php74 subports

### DIFF
--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -1476,7 +1476,7 @@ subport ${php}-openssl {
             reinplace "s|@PREFIX@|${prefix}|g" ${worksrcpath}/ext/openssl/config.m4
         }
 
-        configure.args-replace  --with-openssl=${prefix} --with-openssl=shared
+        configure.args-append   --with-openssl=shared
     } elseif {[vercmp ${branch} 7.4] < 0} {
         configure.args-append   --with-openssl=${prefix}
     } else {

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -21,7 +21,7 @@ long_description        PHP is a widely-used general-purpose scripting \
                         scripting.
 
 # The list of PHP branches this port provides.
-php.branches            5.2 5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
+php.branches            5.2 5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4
 
 # Fix for users specifying the subport name with the wrong case.
 set subport             [string tolower ${subport}]
@@ -149,6 +149,13 @@ switch ${subport_branch} {
                         size    12102012
     }
     7.4 {
+        version         7.4.1
+        use_xz          yes
+        checksums       rmd160  7d426a5d88d4e698dc98fc42556455617dc1e897 \
+                        sha256  561bb866bdd509094be00f4ece7c3543ec971c4d878645ee81437e291cffc762 \
+                        size    10245600
+    }
+    7.5 {
         # When this becomes a stable version, remove the overrides for homepage,
         # master_sites and livecheck, and update php.latest_stable_branch in the
         # php-1.1 portgroup.
@@ -242,7 +249,6 @@ if {[is_sapi_subport]} {
                         --enable-filter \
                         --enable-hash \
                         --enable-json \
-                        --enable-libxml \
                         --enable-pdo \
                         --enable-session \
                         --enable-simplexml \
@@ -252,13 +258,20 @@ if {[is_sapi_subport]} {
                         --enable-xmlwriter \
                         --with-bz2=${prefix} \
                         --with-mhash=${prefix} \
-                        --with-pcre-regex=${prefix} \
-                        --with-libxml-dir=${prefix} \
                         --with-zlib=${prefix} \
-                        --without-pear \
                         --disable-cgi \
                         --disable-cli
-    
+
+    if {[vercmp ${branch} 7.4] < 0} {
+        configure.args-append   --enable-libxml \
+                                --with-libxml-dir=${prefix} \
+                                --with-pcre-regex=${prefix} \
+                                --without-pear
+    } else {
+        configure.args-append   --with-libxml \
+                                --with-external-pcre=${prefix}
+    }
+
     # Ensure we don't regenerate the parsers even if flex/re2c/bison are installed.
     configure.env       LEX=true \
                         RE2C=true \
@@ -344,6 +357,7 @@ subport ${php} {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
     
     depends_run             port:php_select
@@ -406,7 +420,11 @@ subport ${php} {
     # is compatible with PHP's which means PHP can be distributable.
     variant libedit conflicts readline description {Build readline extension using libedit library} {
         depends_lib-append      port:libedit port:ncurses
-        configure.args-append   --with-libedit=${prefix}
+        if {[vercmp ${branch} 7.4] < 0} {
+            configure.args-append   --with-libedit=${prefix}
+        } else {
+            configure.args-append   --with-libedit
+        }
     }
     variant readline conflicts libedit description {Build readline extension using readline library} {
         depends_lib-append      port:ncurses port:readline
@@ -486,6 +504,7 @@ subport ${php}-apache2handler {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
     
     description             ${php} Apache 2 Handler SAPI
@@ -543,6 +562,7 @@ subport ${php}-cgi {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
 
     description             ${php} CGI SAPI
@@ -582,6 +602,7 @@ subport ${php}-fpm {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
 
     description             ${php} FPM SAPI
@@ -650,6 +671,7 @@ subport ${php}-calendar {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
 
     description             a PHP extension for converting between different \
@@ -669,6 +691,7 @@ subport ${php}-curl {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
 
     categories-append       net www
@@ -679,8 +702,12 @@ subport ${php}-curl {
     long_description        ${description}
     
     depends_lib-append      port:curl
-    
-    configure.args-append   --with-curl=${prefix}
+
+    if {[vercmp ${branch} 7.4] < 0} {
+        configure.args-append   --with-curl=${prefix}
+    } else {
+        configure.args-append   --with-curl
+    }
 }
 
 subport ${php}-dba {
@@ -694,6 +721,7 @@ subport ${php}-dba {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
 
     categories-append       databases
@@ -725,6 +753,7 @@ subport ${php}-enchant {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
 
     categories-append       textproc devel
@@ -734,9 +763,13 @@ subport ${php}-enchant {
     long_description        ${name} is ${description}, a common API for many spell libraries.
     
     depends_lib-append      port:enchant
-    
-    configure.args-append   --with-enchant=${prefix}
-    
+
+    if {[vercmp ${branch} 7.4] < 0} {
+        configure.args-append   --with-enchant=${prefix}
+    } else {
+        configure.args-append   --with-enchant
+    }
+
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
         xinstall -d ${destroot}${docdir}
@@ -763,6 +796,7 @@ subport ${php}-exif {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
 
     categories-append       graphics
@@ -783,6 +817,7 @@ subport ${php}-ftp {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
 
     categories-append       net
@@ -808,6 +843,7 @@ subport ${php}-gd {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
 
     categories-append       graphics
@@ -820,22 +856,32 @@ subport ${php}-gd {
                             port:jpeg \
                             port:libpng \
                             port:zlib
-    
-    patchfiles-append       patch-${php}-ext-gd-config.m4.diff
 
     if {[vercmp ${branch} 5.2] <= 0} {
         patchfiles-append   patch-${php}-jpeg-9.diff
     }
 
-    configure.args-append   --with-freetype-dir=${prefix} \
-                            --with-jpeg-dir=${prefix} \
-                            --with-png-dir=${prefix} \
-                            --with-zlib-dir=${prefix} \
-                            --enable-gd-native-ttf
+    configure.args-append   --enable-gd-native-ttf
 
     if {[vercmp ${branch} 7.0] >= 0} {
         depends_lib-append  port:webp
-        configure.args-append --with-webp-dir=${prefix}
+    }
+
+    if {[vercmp ${branch} 7.4] < 0} {
+        patchfiles-append       patch-${php}-ext-gd-config.m4.diff
+
+        configure.args-append   --with-freetype-dir=${prefix} \
+                                --with-jpeg-dir=${prefix} \
+                                --with-png-dir=${prefix} \
+                                --with-zlib-dir=${prefix}
+
+        if {[vercmp ${branch} 7.0] >= 0} {
+            configure.args-append --with-webp-dir=${prefix}
+        }
+    } else {
+        configure.args-append   --with-freetype \
+                                --with-jpeg \
+                                --with-webp
     }
     
     if {[vercmp ${branch} 7.0] < 0} {
@@ -857,6 +903,7 @@ subport ${php}-gettext {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
 
     categories-append       devel
@@ -882,6 +929,7 @@ subport ${php}-gmp {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
 
     categories-append       devel math
@@ -912,6 +960,7 @@ subport ${php}-iconv {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
 
     categories-append       textproc
@@ -937,6 +986,7 @@ subport ${php}-imap {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
 
     categories-append       mail
@@ -953,6 +1003,11 @@ subport ${php}-imap {
     configure.args-append   --with-imap=${prefix} \
                             --with-imap-ssl=${prefix} \
                             --with-kerberos=${prefix}
+
+    if {[vercmp ${branch} 7.4] >= 0} {
+        # PHP isn't reading that OpenSSL is available, needs to be told
+        configure.env-append    PHP_OPENSSL=yes
+    }
 }
 
 if {[vercmp ${branch} 5.3] >= 0} {
@@ -966,6 +1021,7 @@ subport ${php}-intl {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
     
     categories-append       devel
@@ -999,6 +1055,7 @@ subport ${php}-ipc {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
 
     php.extensions          shmop sysvmsg sysvsem sysvshm
@@ -1020,6 +1077,7 @@ subport ${php}-ldap {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
 
     categories-append       databases
@@ -1032,9 +1090,14 @@ subport ${php}-ldap {
     
     depends_lib-append      port:openldap \
                             port:cyrus-sasl2
-    
-    configure.args-append   --with-ldap=${prefix} \
-                            --with-ldap-sasl=${prefix}
+
+    configure.args-append   --with-ldap=${prefix}
+
+    if {[vercmp ${branch} 7.4] < 0} {
+        configure.args-append   --with-ldap-sasl=${prefix}
+    } else {
+        configure.args-append   --with-ldap-sasl
+    }
 }
 
 subport ${php}-mbstring {
@@ -1048,6 +1111,7 @@ subport ${php}-mbstring {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
 
     categories-append       textproc
@@ -1056,6 +1120,10 @@ subport ${php}-mbstring {
                             encodings
     
     long_description        ${description}
+
+    if {[vercmp ${branch} 7.4] >= 0} {
+        depends_lib-append      port:oniguruma6
+    }
 }
 
 if {[vercmp ${branch} 7.2] < 0} {
@@ -1126,6 +1194,7 @@ subport ${php}-mysql {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
 
     php.extensions          mysqli pdo_mysql
@@ -1288,6 +1357,7 @@ subport ${php}-odbc {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
 
     php.extensions          odbc pdo_odbc
@@ -1303,18 +1373,26 @@ subport ${php}-odbc {
         depends_lib-append      port:libiodbc
         
         patchfiles-append       patch-${php}-iODBC.diff
-        
-        configure.args-append   --with-iODBC=${prefix} \
-                                --with-pdo-odbc=iODBC,${prefix}
+
+        configure.args-append   --with-pdo-odbc=iODBC,${prefix}
+        if {[vercmp ${branch} 7.4] < 0} {
+            configure.args-append   --with-iODBC=${prefix}
+        } else {
+            configure.args-append   --with-iODBC
+        }
     }
     
     variant unixodbc conflicts iodbc description {Use unixODBC} {
         depends_lib-append      port:unixODBC
         
         patchfiles-append       patch-${php}-unixODBC.diff
-        
-        configure.args-append   --with-unixODBC=${prefix} \
-                                --with-pdo-odbc=unixODBC,${prefix}
+
+        configure.args-append   --with-pdo-odbc=unixODBC,${prefix}
+        if {[vercmp ${branch} 7.4] < 0} {
+            configure.args-append   --with-unixODBC=${prefix}
+        } else {
+            configure.args-append   --with-unixODBC
+        }
     }
     
     if {![variant_isset iodbc] && ![variant_isset unixodbc]} {
@@ -1331,6 +1409,7 @@ if {[vercmp ${branch} 5.5] >= 0} {
             7.1.33              {revision 0}
             7.2.26              {revision 0}
             7.3.13              {revision 0}
+            7.4.1               {revision 0}
         }
 
         php.extensions.zend opcache
@@ -1346,7 +1425,9 @@ if {[vercmp ${branch} 5.5] >= 0} {
         post-destroot {
             set docdir ${destroot}${prefix}/share/doc/${subport}
             xinstall -d ${docdir}
-            xinstall -W ${destroot.dir} -m 644 README ${docdir}
+            if {[vercmp ${branch} 7.4] < 0} {
+                xinstall -W ${destroot.dir} -m 644 README ${docdir}
+            }
         }
     }
 }
@@ -1362,6 +1443,7 @@ subport ${php}-openssl {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
 
     categories-append       devel security
@@ -1380,8 +1462,7 @@ subport ${php}-openssl {
         move ${php.build_dirs}/config0.m4 ${php.build_dirs}/config.m4
     }
     
-    configure.args-append   --with-kerberos=${prefix} \
-                            --with-openssl=${prefix}
+    configure.args-append   --with-kerberos=${prefix}
 
     if {[vercmp ${branch} 5.6] <= 0} {
         openssl.branch 1.0
@@ -1396,6 +1477,10 @@ subport ${php}-openssl {
         }
 
         configure.args-replace  --with-openssl=${prefix} --with-openssl=shared
+    } elseif {[vercmp ${branch} 7.4] < 0} {
+        configure.args-append   --with-openssl=${prefix}
+    } else {
+        configure.args-append   --with-openssl
     }
 }
 
@@ -1410,6 +1495,7 @@ subport ${php}-oracle {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
 
     php.extensions          oci8 pdo_oci
@@ -1447,6 +1533,7 @@ subport ${php}-pcntl {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
 
     categories-append       sysutils
@@ -1475,6 +1562,7 @@ subport ${php}-posix {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
 
     categories-append       sysutils
@@ -1497,6 +1585,7 @@ subport ${php}-postgresql {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
 
     php.extensions          pgsql pdo_pgsql
@@ -1603,6 +1692,7 @@ subport ${php}-pspell {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
 
     categories-append       textproc
@@ -1628,6 +1718,7 @@ subport ${php}-snmp {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
 
     categories-append       sysutils
@@ -1653,6 +1744,7 @@ subport ${php}-soap {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
 
     categories-append       net
@@ -1662,8 +1754,10 @@ subport ${php}-soap {
     long_description        ${description}
     
     depends_lib-append      port:libxml2
-    
-    configure.args-append   --with-libxml-dir=${prefix}
+
+    if {[vercmp ${branch} 7.4] < 0} {
+        configure.args-append   --with-libxml-dir=${prefix}
+    }
 }
 
 subport ${php}-sockets {
@@ -1677,6 +1771,7 @@ subport ${php}-sockets {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
 
     categories-append       net
@@ -1692,6 +1787,7 @@ subport ${php}-sodium {
     switch -- ${version} {
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
 
     php.extensions          sodium
@@ -1705,7 +1801,11 @@ subport ${php}-sodium {
 
     depends_lib-append      port:libsodium
 
-    configure.args-append   --with-sodium=${prefix}
+    if {[vercmp ${branch} 7.4] < 0} {
+        configure.args-append   --with-sodium=${prefix}
+    } else {
+        configure.args-append   --with-sodium
+    }
 }
 }
 
@@ -1720,6 +1820,7 @@ subport ${php}-sqlite {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
 
     php.extensions          sqlite sqlite3 pdo_sqlite
@@ -1741,10 +1842,16 @@ subport ${php}-sqlite {
     post-extract {
         move ${worksrcpath}/ext/sqlite3/config0.m4 ${worksrcpath}/ext/sqlite3/config.m4
     }
-    
-    configure.args-append   --with-sqlite3=${prefix} \
-                            --with-pdo-sqlite=${prefix} \
-                            --enable-sqlite-utf8
+
+    configure.args-append   --enable-sqlite-utf8
+
+    if {[vercmp ${branch} 7.4] < 0} {
+        configure.args-append   --with-sqlite3=${prefix} \
+                                --with-pdo-sqlite=${prefix}
+    } else {
+        configure.args-append   --with-sqlite3 \
+                                --with-pdo-sqlite
+    }
 }
 }
 
@@ -1759,6 +1866,7 @@ subport ${php}-tidy {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
     
     categories-append       www
@@ -1777,6 +1885,8 @@ subport ${php}-tidy {
     configure.args-append   --with-tidy=${prefix}
 }
 
+if {[vercmp ${branch} 7.4] < 0} {
+# wddx was evicted from PHP core in version 7.4
 subport ${php}-wddx {
     switch -- ${version} {
         5.2.17              {revision 0}
@@ -1802,6 +1912,7 @@ subport ${php}-wddx {
     configure.args-append   --with-libexpat-dir=${prefix} \
                             --with-libxml-dir=${prefix}
 }
+}
 
 subport ${php}-xmlrpc {
     switch -- ${version} {
@@ -1814,6 +1925,7 @@ subport ${php}-xmlrpc {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
 
     categories-append       textproc
@@ -1826,11 +1938,16 @@ subport ${php}-xmlrpc {
                             port:libxml2
     
     depends_lib-append      port:expat
-    
-    configure.args-append   --with-iconv-dir=${prefix} \
-                            --with-libexpat-dir=${prefix} \
-                            --with-libxml-dir=${prefix}
-    
+
+    configure.args-append   --with-iconv-dir=${prefix}
+
+    if {[vercmp ${branch} 7.4] < 0} {
+        configure.args-append   --with-libexpat-dir=${prefix} \
+                                --with-libxml-dir=${prefix}
+    } else {
+        configure.args-append   --with-expat
+    }
+
     pre-configure {
         configure.cppflags-append [exec ${prefix}/bin/xml2-config --cflags]
     }
@@ -1847,6 +1964,7 @@ subport ${php}-xsl {
         7.1.33              {revision 0}
         7.2.26              {revision 0}
         7.3.13              {revision 0}
+        7.4.1               {revision 0}
     }
 
     categories-append       textproc
@@ -1857,9 +1975,13 @@ subport ${php}-xsl {
     long_description        ${description}
     
     depends_lib-append      port:libxslt
-    
-    configure.args-append   --with-xsl=${prefix}
-    
+
+    if {[vercmp ${branch} 7.4] < 0} {
+        configure.args-append   --with-xsl=${prefix}
+    } else {
+        configure.args-append   --with-xsl
+    }
+
     configure.cppflags-append   -I${prefix}/include/${php}/php/ext/dom
 }
 
@@ -1885,6 +2007,11 @@ if {${name} eq ${subport}} {
         system "echo \"${name} is a stub port\" > ${destroot}${prefix}/share/doc/${subport}/README"
     }
 } else {
+    if {[vercmp ${branch} 7.4] >= 0} {
+        # All extensions need pkg-config to build from PHP v7.4
+        depends_build-delete port:pkgconfig
+        depends_build-append port:pkgconfig
+    }
     # Set an explicit distname so the default from the php portgroup doesn't get used.
     distname            ${name}-${version}
 }

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -711,6 +711,8 @@ subport ${php}-curl {
     if {[vercmp ${branch} 7.4] < 0} {
         configure.args-append   --with-curl=${prefix}
     } else {
+        depends_build-append    port:pkgconfig
+
         configure.args-append   --with-curl
     }
 }
@@ -772,6 +774,8 @@ subport ${php}-enchant {
     if {[vercmp ${branch} 7.4] < 0} {
         configure.args-append   --with-enchant=${prefix}
     } else {
+        depends_build-append    port:pkgconfig
+
         configure.args-append   --with-enchant
     }
 
@@ -884,6 +888,8 @@ subport ${php}-gd {
             configure.args-append --with-webp-dir=${prefix}
         }
     } else {
+        depends_build-append    port:pkgconfig
+
         configure.args-append   --with-freetype \
                                 --with-jpeg \
                                 --with-webp
@@ -1010,6 +1016,8 @@ subport ${php}-imap {
                             --with-kerberos=${prefix}
 
     if {[vercmp ${branch} 7.4] >= 0} {
+        depends_build-append    port:pkgconfig
+
         # https://bugs.php.net/bug.php?id=79112
         configure.env-append    PHP_OPENSSL=yes
     }
@@ -1101,6 +1109,8 @@ subport ${php}-ldap {
     if {[vercmp ${branch} 7.4] < 0} {
         configure.args-append   --with-ldap-sasl=${prefix}
     } else {
+        depends_build-append    port:pkgconfig
+
         configure.args-append   --with-ldap-sasl
     }
 }
@@ -1127,6 +1137,8 @@ subport ${php}-mbstring {
     long_description        ${description}
 
     if {[vercmp ${branch} 7.4] >= 0} {
+        depends_build-append    port:pkgconfig
+
         depends_lib-append      port:oniguruma6
     }
 }
@@ -1383,6 +1395,8 @@ subport ${php}-odbc {
         if {[vercmp ${branch} 7.4] < 0} {
             configure.args-append   --with-iODBC=${prefix}
         } else {
+            depends_build-append    port:pkgconfig
+
             configure.args-append   --with-iODBC
         }
     }
@@ -1396,6 +1410,8 @@ subport ${php}-odbc {
         if {[vercmp ${branch} 7.4] < 0} {
             configure.args-append   --with-unixODBC=${prefix}
         } else {
+            depends_build-append    port:pkgconfig
+
             configure.args-append   --with-unixODBC
         }
     }
@@ -1485,6 +1501,8 @@ subport ${php}-openssl {
     } elseif {[vercmp ${branch} 7.4] < 0} {
         configure.args-append   --with-openssl=${prefix}
     } else {
+        depends_build-append    port:pkgconfig
+
         configure.args-append   --with-openssl
     }
 }
@@ -1762,6 +1780,8 @@ subport ${php}-soap {
 
     if {[vercmp ${branch} 7.4] < 0} {
         configure.args-append   --with-libxml-dir=${prefix}
+    } else {
+        depends_build-append    port:pkgconfig
     }
 }
 
@@ -1809,6 +1829,8 @@ subport ${php}-sodium {
     if {[vercmp ${branch} 7.4] < 0} {
         configure.args-append   --with-sodium=${prefix}
     } else {
+        depends_build-append    port:pkgconfig
+
         configure.args-append   --with-sodium
     }
 }
@@ -1854,6 +1876,8 @@ subport ${php}-sqlite {
         configure.args-append   --with-sqlite3=${prefix} \
                                 --with-pdo-sqlite=${prefix}
     } else {
+        depends_build-append    port:pkgconfig
+
         configure.args-append   --with-sqlite3 \
                                 --with-pdo-sqlite
     }
@@ -1950,6 +1974,8 @@ subport ${php}-xmlrpc {
         configure.args-append   --with-libexpat-dir=${prefix} \
                                 --with-libxml-dir=${prefix}
     } else {
+        depends_build-append    port:pkgconfig
+
         configure.args-append   --with-expat
     }
 
@@ -1984,6 +2010,8 @@ subport ${php}-xsl {
     if {[vercmp ${branch} 7.4] < 0} {
         configure.args-append   --with-xsl=${prefix}
     } else {
+        depends_build-append    port:pkgconfig
+
         configure.args-append   --with-xsl
     }
 
@@ -2012,11 +2040,6 @@ if {${name} eq ${subport}} {
         system "echo \"${name} is a stub port\" > ${destroot}${prefix}/share/doc/${subport}/README"
     }
 } else {
-    if {[vercmp ${branch} 7.4] >= 0} {
-        # All extensions need pkg-config to build from PHP v7.4
-        depends_build-delete port:pkgconfig
-        depends_build-append port:pkgconfig
-    }
     # Set an explicit distname so the default from the php portgroup doesn't get used.
     distname            ${name}-${version}
 }

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -217,6 +217,10 @@ if {[is_sapi_subport]} {
     patch.pre_args      -p1
     patchfiles-append   patch-${php}-scripts-php-config.in.diff
 
+    if {[vercmp ${branch} 7.4] >= 0} {
+        patchfiles-append \
+                        patch-${php}-bison-re2c-version.diff
+    }
     if {[vercmp ${branch} 5.3] <= 0} {
         patchfiles-append \
                         patch-${php}-configure.diff

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -149,6 +149,7 @@ switch ${subport_branch} {
                         size    12102012
     }
     7.4 {
+        epoch           2
         version         7.4.1
         use_xz          yes
         checksums       rmd160  7d426a5d88d4e698dc98fc42556455617dc1e897 \

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -252,7 +252,6 @@ if {[is_sapi_subport]} {
                         --enable-ctype \
                         --enable-dom \
                         --enable-filter \
-                        --enable-hash \
                         --enable-json \
                         --enable-pdo \
                         --enable-session \
@@ -268,7 +267,8 @@ if {[is_sapi_subport]} {
                         --disable-cli
 
     if {[vercmp ${branch} 7.4] < 0} {
-        configure.args-append   --enable-libxml \
+        configure.args-append   --enable-hash \
+                                --enable-libxml \
                                 --with-libxml-dir=${prefix} \
                                 --with-pcre-regex=${prefix} \
                                 --without-pear

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -160,7 +160,7 @@ switch ${subport_branch} {
         # master_sites and livecheck, and update php.latest_stable_branch in the
         # php-1.1 portgroup.
         epoch           0
-        version         7.4.0alpha1
+        version         7.5.0alpha1
         homepage        https://qa.php.net/
         master_sites    https://downloads.php.net/~cmb/
         use_xz          yes

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -1010,7 +1010,7 @@ subport ${php}-imap {
                             --with-kerberos=${prefix}
 
     if {[vercmp ${branch} 7.4] >= 0} {
-        # PHP isn't reading that OpenSSL is available, needs to be told
+        # https://bugs.php.net/bug.php?id=79112
         configure.env-append    PHP_OPENSSL=yes
     }
 }

--- a/lang/php/files/patch-php74-bison-re2c-version.diff
+++ b/lang/php/files/patch-php74-bison-re2c-version.diff
@@ -1,0 +1,19 @@
+https://bugs.php.net/bug.php?id=78750
+--- a/configure.orig	2019-12-24 16:15:30.000000000 -0600
++++ b/configure	2019-12-24 16:21:04.000000000 -0600
+@@ -5377,6 +5377,7 @@
+ $as_echo_n "checking for bison version... " >&6; }
+ 
+     php_bison_version=$($YACC --version 2> /dev/null | grep 'GNU Bison' | cut -d ' ' -f 4 | tr -d a-z)
++    [ -z "$php_bison_version" ] && php_bison_version=0.0.0
+     ac_IFS=$IFS; IFS="."
+     set $php_bison_version
+     IFS=$ac_IFS
+@@ -5474,6 +5475,7 @@
+ $as_echo_n "checking for re2c version... " >&6; }
+ 
+     php_re2c_version=$($RE2C --version | cut -d ' ' -f 2 2>/dev/null)
++    [ -z "$php_re2c_version" ] && php_re2c_version=0.0.0
+     ac_IFS=$IFS; IFS="."
+     set $php_re2c_version
+     IFS=$ac_IFS

--- a/lang/php/files/patch-php74-iODBC.diff
+++ b/lang/php/files/patch-php74-iODBC.diff
@@ -1,0 +1,18 @@
+--- ext/odbc/config.m4.orig	2015-04-15 13:05:57.000000000 -0500
++++ ext/odbc/config.m4	2015-04-17 20:15:12.000000000 -0500
+@@ -104,6 +104,7 @@
+ [  --with-odbcver[=HEX]      Force support for the passed ODBC version. A hex number is expected, default 0x0300.
+                              Use the special value of 0 to prevent an explicit ODBCVER to be defined. ], 0x0300)
+ 
++:<<'MACPORTS_DISABLED'
+ if test -z "$ODBC_TYPE"; then
+ PHP_ARG_WITH(adabas,,
+ [  --with-adabas[=DIR]       Include Adabas D support [/usr/local]])
+@@ -386,6 +387,7 @@
+   fi
+ fi
+ 
++MACPORTS_DISABLED
+ if test -z "$ODBC_TYPE"; then
+ PHP_ARG_WITH([iodbc],,
+   [AS_HELP_STRING([--with-iodbc],

--- a/lang/php/files/patch-php74-sapi-fpm-php-fpm.conf.in.diff
+++ b/lang/php/files/patch-php74-sapi-fpm-php-fpm.conf.in.diff
@@ -1,0 +1,39 @@
+--- a/sapi/fpm/php-fpm.conf.in.orig	2016-08-19 01:48:00.000000000 -0500
++++ b/sapi/fpm/php-fpm.conf.in	2016-08-20 10:16:57.000000000 -0500
+@@ -14,14 +14,14 @@
+ ; Pid file
+ ; Note: the default prefix is @EXPANDED_LOCALSTATEDIR@
+ ; Default Value: none
+-;pid = run/php-fpm.pid
++;pid = run/@PHP@/php-fpm.pid
+ 
+ ; Error log file
+ ; If it's set to "syslog", log is sent to syslogd instead of being written
+ ; into a local file.
+ ; Note: the default prefix is @EXPANDED_LOCALSTATEDIR@
+ ; Default Value: log/php-fpm.log
+-;error_log = log/php-fpm.log
++error_log = log/@PHP@/php-fpm.log
+ 
+ ; syslog_facility is used to specify what type of program is logging the
+ ; message. This lets syslogd specify that messages from different facilities
+@@ -34,7 +34,7 @@
+ ; instances running on the same server, you can change the default value
+ ; which must suit common needs.
+ ; Default Value: php-fpm
+-;syslog.ident = php-fpm
++syslog.ident = @PHP@-fpm
+ 
+ ; Log level
+ ; Possible Values: alert, error, warning, notice, debug
+@@ -77,8 +77,9 @@
+ ; process.priority = -19
+ 
+ ; Send FPM to background. Set to 'no' to keep FPM in foreground for debugging.
++; or for use with launchd.
+ ; Default Value: yes
+-;daemonize = yes
++daemonize = no
+ 
+ ; Set open file descriptor rlimit for the master process.
+ ; Default Value: system defined value

--- a/lang/php/files/patch-php74-scripts-php-config.in.diff
+++ b/lang/php/files/patch-php74-scripts-php-config.in.diff
@@ -1,0 +1,11 @@
+--- a/scripts/php-config.in.orig	2011-05-15 01:09:21.000000000 -0500
++++ b/scripts/php-config.in	2011-10-04 05:45:52.000000000 -0500
+@@ -7,7 +7,7 @@
+ version="@PHP_VERSION@"
+ vernum="@PHP_VERSION_ID@"
+ include_dir="@includedir@/php"
+-includes="-I$include_dir -I$include_dir/main -I$include_dir/TSRM -I$include_dir/Zend -I$include_dir/ext -I$include_dir/ext/date/lib"
++includes="-I$include_dir -I$include_dir/main -I$include_dir/TSRM -I$include_dir/Zend -I$include_dir/ext -I$include_dir/ext/date/lib -I@prefix@/include"
+ ldflags="@PHP_LDFLAGS@"
+ libs="@EXTRA_LIBS@"
+ extension_dir='@EXTENSION_DIR@'

--- a/lang/php/files/patch-php74-unixODBC.diff
+++ b/lang/php/files/patch-php74-unixODBC.diff
@@ -1,0 +1,18 @@
+--- ext/odbc/config.m4.orig	2015-04-15 13:05:57.000000000 -0500
++++ ext/odbc/config.m4	2015-04-17 20:13:57.000000000 -0500
+@@ -104,6 +104,7 @@
+ [  --with-odbcver[=HEX]      Force support for the passed ODBC version. A hex number is expected, default 0x0300.
+                              Use the special value of 0 to prevent an explicit ODBCVER to be defined. ], 0x0300)
+ 
++:<<'MACPORTS_DISABLED'
+ if test -z "$ODBC_TYPE"; then
+ PHP_ARG_WITH(adabas,,
+ [  --with-adabas[=DIR]       Include Adabas D support [/usr/local]])
+@@ -446,6 +447,7 @@
+   fi
+ fi
+ 
++MACPORTS_DISABLED
+ if test -z "$ODBC_TYPE"; then
+ PHP_ARG_WITH([unixODBC],,
+   [AS_HELP_STRING([--with-unixODBC],

--- a/lang/php/files/php74
+++ b/lang/php/files/php74
@@ -1,0 +1,6 @@
+bin/php74
+bin/php-config74
+bin/phpize74
+share/man/man1/php74.1.gz
+share/man/man1/php-config74.1.gz
+share/man/man1/phpize74.1.gz


### PR DESCRIPTION
#### Description

Add php74 subports

- Copy php73 with updated checksums.
- Option for `--without-pear` is not needed for php74, as PEAR is now disabled by default.
- Do not add sub-port for `php74-wddx` which is no longer available in core.
- Update configure options for extensions that have moved to pkg-config. See [PHP 7.4 migration notes](https://www.php.net/manual/en/migration74.other-changes.php#migration74.other-changes.pkg-config)
- pkg-config is added a build dependency for php74-*.
- php74-imap: Fix configure issue for OpenSSL by forcing availability. See [Docker Library issue](https://github.com/docker-library/php/issues/891)
- Fixes https://trac.macports.org/ticket/59815

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G2022
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
