### PR TITLE
spring-boot-cli: update to 2.2.3.RELEASE

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            spring-boot-cli
-version         2.2.2
+version         2.2.3
 revision        0
 
 categories      java
@@ -30,9 +30,9 @@ master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/
 
 distname        ${name}-${version}.RELEASE-bin
 
-checksums       rmd160  5e3faaafe3190e7401eb7618b18f7fd76a1d10f4 \
-                sha256  b0e95d051ddb8c8b4958bc4029d3c6e6ed5964a9424f15ee174ced1f524dbf13 \
-                size    11369462
+checksums       rmd160  23c7f5dc5180e75a4b94a5389189f3bd110425dd \
+                sha256  239570a632a230af0d54fb7f0ab19c587f664deeb6f4263d1b6550d9a75197aa \
+                size    11376112
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
#### Description

Update to Spring Boot CLI 2.2.3.RELEASE.

###### Tested on

macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?