### PR TITLE
Restic: restructure Build and add debug variant

### DIFF
--- a/sysutils/restic/Portfile
+++ b/sysutils/restic/Portfile
@@ -29,6 +29,11 @@ variant             docs description {Build the documentation} {
                     port:py${pyver_nodot}-sphinx_rtd_theme
 }
 
+variant             debug description {Enable debug options} {
+    build.post_args-append \
+                    -tags debug
+}
+
 build.cmd           ${go.bin} run
 build.target        build.go
 

--- a/sysutils/restic/Portfile
+++ b/sysutils/restic/Portfile
@@ -29,7 +29,8 @@ variant             docs description {Build the documentation} {
                     port:py${pyver_nodot}-sphinx_rtd_theme
 }
 
-build.cmd           go run build.go
+build.cmd           ${go.bin} run
+build.target        build.go
 
 post-build {
     if {[variant_isset docs]} {
@@ -48,9 +49,9 @@ test {
     system -W ${worksrcpath} \
         "RESTIC_PASSWORD=\"foo\" ./restic -r ${repository_path} init"
     system -W ${worksrcpath} \
-        "RESTIC_PASSWORD=\"foo\" ./restic -r ${repository_path} backup ${file_name}"
+        "RESTIC_PASSWORD=\"foo\" ./restic -r ${repository_path} backup ${file_name} --no-cache"
     system -W ${worksrcpath} \
-        "RESTIC_PASSWORD=\"foo\" ./restic -r ${repository_path} restore latest -t ${restore_path}"
+        "RESTIC_PASSWORD=\"foo\" ./restic -r ${repository_path} restore latest -t ${restore_path} --no-cache"
     system -W ${worksrcpath} \
         "diff -q ${file_name} ${restore_path}/${file_name}"
 }


### PR DESCRIPTION
#### Description
This update splits `build.run` to `build.target` and calls the full path with `${go.bin}`. I also added a variant to build with debug options -- helpful when working with upstream. Testing created local caches and I added a flag to disable.

A revbump is not needed.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G2022
Xcode 11.3 11C29 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
