### PR TITLE
php-zip: Add php74

### DIFF
--- a/php/php-zip/Portfile
+++ b/php/php-zip/Portfile
@@ -9,7 +9,7 @@ platforms           darwin
 maintainers         {ryandesign @ryandesign} openmaintainer
 license             PHP-3.01
 
-php.branches        5.2 5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
+php.branches        5.2 5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4
 php.pecl            yes
 
 if {[vercmp ${php.branch} 4.3] >= 0} {
@@ -30,7 +30,13 @@ if {${name} ne ${subport}} {
     depends_lib-append      port:libzip \
                             port:zlib
 
-    configure.args-append   --enable-zip \
-                            --with-libzip=${prefix} \
-                            --with-zlib-dir=${prefix}
+    if {[vercmp ${php.branch} 7.4] < 0} {
+        configure.args-append --enable-zip \
+                              --with-libzip=${prefix} \
+                              --with-zlib-dir=${prefix}
+    } else {
+        depends_build-append    port:pkgconfig
+        
+        configure.args-append --with-zip
+    }
 }


### PR DESCRIPTION
#### Description

Add php74, which needs updated configure options that have moved to using pkg-config.
See https://www.php.net/manual/en/migration74.other-changes.php#migration74.other-changes.pkg-config

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G2022
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
