### PR TITLE
several ports: remove subports for obsolete Python versions

### DIFF
--- a/devel/boost/Portfile
+++ b/devel/boost/Portfile
@@ -190,7 +190,7 @@ post-destroot {
     }
 }
 
-set pythons_suffixes {26 27 33 34 35 36 37 38}
+set pythons_suffixes {27 35 36 37 38}
 
 set pythons_ports {}
 foreach s ${pythons_suffixes} {

--- a/python/py-alabaster/Portfile
+++ b/python/py-alabaster/Portfile
@@ -5,7 +5,9 @@ PortGroup           python 1.0
 PortGroup           github 1.0
 
 github.setup        bitprophet alabaster 0.7.12
+revision            0
 name                py-alabaster
+
 platforms           darwin
 supported_archs     noarch
 license             BSD
@@ -18,10 +20,11 @@ checksums           rmd160  c8a1853b067ad6a9e4d8d2cf9c33f4d47bbc0230 \
                     sha256  86363e9f894c0cff8c1a3e89a379ad4b38d329021462e18b35ef92f60559369f \
                     size    23144
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 if {${subport} ne ${name}} {
-    depends_build   port:py${python.version}-setuptools
+    depends_build-append \
+                    port:py${python.version}-setuptools
 
-    livecheck.type      none
+    livecheck.type  none
 }

--- a/python/py-chardet/Portfile
+++ b/python/py-chardet/Portfile
@@ -17,9 +17,10 @@ long_description    Character encoding auto-detection in Python. \
                     As smart as your browser.
 
 checksums           rmd160  dd1063a2449fdd6d775adee29b54eb52194c276b \
-                    sha256  ad813ca7b31b19e12c506869ceec53dbd2b9ed5fa73955895394e0245ffe70a2
+                    sha256  ad813ca7b31b19e12c506869ceec53dbd2b9ed5fa73955895394e0245ffe70a2 \
+                    size    1872387
 
-python.versions     26 27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_lib-append \

--- a/python/py-imagesize/Portfile
+++ b/python/py-imagesize/Portfile
@@ -26,13 +26,17 @@ checksums           rmd160  ecc5e8725ead3d02dbd7b5a1ede428519ecdf3cf \
 
 distname            ${python.rootname}-${version}
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 if {$subport ne $name} {
-    depends_build    port:py${python.version}-setuptools
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
     post-destroot {
-        xinstall -m 755 -d ${destroot}${prefix}/share/doc/${subport}
-        xinstall -m 644 -W ${worksrcpath} README.rst \
+        xinstall -d ${destroot}${prefix}/share/doc/${subport}
+        xinstall -m 0644 -W ${worksrcpath} README.rst \
            ${destroot}${prefix}/share/doc/${subport}
     }
+
+    livecheck.type  none
 }

--- a/python/py-nose/Portfile
+++ b/python/py-nose/Portfile
@@ -4,8 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           select 1.0
 
-set my_name         nose
-name                py-${my_name}
+name                py-nose
 version             1.3.7
 revision            1
 categories-append   www
@@ -24,25 +23,27 @@ long_description \
 platforms           darwin
 supported_archs     noarch
 
-homepage            http://somethingaboutorange.com/mrl/projects/${my_name}
-master_sites        pypi:n/${my_name}/
-distname            ${my_name}-${version}
+homepage            https://nose.readthedocs.io/
+master_sites        pypi:n/${python.rootname}/
+distname            ${python.rootname}-${version}
 
 checksums           rmd160  4a3e1bb3121a2620aec0baa51eac1bb5a11cf6e9 \
-                    sha256  f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98
+                    sha256  f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98 \
+                    size    280488
 
-python.versions     26 27 33 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 # already installs version-suffixed executables
 python.link_binaries no
 python.move_binaries no
 
 depends_run-append  port:nosetests_select
+
 if {${name} ne ${subport}} {
     select.group        nosetests
     select.file         ${filespath}/nosetests${python.version}
 
-    depends_lib     port:py${python.version}-setuptools
+    depends_lib-append  port:py${python.version}-setuptools
 
     post-patch {
         reinplace "s|man/man|share/man/man|" ${worksrcpath}/setup.py
@@ -55,7 +56,7 @@ if {${name} ne ${subport}} {
         ln -s ${python.prefix}/bin/nosetests-${python.branch} ${destroot}${prefix}/bin/
         ln -s ${python.prefix}/share/man/man1/nosetests.1 ${destroot}${prefix}/share/man/man1/nosetests${python.branch}.1
 
-        xinstall -m 644 -W ${worksrcpath} \
+        xinstall -m 0644 -W ${worksrcpath} \
             AUTHORS CHANGELOG NEWS README.txt \
             ${destroot}${prefix}/share/doc/${subport}
 
@@ -66,12 +67,6 @@ if {${name} ne ${subport}} {
     }
 
     test.run  yes
-    test.cmd  ${python.bin} setup.py test
 
     livecheck.type  none
-
-} else {
-    livecheck.type  regex
-    livecheck.url   https://pypi.python.org/pypi/${my_name}/json
-    livecheck.regex "${my_name}-(\\d+(?:\\.\\d+)*)${extract.suffix}"
 }

--- a/python/py-nose/files/nosetests26
+++ b/python/py-nose/files/nosetests26
@@ -1,1 +1,0 @@
-bin/nosetests-2.6

--- a/python/py-nose/files/nosetests33
+++ b/python/py-nose/files/nosetests33
@@ -1,1 +1,0 @@
-bin/nosetests-3.3

--- a/python/py-nose/files/nosetests34
+++ b/python/py-nose/files/nosetests34
@@ -1,1 +1,0 @@
-bin/nosetests-3.4

--- a/python/py-packaging/Portfile
+++ b/python/py-packaging/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  4d65d6d8039fd0293c4c4cdaf08baaaea748b88c \
                     sha256  fe1d8331dfa7cc0a883b49d75fc76380b2ab2734b220fbb87d774e4fd4b851f8 \
                     size    72663
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 if {$subport ne $name} {
     depends_lib-append  port:py${python.version}-attrs \
@@ -32,7 +32,7 @@ if {$subport ne $name} {
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
         xinstall -d ${destroot}${docdir}
-        xinstall -m 644 -W ${worksrcpath} CHANGELOG.rst LICENSE LICENSE.APACHE LICENSE.BSD README.rst \
+        xinstall -m 0644 -W ${worksrcpath} CHANGELOG.rst LICENSE LICENSE.APACHE LICENSE.BSD README.rst \
            ${destroot}${docdir}
     }
 }

--- a/python/py-parsing/Portfile
+++ b/python/py-parsing/Portfile
@@ -27,10 +27,12 @@ checksums           rmd160  7df11aad0ddd4de8c0464a8699a7dc8b00d5ba05 \
                     sha256  4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f \
                     size    649181
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
-    depends_build   port:py${python.version}-setuptools
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
     livecheck.type  none
 } else {
     livecheck.name  pyparsing

--- a/python/py-snowballstemmer/Portfile
+++ b/python/py-snowballstemmer/Portfile
@@ -24,7 +24,7 @@ checksums           sha256  df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8
                     rmd160  7bf4fe09842bfd07049336c19c3f56b500d48125 \
                     size    79284
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-sphinxcontrib-websupport/Portfile
+++ b/python/py-sphinxcontrib-websupport/Portfile
@@ -24,15 +24,18 @@ checksums           rmd160  4d7d6c831fae6234ce6a6700ccf0ecbbe42e6d59 \
                     sha256  1501befb0fdf1d1c29a800fdbf4ef5dc5369377300ddbdd16d2cd40e54c6eefc \
                     size    599000
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 if {${subport} ne ${name}} {
-    depends_build   port:py${python.version}-setuptools
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
-        xinstall -m 755 -d ${destroot}${docdir}
-        xinstall -m 644 -W ${worksrcpath} CHANGES LICENSE README.rst \
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} CHANGES LICENSE README.rst \
            ${destroot}${docdir}
     }
+
     livecheck.type  none
 }

--- a/python/py-typing/Portfile
+++ b/python/py-typing/Portfile
@@ -32,7 +32,7 @@ checksums           rmd160  ddf5e06523aa3a0551fe7600af6f3273da1c21e1 \
                     size    77982
 
 # do not add subports for python 3.5 and later; module is in stdlib.
-python.versions     27 34
+python.versions     27
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description
This PR removes subports for EOLed Python versions from several ports that have no dependencies.

###### Tested on
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? 
- [ ] tried a full install with `sudo port -vst install`? 
- [ ] tested basic functionality of all binary files? 

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
