### PR TITLE
QLStephen: Update to 1.5.1

### DIFF
--- a/sysutils/QLStephen/Portfile
+++ b/sysutils/QLStephen/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           xcode 1.0
 
-github.setup        whomwah qlstephen 1.4.4
+github.setup        whomwah qlstephen 1.5.1
 name                QLStephen
 categories          sysutils
 
@@ -16,16 +16,13 @@ description         A QuickLook plugin that lets you view plain text \
                     files without a file extension
 long_description    ${description}
 
-checksums           rmd160  aecbb9cdf7ec2f0380cd929868e79fa0c87c1281 \
-                    sha256  1de62d1547526b780a9c0efb4faf772e79d3733a1d1285abef61573c507c83a9
+checksums           rmd160  14401c57852093917fc9814c0572745fba706547 \
+                    sha256  84d795f713764647d6cb2d2ac1713ed4cd2a0769f7641ca7ff9745600d8b1958 \
+                    size    22137
 
 worksrcdir          ${distname}/QuickLookStephenProject
 
 destroot.violate_mtree  yes
-
-post-extract {
-    reinplace -W ${worksrcpath} "s,AEF4F27A0EDD58F800A55543.*,," QuickLookStephen.xcodeproj/project.pbxproj
-}
 
 destroot {
     xinstall -d ${destroot}/Library/QuickLook


### PR DESCRIPTION
#### Description

I'm running through `port livecheck installed` and trying to update things that have an open maintainer or no maintainer.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E224g
Xcode 11.4 11N111s 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
