### PR TITLE
universal-ctags: New port

### DIFF
--- a/devel/universal-ctags/Portfile
+++ b/devel/universal-ctags/Portfile
@@ -1,0 +1,70 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        universal-ctags ctags feffe43a4a9d339cd6701744589746e2297e4567
+name                universal-ctags
+version             20200111
+
+categories          devel
+platforms           darwin
+license             GPL-2+
+maintainers         {@kaimingguo gmail.com:augustin.guo} openmaintainer
+
+description         A maintained ctags implementation
+long_description \
+    universal-ctags has the objective of continuing the development from what \
+    existed in the Sourceforge area. Github exuberant-ctags repository was \
+    started by Reza Jelveh and was later moved to the universal-ctags organization.
+
+homepage            https://ctags.io
+conflicts           ctags
+
+checksums           rmd160  e37a347213bf94639b68adacc5f66d90fe643388 \
+                    sha256  73ab06a4868f2006c2cdde2276db13f1fc010483b2711cd66ef00b51b680064d \
+                    size    1663558
+
+set python_version  37
+set python_branch   [string range ${python_version} 0 end-1].[string index ${python_version} end]
+
+patchfiles          patch-configure.ac.diff
+
+use_autoconf        yes
+autoconf.cmd        ./autogen.sh
+configure.args      --program-prefix=u --enable-json --enable-yaml
+
+depends_build       port:autoconf \
+                    port:automake \
+                    port:pkgconfig \
+                    port:libtool
+
+depends_lib         port:jansson \
+                    port:libyaml
+
+universal_variant   no
+default_variants    +iconv +libxml2 +manpages
+
+variant aspell description {Enable aspell backend} {
+    depends_lib-append      port:aspell
+    depends_run             port:aspell-dict-en
+    configure.args-append   --enable-aspell
+}
+
+variant debug description {Build with debug support} {
+    configure.args-append   --enable-debugging
+}
+
+variant iconv description {Add iconv support} {
+    depends_lib-append      port:libiconv
+    configure.args-append   --enable-iconv
+}
+
+variant libxml2 description {Extra support for XML based languages} {
+    depends_lib-append      port:libxml2
+    configure.args-append   --enable-xml
+}
+
+variant manpages description {Enable documentation} {
+    depends_build-append    port:py${python_version}-docutils
+}

--- a/devel/universal-ctags/files/patch-configure.ac.diff
+++ b/devel/universal-ctags/files/patch-configure.ac.diff
@@ -1,0 +1,11 @@
+--- configure.ac.orig	2020-01-17 15:08:51.000000000 +0800
++++ configure.ac	2020-01-17 15:09:31.000000000 +0800
+@@ -268,7 +268,7 @@
+ AC_CHECK_PROGS([perl_found], [perl], [yes], [no])
+ AM_CONDITIONAL([RUN_OPTLIB2C], [test "${perl_found}" = "yes"])
+ 
+-AC_PATH_PROGS(RST2MAN, [rst2man rst2man.py rst2man3 rst2man3.py], [no])
++AC_PATH_PROGS(RST2MAN, [rst2man rst2man.py rst2man3 rst2man3.py rst2man-3.7.py], [no])
+ AM_CONDITIONAL([HAVE_RST2MAN], [test "x$RST2MAN" != "xno"])
+ 
+ RST2MAN_OPTIONS=


### PR DESCRIPTION
###### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
universal-ctags has the objective of continuing the development from what existed in the Sourceforge area. Github exuberant-ctags repository was started by Reza Jelveh and was later moved to the universal-ctags organization.

The goal of the project is preparing and maintaining common/unified space where people interested in making ctags better can work together.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.2 19C57
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
