### PR TITLE
Limesuite: update version to 20.01.0

### DIFF
--- a/science/SDRangel/Portfile
+++ b/science/SDRangel/Portfile
@@ -16,10 +16,10 @@ description           SDRangel is an Open Source Qt5 / OpenGL 3.0+ SDR \
     and signal analyzer frontend to various hardware.
 long_description    ${description}
 
-github.setup          f4exb sdrangel 4.12.5 v
-checksums             rmd160 aa0091502dce49a2bd9a683ad030d6be908eeed2 \
-                      sha256 c5357c6c7dbb57ef43fc37fb26d79a6b3cf6ab091491178a7ba6db65a69e4832 \
-                      size   24248384
+github.setup          f4exb sdrangel 4.13.0 v
+checksums             rmd160  d0e04b031aedd92dc86b38d7f950eba40d37639a \
+                      sha256  94f51fbf5421106b174fa6dbe2cb54e85ffcc9c8d57363a0702c935328d2f829 \
+                      size    24427436
 revision              0
 
 compiler.c_standard   2011

--- a/science/gr-limesdr/Portfile
+++ b/science/gr-limesdr/Portfile
@@ -22,7 +22,7 @@ if {[string first "-devel" $subport] > 0} {
     checksums rmd160 17d714dd91847875fe0dbe20c3542137832e8a42 \
               sha256 635a28e408040804761e683b2f511ed1c51bf28049283a7ee041cf72cb868389 \
               size   3086467
-    revision  0
+    revision  1
 
     name            gr-limesdr-devel
     long_description ${description}. This port is kept up with the ${name} \
@@ -36,7 +36,7 @@ if {[string first "-devel" $subport] > 0} {
     checksums       rmd160  c8b2b7a745a316bcc7c6b7b0a1121da2bddea05a \
                     sha256  6f2fcf42dd45ca3893c914752f803dd811e046c21c567286fd1ad35a8d362f05 \
                     size    3083984
-    revision        3
+    revision        4
 
     conflicts       gr-limesdr-devel
 

--- a/science/limesuite/Portfile
+++ b/science/limesuite/Portfile
@@ -21,11 +21,11 @@ homepage            https://myriadrf.org/projects/lime-suite/
 subport limesuite-devel {}
 if {[string first "-devel" $subport] > 0} {
 
-    github.setup myriadrf LimeSuite 538e186b275c449bead829118be1b143a4d1356b
-    version   20200123-[string range ${github.version} 0 7]
-    checksums rmd160 c71304f0aaef1587fb2f4872fb1e4becd6319281 \
-              sha256 d40504dcb60036bf73aeaaef6339b97c106430d599f5890eeb4e9055124aa602 \
-              size   5414976
+    github.setup myriadrf LimeSuite c931854ead81307206bce750c17c2301810b5545
+    version   20200129-[string range ${github.version} 0 7]
+    checksums rmd160  36a513033e9c013b119adb895d21e475d8a70e0f \
+              sha256  48c688f53ec3a6ad437b5f611d15cd87e954ef1da99748541a2e354155031f7b \
+              size    5415614
     revision  0
 
     name            limesuite-devel

--- a/science/limesuite/Portfile
+++ b/science/limesuite/Portfile
@@ -35,11 +35,11 @@ if {[string first "-devel" $subport] > 0} {
 
 } else {
 
-    github.setup    myriadrf LimeSuite 19.04.0 v
-    checksums       rmd160  9b702a15565df94169bb47538522c8cec3774645 \
-                    sha256  1e4d5ac1b6f81ba730e46411a32eb93878f1eb8874574eb01d3c981c918add92 \
-                    size    5357853
-    revision        2
+    github.setup    myriadrf LimeSuite 20.01.0 v
+    checksums       rmd160  ee57027f57c71e2ca734dacd706ec0c15e0e1870 \
+                    sha256  b0aa3db383bec31b613025b58b7f15218f056e6f07c3eabaab8df9097f93854c \
+                    size    5415366
+    revision        0
 
     conflicts       limesuite-devel
     configure.args-append -DLIME_SUITE_EXTVER=release


### PR DESCRIPTION
#### Description

- revision bump of gr-limesdr
- SDRangel version update to 4.13.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
