### PR TITLE
cctools/libmacho: update to 927.0.2

### DIFF
--- a/devel/cctools/Portfile
+++ b/devel/cctools/Portfile
@@ -178,6 +178,15 @@ post-patch {
         reinplace "s:__TRY_SYSTEM_CLANG__:${try_system_clang}:" ${worksrcpath}/as/driver.c
 
         foreach file [glob ${worksrcpath}/{*/,}Makefile] {
+
+            ui_debug "deleting stray rsrc fork from ${file}"
+            if {${os.major} >= 9} {
+                system "cp -X  ${file} ${file}.tmp"
+                system "mv ${file}.tmp ${file}"
+            } else {
+                system "cp /dev/null ${file}/rsrc"
+            }
+
             reinplace -q "s:/usr/local:@PREFIX@:g" ${file}
             reinplace -q "s:/usr:@PREFIX@:g" ${file}
             reinplace -q "s:@PREFIX@:${prefix}:g" ${file}

--- a/devel/cctools/Portfile
+++ b/devel/cctools/Portfile
@@ -5,7 +5,7 @@ PortSystem              1.0
 name                    cctools
 # Xcode 10.0
 version                 921
-set ld64_version        409.12
+set ld64_version        450.3
 revision                5
 categories              devel
 platforms               darwin
@@ -23,10 +23,10 @@ master_sites            https://opensource.apple.com/tarballs/${name}:main \
 
 distfiles               ld64-${ld64_version}.tar.gz:ld64 ${name}-${version}.tar.gz:main
 
-checksums               ld64-409.12.tar.gz \
-                        rmd160  7d616147f3021872962850b1d5909f84a202d5d3 \
-                        sha256  c34561b44210668c51e49efdb7d1e814a33056051ac7698571605ab968d31d5f \
-                        size    730856 \
+checksums               ld64-450.3.tar.gz \
+                        rmd160  4d263cff143228e021c438d3c2d1800ff367c895 \
+                        sha256  140619e676e099581771dbad98277850ff731cd23938bed95b4d7171616acca1 \
+                        size    729639 \
                         cctools-921.tar.gz \
                         rmd160  fedeb6bae83f0322cd131895cc39c525bf549581 \
                         sha256  53449a7f2e316c7df5e6b94fd04e12b6d0356f2487d77aad3000134e4c010cc5 \

--- a/devel/cctools/Portfile
+++ b/devel/cctools/Portfile
@@ -3,7 +3,7 @@
 PortSystem              1.0
 
 name                    cctools
-# Xcode 10.0
+# Xcode 10.2
 version                 927.0.2
 set ld64_version        450.3
 revision                0

--- a/devel/cctools/Portfile
+++ b/devel/cctools/Portfile
@@ -4,9 +4,9 @@ PortSystem              1.0
 
 name                    cctools
 # Xcode 10.0
-version                 921
+version                 927.0.2
 set ld64_version        450.3
-revision                5
+revision                0
 categories              devel
 platforms               darwin
 maintainers             {jeremyhu @jeremyhu} {kencu @kencu} openmaintainer
@@ -27,10 +27,10 @@ checksums               ld64-450.3.tar.gz \
                         rmd160  4d263cff143228e021c438d3c2d1800ff367c895 \
                         sha256  140619e676e099581771dbad98277850ff731cd23938bed95b4d7171616acca1 \
                         size    729639 \
-                        cctools-921.tar.gz \
-                        rmd160  fedeb6bae83f0322cd131895cc39c525bf549581 \
-                        sha256  53449a7f2e316c7df5e6b94fd04e12b6d0356f2487d77aad3000134e4c010cc5 \
-                        size    1755929
+                        cctools-927.0.2.tar.gz \
+                        rmd160  74c906d45173aaa804cba911677dbf64407cfada \
+                        sha256  3d5d35e7120aac187de306019d4b53b3b08dd7ebf48764fcd5c8cefef40b3dbf \
+                        size    1842624
 
 patchfiles              cctools-829-lto.patch \
                         PR-37520.patch \

--- a/devel/cctools/Portfile
+++ b/devel/cctools/Portfile
@@ -40,6 +40,10 @@ patchfiles              cctools-829-lto.patch \
                         cctools-921-noavx512.patch \
                         as-try-clang.patch
 
+# there is a change in cctools/include/mach/i386/_structs.h
+# that causes the build to fail on older systems.
+patchfiles-append cctools-927-revert-i386-struct-header-changes.diff
+
 if {${os.major} < 11} {
     patchfiles-append snowleopard-strnlen.patch
 }

--- a/devel/cctools/files/cctools-927-revert-i386-struct-header-changes.diff
+++ b/devel/cctools/files/cctools-927-revert-i386-struct-header-changes.diff
@@ -1,0 +1,15 @@
+--- include/mach/i386/_structs.h.orig	2020-02-09 10:59:11.000000000 -0800
++++ include/mach/i386/_structs.h	2020-02-09 10:59:34.000000000 -0800
+@@ -627,7 +627,6 @@
+ 	_STRUCT_XMM_REG		__fpu_ymmh15;		/* YMMH 15  */
+ };
+ 
+-#endif /* not __OPEN_SOURCE__ */
+ 
+ #else /* !__DARWIN_UNIX03 */
+ #define	_STRUCT_X86_FLOAT_STATE64	struct x86_float_state64
+@@ -800,3 +799,4 @@
+ };
+ #endif /* !__DARWIN_UNIX03 */
+ 
++#endif /* _MACH_I386__STRUCTS_H_ */

