### PR TITLE
syncthing-macos: add patch for Xcode 9 - 11.3.1 compatibility

### DIFF
--- a/net/syncthing-macos/Portfile
+++ b/net/syncthing-macos/Portfile
@@ -20,7 +20,8 @@ license                 MIT
 
 depends_lib-append      port:syncthing
 
-patchfiles              no-bundled-syncthing.patch
+patchfiles              no-bundled-syncthing.patch \
+                        swift4-upgrade.patch
 
 post-patch {
     reinplace "s|__PREFIX__|${prefix}|" ${worksrcpath}/syncthing/STApplication.m

--- a/net/syncthing-macos/files/swift4-upgrade.patch
+++ b/net/syncthing-macos/files/swift4-upgrade.patch
@@ -1,0 +1,56 @@
+diff --git syncthing.xcodeproj/project.pbxproj syncthing.xcodeproj/project.pbxproj
+index 426d594..ee7c276 100644
+--- syncthing.xcodeproj/project.pbxproj
++++ syncthing.xcodeproj/project.pbxproj
+@@ -640,7 +640,7 @@
+ 				SEPARATE_STRIP = NO;
+ 				SWIFT_OBJC_BRIDGING_HEADER = "syncthing/syncthing-Bridging-Header.h";
+ 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+-				SWIFT_VERSION = 3.0;
++				SWIFT_VERSION = 4.0;
+ 				VALID_ARCHS = x86_64;
+ 			};
+ 			name = Debug;
+@@ -669,7 +669,7 @@
+ 				PROVISIONING_PROFILE_SPECIFIER = "";
+ 				SEPARATE_STRIP = YES;
+ 				SWIFT_OBJC_BRIDGING_HEADER = "syncthing/syncthing-Bridging-Header.h";
+-				SWIFT_VERSION = 3.0;
++				SWIFT_VERSION = 4.0;
+ 				VALID_ARCHS = x86_64;
+ 			};
+ 			name = Release;
+diff --git syncthing/DaemonProcess.swift syncthing/DaemonProcess.swift
+index da88642..da29cb6 100644
+--- syncthing/DaemonProcess.swift
++++ syncthing/DaemonProcess.swift
+@@ -23,25 +23,25 @@ let MaxKeepLogLines = 200
+     private var queue = DispatchQueue(label: "DaemonProcess")
+     private var shouldTerminate = false
+ 
+-    init(path: String, delegate: DaemonProcessDelegate) {
++    @objc init(path: String, delegate: DaemonProcessDelegate) {
+         self.path = path
+         self.delegate = delegate
+     }
+ 
+-    func launch() {
++    @objc func launch() {
+         queue.async {
+             self.launchSync()
+         }
+     }
+ 
+-    func terminate() {
++    @objc func terminate() {
+         queue.async {
+             self.shouldTerminate = true
+             self.process?.terminate()
+         }
+     }
+ 
+-    func restart() {
++    @objc func restart() {
+         queue.async {
+             // Syncthing should exit cleanly when sent the interrupt signal. It will then be restarted.
+             self.process?.interrupt()


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
The current version of syncthing-macos is written in Swift 3 and was released over a year ago.. This patch upgrades the source to Swift 4 based on the [syncthing-macos pull request #97](https://github.com/syncthing/syncthing-macos/pull/97). Since the last commits to the develop-branch date back to June '19, this patch adds compatibility to recent Xcode versions without waiting for a new release. Keep in mind that this change requires Xcode 9 and later.
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3 19D76
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
Fails with `Error: Failed to test syncthing-macos: syncthing-macos has no tests turned on. see 'test.run' in portfile(7)`
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
