### PR TITLE
google-cloud-sdk: update to 279.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             278.0.0
+version             279.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  1cace37b98833c37b45ccd2c90cb906a459b2c53 \
-                    sha256  568b5e820514ca8673afa24c4bfe195ccb1af3ac97cd1b3634fc9da888a9188d \
-                    size    23467711
+    checksums       rmd160  2c50d8c28207aaafbdd5e0a73bfe34eda1be8f64 \
+                    sha256  114ac3c6666facfc6a7ce2149838aaa01d9a84587952e877f157983a7d56023a \
+                    size    23627517
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  b07790d542a40ae4c1c645555b42293cba891fdb \
-                    sha256  8eb7d8d571457c87bd8013e4db61f709f0e0076f6d145baf4acd00ad576acf34 \
-                    size    48721534
+    checksums       rmd160  cd3b79c5eed188a251ceb875f9595d6665aa7bde \
+                    sha256  06db9ca045ffe00c7a3c3d4b0749e77919597af65b7b0e02df6dd0711ce95d1f \
+                    size    48885492
 }
 
 homepage            https://cloud.google.com/sdk/
@@ -58,6 +58,11 @@ destroot {
         ln -s ../libexec/${name}/bin/${f} ${destroot}${prefix}/bin/${f}
     }
     ln -s ../libexec/${name}/bin/git-credential-gcloud.sh ${destroot}${prefix}/bin/git-credential-gcloud
+
+    if { ${configure.build_arch} eq "x86_64" } {
+        # anthoscli is only included in the 64-bit release
+        ln -s ../libexec/${name}/bin/anthoscli ${destroot}${prefix}/bin/anthoscli
+    }
 
     if {[variant_isset bash_completion]} {
         # set completions_path ${prefix}/share/bash-completion/completions


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 279.0.0.

###### Tested on

macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?