### PR TITLE
virtualenv: Bump version to 20.0.13 and add dependencies

### DIFF
--- a/python/py-appdirs/Portfile
+++ b/python/py-appdirs/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  5c20593d89aa579dc571d533efeeb8ee72eb0d58 \
                     sha256  9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92 \
                     size    12700
 
-python.versions     27 35 36 37 38
+python.versions     27 34 35 36 37 38
 
 if {$subport ne $name} {
     depends_test-append \

--- a/python/py-distlib/Portfile
+++ b/python/py-distlib/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-distlib
+version             0.3.0
+revision            0
+maintainers         {@rubendibattista gmail.com:rubendibattista} openmaintainer
+platforms           darwin
+supported_archs     noarch
+description         Low-level components of distutils2/packaging, augmented \
+                    with higher-level APIs for making packaging easier.
+long_description    ${description}
+homepage            https://bitbucket.org/pypa/distlib
+
+license             PSF
+use_zip             yes
+ 
+checksums           rmd160  ac1c0dd3f48183155bdc302c1f172ad1f34e7d87 \
+                    sha256  2e166e231a26b36d6dfe35a48c4464346620f8645ed0ace01ee31822b288de21 \
+                    size    571953
+
+python.versions     27 34 35 36 37 38
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools
+    livecheck.type  none
+}

--- a/python/py-filelock/Portfile
+++ b/python/py-filelock/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  f4045fa508760a35480bef08ea89f2a102dc249a \
                     sha256  18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59 \
                     size    8549
 
-python.versions     27 35 36 37 38
+python.versions     27 34 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-importlib-metadata/Portfile
+++ b/python/py-importlib-metadata/Portfile
@@ -11,7 +11,7 @@ categories-append   devel
 platforms           darwin
 license             Apache
 
-python.versions     27 35 36 37 38
+python.versions     27 34 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-importlib-resources/Portfile
+++ b/python/py-importlib-resources/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-importlib-resources
+version             1.0.2
+revision            0
+maintainers         {@rubendibattista gmail.com:rubendibattista} openmaintainer
+platforms           darwin
+supported_archs     noarch
+description         A backport of Python 3.7’s standard library importlib.resources module for Python 2.7, and 3.4 through 3.6.
+long_description    ${description}
+homepage            http://importlib-resources.readthedocs.io
+distfiles           importlib_resources-${version}.tar.gz
+
+license             PSF
+ 
+checksums           rmd160  ccbed771125ab62eda228842bc87339dd9aa21a8 \
+                    sha256  d3279fd0f6f847cced9f7acc19bd3e5df54d34f93a2e7bb5f238f81545787078 \
+                    size    23602
+
+python.versions     27 34 35 36
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools \
+                            port:py${python.version}-wheel
+    livecheck.type  none
+}

--- a/python/py-more-itertools/Portfile
+++ b/python/py-more-itertools/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 35 36 37 38
+python.versions     27 34 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -35,6 +35,16 @@ if {${name} ne ${subport}} {
         checksums           rmd160  d577e4f1ab2f842de4b462f27be160b89285f696 \
                             sha256  38a936c0a6d98a38bcc2d03fdaaedaba9f412879461dd2ceff8d37564d6522e4 \
                             size    67359
+        depends_lib-append  port:py${python.version}-six
+    }
+
+    if {${python.version} eq 34} {
+        version             7.2.0
+        revision            0
+        distname            ${python.rootname}-${version}
+        checksums           rmd160  6670cda718be6be8f3ed1c993341eeb91d8a7d0d \
+                            sha256  409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832 \
+                            size    73429
         depends_lib-append  port:py${python.version}-six
     }
 

--- a/python/py-setuptools/Portfile
+++ b/python/py-setuptools/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-setuptools
-version             43.0.0
+version             45.2.0
 categories-append   devel
 # License status is murky. The current maintainer decided to relicense as
 # MIT, but he doesn't appear to have obtained the permission of previous
@@ -25,9 +25,10 @@ supported_archs     noarch
 homepage            https://pypi.org/project/setuptools/
 use_zip             yes
 
