### PR TITLE
crossbinutils: Update to 2.34

### DIFF
--- a/_resources/port1.0/group/crossbinutils-1.0.tcl
+++ b/_resources/port1.0/group/crossbinutils-1.0.tcl
@@ -41,6 +41,11 @@ array set crossbinutils.versions_info {
         sha256  ab66fc2d1c3ec0359b8e08843c9f33b63e8707efdff5e4cc5c200eae24722cbf \
         size    21490848
     }}
+    2.34 {xz {
+        rmd160  8ee249f7c98c925ef650eaca3b4d1710d75be4e7 \
+        sha256  f00b0e8803dc9bab1e2165bd568528135be734df3fabf8d0161828cd56028952 \
+        size    21637796
+    }}
 }
 
 proc crossbinutils.setup {target version} {

--- a/cross/arm-elf-binutils/Portfile
+++ b/cross/arm-elf-binutils/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
-crossbinutils.setup arm-elf 2.32
+crossbinutils.setup arm-elf 2.34
 maintainers         nomaintainer
 
 # Fix build problems on powerpc, #29925

--- a/cross/arm-none-eabi-binutils/Portfile
+++ b/cross/arm-none-eabi-binutils/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
-crossbinutils.setup arm-none-eabi 2.33.1
+crossbinutils.setup arm-none-eabi 2.34
 maintainers         nomaintainer
 
 configure.args-append --disable-werror

--- a/cross/arm-none-linux-gnueabi-binutils/Portfile
+++ b/cross/arm-none-linux-gnueabi-binutils/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
-crossbinutils.setup arm-none-linux-gnueabi 2.32
+crossbinutils.setup arm-none-linux-gnueabi 2.34
 maintainers         nomaintainer
 
 # description       FSF Binutils for arm-none-linux-gnueabi cross development, with Code Sourcery patches (for Nokia Internet Tablet)

--- a/cross/avr-binutils/Portfile
+++ b/cross/avr-binutils/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
-crossbinutils.setup avr 2.32
+crossbinutils.setup avr 2.34
 maintainers         {g5pw @g5pw} openmaintainer
 
 # configure.args-append --disable-werror

--- a/cross/i386-elf-binutils/Portfile
+++ b/cross/i386-elf-binutils/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
-crossbinutils.setup i386-elf 2.32
+crossbinutils.setup i386-elf 2.34
 maintainers         nomaintainer
 
 configure.args-append --disable-werror

--- a/cross/i686-w64-mingw32-binutils/Portfile
+++ b/cross/i686-w64-mingw32-binutils/Portfile
@@ -7,7 +7,7 @@ PortGroup           crossbinutils 1.0
 set mingw_name      w64-mingw32
 set mingw_arch      i686
 set mingw_target    ${mingw_arch}-${mingw_name}
-crossbinutils.setup ${mingw_target} 2.33.1
+crossbinutils.setup ${mingw_target} 2.34
 
 maintainers         {mojca @mojca} openmaintainer
 

--- a/cross/m68k-elf-binutils/Portfile
+++ b/cross/m68k-elf-binutils/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
-crossbinutils.setup m68k-elf 2.32
+crossbinutils.setup m68k-elf 2.34
 
 configure.args-append \
                     --disable-werror

--- a/cross/mips-elf-binutils/Portfile
+++ b/cross/mips-elf-binutils/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
-crossbinutils.setup mips-elf 2.32
+crossbinutils.setup mips-elf 2.34
 
 configure.args-append \
                     --disable-werror

--- a/cross/ppc-linux-binutils/Portfile
+++ b/cross/ppc-linux-binutils/Portfile
@@ -3,5 +3,5 @@
 PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
-crossbinutils.setup ppc-linux 2.32
+crossbinutils.setup ppc-linux 2.34
 maintainers         nomaintainer

--- a/cross/spu-binutils/Portfile
+++ b/cross/spu-binutils/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
-crossbinutils.setup spu 2.32
+crossbinutils.setup spu 2.34
 maintainers         nomaintainer
 
 configure.args-append   --disable-werror

--- a/cross/x86_64-elf-binutils/Portfile
+++ b/cross/x86_64-elf-binutils/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
-crossbinutils.setup x86_64-elf 2.32
+crossbinutils.setup x86_64-elf 2.34
 maintainers         nomaintainer
 
 configure.args-append --disable-werror

--- a/cross/x86_64-w64-mingw32-binutils/Portfile
+++ b/cross/x86_64-w64-mingw32-binutils/Portfile
@@ -7,7 +7,7 @@ PortGroup           crossbinutils 1.0
 set mingw_name      w64-mingw32
 set mingw_arch      x86_64
 set mingw_target    ${mingw_arch}-${mingw_name}
-crossbinutils.setup ${mingw_target} 2.33.1
+crossbinutils.setup ${mingw_target} 2.34
 
 maintainers         {mojca @mojca} openmaintainer
 


### PR DESCRIPTION
#### Description

I'm running through `port livecheck installed` and trying to update things that have an open maintainer or no maintainer.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E224g
Xcode 11.4 11N111s 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
