### PR TITLE
db48: namespace the java variant

### DIFF
--- a/databases/db48/Portfile
+++ b/databases/db48/Portfile
@@ -66,12 +66,12 @@ post-destroot {
     }
 }
 
-variant java description {Build the Java API} {
+variant db48_java description {Build the Java API} {
     configure.args-append   --enable-java
 }
 
 if {${os.subplatform} eq "macosx" && ${os.major} < 11} {
-    default_variants +java
+    default_variants +db48_java
 }
 
 variant tcl description {Build Tcl API} {


### PR DESCRIPTION
so it doesn't get pulled in automatically as a dependent
of a port that wants a java variant enabled (eg Octave)
