### PR TITLE
groovy: update to 3.0.0

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            groovy
-version         2.5.9
+version         3.0.0
 revision        0
 
 categories      lang java
@@ -41,9 +41,9 @@ master_sites    https://dl.bintray.com/${name}/maven/
 distname        apache-${name}-binary-${version}
 use_zip         yes
 
-checksums       rmd160  92242769ce678197ccdea419c2d238ad63a7df5d \
-                sha256  fea7dc321a3029c47ffa4aa165055d2bcc78bc280fac4e70ac131c717e45b89b \
-                size    30388421
+checksums       rmd160  9bfedbe6629b857dde71cbf9523e3b41b990d0bf \
+                sha256  f4b2211e7651ed4ec7728c96c1e1961795c4a9de7b0cad6d399df8e92001d682 \
+                size    42775607
 
 worksrcdir      ${name}-${version}
 
@@ -71,7 +71,7 @@ destroot {
     }
 
     # Add symlinks to the scripts
-    foreach f { grape grape_completion groovy groovyConsole groovyConsole_completion groovy_completion groovyc groovyc_completion groovydoc groovydoc_completion groovysh groovysh_completion java2groovy startGroovy } {
+    foreach f { grape grape_completion groovy groovy_completion groovyConsole groovyConsole_completion groovyc groovyc_completion groovydoc groovydoc_completion groovysh groovysh_completion java2groovy startGroovy } {
         ln -s ../share/java/${name}/bin/${f} ${destroot}${prefix}/bin
     }
 }


### PR DESCRIPTION
#### Description

Update to Apache Groovy 3.0.0.

###### Tested on

macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?