### PR TITLE
sudo: fix `sudo -e` and `sudoedit` on catalina

### DIFF
--- a/sysutils/sudo/Portfile
+++ b/sysutils/sudo/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                sudo
 epoch               1
 version             1.8.30
-revision            0
+revision            1
 categories          sysutils security
 license             ISC
 maintainers         {mps @Schamschula}
@@ -27,7 +27,8 @@ checksums           rmd160  853e704b1c60dff84e1b13bbdeca9c8ca4bed988 \
                     sha256  a35ad3ddc7465703e04190d3ff0b8d78ded9246749becf9a014dcb9c31c579e7 \
                     size    3349455
 
-patchfiles          patch-sudoers.in.diff
+patchfiles          patch-sudoers.in.diff \
+                    patch-sudo_edit.c.diff
 
 configure.args      --infodir=${prefix}/share/info \
                     --mandir=${prefix}/share/man \

--- a/sysutils/sudo/files/patch-sudo_edit.c.diff
+++ b/sysutils/sudo/files/patch-sudo_edit.c.diff
@@ -1,0 +1,23 @@
+# HG changeset patch
+# User Todd C. Miller <Todd.Miller@sudo.ws>
+# Date 1579208132 25200
+# Node ID cc636a1af1b6fb9e5e89464b925ad6de66d37687
+# Parent  c59e77060c375a2d0491ac9cb94a9063d5b2a1cc
+Treat EROFS (like EACCES) as a non-fatal error in dir_is_writable().
+Fixes sudoedit on macOS 10.15 and above where the root file system
+is mounted read-only.  See https://support.apple.com/en-us/HT210650.
+From Dan Villiom Podlaski Christiansen.  Bug #913
+
+diff -r c59e77060c37 -r cc636a1af1b6 src/sudo_edit.c
+--- src/sudo_edit.c	Wed Jan 15 14:47:42 2020 -0700
++++ src/sudo_edit.c	Thu Jan 16 13:55:32 2020 -0700
+@@ -133,7 +133,7 @@
+ 
+     if (rc == 0)
+ 	debug_return_int(true);
+-    if (errno == EACCES)
++    if (errno == EACCES || errno == EROFS)
+ 	debug_return_int(false);
+     debug_return_int(-1);
+ }
+


### PR DESCRIPTION
Both `sudo -e` and `sudoedit` are broken on macOS Catalina due to the read-only root file system. I [submitted a patch](https://bugzilla.sudo.ws/show_bug.cgi?id=913) upstream that [they applied](https://www.sudo.ws/repos/sudo/rev/cc636a1af1b6), so I'm adding it here as well.

Without these changes, `sudo -e` always fails like this:

```
$ /usr/bin/sudo -e /etc/hosts
sudo: /etc/hosts: Read-only file system
```

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.2
Xcode 11

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
