### PR TITLE
mercurial: update to 5.3

### DIFF
--- a/devel/mercurial/Portfile
+++ b/devel/mercurial/Portfile
@@ -7,7 +7,7 @@ PortGroup           bitbucket 1.0
 name                mercurial
 # don't forget to update dependents for mercurial:
 # port echo rdepends:mercurial and \( name:hg or name:mercurial \) | grep -v 'py[[:digit:]]'
-version             5.1
+version             5.3
 categories          devel python
 license             GPL-2+
 maintainers         nomaintainer
@@ -29,9 +29,9 @@ long_description    Mercurial is a fast, lightweight Source Control Management \
 homepage            http://www.mercurial-scm.org
 platforms           darwin
 master_sites        https://www.mercurial-scm.org/release/
-checksums           rmd160  23f05ca435a332a9db0e1f42f4841656d463acdf \
-                    sha256  6222d92d860e411e422b7dc58062132bc512fa52ec48a71143b40cab4be7c829 \
-                    size    7283396
+checksums           rmd160  cd7e8fb08f8423413e689a0836ebab4961c05214 \
+                    sha256  e57ff61d6b67695149dd451922b40aa455ab02e01711806a131a1e95c544f9b9 \
+                    size    7499903
 
 depends_build       port:py27-docutils
 


### PR DESCRIPTION
bump version from 5.1 to 5.3

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G2022
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
