### PR TITLE
various Python ports: update to latest version

### DIFF
--- a/python/py-coverage/Portfile
+++ b/python/py-coverage/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-coverage
-version             4.5.4
+version             5.0.3
 revision            0
 
 categories-append   devel
@@ -21,9 +21,9 @@ long_description    Coverage measures code coverage, typically during test \
 
 homepage            https://github.com/nedbat/coveragepy
 
-checksums           rmd160  81ff5f8a5616864d7393a7348c16332667958355 \
-                    sha256  e07d9f1a23e9e93ab5c62902833bf3e4b1f65502927379148b6622686223125c \
-                    size    385185
+checksums           rmd160  5d3ef7bc621ead321b701370b25133fdf885dbb4 \
+                    sha256  77afca04240c40450c331fa796b3eab6f1e15c5ecf8bf2b8bee9706cd5452fef \
+                    size    679171
 
 python.versions     27 35 36 37 38
 

--- a/python/py-natsort/Portfile
+++ b/python/py-natsort/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-natsort
-version             6.2.0
+version             7.0.0
 revision            0
 
 platforms           darwin
@@ -25,13 +25,22 @@ homepage            https://github.com/SethMMorton/${python.rootname}
 master_sites        pypi:n/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  f05e4956317c8d0e7d2ad8cf44ffc64acb251195 \
-                    sha256  58c6fb2f355117e88a19808394ec1ed30a2ff881bdd2c81c436952caebd30668 \
-                    size    139341
+checksums           rmd160  ae994b7efd18867beebcd9caa475f4fed47b7119 \
+                    sha256  7207cddc510e1d5e728a7f73a0230f20a65e3346acd54856be6252291690d3ec \
+                    size    139105
 
 python.versions     27 35 36 37 38
 
 if {${subport} ne ${name}} {
+    if {${python.version} eq 27} {
+        version     6.2.0
+        revision    0
+        distname    ${python.rootname}-${version}
+        checksums   rmd160  f05e4956317c8d0e7d2ad8cf44ffc64acb251195 \
+                    sha256  58c6fb2f355117e88a19808394ec1ed30a2ff881bdd2c81c436952caebd30668 \
+                    size    139341
+    }
+
     depends_lib-append \
                     port:py${python.version}-setuptools
 

--- a/python/py-pytest-runner/Portfile
+++ b/python/py-pytest-runner/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pytest-runner
-version             4.4
+version             5.2
 revision            0
 categories-append   devel
 platforms           darwin
@@ -21,9 +21,9 @@ homepage            https://github.com/pytest-dev/pytest-runner
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  fb011c07f52722e4bf05c808ceb7526c88203b97 \
-                    sha256  00ad6cd754ce55b01b868a6d00b77161e4d2006b3918bde882376a0a884d0df4 \
-                    size    11936
+checksums           rmd160  57cee5045f0b8d5add73e80736b30da6ab095e20 \
+                    sha256  96c7e73ead7b93e388c5d614770d2bae6526efd997757d3543fe17b557a0942b \
+                    size    15534
 
 python.versions     27 35 36 37 38
 

--- a/python/py-six/Portfile
+++ b/python/py-six/Portfile
@@ -4,7 +4,9 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-six
-version             1.13.0
+version             1.14.0
+revision            0
+
 categories-append   devel
 license             MIT
 platforms           darwin
@@ -22,14 +24,27 @@ master_sites        pypi:s/six/
 
 distname            six-${version}
 
-checksums           rmd160  61dd0979ff3a3c7c818fca2db92b3f4de68a3eb2 \
-                    sha256  30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66 \
-                    size    33726
+checksums           rmd160  8ca284d5893a99685f0b218c4e47f4e74f5bb080 \
+                    sha256  236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a \
+                    size    33857
 
-python.versions     27 34 35 36 37 38
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
-    livecheck.type      none
-} else {
-    livecheck.type      pypi
+    depends_test-append \
+                port:py${python.version}-pytest
+
+    test.run    yes
+    test.cmd    py.test-${python.branch}
+    test.target
+    test.env    PYTHONPATH=${worksrcpath}/build/lib
+
+    post-destroot {
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} README.rst LICENSE CHANGES \
+            ${destroot}${docdir}
+    }
+
+    livecheck.type  none
 }

--- a/python/py-tables/Portfile
+++ b/python/py-tables/Portfile
@@ -5,8 +5,8 @@ PortGroup           python 1.0
 PortGroup           mpi 1.0
 
 name                py-tables
-version             3.6.0
-revision            2
+version             3.6.1
+revision            0
 categories-append   science
 platforms           darwin
 license             BSD
