### PR TITLE
group/perl5-1.0.tcl: blacklist compilers that depend on perl5

### DIFF
--- a/_resources/port1.0/group/perl5-1.0.tcl
+++ b/_resources/port1.0/group/perl5-1.0.tcl
@@ -8,6 +8,17 @@
 options perl5.default_branch perl5.branches
 default perl5.default_branch {[perl5_get_default_branch]}
 
+# blacklist compilers that depend on perl5 to avoid circular dependencies
+# applies to perl5 and subports as well as compiled perl modules and apps so they agree on compiler selection
+
+# PortGroup blacklists clang 5.0 and later
+PortGroup clang_dependency 1.0
+
+if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {
+    # perl5 is also in the dependency chain for clang 3.7
+    clang_dependency.extra_versions 3.7
+}
+
 proc perl5_get_default_branch {} {
     global prefix perl5.branches
     # use whatever ${prefix}/bin/perl5 was chosen, and if none, fall back to 5.28

--- a/lang/perl5/Portfile
+++ b/lang/perl5/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem          1.0
 PortGroup           perl5 1.0
-PortGroup           clang_dependency 1.0
 
 name                perl5
 version             5.26.1
@@ -52,11 +51,6 @@ foreach {perl5.v perl5.subversion perl5.revision perl5.rmd160 perl5.sha256 perl5
         depends_lib-append  port:db48 \
                             port:gdbm
 
-        if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {
-            # This port is in the dependency chain for clang 3.7 and later
-            clang_dependency.extra_versions 3.7
-        }
-
         # https://trac.macports.org/ticket/59207
         platform darwin 19 {
             use_parallel_build  no
@@ -77,7 +71,6 @@ foreach {perl5.v perl5.subversion perl5.revision perl5.rmd160 perl5.sha256 perl5
         # Use correct location of db48 (Berkeley Data Base library)
         # https://trac.macports.org/ticket/55207
         patchfiles-append   ${perl5.major}/fix-db_file-paths.patch
-
 
         # - Prevent build from picking up the bind9 port's static libbind, which
         #   duplicates symbols from /usr/lib/libdl (r10638).


### PR DESCRIPTION
Avoids circular dependencies when building perl5 subports on 10.6 and earlier.

Moved here from perl5 so that compiler selection will be consistent across perl libraries
and compiled apps and modules that reference this PortGroup.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.2 19C57
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
