### PR TITLE
openjdk*: add variants for additional JVM capabilities

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -396,6 +396,26 @@ if {${subport} eq "openjdk8"} {
                  This version uses non-compressed references and should be used for applications which require heaps that are over ~57 GB.
 }
 
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
 use_configure    no
 
 build {}


### PR DESCRIPTION
Some java-based APP bundles require additional JVM capabilities to be advertised in order to run with non-Apple Java. This PR provides variants for known capabilities of OpenJDK that are not advertised by default.
See https://derflounder.wordpress.com/2015/08/08/modifying-oracles-java-sdk-to-run-java-applications-on-os-x/  and https://crunchify.com/os-x-mavericks-eclipse-java-issue/ for more background information.

###### Tested on

macOS 10.15.2 19C57
Xcode 11.3 11C29

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?