### PR TITLE
clang-3.4 and 3.7: remove libxml2 dependency

### DIFF
--- a/lang/llvm-3.4/Portfile
+++ b/lang/llvm-3.4/Portfile
@@ -10,7 +10,7 @@ set llvm_version        3.4
 set llvm_version_no_dot 34
 name                    llvm-${llvm_version}
 revision                12
-subport                 clang-${llvm_version} { revision 12 }
+subport                 clang-${llvm_version} { revision 13 }
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
 # prefix for deps using libstdc++ on a libc++ system
@@ -61,6 +61,16 @@ if {${subport} eq "llvm-${llvm_version}"} {
     if {${os.major} >= 11} {
         default_variants    +analyzer
     }
+
+    # port:libxml2 depends on port:icu which now needs a C++11 compiler
+    # this is problematic for bootstrapping, and clang in fact does not require libxml2
+    # (although c-index-test will optionally use it if it is installed)
+    # remove the dependency, and force any installed version of libxml2 to
+    # be ignored during configuration for consistent building
+    if {${os.major} < 13} {
+        depends_lib-delete     port:libxml2
+        configure.env-append   ac_cv_lib_xml2_xmlReadFile=no
+    }
 }
 
 if {${os.platform} eq "darwin" && ${os.major} < 12 && ${cxx_stdlib} eq "libc++"} {
@@ -71,8 +81,6 @@ if {${os.platform} eq "darwin" && ${os.major} < 12 && ${cxx_stdlib} eq "libc++"}
         depends_lib-replace port:python27 port:python27-bootstrap \
                             port:ncurses port:ncurses-bootstrap
     }
-    # libxml2 depends on icu which needs a C++11 compiler
-    depends_lib-replace     port:libxml2 port:libxml2-bootstrap
     configure.cppflags-prepend  -I${bootstrap_prefix}/include
     configure.ldflags-prepend   -L${bootstrap_prefix}/lib
     configure.env-append    PATH=${bootstrap_prefix}/bin:$::env(PATH)

--- a/lang/llvm-3.7/Portfile
+++ b/lang/llvm-3.7/Portfile
@@ -17,7 +17,7 @@ set llvm_version        3.7
 set llvm_version_no_dot 37
 name                    llvm-${llvm_version}
 revision                4
-subport                 clang-${llvm_version} { revision 5 }
+subport                 clang-${llvm_version} { revision 6 }
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
 dist_subdir             llvm
@@ -65,6 +65,16 @@ if {${subport} eq "llvm-${llvm_version}"} {
     # Avoid requiring a bootstrap version of perl5 on 10.6.
     if {${os.major} >= 11} {
         default_variants    +analyzer
+    }
+
+    # port:libxml2 depends on port:icu which now needs a C++11 compiler
+    # this is problematic for bootstrapping, and clang in fact does not require libxml2
+    # (although c-index-test will optionally use it if it is installed)
+    # remove the dependency, and force any installed version of libxml2 to
+    # be ignored during configuration for consistent building
+    if {${os.major} < 13} {
+        depends_lib-delete     port:libxml2
+        configure.env-append   ac_cv_lib_xml2_xmlReadFile=no
     }
 }
 


### PR DESCRIPTION
to simplify bootstrapping

libxml2 is optionally used, only by c-index-test
it is not required, and is opportunistically linked in if found

port:libxml2 now uses port:icu, which requires c++11
this generates bootstrapping hassles that are unnecessary

remove the dependency on libxml2 and force it to be ignored if
opportunistically found.

revbump to generate consistent buildbot builds of clang-3.4 and 3.7
that do not require libxml2

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
