### PR TITLE
macos-fortress: rename hosts-hphosts filename path

### DIFF
--- a/net/macos-fortress/Portfile
+++ b/net/macos-fortress/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                macos-fortress
-version             2019.12.15
+version             2020.01.31
 revision            0
 
 categories          net security

--- a/net/macos-fortress/files/macosfortress_setup_check.sh
+++ b/net/macos-fortress/files/macosfortress_setup_check.sh
@@ -174,7 +174,7 @@ Checking @PREFIX@/etc/@NAME@/hosts-hphosts creation…
 EOF
 
 # pfctl
-if [ -f /etc/hosts-hphosts ]; then
+if [ -f @PREFIX@/etc/@NAME@/hosts-hphosts ]; then
     echo "[✅] @PREFIX@/etc/@NAME@/hosts-hphosts exists"
 else
     "${CAT}" <<EOF


### PR DESCRIPTION
#### Description
<!-- Note: it is best to make pull requests from a branch rather than from master -->

IMHO instead of `/etc/hosts-hphosts` it should be `@PREFIX@/etc/@NAME@/hosts-hphosts`

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
