### PR TITLE
dlib: Update to work with OpenCV 4.2.0 and 3.4.9

### DIFF
--- a/math/dlib/Portfile
+++ b/math/dlib/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake  1.1
 
-github.setup        davisking dlib 19.17 v
+github.setup        davisking dlib 54a9a5bbf3267386dd39a82fb792bab1bb60796c
+version             19.19.1
 homepage            http://dlib.net
 categories          math
 platforms           darwin
@@ -20,9 +21,9 @@ long_description    \
     computing environments. Dlib's open source licensing allows you to use it\
     in any application, free of charge.
 
-checksums           rmd160  07ea026e4caf0292187e9d52cef040a85db83267 \
-                    sha256  98692d0b8bd6d6b26b8884c4b2fedc15f98c4f9f4788761e5f98a77374f1b6a1 \
-                    size 10418767
+checksums           rmd160  5461fafaa539b7e7e0b3983e71dc0185d2cdfa57 \
+                    sha256  ce0d92482fd6c57f6fb31491cd61e329affb4219f5ac13f76837713e24fa5bfe \
+                    size 10564943
 
 compiler.cxx_standard   2011
 configure.cxxflags-append -fvisibility=hidden -fvisibility-inlines-hidden


### PR DESCRIPTION
#### Description

This PR updates Dlib to work with OpenCV 4.2.0 and OpenCV 3.4.9. It points to a commit on Github rather than a release, since the fixes have not made it to a release.

Reference: 
- https://github.com/davisking/dlib/pull/1963
- https://github.com/davisking/dlib/commit/34dc7303045877226ebdd6cd07ce6384c0881eb8


<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
Update

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.2 19C57
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [ x ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ x ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ x ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ x ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ x ] checked your Portfile with `port lint`?
- [ x ] tried existing tests with `sudo port test`?
- [ x ] tried a full install with `sudo port -vst install`?
- [ x ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
