### PR TITLE
broot: update to 0.13.2

### DIFF
--- a/sysutils/broot/Portfile
+++ b/sysutils/broot/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        Canop broot 0.13.0 v
+github.setup        Canop broot 0.13.2 v
 categories          sysutils
 platforms           darwin
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
@@ -20,9 +20,9 @@ long_description    broot is a new way to see and navigate directory trees. \
                     via regular expressions, and more.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  fb2ec3da81abdbb81477bf852f20946372eafb13 \
-                    sha256  1a24869b27259fcb51c9cc6706b88250611e4c1d3921495913264d9c2d58f037 \
-                    size    1681320
+                    rmd160  4a42994844c7489be3bb96ff89d2458e79f1d8ba \
+                    sha256  57ac6df9bbe9eb01511b373255d130147cd3a1c59315d7a248afdae7fffc6afa \
+                    size    1681365
 
 destroot {
     xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/${name} ${destroot}${prefix}/bin/
@@ -61,7 +61,7 @@ cargo.crates \
     crossbeam-queue                  0.2.0  dfd6515864a82d2f877b42813d4553292c6659498c9a2aa31bab5a15243c2700 \
     crossbeam-utils                  0.7.0  ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4 \
     crossbeam-utils                  0.6.6  04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6 \
-    crossterm                       0.15.0  207a948d1b4ff59e5aec9bb9426cc4fd3d17b719e5c7b74e27f0a60c4cc2d095 \
+    crossterm                       0.16.0  b8a3223215bc00c666d6be730e88aef245ad4a4f837e87a16c347e8acf701643 \
     crossterm_winapi                 0.6.1  057b7146d02fb50175fd7dbe5158f6097f33d02831f43b4ee8ae4ddf67b68f5c \
     csv                              1.1.1  37519ccdfd73a75821cac9319d4fce15a81b9fcf75f951df5b9988aa3a0af87d \
     csv-core                         0.1.6  9b5cadb6b25c77aeff80ba701712494213f4a8418fcda2ee11b6560c3ad0bf4c \
@@ -147,7 +147,7 @@ cargo.crates \
     syn                              1.0.7  0e7bedb3320d0f3035594b0b723c8a28d7d336a3eda3881db79e61d676fb644c \
     synstructure                    0.12.1  3f085a5855930c0441ca1288cf044ea4aecf4f43a91668abdb870b4ba546a203 \
     term                             0.6.1  c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5 \
-    termimad                        0.8.12  5fa7167e7faf980ea158947633be776237e54dc22e0c0c82675c575c8c962fdd \
+    termimad                        0.8.13  d06427a59b29e1283fc4dfc42335e45b646471a8e4d2c207082cfda0ff00d5d0 \
     textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
     thiserror                        1.0.4  9fe148fa0fc3363a27092d48f7787363ded15bb8623c5d5dd4e2e9f23e4b21bc \
     thiserror-impl                   1.0.4  258da67e99e590650fa541ac6be764313d23e80cefb6846b516deb8de6b6d921 \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
