### PR TITLE
bashdb: update to 5.0-1.1.2

### DIFF
--- a/devel/bashdb/Portfile
+++ b/devel/bashdb/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 
 name                bashdb
-version             4.4-1.0.1
-revision            1
+version             5.0-1.1.2
+revision            0
 categories          devel
 platforms           darwin
 license             GPL-2
@@ -20,13 +20,13 @@ long_description    bashdb is a script debugger for BASH that follows \
                     code and fix problems once they are identified.
 homepage            http://bashdb.sourceforge.net
 
-depends_lib         port:bash44
+depends_lib         port:bash
 
 master_sites        sourceforge:project/bashdb/${name}/${version}
 use_bzip2           yes
-checksums           rmd160  8d5508444ea4e757fb9868c380e223ac86105be2 \
-                    sha256  bf603b6ee1f60c10861dcb1fef73a10f924327b5ff05cf41e2290f3edc1e6284 \
-                    size    701807
+checksums           rmd160  d653a31ed47f58e11e55838dd07935629b80e170 \
+                    sha256  30176d2ad28c5b00b2e2d21c5ea1aef8fbaf40a8f9d9f723c67c60531f3b7330 \
+                    size    574210
 
 test.run            yes
 test.target         check


### PR DESCRIPTION
#### Description
This updates bashdb for support with bash 5.  I tested the PR by opening a debugger prompt and stepping through some shell scripts and I also ran the `port test` which passed successfully.

###### Type(s)
- [x] enhancement

###### Tested on
macOS 10.14.6 18G2022
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
