### PR TITLE
clang{6,7,8,9,devel}: remove python27 lib dependency when build does not used it

### DIFF
--- a/lang/llvm-6.0/Portfile
+++ b/lang/llvm-6.0/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 # TODO:
 #  * Update clang and lldb subports to build against installed libLLVM/libclang.
 
@@ -12,9 +14,9 @@ set llvm_version_no_dot 60
 set clang_executable_version 6.0
 set lldb_executable_version 6.0.1
 name                    llvm-${llvm_version}
-revision                1
-subport                 clang-${llvm_version} { revision 3 }
-subport                 lldb-${llvm_version} { revision 1 }
+revision                2
+subport                 clang-${llvm_version} { revision 4 }
+subport                 lldb-${llvm_version} { revision 2 }
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
 dist_subdir             llvm
@@ -22,6 +24,10 @@ categories              lang
 platforms               darwin
 license                 NCSA
 maintainers             {jeremyhu @jeremyhu} {larryv @larryv} {kencu @kencu}
+
+# python version to use when required.
+set py_ver              2.7
+set py_ver_nodot        [string map {. {}} ${py_ver}]
 
 if {${subport} eq "llvm-${llvm_version}"} {
     homepage            https://llvm.org/
@@ -49,7 +55,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
                         that can be built using the Clang frontend as a \
                         library to parse C/C++ code.
 
-    depends_lib         port:libxml2 port:libomp port:llvm-${llvm_version} port:python27
+    depends_lib         port:libxml2 port:libomp port:llvm-${llvm_version}
     depends_run         port:clang_select port:ld64
     depends_skip_archcheck-append ld64 subversion
 
@@ -73,7 +79,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
     description         the LLVM debugger
     long_description    Lldb is the "LLVM native" debugger.
 
-    depends_lib         port:libxml2 port:libomp port:llvm-${llvm_version} port:python27 \
+    depends_lib         port:libxml2 port:libomp port:llvm-${llvm_version} port:python${py_ver_nodot} \
                         port:ncurses
     depends_build-append port:swig-python port:doxygen
 
@@ -293,8 +299,8 @@ if {${subport} eq "llvm-${llvm_version}"} {
         -DLLVM_BUILD_RUNTIME=ON \
         -DLIBCXX_ENABLE_SHARED=OFF \
         -DLIBCXX_INSTALL_LIBRARY=OFF \
-        -DPYTHON_EXECUTABLE=${prefix}/bin/python2.7 \
-        -DPYTHON_INCLUDE_DIR=${prefix}/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7
+        -DPYTHON_EXECUTABLE=${prefix}/bin/python${py_ver} \
+        -DPYTHON_INCLUDE_DIR=${prefix}/Library/Frameworks/Python.framework/Versions/${py_ver}/include/python${py_ver}
 }
 
 # llvm-3.5 and later requires a C++11 runtime
@@ -338,6 +344,17 @@ if {[string match macports-clang-* ${configure.compiler}]} {
 if {[lsearch -exact $PortInfo(depends_build) port:cctools] != -1} {
     configure.args-append \
         -DCMAKE_LIBTOOL=${prefix}/bin/libtool
+}
+
+set py_to_use /usr/bin/python
+platform darwin {
+    # requires a newer python than the system default
+    if {${os.major} < 11} {
+        depends_lib-append port:python${py_ver_nodot}
+        set py_to_use      ${prefix}/bin/python${py_ver}
+    }
+    configure.args-append \
+        -DPYTHON_EXECUTABLE:FILEPATH=${py_to_use}
 }
 
 platform darwin {
@@ -580,7 +597,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
                 ${worksrcpath}/tools/clang/tools/scan-build/libexec/ccc-analyzer \
                 ${worksrcpath}/tools/clang/tools/scan-build/libexec/c++-analyzer \
                 ${worksrcpath}/tools/clang/tools/scan-build/bin/scan-build
-            reinplace "s|/usr/bin/env python|${prefix}/bin/python2.7|g" \
+            reinplace "s|/usr/bin/env python|${py_to_use}|g" \
                 ${worksrcpath}/tools/clang/tools/scan-build/bin/set-xcode-analyzer \
                 ${worksrcpath}/tools/clang/tools/scan-view/bin/scan-view
         }

--- a/lang/llvm-7.0/Portfile
+++ b/lang/llvm-7.0/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 # TODO:
 #  * Update clang and lldb subports to build against installed libLLVM/libclang
 
@@ -12,9 +14,9 @@ set llvm_version_no_dot 70
 set clang_executable_version 7
 set lldb_executable_version 7.1.0
 name                    llvm-${llvm_version}
-revision                0
-subport                 clang-${llvm_version} { revision 0 }
-subport                 lldb-${llvm_version} { revision 0 }
+revision                1
+subport                 clang-${llvm_version} { }
+subport                 lldb-${llvm_version} { }
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
 dist_subdir             llvm
@@ -22,6 +24,10 @@ categories              lang
 platforms               darwin
 license                 NCSA
 maintainers             {jeremyhu @jeremyhu} {larryv @larryv} {kencu @kencu}
+
+# python version to use when required.
+set py_ver              2.7
+set py_ver_nodot        [string map {. {}} ${py_ver}]
 
 if {${subport} eq "llvm-${llvm_version}"} {
     homepage            https://llvm.org/
@@ -49,7 +55,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
                         that can be built using the Clang frontend as a \
                         library to parse C/C++ code.
 
-    depends_lib         port:libxml2 port:libomp port:llvm-${llvm_version} port:python27
+    depends_lib         port:libxml2 port:libomp port:llvm-${llvm_version}
     depends_run         port:clang_select port:ld64
     depends_skip_archcheck-append ld64 subversion
 
@@ -73,7 +79,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
     description         the LLVM debugger
     long_description    Lldb is the "LLVM native" debugger.
 
-    depends_lib         port:libxml2 port:libomp port:llvm-${llvm_version} port:python27 \
+    depends_lib         port:libxml2 port:libomp port:llvm-${llvm_version} port:python${py_ver_nodot} \
                         port:ncurses
     depends_build-append port:swig-python port:doxygen
 
@@ -298,8 +304,8 @@ if {${subport} eq "llvm-${llvm_version}"} {
         -DLLVM_BUILD_RUNTIME=ON \
         -DLIBCXX_ENABLE_SHARED=OFF \
         -DLIBCXX_INSTALL_LIBRARY=OFF \
-        -DPYTHON_EXECUTABLE=${prefix}/bin/python2.7 \
-        -DPYTHON_INCLUDE_DIR=${prefix}/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7
+        -DPYTHON_EXECUTABLE=${prefix}/bin/python${py_ver} \
+        -DPYTHON_INCLUDE_DIR=${prefix}/Library/Frameworks/Python.framework/Versions/${py_ver}/include/python${py_ver}
 }
 
 # llvm-3.5 and later requires a C++11 runtime
@@ -343,6 +349,17 @@ if {[string match macports-clang-* ${configure.compiler}]} {
 if {[lsearch -exact $PortInfo(depends_build) port:cctools] != -1} {
     configure.args-append \
         -DCMAKE_LIBTOOL=${prefix}/bin/libtool
+}
+
+set py_to_use /usr/bin/python
+platform darwin {
+    # requires a newer python than the system default
+    if {${os.major} < 11} {
+        depends_lib-append port:python${py_ver_nodot}
+        set py_to_use      ${prefix}/bin/python${py_ver}
+    }
+    configure.args-append \
+        -DPYTHON_EXECUTABLE:FILEPATH=${py_to_use}
 }
 
 platform darwin {
@@ -604,7 +621,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
                 ${worksrcpath}/tools/clang/tools/scan-build/libexec/ccc-analyzer \
                 ${worksrcpath}/tools/clang/tools/scan-build/libexec/c++-analyzer \
                 ${worksrcpath}/tools/clang/tools/scan-build/bin/scan-build
-            reinplace "s|/usr/bin/env python|${prefix}/bin/python2.7|g" \
+            reinplace "s|/usr/bin/env python|${py_to_use}|g" \
                 ${worksrcpath}/tools/clang/tools/scan-build/bin/set-xcode-analyzer \
                 ${worksrcpath}/tools/clang/tools/scan-view/bin/scan-view
         }

--- a/lang/llvm-8.0/Portfile
+++ b/lang/llvm-8.0/Portfile
@@ -15,7 +15,7 @@ set clang_executable_version 8
 set llvm_patch_revision 1
 set lldb_executable_version 8.0.${llvm_patch_revision}
 name                    llvm-${llvm_version}
-revision                0
+revision                1
 subport                 clang-${llvm_version} { }
 subport                 lldb-${llvm_version} { }
 set suffix              mp-${llvm_version}
@@ -25,6 +25,10 @@ categories              lang
 platforms               darwin
 license                 NCSA
 maintainers             {jeremyhu @jeremyhu} {larryv @larryv} {kencu @kencu}
+
+# python version to use when required.
+set py_ver              2.7
+set py_ver_nodot        [string map {. {}} ${py_ver}]
 
 if {${subport} eq "llvm-${llvm_version}"} {
     homepage            https://llvm.org/
@@ -52,7 +56,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
                         that can be built using the Clang frontend as a \
                         library to parse C/C++ code.
 
-    depends_lib         port:libxml2 port:libomp port:llvm-${llvm_version} port:python27
+    depends_lib         port:libxml2 port:libomp port:llvm-${llvm_version}
     depends_run         port:clang_select port:ld64
     depends_skip_archcheck-append ld64 subversion
 
@@ -76,7 +80,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
     description         the LLVM debugger
     long_description    Lldb is the "LLVM native" debugger.
 
-    depends_lib         port:libxml2 port:libomp port:llvm-${llvm_version} port:python27 \
+    depends_lib         port:libxml2 port:libomp port:llvm-${llvm_version} port:python${py_ver_nodot} \
                         port:ncurses
     depends_build-append port:swig-python port:doxygen
 
@@ -310,8 +314,8 @@ if {${subport} eq "llvm-${llvm_version}"} {
         -DLLVM_BUILD_RUNTIME=ON \
         -DLIBCXX_ENABLE_SHARED=OFF \
         -DLIBCXX_INSTALL_LIBRARY=OFF \
-        -DPYTHON_EXECUTABLE=${prefix}/bin/python2.7 \
-        -DPYTHON_INCLUDE_DIR=${prefix}/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7
+        -DPYTHON_EXECUTABLE=${prefix}/bin/python${py_ver} \
+        -DPYTHON_INCLUDE_DIR=${prefix}/Library/Frameworks/Python.framework/Versions/${py_ver}/include/python${py_ver}
 }
 
 # llvm-3.5 and later requires a C++11 runtime
@@ -355,6 +359,17 @@ if {[string match macports-clang-* ${configure.compiler}]} {
 if {[lsearch -exact $PortInfo(depends_build) port:cctools] != -1} {
     configure.args-append \
         -DCMAKE_LIBTOOL=${prefix}/bin/libtool
+}
+
+set py_to_use /usr/bin/python
+platform darwin {
+    # requires a newer python than the system default
+    if {${os.major} < 11} {
+        depends_lib-append port:python${py_ver_nodot}
+        set py_to_use      ${prefix}/bin/python${py_ver}
+    }
+    configure.args-append \
+        -DPYTHON_EXECUTABLE:FILEPATH=${py_to_use}
 }
 
 platform darwin {
@@ -616,7 +631,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
                 ${worksrcpath}/tools/clang/tools/scan-build/libexec/ccc-analyzer \
                 ${worksrcpath}/tools/clang/tools/scan-build/libexec/c++-analyzer \
                 ${worksrcpath}/tools/clang/tools/scan-build/bin/scan-build
-            reinplace "s|/usr/bin/env python|${prefix}/bin/python2.7|g" \
+            reinplace "s|/usr/bin/env python|${py_to_use}|g" \
                 ${worksrcpath}/tools/clang/tools/scan-build/bin/set-xcode-analyzer \
                 ${worksrcpath}/tools/clang/tools/scan-view/bin/scan-view
         }

--- a/lang/llvm-9.0/Portfile
+++ b/lang/llvm-9.0/Portfile
@@ -15,7 +15,7 @@ set clang_executable_version 9
 set lldb_executable_version 9.0.0
 name                    llvm-${llvm_version}
 revision                0
-subport                 clang-${llvm_version} { revision 0 }
+subport                 clang-${llvm_version} { revision 1 }
 subport                 lldb-${llvm_version} { revision 0 }
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
@@ -24,6 +24,10 @@ categories              lang
 platforms               darwin
 license                 NCSA
 maintainers             {jeremyhu @jeremyhu} {larryv @larryv} {kencu @kencu}
+
+# python version to use when required.
+set py_ver              2.7
+set py_ver_nodot        [string map {. {}} ${py_ver}]
 
 if {${subport} eq "llvm-${llvm_version}"} {
     homepage            https://llvm.org/
@@ -51,7 +55,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
                         that can be built using the Clang frontend as a \
                         library to parse C/C++ code.
 
-    depends_lib         port:libxml2 port:libomp port:llvm-${llvm_version} port:python27
+    depends_lib         port:libxml2 port:libomp port:llvm-${llvm_version}
     depends_run         port:clang_select port:ld64
     depends_skip_archcheck-append ld64 subversion
 
@@ -75,7 +79,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
     description         the LLVM debugger
     long_description    Lldb is the "LLVM native" debugger.
 
-    depends_lib         port:libxml2 port:libomp port:llvm-${llvm_version} port:python27 \
+    depends_lib         port:libxml2 port:libomp port:llvm-${llvm_version} port:python${py_ver_nodot} \
                         port:ncurses
     depends_build-append port:swig-python port:doxygen
 
@@ -314,8 +318,8 @@ if {${subport} eq "llvm-${llvm_version}"} {
         -DLLVM_BUILD_RUNTIME=ON \
         -DLIBCXX_ENABLE_SHARED=OFF \
         -DLIBCXX_INSTALL_LIBRARY=OFF \
-        -DPYTHON_EXECUTABLE=${prefix}/bin/python2.7 \
-        -DPYTHON_INCLUDE_DIR=${prefix}/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7
+        -DPYTHON_EXECUTABLE=${prefix}/bin/python${py_ver} \
+        -DPYTHON_INCLUDE_DIR=${prefix}/Library/Frameworks/Python.framework/Versions/${py_ver}/include/python${py_ver}
 }
 
 # llvm-3.5 and later requires a C++11 runtime
@@ -361,14 +365,15 @@ if {[lsearch -exact $PortInfo(depends_build) port:cctools] != -1} {
         -DCMAKE_LIBTOOL=${prefix}/bin/libtool
 }
 
-
+set py_to_use /usr/bin/python
 platform darwin {
     # requires a newer python than the system default
     if {${os.major} < 11} {
-        depends_build-append port:python27
-        configure.args-append \
-            -DPYTHON_EXECUTABLE:FILEPATH=${prefix}/bin/python2.7
+        depends_lib-append port:python${py_ver_nodot}
+        set py_to_use      ${prefix}/bin/python${py_ver}
     }
+    configure.args-append \
+        -DPYTHON_EXECUTABLE:FILEPATH=${py_to_use}
 }
 
 platform darwin {
@@ -632,7 +637,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
                 ${worksrcpath}/tools/clang/tools/scan-build/libexec/ccc-analyzer \
                 ${worksrcpath}/tools/clang/tools/scan-build/libexec/c++-analyzer \
                 ${worksrcpath}/tools/clang/tools/scan-build/bin/scan-build
-            reinplace "s|/usr/bin/env python|${prefix}/bin/python2.7|g" \
+            reinplace "s|/usr/bin/env python|${py_to_use}|g" \
                 ${worksrcpath}/tools/clang/tools/scan-build/bin/set-xcode-analyzer \
                 ${worksrcpath}/tools/clang/tools/scan-view/bin/scan-view
         }

--- a/lang/llvm-devel/Portfile
+++ b/lang/llvm-devel/Portfile
@@ -15,7 +15,7 @@ set clang_executable_version 9
 set lldb_executable_version 9.0.0
 name                    llvm-${llvm_version}
 revision                1
-subport                 clang-${llvm_version} { revision 1 }
+subport                 clang-${llvm_version} { revision 2 }
 subport                 lldb-${llvm_version} { revision 1 }
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
@@ -24,6 +24,10 @@ categories              lang
 platforms               darwin
 license                 NCSA
 maintainers             {jeremyhu @jeremyhu} {larryv @larryv} {kencu @kencu}
+
+# python version to use when required.
+set py_ver              2.7
+set py_ver_nodot        [string map {. {}} ${py_ver}]
 
 if {${subport} eq "llvm-${llvm_version}"} {
     homepage            https://llvm.org/
@@ -51,7 +55,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
                         that can be built using the Clang frontend as a \
                         library to parse C/C++ code.
 
-    depends_lib         port:libxml2 port:libomp port:llvm-${llvm_version} port:python27
+    depends_lib         port:libxml2 port:libomp port:llvm-${llvm_version}
     depends_run         port:clang_select port:ld64
     depends_skip_archcheck-append ld64 subversion
 
@@ -75,7 +79,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
     description         the LLVM debugger
     long_description    Lldb is the "LLVM native" debugger.
 
-    depends_lib         port:libxml2 port:libomp port:llvm-${llvm_version} port:python27 \
+    depends_lib         port:libxml2 port:libomp port:llvm-${llvm_version} port:python${py_ver_nodot} \
                         port:ncurses
     depends_build-append port:swig-python port:doxygen
 
@@ -278,8 +282,8 @@ if {${subport} eq "llvm-${llvm_version}"} {
         -DLLVM_BUILD_RUNTIME=ON \
         -DLIBCXX_ENABLE_SHARED=OFF \
         -DLIBCXX_INSTALL_LIBRARY=OFF \
-        -DPYTHON_EXECUTABLE=${prefix}/bin/python2.7 \
-        -DPYTHON_INCLUDE_DIR=${prefix}/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7
+        -DPYTHON_EXECUTABLE=${prefix}/bin/python${py_ver} \
+        -DPYTHON_INCLUDE_DIR=${prefix}/Library/Frameworks/Python.framework/Versions/${py_ver}/include/python${py_ver}
 }
 
 # llvm-3.5 and later requires a C++11 runtime
@@ -326,14 +330,15 @@ if {[lsearch -exact $PortInfo(depends_build) port:cctools] != -1} {
         -DCMAKE_LIBTOOL=${prefix}/bin/libtool
 }
 
-
+set py_to_use /usr/bin/python
 platform darwin {
     # requires a newer python than the system default
     if {${os.major} < 11} {
-        depends_build-append port:python27
-        configure.args-append \
-            -DPYTHON_EXECUTABLE:FILEPATH=${prefix}/bin/python2.7
+        depends_lib-append port:python${py_ver_nodot}
+        set py_to_use      ${prefix}/bin/python${py_ver}
     }
+    configure.args-append \
+        -DPYTHON_EXECUTABLE:FILEPATH=${py_to_use}
 }
 
 platform darwin {
@@ -591,7 +596,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
                 ${worksrcpath}/tools/clang/tools/scan-build/libexec/ccc-analyzer \
                 ${worksrcpath}/tools/clang/tools/scan-build/libexec/c++-analyzer \
                 ${worksrcpath}/tools/clang/tools/scan-build/bin/scan-build
-            reinplace "s|/usr/bin/env python|${prefix}/bin/python2.7|g" \
+            reinplace "s|/usr/bin/env python|${py_to_use}|g" \
                 ${worksrcpath}/tools/clang/tools/scan-build/bin/set-xcode-analyzer \
                 ${worksrcpath}/tools/clang/tools/scan-view/bin/scan-view
         }


### PR DESCRIPTION
currently the clang-X builds always declare a lib dependency on python27. However, the builds are only explicitly spec'ed to use the MacPorts provided python version on darwin < 11. On the newer systems, the macports version is not used by the build, which instead finds and uses the system version.

This MR simply removes the lib dependency in the cases where it is not currently used. 

On the mailing list, @kencu raised the view that the builds should perhaps be also spec'ed to use the macports python version (as in fact is already the case for the lldb-X builds) for all OS versions. That is certainly an option, but is not done in this PR. It could be added, by either removing the darwin < 11 version checks (or setting the max version to 'large number').

I started looking into this as a user on the mailing list asked why clang-9 requires python27, as they where attempting to purge their local installation of  python27, and use a 3.x builds instead. Apparently LLVM is not yet quite reading for 3.x, so whenever we do use MacPorts python, it should at least for now remain at 2.7. 