### PR TITLE
p5-io-compress-lzma: new port

### DIFF
--- a/perl/p5-io-compress-lzma/Portfile
+++ b/perl/p5-io-compress-lzma/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.branches      5.26 5.28 5.30
+perl5.setup         IO-Compress-Lzma 2.093 ../../authors/id/P/PM/PMQS
+revision            0
+checksums           rmd160  4e52cf6e8a1e50d3711482e250ed911561303e8c \
+                    sha256  f47b85eefac366ca35bd83b207c414a6753761e16473ad57b35ea5c57392c604 \
+                    size    100808
+
+platforms           darwin
+
+license             {Artistic-1 GPL}
+maintainers         {isi.edu:calvin @cardi} openmaintainer
+description         Perl interface to allow reading and writing of \
+                    lzma files/buffers.
+long_description    ${description}
+
+if {${perl5.major} != ""} {
+    depends_lib-append \
+                    port:p${perl5.major}-compress-raw-lzma \
+                    port:p${perl5.major}-io-compress
+
+    supported_archs noarch
+}


### PR DESCRIPTION
#### Description

p5-io-compress-lzma provides IO::Compress::Lzma, a module that provides a Perl interface to allow reading and writing of lzma files/buffers.

###### Tested on
macOS 10.14.6 18G2022
Xcode 11.3 11C29

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?