### PR TITLE
proj6: Fix build on 10.8 and 10.9.

### DIFF
--- a/gis/proj6/Portfile
+++ b/gis/proj6/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           compiler_blacklist_versions 1.0
 
 set realname        proj
 name                ${realname}6
@@ -60,3 +61,7 @@ configure.args      --mandir=${prefix}/lib/proj6/share/man
 livecheck.type      regex
 livecheck.url       ${master_sites}
 livecheck.regex     "${realname}-(\\d+(?:\\.\\d+)*)${extract.suffix}"
+
+# Without this, the build fails with Xcode clang on 10.8/5.1.1 and 10.9/6.2.
+# This is due to an upstream bug requiring a forgiving compiler.
+compiler.blacklist-append {clang < 700}


### PR DESCRIPTION
The update to 6.3.0 removed the compiler blacklisting that was present
in 6.2.1, presumably because it was thought to be covered by the
cxx_standard setting.  But this isn't entirely true, since there's
something in the code which is almost certainly a bug, but which is
ignored by most compilers.  At least two versions of clang, 600 from
Xcode 6.2, and 503 from Xcode 5.1.1, are known not to ignore this,
causing build failures on 10.8 and 10.9.  The fix is to reintroduce a
subset of the former blacklisting, specifically 'clang < 700'.

This change only affects 10.8 and 10.9, since <=10.7 were already
being forced to mp-clang-9.0 for other reasons, and the Xcode clangs
in >=10.10 don't have the problem.

It would be better to fix the upstream bug, but the compiler
constraint is an easier fix for now.

TESTED:
Successfully built on 10.6-10.15, with no compiler-selection changes
other than on 10.8 and 10.9.  No testing on 10.5 due to unrelated
issues with dependencies.  Also successfully built +universal on 10.9.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
