### PR TITLE
google-cloud-sdk: update to 276.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             275.0.0
+version             276.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  13087e1cc2d8c1389d664167dcae8db0b4d02d48 \
-                    sha256  e07f3232a1e5e16e80cc5ab7882a0b1d2641f0a32551a8db6b01322ff755c2fb \
-                    size    23152261
+    checksums       rmd160  521b4ceee8d2c22c3a5ffb00ece013883b506ae2 \
+                    sha256  113b85f421aec48867ca98cd93994e76b395f5c277bcabab866e4e8188b4c4fa \
+                    size    23246676
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  fd74e4752f1eaa4d76123d3551892649477b385f \
-                    sha256  eec3b8aeb29c49d60f2a001a7ba342548c5afdb2188c6495efe6d82514c7799b \
-                    size    23155113
+    checksums       rmd160  e744ead811bd18da96ba72f6e781f3b297ed3d32 \
+                    sha256  2c8b33d4477981e3250376dcdebda4f1612a2ce7191ade68844fdec2e4256dc6 \
+                    size    23247036
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 276.0.0.

###### Tested on

macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?