### PR TITLE
SDRangel: temporary fix for building the software

### DIFF
--- a/science/SDRangel/Portfile
+++ b/science/SDRangel/Portfile
@@ -25,6 +25,11 @@ revision              0
 compiler.c_standard   2011
 compiler.cxx_standard 2011
 
+# TEMPORARY
+# https://trac.macports.org/ticket/60012
+# https://github.com/f4exb/sdrangel/issues/467
+patchfiles            disable-remotetx.patch
+
 depends_lib-append \
     port:boost \
     port:codec2 \

--- a/science/SDRangel/files/disable-remotetx.patch
+++ b/science/SDRangel/files/disable-remotetx.patch
@@ -1,0 +1,11 @@
+--- plugins/channeltx/CMakeLists.txt.orig	2020-01-27 09:57:05.000000000 +0100
++++ plugins/channeltx/CMakeLists.txt	2020-01-27 09:57:17.000000000 +0100
+@@ -9,7 +9,7 @@
+ add_subdirectory(filesource)
+ 
+ if(CM256CC_FOUND)
+-    add_subdirectory(remotesource)
++    #add_subdirectory(remotesource)
+ endif(CM256CC_FOUND)
+ 
+ if (OpenCV_FOUND)


### PR DESCRIPTION
#### Description

disable remotesource plugin

see: https://trac.macports.org/ticket/60012

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
