### PR TITLE
Azure Pipelines: Replace macOS 10.13 with 10.15

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,6 +7,8 @@ jobs:
 
   strategy:
     matrix:
+      mac-10.15:
+        imageName: 'macOS-10.15'
       mac-10.14:
         imageName: 'macOS-10.14'
   pool:


### PR DESCRIPTION
## Description

macOS-10.13 has been deprecated for Azure Pipelines and will be removed
soon. Replace it with the newly added macOS-10.15 instead.

Are we ready to run the tests on macOS 10.15 or do we still need to provide something for the bootstrap script?

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
