### PR TITLE
bandwhich: update to 0.11.0

### DIFF
--- a/net/bandwhich/Portfile
+++ b/net/bandwhich/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        imsnif bandwhich 0.10.0
+github.setup        imsnif bandwhich 0.11.0
 categories          net
 platforms           darwin
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
@@ -22,9 +22,9 @@ long_description    bandwhich sniffs a given network interface and records IP \
                     best effort basis.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  c376d642f1231616b0b777623692b19c43de37dc \
-                    sha256  dd3dbcdc77d2a3652b055629fd3f5133b9ad6c887d5ef9d01d9eb00e4fc280f6 \
-                    size    1561518
+                    rmd160  669635411130c73e0aff74f14663c47fd4e32f47 \
+                    sha256  814c91a66cb9f504d910b97a89f28971a6f1edcacb95b872f144eb3f7ac1d63f \
+                    size    2991681
 
 destroot {
     xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
