### PR TITLE
py-cachy: new port

### DIFF
--- a/python/py-cachy/Portfile
+++ b/python/py-cachy/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-cachy
+version             0.3.0
+revision            0
+categories-append   devel
+platforms           darwin
+license             MIT
+supported_archs     noarch
+
+python.versions     37 38
+
+maintainers         {gmail.com:davidgilman1 @dgilman} openmaintainer
+
+description         Cachy provides a simple yet effective caching library.
+long_description    ${description}
+
+homepage            https://github.com/sdispater/cachy
+
+checksums           rmd160  88f49c70f7e52483733531ddf0f8a2a08bcd9698 \
+                    sha256  186581f4ceb42a0bbe040c407da73c14092379b1e4c0e327fdb72ae4a9b269b1 \
+                    size    15654
+
+if {${name} ne ${subport}} {
+    post-destroot {
+        # https://github.com/sdispater/cachy/issues/9
+        delete ${destroot}${python.pkgd}/tests
+    }
+
+    livecheck.type  none
+}


### PR DESCRIPTION
#### Description
Note that this port has a couple of optional dependencies in its setup.py, a quick overview on how that works is here https://cachy.readthedocs.io/en/latest/configuration.html

The port is functional out of the box but it is reasonable that a later dependency could require one of those optional packages.  I see a couple ways forward:

- Don't depend on the optional dependencies in this Portfile, a later dependency should depend on this package plus the extra package that it requires.  I think this is the most reasonable option so I've implemented this here.
- Put dependencies on all three packages in this Portfile
- Create variants in this Portfile. I don't think this is a winner because other packages can't depend on variants.

I would appreciate any feedback that you have on the issue.

###### Type(s)
- [x] enhancement

###### Tested on
macOS 10.13.6 17G10021
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
