### PR TITLE
k9s: update to 0.13.8

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.13.7 v
+go.setup            github.com/derailed/k9s 0.13.8 v
 
 categories          sysutils
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -19,9 +19,9 @@ platforms           darwin
 supported_archs     x86_64
 license             Apache-2
 
-checksums           rmd160  9045b1f2177a85b37c0379569c2ed524832b3aed \
-                    sha256  147d057acb1b42d0926d49bc32a8e6c482343752a9090c82e8aa670b63163794 \
-                    size    2066015
+checksums           rmd160  591d31f43dd3277539faefe1d1545078428a2f1a \
+                    sha256  93431f7d109610e106771bd8b614556ec1f2629ae9303c4fbc0450687e4a7ef7 \
+                    size    2066762
 
 # Reproduce the "build" target from the upstream Makefile
 set go_ldflags      "-w -X ${go.package}/cmd.version=${version} \


### PR DESCRIPTION
#### Description

Update to k9s 0.13.8.

###### Tested on

macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?