### PR TITLE
kubectl: update kubectl-1.16 to 1.16.7

### DIFF
--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -19,10 +19,10 @@ subport kubectl_select {}
 # *NOTE* Remember to update `latestVersion` on a version upgrade.
 set latestVersion       kubectl-1.16
 subport kubectl-1.16 {
-    set patchNumber     2
-    checksums           rmd160  d8d7848c7b3e276c823f13fec17a50e7db134138 \
-                        sha256  5647a28b8d9f0f2dcb9c8a077d5eb17af6e76c702e55dce43d09e181f70b6577 \
-                        size    53015744
+    set patchNumber     7
+    checksums           rmd160  46a312124aab1c65d9a25d56fbc26dbadac5506e \
+                        sha256  360550c7d957408c613ee979794de4df3238e6569be38d45bd0b2e95be675c58 \
+                        size    48834704
 }
 
 subport kubectl-1.15 {


### PR DESCRIPTION
#### Description

Update to kubectl 1.16.7.

###### Tested on

macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?