### PR TITLE
cmake-1.1: debug variant wait until pre-configure

### DIFF
--- a/_resources/port1.0/group/cmake-1.1.tcl
+++ b/_resources/port1.0/group/cmake-1.1.tcl
@@ -451,25 +451,27 @@ platform darwin {
 configure.universal_args-delete --disable-dependency-tracking
 
 variant debug description "Enable debug binaries" {
-    # this PortGroup uses a custom CMAKE_BUILD_TYPE giving complete control over
-    # the compiler flags. We use that here: replace the default -O2 with -O0, add
-    # debugging options and do otherwise an exactly identical build.
-    configure.cflags-replace         -O2 -O0
-    configure.cxxflags-replace       -O2 -O0
-    configure.objcflags-replace      -O2 -O0
-    configure.objcxxflags-replace    -O2 -O0
-    configure.ldflags-replace        -O2 -O0
-    # get most if not all possible debug info
-    if {[string match *clang* ${configure.cxx}] || [string match *clang* ${configure.cc}]} {
-        set cmake::debugopts "-g -fno-limit-debug-info -DDEBUG"
-    } else {
-        set cmake::debugopts "-g -DDEBUG"
+    pre-configure {
+        # this PortGroup uses a custom CMAKE_BUILD_TYPE giving complete control over
+        # the compiler flags. We use that here: replace the default -O2 with -O0, add
+        # debugging options and do otherwise an exactly identical build.
+        configure.cflags-replace         -O2 -O0
+        configure.cxxflags-replace       -O2 -O0
+        configure.objcflags-replace      -O2 -O0
+        configure.objcxxflags-replace    -O2 -O0
+        configure.ldflags-replace        -O2 -O0
+        # get most if not all possible debug info
+        if {[string match *clang* ${configure.cxx}] || [string match *clang* ${configure.cc}]} {
+            set cmake::debugopts "-g -fno-limit-debug-info -DDEBUG"
+        } else {
+            set cmake::debugopts "-g -DDEBUG"
+        }
+        configure.cflags-append         ${cmake::debugopts}
+        configure.cxxflags-append       ${cmake::debugopts}
+        configure.objcflags-append      ${cmake::debugopts}
+        configure.objcxxflags-append    ${cmake::debugopts}
+        configure.ldflags-append        ${cmake::debugopts}
+        # try to ensure that info won't get stripped
+        configure.args-append           -DCMAKE_STRIP:FILEPATH=/bin/echo
     }
-    configure.cflags-append         ${cmake::debugopts}
-    configure.cxxflags-append       ${cmake::debugopts}
-    configure.objcflags-append      ${cmake::debugopts}
-    configure.objcxxflags-append    ${cmake::debugopts}
-    configure.ldflags-append        ${cmake::debugopts}
-    # try to ensure that info won't get stripped
-    configure.args-append           -DCMAKE_STRIP:FILEPATH=/bin/echo
 }


### PR DESCRIPTION
#### Description

In the debug variant, wait until pre-configure time to inspect the compiler.

The debug variant was inspecting the compiler before a port had a chance to override it, resulting in the clang-specific `-fno-limit-debug-info` flag being passed to non-clang compilers, resulting in failure.

Closes: https://trac.macports.org/ticket/59973

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G8037
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
