### PR TITLE
starship: update to 0.34.1

### DIFF
--- a/sysutils/starship/Portfile
+++ b/sysutils/starship/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        starship starship 0.33.1 v
+github.setup        starship starship 0.34.1 v
 categories          sysutils
 platforms           darwin
 maintainers         {l2dy @l2dy} \
@@ -17,9 +17,9 @@ description         a minimal, blazing fast, and extremely customizable prompt f
 long_description    Starship is ${description}.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  f2cf2e10b23ec217c2bdd20a397f001efa05234c \
-                    sha256  703670923edc74a6af38a2d28c3379fffdf233e56fca766ab5d7df2a9cec2dcd \
-                    size    5137268
+                    rmd160  8821f354ec9b2c067aa96daf9f00d258598977de \
+                    sha256  baac75589a120c8a7aaeb46426e8fe419867886e69bba2dc6d5ca0d56072e08f \
+                    size    5135793
 
 # For crate:openssl-sys
 depends_build       port:pkgconfig
@@ -30,33 +30,30 @@ destroot {
 }
 
 cargo.crates \
-    aho-corasick                     0.7.6  58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d \
-    ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
+    aho-corasick                     0.7.7  5f56c476256dc249def911d6f7580b5fc7e875895b5d7ee88f5d602208035744 \
     ansi_term                       0.12.1  d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2 \
+    ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
     anyhow                          1.0.26  7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c \
-    arrayref                         0.3.5  0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee \
+    arrayref                         0.3.6  a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544 \
     arrayvec                         0.5.1  cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8 \
     arrayvec                        0.4.12  cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9 \
     atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
     autocfg                          0.1.7  1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2 \
     autocfg                          1.0.0  f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d \
-    backtrace                       0.3.42  b4b1549d804b6c73f4817df2ba073709e96e426f12987127c48e6745568c350b \
-    backtrace-sys                   0.1.32  5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491 \
-    base64                          0.11.0  b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7 \
     base64                          0.10.1  0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e \
+    base64                          0.11.0  b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7 \
     battery                          0.7.5  36a698e449024a5d18994a815998bf5e2e4bc1883e35a7d7ba95b6b69ee45907 \
     bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
     blake2b_simd                    0.5.10  d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a \
     bumpalo                          3.1.2  5fb8038c1ddc0a5f73787b130f4cc75151e96ed33e417fde765eb5a81e3532f4 \
     byte-unit                        3.0.3  6894a79550807490d9f19a138a6da0f8830e70c83e83402dd23f16fd6c479056 \
     byteorder                        1.3.2  a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5 \
-    bytes                            0.5.3  10004c15deb332055f7a4a208190aed362cf9a7c2f6ab70a305fba50e1105f38 \
     c2-chacha                        0.2.3  214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb \
     cc                              1.0.50  95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd \
     cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
     chrono                          0.4.10  31850b4a4d6bae316f7a09e691c944c28299298837edc0a03f755618c23cbc01 \
+    chunked_transfer                 1.0.0  f98beb6554de08a14bd7b5c6014963c79d6a25a1c66b1d4ecb9e733ccba51d6c \
     clap                            2.33.0  5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9 \
-    cloudabi                         0.0.3  ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
     constant_time_eq                 0.1.5  245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc \
     core-foundation                  0.6.4  25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d \
     core-foundation-sys              0.6.2  e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b \
@@ -64,45 +61,21 @@ cargo.crates \
     crossbeam-epoch                  0.8.0  5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac \
     crossbeam-queue                  0.2.1  c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db \
     crossbeam-utils                  0.7.0  ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4 \
-    crossbeam-utils                  0.6.6  04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6 \
-    ct-logs                          0.6.0  4d3686f5fa27dbc1d76c751300376e167c5a43387f44bb451fd1c24776e49113 \
     dirs                             2.0.2  13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3 \
     dirs-sys                         0.3.4  afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b \
     doc-comment                      0.3.1  923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97 \
-    dtoa                             0.4.4  ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e \
+    dtoa                             0.4.5  4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3 \
     either                           1.5.3  bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3 \
