### PR TITLE
ld64-latest: build 450.3

### DIFF
--- a/devel/ld64/Portfile
+++ b/devel/ld64/Portfile
@@ -6,8 +6,8 @@ PortGroup               compiler_blacklist_versions 1.0
 name                    ld64
 epoch                   2
 version                 3
-revision                1
-set dyld_version        421.2
+revision                2
+set dyld_version        655.1.1
 categories              devel
 platforms               darwin
 maintainers             {jeremyhu @jeremyhu} {kencu @kencu}
@@ -20,9 +20,9 @@ description             ld64 is the new mach-o linker
 long_description        ld64 combines several object files and libraries, \
                         resolves references, and produces an ouput file.
 
-checksums           dyld-421.2.tar.gz \
-                    rmd160  8985a77c70b6018f456634f89142670834489a4d \
-                    sha256  e922c4e78af8f7af14dd158f1db986f8eb260403e7a0dc67fa35279d2cfdceb7 \
+checksums           dyld-655.1.1.tar.gz \
+                    rmd160  eef3ce30381e5fa23152c637e3bde2d8cf4cde0b \
+                    sha256  8ca6e3cf0263d3f69dfa65e0846e2bed051b0cff92e796352ad178e7e4c92f1d \
                     ld64-97-standalone-libunwind-headers.patch \
                     rmd160  f6da71e097aa61b1055b3fdc12cd39aafed5f492 \
                     sha256  370d02757ea628b5dd145c099e42fc4eb88cc09cf459a59e32d14bbc9b4a105e \
@@ -37,8 +37,11 @@ checksums           dyld-421.2.tar.gz \
                     sha256  8ef36729b643201081ab45ebd8586ede8f9968bc17614b679a940faa82875ca6 \
                     ld64-274.2.tar.gz \
                     rmd160  16e57faf2b1d3f3808fb8e4b167cf23a14f106b0 \
