### PR TITLE
range-v3: new port

### DIFF
--- a/devel/range-v3/Portfile
+++ b/devel/range-v3/Portfile
@@ -1,0 +1,45 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake  1.1
+PortGroup           compiler_blacklist_versions 1.0
+
+github.setup        ericniebler range-v3 0.10.0
+homepage            https://ericniebler.github.io/range-v3
+categories          devel
+platforms           darwin
+maintainers         nomaintainer
+license             MIT
+
+description         Range library for C++14/17/20, basis for C++20's std::ranges.
+long_description    \
+    Range library for C++14/17/20. This code was the basis of a formal \
+    proposal to add range support to the C++ standard library. That proposal \
+    evolved through a Technical Specification, and finally into P0896R4 "The \
+    One Ranges Proposal" which was merged into the C++20 working drafts in \
+    November 2018.  Ranges are an extension of the Standard Template Library \
+    that makes its iterators and algorithms more powerful by making them \
+    composable. Unlike other range-like solutions which seek to do away with \
+    iterators, in range-v3 ranges are an abstraction layer on top of \
+    iterators.  Range-v3 is built on three pillars: Views, Actions, and \
+    Algorithms. The algorithms are the same as those with which you are \
+    already familiar in the STL, except that in range-v3 all the algorithms \
+    have overloads that take ranges in addition to the overloads that take \
+    iterators. Views are composable adaptations of ranges where the \
+    adaptation happens lazily as the view is iterated. And an action is an \
+    eager application of an algorithm to a container that mutates the \
+    container in-place and returns it for further processing. \
+    Views and actions use the pipe syntax (e.g., rng | adapt1 | adapt2 | ...) \
+    so your code is terse and readable from left to right. Development Status: \
+    This code is fairly stable, well-tested, and suitable for casual use, \
+    although currently lacking documentation. In general, no promise is made \
+    about support or long-term stability. This code will evolve without regard \
+    to backwards compatibility.
+
+checksums           rmd160  a9d538fee06f5998833c4715897cdad6c9c98861 \
+                    sha256  9d33f7bdbbd1288f69915d84b5d836e501fa349aaaa4c7e9ea70a357213afb30 \
+                    size    525776
+
+compiler.blacklist-append {clang < 900}
+depends_build-append port:doxygen


### PR DESCRIPTION
#### Description

This PR adds the range-v3 library (https://github.com/ericniebler/range-v3) as a port.

###### Tested on

macOS 10.15.2 19C57
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
