### PR TITLE
pgplot: add installation of *.inc files

### DIFF
--- a/graphics/pgplot/Portfile
+++ b/graphics/pgplot/Portfile
@@ -6,7 +6,7 @@ PortGroup           compilers 1.0
 name                pgplot
 conflicts           miriad
 version             5.2.2
-revision            11
+revision            12
 categories          graphics devel
 license             Noncommercial
 platforms           darwin
@@ -174,7 +174,7 @@ destroot {
         xinstall -m 644 ${fl} ${destroot}${prefix}/lib
     }
 
-    foreach fl [glob -directory ${destroot.dir} -nocomplain *.h] {
+    foreach fl [glob -directory ${destroot.dir} -nocomplain *.h *.inc] {
         xinstall -m 644 ${fl} ${destroot}${prefix}/include
     }
 


### PR DESCRIPTION
#### Description

Revision 11 did not install the *.inc files needed for Fortran users. This revision 12 adds those.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.2
Xcode Command Line Tools 11.3.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
