### PR TITLE
gmt5, gmt6: use github for tarball and livecheck

### DIFF
--- a/science/gmt5/Portfile
+++ b/science/gmt5/Portfile
@@ -2,13 +2,16 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.0
+PortGroup           github 1.0
 
 name                gmt5
-version             5.4.5
+github.setup        GenericMappingTools gmt 5.4.5
+github.tarball_from releases
+distname            ${github.project}-${github.version}-src
 revision            1
 conflicts           gmt6
 subport gmt6 {
-    version         6.0.0
+    github.setup    GenericMappingTools gmt 6.0.0
     revision        0
     epoch           1
     conflicts       gmt5
@@ -25,7 +28,8 @@ long_description GMT is an open source collection of ~120 tools \
     and 3D perspective views.
 
 homepage            https://www.generic-mapping-tools.org/
-master_sites        ftp://ftp.soest.hawaii.edu/gmt          \
+master_sites        https://github.com/GenericMappingTools/gmt/releases/download/${version} \
+                    ftp://ftp.soest.hawaii.edu/gmt          \
                     ftp://ftp.star.nesdis.noaa.gov/pub/sod/lsa/gmt \
                     ftp://ftp.iris.washington.edu/pub/gmt   \
                     ftp://ftp.iag.usp.br/pub/gmt            \
@@ -133,6 +137,8 @@ variant nonfree conflicts lgpl description {enable nonfree code, libraries and b
     configure.args-append   -DLICENSE_RESTRICTED=no
 }
 
+# livecheck for the proper branch (5 or 6) and skipping any release candidates
+set firstchar       [string range ${version} 0 0]
 livecheck.type      regex
-livecheck.url       ${homepage}
-livecheck.regex     {(?i)gmt-(5\.[0-9]+\.[0-9a-z]+)<\/a>}
+livecheck.url       ${github.homepage}/releases/
+livecheck.regex     gmt-(${firstchar}\\.\[0-9]+\\.\[0-9]+)-src${extract.suffix}


### PR DESCRIPTION
#### Description

This makes livecheck on gmt5 and gmt6 work and _en passant_ changes to getting the tarball from github

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.2
Xcode Command Line tools 10.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
