### PR TITLE
libsndfile: patch to build under OS X 10.4

### DIFF
--- a/audio/libsndfile/Portfile
+++ b/audio/libsndfile/Portfile
@@ -29,7 +29,7 @@ depends_build       port:pkgconfig
 depends_lib         port:flac port:libogg port:libvorbis
 
 # GCC < 4.3 does not have -Wvla
-patchfiles          patch-Wvla.diff
+patchfiles          patch-Wvla.diff patch-sndfile-play.diff
 
 configure.args \
     --disable-alsa \

--- a/audio/libsndfile/files/patch-sndfile-play.diff
+++ b/audio/libsndfile/files/patch-sndfile-play.diff
@@ -1,0 +1,13 @@
+--- programs/sndfile-play.c.orig	2018-01-26 23:13:33.000000000 +0100
++++ programs/sndfile-play.c	2018-01-26 23:15:17.000000000 +0100
+@@ -61,7 +61,9 @@
+ 
+ #elif (defined (__MACH__) && defined (__APPLE__))
+ 	#include <AvailabilityMacros.h>
+-	#include <Availability.h>
++	#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1050
++		#include <Availability.h>
++	#endif
+ 
+ #elif HAVE_SNDIO_H
+ 	#include <sndio.h>


### PR DESCRIPTION
#### Description

patch sndfile-play.c.to allow build under OS X 10.4 Tiger.

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
