### PR TITLE
p5-compress-raw-lzma: new port

### DIFF
--- a/perl/p5-compress-raw-lzma/Portfile
+++ b/perl/p5-compress-raw-lzma/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.branches      5.26 5.28 5.30
+perl5.setup         Compress-Raw-Lzma 2.093 ../../authors/id/P/PM/PMQS
+revision            0
+checksums           rmd160  3734772ad134c437a101e1c0ce7f09c354720f64 \
+                    sha256  2eed42733b43a06c00593ed40c9106f341d0146605873e291811db8d86b9453f \
+                    size    116145
+
+platforms           darwin
+
+license             {Artistic-1 GPL}
+maintainers         {isi.edu:calvin @cardi} openmaintainer
+description         Perl low-level interface to allow reading and \
+                    writing of lzma, lzip and xz files/buffers.
+long_description    Compress::Raw::Lzma provides an interface to the \
+                    in-memory compression/uncompression functions from \
+                    the lzma compression library for the modules \
+                    IO::Compress::Lzma, IO::Uncompress::UnLzma, \
+                    IO::Compress::Xz and IO::Uncompress::UnXz
+
+depends_lib-append  port:xz


### PR DESCRIPTION
#### Description

p5-compress-raw-lzma provides Compress::Raw::Lzma, a Perl low-level interface to allow reading and writing of lzma, lzip and xz files/buffers.

###### Tested on
macOS 10.14.6 18G2022
Xcode 11.3 11C29

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
