### PR TITLE
openjdk8: update to GraalVM 19.3.1

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -10,7 +10,7 @@ set build        09
 set major        8
 
 subport openjdk8-graalvm {
-    version      19.3.0.2
+    version      19.3.1
     revision     0
 
     set major    8
@@ -51,7 +51,7 @@ subport openjdk11 {
 }
 
 subport openjdk11-graalvm {
-    version      19.3.0.2
+    version      19.3.1
     revision     0
 
     set major    11
@@ -167,9 +167,9 @@ if {${subport} eq "openjdk8"} {
     distname     graalvm-ce-java${major}-darwin-amd64-${version}
     worksrcdir   graalvm-ce-java${major}-${version}
 
-    checksums    rmd160  fcbd472848afb06702746a1445ab2fe02c5e4d21 \
-                 sha256  39b2e4d456335694a595cbdd0602fe2b4c685ca3f822f9b1c01339ba007c2c1f \
-                 size    356588464
+    checksums    rmd160  8869ada9ed3e7a787dbdaf4653524ba713383405 \
+                 sha256  eba3765174f0279ae2dc57c84fc0eb324da778dbfdcc03c6fa8381fe3728aef9 \
+                 size    357777334
 
     description  GraalVM Community Edition based on OpenJDK ${major}
     long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, \
@@ -250,9 +250,9 @@ if {${subport} eq "openjdk8"} {
     distname     graalvm-ce-java${major}-darwin-amd64-${version}
     worksrcdir   graalvm-ce-java${major}-${version}
 
-    checksums    rmd160  be0ca48f91ed3bb684b8a47918124b958804e895 \
-                 sha256  1c123aef2f18f5d71a80298260a703f634e3f8e3fd5c3aa91614949f8f238301 \
-                 size    448511231
+    checksums    rmd160  d630c59c192d10e31b7d790757c5f2a34129e855 \
+                 sha256  b3ea6cf6545332f667b2cc742bbff9949d47e49eecea06334d14f0b69aa1a3f3 \
+                 size    450067870
 
     description  GraalVM Community Edition based on OpenJDK ${major}
     long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, \


### PR DESCRIPTION
#### Description

Update to GraalVM Community Edition 19.3.1.

###### Tested on

macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?