@@ -24,9 +24,9 @@ homepage            https://pytables.github.io/
 master_sites        pypi:t/tables/ \
                     http://sourceforge.net/projects/pytables/files/pytables/${version}
 
-checksums           rmd160  63669412aa325d85a7c45b10966263534a9808c0 \
-                    sha256  db3488214864fb313a611fca68bf1c9019afe4e7877be54d0e61c84416603d4d \
-                    size    7818293
+checksums           rmd160  05833282f4c44e48f6f39afada9cb2684aa3249a \
+                    sha256  49a972b8a7c27a8a173aeb05f67acb45fe608b64cd8e9fa667c0962a60b71b49 \
+                    size    4641089
 
 distname            ${python.rootname}-${version}
 

--- a/python/py-tox/Portfile
+++ b/python/py-tox/Portfile
@@ -5,8 +5,8 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-tox
-version             3.14.2
-revision            1
+version             3.14.3
+revision            0
 
 categories-append   devel
 maintainers         {gmail.com:pedro.salgado @steenzout} openmaintainer
@@ -22,9 +22,9 @@ master_sites        pypi:t/tox/
 
 distname            tox-${version}
 
-checksums           rmd160  49663d989cfba207eeb33af8ba1a98040eeb3741 \
-                    sha256  7efd010a98339209f3a8292f02909b51c58417bfc6838ab7eca14cf90f96117a \
-                    size    297721
+checksums           rmd160  5305c217b850c840c01ee401a7f3a33fb4bc44d9 \
+                    sha256  06ba73b149bf838d5cd25dc30c2dd2671ae5b2757cf98e5c41a35fe449f131b3 \
+                    size    298265
 
 python.versions     27 35 36 37 38
 

--- a/python/py-xarray/Portfile
+++ b/python/py-xarray/Portfile
@@ -3,11 +3,10 @@
 PortSystem          1.0
 PortGroup           python 1.0
 
-set _name           xarray
-set _n              [string index ${_name} 0]
+name                py-xarray
+version             0.14.1
+revision            0
 
-name                py-${_name}
-version             0.12.3
 categories-append   science math
 platforms           darwin
 supported_archs     noarch
@@ -24,29 +23,40 @@ long_description    \
 
 homepage            https://github.com/pydata/xarray
 
-distname            ${_name}-${version}
-master_sites        pypi:${_n}/${_name}/
-
-checksums           rmd160  577ccb87f98bc4234a36b0f99929d19cfa3fe697 \
-                    sha256  9310e610af988acb57a2627b10025a250bcbe172e66d3750a6dd3b3c5357da56 \
-                    size    1793550
+checksums           rmd160  55914da99f9607acb6cc789ea92868503eba44c1 \
+                    sha256  04b2f4d24707b8871a7ffa37328d0a2de74e81bd30791c9608712612601abd23 \
+                    size    1873976
 
 python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
+    if {${python.version} eq 35} {
+        version     0.13.0
+        revision    0
+        distname    ${python.rootname}-${version}
+        checksums   rmd160  ac1dd2421efed8f0a4ef0ab2c4e7f30551ef2e88 \
+                    sha256  80e5746ffdebb96b997dba0430ff02d98028ef3828e6db6106cbbd6d62e32825 \
+                    size    1821280
+    } elseif {${python.version} eq 27} {
+        version     0.11.3
+        revision    0
+        epoch       1
+        distname    ${python.rootname}-${version}
+        checksums   rmd160  647d3ff71ea80ec48935d3c6375c060bbd66e457 \
+                    sha256  cc3dceb680d67746168c46771e4aa7d2624519a7faf120421f16d6ddfdb984dd \
+                    size    1720693
+
+        depends_test-append \
+                    port:py${python.version}-mock
+    }
+
     depends_build-append    port:py${python.version}-setuptools
 
     depends_lib-append      port:py${python.version}-numpy \
                             port:py${python.version}-pandas
 
-    livecheck.type  none
-} else {
-    livecheck.type  regex
-    livecheck.url   https://pypi.python.org/pypi/${_name}/json
-    livecheck.regex "\"${_name}-(\[.\\d\]+)\\${extract.suffix}\""
-}
+    depends_test-append \
+                    port:py${python.version}-pytest
 
-subport py34-${python.rootname} {
-    replaced_by py35-${python.rootname}
-    PortGroup obsolete 1.0
+    livecheck.type  none
 }


### PR DESCRIPTION
#### Description
This PR updates a variety of Python ports to their latest version.

###### Tested on
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? 
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
