### PR TITLE
pcre: update to 8.44

### DIFF
--- a/devel/pcre/Portfile
+++ b/devel/pcre/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                pcre
-version             8.43
+version             8.44
 subport pcre2 {
     version         10.34
 }
@@ -33,9 +33,9 @@ master_sites        sourceforge:project/pcre/${subport}/${version} \
 distname            ${subport}-${version}
 use_bzip2           yes
 
-set rmd160(pcre)    b99a135d7d2833a16531ee2b2abd5dc99c9e1ea4
-set sha256(pcre)    91e762520003013834ac1adb4a938d53b22a216341c061b0cf05603b290faf6b
-set size(pcre)      1576584
+set rmd160(pcre)    55a361bbbc3481590d6e75880e70f866302d6e40
+set sha256(pcre)    19108658b23b3ec5058edc9f66ac545ea19f9537234be1ec62b714c84399366d
+set size(pcre)      1577611
 set rmd160(pcre2)   bf224aeb1d9d1c8a4f28ff4c6b4148d2b3c6c1c6
 set sha256(pcre2)   74c473ffaba9e13db6951fd146e0143fe9887852ce73406a03277af1d9b798ca
 set size(pcre2)     1714731


### PR DESCRIPTION
#### Description
I used the pcregrep on the command line to validate the change and i also ran `port test pcre` to run the test suite.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