-                    sha256  175d89c419e99d49a7a5f7e4196d3cef4c9e19cc17a425c332e86df6b516f7d7
-
+                    sha256  175d89c419e99d49a7a5f7e4196d3cef4c9e19cc17a425c332e86df6b516f7d7 \
+                    ld64-450.3.tar.gz \
+                    rmd160  4d263cff143228e021c438d3c2d1800ff367c895 \
+                    sha256  140619e676e099581771dbad98277850ff731cd23938bed95b4d7171616acca1 \
+                    size    729639
 
 subport ld64-97 {
     # Xcode 3.2.6
@@ -48,6 +51,7 @@ subport ld64-97 {
     set makefile        "Makefile-97"
     set ld64_ver        97
 
+    # the fallbacks on all current systems (10.6+ at least) are not set up to build this
     compiler.blacklist-append *clang*
 
     patchfiles-append \
@@ -75,6 +79,9 @@ subport ld64-127 {
     # This was the last ld64 release that supported linking ppc executables.
     version             127.2
     revision            14
+
+    # multiple errors with macports clang versions newer than 3.7
+    compiler.blacklist-append {macports-clang-[5-9].0} macports-clang-devel
 
     set makefile        "Makefile-127"
     set ld64_ver        127
@@ -111,6 +118,9 @@ subport ld64-236 {
     # < 100 is a guess.  Xcode 4.1 might work, so I'm leaving it as an option unless someone reports a failure.
     compiler.blacklist-append *gcc* {clang < 100}
 
+    # multiple errors with macports clang versions newer than 5.0
+    compiler.blacklist-append {macports-clang-[6-9].0} macports-clang-devel
+
     set makefile        "Makefile-133"
     set ld64_ver        236
 
@@ -138,17 +148,17 @@ subport ld64-236 {
     }
 }
 
-subport ld64-latest {
+subport ld64-274 {
     # Xcode 8.2.1
     version             274.2
-    revision            2
+    revision            0
 
     # https://trac.macports.org/ticket/43737
     # https://trac.macports.org/ticket/50130
     compiler.blacklist-append *gcc* {clang < 300}
 
     set makefile        "Makefile-274"
-    set ld64_ver        latest
+    set ld64_ver        274
 
     patchfiles-append \
         ld64-version.patch \
@@ -171,6 +181,43 @@ subport ld64-latest {
     supported_archs i386 x86_64
 }
 
+subport ld64-latest {
+    # Xcode 10.2
+    version 450.3
+    set makefile        "Makefile-450"
+
+    revision            0
+
+    # https://trac.macports.org/ticket/43737
+    # https://trac.macports.org/ticket/50130
+    # clang 700.1.81 (10.10) fails with error: use of undeclared identifier '__builtin_mul_overflow'
+    compiler.blacklist-append *gcc* {clang < 701}
+
+    set ld64_ver        latest
+
+    patchfiles-append \
+        ld64-version.patch \
+        ld64-133-no-CrashReporterClient.h.patch \
+        ld64-136-i386-badAddress.patch \
+        ld64-ppc-9610466.patch \
+        ld64-409-snapshot-no-mkpath-np.diff \
+        ld64-409-lto-file-llvm-3.4-fix.diff \
+        ld64-409-Options-strndup.diff \
+        ld64-409-add-missing-machine-defs.diff \
+        ld64-409-options-disable-i386-warning.diff \
+        ld64-450-move-baseplatform-def-to-header.diff \
+
+    depends_lib-append port:libcxx port:libtapi
+    configure.cxx_stdlib libc++
+    configure.cxxflags-append -std=c++11
+
+    # silence some warnings
+    configure.cxxflags-append -Wno-deprecated-declarations
+    configure.cxxflags-append -Wno-parentheses-equality
+
+    supported_archs i386 x86_64
+}
+
 subport ld64-xcode {
     version             2
 }
@@ -184,21 +231,27 @@ if {${subport} eq ${name}} {
     # avoid cyclic macports-clang dep on 10.6/libc++
     configure.cxx_stdlib
 
-    variant ld64_97 conflicts ld64_127 ld64_236 ld64_xcode description {Use ld64-97 as the default linker (last version that works on Tiger)} {}
-    variant ld64_127 conflicts ld64_97 ld64_236 ld64_xcode description {Use ld64-127 as the default linker (last version that supports ppc and works on Leopard)} {}
-    variant ld64_236 conflicts ld64_97 ld64_127 ld64_xcode description {Use ld64-236 as the default linker (last version that builds against OS X's libstdc++)} {}
-    variant ld64_xcode conflicts ld64_97 ld64_127 ld64_236 description {Use ld64-xcode as the default linker (version provided by the selected Xcode.app toolchain)} {}
+    variant ld64_97 conflicts ld64_127 ld64_236 ld64_274 ld64_xcode description {Use ld64-97 as the default linker (last version that works on Tiger)} {}
+    variant ld64_127 conflicts ld64_97 ld64_236 ld64_274 ld64_xcode description {Use ld64-127 as the default linker (last version that supports ppc and works on Leopard)} {}
+    variant ld64_236 conflicts ld64_97 ld64_127 ld64_274 ld64_xcode description {Use ld64-236 as the default linker (last version that builds against OS X's libstdc++)} {}
+    variant ld64_274 conflicts ld64_97 ld64_127 ld64_236 ld64_xcode description {Use ld64-274 as the default linker (last version that builds without libtapi support)} {}
+    variant ld64_xcode conflicts ld64_97 ld64_127 ld64_236 ld64_274 description {Use ld64-xcode as the default linker (version provided by the selected Xcode.app toolchain)} {}
 
-    if {![variant_isset ld64_97] && ![variant_isset ld64_127]} {
+    if {![variant_isset ld64_97] && ![variant_isset ld64_127] && ![variant_isset ld64_236] && ![variant_isset ld64_274] && ![variant_isset ld64_xcode]} {
         if {${os.major} < 9} {
             default_variants +ld64_97
         } elseif {${os.major} < 11} {
+            # os versions < 11 can't build newer ld64 versions with their stock xcode compilers
+            # so need to call in clang-9.0 and that has a runtime dep on ld64 (circular)
             default_variants +ld64_127
+         } elseif {${os.major} < 16} {
+            # os versions < 16 can't build libtapi or newer ld64 versions with their stock xcode compilers
+            # so need to call in clang-9.0 and that has a runtime dep on ld64 (circular)
+            default_variants +ld64_274
         }
     }
 
-    if {[vercmp $xcodeversion 9.0] >= 0} {
-        # only ld64_xcode speaks tapi at present
+    if {[vercmp $xcodeversion 11.0] >= 0} {
         default_variants +ld64_xcode
     }
 
@@ -208,6 +261,8 @@ if {${subport} eq ${name}} {
         set ld64_ver 127
     } elseif {[variant_isset ld64_236]} {
         set ld64_ver 236
+    } elseif {[variant_isset ld64_274]} {
+        set ld64_ver 274
     } elseif {[variant_isset ld64_xcode]} {
         set ld64_ver xcode
     } else {
@@ -369,7 +424,8 @@ if {${subport} eq ${name}} {
             }
         }
 
-        system "cd ${workpath}/dyld-${dyld_version} && patch -p0 < ${filespath}/dyld-421-no-blocks.patch"
+        # what is in this patch might be done as reinplaces, as above.
+        system "cd ${workpath}/dyld-${dyld_version} && patch -p0 < ${filespath}/dyld-655-availability.diff"
     }
 
     configure {
@@ -424,7 +480,18 @@ if {${subport} eq ${name}} {
         file rename ${destroot}${prefix}/bin/rebase ${destroot}${prefix}/bin/rebase-${ld64_ver}
         file rename ${destroot}${prefix}/bin/unwinddump ${destroot}${prefix}/bin/unwinddump-${ld64_ver}
 
-        delete {*}[glob ${destroot}${prefix}/share/man/man1/*]
+        # we can only install one set of man pages from one subport without file collisions
+        # so install only the latest man pages, good for most installations
+        if {![string match ${subport} "${name}-latest"]} {
+            delete {*}[glob ${destroot}${prefix}/share/man/man1/*]
+        }
+
+        # this is not presently working as we need to account for the name.1 -> name-${ld64_ver}.1 syntax
+        #       fs-traverse path ${destroot}${prefix}/share/man/man1 {
+        #           if {[file isfile ${path}]} {
+        #               file rename ${path} ${path}-${ld64_ver}
+        #           }
+        #       }
 
         if {${llvm_version} != ""} {
             system "install_name_tool -change ${prefix}/libexec/llvm-${llvm_version}/lib/libLTO.dylib \
@@ -433,6 +500,27 @@ if {${subport} eq ${name}} {
                     @executable_path/../lib/libLTO.dylib ${destroot}${prefix}/libexec/ld64/ld-${ld64_ver}"
         }
     }
+}
+
+# this should be in base
+if {"${configure.sdkroot}" eq ""} {
+    configure.sdkroot "/"
+}
+
+# for a universal build, we need to run the tests for each arch and clean between
+if {![variant_isset universal]} {
+    test.run     yes
+    test.dir     ${workpath}/ld64-${version}/unit-tests/test-cases
+    test.cmd     perl ../bin/make-recursive.pl \
+                 CXX="${configure.cxx} -arch ${configure.build_arch}"  \
+                 CC="${configure.cc} -arch ${configure.build_arch}" \
+                 BUILT_PRODUCTS_DIR="${workpath}/ld64-${version}" \
+                 LD_SYSROOT="${configure.sdkroot}" \
+                 LD="${workpath}/ld64-${version}/ld" \
+                 OSX_SDK="${configure.sdkroot}" \
+                 ARCH="${configure.build_arch}" \
+                 | perl ../bin/result-filter.pl
+    test.target
 }
 
 livecheck.type          none

--- a/devel/ld64/files/Makefile-450
+++ b/devel/ld64/files/Makefile-450
@@ -1,0 +1,107 @@
+ifdef LLVM_CONFIG
+LLVM_CPPFLAGS := -I$(shell $(LLVM_CONFIG) --includedir) -DLTO_SUPPORT
+LLVM_LDFLAGS := -L$(shell $(LLVM_CONFIG) --libdir) -Wl,-rpath,$(shell $(LLVM_CONFIG) --libdir) -lLTO
+endif
+
+CPPFLAGS = $(LLVM_CPPFLAGS) -Isrc/abstraction -Isrc/ld -Isrc/ld/parsers $(OTHER_CPPFLAGS)
+CFLAGS = -Os $(OTHER_CFLAGS)
+CXXFLAGS = -Os $(OTHER_CXXFLAGS)
+LDFLAGS = $(OTHER_LDFLAGS)
+
+ifndef RANLIB
+RANLIB = ranlib
+endif
+ifndef AR
+AR = ar
+endif
+ifndef PREFIX
+PREFIX = /usr
+endif
+
+# libprunetrie.a
+all : src/ld/configure.h ObjectDump dyldinfo ld machocheck rebase unwinddump
+
+src/ld/Snapshot.o : src/ld/compile_stubs.h
+src/ld/compile_stubs.h : compile_stubs
+	echo "static const char *compile_stubs = " > $@
+	cat $^ | sed s/\"/\\\\\"/g | sed s/^/\"/ | sed s/$$/\\\\n\"/ >> $@
+	echo ";" >> $@
+
+src/ld/configure.h : src/create_configure
+	DERIVED_SOURCES_DIR=src/ld DERIVED_FILE_DIR=src/ld $^ > $@
+
+ObjectDump : src/ld/debugline.o
+ObjectDump : src/ld/parsers/macho_relocatable_file.o
+ObjectDump : src/ld/parsers/lto_file.o
+ObjectDump : src/other/ObjectDump.o
+	$(CXX) $(LLVM_LDFLAGS) $(LDFLAGS) $^ -o $@
+
+dyldinfo : src/other/dyldinfo.o
+	$(CXX) $(LDFLAGS) -Wl,-exported_symbol,__mh_execute_header $^ -o $@
+
+ld : src/ld/debugline.o
+ld : src/ld/ld.o
+ld : src/ld/InputFiles.o
+ld : src/ld/Options.o
+ld : src/ld/OutputFile.o
+ld : src/ld/Resolver.o
+ld : src/ld/Snapshot.o
+ld : src/ld/SymbolTable.o
+ld : src/ld/parsers/archive_file.o
+ld : src/ld/parsers/lto_file.o
+ld : src/ld/parsers/macho_dylib_file.o
+ld : src/ld/parsers/macho_relocatable_file.o
+ld : src/ld/parsers/opaque_section_file.o
+ld : src/ld/parsers/textstub_dylib_file.o
+ld : src/ld/passes/bitcode_bundle.o
+ld : src/ld/passes/branch_island.o
+ld : src/ld/passes/branch_shim.o
+ld : src/ld/passes/code_dedup.o
+ld : src/ld/passes/compact_unwind.o
+ld : src/ld/passes/dtrace_dof.o
+ld : src/ld/passes/dylibs.o
+ld : src/ld/passes/got.o
+ld : src/ld/passes/huge.o
+ld : src/ld/passes/objc.o
+ld : src/ld/passes/order.o
+ld : src/ld/passes/tlvp.o
+ld : src/ld/passes/stubs/stubs.o
+ld : src/ld/passes/thread_starts.o
+	$(CXX) $(LLVM_LDFLAGS) $(LDFLAGS) $(OTHER_LDFLAGS_LD64) -Wl,-exported_symbol,__mh_execute_header $^ -lxar -ltapi -o $@
+
+machocheck : src/other/machochecker.o
+	$(CXX) $(LDFLAGS) $^ -o $@
+
+rebase : src/other/rebase.o
+	$(CXX) $(LDFLAGS) -Wl,-exported_symbol,__mh_execute_header $^ -o $@
+
+unwinddump : src/other/unwinddump.o
+	$(CXX) $(LDFLAGS) -Wl,-exported_symbol,__mh_execute_header $^ -o $@
+
+src/other/PruneTrie.o : src/ld/configure.h
+libprunetrie.a : src/other/PruneTrie.o
+	$(AR) cru $@ $^
+	$(RANLIB) $@
+
+install : all
+	install -d -m 755 $(DESTDIR)$(PREFIX)/bin
+	install -d -m 755 $(DESTDIR)$(PREFIX)/lib
+	install -d -m 755 $(DESTDIR)$(PREFIX)/include/mach-o
+	install -d -m 755 $(DESTDIR)$(PREFIX)/share/man/man1
+
+	install -m 755 ObjectDump $(DESTDIR)$(PREFIX)/bin
+	install -m 755 dyldinfo   $(DESTDIR)$(PREFIX)/bin
+	install -m 755 ld         $(DESTDIR)$(PREFIX)/bin
+	install -m 755 machocheck $(DESTDIR)$(PREFIX)/bin
+	install -m 755 rebase     $(DESTDIR)$(PREFIX)/bin
+	install -m 755 unwinddump $(DESTDIR)$(PREFIX)/bin
+
+	#install -m 644 src/other/prune_trie.h $(DESTDIR)$(PREFIX)/include/mach-o
+	#install -m 644 libprunetrie.a $(DESTDIR)$(PREFIX)/lib
+
+	install -m 644 doc/man/man1/dyldinfo.1   $(DESTDIR)$(PREFIX)/share/man/man1
+	install -m 644 doc/man/man1/ld.1         $(DESTDIR)$(PREFIX)/share/man/man1
+	install -m 644 doc/man/man1/ld64.1       $(DESTDIR)$(PREFIX)/share/man/man1
+	install -m 644 doc/man/man1/rebase.1     $(DESTDIR)$(PREFIX)/share/man/man1
+	install -m 644 doc/man/man1/unwinddump.1 $(DESTDIR)$(PREFIX)/share/man/man1
+

--- a/devel/ld64/files/dyld-655-availability.diff
+++ b/devel/ld64/files/dyld-655-availability.diff
@@ -1,0 +1,27 @@
+--- include/mach-o/dyld.h.orig	2020-01-26 11:37:27.000000000 -0800
++++ include/mach-o/dyld.h	2020-01-26 11:37:39.000000000 -0800
+@@ -35,6 +35,24 @@
+ extern "C" {
+ #endif 
+ 
++
++#undef __OSX_AVAILABLE_STARTING
++#define __OSX_AVAILABLE_STARTING(...)
++#undef __OSX_AVAILABLE_BUT_DEPRECATED
++#define __OSX_AVAILABLE_BUT_DEPRECATED(...)
++#undef __OSX_AVAILABLE_BUT_DEPRECATED_MSG
++#define __OSX_AVAILABLE_BUT_DEPRECATED_MSG(...)
++#undef __API_AVAILABLE
++#define __API_AVAILABLE(...)
++#undef __API_UNAVAILABLE
++#define __API_UNAVAILABLE(...)
++#undef __OSX_DEPRECATED
++#define __OSX_DEPRECATED(...)
++
++#ifndef AVAILABLE_MAC_OS_X_VERSION_10_10_AND_LATER
++# define AVAILABLE_MAC_OS_X_VERSION_10_10_AND_LATER  __attribute__((unavailable))
++#endif
++
+ /*
+  * The following functions allow you to iterate through all loaded images.  
+  * This is not a thread safe operation.  Another thread can add or remove

--- a/devel/ld64/files/ld64-409-Options-strndup.diff
+++ b/devel/ld64/files/ld64-409-Options-strndup.diff
@@ -1,0 +1,37 @@
+diff --git src/ld/Options.cpp.orig src/ld/Options.cpp
+index 3fea3a0..63a9919 100644
+--- src/ld/Options.cpp.orig
++++ src/ld/Options.cpp
+@@ -49,6 +49,32 @@
+ // from FunctionNameDemangle.h
+ extern "C" size_t fnd_get_demangled_name(const char *mangledName, char *outputBuffer, size_t length);
+ 
++#ifndef strnlen
++size_t
++strnlen (const char *s, size_t len)
++{
++    size_t i;
++
++    for(i = 0; i < len && s[i]; i++)
++        ;
++    return i;
++}
++#endif
++
++#ifndef strndup
++char *
++strndup (const char *old, size_t sz)
++{
++  size_t len = strnlen (old, sz);
++  char *t    = (char *)malloc(len + 1);
++
++  if (t != NULL) {
++    memcpy (t, old, len);
++    t[len] = '\0';
++  }
++  return t;
++}
++#endif
+ 
+ // upward dependency on lto::version()
+ namespace lto {

--- a/devel/ld64/files/ld64-409-add-missing-machine-defs.diff
+++ b/devel/ld64/files/ld64-409-add-missing-machine-defs.diff
@@ -1,0 +1,23 @@
+diff --git src/ld/Options.h src/ld/Options.h
+index 67ac22e..0788980 100644
+--- src/ld/Options.h
++++ src/ld/Options.h
+@@ -38,6 +38,18 @@
+ #include "Snapshot.h"
+ #include "MachOFileAbstraction.hpp"
+ 
++#ifndef CPU_SUBTYPE_ARM64_E
++# define CPU_SUBTYPE_ARM64_E    2
++#endif
++
++#ifndef CPU_ARCH_ABI64_32
++# define CPU_ARCH_ABI64_32	0x2000000
++#endif
++
++#ifndef CPU_TYPE_ARM64_32
++#  define CPU_TYPE_ARM64_32                               ((cpu_type_t) (CPU_TYPE_ARM | CPU_ARCH_ABI64_32))
++#endif
++
+ 
+ extern void throwf (const char* format, ...) __attribute__ ((noreturn,format(printf, 1, 2)));
+ extern void warning(const char* format, ...) __attribute__((format(printf, 1, 2)));

--- a/devel/ld64/files/ld64-409-lto-file-llvm-3.4-fix.diff
+++ b/devel/ld64/files/ld64-409-lto-file-llvm-3.4-fix.diff
@@ -1,0 +1,14 @@
+--- ./src/ld/parsers/lto_file.cpp.orig	2020-01-26 12:28:10.000000000 -0800
++++ ./src/ld/parsers/lto_file.cpp	2020-01-26 12:28:38.000000000 -0800
+@@ -1681,7 +1681,11 @@
+ //
+ unsigned int runtime_api_version()
+ {
++#if LTO_API_VERSION >= 17
+ 	return ::lto_api_version();
++#else
++	return LTO_API_VERSION;
++#endif
+ }
+ 
+ 

--- a/devel/ld64/files/ld64-409-options-disable-i386-warning.diff
+++ b/devel/ld64/files/ld64-409-options-disable-i386-warning.diff
@@ -1,0 +1,15 @@
+--- src/ld/Options.cpp.orig	2020-01-28 09:10:14.000000000 -0800
++++ src/ld/Options.cpp	2020-01-28 09:15:46.000000000 -0800
+@@ -5897,8 +5897,10 @@
+ 				break;
+ 			}
+ 		}
+-		if ( !internalSDK )
+-			warning("The i386 architecture is deprecated for macOS (remove from the Xcode build setting: ARCHS)");
++// this warning generates unnecessary errors in configure stages -- disable for MacPorts as we
++// intend to use this linker on older systems where i386 is still used
++//		if ( !internalSDK )
++//			warning("The i386 architecture is deprecated for macOS (remove from the Xcode build setting: ARCHS)");
+ 	}
+ }
+ 

--- a/devel/ld64/files/ld64-409-snapshot-no-mkpath-np.diff
+++ b/devel/ld64/files/ld64-409-snapshot-no-mkpath-np.diff
@@ -1,0 +1,169 @@
+--- ./src/ld/Snapshot.cpp.orig	2020-01-26 11:39:26.000000000 -0800
++++ ./src/ld/Snapshot.cpp	2020-01-26 11:40:12.000000000 -0800
+@@ -23,6 +23,166 @@
+ 
+ #include "compile_stubs.h"
+ 
++int
++_mkpath_np(const char *path, mode_t omode, const char ** firstdir)
++{
++	char *apath = NULL;
++	unsigned int depth = 0;
++	mode_t chmod_mode = 0;
++	int retval = 0;
++	int old_errno = errno;
++	struct stat sbuf;
++
++	/* Try the trivial case first. */
++	if (0 == mkdir(path, omode)) {
++		if (firstdir) {
++			*firstdir = strdup(path);
++		}
++		goto mkpath_exit;
++	}
++
++	/* Anything other than an ENOENT, EEXIST, or EISDIR indicates an
++	 * error that we need to send back to the caller.  ENOENT indicates
++	 * that we need to try a lower level.
++	 */
++	switch (errno) {
++		case ENOENT:
++			break;
++		case EEXIST:
++			if (stat(path, &sbuf) == 0) {
++			    if (S_ISDIR(sbuf.st_mode)) {
++					retval = EEXIST;
++				} else {
++					retval = ENOTDIR;
++				}
++			} else {
++				retval = EIO;
++			}
++			goto mkpath_exit;
++		case EISDIR: /* <rdar://problem/10288022> */
++			retval = EEXIST;
++			goto mkpath_exit;
++		default:
++			retval = errno;
++			goto mkpath_exit;
++	}
++
++	apath = strdup(path);
++	if (apath == NULL) {
++		retval = ENOMEM;
++		goto mkpath_exit;
++	}
++
++	while (1) {
++		/* Increase our depth and try making that directory */
++		char *s = strrchr(apath, '/');
++		if (!s) {
++			/* We should never hit this under normal circumstances,
++			 * but it can occur due to really unfortunate timing
++			 */
++			retval = ENOENT;
++			goto mkpath_exit;
++		}
++		*s = '\0';
++		depth++;
++
++		if (0 == mkdir(apath, S_IRWXU | S_IRWXG | S_IRWXO)) {
++			/* Found our starting point */
++
++			/* POSIX 1003.2:
++			 * For each dir operand that does not name an existing
++			 * directory, effects equivalent to those cased by the
++			 * following command shall occcur:
++			 *
++			 * mkdir -p -m $(umask -S),u+wx $(dirname dir) &&
++			 *    mkdir [-m mode] dir
++			 */
++
++			struct stat dirstat;
++			if (-1 == stat(apath, &dirstat)) {
++				/* Really unfortunate timing ... */
++				retval = ENOENT;
++				goto mkpath_exit;
++			}
++
++			if ((dirstat.st_mode & (S_IWUSR | S_IXUSR)) != (S_IWUSR | S_IXUSR)) {
++			        chmod_mode = dirstat.st_mode | S_IWUSR | S_IXUSR;
++				if (-1 == chmod(apath, chmod_mode)) {
++					/* Really unfortunate timing ... */
++					retval = ENOENT;
++					goto mkpath_exit;
++				}
++			}
++
++			if (firstdir) {
++				*firstdir = strdup(apath);
++			}
++			break;
++		} else if (errno == EEXIST) {
++			/* Some other process won the race in creating this directory
++			 * before we did.  We will use this as our starting point.
++			 * See: <rdar://problem/10279893>
++			 */
++			if (stat(apath, &sbuf) == 0 &&
++			    S_ISDIR(sbuf.st_mode)) {
++
++				if (firstdir) {
++					*firstdir = strdup(apath);
++				}
++				break;
++			}
++
++			retval = ENOTDIR;
++			goto mkpath_exit;
++		} else if (errno != ENOENT) {
++			retval = errno;
++			goto mkpath_exit;
++		}
++	}
++
++	while (depth > 1) {
++		/* Decrease our depth and make that directory */
++		char *s = strrchr(apath, '\0');
++		*s = '/';
++		depth--;
++
++		if (-1 == mkdir(apath, S_IRWXU | S_IRWXG | S_IRWXO)) {
++			/* This handles "." and ".." added to the new section of path */
++			if (errno == EEXIST)
++				continue;
++			retval = errno;
++			goto mkpath_exit;
++		}
++
++		if (chmod_mode) {
++			if (-1 == chmod(apath, chmod_mode)) {
++				/* Really unfortunate timing ... */
++				retval = ENOENT;
++				goto mkpath_exit;
++			}
++		}
++	}
++
++	if (-1 == mkdir(path, omode)) {
++		retval = errno;
++		if (errno == EEXIST &&
++		    stat(path, &sbuf) == 0 &&
++		    !S_ISDIR(sbuf.st_mode)) {
++			retval = ENOTDIR;
++		}
++	}
++
++mkpath_exit:
++	free(apath);
++
++	errno = old_errno;
++	return retval;
++}
++
++int mkpath_np(const char *path, mode_t omode) {
++	return _mkpath_np(path, omode, NULL);
++}
++
+ //#define STORE_PID_IN_SNAPSHOT 1
+ 
+ // Well known snapshot file/directory names. These appear in the root of the snapshot.

--- a/devel/ld64/files/ld64-450-move-baseplatform-def-to-header.diff
+++ b/devel/ld64/files/ld64-450-move-baseplatform-def-to-header.diff
@@ -1,0 +1,50 @@
+diff --git src/ld/ld.cpp src/ld/ld.cpp
+index 763bbd6..87c58a5 100644
+--- src/ld/ld.cpp
++++ src/ld/ld.cpp
+@@ -89,20 +89,6 @@ extern "C" double log2 ( double );
+ #include "parsers/lto_file.h"
+ #include "parsers/opaque_section_file.h"
+ 
+-const ld::Platform ld::basePlatform(const ld::Platform& platform)  {
+-	switch(platform) {
+-		case ld::kPlatform_iOSMac:
+-		case ld::kPlatform_iOSSimulator:
+-			return ld::kPlatform_iOS;
+-		case ld::kPlatform_watchOSSimulator:
+-			return kPlatform_watchOS;
+-		case ld::kPlatform_tvOSSimulator:
+-			return ld::kPlatform_tvOS;
+-		default:
+-			return platform;
+-	}
+-}
+-
+ const ld::VersionSet ld::File::_platforms;
+ 
+ struct PerformanceStatistics {
+diff --git src/ld/ld.hpp src/ld/ld.hpp
+index c8bf3f6..83bd5cf 100644
+--- src/ld/ld.hpp
++++ src/ld/ld.hpp
+@@ -58,6 +58,20 @@ enum Platform {
+ 	kPlatform_watchOSSimulator=9
+ };
+ 
++static const Platform basePlatform(const ld::Platform& platform)  {
++	switch(platform) {
++		case ld::kPlatform_iOSMac:
++		case ld::kPlatform_iOSSimulator:
++			return ld::kPlatform_iOS;
++		case ld::kPlatform_watchOSSimulator:
++			return kPlatform_watchOS;
++		case ld::kPlatform_tvOSSimulator:
++			return ld::kPlatform_tvOS;
++		default:
++			return platform;
++	}
++}
++
+ const ld::Platform basePlatform(const ld::Platform& platform);
+ 
+ typedef std::set<Platform> PlatformSet;


### PR DESCRIPTION
* add man pages if ld64-latest is installed
* add build fixes for older systems
* clarify compiler blacklisting for some older ld64 versions

closes: https://trac.macports.org/ticket/57587
closes: https://trac.macports.org/ticket/53784

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
most systems macOS 10.4 to 10.14
Xcode 2.5 to 11

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
