### PR TITLE
clang_dependency PG: restort original behaviour

### DIFF
--- a/_resources/port1.0/group/clang_dependency-1.0.tcl
+++ b/_resources/port1.0/group/clang_dependency-1.0.tcl
@@ -8,7 +8,9 @@
 proc clang_dependency.extra_versions {versions} {
     global prefix
     foreach ver $versions {
-        compiler.blacklist-append macports-clang-${ver}
+        if {![file exists ${prefix}/bin/clang-mp-${ver}]} {
+            compiler.blacklist-append macports-clang-${ver}
+        }
     }
 }
 


### PR DESCRIPTION
the previous behaviour was changed in bd34287c99ab9372baca32bb78b8471b94780764
to solve an issue with ICU, it appears, that no longer appears relevant.

This allows a newer compiler to be used to build a number of ports,
rather than forcing clang-3.4 or clang-3.7.

This has the benefit of using newer optomizations, allowing functionality in
some ports, and allowing a more consistent force to the default compiler.

There is some possible loss of reproducible builds to be considered, as during updates of
ports that have the clang_dependency PG, a user building the port could use a
newer compiler than a buildbot bootstrapping from no installed ports.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
