### PR TITLE
munge: update to version 0.5.14

### DIFF
--- a/net/munge/Portfile
+++ b/net/munge/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        dun munge 0.5.12 munge-
+github.setup        dun munge 0.5.14 munge-
 revision            1
 categories          net security
 license             {GPL-3+ LGPL-3+}
@@ -22,11 +22,13 @@ long_description    MUNGE (MUNGE Uid 'N' Gid Emporium) is an authentication \
 homepage            https://dun.github.io/munge/
 
 platforms           darwin
-checksums           rmd160 0bc366a2d0a49875e7cf35ea2aebeef33490ed0c \
-                    sha256 23585c1da3f4ea7c2882511c0a08220a2be13d9c03e54486bb8546791fa6c89b
+checksums           rmd160 e16e770d5c9697da521c6537ebcd3787357ef7dd \
+                    sha256 1007d3ea6abd85f7712f5d2601ecb24c16b189ba5b0ec9aa563c11b7e0e9d600 \
+                    size   274981
 
 # We can either use OpenSSL or libgcrypt.  Let's default to OpenSSL.
 depends_lib-append  path:lib/libssl.dylib:openssl
+use_autoreconf      yes
 configure.args      --with-crypto-lib=openssl \
                     --with-openssl-prefix=${prefix}
 
@@ -40,8 +42,11 @@ variant libgcrypt description {Use libgcrypt for cryptographic routines} {
                             --with-libgcrypt-prefix=${prefix}
 }
 
-# Allow doing testing
-test.run            yes
+# The test suite is disabled, because when munged is run, it performs strict
+# security checks on certain directories where munge data live.  Those checks
+# fail on the directory used for the build, and so any test that involve munged
+# fails.
+test.run            no
 test.target         check
 
 # Create some directories, with MUNGE-required permissions.
@@ -57,7 +62,7 @@ destroot.keepdirs-append    ${destroot}${prefix}/etc/munge \
 # When activating, if a MUNGE key doesn't already exist, create a new one.
 post-activate {
     if {![file exists ${prefix}/etc/munge/munge.key]} {
-        system "dd if=/dev/urandom of=${prefix}/etc/munge/munge.key bs=1 count=1024"
+        system "${prefix}/sbin/mungekey"
         file attributes ${prefix}/etc/munge/munge.key -permissions 0600
     }
 }


### PR DESCRIPTION
#### Description

Besides adding OpenSSL 1.1 support, this version of MUNGE makes new installations a little easier: Instead of having to use `dd` to generate some randomness to use as a security key, MUNGE introduces a command (`mungekey`) to do this for you.

Unfortunately, the test suite has been disabled.  When `munged` (the daemon) starts, it performs a strict ownership (by root) and permissions (not group- or world-accessible) check of the directory that holds the key and the log file.  During test, that is the source directory.  Also, a similar check is done on all parent directories, up to the root.  Until I can find a good way around this, I am disabling tests.

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G2022
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?