### PR TITLE
py-commpy: update version to 0.5.0

### DIFF
--- a/python/py-commpy/Portfile
+++ b/python/py-commpy/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-commpy
-version             0.4.0
+version             0.5.0
 revision            0
 
 platforms           darwin
@@ -20,16 +20,25 @@ python.rootname     scikit-commpy
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  dd1642d3fdbf7ef21dbcb2f58a1732dfdc338696 \
-                    sha256  a3903df1a9af50654f354eaf3371d13406514405d75a7c0f8f4cf5957fac90e0 \
-                    size    26768
+checksums           rmd160  c2ecb0c6582bca88b2bf19a64430058cc83f2c54 \
+                    sha256  5cd94641e0916425e8370a2d4ba36669b4fc1516a96ef4aed79d8a5f8ab1da4e \
+                    size    42700
 
 python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
+    if {${python.version} == 27} {
+        version     0.4.0
+        checksums   rmd160  dd1642d3fdbf7ef21dbcb2f58a1732dfdc338696 \
+                    sha256  a3903df1a9af50654f354eaf3371d13406514405d75a7c0f8f4cf5957fac90e0 \
+                    size    26768
+        revision    0
+    }
+
     depends_build-append \
         port:py${python.version}-setuptools
 
+    # py-nose is only for test
     depends_lib-append \
         port:py${python.version}-matplotlib \
         port:py${python.version}-numpy \


### PR DESCRIPTION

#### Description

- remove python 2.7 support

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
