### PR TITLE
k9s: update to 0.13.4

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.13.2 v
+go.setup            github.com/derailed/k9s 0.13.4 v
 
 categories          sysutils
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -19,9 +19,9 @@ platforms           darwin
 supported_archs     x86_64
 license             Apache-2
 
-checksums           rmd160  ac25e5cd6f5f44d64ad799324f8e5a5a590fbb70 \
-                    sha256  779522c1b918f8fb110be0e9ea604fd133776475ed2a490f9c3aea9e79d0809e \
-                    size    1451824
+checksums           rmd160  12be64692dab59d5c9563714d020ed4214d08700 \
+                    sha256  d215fb12bc65f94360ff124582e14776e0a350065d16226592ad07f6647cb2ac \
+                    size    2064671
 
 # Reproduce the "build" target from the upstream Makefile
 set go_ldflags      "-w -X ${go.package}/cmd.version=${version} \


### PR DESCRIPTION
#### Description

Update to k9s 0.13.4.

###### Tested on

macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?