### PR TITLE
texlive-bin: remove deprecated PortGroup cxx11

### DIFF
--- a/tex/texlive-bin/Portfile
+++ b/tex/texlive-bin/Portfile
@@ -3,7 +3,6 @@
 PortSystem      1.0
 PortGroup       compiler_blacklist_versions 1.0
 PortGroup       texlive 1.0
-PortGroup       cxx11 1.1
 
 # Note: due to poppler compatibility issues, we are temporarily using
 # the texlive-provided version of poppler rather than the port; we'll
@@ -47,6 +46,10 @@ master_sites    https://www.ambulatoryclam.net/texlive/ \
 use_xz          yes
 distname        texlive-source-${version}-stripped
 worksrcdir      ${distname}
+
+compiler.cxx_standard \
+                2011
+
 
 set tlpkgdistname   tlpkg-TeXLive-${version}
 distfiles-append    ${tlpkgdistname}${extract.suffix}

--- a/tex/texlive-bin/Portfile
+++ b/tex/texlive-bin/Portfile
@@ -43,7 +43,7 @@ license         Copyleft Permissive LGPL-2.1+ BSD
 master_sites    https://www.ambulatoryclam.net/texlive/ \
                 https://alpaca.cs.washington.edu/texlive/ \
                 https://giraffe.cs.washington.edu/texlive/
-                
+
 use_xz          yes
 distname        texlive-source-${version}-stripped
 worksrcdir      ${distname}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.2
Xcode 11.3.1 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
