### PR TITLE
gtk3: update to 3.24.14

### DIFF
--- a/gnome/gtk3/Portfile
+++ b/gnome/gtk3/Portfile
@@ -9,7 +9,7 @@ PortGroup           compiler_blacklist_versions 1.0
 name                gtk3
 set real_name       gtk+
 epoch               1
-version             3.24.12
+version             3.24.14
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          gnome x11
 license             LGPL-2.1+
@@ -29,9 +29,9 @@ use_xz              yes
 
 master_sites        gnome:sources/gtk+/${branch}/
 
-checksums           rmd160  1ced471ba54f93cc3854954d8183c1ce41095642 \
-                    sha256  1384eba5614fed160044ae0d32369e3df7b4f517b03f4b1f24d383e528f4be83 \
-                    size    20977596
+checksums           rmd160  186d65b346caf0bbabb1b29b51b3f42adc934476 \
+                    sha256  1c4d69f93ab884fd80c6b95115bfbc12d51ecd029178b6dad3672fdc5ff91e88 \
+                    size    20420928
 
 minimum_xcodeversions {9 3.1}
 


### PR DESCRIPTION
#### Description

Update GTK3 to 3.24.14. This contains a significant performance improvement for macOS GTK3 OpenGL applications.

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G3020
Xcode 10.3 10G8 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

