### PR TITLE
New Portfile for maxminddb 1.5.2

### DIFF
--- a/python/py-maxminddb/Portfile
+++ b/python/py-maxminddb/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-maxminddb
+version             1.5.2
+revision            0
+platforms           darwin
+license             Apache-2
+
+python.versions     37 38
+
+maintainers         {@gstaniak gmail.com:gstaniak} openmaintainer
+
+description         Reader for the MaxMind DB format
+
+long_description    This is a Python module for reading MaxMind DB files. The module \
+                    includes both a pure Python reader and an optional C extension.\
+                    \
+                    MaxMind DB is a binary file format that stores data indexed by \
+                    IP address subnets (IPv4 or IPv6).
+
+homepage            https://www.maxmind.com/en/home
+
+checksums           rmd160 caaa546c1daae6781c45a17be906a21a3b4ff654 \
+                    sha256 d0ce131d901eb11669996b49a59f410efd3da2c6dbe2c0094fe2fef8d85b6336 \
+                    size 274594
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                        port:py${python.version}-setuptools
+    depends_lib-append  port:libmaxminddb
+
+    livecheck.type      none
+}


### PR DESCRIPTION
#### Description

A new port of the maxminddb Python module. MacPorts provide the libmaxminddb library, but without manual intervention the maxminddb module will fail to build its C extension when installed using pip, as it will not look in the macports tree for the include files. Without the C extension, pure Python geolocation lookups are orders of magnitude slower.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix
- [X] none of the above

###### Tested on

macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X ] tried a full install with `sudo port -vst install`?
- [X ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