-    encoding_rs                     0.8.22  cd8d03faa7fe0c1431609dfad7bbe827af30f82e1e2ae6f7ee4fca6bd764bc28 \
-    env_logger                       0.6.2  aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3 \
-    failure                          0.1.6  f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9 \
-    failure_derive                   0.1.6  0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08 \
-    fnv                              1.0.6  2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3 \
-    fuchsia-cprng                    0.1.1  a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba \
-    fuchsia-zircon                   0.3.3  2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
-    fuchsia-zircon-sys               0.3.3  3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
-    futures-channel                  0.3.1  fcae98ca17d102fd8a3603727b9259fcf7fa4239b603d2142926189bc8999b86 \
-    futures-core                     0.3.1  79564c427afefab1dfb3298535b21eda083ef7935b4f0ecbfcb121f0aec10866 \
-    futures-io                       0.3.1  e676577d229e70952ab25f3945795ba5b16d63ca794ca9d2c860e5595d20b5ff \
-    futures-macro                    0.3.1  52e7c56c15537adb4f76d0b7a76ad131cb4d2f4f32d3b0bcabcbe1c7c5e87764 \
-    futures-sink                     0.3.1  171be33efae63c2d59e6dbba34186fe0d6394fb378069a76dfd80fdcffd43c16 \
-    futures-task                     0.3.1  0bae52d6b29cf440e298856fec3965ee6fa71b06aa7495178615953fd669e5f9 \
-    futures-util                     0.3.1  c0d66274fb76985d3c62c886d1da7ac4c0903a8c9f754e8fe0f35a6a6cc39e76 \
+    env_logger                       0.7.1  44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36 \
     gethostname                      0.2.1  e692e296bfac1d2533ef168d0b60ff5897b8b70a4009276834014dd8924cc028 \
     getrandom                       0.1.14  7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb \
     git2                            0.11.0  77519ef7c5beee314d0804d4534f01e0f9e8d9acdee2b7a48627e590b27e0ec4 \
-    h2                               0.2.1  b9433d71e471c1736fd5a61b671fc0b148d7a2992f666c958d03cd8feb3b88d1 \
     heck                             0.3.1  20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205 \
     hermit-abi                       0.1.6  eff2656d88f158ce120947499e971d743c05dbcbed62e5bd2f38f1698bbc3772 \
-    http                             0.2.0  b708cc7f06493459026f53b9a61a7a121a5d1ec6238dee58ea4941132b30156b \
-    http-body                        0.3.1  13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b \
-    httparse                         1.3.4  cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9 \
     humantime                        1.3.0  df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f \
-    hyper                           0.13.1  8bf49cfb32edee45d890537d9057d1b02ed55f53b7b6a30bae83a38c9231749e \
-    hyper-rustls                    0.19.0  b89109920197f2c90d75e82addbb96bf424570790d310cc2b18f0b33f4a9cc43 \
     idna                             0.2.0  02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9 \
-    indexmap                         1.3.1  0b54058f0a6ff80b6803da8faf8997cde53872b38f4023728f6830b06cd3c0dc \
-    iovec                            0.1.4  b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e \
-    itoa                             0.4.4  501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f \
-    jobserver                       0.1.19  67b06c1b455f1cf4269a8cfc320ab930a810e2375a42af5075eb8a8b36405ce0 \
+    itoa                             0.4.5  b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e \
+    jobserver                       0.1.21  5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2 \
     js-sys                          0.3.35  7889c7c36282151f6bf465be4700359318aef36baa951462382eae49e9577cf9 \
     kernel32-sys                     0.2.2  7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
@@ -117,120 +90,89 @@ cargo.crates \
     matches                          0.1.8  7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
     memchr                           2.3.0  3197e20c7edb283f87c071ddfc7a2cca8f8e0b888c242959846a6fce03c72223 \
     memoffset                        0.5.3  75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9 \
-    mime                            0.3.16  2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d \
-    mime_guess                       2.0.1  1a0ed03949aef72dbdf3116a383d7b38b4768e6f960528cd6a6044aa9ed68599 \
-    mio                             0.6.21  302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f \
-    miow                             0.2.1  8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919 \
-    net2                            0.2.33  42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88 \
     nix                             0.15.0  3b2e0b4f3320ed72aaedb9a5ac838690a8047c7b275da22711fddff4f8a14229 \
     nodrop                          0.1.14  72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb \
-    nom                              4.2.3  2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6 \
     nom                              5.1.0  c433f4d505fe6ce7ff78523d2fa13a0b9f2690e181fc26168bcbe5ccc5d14e07 \
+    nom                              4.2.3  2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6 \
     ntapi                            0.3.3  f26e041cd983acbc087e30fcba770380cfa352d0e392e175b2344ebaf7ea0602 \
     num-integer                     0.1.42  3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba \
     num-traits                      0.2.11  c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096 \
-    num_cpus                        1.11.1  76dac5ed2a876980778b8b85f75a71b6cbf0db0b1232ee12f826bccb00d09d72 \
-    once_cell                        1.3.0  f5941ec2d5ee5916c709580d71553b81a633df245bcc73c04dcbd62152ceefc4 \
-    open                             1.3.2  94b424e1086328b0df10235c6ff47be63708071881bead9e76997d9291c0134b \
-    openssl-probe                    0.1.2  77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de \
-    os_info                          1.3.1  a418a25db1f8465de856d534c6f0c6f3725ad1f089f9a842a7d7c0209ba58e90 \
+    num_cpus                        1.12.0  46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6 \
+    once_cell                        1.3.1  b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b \
+    open                             1.3.3  3dfa632621d66502e1e9298c038d903090fc810a33cc1e6a02958fa0be65e3fb \
+    os_info                          1.3.3  46c6031e9373f6942a00933638731c7f4543f265b4bd920a1230fbcd62dfdf0c \
     path-slash                       0.1.1  a0858af4d9136275541f4eac7be1af70add84cf356d901799b065ac1b8ff6e2f \
     percent-encoding                 2.1.0  d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
-    pin-project                      0.4.6  94b90146c7216e4cb534069fb91366de4ea0ea353105ee45ed297e2d1619e469 \
-    pin-project-internal             0.4.6  44ca92f893f0656d3cba8158dd0f2b99b94de256a4a54e870bd6922fcc6c8355 \
-    pin-project-lite                 0.1.2  e8822eb8bb72452f038ebf6048efa02c3fe22bf83f76519c9583e47fc194a422 \
-    pin-utils                     0.1.0-alpha.4  5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587 \
     pkg-config                      0.3.17  05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677 \
     ppv-lite86                       0.2.6  74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b \
-    pretty_env_logger                0.3.1  717ee476b1690853d222af4634056d830b5197ffd747726a9a1eee6da9f49074 \
-    proc-macro-hack                 0.5.11  ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5 \
-    proc-macro-nested                0.1.3  369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e \
-    proc-macro2                      1.0.7  0319972dcae462681daf4da1adeeaa066e3ebd29c69be96c6abb1259d2ee2bcc \
+    pretty_env_logger                0.4.0  926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d \
+    proc-macro2                      1.0.8  3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548 \
+    qstring                          0.7.2  d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e \
     quick-error                      1.2.3  a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0 \
     quote                            1.0.2  053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe \
     rand                             0.7.3  6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
     rand_chacha                      0.2.1  03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853 \
-    rand_core                        0.3.1  7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b \
     rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
-    rand_core                        0.4.2  9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc \
     rand_hc                          0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
-    rand_os                          0.1.3  7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071 \
     rayon                            1.3.0  db6ce3297f9c85e16621bb8cca38a06779ffc31bb8184e1be4bed2be4678a098 \
     rayon-core                       1.7.0  08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9 \
-    rdrand                           0.4.0  678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2 \
     redox_syscall                   0.1.56  2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84 \
-    redox_users                      0.3.1  4ecedbca3bf205f8d8f5c2b44d83cd0690e39ee84b951ed649e9f1841132b66d \
-    regex                            1.3.3  b5508c1941e4e7cb19965abef075d35a9a8b5cdf0846f30b4050e9b55dc55e87 \
-    regex-syntax                    0.6.13  e734e891f5b408a29efbf8309e656876276f49ab6a6ac208600b4419bd893d90 \
+    redox_users                      0.3.4  09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431 \
+    regex                            1.3.4  322cf97724bea3ee221b78fe25ac9c46114ebb51747ad5babd51a2fc6a8235a8 \
+    regex-syntax                    0.6.14  b28dfe3fe9badec5dbf0a79a9cccad2cfc2ab5484bdb3e44cbd1ae8b3ba2be06 \
     remove_dir_all                   0.5.2  4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e \
