### PR TITLE
groovy: update to 3.0.1

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            groovy
-version         3.0.0
+version         3.0.1
 revision        0
 
 categories      lang java
@@ -41,9 +41,9 @@ master_sites    https://dl.bintray.com/${name}/maven/
 distname        apache-${name}-binary-${version}
 use_zip         yes
 
-checksums       rmd160  9bfedbe6629b857dde71cbf9523e3b41b990d0bf \
-                sha256  f4b2211e7651ed4ec7728c96c1e1961795c4a9de7b0cad6d399df8e92001d682 \
-                size    42775607
+checksums       rmd160  104a618288b39927c12e05e7ec97d00e766c4476 \
+                sha256  528ae6b5e651ea68e1ecc4d5e7604c71b3b7f521c7486c7dac83f91bc6a61405 \
+                size    42902791
 
 worksrcdir      ${name}-${version}
 


### PR DESCRIPTION
#### Description

Update to Groovy 3.0.1.

###### Tested on

macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?