### PR TITLE
bash: update to 5.0-16

### DIFF
--- a/shells/bash/Portfile
+++ b/shells/bash/Portfile
@@ -4,8 +4,13 @@ name                bash
 set bash_version    5.0
 set bash_patchlevel 16
 subport bash44 {
+   # This port can be removed on March 1, 2021
+   replaced_by         bash
+   PortGroup           obsolete 1.0
+
    set bash_version    4.4
    set bash_patchlevel 23
+   revision            1
 }
 version             ${bash_version}.${bash_patchlevel}
 distname            ${name}-${bash_version}
@@ -32,13 +37,13 @@ master_sites        gnu
 patch_sites         gnu:${name}/${distname}-patches
 dist_subdir         ${name}/${bash_version}_1
 
-# Generate patchfiles
-for {set i 1} {$i <= $bash_patchlevel} {incr i} {
-    patchfiles-append \
-        [format "%s%s-%03d" $name [strsed ${bash_version} {g/\.//}] $i]
-}
-
 if {${subport} eq ${name}} {
+   # Generate patchfiles
+   for {set i 1} {$i <= $bash_patchlevel} {incr i} {
+       patchfiles-append \
+           [format "%s%s-%03d" $name [strsed ${bash_version} {g/\.//}] $i]
+   }
+
    checksums           ${distname}${extract.suffix} \
                        rmd160  a081428a896d617855499376b670eca3433a27c1 \
                        sha256  b4a80f2ac66170b2913efbfb9f2594f1f76c7b1afd11f799e22035d63077fb4d \
@@ -108,85 +113,6 @@ if {${subport} eq ${name}} {
                        rmd160  19d5f631e0181e2671f9bcb8ee7419a46f99008e \
                        sha256  ffd1d7a54a99fa7f5b1825e4f7e95d8c8876bc2ca151f150e751d429c650b06d \
                        size    1534
-
-} elseif {${subport} eq "bash44"} {
-   checksums           ${distname}${extract.suffix} \
-                       rmd160  48869b3a460007d05c02ef99745477b2e526fdec \
-                       sha256  d86b3392c1202e8ff5a423b302e6284db7f8f435ea9f39b5b1b20fd3ac36dfcb
-
-   checksums-append    bash44-001 \
-                       rmd160  a4915a389d04165402193ab681ed975b3e8a29d2 \
-                       sha256  3e28d91531752df9a8cb167ad07cc542abaf944de9353fe8c6a535c9f1f17f0f \
-                       bash44-002 \
-                       rmd160  25623492532efd85f55e12970f157d81fd46279e \
-                       sha256  7020a0183e17a7233e665b979c78c184ea369cfaf3e8b4b11f5547ecb7c13c53 \
-                       bash44-003 \
-                       rmd160  3022c7eba181eb3c9eb3d8fe980ffdaf81c685ed \
-                       sha256  51df5a9192fdefe0ddca4bdf290932f74be03ffd0503a3d112e4199905e718b2 \
-                       bash44-004 \
-                       rmd160  ec182f0390290ce05fe6b0f55e236fe7fdccc65b \
-                       sha256  ad080a30a4ac6c1273373617f29628cc320a35c8cd06913894794293dc52c8b3 \
-                       bash44-005 \
-                       rmd160  e899f89c49cd2b905191041ea06b642546865982 \
-                       sha256  221e4b725b770ad0bb6924df3f8d04f89eeca4558f6e4c777dfa93e967090529 \
-                       bash44-006 \
-                       rmd160  6924afd21adc108a37350f2b3c36d4f7e0159423 \
-                       sha256  6a8e2e2a6180d0f1ce39dcd651622fb6d2fd05db7c459f64ae42d667f1e344b8 \
-                       bash44-007 \
-                       rmd160  270ab48ad0c7dcf9bc2a0856c1eeb5b89819a3ce \
-                       sha256  de1ccc07b7bfc9e25243ad854f3bbb5d3ebf9155b0477df16aaf00a7b0d5edaf \
-                       bash44-008 \
-                       rmd160  f9634425241188bb2ec79b1212d2e76dbfdd4592 \
-                       sha256  86144700465933636d7b945e89b77df95d3620034725be161ca0ca5a42e239ba \
-                       bash44-009 \
-                       rmd160  4beb1212b56e82dc005f1026852aa5564f7eeafe \
-                       sha256  0b6bdd1a18a0d20e330cc3bc71e048864e4a13652e29dc0ebf3918bea729343c \
-                       bash44-010 \
-                       rmd160  a2f825a27b5c9854cb6b3cd9cc9e386ea7517222 \
-                       sha256  8465c6f2c56afe559402265b39d9e94368954930f9aa7f3dfa6d36dd66868e06 \
-                       bash44-011 \
-                       rmd160  63587fcb788ceced48dfd455c55868bb058ee647 \
-                       sha256  dd56426ef7d7295e1107c0b3d06c192eb9298f4023c202ca2ba6266c613d170d \
-                       bash44-012 \
-                       rmd160  0f2768842206beb1f2255cc6ebd80734e5acc4ac \
-                       sha256  fac271d2bf6372c9903e3b353cb9eda044d7fe36b5aab52f21f3f21cd6a2063e \
-                       bash44-013 \
-                       rmd160  3121e90583406f8e2ff8e6d244277ec8940876fa \
-                       sha256  1b25efacbc1c4683b886d065b7a089a3601964555bcbf11f3a58989d38e853b6 \
-                       bash44-014 \
-                       rmd160  99f25cae85452dcd75fa19410d915ad7a3a28d0c \
-                       sha256  a7f75cedb43c5845ab1c60afade22dcb5e5dc12dd98c0f5a3abcfb9f309bb17c \
-                       bash44-015 \
-                       rmd160  416dc900d2139939f0176ab53ca69caae2dc8ade \
-                       sha256  d37602ecbeb62d5a22c8167ea1e621fcdbaaa79925890a973a45c810dd01c326 \
-                       bash44-016 \
-                       rmd160  9619057d82119e8d759ae13a1f33d9305608e4b9 \
-                       sha256  501f91cc89fadced16c73aa8858796651473602c722bb29f86a8ba588d0ff1b1 \
-                       bash44-017 \
-                       rmd160  3bea0eb31a0e2269aa04be132a25a267674c2802 \
-                       sha256  773f90b98768d4662a22470ea8eec5fdd8e3439f370f94638872aaf884bcd270 \
-                       bash44-018 \
-                       rmd160  fb03cd436b286ab705896e024c1ad27ca23c6434 \
-                       sha256  5bc494b42f719a8b0d844b7bd9ad50ebaae560e97f67c833c9e7e9d53981a8cc \
-                       bash44-019 \
-                       rmd160  b9dedc65d70ca7749ffdb743701487fcb3072033 \
-                       sha256  27170d6edfe8819835407fdc08b401d2e161b1400fe9d0c5317a51104c89c11e \
-                       bash44-020 \
-                       rmd160  42acf98c43ef68192f88faab4359bcf1c2e86b3f \
-                       sha256  1840e2cbf26ba822913662f74037594ed562361485390c52813b38156c99522c \
-                       size    5156 \
-                       bash44-021 \
-                       rmd160  e83f25342e36d2e5a815126e161336429e20e3fb \
-                       sha256  bd8f59054a763ec1c64179ad5cb607f558708a317c2bdb22b814e3da456374c1 \
-                       size    1810 \
-                       bash44-022 \
-                       rmd160  d340d1a5111151559494629bab9d7a0fa36a7339 \
-                       sha256  45331f0936e36ab91bfe44b936e33ed8a1b1848fa896e8a1d0f2ef74f297cb79 \
-                       size    1818 \
-                       bash44-023 \
-                       rmd160  aff2b600dd6d77317cc2b8d1e88f6673b6e661f0 \
-                       sha256  4fec236f3fbd3d0c47b893fdfa9122142a474f6ef66c20ffb6c0f4864dd591b6 \
-                       size    1557
 }
 
 depends_build           bin:bison:bison

--- a/shells/bash/Portfile
+++ b/shells/bash/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 
 name                bash
 set bash_version    5.0
-set bash_patchlevel 11
+set bash_patchlevel 16
 subport bash44 {
    set bash_version    4.4
    set bash_patchlevel 23
@@ -87,7 +87,27 @@ if {${subport} eq ${name}} {
                        bash50-011 \
                        rmd160  d2866cbdf4f5a8e1f79ff4795b6045a45bea4627 \
                        sha256  2c4de332b91eaf797abbbd6c79709690b5cbd48b12e8dfe748096dbd7bf474ea \
-                       size    1870
+                       size    1870 \
+                       bash50-012 \
+                       rmd160  3c08d0e8a96645112fe86c407637f2d030319a7a \
+                       sha256  2943ee19688018296f2a04dbfe30b7138b889700efa8ff1c0524af271e0ee233 \
+                       size    1571 \
+                       bash50-013 \
+                       rmd160  824d45c5779bf238b2891a4906a38d7e49f71ea8 \
+                       sha256  f5d7178d8da30799e01b83a0802018d913d6aa972dd2ddad3b927f3f3eb7099a \
+                       size    2328 \
+                       bash50-014 \
+                       rmd160  1f36acc05688999814a8932ac87fcbd8f2f71b4c \
+                       sha256  5d6eee6514ee6e22a87bba8d22be0a8621a0ae119246f1c5a9a35db1f72af589 \
+                       size    1747 \
+                       bash50-015 \
+                       rmd160  540db9eff2543184e504f2de9bff3c07642c2ce5 \
+                       sha256  a517df2dda93b26d5cbf00effefea93e3a4ccd6652f152f4109170544ebfa05e \
+                       size    2565 \
+                       bash50-016 \
+                       rmd160  19d5f631e0181e2671f9bcb8ee7419a46f99008e \
+                       sha256  ffd1d7a54a99fa7f5b1825e4f7e95d8c8876bc2ca151f150e751d429c650b06d \
+                       size    1534
 
 } elseif {${subport} eq "bash44"} {
    checksums           ${distname}${extract.suffix} \


### PR DESCRIPTION
There's a bunch going on here, give me a yell if this PR needs to be shrunk:
- bash44 port is removed.  The only dependency was bashdb, which has a hard, C header file level dependency on bash, and now that it supports bash 5.0 we no longer have a need for bash44.
- bash5 port is updated to patchlevel 16
- bash5 port is reindented

#### Description

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
macOS 10.14.6 18G2022
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
