### PR TITLE
Update QEMU to version 4.2.0 to fix Cocoa crash.

### DIFF
--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -7,7 +7,7 @@ PortGroup compiler_blacklist_versions 1.0
 PortGroup legacysupport 1.0
 
 name                    qemu
-version                 4.1.0
+version                 4.2.0
 revision                0
 categories              emulators
 license                 GPL-2+
@@ -25,9 +25,9 @@ homepage                https://www.qemu.org
 master_sites            https://download.qemu.org/
 use_bzip2               yes
 
-checksums               rmd160  8625c6175f58dc3b96c3bf90444af4ade6a5ff20 \
-                        sha256  49f0de77410d4d0f7d0321ff2c2888b281381f06e1e2dac9ec4d061e3934f4ae \
-                        size    66853497
+checksums               rmd160  e9f1d6ee14de42d24b631a486f62a2ac7e2bf7c5 \
+                        sha256  3cf4f3f73233a12211a045f07eef467fdc7bf3877568cd0c8a0cf36121da9fbd \
+                        size    76041728 
 
 patchfiles              patch-configure.diff
 patch.pre_args          -p1


### PR DESCRIPTION
#### Description

Update QEMU to 4.2.0. This version is required for QEMU to properly run on MacOS 10.15.3. [Link to Bug Report 1847906](https://bugs.launchpad.net/qemu/+bug/1847906)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix
 
###### Tested on

macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
