### PR TITLE
Poetry: new port

### DIFF
--- a/python/poetry/Portfile
+++ b/python/poetry/Portfile
@@ -1,0 +1,63 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               python 1.0
+
+name                    poetry
+version                 1.0.3
+revision                0
+categories-append       devel
+platforms               darwin
+license                 MIT
+supported_archs         noarch
+
+maintainers             {gmail.com:davidgilman1 @dgilman} openmaintainer
+
+description             Python dependency management and packaging made easy.
+
+long_description        Poetry: Dependency Management for Python \
+                        \
+                        Poetry helps you declare, manage and install \
+                        dependencies of Python projects, ensuring you have \
+                        the right stack everywhere.
+
+homepage                https://python-poetry.org/
+
+checksums               rmd160  d6094162b8f01e15d86fb40b7aaab7e15bce76f1 \
+                        sha256  60a079b1c1d8a4f1538d28ee8d1bf79a5d0eae96f497fdae9512eb3c1f8da13b \
+                        size    164894
+
+python.default_version  38
+
+# These are in setup.py order
+depends_lib-append \
+    port:py${python.version}-setuptools \
+    port:py${python.version}-cachecontrol \
+    port:py${python.version}-lockfile \
+    port:py${python.version}-cachy \
+    port:py${python.version}-cleo \
+    port:py${python.version}-clikit \
+    port:py${python.version}-html5lib \
+    port:py${python.version}-jsonschema \
+    port:py${python.version}-pexpect \
+    port:py${python.version}-pkginfo \
+    port:py${python.version}-parsing \
+    port:py${python.version}-pyrsistent \
+    port:py${python.version}-requests-toolbelt \
+    port:py${python.version}-requests \
+    port:py${python.version}-shellingham \
+    port:py${python.version}-tomlkit \
+    port:py${python.version}-keyring
+
+post-extract {
+    reinplace "s|keyring>=20.0.1,<21.0.0|keyring>=20.0.1|" \
+                                                    ${worksrcpath}/setup.py
+    reinplace "s|requests-toolbelt>=0.8.0,<0.9.0|requests-toolbelt>=0.8.0|" \
+                                                    ${worksrcpath}/setup.py
+    reinplace "s|pyrsistent>=0.14.2,<0.15.0|pyrsistent>=0.14.2|" \
+                                                    ${worksrcpath}/setup.py
+}
+
+test.run                yes
+test.cmd                ${python.bin}
+test.target             -m poetry

--- a/python/py-clikit/Portfile
+++ b/python/py-clikit/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-clikit
 version             0.4.1
-revision            0
+revision            1
 categories-append   devel
 platforms           darwin
 license             MIT
@@ -25,8 +25,13 @@ homepage            https://github.com/sdispater/clikit
 checksums           rmd160  7c3448b961cf7ae0e6b1e3e49dfca53cb019dc07 \
                     sha256  8ae4766b974d7b1983e39d501da9a0aadf118a907a0c9b50714d027c8b59ea81 \
                     size    51892
+patchfiles          patch-pastel2.diff
 
 if {${name} ne ${subport}} {
+    post-extract {
+        reinplace "s|pastel>=0.1.0,<0.2.0|pastel>=0.1.0|" ${worksrcpath}/setup.py
+    }
+
     depends_build-append \
         port:py${python.version}-setuptools
 

--- a/python/py-clikit/files/patch-pastel2.diff
+++ b/python/py-clikit/files/patch-pastel2.diff
@@ -1,0 +1,15 @@
+https://github.com/sdispater/clikit/pull/10
+
+diff --git a/src/clikit/adapter/style_converter.py b/src/clikit/adapter/style_converter.py
+index a81d620..a2062e5 100644
+--- src/clikit/adapter/style_converter.py
++++ src/clikit/adapter/style_converter.py
+@@ -16,7 +16,7 @@ def convert(cls, style):  # type: (Style) -> PastelStyle
+             options.append("bold")
+ 
+         if style.is_underlined():
+-            options.append("underscore")
++            options.append("underline")
+ 
+         if style.is_blinking():
+             options.append("blink")


### PR DESCRIPTION
#### Description
This PR has the Portfile for poetry but also the minimal amount of setup.py changes to actually get it up and running.  pkg_resources is checking the entire dependency graph every time poetry is started so some overly restrictive bounds in clikit have to be lifted.

There is an argument for going back over all the poetry-generated setup.py files and stripping off all the upper bounds of all package dependencies. This will keep minor updates in MacPorts from breaking poetry.  I would say it's not a small risk as this port alone has 15 dependencies and pkg_resources is unforgiving. There's also a test added so enterprising hackers can see if they've accidentally broken the package.

###### Type(s)
- [x] enhancement

###### Tested on
macOS 10.13.6 17G10021
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->