### PR TITLE
TexShop4: fix build for macOS 10.14 with Xcode 11

### DIFF
--- a/aqua/TeXShop4/Portfile
+++ b/aqua/TeXShop4/Portfile
@@ -41,6 +41,7 @@ minimum_xcodeversions   {13 6.2}
 # destroot this for reasons that are poorly understood.
 # Remove this when a better fix is known.
 if {[vercmp ${xcodeversion} 10.0] >= 0} {
+    build.pre_args      -UseNewBuildSystem=NO
     destroot.pre_args   -UseNewBuildSystem=NO
 }
 


### PR DESCRIPTION
use old build system also during build phrase

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G2022
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
