### PR TITLE
php74: Add PHP 7.4 to non-core PHP extensions

### DIFF
--- a/php/php-APCu/Portfile
+++ b/php/php-APCu/Portfile
@@ -9,7 +9,7 @@ platforms           darwin
 maintainers         {ryandesign @ryandesign}
 license             PHP-3.01
 
-php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
+php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4
 php.pecl            yes
 
 if {[vercmp ${php.branch} 7] >= 0} {

--- a/php/php-excel/Portfile
+++ b/php/php-excel/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 maintainers         {ryandesign @ryandesign} openmaintainer
 license             PHP-3.01
 
-php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
+php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4
 
 description         PHP interface to LibXL for reading and writing \
                     Microsoft Excel spreadsheets

--- a/php/php-geoip/Portfile
+++ b/php/php-geoip/Portfile
@@ -9,7 +9,7 @@ categories      php devel
 platforms       darwin
 maintainers     {ryandesign @ryandesign} openmaintainer
 
-php.branches    5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
+php.branches    5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4
 php.pecl        yes
 
 if {[vercmp ${php.branch} 7] >= 0} {

--- a/php/php-gmagick/Portfile
+++ b/php/php-gmagick/Portfile
@@ -9,7 +9,7 @@ categories      php devel
 platforms       darwin
 maintainers     {ryandesign @ryandesign} openmaintainer
 
-php.branches    5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
+php.branches    5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4
 php.pecl        yes
 php.pecl.prerelease yes
 

--- a/php/php-imagick/Portfile
+++ b/php/php-imagick/Portfile
@@ -12,7 +12,7 @@ platforms               darwin
 maintainers             {ryandesign @ryandesign} openmaintainer
 license                 PHP-3.01
 
-php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
+php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4
 php.pecl                yes
 
 description             PHP extension to create and modify images with \

--- a/php/php-jsmin/Portfile
+++ b/php/php-jsmin/Portfile
@@ -9,7 +9,7 @@ platforms           darwin
 maintainers         {ryandesign @ryandesign} openmaintainer
 license             PHP-3.01
 
-php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
+php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4
 php.pecl            yes
 
 if {[vercmp ${php.branch} 7] >= 0} {

--- a/php/php-lzf/Portfile
+++ b/php/php-lzf/Portfile
@@ -9,7 +9,7 @@ platforms           darwin
 maintainers         {ryandesign @ryandesign} openmaintainer
 license             PHP-3.01
 
-php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
+php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4
 php.pecl            yes
 
 description         Handles LZF compression / decompression.

--- a/php/php-mailparse/Portfile
+++ b/php/php-mailparse/Portfile
@@ -9,7 +9,7 @@ categories      php mail devel
 platforms       darwin
 maintainers     {ryandesign @ryandesign} openmaintainer
 
-php.branches    5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
+php.branches    5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4
 php.pecl        yes
 
 if {[vercmp ${php.branch} 7] >= 0} {

--- a/php/php-mcrypt/Portfile
+++ b/php/php-mcrypt/Portfile
@@ -10,7 +10,7 @@ maintainers         {ryandesign @ryandesign} openmaintainer
 license             PHP-3.01
 
 # php71-mcrypt and earlier subports are in the php Portfile.
-php.branches        7.2 7.3
+php.branches        7.2 7.3 7.4
 php.pecl            yes
 
 description         a PHP interface to the mcrypt library, which offers \

--- a/php/php-mongodb/Portfile
+++ b/php/php-mongodb/Portfile
@@ -9,7 +9,7 @@ platforms           darwin
 maintainers         {ryandesign @ryandesign} openmaintainer
 license             Apache-2
 
-php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
+php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4
 php.pecl            yes
 
 if {[vercmp ${php.branch} 5.6] >= 0} {

--- a/php/php-mysql-xdevapi/Portfile
+++ b/php/php-mysql-xdevapi/Portfile
@@ -13,7 +13,7 @@ categories              php devel
 
 homepage                https://dev.mysql.com/doc/x-devapi-userguide/en
 
-php.branches            7.1 7.2 7.3
+php.branches            7.1 7.2 7.3 7.4
 php.pecl                yes
 
 if {[vercmp ${php.branch} 7.1] >= 0} {

--- a/php/php-pdflib/Portfile
+++ b/php/php-pdflib/Portfile
@@ -10,7 +10,7 @@ maintainers                 {ryandesign @ryandesign} openmaintainer
 # https://bugs.php.net/bug.php?id=78947
 license                     Restrictive
 
-php.branches                5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
+php.branches                5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4
 php.pecl                    yes
 
 description                 PHP bindings for pdflib

--- a/php/php-propro/Portfile
+++ b/php/php-propro/Portfile
@@ -8,7 +8,7 @@ platforms           darwin
 maintainers         {ryandesign @ryandesign} openmaintainer
 license             BSD
 
-php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
+php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4
 php.pecl            yes
 
 if {[vercmp ${php.branch} 7] >= 0} {

--- a/php/php-raphf/Portfile
+++ b/php/php-raphf/Portfile
@@ -8,7 +8,7 @@ platforms           darwin
 maintainers         {ryandesign @ryandesign} openmaintainer
 license             BSD
 
-php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
+php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4
 php.pecl            yes
 
 if {[vercmp ${php.branch} 7] >= 0} {

--- a/php/php-redis/Portfile
+++ b/php/php-redis/Portfile
@@ -9,7 +9,7 @@ platforms               darwin
 maintainers             {ryandesign @ryandesign} openmaintainer
 license                 PHP-3.01
 
-php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
+php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4
 php.pecl                yes
 
 if {[vercmp ${php.branch} 7.0] >= 0} {

--- a/php/php-scrypt/Portfile
+++ b/php/php-scrypt/Portfile
@@ -9,7 +9,7 @@ platforms               darwin
 maintainers             {ryandesign @ryandesign} openmaintainer
 license                 BSD
 
-php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
+php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4
 php.pecl                yes
 
 version                 1.4.2

--- a/php/php-ssh2/Portfile
+++ b/php/php-ssh2/Portfile
@@ -9,7 +9,7 @@ platforms               darwin
 maintainers             {ryandesign @ryandesign} openmaintainer
 license                 PHP
 
-php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
+php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4
 php.pecl                yes
 php.pecl.prerelease     yes
 

--- a/php/php-stomp/Portfile
+++ b/php/php-stomp/Portfile
@@ -9,7 +9,7 @@ platforms           darwin
 maintainers         {ryandesign @ryandesign} openmaintainer
 license             PHP-3.01
 
-php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
+php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4
 php.pecl            yes
 
 if {[vercmp ${php.branch} 7] >= 0} {

--- a/php/php-svm/Portfile
+++ b/php/php-svm/Portfile
@@ -9,7 +9,7 @@ platforms               darwin
 maintainers             {ryandesign @ryandesign} openmaintainer
 license                 BSD
 
-php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
+php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4
 php.pecl                yes
 php.pecl.prerelease     yes
 

--- a/php/php-taint/Portfile
+++ b/php/php-taint/Portfile
@@ -9,7 +9,7 @@ platforms               darwin
 maintainers             {ryandesign @ryandesign} openmaintainer
 license                 PHP-3.01
 
-php.branches            5.3 5.4 7.0 7.1 7.2 7.3
+php.branches            5.3 5.4 7.0 7.1 7.2 7.3 7.4
 php.pecl                yes
 
 if {[vercmp ${php.branch} 7] >= 0} {

--- a/php/php-timezonedb/Portfile
+++ b/php/php-timezonedb/Portfile
@@ -9,7 +9,7 @@ platforms           darwin
 maintainers         {ryandesign @ryandesign} openmaintainer
 license             PHP-3.01
 
-php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
+php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4
 php.pecl            yes
 
 description         A PECL Timezone Database.

--- a/php/php-uuid/Portfile
+++ b/php/php-uuid/Portfile
@@ -9,7 +9,7 @@ platforms               darwin
 maintainers             {ryandesign @ryandesign} openmaintainer
 license                 LGPL-2.1+
 
-php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
+php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4
 php.pecl                yes
 
 description             A wrapper around libuuid from the ext2utils project.

--- a/php/php-vld/Portfile
+++ b/php/php-vld/Portfile
@@ -9,7 +9,7 @@ platforms           darwin
 maintainers         {ryandesign @ryandesign} openmaintainer
 license             BSD
 
-php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
+php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4
 php.pecl            yes
 php.pecl.prerelease yes
 

--- a/php/php-yaf/Portfile
+++ b/php/php-yaf/Portfile
@@ -9,7 +9,7 @@ platforms               darwin
 maintainers             {ryandesign @ryandesign} openmaintainer
 license                 PHP-3.01
 
-php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
+php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4
 php.pecl                yes
 
 if {[vercmp ${php.branch} 7] >= 0} {

--- a/php/php-yaml/Portfile
+++ b/php/php-yaml/Portfile
@@ -9,7 +9,7 @@ platforms           darwin
 maintainers         {ryandesign @ryandesign} openmaintainer
 license             PHP-3.01
 
-php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
+php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4
 php.pecl            yes
 
 if {[vercmp ${php.branch} 7] >= 0} {

--- a/php/php-yaz/Portfile
+++ b/php/php-yaz/Portfile
@@ -9,7 +9,7 @@ platforms               darwin
 maintainers             {ryandesign @ryandesign} openmaintainer
 license                 PHP
 
-php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
+php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4
 php.pecl                yes
 
 description             PHP/PECL extension for the Z39.50 protocol


### PR DESCRIPTION
#### Description

Following #6147 this makes the extension available as `php74-{name}` where it already has compatibility.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G2022
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
