### PR TITLE
gitlab-runner: update to 12.7.0

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 12.6.0 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 12.7.0 v
 
 categories          devel
 platforms           darwin
@@ -23,9 +23,9 @@ homepage            https://docs.gitlab.com/runner/
 master_sites        https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v${version}/
 distname            gitlab-runner-v${version}
 
-checksums           rmd160  e17e0aae2e55f20bd873bf17583d34797b988316 \
-                    sha256  592239134fda12905d2b2f3e6419e14269f14225b4c849acf7d19ef2a9ab63bd \
-                    size    6951134
+checksums           rmd160  eac0918db2036b1062b65d84ba28c9dcb9bfe787 \
+                    sha256  b752e380e3bb191e6b46f8a6cd700b6c7a56ddbeb481138c9f77eedda7e3d6a7 \
+                    size    6962763
 
 # Reproduce the "build_simple" target from the upstream Makefile
 set go_ldflags      "-X ${go.package}/common.NAME=${go.package} \


### PR DESCRIPTION
#### Description

Update to GitLab Runner 12.7.0.

###### Tested on

macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?