### PR TITLE
libfec: update version to 07632475

### DIFF
--- a/science/libfec/Portfile
+++ b/science/libfec/Portfile
@@ -12,22 +12,16 @@ long_description    implements several popular forward error correction \
     (FEC) algorithms and several low-level routines useful in modems \
     implemented with digital signal processing (DSP).
 
-github.setup fblomqvi libfec 9de5ef59bcdb6d97805cc93a674a6778c3392cfb
-version   20191015-[string range ${github.version} 0 7]
-checksums rmd160 5f94b10460c24a42ba59a2037767553f60a589cf \
-          sha256 ee12f3135dc5f04db9b7f143d7bc94a7effc1665e13ea38d575bce622edc60b6 \
-          size   130523
+github.setup fblomqvi libfec 076324752f842191664b05ef82a8be7dee6ecb0d
+version   20200118-[string range ${github.version} 0 7]
+checksums rmd160 aa5f9e55f535d4ac27503effefd8d8ff3af8fd27 \
+          sha256 ae5a69ea5b57d2ad85da68c9e4c408c2e8f831b4973ecf14345a8c36acd596a0 \
+          size   130532
 revision  0
 
 use_autoreconf  yes
 
 configure.args-append \
     --build="${build_arch}-apple-${os.platform}${os.major}.${os.minor}.0"
-
-post-destroot {
-    # quick and dirty way to fix shared library identification name
-    # seen that the source is stable
-    system "install_name_tool -id ${prefix}/lib/${name}.dylib ${destroot}${prefix}/lib/${name}.dylib"
-}
 
 test.run yes


### PR DESCRIPTION


#### Description

thanks @ryandesign to fix upstream the id name->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
