### PR TITLE
libtapi @ 1000.10.8: new port

### DIFF
--- a/devel/libtapi/Portfile
+++ b/devel/libtapi/Portfile
@@ -1,0 +1,109 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               cmake 1.1
+
+name                    libtapi
+version                 1000.10.8
+revision                0
+categories              devel
+platforms               darwin
+maintainers             {kencu @kencu} {jeremyhu @jeremyhu} openmaintainer
+
+license                 APSL-2
+description             ${name} adds ld64 linker support for text-based API libraries.
+long_description        ${description} Newer MacOS SDKs contain only these TAPI stubs.
+
+homepage                http://opensource.apple.com/source/tapi/
+master_sites            http://opensource.apple.com/tarballs/tapi:tapi
+
+distfiles               tapi-${version}.tar.gz:tapi
+
+checksums               tapi-1000.10.8.tar.gz \
+                        rmd160  f5aad7f6ed579ce83d1206910ea8885043b4ebdb \
+                        sha256  827e996529974305ef7933f3fa790f7ed068caa29db8f8c30b8a83c6826503f7 \
+                        size    205606
+
+depends_build-append     port:python27 port:libxml2
+configure.args-append   -DPYTHON_EXECUTABLE=${prefix}/bin/python2.7
+
+worksrcdir              tapi_build
+
+compiler.cxx_standard   2011
+configure.pre_args-replace -DCMAKE_BUILD_TYPE=MacPorts \
+                           -DCMAKE_BUILD_TYPE=Release
+configure.post_args     ${worksrcpath}/llvm
+
+variant tapiswift description "Build with Apple's swift infrastructure, as per Apple's TAPI from Xcode." {
+
+    # this is the official Apple TAPI build method, using Apple's llvm/clang fork
+
+    master_sites-append https://github.com/apple/swift-llvm/archive:llvm  \
+                        https://github.com/apple/swift-clang/archive:clang
+
+    distfiles-append    swift-4.2.2-RELEASE.tar.gz:llvm \
+                        swift-4.2.4-RELEASE.tar.gz:clang
+
+    checksums-append    swift-4.2.2-RELEASE.tar.gz \
+                        rmd160  bc36eab3ff3e5acf8c77a4b49dbd5cc3dbc75575 \
+                        sha256  50dafb7fa0c31e93b70e19a67e0f4a13f9dd9afc5dc507fd231a495edd7abdbd \
+                        size    37970663 \
+                        swift-4.2.4-RELEASE.tar.gz \
+                        rmd160  d83ffec2a76202da8e6ff0a994f222711bca49cc \
+                        sha256  74d27ed9f0371334de1ae9ad63d60869c60b6dca6ad6d7a39e6f2804e6007013 \
+                        size    17248048
+    post-extract {
+        file mkdir      ${workpath}/${worksrcdir}
+        file rename     ${workpath}/tapi-${version} ${worksrcpath}/tapi
+        file rename     ${workpath}/swift-llvm-swift-4.2.2-RELEASE ${worksrcpath}/llvm
+        file rename     ${workpath}/swift-clang-swift-4.2.4-RELEASE ${worksrcpath}/clang
+    }
+}
+
+variant tapillvm6 description "Build with llvm6 infrastructure" {
+    set llvm_version    6.0.1
+    master_sites-append https://github.com/llvm/llvm-project/archive/:llvm
+    distfiles-append    llvmorg-${llvm_version}.tar.gz:llvm
+    checksums-append    llvmorg-6.0.1.tar.gz \
+                        rmd160  3a934bace1f159adac75e5f5c0b01447561549bc \
+                        sha256  aefadceb231f4c195fe6d6cd3b1a010b269c8a22410f339b5a089c2e902aa177 \
+                        size    100123328
+    post-extract {
+        # we can't use ${llvm_version} here as error: "no such variable"
+        move ${workpath}/llvm-project-llvmorg-6.0.1  ${workpath}/${worksrcdir}
+        file rename ${workpath}/tapi-${version}      ${worksrcpath}/tapi
+        system -W ${worksrcpath} "ln -s ../../tapi   ${worksrcpath}/clang/tools/tapi"
+    }
+
+    patchfiles-append   patch-clang-tools-add-tapi.diff
+}
+
+variant tapillvm7 description "Build with llvm7 infrastructure, plus patches to add zippered TAPI and PPC support" {
+    set llvm_version    7.1.0
+    master_sites-append https://github.com/llvm/llvm-project/archive/:llvm
+    distfiles-append    llvmorg-${llvm_version}.tar.gz:llvm
+    checksums-append    llvmorg-7.1.0.tar.gz \
+                        rmd160  abdbeaa08cb1c5e9ce4008e47263eb10597f5aed \
+                        sha256  71c93979f20e01f1a1cc839a247945f556fa5e63abf2084e8468b238080fd839 \
+                        size    105306132
+    post-extract {
+        # we can't use ${llvm_version} here as error: "no such variable"
+        move ${workpath}/llvm-project-llvmorg-7.1.0 ${workpath}/${worksrcdir}
+        file rename ${workpath}/tapi-${version} ${worksrcpath}/tapi
+        system -W ${worksrcpath} "ln -s ../../tapi ${worksrcpath}/clang/tools/tapi"
+    }
+
+    # patches from https://github.com/iains/tapi to add zippered support, PPC support,
+    # build with llvm7, and adjust version numbering
+    patchfiles-append   patch-tapi-iains.diff
+    patchfiles-append   patch-clang-tools-add-tapi.diff
+}
+
+configure.args-append   -C ${worksrcpath}/tapi/cmake/caches/apple-tapi.cmake
+build.target            distribution
+destroot.target         install-distribution
+
+default_variants-append +tapillvm6
+
+livecheck.type          regex
+livecheck.regex         "tapi-(\[\\d.\]+)"

