### PR TITLE
google-cloud-sdk: update to 278.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             277.0.0
+version             278.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  588b8163d988ef43194d408873509a7de07111d0 \
-                    sha256  c2d63d25c42703f0203181ea098b0ff9b21f5ed0639a1de55089bb1cb3b81325 \
-                    size    23368534
+    checksums       rmd160  1cace37b98833c37b45ccd2c90cb906a459b2c53 \
+                    sha256  568b5e820514ca8673afa24c4bfe195ccb1af3ac97cd1b3634fc9da888a9188d \
+                    size    23467711
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  24edfc994d14bd5099ccf21fbff65ea7be89b4cf \
-                    sha256  772dffb2c1ee928f03ca3a8803e6677884302341be9e456190a7f9c2787ec94d \
-                    size    23368581
+    checksums       rmd160  b07790d542a40ae4c1c645555b42293cba891fdb \
+                    sha256  8eb7d8d571457c87bd8013e4db61f709f0e0076f6d145baf4acd00ad576acf34 \
+                    size    48721534
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 278.0.0.

###### Tested on

macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?