### PR TITLE
zsh-autosuggestions: new Portfile

### DIFF
--- a/sysutils/zsh-autosuggestions/Portfile
+++ b/sysutils/zsh-autosuggestions/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        zsh-users zsh-autosuggestions 0.6.4 v
+
+categories          sysutils shells
+platforms           darwin
+supported_archs     noarch
+license             MIT
+
+maintainers         {@FranklinYu hotmail.com:franklinyu} openmaintainer
+description         Fish-like fast/unobtrusive autosuggestions for zsh
+long_description    Fish-like fast/unobtrusive autosuggestions for zsh. \
+                    It suggests commands as you type based on history and completions.
+
+checksums           rmd160  d2f8da2dd32ca1d3e3bbd0a07114a9ac5afa8b56 \
+                    sha256  393b25d3814682c14c9b90075b0bf90aaeb5ac46a2518279dcee4017ce2d3c45 \
+                    size    29151
+
+use_configure       no
+
+build {}
+
+destroot {
+    set dest_dir ${destroot}${prefix}/share/zsh-autosuggestions
+    xinstall -d ${dest_dir}
+    xinstall -m 644 ${worksrcpath}/zsh-autosuggestions.zsh ${dest_dir}
+}


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/58293

#### Description

Fish-like auto-suggestions.

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?