### PR TITLE
Update charm to version 1.12.0

### DIFF
--- a/office/charm/Portfile
+++ b/office/charm/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 
 name                charm
-version             1.11.0
+version             1.12.0
 
 github.setup        KDAB Charm ${version}
 
@@ -22,6 +22,8 @@ subport ${name}-qt5 {
     conflicts       ${name}
     qt5.depends_component \
                     sqlite-plugin
+    depends_lib-append \
+                    port:qtkeychain-qt5
     configure.args-append \
                     -DCHARM_FORCE_QT4:BOOL=OFF
 }
@@ -29,19 +31,20 @@ subport ${name}-qt5 {
 if {${subport} ne "${name}-qt5"} {
     PortGroup       qt4 1.0
 
-    revision        20151018
+    revision        20200207
 
     conflicts       ${name}-qt5
     depends_build-append \
                     port:automoc
     depends_lib-append \
-                    port:qt4-mac-sqlite3-plugin
+                    port:qt4-mac-sqlite3-plugin port:qtkeychain-qt4
     configure.args-append \
                     -DCHARM_FORCE_QT4:BOOL=ON
 }
 
-checksums           rmd160  da690a57d743e8c79e2d60d8bb2f29a276b69055 \
-                    sha256  8729bc0936a481a113b8a56a747455ec488bf565182ca29d8bb583c74b194267
+checksums           rmd160  543d3bb8c13a9677b47e07f2632007a3ed3b6d2f \
+                    sha256  9616792040a3765f10b303ab0920b1dc72d861c7d11934816d83633b439d0455 \
+                    size    825261
 
 configure.args-append \
                     -DCharm_VERSION="${version}"


### PR DESCRIPTION
#### Description

Update charm to version 1.12.0
```port install charm-qt5``` worked well on my system.

The QT4 version might be broken, though.
@RJVB is it time to drop QT4 support?

###### Type(s)
- [x] update
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G3020
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

