### PR TITLE
Fixing vigra port for debug builds

### DIFF
--- a/graphics/vigra/Portfile
+++ b/graphics/vigra/Portfile
@@ -137,8 +137,9 @@ variant python37 conflicts python27 python35 python36 description "Also build vi
     require_active_variants boost python37
 }
 
-if {![variant_isset python35] && ![variant_isset python36] && ![variant_isset python37]} {
-    default_variants +python27
+if {![variant_isset python27] && ![variant_isset python35] && ![variant_isset python36]} {
+	#default for boost is python37
+    default_variants +python37
 }
 
 if {![variant_isset python27] && ![variant_isset python35] && ![variant_isset python36] && ![variant_isset python37]} {

--- a/graphics/vigra/Portfile
+++ b/graphics/vigra/Portfile
@@ -50,6 +50,9 @@ patchfiles-append   patch-python.diff
 # allow cmake to find MacPorts boost_python library
 patchfiles-append   patch-boost_python.diff
 
+# see https://trac.macports.org/ticket/59970
+patchfiles-append   patch-sifImport.diff
+
 post-patch {
     reinplace "s|@DOCDIR@|${prefix}/share/doc/${name}|g" ${worksrcpath}/config/vigra-config.in
 }

--- a/graphics/vigra/files/patch-sifImport.diff
+++ b/graphics/vigra/files/patch-sifImport.diff
@@ -1,0 +1,11 @@
+--- src/impex/sifImport.cxx.orig	2017-09-21 16:45:40.000000000 +0200
++++ src/impex/sifImport.cxx	2020-01-17 22:19:33.000000000 +0100
+@@ -142,7 +142,7 @@
+         std::string str;
+         getline(siffile, str);
+ #ifdef DEBUG
+-        std::std::cout << str << std::std::endl;
++        std::cout << str << std::endl;
+ #endif
+         if(i==0) {
+             vigra_precondition(str=="Andor Technology Multi-Channel File", "The file is not a valid sif File.");


### PR DESCRIPTION
#### Description
https://trac.macports.org/ticket/59970 describes an issue, which hinders vigra from being compiled in debug build. The patch of this pull request should fix this issue.

###### Type(s)

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G2022
Xcode 11.3.1 11C504 

###### Verification 
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
