### PR TITLE
asciidoc: Update to asciidoc-py3 9.0.0rc1

### DIFF
--- a/textproc/asciidoc/Portfile
+++ b/textproc/asciidoc/Portfile
@@ -2,11 +2,13 @@
 
 PortSystem          1.0
 
+PortGroup           github 1.0
+
+github.setup        asciidoc asciidoc-py3 9.0.0rc1
+checksums           rmd160  4748713386dcc24c2189af772f9fda2fb453cdb6 \
+                    sha256  20d8f3582a1a404003d57d9f6173e6ce1802d0993684e2cd14a4bc4b2cead292 \
+                    size    1143948
 name                asciidoc
-version             8.6.9
-revision            3
-checksums           sha256  78db9d0567c8ab6570a6eff7ffdf84eadd91f2dfc0a92a2d0105d323cab4e1f0 \
-                    rmd160  f19936593e3bed2755d77d38dd78a4769f77c7fa
 
 categories          textproc
 license             GPL-2+
@@ -25,29 +27,35 @@ platforms           darwin
 supported_archs     noarch
 installs_libs       no
 
-homepage            http://asciidoc.org/
-master_sites        sourceforge
+# asciidoc doesn't use openssl, it just uses the python interpreter, which does.
+license_noconflict  openssl
 
-depends_lib         port:python27
-depends_run         port:docbook-xml-4.5 \
-                    port:fop \
+homepage            http://asciidoc.org/
+
+use_autoreconf      yes
+depends_lib         port:python37 \
                     port:libxml2 \
-                    port:libxslt
+                    port:libxslt \
+                    port:docbook-xml-4.5 \
+                    port:docbook-xsl-nons
+depends_run         port:fop
 # Other runtime dependencies include dblatex, w3m and epubcheck, but those are
 # rarely used and large. See #52758.
 
-configure.python    ${prefix}/bin/python2.7
+configure.python    ${prefix}/bin/python3.7
+
+pre-configure {
+    reinplace "s:^\tpython3 :\t${configure.python} :" \
+        ${worksrcpath}/Makefile.in
+    reinplace "s:#!/usr/bin/env python3:#!${configure.python}:" \
+        ${worksrcpath}/asciidoc.py \
+        ${worksrcpath}/a2x.py
+}
 
 destroot.target install docs vimdir=${prefix}/share/vim/vimfiles/
 
 pre-destroot {
     xinstall -d ${destroot}${prefix}/share/vim/vimfiles
-}
-
-post-destroot {
-    reinplace "s:#!/usr/bin/env python:#!${prefix}/bin/python2.7:" \
-        ${destroot}${prefix}/bin/asciidoc \
-        ${destroot}${prefix}/bin/a2x
 }
 
 platform darwin {


### PR DESCRIPTION
#### Description

Switch to a version that supports python 3.x, use python 3.7, set `license_noconflict openssl` because asciidoc doesn't use openssl, it just uses python, which links against openssl.

Since this is a source distribution now, we need to run autoreconf. Additionally, the libxml2, libxslt, docbook-xml-4.5 and docbook-xsl-nons dependencies are now also required at build time. Add them as library dependencies to ensure asciidoc works when compiling manpages, because that might require files from docbook-xsl-nons.

Closes: https://trac.macports.org/ticket/59778
Closes: https://trac.macports.org/ticket/53943
Closes: https://trac.macports.org/ticket/59758

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G3020
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
