### PR TITLE
micronaut: update to 1.2.10

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       java 1.0
 
-github.setup    micronaut-projects micronaut-core 1.2.9 v
+github.setup    micronaut-projects micronaut-core 1.2.10 v
 revision        0
 name            micronaut
 categories      java
@@ -43,9 +43,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        ${name}-${version}
 
-checksums       rmd160  704c441f8d4884a4c5ee01459a9a2e938c5babc5 \
-                sha256  9c679b63c9f2d8065c2cdc896f3a0f94370cfc878eb52b65deae3aa2c41384d7 \
-                size    12928674
+checksums       rmd160  5bf15e4a6fbb520ad8179f472eb5f90aaf348e1a \
+                sha256  8a2641cdeedb6ba53dd4cc6482b6ff80e7b786d5b8a2cc05a3107cb95619f6f2 \
+                size    12928692
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 1.2.10.

###### Tested on

macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?