### PR TITLE
wtfutil: update to 0.26.0

### DIFF
--- a/sysutils/wtfutil/Portfile
+++ b/sysutils/wtfutil/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        wtfutil wtf 0.25.0 v
+github.setup        wtfutil wtf 0.26.0 v
 homepage            https://wtfutil.com
 
 name                wtfutil
@@ -30,7 +30,7 @@ build.env           GOPATH=${workpath} \
 build.target        install
 
 post-extract {
-    reinplace "s|@mv ~/go/bin/wtf ~/go/bin/wtfutil|@mv \$\$GOPATH/bin/wtf \$\$GOPATH/bin/wtfutil|g" ${worksrcpath}/Makefile
+    reinplace "s|~/go|\$\${GOPATH}|g" ${worksrcpath}/Makefile
 }
 
 post-build {


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
