### PR TITLE
zsh-syntax-highlighting: Remove Zsh dependency

### DIFF
--- a/devel/carthage/Portfile
+++ b/devel/carthage/Portfile
@@ -31,6 +31,10 @@ destroot {
     }
 
     system -W ${worksrcpath} "${build.cmd} prefix_install PREFIX=${destroot}${prefix} CARTHAGE_TEMPORARY_FOLDER=${destroot} SWIFTPM_DISABLE_SANDBOX_SHOULD_BE_FLAGGED=should_be_flagged"
+
+    set site-functions ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -d ${site-functions}
+    xinstall ${worksrcpath}/Source/Scripts/carthage-bash-completion ${site-functions}/_${name}
 }
 
 variant bash_completion {
@@ -40,16 +44,6 @@ variant bash_completion {
         set completions_path ${prefix}/share/bash-completion/completions
         xinstall -d ${destroot}${completions_path}
         xinstall -m 644 ${worksrcpath}/Source/Scripts/carthage-bash-completion ${destroot}${completions_path}/${name}
-    }
-}
-
-variant zsh_completion description {Install zsh completion} {
-    depends_run-append path:${prefix}/bin/zsh:zsh
-
-    post-destroot {
-        set site-functions ${destroot}${prefix}/share/zsh/site-functions
-        xinstall -d ${site-functions}
-        xinstall ${worksrcpath}/Source/Scripts/carthage-bash-completion ${site-functions}/_${name}
     }
 }
 

--- a/devel/docker/Portfile
+++ b/devel/docker/Portfile
@@ -39,6 +39,10 @@ pre-build {
 destroot {
     xinstall -d ${destroot}${prefix}/bin
     xinstall -m 755 ${worksrcpath}/bundles/${version}/${build.target}/${name}-${version} ${destroot}${prefix}/bin/${name}
+
+    set site-functions ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -d ${site-functions}
+    xinstall ${worksrcpath}/contrib/completion/zsh/_${name} ${site-functions}/
 }
 
 variant bash_completion {
@@ -48,16 +52,6 @@ variant bash_completion {
         set completions_path ${prefix}/share/bash-completion/completions
         xinstall -d ${destroot}${completions_path}
         xinstall -m 644 ${worksrcpath}/contrib/completion/bash/${name} ${destroot}${completions_path}/
-    }
-}
-
-variant zsh_completion {
-    depends_run-append path:${prefix}/bin/zsh:zsh
-
-    post-destroot {
-        set site-functions ${destroot}${prefix}/share/zsh/site-functions
-        xinstall -d ${site-functions}
-        xinstall ${worksrcpath}/contrib/completion/zsh/_${name} ${site-functions}/
     }
 }
 

--- a/www/doctl/Portfile
+++ b/www/doctl/Portfile
@@ -17,13 +17,19 @@ maintainers         {@kritr gmail.com:krdevmail} openmaintainer
 description         A command line interface for the DigitalOcean API
 long_description    ${description}
 
-depends_build-append port:git
+depends_build       port:git
 
 build.env-append    GO111MODULE=on
 build.target        ${worksrcpath}/cmd/${name}
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin
+
+    set site-functions ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -d ${site-functions}
+    set completion-file [open ${site-functions}/_${name} "w"]
+    puts ${completion-file} [exec ${destroot}${prefix}/bin/${name} completion zsh]
+    close ${completion-file}
 }
 
 variant bash_completion {
@@ -33,17 +39,6 @@ variant bash_completion {
         xinstall -d ${completions_path}
         set completion-file [open ${completions_path}/${name} "w"]
         puts ${completion-file} [exec ${destroot}${prefix}/bin/${name} completion bash]
-        close ${completion-file}
-    }
-}
-
-variant zsh_completion description {Install zsh completion} {
-    depends_run-append path:${prefix}/bin/zsh:zsh
-    post-destroot {
-        set site-functions ${destroot}${prefix}/share/zsh/site-functions
-        xinstall -d ${site-functions}
-        set completion-file [open ${site-functions}/_${name} "w"]
-        puts ${completion-file} [exec ${destroot}${prefix}/bin/${name} completion zsh]
         close ${completion-file}
     }
 }


### PR DESCRIPTION
#### Description

macOS comes with a Zsh new enough. See discussion under e7f0c99ce6603ccc66cde591fa234fb7703ab8cc.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

I didn’t test a lot, but this should be obvious enough.