### PR TITLE
delve: update to 1.4.0

### DIFF
--- a/devel/delve/Portfile
+++ b/devel/delve/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/go-delve/delve 1.3.2 v
+go.setup            github.com/go-delve/delve 1.4.0 v
 
 categories          devel
 license             MIT
@@ -13,9 +13,9 @@ build.target        github.com/go-delve/delve/cmd/dlv
 
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
 
-checksums           rmd160  5d483435c60f35cd3d8fc06bcd0acc0135722e42 \
-                    sha256  832936b9ddb9f32eecc0a41d3e590ec861638c8eb7d8b689ea2550a6f2d2f711 \
-                    size    7733210
+checksums           rmd160  cb29d31a9c1f10cd324a753bec6e9d962610ded7 \
+                    sha256  7439eb8caeaf9c1320e684e3dc6664dc0496c99bdfc3960594f479a249de37ff \
+                    size    7785378
 
 description         Delve is a debugger for the Go programming language.
 long_description    Delve is a debugger for the Go programming language. \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
