### PR TITLE
py-gacode: New Portfile

### DIFF
--- a/python/py-gacode/Portfile
+++ b/python/py-gacode/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           compilers 1.0
+
+name                py-gacode
+version             0.31
+
+compilers.setup     default_fortran
+
+python.versions     37
+
+categories-append   science
+platforms           darwin
+maintainers         {fusion.gat.com:smithsp @smithsp} openmaintainer
+description         python bindings for the GACODE suite
+long_description    ${description}
+
+license             MIT
+homepage            https://gacode.io
+
+checksums           rmd160  7b6e2b90ee03f81ccad771ce36db6baffb3cfbad \
+                    sha256  c53fb613d51697955745e5d029ed2a4008a86a47f5f98e6baf4307b8d4a165f6 \
+                    size    16297
+
+if {${name} ne ${subport}} {
+    livecheck.type       none
+    depends_lib-append   port:py${python.version}-numpy
+}


### PR DESCRIPTION
#### Description

Add python binding for the GACODE suite of research codes used in magnetically confined fusion.  The python bindings are open source.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G87
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
  - I tried adding a test that it imports OK, but I don't know how to deal with the odd namings of the libraries and directories
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
