### PR TITLE
py-pyqt5-*: update to 5.14.1; switch to PyPI

### DIFF
--- a/python/py-pyqt5/Portfile
+++ b/python/py-pyqt5/Portfile
@@ -4,8 +4,9 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    py-pyqt5
+python.rootname         PyQt5
 # we the next bump check --allow-sip-warnings if needed
-version                 5.13.1
+version                 5.14.1
 revision                0
 categories-append       devel
 platforms               darwin
@@ -15,15 +16,9 @@ long_description        ${description}. The bindings \
                         are implemented as a set of Python modules and contain over 620 classes.
 homepage                https://www.riverbankcomputing.com/software/pyqt/intro
 license                 GPL-3
-master_sites            https://www.riverbankcomputing.com/static/Downloads/PyQt5/${version}/
-distname                PyQt5_gpl-${version}
-checksums               rmd160  3b68fe4e6c86e666145e71925e0226f4e2ab672a \
-                        sha256  54b7f456341b89eeb3930e786837762ea67f235e886512496c4152ebe106d4af \
-                        size    3162737
-
-livecheck.type          regex
-livecheck.url           https://www.riverbankcomputing.com/software/pyqt/download5
-livecheck.regex         >PyQt5_gpl-(\[0-9.\]*).tar.gz<
+checksums               rmd160  3cb6fbdc9e83dffe2972125c56afe858a6e1f66c \
+                        sha256  2f230f2dbd767099de7a0cb915abdf0cbc3256a0b5bb910eb09b99117db7a65b \
+                        size    3241571
 
 python.versions 27 35 36 37 38
 subport "${name}-common" {}
@@ -72,40 +67,29 @@ if {${subport} eq "${name}-common"} {
     destroot.destdir    DESTDIR=${destroot}
 
     if {[string first "webengine" ${subport}] != -1} {
-        version             5.13.1
+        python.rootname     PyQtWebEngine
+        version             5.14.0
         revision            0
         description         PyQt5 Webengine bindings
         long_description    ${description}
-        master_sites        https://www.riverbankcomputing.com/static/Downloads/PyQtWebEngine/${version}
-        distname            PyQtWebEngine_gpl-${version}
-        checksums           rmd160  88d23dacc583ca028b7444c3233d82901e2ad7da \
-                            sha256  8d8c1262005d8465653a848bf67327fb338e0d3c2d26090a6f7eb071dbb42092 \
-                            size    44883
+        checksums           rmd160  00981c8d95d1fb76208c0c089eda7ffb5746c586 \
+                            sha256  e11595051f8bfbfa49175d899b2c8c2eea3a3deac4141edf4db68c3555221c92 \
+                            size    47794
 
         qt5.depends_component \
                             qtwebengine
-
-        livecheck.type      regex
-        livecheck.url       https://www.riverbankcomputing.com/software/pyqtwebengine/download
-        livecheck.regex     >PyQtWebEngine_gpl-(\[0-9.\]*).tar.gz<
-
     } elseif {[string first "chart" ${subport}] != -1} {
-        version             5.13.0
+        python.rootname     PyQtChart
+        version             5.14.0
         revision            0
         description         PyQt5 Charts bindings
         long_description    ${description}
-        master_sites        https://www.riverbankcomputing.com/static/Downloads/PyQtChart/${version}
-        distname            PyQtChart_gpl-${version}
-        checksums           rmd160  731013f88098d6236ebf4a7ac544ac58a1b2fb6f \
-                            sha256  21742b84343a3d598956f291cb971a734be849a47cd30ec74d1538e95c074a49 \
-                            size    64350
+        checksums           rmd160  d415605d1680bc7b276754f3d281a3c2b958b94a \
+                            sha256  f9004861441becab7a4a48e834da14c3976e4c03e5513c93e005d5df36085046 \
+                            size    68193
 
         qt5.depends_component \
                             qtcharts
-
-        livecheck.type      regex
-        livecheck.url       https://www.riverbankcomputing.com/software/pyqtchart/download
-        livecheck.regex     >PyQtChart_gpl-(\[0-9.\]*).tar.gz<
     }
 
 } elseif {${name} ne ${subport}} {


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.13.6 17G11023
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

Actually, `port lint` gives `Error: Line 112 repeats inclusion of PortGroup qmake5`, but the message is not correct: there are two inclusions of PortGroup qmake5 but in mutually exclusive conditionals, so only one is executed.

- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

I only tested py37-pyqt5 and py37-pyqt5-webengine.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
