### PR TITLE
py-[qdarkstyle|watchdog|xarray]: update to latest versions

### DIFF
--- a/python/py-argh/Portfile
+++ b/python/py-argh/Portfile
@@ -16,17 +16,16 @@ description         A simple argparse wrapper
 long_description    ${description}
 
 homepage            https://github.com/neithere/${python.rootname}
-master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
-distname            ${python.rootname}-${version}
 
 checksums           rmd160  42da2aa1dfae654419acfc62db73d0fb27ecd23f \
                     sha256  e9535b8c84dc9571a48999094fda7f33e63c3f1b74f3e5f3ac0105a58405bb65 \
                     size    32913
 
-python.versions     27 35 36 37
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
-    depends_build  port:py${python.version}-setuptools
+    depends_build-append \
+                    port:py${python.version}-setuptools
 
     livecheck.type  none
 }

--- a/python/py-pathtools/Portfile
+++ b/python/py-pathtools/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                py-pathtools
 version             0.1.2
+revision            0
 
 platforms           darwin
 supported_archs     noarch
@@ -15,14 +16,12 @@ description         File system general utilities
 long_description    ${description}
 
 homepage            https://pythonhosted.org/pathtools
-master_sites        pypi:p/${python.rootname}
-distname            ${python.rootname}-${version}
 
 checksums           rmd160  cdc2001f64f953bcff70e1dd85d2527665a12272 \
                     sha256  7c35c5421a39bb82e58018febd90e3b6e5db34c5443aaaf742b3f33d4655f1c0 \
                     size    11006
 
-python.versions     27 35 36 37
+python.versions     27 35 36 37 38
 
 if { ${name} ne ${subport} } {
     depends_build-append \

--- a/python/py-qdarkstyle/Portfile
+++ b/python/py-qdarkstyle/Portfile
@@ -5,42 +5,38 @@ PortGroup           python 1.0
 
 name                py-qdarkstyle
 python.rootname     QDarkStyle
-version             2.7
+version             2.8
 revision            0
+
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
 license             MIT
-
 maintainers         {petr @petrrr} openmaintainer
 
 description         A dark stylesheet for Python and Qt applications
-
 long_description    This package provides a dark style sheet for \
                     PySide/PyQt4/PyQt5 applications.
 
 homepage            https://github.com/ColinDuquesnoy/QDarkStyleSheet
 
-master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
-distname            ${python.rootname}-${version}
-
-checksums           sha256  de7aba62119a839556afd7b3b962588410b6249cbcfcbd56e51e6e827264c38f \
-                    rmd160  3ccddb5ad4c2c7b656cfc8352c5520a5069e3ff2 \
-                    size    1245786
+checksums           sha256  6a967c4b664446f8bed9df12d1032cf68cb54f186bfc9cbfdbbc756bf9a5d475 \
+                    rmd160  95b7cbcdbec958e2ee685aff8348e5601a2a1c35 \
+                    size    405579
 
 python.versions     27 35 36 37
 
 if {${name} ne ${subport}} {
-    depends_lib-append  port:py${python.version}-setuptools
-
     depends_lib-append \
-                    port:py${python.version}-helpdev
+                    port:py${python.version}-helpdev \
+                    port:py${python.version}-qtpy \
+                    port:py${python.version}-setuptools
 
     post-destroot {
         set dest_doc ${destroot}${prefix}/share/doc/${subport}
         xinstall -d ${dest_doc}
-        xinstall -m 0644 -W ${worksrcpath} AUTHORS.md CHANGES.md \
-            LICENSE.md CONTRIBUTING.md README.md ${dest_doc}
+        xinstall -m 0644 -W ${worksrcpath} AUTHORS.rst CHANGES.rst \
+            LICENSE.rst CONTRIBUTING.rst README.rst ${dest_doc}
     }
 
     livecheck.type  none

--- a/python/py-watchdog/Portfile
+++ b/python/py-watchdog/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-watchdog
-version             0.9.0
+version             0.10.2
 revision            0
 
 categories-append   sysutils
@@ -16,14 +16,12 @@ description         Python API and shell utilities to monitor file system events
 long_description    ${description}
 
 homepage            https://github.com/gorakhargosh/watchdog
-master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}/
-distname            ${python.rootname}-${version}
 
-checksums           sha256  965f658d0732de3188211932aeb0bb457587f04f63ab4c1e33eab878e9de961d \
-                    rmd160  7a6cea352e1077d76ca71c240281dcd08ce25f09 \
-                    size    85549
+checksums           sha256  c560efb643faed5ef28784b2245cf8874f939569717a4a12826a173ac644456b \
+                    rmd160  8bc3be3df4fcdedfd2e290c2f0f99f4b189efc18 \
+                    size    95505
 
-python.versions     27 35 36 37
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_lib-append      port:py${python.version}-argh \

--- a/python/py-xarray/Portfile
+++ b/python/py-xarray/Portfile
@@ -4,18 +4,16 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-xarray
-version             0.14.1
+version             0.15.0
 revision            0
 
 categories-append   science math
 platforms           darwin
 supported_archs     noarch
 license             Apache-2
-
 maintainers         {petr @petrrr} openmaintainer
 
 description         Provides N-D labeled arrays and datasets in Python
-
 long_description    \
     xarray (formerly xray) is an open source project and Python package that \
     aims to bring the labeled data power of pandas to the physical sciences, \
@@ -23,9 +21,9 @@ long_description    \
 
 homepage            https://github.com/pydata/xarray
 
-checksums           rmd160  55914da99f9607acb6cc789ea92868503eba44c1 \
-                    sha256  04b2f4d24707b8871a7ffa37328d0a2de74e81bd30791c9608712612601abd23 \
-                    size    1873976
+checksums           rmd160  183dda75d79215d8a8fda0cf32f33fa67f09d937 \
+                    sha256  c72d160c970725201f769e80fb91cbad68d6ebf21d68fcc371385a6c950459c3 \
+                    size    1911362
 
 python.versions     27 35 36 37 38
 
@@ -48,6 +46,9 @@ if {${name} ne ${subport}} {
 
         depends_test-append \
                     port:py${python.version}-mock
+    } else {
+        depends_build-append \
+                    port:py${python.version}-setuptools_scm
     }
 
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description
- py-qdarkstyle: update to 2.8
- py-watchdog: update to 0.10.2, add py38 subport
- py-xarray: update to 0.15.0 

###### Tested on
macOS 10.14.6 18G3020
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
