### PR TITLE
bitcoin: Update to 0.19.1

### DIFF
--- a/finance/bitcoin/Portfile
+++ b/finance/bitcoin/Portfile
@@ -1,12 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
-PortGroup               cxx11 1.1
 
 name                    bitcoin
 categories              finance crypto
-version                 0.17.1
-revision                4
+version                 0.19.1
+revision                0
 platforms               darwin
 license                 MIT
 maintainers             {easieste @easye} yopmail.com:sami.laine openmaintainer
@@ -20,14 +19,13 @@ long_description        Bitcoin is a peer-to-peer digital currency. By peer-to-p
 homepage                https://bitcoin.org/
 master_sites            ${homepage}bin/bitcoin-core-${version}/
 
-checksums           rmd160  06ebececcd2888803b50d7d741b0b6d5695ccdbe \
-                    sha256  3e564fb5cf832f39e930e19c83ea53e09cfe6f93a663294ed83a32e194bda42a \
-                    size    6992687
+checksums           rmd160  ce8b3651d6d167d192214b3334336f5f977cb0f6 \
+                    sha256  f2591d555b8e8c2e1bd780e40d53a91e165d8b3c7e0391ae2d24a0c0f23a7cc0 \
+                    size    7414508
 
 depends_build           port:libtool		\
                         port:pkgconfig		\
-                        port:protobuf3-cpp	\
-                        port:python37
+                        port:python38
 
 depends_lib             port:boost	\
                         port:libevent	\
@@ -42,13 +40,8 @@ configure.args		--disable-ccache		\
 			--disable-upnp-default		\
 			--enable-tests			\
 			--disable-bench			\
-			--disable-hardening		\
-			--disable-reduce-exports	\
-			--disable-glibc-back-compat	\
-			--disable-experimental-asm	\
 			--enable-zmq			\
 			--enable-man			\
-			--disable-debug			\
 			--enable-werror			\
 			--enable-largefile		\
 			--with-miniupnpc		\
@@ -56,8 +49,7 @@ configure.args		--disable-ccache		\
 			--with-utils			\
 			--with-libs
 
-# --disable-lcov enables lcov in 0.15.1
-# https://github.com/bitcoin/bitcoin/issues/10828
+compiler.cxx_standard   2011
 
 configure.args-append   --with-daemon=no
 configure.args-append   --with-gui=no
@@ -111,8 +103,10 @@ variant gui description {Build the Qt5 GUI} {
 }
 
 variant wallet description {Build with support for wallet} {
-    configure.args-replace --enable-wallet=no --enable-wallet=yes
     depends_lib-append port:db48
+    configure.args-replace --enable-wallet=no --enable-wallet=yes
+    configure.cppflags-append   "-I${prefix}/include/db48"
+    configure.ldflags-append    "-L${prefix}/lib/db48"
 }
 
 post-destroot {


### PR DESCRIPTION
## Description
Update Bitcoin Core to 0.19.1
Enable hardening.
Protobuf is no longer required.
Use Python 3.8.
`--disable-experimental-asm` was renamed `--enable-asm` and is used by default.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G2022
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?