### PR TITLE
cargo: update to 0.41.0

### DIFF
--- a/devel/cargo/Portfile
+++ b/devel/cargo/Portfile
@@ -1,12 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=portfile:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+
 name                cargo
+
 if {${subport} ne "${name}-bootstrap"} {
     PortGroup       github 1.0
-    github.setup    rust-lang ${name} 0.40.0
+
+    github.setup    rust-lang ${name} 0.41.0
 } else {
-    version         0.39.0
+    version         0.41.0
 }
 PortGroup           cargo 1.0
 
@@ -38,9 +41,9 @@ if {${subport} ne "${name}-bootstrap"} {
                     port:rust
 
     checksums       ${distname}${extract.suffix} \
-                    rmd160  f939a47290786047aab5c9707a5482b7a7a98e8c \
-                    sha256  6fae1075fb89d69edc7f94310ecd8b80b4c6fca32a5561c5426f827c7f71ed8c \
-                    size    1093988
+                    rmd160  cf8677206ade9f895be0ed06119317a912f0dd95 \
+                    sha256  84feda98d78943cdfa8c615c58f1d05812b958cc8612dcfffe6587eb94462fcd \
+                    size    1122365
 
     pre-configure {
         # create Cargo.lock
@@ -103,15 +106,15 @@ if {${subport} ne "${name}-bootstrap"} {
 
     checksums-append \
         ${name}-${version}-i686-apple-darwin${extract.suffix} \
-                    rmd160  4a472d8d25e6ddcbc50f4f490393905bc476c36a \
-                    sha256  b24650691bf62adcd6f6e150b3177b6fef390807dcd6dd66eabfa8519eec8990 \
-                    size    5362857
+                    rmd160  d1172497536db584763440acf7100dc310f01d26 \
+                    sha256  57533f5188933cf0d0d196526918b2f158f91aa0716f0e996f436b1913a2d25b \
+                    size    5238160
 
     checksums-append \
         ${name}-${version}-x86_64-apple-darwin${extract.suffix} \
-                    rmd160  831ccc90526e98f9060797be93c595f46dad3883 \
-                    sha256  107af82e268dfe7dbb35908ab0dfd96d0356c3750520612f1add1ecb8ecbc535 \
-                    size    5441089
+                    rmd160  9d3e946459d6993087771ab531d2c8f904e812fd \
+                    sha256  1ef77a6be5e697bb7dde40854651fc67e91f119d5a9ddf747a25e30c1179fbe1 \
+                    size    5371818
 
     if {![variant_isset universal]} {
         set rust_platform [cargo.rust_platform ${build_arch}]
@@ -151,36 +154,40 @@ subport ${name}-bootstrap {}
 subport ${name}-stage1 {
     # can be removed on 11/23/2020
     PortGroup   obsolete 1.0
+
     replaced_by ${name}-bootstrap
 }
 
 if {${subport} ne "${name}-bootstrap"} {
     cargo.crates \
         adler32                          1.0.4  5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2 \
-        aho-corasick                     0.7.6  58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d \
+        aho-corasick                     0.7.8  743ad5a418686aad3b87fd14c43badd828cf26e214a00f92a384291cf22e1811 \
         ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
-        atty                            0.2.13  1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90 \
+        atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
         autocfg                          0.1.7  1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2 \
-        backtrace                       0.3.40  924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea \
+        autocfg                          1.0.0  f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d \
+        backtrace                       0.3.44  e4036b9bf40f3cf16aba72a3d65e8a520fc4bafcdc7079aea8f848c58c5b5536 \
         backtrace-sys                   0.1.32  5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491 \
         bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
-        bstr                             0.2.8  8d6c2c5b58ab920a4f5aeaaca34b4488074e8cc7596af94e6f8c6ff247c60245 \
+        bstr                            0.2.11  502ae1441a0a5adb8fbd38a5955a6416b9493e92b465de5e4a9bde6a539c2c48 \
         bytesize                         1.0.0  716960a18f978640f25101b5cbf1c6f6b0d3192fab36a2d98ca96f0ecbe41010 \
         c2-chacha                        0.2.3  214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb \
-        cc                              1.0.47  aa87058dce70a3ff5621797f1506cb837edd02ac4c0ae642b4542dce802908b8 \
+        cc                              1.0.50  95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd \
         cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
-        chrono                           0.4.9  e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68 \
+        chrono                          0.4.10  31850b4a4d6bae316f7a09e691c944c28299298837edc0a03f755618c23cbc01 \
         clap                            2.33.0  5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9 \
         commoncrypto                     0.2.0  d056a8586ba25a1e4d61cb090900e495952c7886786fc55f909ab2f819b69007 \
         commoncrypto-sys                 0.2.0  1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2 \
         core-foundation                  0.6.4  25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d \
         core-foundation-sys              0.6.2  e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b \
         crc32fast                        1.2.0  ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1 \
-        crossbeam-channel                0.3.9  c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa \
+        crossbeam-channel                0.4.0  acec9a3b0b3559f15aee4f90746c4e5e293b701c0f7d3925d24e01645267b68c \
+        crossbeam-utils                  0.7.0  ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4 \
         crossbeam-utils                  0.6.6  04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6 \
         crypto-hash                      0.3.4  8a77162240fd97248d19a564a565eb563a3f592b386e4136fb300909e67dddca \
         curl                            0.4.25  06aa71e9208a54def20792d877bc663d6aae0732b9852e612c4a933177c31283 \
-        curl-sys                        0.4.24  f659f3ffac9582d6177bb86d1d2aa649f4eb9d0d4de9d03ccc08b402832ea340 \
+        curl-sys                        0.4.26  0853fe2a575bb381b1f173610372c7722d9fa9bc4056512ed99fe6a644c388c6 \
+        env_logger                       0.7.1  44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36 \
         env_logger                       0.6.2  aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3 \
         failure                          0.1.6  f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9 \
         failure_derive                   0.1.6  0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08 \
@@ -191,100 +198,98 @@ if {${subport} ne "${name}-bootstrap"} {
         foreign-types-shared             0.1.1  00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b \
         fs2                              0.4.3  9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213 \
         fwdansi                          1.1.0  08c1f5787fe85505d1f7777268db5103d80a7a374d2316a7ce262e57baf8f208 \
-        getrandom                       0.1.13  e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407 \
+        getrandom                       0.1.14  7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb \
         git2                            0.10.2  7c1af51ea8a906616af45a4ce78eacf25860f7a13ae7bf8a814693f0f4037a26 \
         git2-curl                       0.11.0  cd6527e480187ce19aaf4fa6acfb7657b25628ce31cb8ffabdfca3bf731524c5 \
         glob                             0.3.0  9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574 \
         globset                          0.4.4  925aa2cac82d8834e2b2a4415b6f6879757fb5c0928fc445ae76461a12eed8f2 \
-        hermit-abi                       0.1.3  307c3c9f937f38e3534b1d6447ecf090cafcc9744e4a6360e8b037b2cf5af120 \
+        hermit-abi                       0.1.7  e2c55f143919fbc0bc77e427fe2d74cf23786d7c1875666f2fde3ac3c659bb67 \
+        hex                              0.4.2  644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35 \
         hex                              0.3.2  805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77 \
-        hex                              0.4.0  023b39be39e3a2da62a94feb433e91e8bcd37676fbc8bea371daf52b7a769a3e \
-        home                             0.5.1  a3753954f7bd71f0e671afb8b5a992d1724cf43b7f95a563cd4a0bde94659ca8 \
+        home                             0.5.3  2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654 \
         humantime                        1.3.0  df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f \
         idna                             0.2.0  02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9 \
-        ignore                          0.4.10  0ec16832258409d571aaef8273f3c3cc5b060d784e159d1a0f3b0017308f84a7 \
+        ignore                          0.4.11  522daefc3b69036f80c7d2990b28ff9e0471c683bad05ca258e0a01dd22c5a1e \
         im-rc                           13.0.0  0a0197597d095c0d11107975d3175173f810ee572c2501ff4de64f4f3f119806 \
-        itoa                             0.4.4  501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f \
-        jobserver                       0.1.17  f2b1d42ef453b30b7387e113da1c83ab1605d90c5b4e0eb8e96d016ed3b8c160 \
+        itoa                             0.4.5  b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e \
+        jobserver                       0.1.21  5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2 \
         lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
         lazycell                         1.2.1  b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f \
-        libc                            0.2.65  1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8 \
+        libc                            0.2.67  eb147597cdf94ed43ab7a9038716637d2d1bf2bc571da995d0028dec06bd3018 \
         libgit2-sys                      0.9.2  4870c781f6063efb83150cd22c1ddf6ecf58531419e7570cdcced46970f64a16 \
         libnghttp2-sys                   0.1.2  02254d44f4435dd79e695f2c2b83cd06a47919adea30216ceaf0c57ca0a72463 \
-        libssh2-sys                     0.2.13  5fcd5a428a31cbbfe059812d74f4b6cd3b9b7426c2bdaec56993c5365da1c328 \
+        libssh2-sys                     0.2.14  36aa6e813339d3a063292b77091dfbbb6152ff9006a459895fa5bebed7d34f10 \
         libz-sys                        1.0.25  2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe \
         log                              0.4.8  14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7 \
         matches                          0.1.8  7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
-        memchr                           2.2.1  88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e \
-        miniz_oxide                      0.3.5  6f3f74f726ae935c3f514300cc6773a0c9492abc5e972d42ba0c0ebb88757625 \
+        memchr                           2.3.2  53445de381a1f436797497c61d851644d0e8e88e6140f22872ad33a704933978 \
+        miniz_oxide                      0.3.6  aa679ff6578b1cddee93d7e82e263b94a575e0bfced07284eb0c037c1d2416a5 \
         miow                             0.3.3  396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226 \
-        num-integer                     0.1.41  b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09 \
-        num-traits                      0.2.10  d4c81ffc11c212fa327657cb19dd85eb7419e163b5b076bede2bdb5c974c07e4 \
-        num_cpus                        1.11.1  76dac5ed2a876980778b8b85f75a71b6cbf0db0b1232ee12f826bccb00d09d72 \
+        num-integer                     0.1.42  3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba \
+        num-traits                      0.2.11  c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096 \
+        num_cpus                        1.12.0  46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6 \
         opener                           0.4.1  13117407ca9d0caf3a0e74f97b490a7e64c0ae3aa90a8b7085544d0c37b6f3ae \
-        openssl                        0.10.26  3a3cc5799d98e1088141b8e01ff760112bbd9f19d850c124500566ca6901a585 \
+        openssl                        0.10.28  973293749822d7dd6370d6da1e523b0d1db19f06c459134c658b2a4261378b52 \
         openssl-probe                    0.1.2  77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de \
-        openssl-src                   111.6.0+1.1.1d  b9c2da1de8a7a3f860919c01540b03a6db16de042405a8a07a5e9d0b4b825d9c \
-        openssl-sys                     0.9.53  465d16ae7fc0e313318f7de5cecf57b2fbe7511fd213978b457e1c96ff46736f \
+        openssl-src                   111.6.1+1.1.1d  c91b04cb43c1a8a90e934e0cd612e2a5715d976d2d6cff4490278a0cddf35005 \
+        openssl-sys                     0.9.54  1024c0a59774200a555087a6da3f253a9095a5f344e353b212ac4c8b8e450986 \
         percent-encoding                 2.1.0  d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
         pkg-config                      0.3.17  05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677 \
         ppv-lite86                       0.2.6  74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b \
         pretty_env_logger                0.3.1  717ee476b1690853d222af4634056d830b5197ffd747726a9a1eee6da9f49074 \
-        proc-macro2                      1.0.6  9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27 \
-        quick-error                      1.2.2  9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0 \
+        proc-macro2                      1.0.8  3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548 \
+        quick-error                      1.2.3  a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0 \
         quote                            1.0.2  053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe \
-        rand                             0.7.2  3ae1b169243eaf61759b8475a998f0a385e42042370f3a7dbaf35246eacc8412 \
+        rand                             0.7.3  6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
         rand_chacha                      0.2.1  03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853 \
         rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
         rand_hc                          0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
         redox_syscall                   0.1.56  2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84 \
-        regex                            1.3.1  dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd \
-        regex-syntax                    0.6.12  11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716 \
+        regex                            1.3.4  322cf97724bea3ee221b78fe25ac9c46114ebb51747ad5babd51a2fc6a8235a8 \
+        regex-syntax                    0.6.14  b28dfe3fe9badec5dbf0a79a9cccad2cfc2ab5484bdb3e44cbd1ae8b3ba2be06 \
         remove_dir_all                   0.5.2  4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e \
         rustc-demangle                  0.1.16  4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783 \
         rustc-workspace-hack             1.0.0  fc71d2faa173b74b232dedc235e3ee1696581bb132fc116fa3626d6151a1a8fb \
         rustc_version                    0.2.3  138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a \
         rustfix                          0.4.6  7150ac777a2931a53489f5a41eb0937b84e3092a20cd0e73ad436b65b507f607 \
         ryu                              1.0.2  bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8 \
-        same-file                        1.0.5  585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421 \
-        schannel                        0.1.16  87f550b06b6cba9c8b8be3ee73f391990116bf527450d2556e9b9ce263b9a021 \
-        scopeguard                       1.0.0  b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d \
+        same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
+        schannel                        0.1.17  507a9e6e8ffe0a4e0ebb9a10293e62fdf7657c06f1b8bb07a8fcf697d2abf295 \
         semver                           0.9.0  1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403 \
         semver-parser                    0.7.0  388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
-        serde                          1.0.102  0c4b39bd9b0b087684013a792c59e3e07a46a01d2322518d8a1104641a0b1be0 \
-        serde_derive                   1.0.102  ca13fc1a832f793322228923fbb3aba9f3f44444898f835d31ad1b74fa0a2bf8 \
-        serde_ignored                    0.1.0  3c24bbb8f4b81834f618cd3e28698235c2fba06ddf7f4fbe30519dd081364e59 \
-        serde_json                      1.0.41  2f72eb2a68a7dc3f9a691bfda9305a1c017a6215e5a4545c258500d2099a37c2 \
+        serde                          1.0.104  414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449 \
+        serde_derive                   1.0.104  128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64 \
+        serde_ignored                    0.1.1  7248fdcbd17d3f2604fc2a02d0ecc844d9a7bf52bf95fc196d9f0a38f6da6a0e \
+        serde_json                      1.0.48  9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25 \
         shell-escape                     0.1.4  170a13e64f2a51b77a45702ba77287f5c6829375b04a69cf2222acd17d0cfab9 \
         sized-chunks                     0.3.1  f01db57d7ee89c8e053245deb77040a6cc8508311f381c88749c33d4b9b78785 \
-        smallvec                         1.0.0  4ecf3b85f68e8abaa7555aa5abdb1153079387e60b718283d732f03897fcfc86 \
+        smallvec                         1.2.0  5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc \
         socket2                         0.3.11  e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85 \
         strip-ansi-escapes               0.1.0  9d63676e2abafa709460982ddc02a3bb586b6d15a49b75c212e06edd3933acee \
         strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
-        syn                              1.0.8  661641ea2aa15845cddeb97dad000d22070bb5c1fb456b96c1cba883ec691e92 \
+        syn                             1.0.14  af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5 \
         synstructure                    0.12.3  67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545 \
         tar                             0.4.26  b3196bfbffbba3e57481b6ea32249fbaf590396a52505a2615adbb79d9d826d3 \
         tempfile                         3.1.0  7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9 \
-        termcolor                        1.0.5  96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e \
+        termcolor                        1.1.0  bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f \
         textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
-        thread_local                     0.3.6  c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b \
+        thread_local                     1.0.1  d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14 \
         time                            0.1.42  db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f \
-        toml                             0.5.5  01d1404644c8b12b16bfcffa4322403a91a451584daaaa7c28d3152e6cbc98cf \
+        toml                             0.5.6  ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a \
         typenum                         1.11.2  6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9 \
         unicode-bidi                     0.3.4  49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5 \
-        unicode-normalization           0.1.11  b561e267b2326bb4cebfc0ef9e68355c7abe6c6f522aeac2f5bf95d56c59bdcf \
-        unicode-width                    0.1.6  7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20 \
+        unicode-normalization           0.1.12  5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4 \
+        unicode-width                    0.1.7  caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479 \
         unicode-xid                      0.2.0  826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c \
-        url                              2.1.0  75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61 \
+        url                              2.1.1  829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb \
         utf8parse                        0.1.1  8772a4ccbb4e89959023bc5b7cb8623a795caa7092d99f3aa9501b9484d4557d \
-        vcpkg                            0.2.7  33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95 \
+        vcpkg                            0.2.8  3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168 \
         vec_map                          0.8.1  05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a \
         vte                              0.3.3  4f42f536e22f7fcbb407639765c8fd78707a33109301f834a594758bedd6e8cf \
-        walkdir                          2.2.9  9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e \
-        wasi                             0.7.0  b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d \
+        walkdir                          2.3.1  777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d \
+        wasi                          0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
         winapi                           0.3.8  8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6 \
         winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
-        winapi-util                      0.1.2  7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9 \
-        winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
-        wincolor                         1.0.2  96f5016b18804d24db43cebf3c77269e7569b8954a8464501c216cc5e070eaa9
+        winapi-util                      0.1.3  4ccfbf554c6ad11084fb7517daca16cfdcaccbdadba4fc336f032a8b12c2ad80 \
+        winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f
 }


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
