### PR TITLE
openjdk8: update to AdoptOpenJDK 13.0.2+8

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -102,29 +102,29 @@ subport openjdk12-openj9-large-heap {
 }
 
 subport openjdk13 {
-    version      13.0.1
+    version      13.0.2
     revision     0
 
-    set build    9
+    set build    8
     set major    13
 }
 
 subport openjdk13-openj9 {
-    version      13.0.1
-    revision     1
+    version      13.0.2
+    revision     0
 
-    set build    9
+    set build    8
     set major    13
-    set openj9_version 0.17.0
+    set openj9_version 0.18.0
 }
 
 subport openjdk13-openj9-large-heap {
-    version      13.0.1
-    revision     1
+    version      13.0.2
+    revision     0
 
-    set build    9
+    set build    8
     set major    13
-    set openj9_version 0.17.0
+    set openj9_version 0.18.0
 }
 
 categories       java devel
@@ -345,20 +345,18 @@ if {${subport} eq "openjdk8"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}/
     distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}_${build}
 
-    checksums    rmd160  1c7fef6b601c262f245a3b40fab279abfa5fec6c \
-                 sha256  9c82de98ce9bc2353bcf314d85366c9a2c572db034e10a71aa47e804e13748c1 \
-                 size    198205689
+    checksums    rmd160  0de593a1b3df57a6a91d9ab3e3d0ee7475bc1e0d \
+                 sha256  0ddb24efdf5aab541898d19b7667b149a1a64a8bd039b708fc58ee0284fa7e07 \
+                 size    198206427
 
     worksrcdir   jdk-${version}+${build}
 } elseif {${subport} eq "openjdk13-openj9"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.${revision}_openj9-${openj9_version}/
-    # Temporary dist_subdir for stealth update: https://trac.macports.org/wiki/PortfileRecipes#stealth-updates
-    dist_subdir  ${name}/${version}_${revision}
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
 
-    checksums    rmd160  8bd31c96ae660af6af81be78dd50b2103424bfa5 \
-                 sha256  ea578286d726c0cc9660625f4cd93f67fe1ca89d47584bc4d14bda71f9cb2d5d \
-                 size    201722075
+    checksums    rmd160  193fc075719f33545f7f9deafebd783b5d7e8df1 \
+                 sha256  dd8d92eec98a3455ec5cd065a0a6672cc1aef280c6a68c507c372ccc1d98fbaa \
+                 size    201152468
 
     worksrcdir   jdk-${version}+${build}
 
@@ -370,14 +368,12 @@ if {${subport} eq "openjdk8"} {
                  VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
                  suitable for running all workloads.
 } elseif {${subport} eq "openjdk13-openj9-large-heap"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.${revision}_openj9-${openj9_version}/
-    # Temporary dist_subdir for stealth update: https://trac.macports.org/wiki/PortfileRecipes#stealth-updates
-    dist_subdir  ${name}/${version}_${revision}
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
 
-    checksums    rmd160  401a9beec2f300b0739d7757aa1bc3aacd676b44 \
-                 sha256  0f8b8b11faa2d128adba469429d5fbfd524bc9948e9b16bb78ab8efb43b4018c \
-                 size    201721778
+    checksums    rmd160  7e71c9b1bd5aa8365af66803e3b5292b391e710b \
+                 sha256  a9b7cf11ec9c5df29a09336c91dd7e3232f6fae423e10eec60836330efc2c8cc \
+                 size    201151793
 
     worksrcdir   jdk-${version}+${build}
 


### PR DESCRIPTION
#### Description

Update to AdoptOpenJDK 13.0.2+8.

###### Tested on

macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?