### PR TITLE
cctools: Update as patch to allow search for MacPorts clang to be disabled

### DIFF
--- a/devel/cctools/Portfile
+++ b/devel/cctools/Portfile
@@ -6,7 +6,7 @@ name                    cctools
 # Xcode 10.2
 version                 927.0.2
 set ld64_version        450.3
-revision                0
+revision                1
 categories              devel
 platforms               darwin
 maintainers             {jeremyhu @jeremyhu} {kencu @kencu} openmaintainer

--- a/devel/cctools/files/as-try-clang.patch
+++ b/devel/cctools/files/as-try-clang.patch
@@ -1,6 +1,6 @@
 --- as/driver.c.orig	2019-05-25 16:26:59.000000000 +0100
-+++ as/driver.c	2019-05-25 16:49:42.000000000 +0100
-@@ -295,11 +295,26 @@
++++ as/driver.c	2020-02-20 23:44:18.000000000 +0000
+@@ -295,11 +295,28 @@
  	    arch_flag.cputype == CPU_TYPE_ARM64 ||
  	    arch_flag.cputype == CPU_TYPE_ARM64_32 ||
  	    arch_flag.cputype == CPU_TYPE_ARM)){
@@ -9,19 +9,21 @@
 -		printf("%s: assembler (%s) not installed\n", progname, as);
 -		exit(1);
 -	    }
-+          const char * mp_comps[] = { __MP_CLANG_NAMES__ };
-+          const size_t n_comps = sizeof(mp_comps) / sizeof(mp_comps[0]);
-+          for ( size_t i = 0; i < n_comps; ++i ) {
-+            as = makestr(prefix, mp_comps[i], NULL);
-+            if(access(as, F_OK) == 0){
-+              // found working compiler so break
-+              break;
-+            } else {
-+              as = NULL;
++          if ( NULL == getenv("DISABLE_MACPORTS_AS_CLANG_SEARCH") ) {
++            const char * mp_comps[] = { __MP_CLANG_NAMES__ };
++            const size_t n_comps = sizeof(mp_comps) / sizeof(mp_comps[0]);
++            for ( size_t i = 0; i < n_comps; ++i ) {
++              as = makestr(prefix, mp_comps[i], NULL);
++              if(access(as, F_OK) == 0){
++                // found working compiler so break
++                break;
++              } else {
++                as = NULL;
++              }
 +            }
 +          }
 +#if __TRY_SYSTEM_CLANG__
-+          if ( as == NULL ) {
++          if ( NULL == as && NULL == getenv("DISABLE_XCODE_AS_CLANG_SEARCH") ) {
 +            as = "/usr/bin/clang";
 +            if(access(as, F_OK) != 0){
 +              as = NULL;
@@ -32,7 +34,7 @@
  	    new_argv = allocate((argc + 8) * sizeof(char *));
  	    new_argv[0] = as;
  	    j = 1;
-@@ -360,6 +375,7 @@
+@@ -360,6 +377,7 @@
  		exit(0);
  	    else
  		exit(1);


### PR DESCRIPTION
Updates the patch for as to add the ability for the search for a valid macports provided clang to be  temporarily disabled as required. e.g. Default behaviour is as before

```
> as --version                                   
clang version 9.0.1 
Target: x86_64-apple-darwin19.3.0
Thread model: posix
InstalledDir: /opt/local/libexec/llvm-9.0/bin
```

but if the user sets the environment variable `DISABLE_MACPORTS_AS_CLANG_SEARCH` the use of macports provided clang builds is disabled.

```
> DISABLE_MACPORTS_AS_CLANG_SEARCH=1 as --version     
Apple clang version 11.0.0 (clang-1100.0.33.17)
Target: x86_64-apple-darwin19.3.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

@kencu FYI