### PR TITLE
nano: Update to 4.8

### DIFF
--- a/editors/nano/Portfile
+++ b/editors/nano/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 
 name            nano
-version         4.7
+version         4.8
 categories      editors
 platforms       darwin freebsd
 license         GPL-3
@@ -19,9 +19,9 @@ long_description \
 homepage        https://www.nano-editor.org
 master_sites    ${homepage}/dist/v[strsed ${version} {/\.[0-9]*$//}]/ gnu
 
-checksums           rmd160  816c623688271320d47d65c46728a7e7c14c85a3 \
-                    sha256  11c4939a5b9ba6627e57e2796c634e1f1e94063b7ce9cc7fcb7e99d2917196f8 \
-                    size    2977920
+checksums           rmd160  2e32ec309b4ba0cfad02982de74275145ce3dc49 \
+                    sha256  335c5c90f17e5863999de012eb4cd7e96e16de24e3255ee20d7aa702e5ef1106 \
+                    size    2995765
 
 depends_lib     port:gettext \
                 port:libiconv \


### PR DESCRIPTION
#### Description

I'm running through `port livecheck installed` and trying to update things that have an open maintainer or no maintainer.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E224g
Xcode 11.4 11N111s 
###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
