### PR TITLE
broot: update to 0.12.2

### DIFF
--- a/sysutils/broot/Portfile
+++ b/sysutils/broot/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        Canop broot 0.12.1 v
+github.setup        Canop broot 0.12.2 v
 categories          sysutils
 platforms           darwin
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
@@ -20,9 +20,9 @@ long_description    broot is a new way to see and navigate directory trees. \
                     via regular expressions, and more.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  ff2738131b98601668d038139a863b18a6a3c875 \
-                    sha256  3b2549ea97cac8d6c4323ca0b84aa6d555622d26b8fd7951fab0fc797d72309d \
-                    size    1601387
+                    rmd160  ea82b9d6b2bdbb065e4e1b5c99eb830f8a08eb03 \
+                    sha256  f4cb0af5fb6de2ebee44ef9bba56df5cbcc4a99453c29e8d4590b8bc3b5e811d \
+                    size    1601397
 
 destroot {
     xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/${name} ${destroot}${prefix}/bin/
@@ -61,8 +61,8 @@ cargo.crates \
     crossbeam-queue                  0.2.0  dfd6515864a82d2f877b42813d4553292c6659498c9a2aa31bab5a15243c2700 \
     crossbeam-utils                  0.7.0  ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4 \
     crossbeam-utils                  0.6.6  04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6 \
-    crossterm                       0.14.2  5750773d74a7dc612eac2ded3f55e9cdeeaa072210cd17c0192aedb48adb3618 \
-    crossterm_winapi                 0.5.1  8777c700901e2d5b50c406f736ed6b8f9e43645c7e104ddb74f8bc42b8ae62f6 \
+    crossterm                       0.15.0  207a948d1b4ff59e5aec9bb9426cc4fd3d17b719e5c7b74e27f0a60c4cc2d095 \
+    crossterm_winapi                 0.6.1  057b7146d02fb50175fd7dbe5158f6097f33d02831f43b4ee8ae4ddf67b68f5c \
     csv                              1.1.1  37519ccdfd73a75821cac9319d4fce15a81b9fcf75f951df5b9988aa3a0af87d \
     csv-core                         0.1.6  9b5cadb6b25c77aeff80ba701712494213f4a8418fcda2ee11b6560c3ad0bf4c \
     custom_error                     1.7.1  93a0fc65739ae998afc8d68e64bdac2efd1bc4ffa1a0703d171ef2defae3792f \
@@ -92,7 +92,7 @@ cargo.crates \
     memchr                           2.2.1  88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e \
     memoffset                        0.5.2  4a85c1a8c329f11437034d7313dca647c79096523533a1c79e86f1d0f657c7cc \
     minimad                          0.6.3  64d5877afe19e4cfe00810dd338fb208aafe5672316ca31604de92b7218b9fb7 \
-    mio                             0.6.19  83f51996a3ed004ef184e16818edc51fadffe8e7ca68be67f9dee67d84d0ff23 \
+    mio                             0.6.21  302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f \
     miow                             0.2.1  8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919 \
     net2                            0.2.33  42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88 \
     nodrop                          0.1.14  72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb \
@@ -130,7 +130,7 @@ cargo.crates \
     serde                          1.0.102  0c4b39bd9b0b087684013a792c59e3e07a46a01d2322518d8a1104641a0b1be0 \
     serde_derive                   1.0.103  a8c6faef9a2e64b0064f48570289b4bf8823b7581f1d6157c1b52152306651d0 \
     serde_json                      1.0.42  1a3351dcbc1f067e2c92ab7c3c1f288ad1a4cffc470b5aaddb4c2e0a3ae80043 \
-    signal-hook                     0.1.12  7a9c17dd3ba2d36023a5c9472ecddeda07e27fd0b05436e8c1e0c8f178185652 \
+    signal-hook                     0.1.13  10b9f3a1686a29f53cfd91ee5e3db3c12313ec02d33765f02c1a9645a1811e2c \
     signal-hook-registry             1.2.0  94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41 \
     simplelog                        0.7.4  05a3e303ace6adb0a60a9e9e2fbc6a33e1749d1e43587e2125f7efa9c5e107c5 \
     slab                             0.4.2  c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8 \
@@ -139,7 +139,7 @@ cargo.crates \
     syn                              1.0.7  0e7bedb3320d0f3035594b0b723c8a28d7d336a3eda3881db79e61d676fb644c \
     synstructure                    0.12.1  3f085a5855930c0441ca1288cf044ea4aecf4f43a91668abdb870b4ba546a203 \
     term                             0.6.1  c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5 \
-    termimad                        0.8.11  a532cffbcd43ef60faf1e7e375bd2192c2dccf3ebc2a48b1d6fa7f92ac16f26f \
+    termimad                        0.8.12  5fa7167e7faf980ea158947633be776237e54dc22e0c0c82675c575c8c962fdd \
     textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
     thiserror                        1.0.4  9fe148fa0fc3363a27092d48f7787363ded15bb8623c5d5dd4e2e9f23e4b21bc \
     thiserror-impl                   1.0.4  258da67e99e590650fa541ac6be764313d23e80cefb6846b516deb8de6b6d921 \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
