### PR TITLE
wireguard-tools: update to 1.0.20200206

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-tools
-version             1.0.20200121
+version             1.0.20200206
 revision            0
-checksums           rmd160  15e23a312ab59e9ce64c504026cd80827b280451 \
-                    sha256  15bfdbdbecbd3870ced9a7e68286c871bfcb2071d165f113808081f2e428faa3 \
-                    size    92804
+checksums           rmd160  53650ceddf5eb908cba77471b8dca591db4fc3b0 \
+                    sha256  f5207248c6a3c3e3bfc9ab30b91c1897b00802ed861e1f9faaed873366078c64 \
+                    size    92288
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
###### Tested on
macOS 10.13.6 17G8037
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?