### PR TITLE
Python PG: fix appending of 'm' suffix to be just 3.0 <= PyVer <= 3.7

### DIFF
--- a/_resources/port1.0/group/python-1.0.tcl
+++ b/_resources/port1.0/group/python-1.0.tcl
@@ -292,7 +292,9 @@ proc python_get_defaults {var} {
                 # look for "${inc_dir}*" and pick the first one found;
                 # make assumptions if none are found
                 if {[catch {set inc_dirs [glob ${inc_dir}*]}]} {
-                    if {${python.version} < 30} {
+                    # append 'm' suffix if 30 <= PyVer <= 37
+                    # Py27- and Py38+ do not use this suffix
+                    if {${python.version} < 30 || ${python.version} > 37} {
                         return ${inc_dir}
                     } else {
                         return ${inc_dir}m

--- a/python/py-sip/Portfile
+++ b/python/py-sip/Portfile
@@ -73,7 +73,7 @@ if {${name} ne ${subport}} {
     checksums           rmd160 e52170c8ac2c80a42b73fd4d5178e8d85bfd39e2 \
                         sha256 6af9979ab41590e8311b8cc94356718429ef96ba0e3592bdd630da01211200ae \
                         size   1050654
-    revision            0
+    revision            1
 
     patchfiles          patch-siputils.py.diff \
                         patch-specs_macx-g++.diff \


### PR DESCRIPTION
Python38 removes the `include` directory suffix ('m') that was part of 3.0 through 3.7. This PR updates the Python PG accordingly.

Noted in: https://trac.macports.org/ticket/60104

Some binaries might need to be rebuilt for this change to take effect.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G3020
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
