### PR TITLE
tig: Update to 2.5.0

### DIFF
--- a/devel/tig/Portfile
+++ b/devel/tig/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        jonas tig 2.4.1 tig-
+github.setup        jonas tig 2.5.0 tig-
 github.tarball_from releases
-checksums           rmd160  1245649ee1ea022583bdcc8e326290cfb1899358 \
-                    sha256  b6b6aa183e571224d0e1fab3ec482542c1a97fa7a85b26352dc31dbafe8558b8 \
-                    size    1181900
+checksums           rmd160  d0235e03aab2c564e4857048f9a9979affd969f1 \
+                    sha256  ff537c67af9201e7e7276ce8a0ff9961e9d9c6a8a78790f5817124bd7755aef4 \
+                    size    1143004
 
 categories          devel
 maintainers         {cal @neverpanic} \


### PR DESCRIPTION
#### Description

I'm running through `port livecheck installed` and trying to update things that have an open maintainer or no maintainer.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3 19D62e
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
