### PR TITLE
fish: update to version 3.0.2

### DIFF
--- a/shells/fish/Portfile
+++ b/shells/fish/Portfile
@@ -28,15 +28,6 @@ depends_lib             port:libiconv \
                         port:ncurses \
                         port:gettext
 
-# remove unguarded-availability flag, accepted only on new clangs
-# set pipefail only if the bash version is sufficiently new to accept it
-patchfiles              patch-remove-unguarded-availability.diff \
-                        patch-share_config_fish.diff \
-                        patch-tests-bash-check.diff
-post-patch {
-    reinplace "s|@@PREFIX@@|${prefix}/bin|g"     "${worksrcpath}/share/config.fish"
-}
-
 compiler.cxx_standard   2011
 
 # doxygen appears to only regenerate html files and is not needed to install man pages

--- a/shells/fish/Portfile
+++ b/shells/fish/Portfile
@@ -5,8 +5,8 @@ PortGroup               github 1.0
 PortGroup               cmake 1.1
 PortGroup               legacysupport 1.0
 
-github.setup            fish-shell fish-shell 3.0.2
-revision                1
+github.setup            fish-shell fish-shell 3.1.0
+revision                0
 name                    fish
 license                 GPL-2
 categories              shells
@@ -20,9 +20,9 @@ homepage                https://fishshell.com/
 github.tarball_from     releases
 distname                ${name}-${version}
 
-checksums               rmd160  3c89a5ae33514390a3acda559ffa7fe6becceaf5 \
-                        sha256  14728ccc6b8e053d01526ebbd0822ca4eb0235e6487e832ec1d0d22f1395430e \
-                        size    6477869
+checksums               rmd160  75fbb9270035b6f172d3b1d7781430eb1e638c83 \
+                        sha256  e5db1e6839685c56f172e1000c138e290add4aa521f187df4cd79d4eab294368 \
+                        size    6810953
 
 depends_lib             port:libiconv \
                         port:ncurses \


### PR DESCRIPTION
#### Description

- Update to version 3.1.0

Closes: [https://trac.macports.org/ticket/60082](https://trac.macports.org/ticket/60082)

###### Type(s)
- [x] update

###### Tested on
macOS 10.14.6 18G3020
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?

[mp_fish310_build.log](https://github.com/macports/macports-ports/files/4202330/mp_fish310_build.log)
