### PR TITLE
Hamlib: add -devel subport

### DIFF
--- a/comms/xlog/Portfile
+++ b/comms/xlog/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  a1a78a90c74d7f73ea680fe80a324eaea3e36e95 \
 
 patchfiles          patch-configure.diff
 
-depends_lib         port:hamlib \
+depends_lib         path:lib/libhamlib.dylib:hamlib \
                     port:gtk2
 depends_build       port:pkgconfig
 

--- a/science/CubicSDR/Portfile
+++ b/science/CubicSDR/Portfile
@@ -50,7 +50,7 @@ configure.cxxflags-append \
     -D_WCHAR_H_CPLUSPLUS_98_CONFORMANCE_
 
 variant hamlib description {Support hamlib for radio control functions} {
-    depends_lib-append      port:hamlib
+    depends_lib-append      path:lib/libhamlib.dylib:hamlib
     configure.args-append   -DUSE_HAMLIB=1
 }
 

--- a/science/SoapyAudio/Portfile
+++ b/science/SoapyAudio/Portfile
@@ -24,7 +24,7 @@ depends_build-append \
 
 depends_lib-append \
     port:SoapySDR \
-    port:hamlib \
+    path:lib/libhamlib.dylib:hamlib \
     port:rtaudio
 
 configure.args-append \

--- a/science/fldigi/Portfile
+++ b/science/fldigi/Portfile
@@ -27,7 +27,7 @@ depends_build-append \
 
 depends_lib-append \
     path:lib/libfltk.dylib:fltk \
-    port:hamlib \
+    path:lib/libhamlib.dylib:hamlib \
     port:libpng \
     port:libsamplerate \
     port:libsndfile \

--- a/science/freedv-gui/Portfile
+++ b/science/freedv-gui/Portfile
@@ -32,7 +32,7 @@ wxWidgets.use \
 depends_lib-append \
     port:${wxWidgets.port} \
     port:portaudio \
-    port:hamlib \
+    path:lib/libhamlib.dylib:hamlib \
     port:libsndfile \
     port:libsamplerate \
     port:libao \

--- a/science/grig/Portfile
+++ b/science/grig/Portfile
@@ -3,6 +3,7 @@
 PortSystem              1.0
 name                    grig
 version                 0.8.1
+revision                1
 categories              science
 license                 GPL-2+
 platforms               darwin
@@ -15,8 +16,10 @@ master_sites            sourceforge:groundstation
 
 depends_build           port:pkgconfig
 depends_lib             port:gtk2 \
-                        port:hamlib
+                        path:lib/libhamlib.dylib:hamlib
 
-checksums           rmd160  01deadaea1ae2e6ed3e27ada07ad4557039ddf8c \
-                    sha256  be8687418fb23efa0468674c3fdd15340fed06eef09be9de21106cc17e033c25 \
-                    size    621728
+checksums               rmd160  01deadaea1ae2e6ed3e27ada07ad4557039ddf8c \
+                        sha256  be8687418fb23efa0468674c3fdd15340fed06eef09be9de21106cc17e033c25 \
+                        size    621728
+
+patchfiles              patch-hamlib4.diff

