### PR TITLE
openjdk8: update to AdoptOpenJDK 11.0.6+10

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -43,7 +43,7 @@ subport openjdk10 {
 }
 
 subport openjdk11 {
-    version      11.0.5
+    version      11.0.6
     revision     0
 
     set build    10
@@ -58,21 +58,21 @@ subport openjdk11-graalvm {
 }
 
 subport openjdk11-openj9 {
-    version      11.0.5
-    revision     1
+    version      11.0.6
+    revision     0
 
     set build    10
     set major    11
-    set openj9_version 0.17.0
+    set openj9_version 0.18.0
 }
 
 subport openjdk11-openj9-large-heap {
-    version      11.0.5
-    revision     1
+    version      11.0.6
+    revision     0
 
     set build    10
     set major    11
-    set openj9_version 0.17.0
+    set openj9_version 0.18.0
 }
 
 subport openjdk12 {
@@ -239,9 +239,9 @@ if {${subport} eq "openjdk8"} {
 } elseif {${subport} eq "openjdk11"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}/
 
-    checksums    rmd160  d4099ff93dce27338c2675b356e4f2859082bf8e \
-                 sha256  0825d0d3177832320b697944cd8e7b2e7fe3893fafe8bfcf33ee3631aa5ca96b \
-                 size    188745854
+    checksums    rmd160  a45caba85e458dd5927a34828404574d3da252be \
+                 sha256  b87102274d983bf6bb0aa6c2c623301d0ff5eb7f61043ffd04abb00f962c2dcd \
+                 size    189024328
 
     distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}_${build}
     worksrcdir   jdk-${version}+${build}
@@ -261,13 +261,11 @@ if {${subport} eq "openjdk8"} {
 
     homepage     https://www.graalvm.org
 } elseif {${subport} eq "openjdk11-openj9"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.${revision}_openj9-${openj9_version}/
-    # Temporary dist_subdir for stealth update: https://trac.macports.org/wiki/PortfileRecipes#stealth-updates
-    dist_subdir  ${name}/${version}_${revision}
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
 
-    checksums    rmd160  1915fac0403ce775419dcccaafe74de9a8432cac \
-                 sha256  97dc8234b73e233316b5dfdca75af9a0d54aa23b1309b1a68fd0a5d2fa928e05 \
-                 size    196981668
+    checksums    rmd160  a4538de5064c1aff39ea807887be6826a048a90f \
+                 sha256  28bb4b67307767992c26f2af3eed4d3ebfda1b206d44b469be24dbcc4fc6cdd7 \
+                 size    196635233
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
     worksrcdir   jdk-${version}+${build}
@@ -280,13 +278,11 @@ if {${subport} eq "openjdk8"} {
                  VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
                  suitable for running all workloads.
 } elseif {${subport} eq "openjdk11-openj9-large-heap"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.${revision}_openj9-${openj9_version}/
-    # Temporary dist_subdir for stealth update: https://trac.macports.org/wiki/PortfileRecipes#stealth-updates
-    dist_subdir  ${name}/${version}_${revision}
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
 
-    checksums    rmd160  5d0f9d8f81dec18bd5d2a57fcf2684759e87b9d3 \
-                 sha256  5bfc4ad3b3568303091e3863c4c9baff279929a35326dd48fb26d8e95e8e3174 \
-                 size    196984646
+    checksums    rmd160  7819d1fea6e2c6c7cb31e4ea2ab960e6a2537bee \
+                 sha256  3d00cb1f6f2a505f94b640704ad99e7f60db1641a21746b41adf1c37091b5505 \
+                 size    196627485
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
     worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to AdoptOpenJDK 11.0.6+10.

###### Tested on

macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?