### PR TITLE
nvm: new Portfile

### DIFF
--- a/devel/nvm/Portfile
+++ b/devel/nvm/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        nvm-sh nvm 0.35.2 v
+
+categories          devel
+platforms           darwin
+supported_archs     noarch
+license             MIT
+
+maintainers         {@FranklinYu hotmail.com:franklinyu} openmaintainer
+description         Node version manager
+long_description    NVM is a simple shell script to manage multiple active Node.js versions.
+
+checksums           rmd160  f4e76639c4c52a8855ef93481eee5f5a0e874d3f \
+                    sha256  f1369519f9eb36ffba2393ddb5829844c7c4d941304934282d0f43d39f176f39 \
+                    size    114181
+
+use_configure       no
+
+build {}
+
+destroot {
+    set nvm_dir ${destroot}${prefix}/share/nvm
+    xinstall -d ${nvm_dir}
+    xinstall -m 644 ${worksrcpath}/nvm.sh ${filespath}/init-nvm.sh ${nvm_dir}
+    xinstall ${worksrcpath}/nvm-exec ${nvm_dir}
+    reinplace "s|@NVM_SHARE@|${prefix}/share/nvm|g" ${nvm_dir}/init-nvm.sh
+
+    set completions_dir ${destroot}${prefix}/share/bash-completion/completions
+    xinstall -d ${completions_dir}
+    xinstall ${worksrcpath}/bash_completion ${completions_dir}/nvm
+}

--- a/devel/nvm/files/init-nvm.sh
+++ b/devel/nvm/files/init-nvm.sh
@@ -1,0 +1,7 @@
+[ -z "$NVM_DIR" ] && export NVM_DIR="$HOME/.nvm"
+source @NVM_SHARE@/nvm.sh
+
+# "nvm exec" and certain 3rd party scripts expect "nvm.sh" and "nvm-exec" to exist under $NVM_DIR
+[ -e "$NVM_DIR" ] || mkdir -p "$NVM_DIR"
+[ -e "$NVM_DIR/nvm.sh" ] || ln -s @NVM_SHARE@/nvm.sh "$NVM_DIR/nvm.sh"
+[ -e "$NVM_DIR/nvm-exec" ] || ln -s @NVM_SHARE@/nvm-exec "$NVM_DIR/nvm-exec"


### PR DESCRIPTION
See: https://trac.macports.org/ticket/53038

#### Description

NVM is a Node.js version manager. Actually, it’s arguably the most famous one for Node.js. The port is made with help from https://aur.archlinux.org/packages/nvm/.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?