### PR TITLE
bandwhich: new port

### DIFF
--- a/net/bandwhich/Portfile
+++ b/net/bandwhich/Portfile
@@ -1,0 +1,251 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo 1.0
+
+github.setup        imsnif bandwhich 0.9.0
+categories          net
+platforms           darwin
+maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
+license             MIT
+
+description         Terminal bandwidth utilization tool (formerly known as \
+                    \"what\")
+
+long_description    bandwhich sniffs a given network interface and records IP \
+                    packet size, cross referencing it with the /proc \
+                    filesystem on linux or lsof on macOS. It is responsive to \
+                    the terminal window size, displaying less info if there \
+                    is no room for it. It will also attempt to resolve ips to \
+                    their host name in the background using reverse DNS on a \
+                    best effort basis.
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  99aade46c602216de3d52a11afcd8b85a1641a3a \
+                    sha256  5ad80f236c748e46dba2b92efc50615c7d76ef421ee8e2d07f983629373c4af2 \
+                    size    1557861
+
+destroot {
+    set gzip [findBinary gzip ${portutil::autoconf::gzip_path}]
+    set manpage "${prefix}/share/man/man1/${name}.1"
+
+    xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/${name} ${destroot}${prefix}/bin/
+
+    copy ${worksrcpath}/docs/${name}.1 "${destroot}${manpage}"
+}
+
+cargo.crates \
+    adler32                          1.0.4  5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2 \
+    aho-corasick                     0.7.6  58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d \
+    aho-corasick                    0.6.10  81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5 \
+    ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
+    arc-swap                         0.4.3  f1a1eca3195b729bbd64e292ef2f5fff6b1c28504fed762ce2b1013dde4d8e92 \
+    async-trait                     0.1.21  8b6dd385bb33043b833ba049048d57bdbb4d654a121ed68c71871ca51ff67070 \
+    atty                            0.2.13  1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90 \
+    autocfg                          0.1.7  1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2 \
+    backtrace                       0.3.40  924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea \
+    backtrace-sys                   0.1.32  5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491 \
+    bitflags                         0.5.0  4f67931368edf3a9a51d29886d245f1c3db2f1ef0dcc9e35ff70341b78c10d23 \
+    bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
+    block-buffer                     0.7.3  c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b \
+    block-padding                    0.1.5  fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5 \
+    byte-tools                       0.3.1  e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7 \
+    byteorder                        1.3.2  a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5 \
+    bytes                            0.5.0  549c8cf9befa7948bfd9ebb0ed84c6b25b0400046b6db1b73c026e4117c26c12 \
+    c2-chacha                        0.2.3  214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb \
+    cargo-insta                     0.11.0  e22a28c661f0fb0474ef90d63b4bc834bf2c179550608783594f358f5ac74cc2 \
+    cassowary                        0.3.0  df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53 \
+    cc                              1.0.47  aa87058dce70a3ff5621797f1506cb837edd02ac4c0ae642b4542dce802908b8 \
+    cfg-if                           0.1.9  b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33 \
+    chrono                           0.4.9  e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68 \
+    clap                            2.33.0  5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9 \
+    clicolors-control                1.0.1  90082ee5dcdd64dc4e9e0d37fbf3ee325419e39c0092191e0393df65518f741e \
+    cloudabi                         0.0.3  ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
+    console                          0.9.1  f5d540c2d34ac9dd0deb5f3b5f54c36c79efa78f6b3ad19106a554d07a7b5d9f \
+    console                          0.7.7  8ca57c2c14b8a2bf3105bc9d15574aad80babf6a9c44b1058034cdf8bd169628 \
+    console                          0.8.0  b147390a412132d75d10dd3b7b175a69cf5fd95032f7503c7091b8831ba10242 \
+    crc32fast                        1.2.0  ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1 \
+    derive-new                       0.5.8  71f31892cd5c62e414316f2963c5689242c43d8e7bbcaaeca97e5e28c95d91d9 \
+    difference                       2.0.0  524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198 \
+    digest                           0.8.1  f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5 \
+    dtoa                             0.4.4  ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e \
+    either                           1.5.3  bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3 \
+    encode_unicode                   0.3.6  a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f \
+    enum-as-inner                    0.3.0  900a6c7fbe523f4c2884eaf26b57b81bb69b6810a01a236390a7ac021d09492e \
+    failure                          0.1.6  f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9 \
+    failure_derive                   0.1.6  0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08 \
+    fake-simd                        0.1.2  e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed \
+    fnv                              1.0.6  2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3 \
+    fuchsia-cprng                    0.1.1  a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba \
+    fuchsia-zircon                   0.3.3  2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
+    fuchsia-zircon-sys               0.3.3  3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
+    futures                          0.3.1  b6f16056ecbb57525ff698bb955162d0cd03bee84e6241c27ff75c08d8ca5987 \
+    futures-channel                  0.3.1  fcae98ca17d102fd8a3603727b9259fcf7fa4239b603d2142926189bc8999b86 \
+    futures-core                     0.3.1  79564c427afefab1dfb3298535b21eda083ef7935b4f0ecbfcb121f0aec10866 \
+    futures-executor                 0.3.1  1e274736563f686a837a0568b478bdabfeaec2dca794b5649b04e2fe1627c231 \
+    futures-io                       0.3.1  e676577d229e70952ab25f3945795ba5b16d63ca794ca9d2c860e5595d20b5ff \
+    futures-macro                    0.3.1  52e7c56c15537adb4f76d0b7a76ad131cb4d2f4f32d3b0bcabcbe1c7c5e87764 \
+    futures-sink                     0.3.1  171be33efae63c2d59e6dbba34186fe0d6394fb378069a76dfd80fdcffd43c16 \
+    futures-task                     0.3.1  0bae52d6b29cf440e298856fec3965ee6fa71b06aa7495178615953fd669e5f9 \
+    futures-util                     0.3.1  c0d66274fb76985d3c62c886d1da7ac4c0903a8c9f754e8fe0f35a6a6cc39e76 \
+    generic-array                   0.12.3  c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec \
+    getrandom                       0.1.13  e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407 \
+    glob                            0.2.11  8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb \
+    heck                             0.3.1  20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205 \
+    hex                              0.4.0  023b39be39e3a2da62a94feb433e91e8bcd37676fbc8bea371daf52b7a769a3e \
+    hostname                         0.1.5  21ceb46a83a85e824ef93669c8b390009623863b5c195d1ba747292c0c72f94e \
+    idna                             0.2.0  02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9 \
+    insta                           0.12.0  0d499dc062e841590a67230d853bce62d0abeb91304927871670b7c55c461349 \
+    insta                           0.11.0  23f83ab4ee86f38b292f0420c27fd412690a4baa9ea0ad4e3fa624bf34379b76 \
+    iovec                            0.1.4  b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e \
+    ipconfig                         0.2.1  aa79fa216fbe60834a9c0737d7fcd30425b32d1c58854663e24d4c4b328ed83f \
+    ipnetwork                       0.15.0  bf7762e2b430ad80cbef992a1d4f15a15d9d4068bdd8e57acb0a3d21d0cf7f40 \
+    ipnetwork                       0.12.8  70783119ac90828aaba91eae39db32c6c1b8838deea3637e5238efa0130801ab \
+    itertools                        0.8.1  87fa75c9dea7b07be3138c49abbb83fd4bea199b5cdc76f9804458edc5da0d6e \
+    itoa                             0.4.4  501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f \
+    kernel32-sys                     0.2.2  7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    libc                            0.2.65  1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8 \
+    libflate                        0.1.27  d9135df43b1f5d0e333385cb6e7897ecd1a43d7d11b91ac003f4d2c2d2401fdd \
+    linked-hash-map                  0.5.2  ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83 \
+    lock_api                         0.3.1  f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc \
+    log                              0.4.8  14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7 \
+    log                              0.3.9  e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b \
+    lru-cache                        0.1.2  31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c \
+    maplit                           1.0.2  3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d \
+    matches                          0.1.8  7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
+    maybe-uninit                     2.0.0  60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00 \
+    memchr                           2.2.1  88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e \
+    mio                             0.6.21  302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f \
+    miow                             0.2.1  8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919 \
+    net2                            0.2.33  42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88 \
+    num-integer                     0.1.41  b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09 \
+    num-traits                       0.2.8  6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32 \
+    numtoa                           0.1.0  b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef \
+    opaque-debug                     0.2.3  2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c \
+    packet-builder                   0.4.0  c3a4c42f976f5e39b18002d165d238fadb0a897e1252cf96e39109f515e85aa8 \
+    parking_lot                      0.9.0  f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252 \
+    parking_lot_core                 0.6.2  b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b \
+    percent-encoding                 2.1.0  d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
+    pest                             2.1.2  7e4fb201c5c22a55d8b24fef95f78be52738e5e1361129be1b5e862ecdb6894a \
+    pest_derive                      2.1.0  833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0 \
+    pest_generator                   2.1.1  7b9fcf299b5712d06ee128a556c94709aaa04512c4dffb8ead07c5c998447fc0 \
+    pest_meta                        2.1.2  df43fd99896fd72c485fe47542c7b500e4ac1e8700bf995544d1317a60ded547 \
+    pin-project-lite                 0.1.1  f0af6cbca0e6e3ce8692ee19fb8d734b641899e07b68eb73e9bbbd32f1703991 \
+    pin-utils                     0.1.0-alpha.4  5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587 \
+    pnet                            0.23.0  5cf9ef46222a90a9d1e35bb4fa208e1076c6663a02d8ecf3e264fd5001ab6e8e \
+    pnet_bandwhich_fork             0.23.1  e146697b998acfb2491f2524d1570f81f650a017402ce45b99539c5a5935a605 \
+    pnet_base                       0.23.0  f7d818b94d0897cd22f7a18f6c2a94f7ae1dfcedc194bf1665880f6c1155e051 \
+    pnet_base_bandwhich_fork        0.23.0  f0886cdc1878c06687cbee7d3ed5045380e57b164bf69f036570559c07f6de88 \
+    pnet_datalink                   0.23.0  557ff7deb5ad2b35ac17a495d629d64dfeacf02e7f4834974dceb5e2cc544d55 \
+    pnet_datalink_bandwhich_fork    0.23.1  697cdb8110661cb4eea5aa08684ab50b0b2ab9b0ca88e9bcef2aa232f7c41369 \
+    pnet_macros                     0.21.0  5d228096fd739d4e3e60dee9e1e4f07d9ae0f3f309c876834192538748e561e4 \
+    pnet_macros_support             0.23.0  d6158bbc3627b9ce01526f5ff8b9895224a0dc96c27baaf79cda0f703a4898ea \
+    pnet_packet                     0.23.0  7efa93f5572ed735852737232ba7539977799861642aaba05de87b6a03dc0f74 \
+    pnet_sys                        0.23.0  ab2f8311f738773513fc8192a77e8f77461d97333184c23597a23cb9eb0bd0eb \
+    pnet_sys_bandwhich_fork         0.23.0  019c5cdc431afe23ae950d145cdf6cc321a8ef4ece501a4cb92c79c3ed4cdabf \
+    pnet_transport                  0.23.0  40851df523364df420e1c85e4885319656904a189a9352657ececcb3c2314fc0 \
+    ppv-lite86                       0.2.6  74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b \
+    proc-macro-error                 0.2.6  aeccfe4d5d8ea175d5f0e4a2ad0637e0f4121d63bd99d356fb1f39ab2e7c6097 \
+    proc-macro-hack                 0.5.11  ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5 \
+    proc-macro-nested                0.1.3  369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e \
+    proc-macro2                      1.0.6  9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27 \
+    proc-macro2                     0.4.30  cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759 \
+    procfs                           0.7.4  c81c52c5396135378949a5a71a04339c1e6129f67cd58a62fd4c00d2fa0f177e \
+    quick-error                      1.2.2  9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0 \
+    quote                            1.0.2  053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe \
+    quote                           0.6.13  6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1 \
+    rand                             0.6.5  6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca \
+    rand                             0.7.2  3ae1b169243eaf61759b8475a998f0a385e42042370f3a7dbaf35246eacc8412 \
+    rand_chacha                      0.1.1  556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef \
+    rand_chacha                      0.2.1  03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853 \
+    rand_core                        0.3.1  7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b \
+    rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
+    rand_core                        0.4.2  9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc \
+    rand_hc                          0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
+    rand_hc                          0.1.0  7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4 \
+    rand_isaac                       0.1.1  ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08 \
+    rand_jitter                      0.1.4  1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b \
+    rand_os                          0.1.3  7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071 \
+    rand_pcg                         0.1.2  abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44 \
+    rand_xorshift                    0.1.1  cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c \
+    rdrand                           0.4.0  678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2 \
+    redox_syscall                   0.1.56  2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84 \
+    redox_termios                    0.1.1  7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76 \
+    regex                           0.2.11  9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384 \
+    regex                            1.3.1  dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd \
+    regex-syntax                    0.6.12  11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716 \
+    regex-syntax                     0.5.6  7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7 \
+    resolv-conf                      0.6.2  b263b4aa1b5de9ffc0054a2386f96992058bb6870aab516f8cdeb8a667d56dcb \
+    rle-decode-fast                  1.0.1  cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac \
+    rustc-demangle                  0.1.16  4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783 \
+    rustc-serialize                 0.3.24  dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda \
+    rustc_version                    0.2.3  138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a \
+    ryu                              1.0.2  bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8 \
+    same-file                        1.0.5  585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421 \
+    scopeguard                       1.0.0  b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d \
+    semver                           0.9.0  1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403 \
+    semver-parser                    0.7.0  388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
+    serde                          1.0.102  0c4b39bd9b0b087684013a792c59e3e07a46a01d2322518d8a1104641a0b1be0 \
+    serde_derive                   1.0.102  ca13fc1a832f793322228923fbb3aba9f3f44444898f835d31ad1b74fa0a2bf8 \
+    serde_json                      1.0.41  2f72eb2a68a7dc3f9a691bfda9305a1c017a6215e5a4545c258500d2099a37c2 \
+    serde_yaml                      0.8.11  691b17f19fc1ec9d94ec0b5864859290dff279dbd7b03f017afda54eb36c3c35 \
+    sha-1                            0.8.1  23962131a91661d643c98940b20fcaffe62d776a823247be80a48fcb8b6fce68 \
+    signal-hook                     0.1.11  cb543aecec4ba8b867f41284729ddfdb7e8fcd70ec3d7d37fca3007a4b53675f \
+    signal-hook-registry             1.1.1  1797d48f38f91643908bb14e35e79928f9f4b3cefb2420a564dde0991b4358dc \
+    slab                             0.4.2  c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8 \
+    smallvec                         1.0.0  4ecf3b85f68e8abaa7555aa5abdb1153079387e60b718283d732f03897fcfc86 \
+    smallvec                        0.6.13  f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6 \
+    socket2                         0.3.11  e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85 \
+    strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
+    structopt                       0.2.18  16c2cdbf9cc375f15d1b4141bc48aeef444806655cd0e904207edc8d68d86ed7 \
+    structopt                        0.3.4  c167b61c7d4c126927f5346a4327ce20abf8a186b8041bbeb1ce49e5db49587b \
+    structopt-derive                0.2.18  53010261a84b37689f9ed7d395165029f9cc7abb9f56bbfe86bee2597ed25107 \
+    structopt-derive                 0.3.4  519621841414165d2ad0d4c92be8f41844203f2b67e245f9345a5a12d40c69d7 \
+    syn                              1.0.8  661641ea2aa15845cddeb97dad000d22070bb5c1fb456b96c1cba883ec691e92 \
+    syn                            0.15.44  9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5 \
+    synstructure                    0.12.3  67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545 \
+    syntex                          0.42.2  0a30b08a6b383a22e5f6edc127d169670d48f905bb00ca79a00ea3e442ebe317 \
+    syntex_errors                   0.42.0  04c48f32867b6114449155b2a82114b86d4b09e1bddb21c47ff104ab9172b646 \
+    syntex_pos                      0.42.0  3fd49988e52451813c61fecbe9abb5cfd4e1b7bb6cdbb980a6fbcbab859171a6 \
+    syntex_syntax                   0.42.0  7628a0506e8f9666fdabb5f265d0059b059edac9a3f810bda077abb5d826bd8d \
+    take_mut                         0.2.2  f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60 \
+    term                             0.4.6  fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1 \
+    termion                          1.5.3  6a8fb22f7cde82c8220e5aeacb3258ed7ce996142c77cba193f203515e26c330 \
+    termios                          0.3.1  72b620c5ea021d75a735c943269bb07d30c9b77d6ac6b236bc8b5c496ef05625 \
+    textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
+    thread_local                     0.3.6  c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b \
+    time                            0.1.42  db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f \
+    tokio                            0.2.2  2e765bf9f550bd9b8a970633ca3b56b8120c4b6c5dcbe26a93744cb02fee4b17 \
+    trust-dns-proto                 0.18.1  253a722ff22a1217b7af6199cb2ec5824a19c5110e0db21d3fcb28d5f6e1b0ee \
+    trust-dns-resolver              0.18.1  72d7df08b45f4d6d124cdae3c303f9908159a17b39e633e524349e91bc798d32 \
+    tui                              0.5.1  4ff64c925f5e20d7a393c598a33b6afc9c9942e7ebc530085588f5b7667ea559 \
+    typenum                         1.11.2  6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9 \
+    ucd-trie                         0.1.2  8f00ed7be0c1ff1e24f46c3d2af4859f7e863672ba3a6e92e7cff702bf9f06c2 \
+    ucd-util                         0.1.5  fa9b3b49edd3468c0e6565d85783f51af95212b6fa3986a5500954f00b460874 \
+    unicode-bidi                     0.3.4  49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5 \
+    unicode-normalization            0.1.9  09c8070a9942f5e7cfccd93f490fdebd230ee3c3c9f107cb25bad5351ef671cf \
+    unicode-segmentation             1.6.0  e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0 \
+    unicode-width                    0.1.6  7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20 \
+    unicode-xid                      0.2.0  826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c \
+    unicode-xid                      0.0.3  36dff09cafb4ec7c8cf0023eb0b686cb6ce65499116a12201c9e11840ca01beb \
+    unicode-xid                      0.1.0  fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc \
+    url                              2.1.0  75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61 \
+    utf8-ranges                      1.0.4  b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba \
+    uuid                             0.8.1  9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11 \
+    uuid                             0.7.4  90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a \
+    vec_map                          0.8.1  05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a \
+    walkdir                          2.2.9  9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e \
+    wasi                             0.7.0  b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d \
+    widestring                       0.4.0  effc0e4ff8085673ea7b9b2e3c73f6bd4d118810c9009ed8f1e16bd96c331db6 \
+    winapi                           0.3.8  8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6 \
+    winapi                           0.2.8  167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
+    winapi-build                     0.1.1  2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                      0.1.2  7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    winreg                           0.6.2  b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9 \
+    winutil                          0.1.1  7daf138b6b14196e3830a588acf1e86966c694d3e8fb026fb105b8b5dca07e6e \
+    ws2_32-sys                       0.2.1  d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e \
+    yaml-rust                        0.4.3  65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