--- a/devel/libtapi/files/patch-clang-tools-add-tapi.diff
+++ b/devel/libtapi/files/patch-clang-tools-add-tapi.diff
@@ -1,0 +1,8 @@
+--- clang/tools/CMakeLists.txt.orig	2020-01-16 15:51:11.000000000 -0800
++++ clang/tools/CMakeLists.txt	2020-01-16 15:51:50.000000000 -0800
+@@ -35,3 +35,5 @@
+ 
+ # libclang may require clang-tidy in clang-tools-extra.
+ add_clang_subdirectory(libclang)
++
++add_clang_subdirectory(tapi)

--- a/devel/libtapi/files/patch-tapi-iains.diff
+++ b/devel/libtapi/files/patch-tapi-iains.diff
@@ -1,0 +1,513 @@
+From 36b039df99f82c5cb1b2eb112b0d1eedfeadea81 Mon Sep 17 00:00:00 2001
+From: Iain Sandoe <iain@sandoe.co.uk>
+Date: Sun, 2 Sep 2018 16:40:25 +0100
+Subject: [PATCH] [tapi] Diagnostics generation needs declaration of
+ TextSubstitution class.
+
+---
+ include/tapi/Diagnostics/DiagnosticTAPIKinds.td | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git tapi/include/tapi/Diagnostics/DiagnosticTAPIKinds.td tapi/include/tapi/Diagnostics/DiagnosticTAPIKinds.td
+index 76eb025..0029221 100644
+--- tapi/include/tapi/Diagnostics/DiagnosticTAPIKinds.td
++++ tapi/include/tapi/Diagnostics/DiagnosticTAPIKinds.td
+@@ -7,6 +7,15 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// Textual substitutions which may be performed on the text of diagnostics
++class TextSubstitution<string Text> {
++  string Substitution = Text;
++  // TODO: These are only here to allow substitutions to be declared inline with
++  // diagnostics
++  string Component = "";
++  string CategoryName = "";
++}
++
+ // Define the diagnostic severities.
+ class Severity<string N> {
+   string Name = N;From eacea331c34b738832c0d79e2ebc900b44e50189 Mon Sep 17 00:00:00 2001
+From: Iain Sandoe <iain@sandoe.co.uk>
+Date: Sun, 2 Sep 2018 16:30:49 +0100
+Subject: [PATCH] [tapi, llvm] VersionTuple from Support.
+
+---
+ include/tapi/Core/ArchitectureSupport.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git tapi/include/tapi/Core/ArchitectureSupport.h tapi/include/tapi/Core/ArchitectureSupport.h
+index 148c5ca..56f2d91 100644
+--- tapi/include/tapi/Core/ArchitectureSupport.h
++++ tapi/include/tapi/Core/ArchitectureSupport.h
+@@ -21,9 +21,9 @@
+ #include "tapi/LinkerInterfaceFile.h"
+ #include "tapi/PackedVersion32.h"
+ #include "tapi/tapi.h"
+-#include "clang/Basic/VersionTuple.h"
+ #include "llvm/ADT/StringRef.h"
+ #include "llvm/Support/raw_ostream.h"
++#include "llvm/Support/VersionTuple.h"
+ #include <utility>
+ 
+ TAPI_NAMESPACE_INTERNAL_BEGIN
+@@ -35,7 +35,7 @@ struct PackedVersion {
+   constexpr PackedVersion(uint32_t version) : _version(version) {}
+   PackedVersion(unsigned major, unsigned minor, unsigned subminor)
+       : _version((major << 16) | ((minor & 0xff) << 8) | (subminor & 0xff)) {}
+-  PackedVersion(clang::VersionTuple version) {
++  PackedVersion(llvm::VersionTuple version) {
+     _version = version.getMajor() << 16;
+     if (auto minor = version.getMinor())
+       _version |= (*minor & 0xff) << 8;From 304a6643b278b467889914140bfd1f801e45dbfa Mon Sep 17 00:00:00 2001
+From: Iain Sandoe <iain@sandoe.co.uk>
+Date: Fri, 5 Jul 2019 13:09:53 +0100
+Subject: [PATCH] [tapi] Add a missed <vector> header.
+
+---
+ include/tapi/Core/HeaderFile.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git tapi/include/tapi/Core/HeaderFile.h tapi/include/tapi/Core/HeaderFile.h
+index eaf5f77..baeb610 100644
+--- tapi/include/tapi/Core/HeaderFile.h
++++ tapi/include/tapi/Core/HeaderFile.h
+@@ -19,6 +19,7 @@
+ #include "tapi/Defines.h"
+ #include "llvm/ADT/StringRef.h"
+ #include <string>
++#include <vector>
+ 
+ TAPI_NAMESPACE_INTERNAL_BEGIN
+ From e94d740d690ae84b2ba74cad261d44c141c57fb3 Mon Sep 17 00:00:00 2001
+From: Iain Sandoe <iain@sandoe.co.uk>
+Date: Sun, 2 Sep 2018 16:48:58 +0100
+Subject: [PATCH] [tapi] API changes for ExecuteAndWait().
+
+---
+ lib/Driver/InstallAPIDriver.cpp | 23 ++++++++++++++---------
+ 1 file changed, 14 insertions(+), 9 deletions(-)
+
+diff --git tapi/lib/Driver/InstallAPIDriver.cpp tapi/lib/Driver/InstallAPIDriver.cpp
+index 8f5a3be..ddb9454 100644
+--- tapi/lib/Driver/InstallAPIDriver.cpp
++++ tapi/lib/Driver/InstallAPIDriver.cpp
+@@ -331,7 +331,8 @@ getCodeCoverageSymbols(DiagnosticsEngine &diag,
+   std::string installDir = toolchainBinDir;
+   std::vector<std::unique_ptr<ExtendedInterfaceFile>> files;
+   for (const auto &target : targets) {
+-    const char *clangArgs[] = {"clang",
++    SmallVector<const char*, 128> ClangArgv =
++			      {"clang",
+                                "-target",
+                                target.str().c_str(),
+                                "-dynamiclib",
+@@ -353,12 +354,16 @@ getCodeCoverageSymbols(DiagnosticsEngine &diag,
+                                      ec);
+     FileRemover removeStderrFile(stderrFile);
+ 
+-    const Optional<StringRef> redirects[] = {/*STDIN=*/llvm::None,
+-                                             /*STDOUT=*/llvm::None,
+-                                             /*STDERR=*/StringRef(stderrFile)};
+-
+-    bool failed = sys::ExecuteAndWait(clangBinary.get(), clangArgs,
+-                                      /*env=*/nullptr, redirects);
++    StringRef stderrFileStr(stderrFile);
++    SmallVector<llvm::Optional<StringRef>, 3> Rd =
++      {/*STDIN=*/ llvm::None,
++       /*STDOUT=*/llvm::None,
++       /*STDERR=*/StringRef(stderrFile)};
++    ArrayRef<Optional<StringRef>> Redirects(Rd);
++    Optional<ArrayRef<StringRef>> Env;
++    auto Args = llvm::toStringRefArray(ClangArgv.data());
++    bool failed = sys::ExecuteAndWait(clangBinary.get(), Args,
++                                      Env, Redirects);
+ 
+     if (failed) {
+       auto bufferOr = MemoryBuffer::getFile(stderrFile);
+@@ -366,8 +371,8 @@ getCodeCoverageSymbols(DiagnosticsEngine &diag,
+         return make_error<StringError>("unable to read file", ec);
+ 
+       std::string message = "'clang' invocation failed:\n";
+-      for (auto *arg : clangArgs) {
+-        if (arg == nullptr)
++      for (auto arg : Args) {
++        if (arg == "")
+           continue;
+         message.append(arg).append(1, ' ');
+       }From 7b2d305d6c16cbd503a1ad2c2312697e8e484ad6 Mon Sep 17 00:00:00 2001
+From: Iain Sandoe <iain@sandoe.co.uk>
+Date: Sun, 2 Sep 2018 16:50:15 +0100
+Subject: [PATCH] [tapi, test] Allow the use of a specified sysroot.
+
+---
+ test/CMakeLists.txt  | 2 ++
+ test/lit.cfg         | 3 ++-
+ test/lit.site.cfg.in | 1 +
+ 3 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git tapi/test/CMakeLists.txt tapi/test/CMakeLists.txt
+index 90fe6c4..50e91c4 100644
+--- tapi/test/CMakeLists.txt
++++ tapi/test/CMakeLists.txt
+@@ -53,7 +53,9 @@ ExternalProject_Add(TestInputs
+     -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+     -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+     -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}
++    -DCMAKE_SYSROOT=${CMAKE_SYSROOT}
+     -DCMAKE_OSX_SYSROOT=${CMAKE_OSX_SYSROOT}
++    -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}
+     -DCMAKE_BUILD_TYPE=Release
+   LOG_CONFIGURE 1
+   LOG_BUILD 1
+diff --git tapi/test/lit.cfg tapi/test/lit.cfg
+index fd08bbe..92d45a4 100644
+--- tapi/test/lit.cfg
++++ tapi/test/lit.cfg
+@@ -264,7 +264,8 @@ config.inputs = os.path.join(tapi_obj_root, 'Inputs')
+ config.tapi = infer_tapi(config.environment['PATH']).replace('\\', '/')
+ config.tapi_run = infer_tapi_run(config.environment['PATH']).replace('\\', '/')
+ config.tapi_frontend = infer_tapi_frontend(config.environment['PATH']).replace('\\', '/')
+-config.sysroot = get_macos_sdk_path(config)
++if config.sysroot == '':
++    config.sysroot = get_macos_sdk_path(config)
+ lit_config.note('using SDKROOT: %r' % config.sysroot)
+ 
+ config.substitutions.append( ('%inputs', config.inputs) )
+diff --git tapi/test/lit.site.cfg.in tapi/test/lit.site.cfg.in
+index 5e54c18..0fc027b 100644
+--- tapi/test/lit.site.cfg.in
++++ tapi/test/lit.site.cfg.in
+@@ -9,6 +9,7 @@ config.llvm_libs_dir = "@LLVM_LIBS_DIR@"
+ config.lit_tools_dir = "@LLVM_LIT_TOOLS_DIR@"
+ config.tapi_obj_root = "@TAPI_BINARY_DIR@"
+ config.llvm_use_sanitizer = "@LLVM_USE_SANITIZER@"
++config.sysroot = "@TAPI_SYSROOT@"
+ 
+ 
+ # Support substitution of the tools and libs dirs with user parameters. This isFrom 0b204f83e9907456deb1a44ab36f08a8362fd6f0 Mon Sep 17 00:00:00 2001
+From: Iain Sandoe <iain@sandoe.co.uk>
+Date: Fri, 5 Jul 2019 20:26:06 +0100
+Subject: [PATCH] tapi - add ppc and ppc64 archs.
+
+---
+ include/tapi/Core/Architecture.def | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git tapi/include/tapi/Core/Architecture.def tapi/include/tapi/Core/Architecture.def
+index 32b4bb5..37df40f 100644
+--- tapi/include/tapi/Core/Architecture.def
++++ tapi/include/tapi/Core/Architecture.def
+@@ -4,6 +4,14 @@
+ #define ARCHINFO(arch)
+ #endif
+ 
++#ifdef SUPPORT_ARCH_PPC
++ARCHINFO(ppc, MachO::CPU_TYPE_POWERPC, MachO::CPU_SUBTYPE_POWERPC_ALL)
++#endif
++
++#ifdef SUPPORT_ARCH_PPC64
++ARCHINFO(ppc64, MachO::CPU_TYPE_POWERPC64, MachO::CPU_SUBTYPE_POWERPC_ALL)
++#endif
++
+ ///
+ /// X86 architectures sorted by cpu type and sub type id.
+ ///From 27d5ad3a7455a60df2ecf9d493e481b8bcb55811 Mon Sep 17 00:00:00 2001
+From: Iain Sandoe <iain@sandoe.co.uk>
+Date: Wed, 3 Apr 2019 16:49:38 +0100
+Subject: [PATCH] [tapi 2.0.2] Update README to outline how this fits in.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Also make the version show that this is not Apple’s one.
+---
+ CMakeLists.txt            | 10 +++++-----
+ Readme.md                 | 33 +++++++++++++++++++++++++++++++++
+ tools/libtapi/Version.cpp |  2 +-
+ 3 files changed, 39 insertions(+), 6 deletions(-)
+
+diff --git tapi/CMakeLists.txt tapi/CMakeLists.txt
+index d231a06..7b28398 100644
+--- tapi/CMakeLists.txt
++++ tapi/CMakeLists.txt
+@@ -5,7 +5,7 @@ endif()
+ set(TAPI_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+ set(TAPI_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
+ 
+-set(TAPI_FULL_VERSION "2.0.0" CACHE STRING "Specify tapi version.")
++set(TAPI_FULL_VERSION "2.0.2" CACHE STRING "Specify tapi version.")
+ message(STATUS "TAPI version: ${TAPI_FULL_VERSION}")
+ 
+ string(REGEX REPLACE "([0-9]+)\\.[0-9]+(\\.[0-9]+)*" "\\1" TAPI_VERSION_MAJOR
+@@ -21,7 +21,7 @@ else()
+ endif()
+ set(TAPI_VERSION "${TAPI_VERSION_MAJOR}.${TAPI_VERSION_MINOR}.${TAPI_VERSION_PATCH}")
+ 
+-set(TAPI_REPOSITORY_STRING "" CACHE STRING
++set(TAPI_REPOSITORY_STRING "https://github.com/iains/tapi.git" CACHE STRING
+   "Vendor-specific text for showing the repository the source is taken from.")
+ 
+ if(TAPI_REPOSITORY_STRING)
+@@ -38,11 +38,11 @@ endif()
+ if(DEFINED ENV{RC_SUPPORTED_ARCHS})
+   string(REPLACE " " ";" TAPI_SUPPORTED_ARCHS $ENV{RC_SUPPORTED_ARCHS})
+ elseif(NOT DEFINED TAPI_SUPPORTED_ARCHS)
+-  set(TAPI_SUPPORTED_ARCHS i386 x86_64 x86_64h armv4t armv6 armv5 armv7 armv7s armv7k armv6m armv7m armv7em arm64)
++  set(TAPI_SUPPORTED_ARCHS i386 x86_64 x86_64h armv4t armv6 armv5 armv7 armv7s armv7k armv6m armv7m armv7em arm64 ppc ppc64)
+ endif()
+ message(STATUS "Supported Architectures: ${TAPI_SUPPORTED_ARCHS}")
+ 
+-set(KNOWN_ARCHS i386 x86_64 x86_64h armv4t armv6 armv5 armv7 armv7s armv7k armv6m armv7m armv7em arm64)
++set(KNOWN_ARCHS i386 x86_64 x86_64h armv4t armv6 armv5 armv7 armv7s armv7k armv6m armv7m armv7em arm64 ppc ppc64)
+ 
+ set (CONFIG_FILE ${CMAKE_CURRENT_BINARY_DIR}/include/tapi/Core/ArchitectureConfig.h)
+ file(WRITE ${CONFIG_FILE} "#ifndef TAPI_CORE_ARCHITECTURE_CONFIG_H\n")
+@@ -183,7 +183,7 @@ get_property(TAPI_TABLEGEN_TARGETS GLOBAL PROPERTY TAPI_TABLEGEN_TARGETS)
+ list(APPEND LLVM_COMMON_DEPENDS ${TAPI_TABLEGEN_TARGETS})
+ add_subdirectory(lib)
+ add_subdirectory(tools)
+-if( TAPI_INCLUDE_TESTS )
++if( NO AND TAPI_INCLUDE_TESTS )
+   if(EXISTS ${LLVM_MAIN_SRC_DIR}/utils/unittest/googletest/include/gtest/gtest.h)
+     add_subdirectory(unittests)
+     list(APPEND TAPI_TEST_DEPS TapiUnitTests)
+diff --git tapi/Readme.md tapi/Readme.md
+index 89af308..c85cc28 100644
+--- tapi/Readme.md
++++ tapi/Readme.md
+@@ -1,3 +1,36 @@
++## wip-on-1000-10-8-for-llvm-7-1
++
++This is based off the Xcode 10 tapi sources (1000.10.8) but to build on top
++of LLVM 7.1, rather than llvm-swift.
++
++## tapi-201-for-llvm-7-1-with-emuTLS
++
++This is a branch for building toolchains based on GCC when the emulatedTLS
++has been split into a CRT (e.g. https://github.com/iains/gcc-8-branch.git)
++
++This branch has been tested with LLVM 7.1 with some additions to support
++older Darwin versions (https://github.com/iains/LLVM-7-branch.git).
++
++It builds automatically (using the branch mentioned) when this repo is cloned
++to the same level as the LLVM monorepo clone.
++
++Building outside this context hasn't been tried.
++
++# on-700rc2
++
++So I tried this on top of the 7.0.0rc2 sources with the changes here.
++
++plus:
++
++a) Add the ObjcMetadata library from Apple clang-800.0.42.1
++b) symlink tapi into clang/tools/tapi
++c) add  to clang/tools/CMakeLists.txt
++
++    add_llvm_external_project(tapi tapi)
++
++currently, 13 tests fail (and the inputs for IVarTest and Simple have to be
++commented out to get the build to run).
++
+ # TAPI
+ 
+ TAPI is a **T**ext-based **A**pplication **P**rogramming **I**nterface. It
+diff --git tapi/tools/libtapi/Version.cpp tapi/tools/libtapi/Version.cpp
+index e1c8764..eb925b8 100644
+--- tapi/tools/libtapi/Version.cpp
++++ tapi/tools/libtapi/Version.cpp
+@@ -37,7 +37,7 @@ std::string Version::getFullVersionAsString() noexcept {
+ #ifdef TAPI_VENDOR
+   result += TAPI_VENDOR;
+ #endif
+-  result += "TAPI version " TAPI_MAKE_STRING(TAPI_VERSION);
++  result += " Based on Apple TAPI version " TAPI_MAKE_STRING(TAPI_VERSION);
+ 
+ #ifdef TAPI_REPOSITORY_STRING
+   result += " (" TAPI_REPOSITORY_STRING ")";From 0f6883658b053e4d66579ac694ce08b242ac3735 Mon Sep 17 00:00:00 2001
+From: Iain Sandoe <iain@sandoe.co.uk>
+Date: Fri, 3 Jan 2020 08:42:04 +0000
+Subject: [PATCH] [tapi] Implement zippered support.
+
+Recent SDKs have introduced a platform type 'zippered'.  This
+is understood to allow the same specfication to be used for
+MacOS and iOSMac.
+
+This is an implementation of support estimated as needed.
+It is sufficient, at present, to use Darwin18 and 19 SDKs.
+---
+ include/tapi/Core/Platform.h          | 1 +
+ include/tapi/LinkerInterfaceFile.h    | 3 +++
+ lib/Core/Platform.cpp                 | 4 ++++
+ lib/Core/YAML.cpp                     | 1 +
+ tools/libtapi/LinkerInterfaceFile.cpp | 2 ++
+ 5 files changed, 11 insertions(+)
+
+diff --git tapi/include/tapi/Core/Platform.h tapi/include/tapi/Core/Platform.h
+index afe19df..ff39fd3 100644
+--- tapi/include/tapi/Core/Platform.h
++++ tapi/include/tapi/Core/Platform.h
+@@ -34,6 +34,7 @@ enum class Platform : uint8_t {
+   watchOS,
+   watchOSSimulator,
+   bridgeOS,
++  zippered,
+ };
+ 
+ Platform mapToSim(Platform platform, bool wantSim);
+diff --git tapi/include/tapi/LinkerInterfaceFile.h tapi/include/tapi/LinkerInterfaceFile.h
+index a18d9be..987cc4b 100644
+--- tapi/include/tapi/LinkerInterfaceFile.h
++++ tapi/include/tapi/LinkerInterfaceFile.h
+@@ -64,6 +64,9 @@ enum class Platform : unsigned {
+   /// \since 1.2
+   bridgeOS = 5,
+ 
++  /// \brief zippered
++  /// \since 2.0
++  zippered = 6,
+ };
+ 
+ ///
+diff --git tapi/lib/Core/Platform.cpp tapi/lib/Core/Platform.cpp
+index 29e1ab4..af62f3d 100644
+--- tapi/lib/Core/Platform.cpp
++++ tapi/lib/Core/Platform.cpp
+@@ -93,6 +93,8 @@ StringRef getPlatformName(Platform platform) {
+     return "tvOSSimulator";
+   case Platform::bridgeOS:
+     return "bridgeOS";
++  case Platform::zippered:
++    return "zippered";
+   }
+ }
+ 
+@@ -116,6 +118,8 @@ std::string getOSAndEnvironmentName(Platform platform, std::string version) {
+     return "tvos" + version + "-simulator";
+   case Platform::bridgeOS:
+     return "bridgeos" + version;
++  case Platform::zippered:
++    return "zippered" + version;
+   }
+ }
+ 
+diff --git tapi/lib/Core/YAML.cpp tapi/lib/Core/YAML.cpp
+index 3aa286e..823a542 100644
+--- tapi/lib/Core/YAML.cpp
++++ tapi/lib/Core/YAML.cpp
+@@ -55,6 +55,7 @@ void ScalarEnumerationTraits<Platform>::enumeration(IO &io,
+   io.enumCase(platform, "tvos", Platform::tvOS);
+   io.enumCase(platform, "tvos", Platform::tvOSSimulator);
+   io.enumCase(platform, "bridgeos", Platform::bridgeOS);
++  io.enumCase(platform, "zippered", Platform::zippered);
+ }
+ 
+ using TAPI_INTERNAL::Architecture;
+diff --git tapi/tools/libtapi/LinkerInterfaceFile.cpp tapi/tools/libtapi/LinkerInterfaceFile.cpp
+index b678999..c0f1ff0 100644
+--- tapi/tools/libtapi/LinkerInterfaceFile.cpp
++++ tapi/tools/libtapi/LinkerInterfaceFile.cpp
+@@ -298,6 +298,8 @@ static tapi::Platform mapPlatform(tapi::internal::Platform platform) {
+     return Platform::tvOS;
+   case tapi::internal::Platform::bridgeOS:
+     return Platform::bridgeOS;
++  case tapi::internal::Platform::zippered:
++    return Platform::zippered;
+   }
+ }
+ From 0a634b750eb1222c6b7517d7ecebd0720f3381f7 Mon Sep 17 00:00:00 2001
+From: Iain Sandoe <iain@sandoe.co.uk>
+Date: Fri, 3 Jan 2020 08:31:33 +0000
+Subject: [PATCH] [tapi 2.0.3] Update version and version printing.
+
+Updated to reflect the addition of zippered support and made
+the printing of the version information more specific.
+---
+ CMakeLists.txt               |  9 ++++++++-
+ Readme.md                    | 10 ++++++++++
+ tools/libtapi/CMakeLists.txt |  2 +-
+ tools/libtapi/Version.cpp    |  9 +++++++--
+ 4 files changed, 26 insertions(+), 4 deletions(-)
+
+diff --git tapi/CMakeLists.txt tapi/CMakeLists.txt
+index 7b28398..47cbf85 100644
+--- tapi/CMakeLists.txt
++++ tapi/CMakeLists.txt
+@@ -5,9 +5,12 @@ endif()
+ set(TAPI_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+ set(TAPI_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
+ 
+-set(TAPI_FULL_VERSION "2.0.2" CACHE STRING "Specify tapi version.")
++set(TAPI_FULL_VERSION "2.0.3" CACHE STRING "Specify tapi version.")
+ message(STATUS "TAPI version: ${TAPI_FULL_VERSION}")
+ 
++set(TAPI_APPLE_VERSION "1000.10.8" CACHE STRING "Specify tapi version.")
++message(STATUS "APPLE Tapi version: ${TAPI_APPLE_VERSION}")
++
+ string(REGEX REPLACE "([0-9]+)\\.[0-9]+(\\.[0-9]+)*" "\\1" TAPI_VERSION_MAJOR
+   ${TAPI_FULL_VERSION})
+ string(REGEX REPLACE "[0-9]+\\.([0-9]+)(\\.[0-9]+)*" "\\1" TAPI_VERSION_MINOR
+@@ -35,6 +38,10 @@ if (TAPI_VENDOR)
+   add_definitions( -DTAPI_VENDOR="${TAPI_VENDOR} ")
+ endif()
+ 
++if (TAPI_APPLE_VERSION)
++  add_definitions( -DAPPLE_VERSION="${TAPI_APPLE_VERSION}")
++endif ()
++
+ if(DEFINED ENV{RC_SUPPORTED_ARCHS})
+   string(REPLACE " " ";" TAPI_SUPPORTED_ARCHS $ENV{RC_SUPPORTED_ARCHS})
+ elseif(NOT DEFINED TAPI_SUPPORTED_ARCHS)
+diff --git tapi/Readme.md tapi/Readme.md
+index c85cc28..0cfedec 100644
+--- tapi/Readme.md
++++ tapi/Readme.md
+@@ -1,3 +1,13 @@
++## wip-on-1000-10-8-for-LLVM-7.1.1
++
++Version 2.0.3
++
++* This adds support for the 'zippered' platform type.  It is sufficient to
++consume the SDKs for Darwin18/MacOS10.14 and Darwin19/MacOS10.15.
++
++* The library version now reflects the TAPI edition, rather than the LLVM
++version it was built on top of.
++
+ ## wip-on-1000-10-8-for-llvm-7-1
+ 
+ This is based off the Xcode 10 tapi sources (1000.10.8) but to build on top
+diff --git tapi/tools/libtapi/CMakeLists.txt tapi/tools/libtapi/CMakeLists.txt
+index ea7a247..ea14471 100644
+--- tapi/tools/libtapi/CMakeLists.txt
++++ tapi/tools/libtapi/CMakeLists.txt
+@@ -23,7 +23,7 @@ set_target_properties(libtapi
+ set(DYLIB_VERSION "${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}")
+ set_property(TARGET libtapi APPEND_STRING
+   PROPERTY
+-  LINK_FLAGS " -current_version ${DYLIB_VERSION} -compatibility_version 1 -allowable_client ld"
++  LINK_FLAGS " -current_version ${TAPI_VERSION} -compatibility_version 1 -allowable_client ld"
+   )
+ 
+ if(LINKER_SUPPORTS_NO_INITS)
+diff --git tapi/tools/libtapi/Version.cpp tapi/tools/libtapi/Version.cpp
+index eb925b8..2c198f5 100644
+--- tapi/tools/libtapi/Version.cpp
++++ tapi/tools/libtapi/Version.cpp
+@@ -37,8 +37,13 @@ std::string Version::getFullVersionAsString() noexcept {
+ #ifdef TAPI_VENDOR
+   result += TAPI_VENDOR;
+ #endif
+-  result += " Based on Apple TAPI version " TAPI_MAKE_STRING(TAPI_VERSION);
+-
++#ifdef TAPI_VERSION
++  result += TAPI_MAKE_STRING(TAPI_VERSION);
++#endif
++  result += " based on Apple TAPI";
++#ifdef APPLE_VERSION
++  result += " version " APPLE_VERSION;
++#endif
+ #ifdef TAPI_REPOSITORY_STRING
+   result += " (" TAPI_REPOSITORY_STRING ")";
+ #endif
+ 


### PR DESCRIPTION
adds Text-Based API support to ld64
allows open-source versions of ld64 to support newer
MacOS SDK versions that come with only *.tbd files
instead of full or stub dylibs to link against

see https://trac.macports.org/ticket/53784

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G2022
Xcode 11.3 11C29 

macOS 10.13
Xcode 10.3


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
