### PR TITLE
buildbot 2: switch to python 3.8

### DIFF
--- a/devel/buildbot-2/Portfile
+++ b/devel/buildbot-2/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                buildbot-2
 version             2.5.1
-revision            0
+revision            1
 
 categories          devel python
 platforms           darwin
@@ -32,7 +32,7 @@ checksums           rmd160  6d0b8dd48eb33d7a7e299a076a7ecc4c807cdee9 \
                     size    3181297
 
 python.default_version \
-                    37
+                    38
 depends_run-append  port:py${python.version}-buildbot \
                     port:py${python.version}-buildbot-www \
                     port:py${python.version}-buildbot-console-view \

--- a/devel/buildbot-worker/Portfile
+++ b/devel/buildbot-worker/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                buildbot-worker
 version             2.5.1
-revision            0
+revision            1
 
 maintainers         {ryandesign @ryandesign} {rajdeep @rajdeepbharati} {mojca @mojca} openmaintainer
 description         Buildbot Worker Daemon
@@ -25,7 +25,7 @@ checksums           rmd160  381525bd59876844557b7e9a0ec62e1d12fd430e \
                     size    113331
 
 python.default_version \
-                    37
+                    38
 
 depends_build-append \
                     port:py${python.version}-setuptools

--- a/python/py-buildbot-console-view/Portfile
+++ b/python/py-buildbot-console-view/Portfile
@@ -24,7 +24,7 @@ checksums           sha256  aa1e217c255688261746661f8fc34c0af01b88aad20b9b97c25c
                     rmd160  2adffded98582b1337ff1092f393f1cab4146c8f \
                     size    17532
 
-python.versions     37
+python.versions     38
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-buildbot-grid-view/Portfile
+++ b/python/py-buildbot-grid-view/Portfile
@@ -24,7 +24,7 @@ checksums           sha256  813f09ec8af49eb4cc506e478722d7f3b66853fb0142462b30f4
                     rmd160  3782bae9d66b3cf7b7dfeebffc5cb79ad128e5c9 \
                     size    13272
 
-python.versions     37
+python.versions     38
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-buildbot-macports-custom-views/Portfile
+++ b/python/py-buildbot-macports-custom-views/Portfile
@@ -24,7 +24,7 @@ checksums           sha256  4fcc176f033f5b838dd7376628ef2054053f3b8f51560940e510
                     rmd160  cd224aaa98114324b046094f6d7b2aac8b31389a \
                     size    447418
 
-python.versions     37
+python.versions     38
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-buildbot-pkg/Portfile
+++ b/python/py-buildbot-pkg/Portfile
@@ -24,7 +24,7 @@ checksums           sha256  064436ce1c725eb0ce4bd6b82212d1ed7ccbd92120896f1cc841
                     rmd160  80c658d712fd03f8989eca50866acb50e09249e4 \
                     size    4746
 
-python.versions     37
+python.versions     38
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-buildbot-waterfall-view/Portfile
+++ b/python/py-buildbot-waterfall-view/Portfile
@@ -24,7 +24,7 @@ checksums           sha256  34e5e9bcbddc6585fce3bca29e3736a553f52cea79c9f877ac49
                     rmd160  2103ef07a34af079c7e103d4cf3d700b427d7743 \
                     size    190921
 
-python.versions     37
+python.versions     38
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-buildbot-www/Portfile
+++ b/python/py-buildbot-www/Portfile
@@ -24,7 +24,7 @@ checksums           sha256  dc96d53c899d0f67b2a0fb68fc5f7ab5e7d5110e1097cb28999e
                     rmd160  50446318484ccf26a3026736fc492b08d3474494 \
                     size    3176823
 
-python.versions     37
+python.versions     38
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-buildbot/Portfile
+++ b/python/py-buildbot/Portfile
@@ -26,7 +26,7 @@ checksums           sha256  599f15ed9bae2030d01f8a3c5678788534f5d6154ecb971efd42
                     rmd160  6d0b8dd48eb33d7a7e299a076a7ecc4c807cdee9 \
                     size    3181297
 
-python.versions     37
+python.versions     38
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

I didn't do functional testing yet, but I don't expect any problems.
I suspect that version 2.6.0 will be release very soon, so we can just as well wait for that one if needed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G9016
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? (at least I tested some, not sure if all of them)
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
