### PR TITLE
mysql8 @8.0.19: fix build on older systems

### DIFF
--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -134,7 +134,8 @@ if {$subport eq $name} {
     patchfiles      patch-cmake-install_macros.cmake.diff \
                     patch-cmake-install_layout.cmake.diff \
                     patch-mysql8-workaround-no-SC_PHYS_PAGES.diff \
-                    patch-sql-local-boost.diff
+                    patch-sql-local-boost.diff \
+                    patch-mysql8-ffsll-apple.diff
 
     post-extract {
         file mkdir ${cmake.build_dir}/macports
@@ -157,7 +158,8 @@ if {$subport eq $name} {
 
         # don't force /usr/bin/libtool -- allow cctools' version to be used
         reinplace "s|/usr/bin/libtool|libtool|g" \
-            ${worksrcpath}/cmake/libutils.cmake
+            ${worksrcpath}/cmake/libutils.cmake \
+            ${worksrcpath}/cmake/os/Darwin.cmake
     }
 
     post-destroot {

--- a/databases/mysql8/files/patch-mysql8-ffsll-apple.diff
+++ b/databases/mysql8/files/patch-mysql8-ffsll-apple.diff
@@ -1,0 +1,13 @@
+--- a/include/tables_contained_in.h.orig	2020-01-26 18:23:40.000000000 -0800
++++ b/include/tables_contained_in.h	2020-01-26 18:24:52.000000000 -0800
+@@ -29,6 +29,10 @@
+ #include "my_inttypes.h"
+ #include "sql/sql_optimizer.h"
+ 
++#ifndef ffsll
++#define ffsll __builtin_ffsll
++#endif
++
+ #ifdef _MSC_VER
+ #include <intrin.h>
+ #pragma intrinsic(_BitScanForward64)


### PR DESCRIPTION
replace another fixed /usr/bin/libtool
replace a function available only on 10.13 or newer

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.6.8
Xcode 4.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
