### PR TITLE
meson: Update to 0.53.1

### DIFF
--- a/devel/meson/Portfile
+++ b/devel/meson/Portfile
@@ -4,8 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        mesonbuild meson 0.52.1
-revision            0
+github.setup        mesonbuild meson 0.53.1
 
 github.tarball_from releases
 license             Apache-2
@@ -23,9 +22,9 @@ long_description    Meson is a build system designed to optimize programmer prod
                     Valgrind, CCache and the like. It is both extremely fast, and, even more importantly, \
                     as user friendly as possible.
 
-checksums           rmd160  23a70a0fdcfc66d060ac8f8b413fa160aae8287b \
-                    sha256  0c277472e49950a5537e3de3e60c57b80dbf425788470a1a8ed27446128fc035 \
-                    size    1507726
+checksums           rmd160  e15d73b1d10249365da4562d3cef3bfb4a1a56df \
+                    sha256  ec1ba33eea701baca2c1607dac458152dc8323364a51fdef6babda2623413b04 \
+                    size    1552121
 
 # as of verison 0.45.0,requires python 3.5 or better
 
@@ -57,10 +56,10 @@ post-destroot {
 }
 
 # the following block avoids requiring users to 'sudo port select python3 python37'
-# doing a file test for ${prefix}/bin/python3 and requiring this 
+# doing a file test for ${prefix}/bin/python3 and requiring this
 # to be honest would have been much simpler, but not the "MacPorts way"
 pre-test {
-    reinplace "s|/usr/bin/env python3|/usr/bin/env python3.7|" \
+    reinplace "s|/usr/bin/env python3$|/usr/bin/env python3.7|" \
         ${worksrcpath}/run_tests.py \
         ${worksrcpath}/run_cross_test.py \
         ${worksrcpath}/run_meson_command_tests.py \
@@ -70,7 +69,7 @@ pre-test {
     set testpath "${worksrcpath}/test\\ cases"
     fs-traverse f ${testpath} {
         if { [string match *.py ${f}] } {
-            reinplace "s|/usr/bin/env python3|/usr/bin/env python3.7|" ${f}
+            reinplace "s|/usr/bin/env python3$|/usr/bin/env python3.7|" ${f}
         }
     }
 }


### PR DESCRIPTION
#### Description

I'm running through `port livecheck installed` and trying to update things that have an open maintainer or no maintainer.

The tests seem to have some issues finding Python because of the trace sandbox. Is there a way to specify its existence for this?

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E224g
Xcode 11.4 11N111s 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
