### PR TITLE
kubectl: add kubectl-1.17 subport

### DIFF
--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -17,7 +17,14 @@ maintainers             {@patarra gmail.com:patarra} \
 subport kubectl_select {}
 
 # *NOTE* Remember to update `latestVersion` on a version upgrade.
-set latestVersion       kubectl-1.16
+set latestVersion       kubectl-1.17
+subport kubectl-1.17 {
+    set patchNumber     3
+    checksums           rmd160  9ed5190ce4ea3e6d13b35fb05630e202c0a51d0f \
+                        sha256  f6eb09a1734c203a915c8f406c8508f3613752dc35e331db148646066606ef92 \
+                        size    49577376
+}
+
 subport kubectl-1.16 {
     set patchNumber     2
     checksums           rmd160  d8d7848c7b3e276c823f13fec17a50e7db134138 \


### PR DESCRIPTION
#### Description

Added subport for kubectl 1.17.x.

###### Tested on

macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?