### PR TITLE
gnome-internet-radio-locator: Update to 3.0.0

### DIFF
--- a/gnome/gnome-internet-radio-locator/Portfile
+++ b/gnome/gnome-internet-radio-locator/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                gnome-internet-radio-locator
-version             2.8.0
+version             3.0.0
 set branch          [join [lrange [split $version .] 0 1] .]
 
 categories          gnome
@@ -18,9 +18,9 @@ master_sites        gnome:sources/${name}/${branch}/
 
 use_xz              yes
 
-checksums           rmd160  02e49b5d0e1b97069ab48dcf53745c4c113b4cfb \
-                    sha256  da6fd145950c1004ec96909af45f26d30058f01df2b66ad04db70db194f4ab42 \
-                    size    561172
+checksums           rmd160  81702284088bf149d29a2f6baa4d9fd36d35b708 \
+                    sha256  1a84118e48b5b6cca6f5d409c45e8eba25891811b5a1861390dff7a039e296c6 \
+                    size    561696
 
 depends_build       port:autoconf \
                     port:automake \


### PR DESCRIPTION
#### Description

GNOME Internet Radio Locator version 3.0.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->