### PR TITLE
nco: update to 4.9.2

### DIFF
--- a/science/nco/Portfile
+++ b/science/nco/Portfile
@@ -5,7 +5,7 @@ PortGroup           compilers 1.0
 PortGroup           github 1.0
 
 github.setup        nco nco 4.9.2
-revision            1
+revision            0
 platforms           darwin
 maintainers         {takeshi @tenomoto}
 license             GPL-3

--- a/science/nco/Portfile
+++ b/science/nco/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           compilers 1.0
 PortGroup           github 1.0
 
-github.setup        nco nco 4.9.1
+github.setup        nco nco 4.9.2
 revision            1
 platforms           darwin
 maintainers         {takeshi @tenomoto}
@@ -19,9 +19,9 @@ if {${os.major} > 12} {
     compilers.setup -clang33 -clang34
 }
 
-checksums           rmd160  a324263189ea2433c1fe0a0f716896b950061775 \
-                    sha256  b38c0a511e4d97b36dd733e33ef64cda488d065ef5c8343be636024543ab96ff \
-                    size    5275919
+checksums           rmd160  fd3c26d4c365be2d7e13595826fbaf8dc5ba2aec \
+                    sha256  82ffc3fea50d773bd860e20cdbf8a1b2566da66ff7de02635552ae4cac8e9f2d \
+                    size    5282345
 
 homepage            http://nco.sourceforge.net/
 long_description \
@@ -107,3 +107,7 @@ variant accelerate conflicts atlas description {use Accelerate framework for LAP
 variant atlas conflicts accelerate description {use Atlas for LAPACK} {
     depends_lib-append  port:atlas
 }
+
+livecheck.type              regex
+livecheck.url               ${homepage}
+livecheck.regex             {nco-([0-9]+\.[0-9]+\.[0-9]+).tar.gz}


### PR DESCRIPTION
#### Description

Simple update to version 4.9.2, plus the introduction of "livecheck"

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.3
Xcode 11.3.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
