### PR TITLE
openjdk8: update to AdoptOpenJDK 8u242 with HotSpot VM

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -3,10 +3,10 @@
 PortSystem       1.0
 
 name             openjdk8
-version          8u232
+version          8u242
 revision         0
 
-set build        09
+set build        08
 set major        8
 
 subport openjdk8-graalvm {
@@ -154,9 +154,9 @@ if {${subport} eq "openjdk8"} {
 if {${subport} eq "openjdk8"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}/
     
-    checksums    rmd160  c659d3f0f5611aa03859fb9442b6eca138485788 \
-                 sha256  c237b2c2c32c893e4ee60cdac8c4bcc34ca731a5445986c03b95cf79918e40c3 \
-                 size    102496705
+    checksums    rmd160  8127d78a0a6455d7a5cbb1e2de5b498389678a6a \
+                 sha256  06675b7d65bce0313ee1f2e888dd44267e8afeced75e0b39b5ad1f5fdff54e0b \
+                 size    102535673
 
     distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}b${build}
     worksrcdir   jdk${version}-b${build}


### PR DESCRIPTION
#### Description

Update to AdoptOpenJDK 8u242 with HotSpot VM.

###### Tested on

macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?