### PR TITLE
lablgtk2: Update to 2.18.9 and fix livecheck

### DIFF
--- a/x11/lablgtk2/Portfile
+++ b/x11/lablgtk2/Portfile
@@ -112,5 +112,4 @@ if {![variant_isset quartz]} {
     require_active_variants gtk2 quartz x11
 }
 
-livecheck.type      regex
-livecheck.regex     {lablgtk-([0-9]+(\.[0-9]+)+)\.}
+github.livecheck.regex     {(\d+(?:\.\d+)+)}

--- a/x11/lablgtk2/Portfile
+++ b/x11/lablgtk2/Portfile
@@ -5,10 +5,13 @@ PortGroup           ocaml 1.0
 PortGroup           active_variants 1.1
 PortGroup           github 1.0
 
-github.setup        garrigue lablgtk lablgtk2188
+github.setup        garrigue lablgtk 2.18.9
+revision            0
+checksums           rmd160  27d482e4d1d0edd86e57001ac697c77662231a3b \
+                    sha256  c8968f24bfe3459823637d13ba12e70338cf88d3e602994763d593ce550db51f \
+                    size    1068410
+
 name                lablgtk2
-version             2.18.8
-revision            1
 categories          x11 ocaml
 platforms           darwin
 maintainers         {pmetzger @pmetzger} openmaintainer
@@ -22,14 +25,9 @@ long_description    LablGTK2 is is an OCaml interface to gtk+ 2.x. \
                     strongly typed, yet very comfortable, object-oriented \
                     interface to gtk+.
 
-github.tarball_from releases
-distname            ${github.project}-${version}
+github.tarball_from archive
 
 homepage            http://lablgtk.forge.ocamlcore.org/
-
-checksums           rmd160  82d73a490a71b9978b0df275fd3ce818a2639b0e \
-                    sha256  91f59bafd07989ea00080f4fd65512ce339878c7117bf5116bad3b93b64d4de3 \
-                    size    855263
 
 depends_build       port:pkgconfig
 


### PR DESCRIPTION
#### Description

Updates lablgtk2 to 2.18.9 and fixes livecheck.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G8037
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
