### PR TITLE
rust: update to 1.41.0

### DIFF
--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -5,7 +5,7 @@ PortGroup           muniversal 1.0
 PortGroup           active_variants 1.1
 
 name                rust
-version             1.39.0
+version             1.41.0
 revision            0
 categories          lang devel
 platforms           darwin
@@ -27,9 +27,9 @@ long_description    Rust is a curly-brace, block-structured expression \
 homepage            https://www.rust-lang.org/
 
 # Get from src/stage0.txt
-set ruststd_version 1.38.0
-set rustc_version   1.38.0
-set cargo_version   0.39.0
+set ruststd_version 1.40.0
+set rustc_version   1.40.0
+set cargo_version   0.41.0
 set llvm_version    9.0
 
 # can use cmake or cmake-devel; default to cmake.
@@ -68,37 +68,37 @@ foreach arch ${architectures} {
 }
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  d5b04b87fc336e3be7d592f70de0363aa66622aa \
-                    sha256  b4a1f6b6a93931f270691aba4fc85eee032fecda973e6b9c774cd06857609357 \
-                    size    152803201
+                    rmd160  47d5cd072f667cc52fd6c7a4096eb425e55a982a \
+                    sha256  5546822c09944c4d847968e9b7b3d0e299f143f307c00fa40e84a99fabf8d74b \
+                    size    135348467
 
 checksums-append \
                     rust-std-${ruststd_version}-i686-apple-${os.platform}${extract.suffix} \
-                    rmd160  abaf5a71b5fd88d2862cf0d7eb8f1cf3df796430 \
-                    sha256  f908048e106490d884fa62ef87be2ec25572022898bfc23427483389909329fa \
-                    size    207734917 \
+                    rmd160  b0d33fbff6d6a396570c817304eea2d35dde0751 \
+                    sha256  5812c8a1a89afd0e348a87c9e0f87956e2c1688738a03b5e3adcd3b3846c6809 \
+                    size    22442282 \
                     rustc-${rustc_version}-i686-apple-${os.platform}${extract.suffix} \
-                    rmd160  ce1278bb7cabe8e12c031617d16fbb3dc611e7aa \
-                    sha256  6c758ead07e330e1b6b08f491a85844a9170c15316953da54fd4321de216cb9a \
-                    size    88668711 \
+                    rmd160  79d84b7bd1287c5af1c4f6e3f4a0754ebab19cc9 \
+                    sha256  8fa281d23b2c251ca3ada1b85ee2f2550670eb56cd0d322504dbfd6e4596407c \
+                    size    80595214 \
                     cargo-${cargo_version}-i686-apple-${os.platform}${extract.suffix} \
-                    rmd160  4a472d8d25e6ddcbc50f4f490393905bc476c36a \
-                    sha256  b24650691bf62adcd6f6e150b3177b6fef390807dcd6dd66eabfa8519eec8990 \
-                    size    5362857
+                    rmd160  d1172497536db584763440acf7100dc310f01d26 \
+                    sha256  57533f5188933cf0d0d196526918b2f158f91aa0716f0e996f436b1913a2d25b \
+                    size    5238160
 
 checksums-append \
                     rust-std-${ruststd_version}-x86_64-apple-${os.platform}${extract.suffix} \
-                    rmd160  b8adb0a397d18c8d67ba7cec6d3917dadc243bde \
-                    sha256  b1a986e8676aaed25959e9f6dd7c8c5aa67fb829d0d694edea34d8169658a125 \
-                    size    206673254 \
+                    rmd160  5646ba5fe5c25bb95614e4a64938d2a863e57ee5 \
+                    sha256  1eff41b353403cc284a09debb00cfd41d663447eabf5ad2d4cf736c8c8db0458 \
+                    size    22509207 \
                     rustc-${rustc_version}-x86_64-apple-${os.platform}${extract.suffix} \
-                    rmd160  450653a2d94be976b4cb1a12b1752aacadafb62a \
-                    sha256  ac34aee5a5f67003b8f7f857ddb1fa68f89a32680a591ab77561282721b75256 \
-                    size    91334955 \
+                    rmd160  dc0c4e8afe25c87b31be763be26b0b5ed210a105 \
+                    sha256  f45bb00a9a59ca819a8266e9de77f7232f4b704d64f1c45d3870e2db4f646a77 \
+                    size    83133251 \
                     cargo-${cargo_version}-x86_64-apple-${os.platform}${extract.suffix} \
-                    rmd160  831ccc90526e98f9060797be93c595f46dad3883 \
-                    sha256  107af82e268dfe7dbb35908ab0dfd96d0356c3750520612f1add1ecb8ecbc535 \
-                    size    5441089
+                    rmd160  9d3e946459d6993087771ab531d2c8f904e812fd \
+                    sha256  1ef77a6be5e697bb7dde40854651fc67e91f119d5a9ddf747a25e30c1179fbe1 \
+                    size    5371818
 
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
     known_fail yes


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