-    reqwest                         0.10.1  c0e798e19e258bf6c30a304622e3e9ac820e483b06a1857a026e1f109b113fe4 \
-    ring                            0.16.9  6747f8da1f2b1fabbee1aaa4eb8a11abf9adef0bf58a41cee45db5d59cecdfac \
-    rust-argon2                      0.5.1  4ca4eaef519b494d1f2848fc602d18816fed808a981aedf4f1f00ceb7c9d32cf \
-    rustc-demangle                  0.1.16  4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783 \
+    ring                           0.16.10  113f53b644c5442e20ff3a299be3d6c61ba143737af5bd2ab298e248a7575b2d \
+    rust-argon2                      0.7.0  2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017 \
     rustc_version                    0.2.3  138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a \
     rustls                          0.16.0  b25a18b1bf7387f0145e7f8324e700805aade3842dd3db2e74e4cdeb4677c09e \
-    rustls-native-certs              0.1.0  51ffebdbb48c14f84eba0b715197d673aff1dd22cc1007ca647e28483bbcc307 \
     ryu                              1.0.2  bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8 \
-    schannel                        0.1.16  87f550b06b6cba9c8b8be3ee73f391990116bf527450d2556e9b9ce263b9a021 \
     scopeguard                       1.0.0  b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d \
     sct                              0.6.0  e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c \
-    security-framework               0.3.4  8ef2429d7cefe5fd28bd1d2ed41c944547d4ff84776f5935b456da44593a16df \
-    security-framework-sys           0.3.3  e31493fc37615debb8c5090a7aeb4a9730bc61e77ab10b9af59f1a202284f895 \
     semver                           0.9.0  1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403 \
     semver-parser                    0.7.0  388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
     serde                          1.0.104  414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449 \
     serde_derive                   1.0.104  128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64 \
-    serde_json                      1.0.44  48c575e0cc52bdd09b47f330f646cf59afc586e9c4e3ccd6fc1f625b8ea1dad7 \
+    serde_json                      1.0.46  21b01d7f0288608a01dca632cf1df859df6fd6ffa885300fc275ce2ba6221953 \
     serde_urlencoded                 0.6.1  9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97 \
-    slab                             0.4.2  c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8 \
-    smallvec                         1.1.0  44e59e0c9fa00817912ae6e4e6e3c4fe04455e75699d06eedc7d85917ed8e8f4 \
+    smallvec                         1.2.0  5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc \
     sourcefile                       0.1.4  4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3 \
     spin                             0.5.2  6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d \
     static_assertions                0.3.4  7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3 \
     strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
-    syn                             1.0.13  1e4ff033220a41d1a57d8125eab57bf5263783dfdcc18688b1dacc6ce9651ef8 \
-    synstructure                    0.12.3  67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545 \
-    sysinfo                         0.10.4  99474859bbf2710ae8f09912a047cfe24d2c1076af9eb86661eb906ca7d1e994 \
+    syn                             1.0.14  af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5 \
+    sysinfo                         0.10.5  b8834e42be61ae4f6338b216fbb69837c7f33c3d4d3a139fb073735b25af4d9e \
     tempfile                         3.1.0  7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9 \
     term_size                        0.3.1  9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327 \
     termcolor                        1.1.0  bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f \
     textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
     thread_local                     1.0.1  d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14 \
     time                            0.1.42  db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f \
-    tokio                            0.2.9  ffa2fdcfa937b20cb3c822a635ceecd5fc1a27a6a474527e5516aa24b8c8820a \
-    tokio-rustls                    0.12.2  141afec0978abae6573065a48882c6bae44c5cc61db9b511ac4abf6a09bfd9cc \
-    tokio-util                       0.2.0  571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930 \
-    toml                             0.5.5  01d1404644c8b12b16bfcffa4322403a91a451584daaaa7c28d3152e6cbc98cf \
-    tower-service                    0.3.0  e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860 \
-    try-lock                         0.2.2  e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382 \
+    toml                             0.5.6  ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a \
     typenum                         1.11.2  6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9 \
