### PR TITLE
welle.io: Update welle.io-devel & rearranage variants for binary distribution

### DIFF
--- a/multimedia/welle.io/Portfile
+++ b/multimedia/welle.io/Portfile
@@ -19,7 +19,7 @@ long_description        This is an open source DAB and DAB+ software defined rad
                         like Raspberry Pi 2/3 and 100€ China Windows 10 tablets.
 
 license                 GPL-3+
-license_noconflict      openssl
+license_noconflict      openssl mpg123
 
 homepage                https://www.welle.io/
 
@@ -56,11 +56,48 @@ variant airspy description {Add Airspy support} {
     depends_lib-append port:airspy
 }
 
+variant cli description {Also compile welle-cli} {
+    # mpg123 is licensed as LGPL-2.1 except for 
+    # file src/libout123/modules/coreaudio.c which is GPL-2
+    # welle-cli relies on libout123 while the GUI does not.
+    # In order to have binaries distributed for welle-io,
+    # we enable only welle-gui by default. The user can enable
+    # cli variant to build also welle-cli locally.
+
+    configure.pre_args-replace -DBUILD_WELLE_CLI=OFF -DBUILD_WELLE_CLI=ON
+
+    license_noconflict-delete   mpg123
+
+    post-patch {
+        reinplace "s!\"index.html\"!\"${applications_dir}/welle-io.app/Contents/Resources/welle-cli/index.html\"!" \
+        ${worksrcpath}/src/welle-cli/webradiointerface.cpp
+        reinplace "s!\"index.js\"!\"${applications_dir}/welle-io.app/Contents/Resources/welle-cli/index.js\"!" \
+        ${worksrcpath}/src/welle-cli/webradiointerface.cpp
+    }
+
+    post-destroot {
+        ln -s ${applications_dir}/welle-io.app/Contents/MacOS/welle-cli \
+            ${destroot}${prefix}/bin/welle-cli
+    }
+}
+
+variant profiling description {Enable profiling (see README.md)} {
+    configure.pre_args-append \
+        -DPROFILING=ON
+}
+
+variant kiss_fft description {Use KISS FFT instead of FFTW} {
+    configure.pre_args-append \
+        -DKISS_FFT=ON
+    depends_lib-delete  port:fftw-3-single
+}
+
 if {${subport} eq ${name}} {
     # stable
     github.setup            AlbrechtL welle.io 2.1 v
     github.tarball_from     archive
     epoch                   1
+    revision                1
 
     conflicts               welle.io-devel
 
@@ -72,34 +109,26 @@ if {${subport} eq ${name}} {
         -DGIT_COMMIT_HASH=${version}
 } else {
     # devel
-    github.setup            AlbrechtL welle.io c94b878950c91bd51abde9e2b119eb9e6a8653e6
+    github.setup            AlbrechtL welle.io 81f757ca4591a0255ec9dade5a2b73091bcea73b
     set githash             [string range ${github.version} 0 6]
-    version                 20191210+git${githash}
+    version                 20200114+git${githash}
 
     conflicts               welle.io
 
-    checksums               rmd160  1551396c53e41c1770177be8ac55b7cfd7e7e876 \
-                            sha256  1e848d6cdc65f95837f7a50db3092cbd92d058dece91cd407245413d84cad50c \
-                            size    1637224
+    checksums               rmd160  6e46bf40bfccc2954de1d31e72df4fcd4106a885 \
+                            sha256  c17d45b1289660ec65b4a3b36460f8c09202219d78ec9c44337da311c8d4eae9 \
+                            size    1645049
 
     configure.pre_args-append \
         -DGIT_COMMIT_HASH=${githash}
 }
 
 configure.pre_args-append \
+    -DBUILD_WELLE_CLI=OFF \
     -DBUNDLE_INSTALL_DIR=${applications_dir} \
     -DGIT_DESCRIBE=${version} \
     -DWELLE-IO_VERSION=${version}
 
 post-patch {
     reinplace "s/\$(PRODUCT_BUNDLE_IDENTIFIER)/@PRODUCT_BUNDLE_IDENTIFIER@/" ${worksrcpath}/welle-io.plist
-    reinplace "s!\"index.html\"!\"${applications_dir}/welle-io.app/Contents/Resources/welle-cli/index.html\"!" \
-        ${worksrcpath}/src/welle-cli/webradiointerface.cpp
-    reinplace "s!\"index.js\"!\"${applications_dir}/welle-io.app/Contents/Resources/welle-cli/index.js\"!" \
-        ${worksrcpath}/src/welle-cli/webradiointerface.cpp
-}
-
-post-destroot {
-    ln -s ${applications_dir}/welle-io.app/Contents/MacOS/welle-cli \
-        ${destroot}${prefix}/bin/welle-cli
 }


### PR DESCRIPTION
- update welle.io-devel to 20200114
- bump welle.io revision to "1"
- disable welle-cli by default and make it a variant (to enable binary distribution of welle.io GUI because of licensing issues) [ Closes: https://trac.macports.org/ticket/59779 ]
- add "kiss_fft" variant
- add "profiling" variant

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