-checksums           md5 792983f474cd2bd314fa3af28813cdb6 \
-                    rmd160 b0c380d5789a76b43c409d35f3250efd8577fd91 \
-                    sha256 db45ebb4a4b3b95ff0aca3ce5fe1e820ce17be393caf8902c78aa36240e8c378
+checksums           md5     0c956eea142af9c2b02d72e3c042af30 \
+                    rmd160  2b6691453a582db383321c5342ae5ae5eedd870b \
+                    sha256  89c6e6011ec2f6d57d43a3f9296c4ef022c2cbf49bab26b407fe67992ae3397f \
+                    size    859896
 
 python.versions     26 27 33 34 35 36 37 38
 python.link_binaries no

--- a/python/py-setuptools/Portfile
+++ b/python/py-setuptools/Portfile
@@ -34,18 +34,33 @@ python.versions     26 27 33 34 35 36 37 38
 python.link_binaries no
 
 if {$subport ne $name} {
-    if {${python.version} == 26} {
-        version     36.8.0
-        revision    0
-        checksums   md5    3ecaa938a4c95a74dfbcd6340a47c7c5 \
-                    rmd160 457c838b9fb09cf0bf9ba519a098e1c009710aa3 \
-                    sha256 b2aa5a00e9e4fd20f3c3dd412d490921746efe14bda34d53973c4a59ab05b35d
-    } elseif {${python.version} == 33} {
-        version     39.2.0
-        revision    0
-        checksums   rmd160 6070de164cf74412fe7c9a9d04031112b06cfc2a \
-                    sha256 f7cddbb5f5c640311eb00eab6e849f7701fa70bf6a183fc8a2c33dd1d1672fb2
+
+    switch ${python.version} {
+        26 {
+            version     36.8.0
+            revision    0
+            checksums   md5    3ecaa938a4c95a74dfbcd6340a47c7c5 \
+                        rmd160 457c838b9fb09cf0bf9ba519a098e1c009710aa3 \
+                        sha256 b2aa5a00e9e4fd20f3c3dd412d490921746efe14bda34d53973c4a59ab05b35d
+        }
+
+        33 {
+            version     39.2.0
+            revision    0
+            checksums   rmd160 6070de164cf74412fe7c9a9d04031112b06cfc2a \
+                        sha256 f7cddbb5f5c640311eb00eab6e849f7701fa70bf6a183fc8a2c33dd1d1672fb2
+        }
+
+        34 {
+            version     43.0.0
+            revision    0
+            checksums   rmd160  b0c380d5789a76b43c409d35f3250efd8577fd91 \
+                        sha256  db45ebb4a4b3b95ff0aca3ce5fe1e820ce17be393caf8902c78aa36240e8c378 \
+                        size    858857
+        }
     }
+
+
 
     build.env-append    SETUPTOOLS_INSTALL_WINDOWS_SPECIFIC_FILES=0
     destroot.env-append SETUPTOOLS_INSTALL_WINDOWS_SPECIFIC_FILES=0

--- a/python/py-setuptools_scm/Portfile
+++ b/python/py-setuptools_scm/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 35 36 37 38
+python.versions     27 34 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -25,7 +25,9 @@ checksums           rmd160  4c63618354c506cb64dd75bd1ca605d00342c1ce \
                     size    46272
 
 if {${name} ne ${subport}} {
-    depends_lib-append  port:py${python.version}-setuptools
+    depends_build-append port:py${python.version}-setuptools \
+                         
+    depends_run-append   port:py${python.version}-toml
 
     # https://trac.macports.org/ticket/57199
     use_configure       yes

--- a/python/py-six/Portfile
+++ b/python/py-six/Portfile
@@ -28,7 +28,7 @@ checksums           rmd160  8ca284d5893a99685f0b218c4e47f4e74f5bb080 \
                     sha256  236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a \
                     size    33857
 
-python.versions     27 35 36 37 38
+python.versions     27 34 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_test-append \

--- a/python/py-toml/Portfile
+++ b/python/py-toml/Portfile
@@ -20,7 +20,7 @@ checksums           rmd160 8f619d6251935a9b17370ec8e0b71050d2937451 \
                     sha256 229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c \
                     size 16719
 
-python.versions     27 35 36 37 38
+python.versions     27 34 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build   port:py${python.version}-setuptools

--- a/python/py-virtualenv/Portfile
+++ b/python/py-virtualenv/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-virtualenv
-version             16.7.9
+version             20.0.5
 revision            0
 
 categories-append   devel
@@ -19,24 +19,46 @@ long_description    virtualenv is a tool to create isolated Python \
                     environments.
 
 homepage            https://virtualenv.pypa.io
-master_sites        pypi:v/${python.rootname}
-distname            ${python.rootname}-${version}
 
-checksums           rmd160  1ec5152c8d82350fd24358cfa0d112fdf70e7094 \
-                    sha256  0d62c70883c0342d59c11d0ddac0d954d0431321a41ab20851facf2b222598f3 \
-                    size    5121717
+checksums           rmd160  225a529e632c9fd4281601d11fe8179976157525 \
+                    sha256  531b142e300d405bb9faedad4adbeb82b4098b918e35209af2adef3129274aae \
+                    size    7978815
 
 # keep older Python versions here, do add the EOL version to the list below
 python.versions     27 34 35 36 37 38
 
 if {${name} ne ${subport}} {
     # add EOL warnings
-    if {${python.version} in "34"} {
+    if {${python.version} in "27 34"} {
         PortGroup   deprecated 1.0
+
         deprecated.eol_version  yes
     }
 
-    depends_lib-append  port:py${python.version}-setuptools
+    depends_build-append     port:py${python.version}-setuptools \
+                             port:py${python.version}-setuptools_scm
+
+    depends_lib-append       port:py${python.version}-appdirs \
+                             port:py${python.version}-distlib \
+                             port:py${python.version}-filelock \
+                             port:py${python.version}-six
+
+    if {${python.version} < 33} {
+        depends_lib-append  port:py${python.version}-contextlib2
+    }
+
+    if {${python.version} < 34} {
+        depends_lib-append port:py${python.version}-pathlib2
+    }
+
+    if {${python.version} < 37} {
+        depends_lib-append port:py${python.version}-importlib-resources
+    }
+
+    if {${python.version} < 38} {
+        depends_lib-append  port:py${python.version}-importlib-metadata
+    }
+    
 
     depends_run-append  port:virtualenv_select
 
@@ -46,7 +68,7 @@ if {${name} ne ${subport}} {
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
         xinstall -d ${destroot}${docdir}/docs/changelog
-        xinstall -m 0644 -W ${worksrcpath} README.rst LICENSE.txt AUTHORS.txt \
+        xinstall -m 0644 -W ${worksrcpath} README.md LICENSE \
             ${destroot}${docdir}
         xinstall -m 0644 {*}[glob -directory ${worksrcpath}/docs *.rst] \
                 ${destroot}${docdir}/docs

--- a/python/py-virtualenv/Portfile
+++ b/python/py-virtualenv/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-virtualenv
-version             20.0.5
+version             20.0.13
 revision            0
 
 categories-append   devel
@@ -20,9 +20,9 @@ long_description    virtualenv is a tool to create isolated Python \
 
 homepage            https://virtualenv.pypa.io
 
-checksums           rmd160  225a529e632c9fd4281601d11fe8179976157525 \
-                    sha256  531b142e300d405bb9faedad4adbeb82b4098b918e35209af2adef3129274aae \
-                    size    7978815
+checksums           rmd160  c10bfef5f917116dfb96e09d5c8201be08ff1f34 \
+                    sha256  f3128d882383c503003130389bf892856341c1da12c881ae24d6358c82561b55 \
+                    size    7989904
 
 # keep older Python versions here, do add the EOL version to the list below
 python.versions     27 34 35 36 37 38

--- a/python/py-wheel/Portfile
+++ b/python/py-wheel/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  c8cde8bb1dfd7ed8e237cd53d1a370fdcef1ea0f \
                     sha256  8788e9155fe14f54164c1b9eb0a319d98ef02c160725587ad60f14ddc57b6f96 \
                     size    58330
 
-python.versions     27 35 36 37 38
+python.versions     27 34 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-zipp/Portfile
+++ b/python/py-zipp/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 platforms           darwin
 license             MIT
 
-python.versions     27 35 36 37 38
+python.versions     27 34 35 36 37 38
 
 maintainers         {stromnov @stromnov} openmaintainer
 


### PR DESCRIPTION
Add py-distlib port that is a depenency of virtualenv

Fix this bug: https://github.com/pypa/virtualenv/issues/1581

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.2
Xcode 11.3.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
