### PR TITLE
nebula: update to 1.1.0

### DIFF
--- a/net/nebula/Portfile
+++ b/net/nebula/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        slackhq nebula 1.0.0 v
+github.setup        slackhq nebula 1.1.0 v
 
 categories          net
 license             MIT
@@ -11,9 +11,9 @@ platforms           darwin
 
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
 
-checksums           rmd160  8d33d443ee8a5d7ebe121fb378807d4d0b211b41 \
-                    sha256  fa5d0afa58f93bf115143f65f26dfa4025dff4797b8708b8e56b672c58d48dea \
-                    size    104683
+checksums           rmd160  c091be293df47e7824ba29b5f2e1bafe62ad8d0c \
+                    sha256  f56c72957f3e6cb82bf8b12d10d4c1ac775f929fda288fca38fb12d93f2c70d4 \
+                    size    113878
 
 description         A scalable overlay networking tool with a focus on \
                     performance, simplicity and security.
@@ -38,14 +38,12 @@ set neb_share_dir   ${prefix}/share/${name}
 set neb_conf_dir    ${prefix}/etc/${name}
 set neb_example_dir ${neb_share_dir}/examples
 
-set neb_sample_config   ${neb_example_dir}/config.yaml
+set neb_sample_config   ${neb_example_dir}/config.yml
 
 destroot {
-    xinstall -m 755 ${worksrcpath}/build/darwin/nebula \
-      ${destroot}${prefix}/bin/
+    xinstall -m 755 ${worksrcpath}/nebula ${destroot}${prefix}/bin/
 
-    xinstall -m 755 ${worksrcpath}/build/darwin/nebula-cert \
-      ${destroot}${prefix}/bin/
+    xinstall -m 755 ${worksrcpath}/nebula-cert ${destroot}${prefix}/bin/
 
     xinstall -d ${destroot}${neb_conf_dir}
     xinstall -d ${destroot}${neb_example_dir}
@@ -53,7 +51,7 @@ destroot {
     copy {*}[glob ${worksrcpath}/examples/*] ${destroot}${neb_example_dir}
 
     reinplace "s|/etc/nebula|${prefix}/etc/nebula|g" \
-      ${destroot}${neb_sample_config}
+        "${destroot}${neb_sample_config}"
 }
 
 destroot.keepdirs   ${destroot}${neb_conf_dir}


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