-    unicase                          2.6.0  50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6 \
     unicode-bidi                     0.3.4  49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5 \
-    unicode-normalization           0.1.11  b561e267b2326bb4cebfc0ef9e68355c7abe6c6f522aeac2f5bf95d56c59bdcf \
+    unicode-normalization           0.1.12  5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4 \
     unicode-segmentation             1.6.0  e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0 \
     unicode-width                    0.1.7  caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479 \
     unicode-xid                      0.2.0  826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c \
     untrusted                        0.7.0  60369ef7a31de49bcb3f6ca728d4ba7300d9a1658f94c727d4cab8c8d9f4aece \
     uom                             0.26.0  4cec796ec5f7ac557631709079168286056205c51c60aac33f51764bdc7b8dc4 \
+    ureq                            0.11.3  b5281c8b41934f65338942a87ef7dc32052f2a2c1b2f5c53c6a96643ba674372 \
     url                              2.1.1  829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb \
     urlencoding                      1.0.0  3df3561629a8bb4c57e5a2e4c43348d9e29c7c29d9b1c4c1f47166deca8f37ed \
     vcpkg                            0.2.8  3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168 \
     vec_map                          0.8.1  05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a \
-    version_check                    0.9.1  078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce \
     version_check                    0.1.5  914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd \
     void                             1.0.2  6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d \
-    want                             0.3.0  1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0 \
     wasi                          0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
     wasm-bindgen                    0.2.58  5205e9afdf42282b192e2310a5b463a6d1c1d774e30dc3c791ac37ab42d2616c \
     wasm-bindgen-backend            0.2.58  11cdb95816290b525b32587d76419facd99662a07e59d3cdb560488a819d9a45 \
-    wasm-bindgen-futures             0.4.8  8bbdd49e3e28b40dec6a9ba8d17798245ce32b019513a845369c641b275135d9 \
     wasm-bindgen-macro              0.2.58  574094772ce6921576fb6f2e3f7497b8a76273b6db092be18fc48a082de09dc3 \
     wasm-bindgen-macro-support      0.2.58  e85031354f25eaebe78bb7db1c3d86140312a911a106b2e29f9cc440ce3e7668 \
     wasm-bindgen-shared             0.2.58  f5e7e61fc929f4c0dddb748b102ebf9f632e2b8d739f2016542b4de2965a9601 \
     wasm-bindgen-webidl             0.2.58  ef012a0d93fc0432df126a8eaf547b2dce25a8ce9212e1d3cbeef5c11157975d \
     web-sys                         0.3.35  aaf97caf6aa8c2b1dac90faf0db529d9d63c93846cca4911856f78a83cebf53b \
-    webpki                          0.21.0  d7e664e770ac0110e2384769bcc59ed19e329d81f555916a6e072714957b81b4 \
-    webpki-roots                    0.17.0  a262ae37dd9d60f60dd473d1158f9fbebf110ba7b6a5051c8160460f6043718b \
+    webpki                          0.21.2  f1f50e1972865d6b1adb54167d1c8ed48606004c2c9d0ea5f1eeb34d95e863ef \
+    webpki-roots                    0.18.0  91cd5736df7f12a964a5067a12c62fa38e1bd8080aff1f80bc29be7c80d19ab4 \
     weedle                          0.10.0  3bb43f70885151e629e2a19ce9e50bd730fd436cfd4b666894c9ce4de9141164 \
     winapi                           0.3.8  8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6 \
     winapi                           0.2.8  167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
@@ -238,6 +180,4 @@ cargo.crates \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
     winapi-util                      0.1.3  4ccfbf554c6ad11084fb7517daca16cfdcaccbdadba4fc336f032a8b12c2ad80 \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
-    winreg                           0.6.2  b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9 \
-    ws2_32-sys                       0.2.1  d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e \
     yaml-rust                        0.4.3  65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
