### PR TITLE
py-CacheControl: new port

### DIFF
--- a/python/py-cachecontrol/Portfile
+++ b/python/py-cachecontrol/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-cachecontrol
+python.rootname     CacheControl
+version             0.12.6
+revision            0
+categories-append   devel
+platforms           darwin
+license             Apache-2
+supported_archs     noarch
+
+python.versions     37 38
+
+maintainers         {gmail.com:davidgilman1 @dgilman} openmaintainer
+
+description         httplib2 caching for requests
+long_description    \
+    CacheControl is a port of the caching algorithms in \
+    httplib2 for use with requests session object.
+
+homepage            https://github.com/ionrock/cachecontrol
+
+checksums           rmd160  67bcb07c66fed67504390434cce0e02050336f72 \
+                    sha256  be9aa45477a134aee56c8fac518627e1154df063e85f67d4f83ce0ccc23688e8 \
+                    size    14616
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+        port:py${python.version}-setuptools
+
+    depends_lib-append \
+        port:py${python.version}-requests \
+        port:py${python.version}-msgpack
+
+    livecheck.type  none
+}


### PR DESCRIPTION
#### Description
This is another package with optional dependencies.  I have chosen to avoid adding any of them here, leaving it on further packages to bring in the dependencies required to enable different caching features.

###### Type(s)
- [x] enhancement

###### Tested on
macOS 10.13.6 17G10021
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
