### PR TITLE
mercurial: add py27-gnureadline as a runtime dependency.

### DIFF
--- a/devel/mercurial/Portfile
+++ b/devel/mercurial/Portfile
@@ -8,6 +8,7 @@ name                mercurial
 # don't forget to update dependents for mercurial:
 # port echo rdepends:mercurial and \( name:hg or name:mercurial \) | grep -v 'py[[:digit:]]'
 version             5.3
+revision            1
 categories          devel python
 license             GPL-2+
 maintainers         nomaintainer
@@ -35,7 +36,8 @@ checksums           rmd160  cd7e8fb08f8423413e689a0836ebab4961c05214 \
 
 depends_build       port:py27-docutils
 
-depends_run         path:share/curl/curl-ca-bundle.crt:curl-ca-bundle
+depends_run         path:share/curl/curl-ca-bundle.crt:curl-ca-bundle \
+                    port:py27-gnureadline
 
 patchfiles          patch-setup.py.diff
 


### PR DESCRIPTION
#### Description

Mercurial prompts with ANSI-escape sequences are misrendered when GNU readline bindings are missing, as documented in https://trac.macports.org/ticket/60041.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G3020
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
