### PR TITLE
mysql8: update to 8.0.19

### DIFF
--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -3,7 +3,7 @@
 PortSystem              1.0
 
 name                    mysql8
-version                 8.0.18
+version                 8.0.19
 set boost_version       1.70.0
 categories              databases
 platforms               darwin
@@ -44,9 +44,9 @@ if {$subport eq $name} {
                         ${boost_distname}${extract.suffix}:boost
 
     checksums           ${distname}${extract.suffix} \
-                        rmd160  cc43f36cf917ad60361a47eef7ee86a2791710aa \
-                        sha256  4cb39a315298eb243c25c53c184b3682b49c2a907a1d8432ba0620534806ade8 \
-                        size    197457483 \
+                        rmd160  95e609d2180269815796a91abe41b8a22ab41846 \
+                        sha256  a62786d67b5e267eef928003967b4ccfe362d604b80f4523578e0688f5b9f834 \
+                        size    266717983 \
                         ${boost_distname}${extract.suffix} \
                         rmd160  1c39413060dca46a02ea2143788d6ee061b79d03 \
                         sha256  882b48708d211a5f48e60b0124cf5863c1534cd544ecd0664bb534a4b5d506e9 \
@@ -131,10 +131,10 @@ if {$subport eq $name} {
 #       -DROUTER_INSTALL_PLUGINDIR="lib/${name_mysql}/mysqlrouter"
 
     patch.pre_args  -p1
-    patchfiles      patch-cmake-install_layout.cmake.diff \
-                    patch-sql-local-boost.diff \
+    patchfiles      patch-cmake-install_macros.cmake.diff \
+                    patch-cmake-install_layout.cmake.diff \
                     patch-mysql8-workaround-no-SC_PHYS_PAGES.diff \
-                    patch-cmake-install_macros.cmake.diff
+                    patch-sql-local-boost.diff
 
     post-extract {
         file mkdir ${cmake.build_dir}/macports

--- a/databases/mysql8/files/patch-cmake-install_layout.cmake.diff
+++ b/databases/mysql8/files/patch-cmake-install_layout.cmake.diff
@@ -1,28 +1,27 @@
---- a/cmake/install_layout.cmake        2019-10-24 09:35:40.000000000 -0500
-+++ b/cmake/install_layout.cmake	2019-10-24 09:40:23.000000000 -0500
-@@ -85,7 +85,7 @@
+--- a/cmake/install_layout.cmake	2020-01-14 10:35:21.000000000 -0500
++++ b/cmake/install_layout.cmake	2020-01-14 10:37:37.000000000 -0500
+@@ -80,7 +80,7 @@
  ENDIF()
  
  SET(INSTALL_LAYOUT "${DEFAULT_INSTALL_LAYOUT}"
--CACHE STRING "Installation directory layout. Options are: TARGZ (as in tar.gz installer), STANDALONE, RPM, DEB, SVR4, FREEBSD, GLIBC, OSX")
-+CACHE STRING "Installation directory layout. Options are: TARGZ (as in tar.gz installer), STANDALONE, RPM, DEB, SVR4, FREEBSD, GLIBC, OSX, MACPORTS")
+-  CACHE STRING "Installation directory layout. Options are: TARGZ (as in tar.gz installer), STANDALONE, RPM, DEB, SVR4"
++  CACHE STRING "Installation directory layout. Options are: TARGZ (as in tar.gz installer), STANDALONE, RPM, DEB, SVR4, MACPORTS"
+   )
  
  IF(UNIX)
-   IF(INSTALL_LAYOUT MATCHES "RPM")
-@@ -102,7 +102,7 @@
+@@ -98,7 +98,7 @@
        CACHE PATH "install prefix" FORCE)
    ENDIF()
    SET(VALID_INSTALL_LAYOUTS
--    "RPM" "DEB" "SVR4" "FREEBSD" "GLIBC" "OSX" "TARGZ" "STANDALONE")
-+    "RPM" "DEB" "SVR4" "FREEBSD" "GLIBC" "OSX" "TARGZ" "STANDALONE" "MACPORTS")
+-    "RPM" "DEB" "SVR4" "TARGZ" "STANDALONE")
++    "RPM" "DEB" "SVR4" "TARGZ" "STANDALONE" "MACPORTS")
    LIST(FIND VALID_INSTALL_LAYOUTS "${INSTALL_LAYOUT}" ind)
    IF(ind EQUAL -1)
      MESSAGE(FATAL_ERROR "Invalid INSTALL_LAYOUT parameter:${INSTALL_LAYOUT}."
-@@ -306,6 +306,37 @@
- SET(INSTALL_MYSQLKEYRINGDIR_RPM         "/var/lib/mysql-keyring")
+@@ -225,6 +225,36 @@
  SET(INSTALL_SECURE_FILE_PRIVDIR_RPM     ${secure_file_priv_path})
  
-+
+ #
 +# MACPORTS layout
 +#
 +SET(INSTALL_BINDIR_MACPORTS                       "lib/@NAME@/bin")
@@ -52,7 +51,7 @@
 +SET(INSTALL_SECURE_FILE_PRIV_EMBEDDEDDIR_MACPORTS "${CMAKE_INSTALL_PREFIX}/var/db/@NAME@-files")
 +SET(INSTALL_PLUGINTESTDIR_MACPORTS                ${plugin_tests})
 +
-+
- #
++#
  # DEB layout
  #
+ SET(INSTALL_BINDIR_DEB                  "bin")

--- a/databases/mysql8/files/patch-cmake-install_macros.cmake.diff
+++ b/databases/mysql8/files/patch-cmake-install_macros.cmake.diff
@@ -1,6 +1,6 @@
---- a/cmake/install_macros.cmake	2019-12-10 15:50:53.000000000 -0500
-+++ b/cmake/install_macros.cmake	2019-12-10 16:43:28.000000000 -0500
-@@ -324,11 +324,11 @@
+--- a/cmake/install_macros.cmake	2020-01-14 10:39:02.000000000 -0500
++++ b/cmake/install_macros.cmake	2020-01-14 10:39:36.000000000 -0500
+@@ -345,11 +345,11 @@
      ADD_CUSTOM_COMMAND(TARGET ${TARGET} POST_BUILD
        COMMAND install_name_tool -change
        "@rpath/$<TARGET_FILE_NAME:libprotobuf-lite>"


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
