### PR TITLE
kubectx: update to 0.8.0

### DIFF
--- a/sysutils/kubectx/Portfile
+++ b/sysutils/kubectx/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        ahmetb kubectx 0.7.1 v
+github.setup        ahmetb kubectx 0.8.0 v
 revision            0
 categories          sysutils
 platforms           darwin
@@ -15,11 +15,11 @@ description         Power tools for kubectl
 long_description    kubectx helps you switch between clusters back and forth. \
                     kubens helps you switch between Kubernetes namespaces smoothly.
 
-checksums           rmd160  1febd41c44979de11f2847006c7388bbaf9f0e10 \
-                    sha256  e70c496af1aff89cddf3d11eaa6ac0197e8c4cb02c69216f63602d6bd2be7045 \
-                    size    484187
+checksums           rmd160  cd1c245dedccbaf0a7f897f836be7a06ff543f24 \
+                    sha256  6c4f544273bac5f5d55cdb5a9d05d6b36f9ca262f079101ac620a1f967b7bb00 \
+                    size    485499
 
-depends_run         path:${prefix}/bin/kubectl:kubectl-1.16
+depends_run         path:${prefix}/bin/kubectl:kubectl-1.17
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

Update to kubectx 0.8.0.

###### Tested on

macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?