### PR TITLE
openjdk8: update to OpenJ9 0.18.1

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -17,21 +17,21 @@ subport openjdk8-graalvm {
 }
 
 subport openjdk8-openj9 {
-    version      8u232
-    revision     1
+    version      8u242
+    revision     0
 
-    set build    09
+    set build    08
     set major    8
-    set openj9_version 0.17.0
+    set openj9_version 0.18.1
 }
 
 subport openjdk8-openj9-large-heap {
-    version      8u232
-    revision     1
+    version      8u242
+    revision     0
 
-    set build    09
+    set build    08
     set major    8
-    set openj9_version 0.17.0
+    set openj9_version 0.18.1
 }
 
 subport openjdk10 {
@@ -59,20 +59,20 @@ subport openjdk11-graalvm {
 
 subport openjdk11-openj9 {
     version      11.0.6
-    revision     0
+    revision     1
 
     set build    10
     set major    11
-    set openj9_version 0.18.0
+    set openj9_version 0.18.1
 }
 
 subport openjdk11-openj9-large-heap {
     version      11.0.6
-    revision     0
+    revision     1
 
     set build    10
     set major    11
-    set openj9_version 0.18.0
+    set openj9_version 0.18.1
 }
 
 subport openjdk12 {
@@ -178,13 +178,11 @@ if {${subport} eq "openjdk8"} {
 
     homepage     https://www.graalvm.org
 } elseif {${subport} eq "openjdk8-openj9"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}.${revision}_openj9-${openj9_version}/
-    # Temporary dist_subdir for stealth update: https://trac.macports.org/wiki/PortfileRecipes#stealth-updates
-    dist_subdir  ${name}/${version}_${revision}
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
 
-    checksums    rmd160  d90d77e1ee0d2752f992ba8a53dbcad9602e191d \
-                 sha256  168079dcc20f62ac4409800c78d23a63ba7c665e58cd7ac8bde21ebbbb2b6d48 \
-                 size    114222397
+    checksums    rmd160  6db70061a643d19c2bbe41637e085293a94aab7e \
+                 sha256  665dc9c8239b7270b007ab9dd7522570e2686e327d89caf57a6aa6e5c6450078 \
+                 size    114579018
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}b${build}_openj9-${openj9_version}
     worksrcdir   jdk${version}-b${build}
@@ -197,13 +195,11 @@ if {${subport} eq "openjdk8"} {
                  VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
                  suitable for running all workloads.
 } elseif {${subport} eq "openjdk8-openj9-large-heap"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}.${revision}_openj9-${openj9_version}/
-    # Temporary dist_subdir for stealth update: https://trac.macports.org/wiki/PortfileRecipes#stealth-updates
-    dist_subdir  ${name}/${version}_${revision}
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
 
-    checksums    rmd160  5b541680f690a2eb353c764dba8c5ddf62f8f366 \
-                 sha256  e28e308321886fe98caada4148a6ee768b22e97486696220ffde6c174fe75fa9 \
-                 size    114212346
+    checksums    rmd160  3b319be42f052139b6432b6f89ba667a13aa4e08 \
+                 sha256  e1f8e053899a5d4eba9de8928d4744041b1d127a98959bc9683e4b31868b25cc \
+                 size    114576741
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}b${build}_openj9-${openj9_version}
     worksrcdir   jdk${version}-b${build}
@@ -263,9 +259,9 @@ if {${subport} eq "openjdk8"} {
 } elseif {${subport} eq "openjdk11-openj9"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
 
-    checksums    rmd160  a4538de5064c1aff39ea807887be6826a048a90f \
-                 sha256  28bb4b67307767992c26f2af3eed4d3ebfda1b206d44b469be24dbcc4fc6cdd7 \
-                 size    196635233
+    checksums    rmd160  a20f46cf19d34e4b489b5bffb1755d2465fc7cd9 \
+                 sha256  9a5c5b3bb51a82e666c46b2d1bbafa8c2bbc3aae50194858c8f96c5d43a96f64 \
+                 size    196636566
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
     worksrcdir   jdk-${version}+${build}
@@ -280,9 +276,9 @@ if {${subport} eq "openjdk8"} {
 } elseif {${subport} eq "openjdk11-openj9-large-heap"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
 
-    checksums    rmd160  7819d1fea6e2c6c7cb31e4ea2ab960e6a2537bee \
-                 sha256  3d00cb1f6f2a505f94b640704ad99e7f60db1641a21746b41adf1c37091b5505 \
-                 size    196627485
+    checksums    rmd160  e134ac760608708bab54ac9fdc863cf5a1ccafa2 \
+                 sha256  bb6eec01ebd74a85c178a13d3568d3d657eb48d583d6602627c8237355b801cf \
+                 size    196630490
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
     worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to OpenJ9 0.18.1.

###### Tested on

macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?