### PR TITLE
google-cloud-sdk: update to 277.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             276.0.0
+version             277.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  521b4ceee8d2c22c3a5ffb00ece013883b506ae2 \
-                    sha256  113b85f421aec48867ca98cd93994e76b395f5c277bcabab866e4e8188b4c4fa \
-                    size    23246676
+    checksums       rmd160  588b8163d988ef43194d408873509a7de07111d0 \
+                    sha256  c2d63d25c42703f0203181ea098b0ff9b21f5ed0639a1de55089bb1cb3b81325 \
+                    size    23368534
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  e744ead811bd18da96ba72f6e781f3b297ed3d32 \
-                    sha256  2c8b33d4477981e3250376dcdebda4f1612a2ce7191ade68844fdec2e4256dc6 \
-                    size    23247036
+    checksums       rmd160  24edfc994d14bd5099ccf21fbff65ea7be89b4cf \
+                    sha256  772dffb2c1ee928f03ca3a8803e6677884302341be9e456190a7f9c2787ec94d \
+                    size    23368581
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 277.0.0.

###### Tested on

macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?