### PR TITLE
OpenBLAS: update to 0.3.8

### DIFF
--- a/math/OpenBLAS/Portfile
+++ b/math/OpenBLAS/Portfile
@@ -76,16 +76,17 @@ if {[string first "-devel" $subport] > 0} {
 
 } else {
 
-    github.setup    xianyi OpenBLAS 0.3.7 v
-    checksums       rmd160 1e3698279f8d3084bfe9b34f22b33bfa56d8dbbf \
-                    sha256 c8943b3ce749c3f5c1eb5a72982178f5f6e383b54f09525983aa6b0ca2966d49 \
-                    size   11991860
+    github.setup    xianyi OpenBLAS 0.3.8 v
+    checksums       rmd160 f13b757446293fde3e5c2a0bd2195425f509c48d \
+                    sha256 69b6351db7821354164d1c513691bbb252d2c5eccdbd4632853766ba4348f638 \
+                    size   12180349
     revision        0
 
     conflicts       OpenBLAS-devel
 
     patchfiles      patch-libnoarch.release.diff \
-                    patch-OpenBLAS-i386-Apple.diff
+                    patch-OpenBLAS-i386-Apple.diff \
+                    patch-revert-5f6206fa-c_check-only.diff
 
     if {![variant_isset native]} {
         notes "


### PR DESCRIPTION
#### Description

update OpenBLAS from 0.3.7 to 0.3.8

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G3020
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
