### PR TITLE
SourceKitten: Update to 0.29.0

### DIFF
--- a/devel/SourceKitten/Portfile
+++ b/devel/SourceKitten/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           xcodeversion 1.0
 
 use_xcode           yes
-github.setup        jpsim SourceKitten 0.27.0
+github.setup        jpsim SourceKitten 0.29.0
 categories          devel
 platforms           darwin
 
@@ -24,13 +24,13 @@ use_configure       no
 # everything is built during the prefix_install target
 build               {}
 
-minimum_xcodeversions {17 10 18 10}
+minimum_xcodeversions {18 10.2}
 
 platform darwin {
-    if {${os.major} < 17} {
+    if {${os.major} < 18} {
         known_fail  yes
         pre-fetch {
-            ui_error "SourceKitten requires 10.13 and Xcode 10 to build."
+            ui_error "SourceKitten requires 10.14 and Xcode 10.2 to build."
             return -code error "incompatible macOS version"
         }
     }


### PR DESCRIPTION
#### Description

I'm running through `port livecheck installed` and trying to update things that have an open maintainer or no maintainer.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3 19D62e
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
