### PR TITLE
geos: Fix build on 10.7 and 10.8.

### DIFF
--- a/science/geos/Portfile
+++ b/science/geos/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           cxx11 1.1
+PortGroup           compiler_blacklist_versions 1.0
 
 name                geos
 version             3.8.0
@@ -28,7 +29,7 @@ checksums           rmd160  9561f29ebb139b891e0d33344875e12de616f2de \
                     sha256  99114c3dc95df31757f44d2afde73e61b9f742f0b683fd1894cbbee05dda62d5 \
                     size    2399403
 
-compiler.blacklist  llvm-gcc-4.2 macports-llvm-gcc-4.2
+compiler.blacklist  llvm-gcc-4.2 macports-llvm-gcc-4.2 {clang < 600}
 
 use_parallel_build  yes
 


### PR DESCRIPTION
On 10.7, with Xcode 4.6.3 and clang 425, there's a compilation error
which should probably be fixed upstream, though it doesn't fail with
other compilers.

On 10.8, with Xcode 5.1.1 and clang 503, the aforementioned error is
treated as a warning, but there are link-time errors.

Blacklisting clang < 600 switches both cases to successfully build
with MacPorts Clang 9.0, while leaving other compiler selections
unchanged.

TESTED:
Successfully built -universal on 10.5-10.15, including 10.5 PPC.
Built +universal on 10.6-10.13, with 10.5 x86 being the only supported
but untested case (due to broken dependencies).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
