### PR TITLE
fontforge: update to latest master, use CMake

### DIFF
--- a/graphics/fontforge/Portfile
+++ b/graphics/fontforge/Portfile
@@ -1,12 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
-github.setup        fontforge fontforge 20190801
-revision            1
-github.tarball_from releases
+github.setup        fontforge fontforge 3bba62de425c86d41937daf869c698fa04a1a223
+version             20200202
+# TODO: once the release gets out, we should put this back in place instead
+# github.setup        fontforge fontforge 2020xxxx
+# github.tarball_from releases
 
 categories          graphics fonts
 platforms           darwin
@@ -22,9 +25,9 @@ long_description    FontForge allows you to edit outline and bitmap fonts.  You 
 
 homepage            http://fontforge.github.io/
 
-checksums           rmd160  1b8e8ba52dc35034e250c0b2cd9c4acef01794f2 \
-                    sha256  d92075ca783c97dc68433b1ed629b9054a4b4c74ac64c54ced7f691540f70852 \
-                    size    20766334
+checksums           rmd160  91e30350c50a26ae42087f4c0d204d1d351f8bbc \
+                    sha256  9f5f099fa71673cfa2b9be876ca76380f52a9e70db2c49eab0ca611fa7953e45 \
+                    size    21806079
 
 depends_build       port:pkgconfig
 
@@ -45,10 +48,26 @@ depends_lib         path:lib/pkgconfig/cairo.pc:cairo \
                     port:woff2 \
                     port:zlib
 
+cmake.generator     Ninja
+
 # Needs C11
-#compiler.c_standard 2011
-compiler.blacklist  {clang < 500} *gcc-4.2 gcc-4.0 gcc-3.3
-configure.cflags-append -std=gnu11
+compiler.c_standard 2011
+#compiler.blacklist  {clang < 500} *gcc-4.2 gcc-4.0 gcc-3.3
+#configure.cflags-append -std=gnu11
+
+configure.args      -DENABLE_GUI=OFF \
+                    -DENABLE_LIBGIF=ON \
+                    -DENABLE_LIBJPEG=ON \
+                    -DENABLE_LIBPNG=ON \
+                    -DENABLE_LIBREADLINE=ON \
+                    -DENABLE_LIBSPIRO=ON \
+                    -DENABLE_LIBTIFF=ON \
+                    -DENABLE_LIBUNINAMESLIST=ON \
+                    -DENABLE_PYTHON_EXTENSION=OFF \
+                    -DENABLE_PYTHON_SCRIPTING=OFF \
+                    -DENABLE_WOFF2=ON \
+                    -DENABLE_WRITE_PFM=OFF \
+                    -DENABLE_X11=OFF
 
 # fix 32bit builds by masking an old Carbon call to GetTime
 patchfiles-append   patch-fontforge-carbon-gettime-namecollision.diff
@@ -56,7 +75,7 @@ patchfiles-append   patch-fontforge-carbon-gettime-namecollision.diff
 # use older noerr macros, and replace missing SRefCon definition
 if {${os.platform} eq "darwin" && ${os.major} <= 9} {
     patchfiles-append \
-                patch-fontforge-startui-require-noerr-and-SRefCon-fix.diff \
+                    patch-fontforge-startui-require-noerr-and-SRefCon-fix.diff \
 }
 
 # the date command on Tiger is too old for this port, use gnu coreutils dates instead
@@ -65,35 +84,22 @@ platform darwin 8 {
     configure.env-append PATH=${prefix}/libexec/gnubin/:$env(PATH)
 }
 
-configure.args      --mandir=${prefix}/share/man \
-                    --disable-python-scripting \
-                    --disable-python-extension \
-                    --without-x \
-                    --enable-woff2 \
-                    --disable-silent-rules
-
-variant python37 description {Enable Python support (Python 3.7)} {
-    depends_lib-append      port:python37
-    configure.args-delete   --disable-python-scripting \
-                            --disable-python-extension
-    configure.python        ${prefix}/bin/python3.7
-    configure.pkg_config_path \
-                            "${frameworks_dir}/Python.framework/Versions/3.7/lib/pkgconfig"
+variant python38 description {Enable Python support (Python 3.8)} {
+    depends_lib-append      port:python38
+    configure.python        ${prefix}/bin/python3.8
+    configure.args-replace  -DENABLE_PYTHON_EXTENSION=OFF -DENABLE_PYTHON_EXTENSION=ON
+    configure.args-replace  -DENABLE_PYTHON_SCRIPTING=OFF -DENABLE_PYTHON_SCRIPTING=ON
+    # TODO: not sure what the correct location is
+    configure.args-append   -DPYHOOK_INSTALL_DIR="${frameworks_dir}/Python.framework/Versions/3.8/lib/pkgconfig"
 }
 
 variant gui description {Enable GUI support} {
-    depends_lib-append      port:xorg-libXi port:gtk3
-    configure.args-replace  --without-x --with-x
-    configure.args-append   --enable-gdk=yes
+    PortGroup               app 1.0
+    depends_lib-append      port:gtk3
+    configure.args-replace  -DENABLE_GUI=OFF -DENABLE_GUI=ON
+    app.name                FontForge
+    app.icon                ${worksrcpath}/osx/FontForge.app/Contents/Resources/FontForge.icns
 }
 
-post-destroot {
-    delete ${destroot}${prefix}/share/fontforge/osx/FontForge.app
-}
-
-notes "
-macOS app bundles are available here:
-
-    https://dl.bintray.com/fontforge/fontforge/
-"
-default_variants    +python37 +gui
+# TODO: any reason not to make these default?
+default_variants    +python38 +gui


### PR DESCRIPTION
#### Description

@tessus

Preliminary version which hopefully works (or at least builds) much better than the existing port. This has been brought to our attention in https://github.com/fontforge/fontforge/issues/3281. Apparently a new version is about to be released very soon, so I would probably wait for the new release.

* This might need a review of dependencies.
* Do we really need to make `python` and `gui` variants optional? I would simply unconditionally include them unless there's a good reason not to do so. In the past it might  have been the difficulty to build it.
* I tested with `gtk3 +x11` which I happen to have installed on my computer. It would make sense to test with `gtk3 +quartz` which probably also works much better.
* Maybe we need an explicit variant based on what variant `gtk3` has been built with. I didn't check  whether the files installed by fontforge are the same or not.
* Please note that I did absolutely zero checking on any older systems, I didn't even test if patches still apply in a clean fashion.
* I didn't bother checking the "requires some recent C standard" part.
* I'm pretty sure that the port has some dependents which would require revbumping. I didn't check those either.
* Upstream ships all resources required to build the app bundle and already contains a cmake target to build it, but that target does the build from scratch. It would be nice if someone would be willing to take some time to adapt CMakeLists.txt to allow using those same existing resources to create MacPorts-friendly FontForge.app without the app PortGroup.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G9016
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
