### PR TITLE
gnome-internet-radio-locator: Update to 2.8.0

### DIFF
--- a/gnome/gnome-internet-radio-locator/Portfile
+++ b/gnome/gnome-internet-radio-locator/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                gnome-internet-radio-locator
-version             2.4.0
+version             2.6.0
 set branch          [join [lrange [split $version .] 0 1] .]
 
 categories          gnome
@@ -18,9 +18,9 @@ master_sites        gnome:sources/${name}/${branch}/
 
 use_xz              yes
 
-checksums           rmd160  ebc2cae76d1078acbcee8ba6e0b0d8342cb1f416 \
-                    sha256  e806a56aed3eb747bb9b623cf493cbfdc58aecd73921e67393e33074ef7ed379 \
-                    size    560100
+checksums           rmd160  4321ead0156b2a17a5a568bc45d1b4746533f828 \
+                    sha256  5cbf0570fa72d486766dfa04929a0c1057f63e9ba6ef61ff757c5a818cad2b9c \
+                    size    560884
 
 depends_build       port:autoconf \
                     port:automake \

--- a/gnome/gnome-internet-radio-locator/Portfile
+++ b/gnome/gnome-internet-radio-locator/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                gnome-internet-radio-locator
-version             2.6.0
+version             2.8.0
 set branch          [join [lrange [split $version .] 0 1] .]
 
 categories          gnome
@@ -18,9 +18,9 @@ master_sites        gnome:sources/${name}/${branch}/
 
 use_xz              yes
 
-checksums           rmd160  4321ead0156b2a17a5a568bc45d1b4746533f828 \
-                    sha256  5cbf0570fa72d486766dfa04929a0c1057f63e9ba6ef61ff757c5a818cad2b9c \
-                    size    560884
+checksums           rmd160  02e49b5d0e1b97069ab48dcf53745c4c113b4cfb \
+                    sha256  da6fd145950c1004ec96909af45f26d30058f01df2b66ad04db70db194f4ab42 \
+                    size    561172
 
 depends_build       port:autoconf \
                     port:automake \

--- a/gnome/gnome-internet-radio-locator/Portfile
+++ b/gnome/gnome-internet-radio-locator/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                gnome-internet-radio-locator
-version             2.2.0
+version             2.4.0
 set branch          [join [lrange [split $version .] 0 1] .]
 
 categories          gnome
@@ -18,9 +18,9 @@ master_sites        gnome:sources/${name}/${branch}/
 
 use_xz              yes
 
-checksums           rmd160  20626440092fe63abe3f18b9247b69f53034efb3 \
-                    sha256  bad897d51fa7d759341e8a0520ce8a0040c78de4893230b06c27d886ac11d5fe \
-                    size    559720
+checksums           rmd160  ebc2cae76d1078acbcee8ba6e0b0d8342cb1f416 \
+                    sha256  e806a56aed3eb747bb9b623cf493cbfdc58aecd73921e67393e33074ef7ed379 \
+                    size    560100
 
 depends_build       port:autoconf \
                     port:automake \


### PR DESCRIPTION
#### Description

GNOME Internet Radio Locator version 2.8.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.2 19C57
Xcode 11.2 11B52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->