### PR TITLE
py-twine: update to 3.1.1

### DIFF
--- a/python/py-twine/Portfile
+++ b/python/py-twine/Portfile
@@ -2,30 +2,47 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
-PortGroup           github 1.0
-
-github.setup        pypa twine 1.12.2
 
 name                py-twine
+version             3.1.1
 platforms           darwin
 supported_archs     noarch
 license             apache
 maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
 
+homepage            https://twine.readthedocs.io
 description         Twine is a utility for interacting with PyPI.
 long_description    ${description}
 
-checksums           rmd160  5d86babb0456740a5f3fed5904e049d6ea7b0f00 \
-                    sha256  2bbef0372c9b0d5011560f4e1d09c7f78a09f004ef7adc2548fc69d0ddeaf344 \
-                    size    62716
+checksums           rmd160  b2687dcbae3d817251d3ced75eb8564f9a0d886a \
+                    sha256  d561a5e511f70275e5a485a6275ff61851c16ffcb3a95a602189161112d9f160 \
+                    size    146258
 
-python.versions     27 36 37
+python.versions     27 36 37 38
 
 if {${name} ne ${subport}} {
-    depends_build-append    port:py${python.version}-setuptools
+    if {${python.version} < 36} {
+        version     1.15.0
+
+        checksums   rmd160  32f9a8e1acd7f03011b3703687e2e9aa7eea1fb0 \
+                    sha256  a3d22aab467b4682a22de4a422632e79d07eebd07ff2a7079effb13f8a693787 \
+                    size    139576
+    } elseif {${python.version} < 38} {
+        depends_run-append \
+            port:py${python.version}-importlib-metadata
+    }
+
+    if {${python.version} >= 36} {
+        depends_build-append \
+            port:py${python.version}-setuptools_scm
+    }
+
+    depends_build-append \
+        port:py${python.version}-setuptools
     depends_run-append \
         port:py${python.version}-readme_renderer \
         port:py${python.version}-requests-toolbelt \
         port:py${python.version}-tqdm \
         port:py${python.version}-pkginfo
+
 }


### PR DESCRIPTION
#### Description

Update py-twine to 3.1.1.

* Drop support for Python 2.7, which is no longer supported upstream.
* Add support for Python 3.8.
* Switch fetch type to git. Since upstream uses setuptools_scm,
  the tarballs produced by GitHub are not supported; only git clones
  and PyPI tarballs are supported.
* Update runtime dependencies.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.2 19C57
Xcode 11.3.1 11C504 