### PR TITLE
py-lockfile: update to 0.12.2

### DIFF
--- a/python/py-lockfile/Portfile
+++ b/python/py-lockfile/Portfile
@@ -1,17 +1,18 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-lockfile
-set real_name       pylockfile
-version             0.9.1
+version             0.12.2
 categories-append   devel
 platforms           darwin
 license             MIT
-maintainers         nomaintainer
+maintainers         {gmail.com:davidgilman1 @dgilman} openmaintainer
 supported_archs     noarch
 
 description         Platform-independent file locking module
-long_description  \
+long_description    \
     This package exports a LockFile class which provides a simple API for \
     locking files. Unlike the Windows msvcrt.locking function, the fcntl.lockf \
     and flock functions, and the deprecated posixfile module, the API is \
@@ -21,11 +22,17 @@ long_description  \
     also provided, more as a demonstration of the possibilities it provides \
     than as production-quality code.
 
-homepage            https://code.google.com/p/${real_name}/
-master_sites        googlecode:${real_name} http://distfiles.macports.org/python/
-distname            lockfile-${version}
-checksums           md5     4e4c7ea4c4301500da5e7f3b51e01cfe \
-                    sha1    1eebaee375641c9f29aeb21768f917dd2b985752 \
-                    rmd160  c94c1a638f2a11181063d6025a6c5acc8c9d09e6
+homepage            https://pypi.org/project/lockfile/
 
-python.versions     27
+checksums           rmd160  6aaa40fb1a1bd4322f26182fca631a6c4c1f8d24 \
+                    sha256  6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799 \
+                    size    20874
+
+python.versions     27 37 38
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools \
+                    port:py${python.version}-pbr
+    livecheck.type  none
+}


### PR DESCRIPTION
#### Description
Update to what is probably the final release of pylockfile as upstream is no longer maintaining it.  python2 compatibility is required for the handful of ports that depend on this.

###### Type(s)
- [x] enhancement

###### Tested on
macOS 10.13.6 17G10021
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
