### PR TITLE
groovy: update to 2.5.9

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -4,8 +4,8 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            groovy
-version         2.5.8
-revision        1
+version         2.5.9
+revision        0
 
 categories      lang java
 maintainers     {breun.nl:nils @breun} openmaintainer
@@ -41,9 +41,9 @@ master_sites    https://dl.bintray.com/${name}/maven/
 distname        apache-${name}-binary-${version}
 use_zip         yes
 
-checksums       rmd160  2df28ec5e7c917570827578bda24b8e3a063ad4b \
-                sha256  49fb14b98f9fed1744781e4383cf8bff76440032f58eb5fabdc9e67a5daa8742 \
-                size    30368648
+checksums       rmd160  92242769ce678197ccdea419c2d238ad63a7df5d \
+                sha256  fea7dc321a3029c47ffa4aa165055d2bcc78bc280fac4e70ac131c717e45b89b \
+                size    30388421
 
 worksrcdir      ${name}-${version}
 


### PR DESCRIPTION
#### Description

Update to Groovy 2.5.9.

###### Tested on

macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?