### PR TITLE
micronaut: update to 1.3.1

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       java 1.0
 
-github.setup    micronaut-projects micronaut-core 1.3.0 v
+github.setup    micronaut-projects micronaut-core 1.3.1 v
 revision        0
 name            micronaut
 categories      java
@@ -43,9 +43,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        ${name}-${version}
 
-checksums       rmd160  20b236d6c3d0201041e7f5929d5b93f052545e03 \
-                sha256  5c2cf8d05328a6f18f16215c873c877863425b4ef41cd54c2e47bbfe47e1e850 \
-                size    13037972
+checksums       rmd160  cc8f0c53100052783c3431ef82fed1ac8a4de32f \
+                sha256  af992cc2ca74f7893c6dde8f43abbc5ea7962ea23f3b1bb1ba77cb5e908fedbf \
+                size    13037963
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 1.3.1.

###### Tested on

macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?