### PR TITLE
broot: update to 0.12.0

### DIFF
--- a/sysutils/broot/Portfile
+++ b/sysutils/broot/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        Canop broot 0.11.9 v
+github.setup        Canop broot 0.12.0 v
 categories          sysutils
 platforms           darwin
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
@@ -20,9 +20,9 @@ long_description    broot is a new way to see and navigate directory trees. \
                     via regular expressions, and more.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  3b2d1d58744a38961d5dfbc00716f7acf49fe0a1 \
-                    sha256  9f011d8869941ac12e645e09ad4d293059f6ba010cfd6c34c4afe0a1e7881c0a \
-                    size    1599016
+                    rmd160  44cb6529a8bf2d533eefa5a41dc114fd8f42b618 \
+                    sha256  3cd25b9ef85f52f24527219c122d0251ca8e149e6878c350de37a16b789c5c24 \
+                    size    1600973
 
 destroot {
     xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/${name} ${destroot}${prefix}/bin/
@@ -102,6 +102,7 @@ cargo.crates \
     open                             1.3.2  94b424e1086328b0df10235c6ff47be63708071881bead9e76997d9291c0134b \
     parking_lot                     0.10.0  92e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc \
     parking_lot_core                 0.7.0  7582838484df45743c8434fbff785e8edf260c28748353d44bc0da32e0ceabf1 \
+    pathdiff                         0.1.0  a3bf70094d203e07844da868b634207e71bfab254fe713171fae9a6e751ccf31 \
     proc-macro2                      1.0.6  9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27 \
     quote                            1.0.2  053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe \
     rand_core                        0.4.2  9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
