### PR TITLE
Several new Python libraries

### DIFF
--- a/python/py-CacheControl/Portfile
+++ b/python/py-CacheControl/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-CacheControl
+version             0.12.6
+revision            0
+categories-append   devel
+platforms           darwin
+license             Apache-2
+supported_archs     noarch
+
+python.versions     27 34 35 36 37 38
+
+maintainers         {gmail.com:davidgilman1 @dgilman} openmaintainer
+
+description         httplib2 caching for requests
+long_description    CacheControl is a port of the caching algorithms in \
+                    httplib2 for use with requests session object.
+
+homepage            https://github.com/ionrock/cachecontrol
+
+checksums           rmd160  67bcb07c66fed67504390434cce0e02050336f72 \
+                    sha256  be9aa45477a134aee56c8fac518627e1154df063e85f67d4f83ce0ccc23688e8 \
+                    size    14616
+
+if {${name} ne ${subport}} {
+    # Depend on lockfile to enable the "filecache" extra.
+    depends_build-append port:py${python.version}-setuptools
+    depends_lib-append port:py${python.version}-requests \
+                       port:py${python.version}-msgpack \
+                       port:py${python.version}-lockfile
+    livecheck.type      none
+}

--- a/python/py-cachy/Portfile
+++ b/python/py-cachy/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-cachy
+version             0.3.0
+revision            0
+categories-append   devel
+platforms           darwin
+license             MIT
+supported_archs     noarch
+
+python.versions     27 34 35 36 37 38
+
+maintainers         {gmail.com:davidgilman1 @dgilman} openmaintainer
+
+description         Cachy provides a simple yet effective caching library.
+long_description    ${description}
+
+homepage            https://github.com/sdispater/cachy
+
+checksums           rmd160  88f49c70f7e52483733531ddf0f8a2a08bcd9698 \
+                    sha256  186581f4ceb42a0bbe040c407da73c14092379b1e4c0e327fdb72ae4a9b269b1 \
+                    size    15654
+
+post-destroot {
+   # https://github.com/sdispater/cachy/issues/9
+   delete ${destroot}${python.pkgd}/tests
+}
+
+if {${name} ne ${subport}} {
+    depends_build-append port:py${python.version}-setuptools
+
+    livecheck.type       none
+}

--- a/python/py-cleo/Portfile
+++ b/python/py-cleo/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-cleo
+version             0.7.6
+revision            0
+categories-append   devel
+platforms           darwin
+license             MIT
+supported_archs     noarch
+
+python.versions     27 35 36 37 38
+
+maintainers         {gmail.com:davidgilman1 @dgilman} openmaintainer
+
+description         Cleo allows you to create beautiful and testable \
+                    command-line interfaces.
+
+long_description    Create beautiful and testable command-line interfaces. \
+                    \
+                    Cleo is mostly a higher level wrapper for CliKit, so a \
+                    lot of the components and utilities comes from it. \
+                    Refer to its documentation for more information.
+
+homepage            https://github.com/sdispater/cleo
+
+checksums           rmd160  96b2169c88f311ea843942a0963b3a8c3af95b93 \
+                    sha256  99cf342406f3499cec43270fcfaf93c126c5164092eca201dfef0f623360b409 \
+                    size    21835
+
+if {${name} ne ${subport}} {
+    depends_build-append port:py${python.version}-setuptools
+    depends_lib-append   port:py${python.version}-clikit
+
+    livecheck.type       none
+}

--- a/python/py-clikit/Portfile
+++ b/python/py-clikit/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-clikit
+version             0.4.1
+revision            0
+categories-append   devel
+platforms           darwin
+license             MIT
+supported_archs     noarch
+
+python.versions     27 35 36 37 38
+
+maintainers         {gmail.com:davidgilman1 @dgilman} openmaintainer
+
+description         CliKit is a group of utilities to build beautiful and testable \
+                    command line interfaces.
+long_description    ${description}
+
+homepage            https://github.com/sdispater/clikit
+
+checksums           rmd160  7c3448b961cf7ae0e6b1e3e49dfca53cb019dc07 \
+                    sha256  8ae4766b974d7b1983e39d501da9a0aadf118a907a0c9b50714d027c8b59ea81 \
+                    size    51892
+
+if {${name} ne ${subport}} {
+    depends_build-append port:py${python.version}-setuptools
+    depends_lib-append   port:py${python.version}-pastel \
+                         port:py${python.version}-pylev
+
+    livecheck.type       none
+}

--- a/python/py-lockfile/Portfile
+++ b/python/py-lockfile/Portfile
@@ -1,13 +1,14 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-lockfile
-set real_name       pylockfile
-version             0.9.1
+version             0.12.2
 categories-append   devel
 platforms           darwin
 license             MIT
-maintainers         nomaintainer
+maintainers         {gmail.com:davidgilman1 @dgilman} openmaintainer
 supported_archs     noarch
 
 description         Platform-independent file locking module
@@ -21,11 +22,18 @@ long_description  \
     also provided, more as a demonstration of the possibilities it provides \
     than as production-quality code.
 
