### PR TITLE
py-nclib: Enable support for Python 3.8

### DIFF
--- a/python/py-nclib/Portfile
+++ b/python/py-nclib/Portfile
@@ -21,7 +21,7 @@ categories-append    net
 platforms            darwin
 maintainers          {@F30 f30.me:f30} openmaintainer
 
-python.versions      27 35 36 37
+python.versions      27 35 36 37 38
 
 master_sites         pypi:n/nclib
 distname             nclib-${version}


### PR DESCRIPTION
#### Description
Enable Python 3.8 support for py-nclib.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G3020
Command Line Tools for Xcode 10.3

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?