### PR TITLE
gdb: Update to 9.1

### DIFF
--- a/devel/gdb/Portfile
+++ b/devel/gdb/Portfile
@@ -5,7 +5,7 @@ PortGroup       muniversal 1.0
 PortGroup       compiler_blacklist_versions 1.0
 
 name            gdb
-version         8.3.1
+version         9.1
 revision        0
 categories      devel
 license         GPL-3+
@@ -33,9 +33,9 @@ supported_archs x86_64 i386
 
 master_sites    gnu
 
-checksums       rmd160  82c6d7d2c96b4716f9f338b116122b7395b07e90 \
-                sha256  26ce655216cd03f4611518a7a1c31d80ec8e884c16715e9ba8b436822e51434b \
-                size    38130999
+checksums       rmd160  fd9cc7af22ed0700f5de7a2bc21e79b5353e6385 \
+                sha256  fcda54d4f35bc53fb24b50009a71ca98410d71ff2620942e3c829a7f5d614252 \
+                size    39255376
 
 # these dependencies are listed under depends_lib rather than depends_build
 # because gdb will link with libraries they provide if installed.
@@ -56,12 +56,20 @@ compiler.blacklist      {clang < 601}
 # compiler supports the standard - getting rid of old Apple GCC versions and the like?
 compiler.cxx_standard   2011
 
+configure.dir ${workpath}/build
+configure.cmd ${worksrcpath}/configure
 configure.args \
     --with-docdir=${prefix}/share/doc \
     --without-guile \
     --without-python \
     --program-prefix=g \
     --disable-werror
+
+pre-configure {
+    file mkdir ${configure.dir}
+}
+
+build.dir ${configure.dir}
 
 post-destroot {
     if {${os.platform} eq "darwin" && ${os.major} < 12} {


### PR DESCRIPTION
#### Description

I'm running through `port livecheck installed` and trying to update things that have an open maintainer or no maintainer.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E224g
Xcode 11.4 11N111s 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
