### PR TITLE
google-cloud-sdk: update to 281.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             280.0.0
+version             281.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  e7506fcc531dbe63555689eac471afe2478dcb23 \
-                    sha256  50c80701e1307ccd8e78fba34d34cec446cf24ee0a7ef30cef260c72676c0980 \
-                    size    47945195
+    checksums       rmd160  a72547640506b006c8b326b8497e99c40746b876 \
+                    sha256  1ee756ffeedabc4f6caa8959f2f38a53650fc2cfb03f09f8aa872e157f2b4cfc \
+                    size    48154129
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  493b6686c49a6088df04fbf7cbf2ad96faffe8ed \
-                    sha256  c9554507bc217a503b42bef7dfa72179bae57ad7e4e696af4205c50b373d3576 \
-                    size    48989316
+    checksums       rmd160  8cf19e1740aaa8bd67e672ae9037f90b1d729c2f \
+                    sha256  d9c4a987e64ab4f1ac2ce641be6ab2bd3113352f20b7043154c959da8640e441 \
+                    size    49202100
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 281.0.0.

###### Tested on

macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?