### PR TITLE
lazygit: update to 0.14.4

### DIFF
--- a/devel/lazygit/Portfile
+++ b/devel/lazygit/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/jesseduffield/lazygit 0.14.3 v
+go.setup            github.com/jesseduffield/lazygit 0.14.4 v
 categories          devel
 license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
@@ -11,9 +11,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
 description         A simple terminal UI for git commands, written in Go
 long_description    {*}$description
 
-checksums           rmd160  fff48a8d7c34b2aa90a9efa6efdc65d5e5455cdd \
-                    sha256  4239d67f448acff9eb8a534ece2ea120f031ab59a432181a636fb4585046c341 \
-                    size    7127566
+checksums           rmd160  cf3591c7723041b84f9004032d9294d30fc1873e \
+                    sha256  7c8b314f26a0f66bdd130a9d25cb6a8e0e7adfc51d05415d9fadfaf80d2774cd \
+                    size    7127518
 
 build.args          -ldflags \
                       '-X main.version=${version} -X main.buildSource=macports'


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
