### PR TITLE
Update plumed 2.6.0

### DIFF
--- a/python/py-plumed/Portfile
+++ b/python/py-plumed/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        plumed plumed2 2.5.3 v
+github.setup        plumed plumed2 2.6.0 v
 name                py-plumed
 categories          python
 
@@ -18,11 +18,11 @@ long_description    ${description} They allow the plumed library to be directly 
 
 homepage            http://www.plumed.org
 
-checksums           rmd160  b8177e64c230f968a1c8bf0941b8a38ffa8f6476 \
-                    sha256  75be9e8caeef2ded69b844be0eb12ad69e25c1ee9d193a179a5ba3e9b5cd09ab \
-                    size    69826544
+checksums           rmd160  4aacc2e0bc31f94f7432d2be1a75c9fd10c0907d \
+                    sha256  117d15bf8b74268243b615576a19676beb21e3fb2542a131d7ab9768b9502f87 \
+                    size    74671170
 
-python.versions     27 36 37
+python.versions     36 37 38
 
 # python setup is located in python subdir of plumed repository
 worksrcdir  ${distname}/python
@@ -38,7 +38,10 @@ if {${name} ne ${subport}} {
 
     depends_lib-append      path:${prefix}/lib/libplumedKernel.dylib:plumed
 
-    depends_test-append     port:py${python.version}-nose
+    depends_test-append     port:py${python.version}-nose \
+                            port:py${python.version}-numpy \
+                            port:py${python.version}-pandas
+
     test.cmd                nosetests-${python.branch}
 # needed since the module is placed in something like ${worksrcpath}/build/lib.macosx-10.11-x86_64-3.7
     test.env                PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]

--- a/science/plumed/Portfile
+++ b/science/plumed/Portfile
@@ -9,7 +9,7 @@ PortGroup           mpi 1.0
 PortGroup           linear_algebra 1.0
 PortGroup           debug 1.0
 
-github.setup        plumed plumed2 2.5.3 v
+github.setup        plumed plumed2 2.6.0 v
 name                plumed
 
 categories          science
@@ -28,10 +28,13 @@ platforms           darwin
 
 homepage            http://www.plumed.org/
 
-checksums           rmd160  b8177e64c230f968a1c8bf0941b8a38ffa8f6476 \
-                    sha256  75be9e8caeef2ded69b844be0eb12ad69e25c1ee9d193a179a5ba3e9b5cd09ab \
-                    size    69826544
+checksums           rmd160  4aacc2e0bc31f94f7432d2be1a75c9fd10c0907d \
+                    sha256  117d15bf8b74268243b615576a19676beb21e3fb2542a131d7ab9768b9502f87 \
+                    size    74671170
 
+# Enable optional features.
+# --enable-asmjit:        Compile internal asmjit. Notice that internal asmjit is protected in
+#                         PLUMED namespace so will not collide with other asmjit implementations.
 # Disable additional features.
 # --disable-doc:          Do not create documentation, and avoid searching for Doxygen.
 # --disable-libsearch:    Avoid searching libraries using their default names.
@@ -43,6 +46,7 @@ checksums           rmd160  b8177e64c230f968a1c8bf0941b8a38ffa8f6476 \
 # --disable-mpi:          Do not search for MPI compiler (replaced when enabling mpi, see below)
 # --disable-python:       Python wrappers will be installed with a separate python port
 configure.args-append \
+                    --enable-asmjit \
                     --disable-doc \
                     --disable-libsearch \
                     --disable-static-patch \
@@ -82,7 +86,8 @@ configure.cxxflags-replace -Os -O3
 # only requested packages are linked.
 configure.ldflags-append \
                     -lxdrfile -lz -lgsl
-depends_lib-append  port:gsl \
+depends_lib-append  port:gawk \
+                    port:gsl \
                     port:xdrfile \
                     port:zlib
 
@@ -111,14 +116,14 @@ pre-configure {
 # plumed-devel subport
 # This subport installs the developer version
 subport plumed-devel {
-    github.setup        plumed plumed2 b7009ae74dd2419de80adec71777d199c8969214
-    version             2.6-20191011
+    github.setup        plumed plumed2 a33c1fc6934e73f26979059b96f03493c7285f00
+    version             2.7-20200127
     description         ${description} (development version)
     long_description    ${long_description} (development version)
     conflicts plumed
-    checksums           rmd160  6f936147e12f79c459ec71a5db05714245727669 \
-                        sha256  3910611c02dc92744abe4f7bd04a69e74ce92c7b0e8087bdebb9bf23aa721f39 \
-                        size    73784858
+    checksums           rmd160  b8b0dd634343fa1166dbdee6c06c578ff0aaaa25 \
+                        sha256  0a468f094ee7275e8dea255f19e8b67b4a14b1c9b9446f3601591bf3e37de947 \
+                        size    75067013
 }
 
 # Allow running tests from MacPorts


### PR DESCRIPTION
#### Description

Update plumed and py-plumed packages.

Notice that a test in the plumed package is failing. This is just due to a tiny numerical discrepancy with a precomputed reference output, likely due to the use of a different compiler. I will try to decrease the number of digits upstream, but the failure itself is harmless.

Also notice that for the python wrappers I removed python 2.7 (that is unsupported by the newest py-plumed package) and added python 3.8

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G2022
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
