### PR TITLE
angle-grinder: update to 0.13.0

### DIFF
--- a/sysutils/angle-grinder/Portfile
+++ b/sysutils/angle-grinder/Portfile
@@ -4,9 +4,9 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        rcoh angle-grinder 0.12.0 v
+github.setup        rcoh angle-grinder 0.13.0 v
 
-categories          sysutils
+categories          sysutils textproc
 license             MIT
 platforms           darwin
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
@@ -21,9 +21,9 @@ long_description    Angle-grinder allows you to parse, aggregate, sum, \
                     but still want to be able to do sophisticated analytics.
 
 checksums-append    ${distfiles} \
-                    rmd160  e85cb752555f3bc654528f9af5359a57a23af145 \
-                    sha256  cd748c61a5a4634aa85f95668662702b00254829b7bf6603a40c6ffa5af29042 \
-                    size    925676
+                    rmd160  a1ea0096f442a286b464b324df6e7dfeaec7fbb7 \
+                    sha256  04edeef87dfdde8a746c4c2498c8491b6b4625ff09696d496be4a580b583a458 \
+                    size    934367
 
 depends_lib-append  path:lib/libssl.dylib:openssl
 
@@ -36,231 +36,263 @@ destroot {
 notes "angle-grinder is installed as ${bin_name}"
 
 cargo.crates \
-    MacTypes-sys                     1.3.0  7dbbe033994ae2198a18517c7132d952a29fb1db44249a1234779da7c50f4698 \
-    adler32                          1.0.3  7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c \
-    aho-corasick                     0.6.9  1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e \
+    adler32                          1.0.4  5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2 \
+    aho-corasick                     0.7.8  743ad5a418686aad3b87fd14c43badd828cf26e214a00f92a384291cf22e1811 \
     annotate-snippets                0.5.0  e8bcdcd5b291ce85a78f2b9d082a8de9676c12b1840d386d67bc5eea6f9d2b4e \
     ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
-    arrayvec                        0.4.10  92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71 \
+    anyhow                          1.0.26  7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c \
     assert_cli                       0.6.3  a29ab7c0ed62970beb0534d637a8688842506d0ff9157de83286dacd065c8149 \
-    atty                            0.2.11  9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652 \
-    autocfg                          0.1.1  4e5f34df7a019573fb8bdc7e24a2bfebe51a2a1d6bfdbaeccedb3c41fc574727 \
-    backtrace                       0.3.13  b5b493b66e03090ebc4343eb02f94ff944e0cbc9ac6571491d170ba026741eb5 \
-    backtrace-sys                   0.1.28  797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6 \
+    atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+    autocfg                          0.1.7  1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2 \
+    autocfg                          1.0.0  f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d \
+    backtrace                       0.3.43  7f80256bc78f67e7df7e36d77366f636ed976895d91fe2ab9efa3973e8fe8c4f \
+    backtrace-sys                   0.1.32  5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491 \
+    base64                          0.10.1  0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e \
     base64                           0.9.3  489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643 \
-    bitflags                         1.0.4  228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12 \
-    build_const                      0.2.1  39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39 \
+    bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
+    bstr                            0.2.11  502ae1441a0a5adb8fbd38a5955a6416b9493e92b465de5e4a9bde6a539c2c48 \
+    bumpalo                          3.2.0  1f359dc14ff8911330a51ef78022d376f25ed00248912803b58f00cb1c27f742 \
     bytecount                        0.3.2  f861d9ce359f56dbcb6e0c2a1cb84e52ad732cadb57b806adeb3c7668caccbd8 \
-    byteorder                        1.2.7  94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d \
-    bytes                           0.4.11  40ade3d27603c2cb345eb0912aec461a6dec7e06a4ae48589904e808335c7afa \
+    byteorder                        1.3.4  08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de \
+    bytes                           0.4.12  206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c \
     bzip2                            0.3.3  42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b \
     bzip2-sys                        0.1.7  6584aa36f5ad4c9247f5323b0a42f37802b37a836f0ad87084d7a33961abe25f \
-    cc                              1.0.28  bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749 \
-    cfg-if                           0.1.6  082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4 \
-    clap                            2.32.0  b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e \
+    c2-chacha                        0.2.3  214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb \
+    cast                             0.2.3  4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0 \
+    cc                              1.0.50  95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd \
+    cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
+    clap                            2.33.0  5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9 \
     clap-verbosity-flag              0.2.0  bda14f5323b2b747f52908c5b7b8af7790784088bc7c2957a11695e39ad476dc \
     cloudabi                         0.0.3  ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
-    colored                          1.6.1  dc0a60679001b62fb628c4da80e574b9645ab4646056d7c9018885efffe45533 \
-    core-foundation                  0.5.1  286e0b41c3a20da26536c6000a280585d519fd07b3956b43aed8a79e9edce980 \
-    core-foundation-sys              0.5.1  716c271e8613ace48344f723b60b900a93150271e5be206212d052bbc0883efa \
-    crc                              1.8.1  d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb \
-    crc32fast                        1.1.2  e91d5240c6975ef33aeb5f148f35275c25eda8e8a5f95abe421978b05b8bf192 \
-    crossbeam-channel                0.3.4  5b2a9ea8f77c7f9efd317a8a5645f515d903a2d86ee14d2337a5facd1bd52c12 \
-    crossbeam-deque                  0.6.3  05e44b8cf3e1a625844d1750e1f7820da46044ff6d28f4d43e455ba3e5bb2c13 \
-    crossbeam-deque                  0.2.0  f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3 \
-    crossbeam-epoch                  0.3.1  927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150 \
-    crossbeam-epoch                  0.7.0  f10a4f8f409aaac4b16a5474fb233624238fcdeefb9ba50d5ea059aab63ba31c \
-    crossbeam-utils                  0.2.2  2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9 \
-    crossbeam-utils                  0.6.3  41ee4864f4797060e52044376f7d107429ce1fb43460021b126424b7180ee21a \
+    colored                          1.9.2  8815e2ab78f3a59928fc32e141fbeece88320a240e43f47b2fd64ea3a88a5b3d \
+    cookie                          0.12.0  888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5 \
+    cookie_store                     0.7.0  46750b3f362965f197996c4448e4a0935e791bf7d6631bfce9ee0af3d24c919c \
+    core-foundation                  0.6.4  25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d \
+    core-foundation-sys              0.6.2  e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b \
+    crc32fast                        1.2.0  ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1 \
+    criterion                        0.3.1  1fc755679c12bda8e5523a71e4d654b6bf2e14bd838dfc48cde6559a05caf7d1 \
+    criterion-plot                   0.4.1  a01e15e0ea58e8234f96146b1f91fa9d0e4dd7a38da93ff7a75d42c0b9d3a545 \
+    crossbeam-channel                0.3.9  c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa \
+    crossbeam-channel                0.4.0  acec9a3b0b3559f15aee4f90746c4e5e293b701c0f7d3925d24e01645267b68c \
+    crossbeam-deque                  0.7.2  c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca \
+    crossbeam-epoch                  0.8.0  5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac \
+    crossbeam-queue                  0.2.1  c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db \
+    crossbeam-utils                  0.7.0  ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4 \
+    crossbeam-utils                  0.6.6  04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6 \
+    csv                              1.1.3  00affe7f6ab566df61b4be3ce8cf16bc2576bca0963ceb0955e45d514bf9a279 \
+    csv-core                         0.1.6  9b5cadb6b25c77aeff80ba701712494213f4a8418fcda2ee11b6560c3ad0bf4c \
     difference                       2.0.0  524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198 \
-    dtoa                             0.4.3  6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd \
-    either                           1.5.0  3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0 \
-    encoding_rs                     0.8.13  1a8fa54e6689eb2549c4efed8d00d7f3b2b994a064555b0e8df4ae3764bcc4be \
+    dtoa                             0.4.5  4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3 \
+    either                           1.5.3  bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3 \
+    encoding_rs                     0.8.22  cd8d03faa7fe0c1431609dfad7bbe827af30f82e1e2ae6f7ee4fca6bd764bc28 \
     env_logger                      0.5.13  15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38 \
     environment                      0.1.1  1f4b14e20978669064c33b4c1e0fb4083412e40fe56cbea2eae80fd7591503ee \
+    error-chain                     0.12.1  3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9 \
     exitfailure                      0.5.1  2ff5bd832af37f366c6c194d813a11cd90ac484f124f079294f28e357ae40515 \
-    failure                          0.1.3  6dd377bcc1b1b7ce911967e3ec24fa19c3224394ec05b54aa7b083d498341ac7 \
-    failure_derive                   0.1.3  64c2d913fe8ed3b6c6518eedf4538255b989945c14c2a7d5cbff62a5e2120596 \
-    filetime                         0.2.4  a2df5c1a8c4be27e7707789dc42ae65976e60b394afd293d1419ab915833e646 \
-    flate2                           1.0.6  2291c165c8e703ee54ef3055ad6188e3d51108e2ded18e9f2476e774fc5ad3d4 \
+    failure                          0.1.6  f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9 \
+    failure_derive                   0.1.6  0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08 \
+    filetime                         0.2.8  1ff6d4dab0aa0c8e6346d46052e93b13a16cf847b54ed357087c35011048cc7d \
+    flate2                          1.0.13  6bd6d6f4752952feb71363cffc9ebac9411b75b87c6ab6058c40c8900cf43c0f \
     fnv                              1.0.6  2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3 \
     foreign-types                    0.3.2  f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1 \
     foreign-types-shared             0.1.1  00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b \
+    fuchsia-cprng                    0.1.1  a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba \
     fuchsia-zircon                   0.3.3  2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
     fuchsia-zircon-sys               0.3.3  3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
-    futures                         0.1.25  49e7653e374fe0d0c12de4250f0bdb60680b8c80eed558c5c7538eec9c89e21b \
+    futures                         0.1.29  1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef \
     futures-cpupool                  0.1.8  ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4 \
-    getopts                         0.2.18  0a7292d30132fb5424b354f5dc02512a86e4c516fe544bb7a25e7f266951b797 \
-    globset                          0.4.2  4743617a7464bbda3c8aec8558ff2f9429047e025771037df561d383337ff865 \
+    getopts                         0.2.21  14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5 \
+    getrandom                       0.1.14  7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb \
+    glob                            0.2.11  8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb \
+    globset                          0.4.4  925aa2cac82d8834e2b2a4415b6f6879757fb5c0928fc445ae76461a12eed8f2 \
     globwalk                         0.3.1  ce5d04da8cf35b507b2cbec92bbf2d5085292d07cd87637994fd437fe1617bbb \
-    h2                              0.1.14  1ac030ae20dee464c5d0f36544d8b914a6bc606da44a57e052d2b0f5dae129e0 \
+    h2                              0.1.26  a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462 \
     heck                             0.3.1  20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205 \
-    http                            0.1.14  02096a6d2c55e63f7fcb800690e4f889a25f6ec342e3adb4594e293b625215ab \
-    httparse                         1.3.3  e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83 \
+    hermit-abi                       0.1.6  eff2656d88f158ce120947499e971d743c05dbcbed62e5bd2f38f1698bbc3772 \
+    http                            0.1.21  d6ccf5ede3a895d8856620237b2f02972c1bbc78d2965ad7fe8838d4a0ed41f0 \
+    http-body                        0.1.0  6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d \
+    httparse                         1.3.4  cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9 \
     human-panic                      1.0.1  21638c5955a6daf3ecc42cae702335fc37a72a4abcc6959ce457b31a7d43bbdd \
-    humantime                        1.2.0  3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114 \
-    hyper                          0.12.19  f1ebec079129e43af5e234ef36ee3d7e6085687d145b7ea653b262d16c6b65f1 \
+    humantime                        1.3.0  df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f \
+    hyper                          0.12.35  9dbe6ed1438e1f8ad955a4701e9a944938e9519f6888d12d8558b645e247d5f6 \
     hyper-old-types                 0.11.0  6896be51ecf3966c0fa14ff2da3233dbb9aef57ccea1be1afe55f105f4d4c9c4 \
-    hyper-tls                        0.3.1  32cd73f14ad370d3b4d4b7dce08f69b81536c82e39fcc89731930fe5788cd661 \
+    hyper-tls                        0.3.2  3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f \
     idna                             0.1.5  38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e \
-    ignore                           0.4.5  d3a7927f029a610b866d545c488dd1fc403c4fed1cb4aea2ad568eaa9fc79cd9 \
+    idna                             0.2.0  02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9 \
+    ignore                          0.4.11  522daefc3b69036f80c7d2990b28ff9e0471c683bad05ca258e0a01dd22c5a1e \
     im                              13.0.0  8db49f8bc08d5cc4e2bb0f7d25a6d1db2c79bc6f7d7c86c96c657eb3d214125f \
-    indexmap                         1.0.2  7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d \
-    iovec                            0.1.2  dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08 \
-    itertools                        0.8.0  5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358 \
-    itoa                             0.4.3  1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b \
+    include_dir                      0.2.1  f41a8bee1894b3fb755d8f09ccd764650476358197a0582555f698fe84b0ae93 \
+    include_dir_impl                 0.2.1  0c4b029199aef0fb9921fdc5623843197e6f4a035774523817599a9f55e4bf3b \
+    indexmap                         1.3.2  076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292 \
+    iovec                            0.1.4  b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e \
+    itertools                        0.8.2  f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484 \
+    itoa                             0.4.5  b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e \
+    js-sys                          0.3.35  7889c7c36282151f6bf465be4700359318aef36baa951462382eae49e9577cf9 \
     kernel32-sys                     0.2.2  7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d \
     language-tags                    0.2.2  a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a \
-    lazy_static                      1.2.0  a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1 \
-    lazycell                         1.2.1  b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f \
-    libc                            0.2.45  2d2857ec59fadc0773853c664d2d18e7198e83883e7060b63c924cb077bd5c74 \
-    libflate                        0.1.19  bff3ac7d6f23730d3b533c35ed75eef638167634476a499feef16c428d74b57b \
-    lock_api                         0.1.5  62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c \
-    log                              0.4.6  c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6 \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    libc                            0.2.66  d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558 \
+    lock_api                         0.3.3  79b2de95ecb4691949fea4716ca53cdbcfccb2c612e19644a8bad05edcf9f47b \
+    log                              0.4.8  14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7 \
     logfmt                           0.0.2  879777f0cc6f3646a044de60e4ab98c75617e3f9580f7a2032e6ad7ea0cd3054 \
-    maplit                           1.0.1  08cbb6b4fef96b6d77bfc40ec491b1690c779e77b05cd9f07f787ed376fd4c43 \
+    maplit                           1.0.2  3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d \
     matches                          0.1.8  7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
-    memchr                           2.1.2  db4c41318937f6e76648f42826b1d9ade5c09cafb5aef7e351240a70f39206e9 \
-    memoffset                        0.2.1  0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3 \
-    mime                            0.3.12  0a907b83e7b9e987032439a387e187119cddafc92d5c2aaeb1d92580a793f630 \
-    mime_guess                    2.0.0-alpha.6  30de2e4613efcba1ec63d8133f344076952090c122992a903359be5a4f99c3ed \
-    miniz-sys                       0.1.11  0300eafb20369952951699b68243ab4334f4b10a88f411c221d444b36c40e649 \
-    miniz_oxide                      0.2.0  5ad30a47319c16cde58d0314f5d98202a80c9083b5f61178457403dfb14e509c \
-    miniz_oxide_c_api                0.2.0  28edaef377517fd9fe3e085c37d892ce7acd1fbeab9239c5a36eec352d8a8b7e \
-    mio                             0.6.16  71646331f2619b1026cc302f87a2b8b648d5c6dd6937846a16cc8ce0f347f432 \
-    mio-uds                          0.6.7  966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125 \
+    maybe-uninit                     2.0.0  60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00 \
+    memchr                           2.3.0  3197e20c7edb283f87c071ddfc7a2cca8f8e0b888c242959846a6fce03c72223 \
+    memoffset                        0.5.3  75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9 \
+    mime                            0.3.16  2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d \
+    mime_guess                       2.0.1  1a0ed03949aef72dbdf3116a383d7b38b4768e6f960528cd6a6044aa9ed68599 \
+    miniz_oxide                      0.3.6  aa679ff6578b1cddee93d7e82e263b94a575e0bfced07284eb0c037c1d2416a5 \
+    mio                             0.6.21  302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f \
     miow                             0.2.1  8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919 \
-    native-tls                       0.2.2  ff8e08de0070bbf4c31f452ea2a70db092f36f6f2e4d897adf5674477d488fb2 \
+    native-tls                       0.2.3  4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e \
     net2                            0.2.33  42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88 \
-    nodrop                          0.1.13  2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945 \
     nom                              4.2.3  2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6 \
     nom_locate                       0.3.1  6a47c112b3861d81f7fbf73892b9271af933af32bd5dee6889aa3c3fa9caed7e \
-    num-derive                       0.2.3  8af1847c907c2f04d7bfd572fb25bbb4385c637fe5be163cf2f8c5d778fe1e7d \
-    num-traits                       0.2.6  0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1 \
-    num_cpus                         1.9.0  5a69d464bdc213aaaff628444e99578ede64e9c854025aa43b9796530afa9238 \
-    openssl                        0.10.16  ec7bd7ca4cce6dbdc77e7c1230682740d307d1218a87fb0349a571272be749f9 \
+    num-derive                       0.2.5  eafd0b45c5537c3ba526f79d3e75120036502bebacbb3f3220914067ce39dbf2 \
+    num-traits                      0.2.11  c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096 \
+    num_cpus                        1.12.0  46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6 \
+    numtoa                           0.1.0  b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef \
+    oorandom                        11.1.0  ebcec7c9c2a95cacc7cd0ecb89d8a8454eca13906f6deb55258ffff0adeb9405 \
+    openssl                        0.10.28  973293749822d7dd6370d6da1e523b0d1db19f06c459134c658b2a4261378b52 \
     openssl-probe                    0.1.2  77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de \
-    openssl-sys                     0.9.40  1bb974e77de925ef426b6bc82fce15fd45bdcbeb5728bffcfc7cdeeb7ce1c2d6 \
-    ordered-float                    1.0.1  2f0015e9e8e28ee20c581cfbfe47c650cedeb9ed0721090e0b7ebb10b9cdbcc2 \
+    openssl-sys                     0.9.54  1024c0a59774200a555087a6da3f253a9095a5f344e353b212ac4c8b8e450986 \
+    ordered-float                    1.0.2  18869315e81473c951eb56ad5558bbc56978562d3ecfb87abb7a1e944cea4518 \
     os_type                          2.2.0  7edc011af0ae98b7f88cf7e4a83b70a54a75d2b8cb013d6efd02e5956207e9eb \
-    owning_ref                       0.4.0  49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13 \
-    parking_lot                      0.7.0  9723236a9525c757d9725b993511e3fc941e33f27751942232f0058298297edf \
-    parking_lot                      0.6.4  f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5 \
-    parking_lot_core                 0.4.0  94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9 \
-    parking_lot_core                 0.3.1  ad7f7e6ebdc79edff6fdcb87a55b620174f7a989e3eb31b65231f4af57f00b8c \
-    pbr                              1.0.1  deb73390ab68d81992bd994d145f697451bb0b54fd39738e72eef32458ad6907 \
+    parking_lot                      0.9.0  f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252 \
+    parking_lot_core                 0.6.2  b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b \
+    pbr                              1.0.2  4403eb718d70c03ee279e51737782902c68cca01e870a33b6a2f9dfb50b9cd83 \
     percent-encoding                 1.0.1  31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831 \
-    phf                             0.7.23  cec29da322b242f4c3098852c77a0ca261c9c01b806cae85a5572a1eb94db9a6 \
-    phf_codegen                     0.7.23  7d187f00cd98d5afbcd8898f6cf181743a449162aeb329dcd2f3849009e605ad \
-    phf_generator                   0.7.23  03dc191feb9b08b0dc1330d6549b795b9d81aec19efe6b4a45aec8d4caee0c4b \
-    phf_shared                      0.7.23  b539898d22d4273ded07f64a05737649dc69095d92cb87c7097ec68e3f150b93 \
-    pkg-config                      0.3.14  676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c \
+    percent-encoding                 2.1.0  d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
+    pkg-config                      0.3.17  05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677 \
+    plotters                        0.2.12  4e3bb8da247d27ae212529352020f3e5ee16e83c0c258061d27b08ab92675eeb \
     podio                            0.1.6  780fb4b6698bbf9cf2444ea5d22411cef2953f0824b98f33cf454ec5615645bd \
-    proc-macro2                     0.4.24  77619697826f31a02ae974457af0b29b723e5619e113e9397b8b82c6bd253f09 \
+    ppv-lite86                       0.2.6  74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b \
+    proc-macro-hack                  0.4.2  463bf29e7f11344e58c9e01f171470ab15c925c6822ad75028cc1c0e1d1eb63b \
+    proc-macro-hack-impl             0.4.2  38c47dcb1594802de8c02f3b899e2018c78291168a22c281be21ea0fb4796842 \
+    proc-macro2                     0.4.30  cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759 \
+    proc-macro2                      1.0.8  3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548 \
+    publicsuffix                     1.5.4  3bbaa49075179162b49acac1c6aa45fb4dafb5f13cf6794276d77bc7fd95757b \
     pulldown-cmark                   0.2.0  eef52fac62d0ea7b9b4dc7da092aa64ea7ec3d90af6679422d3d7e0e14b6ee15 \
     quantiles                        0.7.1  c10fa813fb26fb6c321a6f3085b5ade4cb4730d08d0b9e70a3759136940957f2 \
-    quick-error                      1.2.2  9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0 \
+    quick-error                      1.2.3  a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0 \
     quicli                           0.4.0  9e8539e98d5a5e3cb0398aedac3e9642ead7d3047a459893526710cb5ad86f6c \
-    quote                           0.6.10  53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c \
-    rand                             0.6.1  ae9d223d52ae411a33cf7e54ec6034ec165df296ccd23533d671a28252b6f66a \
-    rand                             0.4.3  8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd \
-    rand                             0.5.5  e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c \
-    rand_chacha                      0.1.0  771b009e3a508cb67e8823dda454aaa5368c7bc1c16829fb77d3e980440dd34a \
-    rand_core                        0.2.2  1961a422c4d189dfb50ffa9320bf1f2a9bd54ecb92792fb9477f99a1045f3372 \
-    rand_core                        0.3.0  0905b6b7079ec73b314d4c748701f6931eb79fd97c668caa3f1899b22b32c6db \
+    quote                            1.0.2  053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe \
+    quote                           0.6.13  6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1 \
+    rand                             0.4.6  552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293 \
+    rand                             0.6.5  6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca \
+    rand                             0.7.3  6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
+    rand_chacha                      0.1.1  556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef \
+    rand_chacha                      0.2.1  03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853 \
+    rand_core                        0.3.1  7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b \
+    rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
+    rand_core                        0.4.2  9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc \
+    rand_hc                          0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
     rand_hc                          0.1.0  7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4 \
     rand_isaac                       0.1.1  ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08 \
-    rand_pcg                         0.1.1  086bd09a33c7044e56bb44d5bdde5a60e7f119a9e95b0775f545de759a32fe05 \
-    rand_xorshift                    0.1.0  effa3fcaa47e18db002bdde6060944b6d2f9cfd8db471c30e873448ad9187be3 \
-    rayon                            1.0.3  373814f27745b2686b350dd261bfd24576a6fb0e2c5919b3a2b6005f820b0473 \
-    rayon-core                       1.4.1  b055d1e92aba6877574d8fe604a63c8b5df60f60e5982bf7ccbb1338ea527356 \
-    redox_syscall                   0.1.44  a84bcd297b87a545980a2d25a0beb72a1f490c31f0a9fde52fca35bfbb1ceb70 \
+    rand_jitter                      0.1.4  1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b \
+    rand_os                          0.1.3  7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071 \
+    rand_pcg                         0.1.2  abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44 \
+    rand_xorshift                    0.1.1  cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c \
+    rayon                            1.3.0  db6ce3297f9c85e16621bb8cca38a06779ffc31bb8184e1be4bed2be4678a098 \
+    rayon-core                       1.7.0  08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9 \
+    rdrand                           0.4.0  678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2 \
+    redox_syscall                   0.1.56  2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84 \
     redox_termios                    0.1.1  7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76 \
-    regex                            1.1.0  37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f \
-    regex-syntax                     0.6.4  4e47a2ed29da7a9e1960e1639e7a982e6edc6d49be308a3b02daf511504a16d1 \
-    remove_dir_all                   0.5.1  3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5 \
-    reqwest                          0.9.5  ab52e462d1e15891441aeefadff68bdea005174328ce3da0a314f2ad313ec837 \
-    rustc-demangle                  0.1.11  01b90379b8664dd83460d59bdc5dd1fd3172b8913788db483ed1325171eab2f7 \
+    regex                            1.3.4  322cf97724bea3ee221b78fe25ac9c46114ebb51747ad5babd51a2fc6a8235a8 \
+    regex-automata                   0.1.8  92b73c2a1770c255c240eaa4ee600df1704a38dc3feaa6e949e7fcd4f8dc09f9 \
+    regex-syntax                    0.6.14  b28dfe3fe9badec5dbf0a79a9cccad2cfc2ab5484bdb3e44cbd1ae8b3ba2be06 \
+    remove_dir_all                   0.5.2  4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e \
+    reqwest                         0.9.24  f88643aea3c1343c804950d7bf983bd2067f5ab59db6d613a08e05572f2714ab \
+    rustc-demangle                  0.1.16  4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783 \
     rustc_version                    0.2.3  138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a \
-    ryu                              0.2.7  eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7 \
-    safemem                          0.3.0  8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9 \
-    same-file                        1.0.4  8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267 \
-    schannel                        0.1.14  0e1a231dc10abf6749cfa5d7767f25888d484201accbd919b66ab5413c502d56 \
-    scopeguard                       0.3.3  94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27 \
-    security-framework               0.2.1  697d3f3c23a618272ead9e1fb259c1411102b31c6af8b93f1d64cca9c3b0e8e0 \
-    security-framework-sys           0.2.2  40d95f3d7da09612affe897f320d78264f0d2320f3e8eea27d12bd1bd94445e2 \
-    self_update                      0.5.0  4a91301ec87d3925a64c06f667a2f244cf4edb7bd512b1e0aa72abc1963141e3 \
+    ryu                              1.0.2  bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8 \
+    safemem                          0.3.3  ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072 \
+    same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
+    schannel                        0.1.17  507a9e6e8ffe0a4e0ebb9a10293e62fdf7657c06f1b8bb07a8fcf697d2abf295 \
+    scopeguard                       1.0.0  b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d \
+    security-framework               0.3.4  8ef2429d7cefe5fd28bd1d2ed41c944547d4ff84776f5935b456da44593a16df \
+    security-framework-sys           0.3.3  e31493fc37615debb8c5090a7aeb4a9730bc61e77ab10b9af59f1a202284f895 \
+    self_update                      0.5.1  4e4997d828329f3bea234b5efd084f0ee07b284a556d64023cc0e3e47cc44d74 \
     semver                           0.9.0  1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403 \
     semver-parser                    0.7.0  388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
-    serde                           1.0.82  6fa52f19aee12441d5ad11c9a00459122bd8f98707cadf9778c540674f1935b6 \
-    serde_derive                    1.0.82  96a7f9496ac65a2db5929afa087b54f8fc5008dcfbe48a8874ed20049b0d6154 \
-    serde_json                      1.0.33  c37ccd6be3ed1fdf419ee848f7c758eb31b054d7cd3ae3600e3bae0adf569811 \
-    serde_urlencoded                 0.5.4  d48f9f99cd749a2de71d29da5f948de7f2764cc5a9d7f3c97e3514d4ee6eabf2 \
-    siphasher                        0.2.3  0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac \
-    sized-chunks                     0.3.0  a2a2eb3fe454976eefb479f78f9b394d34d661b647c6326a3a6e66f68bb12c26 \
-    slab                             0.4.1  5f9776d6b986f77b35c6cf846c11ad986ff128fe0b2b63a3628e3755e8d3102d \
-    smallvec                         0.6.7  b73ea3738b47563803ef814925e69be00799a8c07420be8b996f8e98fb2336db \
-    stable_deref_trait               1.1.1  dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8 \
+    serde                          1.0.104  414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449 \
+    serde_derive                   1.0.104  128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64 \
+    serde_json                      1.0.47  15913895b61e0be854afd32fd4163fcd2a3df34142cf2cb961b310ce694cbf90 \
+    serde_urlencoded                 0.5.5  642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a \
+    sized-chunks                     0.3.1  f01db57d7ee89c8e053245deb77040a6cc8508311f381c88749c33d4b9b78785 \
+    slab                             0.4.2  c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8 \
+    smallvec                         1.2.0  5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc \
+    smallvec                        0.6.13  f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6 \
+    sourcefile                       0.1.4  4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3 \
     strfmt                           0.1.6  b278b244ef7aa5852b277f52dd0c6cac3a109919e1f6d699adde63251227a30f \
-    string                           0.1.2  98998cced76115b1da46f63388b909d118a37ae0be0f82ad35773d4a4bc9d18d \
-    strsim                           0.7.0  bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550 \
+    string                           0.2.1  d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d \
     strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
-    structopt                       0.2.14  670ad348dc73012fcf78c71f06f9d942232cdd4c859d4b6975e27836c3efc0c3 \
-    structopt-derive                0.2.14  ef98172b1a00b0bec738508d3726540edcbd186d50dfd326f2b1febbb3559f04 \
-    syn                            0.15.23  9545a6a093a3f0bd59adb472700acc08cad3776f860f16a897dfce8c88721cbc \
-    synstructure                    0.10.1  73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015 \
-    tar                             0.4.20  a303ba60a099fcd2aaa646b14d2724591a96a75283e4b7ed3d1a1658909d9ae2 \
+    structopt                       0.2.18  16c2cdbf9cc375f15d1b4141bc48aeef444806655cd0e904207edc8d68d86ed7 \
+    structopt-derive                0.2.18  53010261a84b37689f9ed7d395165029f9cc7abb9f56bbfe86bee2597ed25107 \
+    syn                             1.0.14  af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5 \
+    syn                             0.14.9  261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741 \
+    syn                            0.15.44  9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5 \
+    synstructure                    0.12.3  67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545 \
+    tar                             0.4.26  b3196bfbffbba3e57481b6ea32249fbaf590396a52505a2615adbb79d9d826d3 \
     tempdir                          0.3.7  15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8 \
-    tempfile                         3.0.5  7e91405c14320e5c79b3d148e1c86f40749a36e490642202a31689cb1a3452b2 \
+    tempfile                         3.1.0  7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9 \
     termcolor                        0.3.6  adc4587ead41bf016f11af03e55a624c06568b5a19db4e90fde573d805074f83 \
-    termcolor                        1.0.4  4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f \
-    terminal_size                    0.1.8  023345d35850b69849741bd9a5432aa35290e3d8eb76af8717026f270d1cf133 \
-    termion                          1.5.1  689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096 \
-    textwrap                        0.10.0  307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6 \
-    thread_local                     0.3.6  c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b \
-    time                            0.1.41  847da467bf0db05882a9e2375934a8a55cffdc9db0d128af1518200260ba1f6c \
-    tokio                           0.1.13  a7817d4c98cc5be21360b3b37d6036fe9b7aefa5b7a201b7b16ff33423822f7d \
-    tokio-codec                      0.1.1  5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f \
-    tokio-current-thread             0.1.4  331c8acc267855ec06eb0c94618dcbbfea45bed2d20b77252940095273fb58f6 \
-    tokio-executor                   0.1.5  c117b6cf86bb730aab4834f10df96e4dd586eff2c3c27d3781348da49e255bde \
-    tokio-fs                         0.1.4  60ae25f6b17d25116d2cba342083abe5255d3c2c79cb21ea11aa049c53bf7c75 \
-    tokio-io                        0.1.10  7392fe0a70d5ce0c882c4778116c519bd5dbaa8a7c3ae3d04578b3afafdcda21 \
-    tokio-reactor                    0.1.7  502b625acb4ee13cbb3b90b8ca80e0addd263ddacf6931666ef751e610b07fb5 \
-    tokio-tcp                        0.1.2  7ad235e9dadd126b2d47f6736f65aa1fdcd6420e66ca63f44177bc78df89f912 \
-    tokio-threadpool                 0.1.9  56c5556262383032878afad66943926a1d1f0967f17e94bd7764ceceb3b70e7f \
-    tokio-timer                      0.2.8  4f37f0111d76cc5da132fe9bc0590b9b9cfd079bc7e75ac3846278430a299ff8 \
-    tokio-udp                        0.1.3  66268575b80f4a4a710ef83d087fdfeeabdce9b74c797535fbac18a2cb906e92 \
-    tokio-uds                        0.2.4  99ce87382f6c1a24b513a72c048b2c8efe66cb5161c9061d00bee510f08dc168 \
+    termcolor                        1.1.0  bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f \
+    terminal_size                   0.1.10  e25a60e3024df9029a414be05f46318a77c22538861a22170077d0388c0e926e \
+    termion                          1.5.5  c22cec9d8978d906be5ac94bceb5a010d885c626c4c8855721a4dbd20e3ac905 \
+    textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
+    thread_local                     1.0.1  d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14 \
+    time                            0.1.42  db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f \
+    tinytemplate                     1.0.3  57a3c6667d3e65eb1bc3aed6fd14011c6cbc3a0665218ab7f5daf040b9ec371a \
+    tokio                           0.1.22  5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6 \
+    tokio-buf                        0.1.1  8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46 \
+    tokio-current-thread             0.1.7  b1de0e32a83f131e002238d7ccde18211c0a5397f60cbfffcb112868c2e0e20e \
+    tokio-executor                  0.1.10  fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671 \
+    tokio-io                        0.1.13  57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674 \
+    tokio-reactor                   0.1.12  09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351 \
+    tokio-sync                       0.1.8  edfe50152bc8164fcc456dab7891fa9bf8beaf01c5ee7e1dd43a397c3cf87dee \
+    tokio-tcp                        0.1.4  98df18ed66e3b72e742f185882a9e201892407957e45fbff8da17ae7a7c51f72 \
+    tokio-threadpool                0.1.18  df720b6581784c118f0eb4310796b12b1d242a7eb95f716a8367855325c25f89 \
+    tokio-timer                     0.2.13  93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296 \
     toml                            0.4.10  758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f \
     try-lock                         0.2.2  e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382 \
-    typenum                         1.10.0  612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169 \
-    ucd-util                         0.1.3  535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86 \
-    unicase                          2.2.0  9d3218ea14b4edcaccfa0df0a64a3792a2c32cc706f1b336e48867f9d3147f90 \
-    unicase                          1.4.2  7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33 \
+    try_from                         0.3.2  283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b \
+    typenum                         1.11.2  6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9 \
+    unicase                          2.6.0  50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6 \
     unicode-bidi                     0.3.4  49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5 \
-    unicode-normalization            0.1.7  6a0180bc61fc5a987082bfa111f4cc95c4caff7f9799f3e46df09163a937aa25 \
-    unicode-segmentation             1.2.1  aa6024fc12ddfd1c6dbc14a80fa2324d4568849869b779f6bd37e5e4c03344d1 \
-    unicode-width                    0.1.5  882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526 \
+    unicode-normalization           0.1.12  5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4 \
+    unicode-segmentation             1.6.0  e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0 \
+    unicode-width                    0.1.7  caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479 \
+    unicode-xid                      0.2.0  826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c \
     unicode-xid                      0.1.0  fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc \
-    unreachable                      1.0.0  382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56 \
     url                              1.7.2  dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a \
-    utf8-ranges                      1.0.2  796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737 \
+    url                              2.1.1  829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb \
     uuid                             0.6.5  e1436e58182935dcd9ce0add9ea0b558e8a87befe01c1a301e6020aeb0876363 \
-    uuid                             0.7.1  dab5c5526c5caa3d106653401a267fed923e7046f35895ffcb5ca42db64942e6 \
-    vcpkg                            0.2.6  def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d \
+    uuid                             0.7.4  90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a \
+    vcpkg                            0.2.8  3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168 \
     vec_map                          0.8.1  05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a \
+    version_check                    0.9.1  078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce \
     version_check                    0.1.5  914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd \
-    void                             1.0.2  6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d \
-    walkdir                          2.2.7  9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1 \
-    want                             0.0.6  797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3 \
+    walkdir                          2.3.1  777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d \
+    want                             0.2.0  b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230 \
+    wasi                          0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
+    wasm-bindgen                    0.2.58  5205e9afdf42282b192e2310a5b463a6d1c1d774e30dc3c791ac37ab42d2616c \
+    wasm-bindgen-backend            0.2.58  11cdb95816290b525b32587d76419facd99662a07e59d3cdb560488a819d9a45 \
+    wasm-bindgen-macro              0.2.58  574094772ce6921576fb6f2e3f7497b8a76273b6db092be18fc48a082de09dc3 \
+    wasm-bindgen-macro-support      0.2.58  e85031354f25eaebe78bb7db1c3d86140312a911a106b2e29f9cc440ce3e7668 \
+    wasm-bindgen-shared             0.2.58  f5e7e61fc929f4c0dddb748b102ebf9f632e2b8d739f2016542b4de2965a9601 \
+    wasm-bindgen-webidl             0.2.58  ef012a0d93fc0432df126a8eaf547b2dce25a8ce9212e1d3cbeef5c11157975d \
+    web-sys                         0.3.35  aaf97caf6aa8c2b1dac90faf0db529d9d63c93846cca4911856f78a83cebf53b \
+    weedle                          0.10.0  3bb43f70885151e629e2a19ce9e50bd730fd436cfd4b666894c9ce4de9141164 \
+    winapi                           0.3.8  8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6 \
     winapi                           0.2.8  167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
-    winapi                           0.3.6  92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0 \
     winapi-build                     0.1.1  2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
-    winapi-util                      0.1.1  afc5508759c5bf4285e61feb862b6083c8480aec864fa17a81fdec6f69b461ab \
+    winapi-util                      0.1.3  4ccfbf554c6ad11084fb7517daca16cfdcaccbdadba4fc336f032a8b12c2ad80 \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
-    wincolor                         1.0.1  561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba \
     wincolor                         0.1.6  eeb06499a3a4d44302791052df005d5232b927ed1a9658146d842165c4de7767 \
+    winreg                           0.6.2  b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9 \
     ws2_32-sys                       0.2.1  d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e \
     xattr                            0.2.2  244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c \
-    zip                              0.5.0  00acf1fafb786ff450b6726e5be41ef029142597b47a40ce80f952f1471730a0
+    zip                              0.5.4  e41ff37ba788e2169b19fa70253b70cb53d9f2db9fb9aea9bcfc5047e02c3bae


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