-homepage            https://code.google.com/p/${real_name}/
-master_sites        googlecode:${real_name} http://distfiles.macports.org/python/
-distname            lockfile-${version}
-checksums           md5     4e4c7ea4c4301500da5e7f3b51e01cfe \
-                    sha1    1eebaee375641c9f29aeb21768f917dd2b985752 \
-                    rmd160  c94c1a638f2a11181063d6025a6c5acc8c9d09e6
+homepage            https://pypi.org/project/lockfile/
 
-python.versions     27
+checksums           rmd160  6aaa40fb1a1bd4322f26182fca631a6c4c1f8d24 \
+                    sha256  6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799 \
+                    size    20874
+
+python.versions     27 34 35 36 37 38
+
+if {${name} ne ${subport}} {
+    depends_build-append port:py${python.version}-setuptools \
+                         port:py${python.version}-pbr
+
+    livecheck.type       none
+}
+

--- a/python/py-pastel/Portfile
+++ b/python/py-pastel/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-pastel
+version             0.2.0
+revision            0
+categories-append   devel
+platforms           darwin
+license             MIT
+supported_archs     noarch
+
+python.versions     27 35 36 37 38
+
+maintainers         {gmail.com:davidgilman1 @dgilman} openmaintainer
+
+description         Bring colors to your terminal.
+
+long_description    Pastel is a simple library to help you colorize strings \
+                    in your terminal.
+
+homepage            https://github.com/sdispater/pastel
+
+checksums           rmd160  206c6be637d33defddc12bcf2ff76cef01980ae8 \
+                    sha256  46155fc523bdd4efcd450bbcb3f2b94a6e3b25edc0eb493e081104ad09e1ca36 \
+                    size    7601
+
+post-destroot {
+   # https://github.com/sdispater/pastel/issues/7
+   delete ${destroot}${python.pkgd}/tests
+}
+
+if {${name} ne ${subport}} {
+    depends_build-append port:py${python.version}-setuptools
+    livecheck.type      none
+}

--- a/python/py-pylev/Portfile
+++ b/python/py-pylev/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-pylev
+version             1.3.0
+revision            0
+categories-append   devel
+platforms           darwin
+license             BSD
+supported_archs     noarch
+
+python.versions     27 33 34 35 36 37 38
+
+maintainers         {gmail.com:davidgilman1 @dgilman} openmaintainer
+
+description         A pure Python Levenshtein implementation that's not \
+                    freaking GPL'd.
+long_description    ${description}
+
+homepage            https://github.com/toastdriven/pylev
+
+checksums           rmd160  1d5d5afc09e506faa6c7495b4d55841669a080dd \
+                    sha256  063910098161199b81e453025653ec53556c1be7165a9b7c50be2f4d57eae1c3 \
+                    size    3193
+
+if {${name} ne ${subport}} {
+    depends_build-append port:py${python.version}-setuptools
+    livecheck.type      none
+}

--- a/python/py-shellingham/Portfile
+++ b/python/py-shellingham/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-shellingham
+version             1.3.1
+revision            0
+categories-append   devel
+platforms           darwin
+license             ISC
+supported_archs     noarch
+
+python.versions     27 35 36 37 38
+
+maintainers         {gmail.com:davidgilman1 @dgilman} openmaintainer
+
+description         Tool to Detect Surrounding Shell
+
+long_description    Shellingham detects what shell the current Python \
+                    executable is running in.
+
+homepage            https://github.com/sarugaku/shellingham
+
+checksums           rmd160  1147d071b343eb237da14441f9680c0eec5e9ad4 \
+                    sha256  985b23bbd1feae47ca6a6365eacd314d93d95a8a16f8f346945074c28fe6f3e0 \
+                    size    7938
+
+if {${name} ne ${subport}} {
+    depends_build-append port:py${python.version}-setuptools
+    livecheck.type      none
+}

--- a/python/py-tomlkit/Portfile
+++ b/python/py-tomlkit/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-tomlkit
+version             0.5.8
+revision            0
+categories-append   devel
+platforms           darwin
+license             MIT
+supported_archs     noarch
+
+python.versions     35 36 37 38
+
+maintainers         {gmail.com:davidgilman1 @dgilman} openmaintainer
+
+description         Style preserving TOML library
+long_description    ${description}
+
+homepage            https://github.com/sdispater/tomlkit
+
+checksums           rmd160  594810a362d5ba3bca3d1154ea11fcf923f12574 \
+                    sha256  32c10cc16ded7e4101c79f269910658cc2a0be5913f1252121c3cd603051c269 \
+                    size    66567
+
+post-destroot {
+   # https://github.com/sdispater/pastel/issues/7
+   delete ${destroot}${python.pkgd}/tests
+}
+
+if {${name} ne ${subport}} {
+    depends_build-append port:py${python.version}-setuptools
+    livecheck.type      none
+}


### PR DESCRIPTION
#### Description
This adds portfiles for several new python libraries, all required to run poetry.  The py-lockfile port was updated to its latest (final) version and added python3 support.

###### Type(s)
- [x] enhancement

###### Tested on
macOS 10.13.6 17G10021
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
