### PR TITLE
git-lfs: update to 2.10.0

### DIFF
--- a/devel/git-lfs/Portfile
+++ b/devel/git-lfs/Portfile
@@ -3,8 +3,8 @@
 PortSystem              1.0
 PortGroup               golang 1.0
 
-go.setup                github.com/git-lfs/git-lfs 2.9.0 v
-revision                1
+go.setup                github.com/git-lfs/git-lfs 2.10.0 v
+revision                0
 maintainers             {raimue @raimue} \
                         openmaintainer
 platforms               darwin
@@ -16,9 +16,9 @@ long_description        {*}${description} is an extension for versioning large f
 homepage                https://git-lfs.github.com/
 license                 MIT
 
-checksums               rmd160  9374f0b32fa30d16aec69448813647cf0192fb38 \
-                        sha256  cdf2fe82aaf57a094df26c4240fd42f0c00fa1f6c8260deb02d0d69e42584eb9 \
-                        size    2493649
+checksums               rmd160  accffea1f64c41056f637c1a41120e4fb673e9e0 \
+                        sha256  c7bb53d372e9ed8f6c2939de5b8f1d5aaf30ad449ad9a66909dc575f5798ecbf \
+                        size    2771826
 
 depends_build-append    port:rb24-ronn-ng
 depends_run             port:git


### PR DESCRIPTION
#### Description

git-lfs: update to 2.10.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3 19D76
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
