### PR TITLE
Dovecot remove obsolete variants

### DIFF
--- a/mail/dovecot/Portfile
+++ b/mail/dovecot/Portfile
@@ -254,103 +254,66 @@ if {${name} eq ${subport}} {
     }
 
     variant postgresql96 \
-        conflicts postgresql82 postgresql83 postgresql84 \
-            postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 \
-            postgresql95 \
+        conflicts postgresql10 postgresql11 postgresql12 \
         description "Enable PostgreSQL 9.6 support" {
         depends_lib-append          port:postgresql96
         configure.env-append        PG_CONFIG=${prefix}/lib/postgresql96/bin/pg_config
         configure.args-append       --with-pgsql
     }
 
-    variant postgresql95 \
-        conflicts postgresql82 postgresql83 postgresql84 \
-            postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 \
-            postgresql96 \
-        description "Enable PostgreSQL 9.5 support" {
-        depends_lib-append          port:postgresql95
-        configure.env-append        PG_CONFIG=${prefix}/lib/postgresql95/bin/pg_config
+    variant postgresql10 \
+        conflicts postgresql96 postgresql11 postgresql12 \
+        description "Enable PostgreSQL 10 support" {
+        depends_lib-append          port:postgresql10
+        configure.env-append        PG_CONFIG=${prefix}/lib/postgresql10/bin/pg_config
         configure.args-append       --with-pgsql
     }
 
-    variant postgresql94 \
-        conflicts postgresql82 postgresql83 postgresql84 \
-            postgresql90 postgresql91 postgresql92 postgresql93 \
-            postgresql95 postgresql96 \
-        description "Enable PostgreSQL 9.4 support" {
-        depends_lib-append          port:postgresql94
-        configure.env-append        PG_CONFIG=${prefix}/lib/postgresql94/bin/pg_config
+    variant postgresql11 \
+        conflicts postgresql96 postgresql10 postgresql12 \
+        description "Enable PostgreSQL 11 support" {
+        depends_lib-append          port:postgresql11
+        configure.env-append        PG_CONFIG=${prefix}/lib/postgresql11/bin/pg_config
         configure.args-append       --with-pgsql
     }
 
-    variant postgresql93 \
-        conflicts postgresql82 postgresql83 postgresql84 \
-            postgresql90 postgresql91 postgresql92 \
-            postgresql94 postgresql95 postgresql96 \
-        description "Enable PostgreSQL 9.3 support" {
-        depends_lib-append          port:postgresql93
-        configure.env-append        PG_CONFIG=${prefix}/lib/postgresql93/bin/pg_config
+    variant postgresql12 \
+        conflicts postgresql96 postgresql10 postgresql11 \
+        description "Enable PostgreSQL 12 support" {
+        depends_lib-append          port:postgresql12
+        configure.env-append        PG_CONFIG=${prefix}/lib/postgresql12/bin/pg_config
         configure.args-append       --with-pgsql
     }
 
-    variant postgresql92 \
-        conflicts postgresql82 postgresql83 postgresql84 \
-            postgresql90 postgresql91 \
-            postgresql93 postgresql94 postgresql95 postgresql96 \
-        description "Enable PostgreSQL 9.2 support" {
-        depends_lib-append          port:postgresql92
-        configure.env-append        PG_CONFIG=${prefix}/lib/postgresql92/bin/pg_config
-        configure.args-append       --with-pgsql
-    }
+    # remove 2021-03-02
+    variant postgresql95 requires postgresql11 description "Legacy compatibility variant" {}
 
-    variant postgresql91 \
-        conflicts postgresql82 postgresql83 postgresql84 \
-            postgresql90 \
-            postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 \
-        description "Enable PostgreSQL 9.1 support" {
-        depends_lib-append          port:postgresql91
-        configure.env-append        PG_CONFIG=${prefix}/lib/postgresql91/bin/pg_config
-        configure.args-append       --with-pgsql
-    }
+    # remove 2021-03-02
+    variant postgresql94 requires postgresql11 description "Legacy compatibility variant" {}
 
-    variant postgresql90 \
-        conflicts postgresql82 postgresql83 postgresql84 \
-            postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 \
-        description "Enable PostgreSQL 9.0 support" {
-        depends_lib-append          port:postgresql90
-        configure.env-append        PG_CONFIG=${prefix}/lib/postgresql90/bin/pg_config
-        configure.args-append       --with-pgsql
-    }
+    # remove 2021-03-02
+    variant postgresql93 requires postgresql11 description "Legacy compatibility variant" {}
 
-    variant postgresql84 \
-        conflicts postgresql82 postgresql83 \
-            postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 \
-        description "Enable PostgreSQL 8.4 support" {
-        depends_lib-append          port:postgresql84
-        configure.env-append        PG_CONFIG=${prefix}/lib/postgresql84/bin/pg_config
-        configure.args-append       --with-pgsql
-    }
+    # remove 2021-03-02
+    variant postgresql92 requires postgresql11 description "Legacy compatibility variant" {}
 
-    variant postgresql83 \
-        conflicts postgresql82 postgresql84 \
-            postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 \
-        description "Enable PostgreSQL 8.3 support" {
-        depends_lib-append          port:postgresql83
-        configure.env-append        PG_CONFIG=${prefix}/lib/postgresql83/bin/pg_config
-        configure.args-append       --with-pgsql
-    }
+    # remove 2021-03-02
+    variant postgresql91 requires postgresql11 description "Legacy compatibility variant" {}
 
-    variant postgresql82  \
-        conflicts postgresql83 postgresql84 \
-            postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 \
-        description "Enable PostgreSQL 8.2 support" {
-        depends_lib-append          port:postgresql82
-        configure.env-append        PG_CONFIG=${prefix}/lib/postgresql82/bin/pg_config
-        configure.args-append       --with-pgsql
-    }
+    # remove 2021-03-02
+    variant postgresql90 requires postgresql11 description "Legacy compatibility variant" {}
+
+    # remove 2021-03-02
+    variant postgresql84 requires postgresql11 description "Legacy compatibility variant" {}
+
+    # remove 2021-03-02
+    variant postgresql83 requires postgresql11 description "Legacy compatibility variant" {}
+
+    # remove 2021-03-02
+    variant postgresql82 requires postgresql11 description "Legacy compatibility variant" {}
 
     variant percona \
-        conflicts mysql5 mysql51 mysql55 mysql56 mariadb \
+        conflicts mysql57 mysql8 mariadb mariadb10.1 \
         description "Enable Percona (MySQL) support" {
             depends_lib-append          port:percona
             configure.env-append        MYSQL_CONFIG=${prefix}/lib/percona/bin/mysql_config
@@ -358,42 +321,34 @@ if {${name} eq ${subport}} {
     }
 
     variant mariadb \
-        conflicts mysql5 mysql51 mysql55 mysql56 percona \
+        conflicts mysql57 mysql8 mariadb10.1 percona \
         description "Enable MariaDB (MySQL) support" {
         depends_lib-append          port:mariadb
         configure.env-append        MYSQL_CONFIG=${prefix}/lib/mariadb/bin/mysql_config
         configure.args-append       --with-mysql
     }
 
-    variant mysql56 \
-        conflicts mysql5 mysql51 mysql55 mariadb percona \
-        description "Enable MySQL 5.6 support" {
-        depends_lib-append          port:mysql56
-        configure.env-append        MYSQL_CONFIG=${prefix}/lib/mysql56/bin/mysql_config
+    variant mariadb10.1 \
+        conflicts mysql57 mysql8 mariadb percona \
+        description "Enable MariaDB 10.1 (MySQL) support" {
+        depends_lib-append          port:mariadb-10.1
+        configure.env-append        MYSQL_CONFIG=${prefix}/lib/mariadb-10.1/bin/mysql_config
         configure.args-append       --with-mysql
     }
 
-    variant mysql55 \
-        conflicts mysql5 mysql51 mysql56 mariadb percona \
-        description "Enable MySQL 5.5 support" {
-        depends_lib-append          port:mysql55
-        configure.env-append        MYSQL_CONFIG=${prefix}/lib/mysql55/bin/mysql_config
+    variant mysql57 \
+        conflicts mysql8 mariadb mariadb10.1 percona \
+        description "Enable MySQL 5.7 support" {
+        depends_lib-append          port:mysql57
+        configure.env-append        MYSQL_CONFIG=${prefix}/lib/mysql57/bin/mysql_config
         configure.args-append       --with-mysql
     }
 
-    variant mysql51 \
-        conflicts mysql5 mysql55 mysql56 mariadb percona \
-        description "Enable MySQL 5.1 support" {
-        depends_lib-append          port:mysql51
-        configure.env-append        MYSQL_CONFIG=${prefix}/lib/mysql51/bin/mysql_config
-        configure.args-append       --with-mysql
-    }
-
-    variant mysql5 \
-        conflicts mysql51 mysql55 mysql56 mariadb percona \
-        description "Enable MySQL 5.1 support" {
-        depends_lib-append          port:mysql5
-        configure.env-append        MYSQL_CONFIG=${prefix}/lib/mysql5/bin/mysql_config
+    variant mysql8 \
+        conflicts mysql57 mariadb mariadb10.1 percona \
+        description "Enable MySQL 8 support" {
+        depends_lib-append          port:mysql8
+        configure.env-append        MYSQL_CONFIG=${prefix}/lib/mysql8/bin/mysql_config
         configure.args-append       --with-mysql
     }
 

--- a/mail/mail-server/Portfile
+++ b/mail/mail-server/Portfile
@@ -27,7 +27,7 @@ homepage                https://www.postfix.org/
 set postfix_required_variants \
                         [lsort {dovecot_sasl pcre smtputf8 tls}]
 set dovecot_required_variants \
-                        [lsort {gssapi solr}]
+                        [lsort {solr}]
 
 depends_lib-append      port:dcc \
                         port:dovecot \


### PR DESCRIPTION
Dovecot remove obsolete variants

* Completes steps to update dovecot Portfile in stalled PR https://github.com/macports/macports-ports/pull/5236/
* Removes a reference to the now-nonexistent variant dovecot gssapi 

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
