### PR TITLE
prometheus: update to 2.16.0

### DIFF
--- a/net/prometheus/Portfile
+++ b/net/prometheus/Portfile
@@ -1,7 +1,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        prometheus prometheus 2.15.2 v
+github.setup        prometheus prometheus 2.16.0 v
 github.tarball_from archive
 
 description         The Prometheus monitoring system and time series database
@@ -42,9 +42,9 @@ set prom_share_dir  ${prefix}/share/${name}
 set prom_log_dir    ${prefix}/var/log/${name}
 set prom_log_file   ${prom_log_dir}/${name}.log
 
-checksums   rmd160  e6c1c4f380711cd4a3c73bf5ededed4be17c8109 \
-            sha256  2ba37bced3e90c5e7dd3248918f13f2f3444de748cfe413b0a09f82532c3c553 \
-            size    12852804
+checksums   rmd160  54e500252e9429e0739bb7e39e79da500bf59d15 \
+            sha256  5649b33a752eb231f86649a4781af2a532d7df5afb212bf0e6ec57fd1826cbbc \
+            size    12984571
 
 add_users           ${prom_user} \
                     group=${prom_user} \


### PR DESCRIPTION

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
