### PR TITLE
py-shellingham: new port

### DIFF
--- a/python/py-shellingham/Portfile
+++ b/python/py-shellingham/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-shellingham
+version             1.3.1
+revision            0
+categories-append   devel
+platforms           darwin
+license             ISC
+supported_archs     noarch
+
+python.versions     37 38
+
+maintainers         {gmail.com:davidgilman1 @dgilman} openmaintainer
+
+description         Tool to Detect Surrounding Shell
+
+long_description    Shellingham detects what shell the current Python \
+                    executable is running in.
+
+homepage            https://github.com/sarugaku/shellingham
+
+checksums           rmd160  1147d071b343eb237da14441f9680c0eec5e9ad4 \
+                    sha256  985b23bbd1feae47ca6a6365eacd314d93d95a8a16f8f346945074c28fe6f3e0 \
+                    size    7938
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+    livecheck.type  none
+}


### PR DESCRIPTION
#### Description
New port

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G10021
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