--- a/science/grig/files/patch-hamlib4.diff
+++ b/science/grig/files/patch-hamlib4.diff
@@ -1,0 +1,147 @@
+diff --git a/src/rig-daemon-check.c b/src/rig-daemon-check.c
+index c5c0d14..0ced05a 100644
+--- src/rig-daemon-check.c
++++ src/rig-daemon-check.c
+@@ -42,6 +42,9 @@
+ #include <gtk/gtk.h>
+ #include <glib/gi18n.h>
+ #include <hamlib/rig.h>
++#ifdef HAVE_CONFIG_H
++#  include <config.h>
++#endif
+ #include "rig-data.h"
+ #include "grig-debug.h"
+ #include "rig-daemon-check.h"
+@@ -396,15 +399,26 @@ rig_daemon_check_mode     (RIG               *myrig,
+ 			   this list is good for current mode   AND
+ 			   the current frequency is within this range
+ 			*/
++#if HAMLIB_MAJOR_VERSION >= 4
+ 			if (!found_mode &&
+ 			    ((mode & myrig->state.rx_range_list[i].modes) == mode) &&
+-			    (get->freq1 >= myrig->state.rx_range_list[i].start)    &&
+-			    (get->freq1 <= myrig->state.rx_range_list[i].end)) {
+-					
+-				found_mode = 1;
+-				get->fmin = myrig->state.rx_range_list[i].start;
+-				get->fmax = myrig->state.rx_range_list[i].end;
++			    (get->freq1 >= myrig->state.rx_range_list[i].startf)    &&
++			    (get->freq1 <= myrig->state.rx_range_list[i].endf)) {
++
++				get->fmin = myrig->state.rx_range_list[i].startf;
++				get->fmax = myrig->state.rx_range_list[i].endf;
++#else
++                        if (!found_mode &&
++                            ((mode & myrig->state.rx_range_list[i].modes) == mode) &&
++                            (get->freq1 >= myrig->state.rx_range_list[i].start)    &&
++                            (get->freq1 <= myrig->state.rx_range_list[i].end)) {
++
++                                get->fmin = myrig->state.rx_range_list[i].start;
++                                get->fmax = myrig->state.rx_range_list[i].end;
++#endif
+ 				
++				found_mode = 1;
++
+ 				grig_debug_local (RIG_DEBUG_VERBOSE,
+ 						  _("%s: Found frequency range for mode %d"),
+ 						  __FUNCTION__, mode);
+diff --git a/src/rig-daemon.c b/src/rig-daemon.c
+index ddd922f..f86c3aa 100644
+--- src/rig-daemon.c
++++ src/rig-daemon.c
+@@ -50,6 +50,9 @@
+ #include <hamlib/rig.h>
+ #include <string.h>
+ #include <stdlib.h>
++#ifdef HAVE_CONFIG_H
++#  include <config.h>
++#endif
+ #include "grig-config.h"
+ #include "grig-debug.h"
+ #include "rig-anomaly.h"
+@@ -1673,13 +1676,23 @@ rig_daemon_exec_cmd         (rig_cmd_t cmd,
+ 						/* is this list good for current mode?
+ 						   is the current frequency within this range?
+ 						*/
++#if HAMLIB_MAJOR_VERSION >= 4
+ 						if (((mode & myrig->state.rx_range_list[i].modes) == mode) &&
+-						    (get->freq1 >= myrig->state.rx_range_list[i].start)    &&
+-						    (get->freq1 <= myrig->state.rx_range_list[i].end)) {
+-					
++						    (get->freq1 >= myrig->state.rx_range_list[i].startf)    &&
++						    (get->freq1 <= myrig->state.rx_range_list[i].endf)) {
++
++							get->fmin = myrig->state.rx_range_list[i].startf;
++							get->fmax = myrig->state.rx_range_list[i].endf;
++#else
++                                                if (((mode & myrig->state.rx_range_list[i].modes) == mode) &&
++                                                    (get->freq1 >= myrig->state.rx_range_list[i].start)    &&
++                                                    (get->freq1 <= myrig->state.rx_range_list[i].end)) {
++
++                                                        get->fmin = myrig->state.rx_range_list[i].start;
++                                                        get->fmax = myrig->state.rx_range_list[i].end;
++#endif
++
+ 							found_mode = 1;
+-							get->fmin = myrig->state.rx_range_list[i].start;
+-							get->fmax = myrig->state.rx_range_list[i].end;
+ 				
+ 							grig_debug_local (RIG_DEBUG_VERBOSE,
+ 									  _("%s: Found frequency range for mode %d"),
+diff --git a/configure.ac b/configure.ac
+index 86f1091..de6ee39 100644
+--- configure.ac
++++ configure.ac
+@@ -89,7 +89,9 @@ GDK_V=`pkg-config --modversion gdk-2.0`
+ GTK_V=`pkg-config --modversion gtk+-2.0`
+ 
+ AC_DEFINE_UNQUOTED([HAMLIB_VERSION],[`pkg-config --modversion hamlib`],["Hamlib version"])
+-
++AC_DEFINE_UNQUOTED([HAMLIB_MAJOR_VERSION],[`pkg-config --modversion hamlib | cut -d'.' -f1`],["Hamlib major version"])
++AC_DEFINE_UNQUOTED([HAMLIB_MINOR_VERSION],[`pkg-config --modversion hamlib | cut -d'.' -f2 | cut -d'~' -f1`],["Hamlib minor version"])
++AC_DEFINE_UNQUOTED([HAMLIB_PATCH_VERSION],[`pkg-config --modversion hamlib | cut -d'.' -f2 | cut -d'~' -f2`],["Hamlib patch version"])
+ 
+ AC_SUBST(CFLAGS)
+ AC_SUBST(LDFLAGS)
+diff --git a/configure b/configure
+index acb75d2..9e00929 100755
+--- configure
++++ configure
+@@ -14091,8 +14091,19 @@ cat >>confdefs.h <<_ACEOF
+ _ACEOF
+ 
+ 
++cat >>confdefs.h <<_ACEOF
++#define HAMLIB_MAJOR_VERSION `pkg-config --modversion hamlib | cut -d'.' -f1`
++_ACEOF
++
++
++cat >>confdefs.h <<_ACEOF
++#define HAMLIB_MINOR_VERSION `pkg-config --modversion hamlib | cut -d'.' -f2 | cut -d'~' -f1`
++_ACEOF
+ 
+ 
++cat >>confdefs.h <<_ACEOF
++#define HAMLIB_PATCH_VERSION `pkg-config --modversion hamlib | cut -d'.' -f2 | cut -d'~' -f2`
++_ACEOF
+ 
+ 
+ ac_config_files="$ac_config_files Makefile doc/Makefile doc/man/grig.1 doc/man/Makefile grig.spec src/Makefile pixmaps/Makefile po/Makefile.in"
+--- config.h.in.orig	2015-12-20 22:15:13.000000000 +0100
++++ config.h.in	2020-01-27 13:07:46.000000000 +0100
+@@ -10,6 +10,15 @@
+ /* The gettext domain */
+ #undef GETTEXT_PACKAGE
+ 
++/* "Hamlib major version" */
++#undef HAMLIB_MAJOR_VERSION
++
++/* "Hamlib minor version" */
++#undef HAMLIB_MINOR_VERSION
++
++/* "Hamlib patch version" */
++#undef HAMLIB_PATCH_VERSION
++
+ /* "Hamlib version" */
+ #undef HAMLIB_VERSION
+ 

--- a/science/hamlib/Portfile
+++ b/science/hamlib/Portfile
@@ -3,9 +3,6 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        hamlib hamlib 3.3
-github.tarball_from releases
-
 name                hamlib
 categories          science
 platforms           darwin
@@ -20,12 +17,47 @@ long_description    Flexible and portable shared libraries that offer a \
 
 homepage            https://hamlib.github.io
 
-checksums           rmd160  e9a09b5878101b44802adf2a82cb697e3560c918 \
+subport hamlib-devel {}
+if {[string first "-devel" $subport] > 0} {
+
+    github.setup    Hamlib Hamlib ed50f580dee720cf36f8350f0d8d47a1e26c7d71
+    version         20191224-[string range ${github.version} 0 7]
+    checksums       rmd160  5b2a7cc222e25185a1e4b7cc191206ee7b18f989 \
+                    sha256  9f5b271f890640965d8f482db52d0df27d176605651caa19410c5b147645351b \
+                    size    1417417
+    revision        0
+
+    name            hamlib-devel
+    long_description ${long_description} This port is kept up with the Hamlib \
+        GIT 'master' branch, is typically updated weekly to monthly.
+    conflicts       hamlib
+
+    use_autoconf    yes
+    autoconf.cmd    ./bootstrap
+
+    # need for autoconf
+    depends_build-append \
+        port:autoconf    \
+        port:automake    \
+        port:libtool
+
+} else {
+
+    github.setup    Hamlib Hamlib 3.3
+    github.tarball_from releases
+    checksums       rmd160  e9a09b5878101b44802adf2a82cb697e3560c918 \
                     sha256  c90b53949c767f049733b442cd6e0a48648b55d99d4df5ef3f852d985f45e880 \
                     size    2192119
+    revision        0
 
-depends_build       port:pkgconfig
+    conflicts       hamlib-devel
 
-depends_lib         port:libtool \
-                    port:libusb-compat \
-                    port:libxml2
+}
+
+depends_build-append \
+    port:pkgconfig
+
+depends_lib-append \
+    port:libtool \
+    port:libusb-compat \
+    port:libxml2


### PR DESCRIPTION
#### Description

this introduce the hamlib-devel subport.
the latest stable version is 3.3 and it is two years old; seems that the developers are using only commits for the moment therefore to support new features we need to add -devel.

grig: require a patch to support the new struct

changes from `port` to `path` are needed to support `hamlib` and `hamlib-devel` and they should not require rev-bump.

can't check trac.macports.org because it is offline

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
