### PR TITLE
kubectl: update kubectl-1.15 to 1.15.10

### DIFF
--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -26,10 +26,10 @@ subport kubectl-1.16 {
 }
 
 subport kubectl-1.15 {
-    set patchNumber     5
-    checksums           rmd160  2492d019a762096a2211b7fc38d0a0a493060d82 \
-                        sha256  6bc71aa53567ad6dda92d0cc733adce67251434851847dbae6216a1f254336f3 \
-                        size    48596112
+    set patchNumber     10
+    checksums           rmd160  22bfa8f33cc5edfcff86bccd6a45a051979799cc \
+                        sha256  ac14a937e3b8d70f86f635b08272813f2e00282d05c61c3087bbbd9333738d02 \
+                        size    48600048
 }
 
 subport kubectl-1.14 {


### PR DESCRIPTION
#### Description

Update kubectl-1.15 to 1.15.10.

###### Tested on

macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?