### PR TITLE
argp-standalone: fix livecheck regex

### DIFF
--- a/devel/argp-standalone/Portfile
+++ b/devel/argp-standalone/Portfile
@@ -25,10 +25,11 @@ long_description    It is standalone version of argp - part of glibc library. \
                     variables keeping track of the parser state.
 
 homepage            https://www.freshports.org/devel/argp-standalone/
-master_sites        http://www.lysator.liu.se/~nisse/misc/
+master_sites        https://www.lysator.liu.se/~nisse/misc/
 
 checksums           rmd160  1c5cd0b1c382d93774be636a1ea2758d530cfef4 \
-                    sha256  dec79694da1319acd2238ce95df57f3680fea2482096e483323fddf3d818d8be
+                    sha256  dec79694da1319acd2238ce95df57f3680fea2482096e483323fddf3d818d8be \
+                    size    130255
 
 patchfiles          patch-argp-fmtstream.h.diff
 
@@ -38,3 +39,5 @@ post-destroot {
     xinstall ${worksrcpath}/libargp.a ${destroot}${prefix}/lib
     xinstall ${worksrcpath}/argp.h ${destroot}${prefix}/include
 }
+
+livecheck.regex     ${name}-(\\d+(?:\\.\\d+)*)${extract.suffix}


### PR DESCRIPTION
#### Description


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
macOS 10.14.6 18G2022
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