--- a/devel/libmacho/Portfile
+++ b/devel/libmacho/Portfile
@@ -52,6 +52,13 @@ if {${subport} eq "${name}-headers"} {
         default_variants +universal
     }
 
+    post-patch {
+        # macOS 10.14's SDKs have newer versions that are needed to compile
+        if {${os.major} > 17} {
+            file delete -force ${worksrcpath}/include/mach/i386
+        }
+    }
+
     build.dir               ${worksrcpath}/libmacho
     destroot.dir            ${build.dir}
 

--- a/devel/libmacho/Portfile
+++ b/devel/libmacho/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem              1.0
 name                    libmacho
-version                 921
+version                 927.0.2
 subport ${name}-headers { }
 categories              devel
 platforms               darwin
@@ -18,11 +18,12 @@ master_sites            https://opensource.apple.com/tarballs/cctools/
 
 distname                cctools-${version}
 
-checksums               rmd160  fedeb6bae83f0322cd131895cc39c525bf549581 \
-                        sha256  53449a7f2e316c7df5e6b94fd04e12b6d0356f2487d77aad3000134e4c010cc5 \
-                        size    1755929
+checksums               rmd160  74c906d45173aaa804cba911677dbf64407cfada \
+                        sha256  3d5d35e7120aac187de306019d4b53b3b08dd7ebf48764fcd5c8cefef40b3dbf \
+                        size    1842624
 
-patchfiles              cctools-921-noavx512.patch
+patchfiles              cctools-921-noavx512.patch \
+                        cctools-927-revert-i386-struct-header-changes.diff
 
 use_configure           no
 

--- a/devel/libmacho/Portfile
+++ b/devel/libmacho/Portfile
@@ -48,7 +48,9 @@ if {${subport} eq "${name}-headers"} {
     depends_lib-append port:libmacho-headers
 
     variant universal       {}
-    default_variants +universal
+    if {${os.major} < 18} {
+        default_variants +universal
+    }
 
     build.dir               ${worksrcpath}/libmacho
     destroot.dir            ${build.dir}

--- a/devel/libmacho/files/cctools-927-revert-i386-struct-header-changes.diff
+++ b/devel/libmacho/files/cctools-927-revert-i386-struct-header-changes.diff
@@ -1,0 +1,15 @@
+--- include/mach/i386/_structs.h.orig	2020-02-09 10:59:11.000000000 -0800
++++ include/mach/i386/_structs.h	2020-02-09 10:59:34.000000000 -0800
+@@ -627,7 +627,6 @@
+ 	_STRUCT_XMM_REG		__fpu_ymmh15;		/* YMMH 15  */
+ };
+ 
+-#endif /* not __OPEN_SOURCE__ */
+ 
+ #else /* !__DARWIN_UNIX03 */
+ #define	_STRUCT_X86_FLOAT_STATE64	struct x86_float_state64
+@@ -800,3 +799,4 @@
+ };
+ #endif /* !__DARWIN_UNIX03 */
+ 
++#endif /* _MACH_I386__STRUCTS_H_ */


### PR DESCRIPTION
It appears that some files in the source download have resource forks on them that tcl's reinplace does not like.

The i386 directory deletion was also needed on 10.6.8 now -- I don't yet fully understand this issue, or if this is the ideal solution to it.

Once we decide on this as the right approach, and test on more systems, I'll squash all this down into one commit and clean out the informational bits left in for now for assessment.

This may close some tickets -- will review that later.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.6.8, 10.14
Xcode various

