### PR TITLE
starship: update to 0.36.1

### DIFF
--- a/sysutils/starship/Portfile
+++ b/sysutils/starship/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        starship starship 0.35.1 v
+github.setup        starship starship 0.36.1 v
 categories          sysutils
 platforms           darwin
 maintainers         {l2dy @l2dy} \
@@ -17,9 +17,9 @@ description         a minimal, blazing fast, and extremely customizable prompt f
 long_description    Starship is ${description}.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  1b07c063e3ab21810de9ddf591b5b282fbf26383 \
-                    sha256  9a0cfa6cfd5eb7cacd4de1cb863b6d1fbeb2faf33ab666b6627bf7fd59be5b37 \
-                    size    5142384
+                    rmd160  3a697463437091d906be5d14382c006b7e4db86b \
+                    sha256  f4ae565462ce15f2f334e3ea769d5dce3f8e1bd5c67a56f8958ce8277032fab1 \
+                    size    5139290
 
 # For crate:openssl-sys
 depends_build       port:pkgconfig
@@ -45,9 +45,9 @@ cargo.crates \
     battery                          0.7.5  36a698e449024a5d18994a815998bf5e2e4bc1883e35a7d7ba95b6b69ee45907 \
     bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
     blake2b_simd                    0.5.10  d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a \
-    bumpalo                          3.1.2  5fb8038c1ddc0a5f73787b130f4cc75151e96ed33e417fde765eb5a81e3532f4 \
+    bumpalo                          3.2.0  1f359dc14ff8911330a51ef78022d376f25ed00248912803b58f00cb1c27f742 \
     byte-unit                        3.0.3  6894a79550807490d9f19a138a6da0f8830e70c83e83402dd23f16fd6c479056 \
-    byteorder                        1.3.2  a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5 \
+    byteorder                        1.3.4  08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de \
     bytes                            0.5.4  130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1 \
     c2-chacha                        0.2.3  214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb \
     cc                              1.0.50  95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd \
@@ -72,19 +72,19 @@ cargo.crates \
     fnv                              1.0.6  2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3 \
     fuchsia-zircon                   0.3.3  2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
     fuchsia-zircon-sys               0.3.3  3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
-    futures-channel                  0.3.3  7264eb65b194d2fa6ec31b898ead7c332854bfa42521659226e72a585fca5b85 \
-    futures-core                     0.3.3  b597b16aa1a19ce2dfde5128a7c656d75346b35601a640be2d9efd4e9c83609d \
-    futures-io                       0.3.3  3d429f824b5e5dbd45fc8e54e1005a37e1f8c6d570cd64d0b59b24d3a80b8b8e \
-    futures-macro                    0.3.3  a1d75b72904b78044e0091355fc49d29f48bff07a68a719a41cf059711e071b4 \
-    futures-sink                     0.3.3  04299e123547ea7c56f3e1b376703142f5fc0b6700433eed549e9d0b8a75a66c \
-    futures-task                     0.3.3  86f9ceab4bce46555ee608b1ec7c414d6b2e76e196ef46fa5a8d4815a8571398 \
-    futures-util                     0.3.3  7d2f1296f7644d2cd908ebb2fa74645608e39f117c72bac251d40418c6d74c4f \
+    futures-channel                  0.3.4  f0c77d04ce8edd9cb903932b608268b3fffec4163dc053b3b402bf47eac1f1a8 \
+    futures-core                     0.3.4  f25592f769825e89b92358db00d26f965761e094951ac44d3663ef25b7ac464a \
+    futures-io                       0.3.4  a638959aa96152c7a4cddf50fcb1e3fede0583b27157c26e67d6f99904090dc6 \
+    futures-macro                    0.3.4  9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7 \
+    futures-sink                     0.3.4  3466821b4bc114d95b087b850a724c6f83115e929bc88f1fa98a3304a944c8a6 \
+    futures-task                     0.3.4  7b0a34e53cf6cdcd0178aa573aed466b646eb3db769570841fda0c7ede375a27 \
+    futures-util                     0.3.4  22766cf25d64306bedf0384da004d05c9974ab104fcc4528f1236181c18004c5 \
     gethostname                      0.2.1  e692e296bfac1d2533ef168d0b60ff5897b8b70a4009276834014dd8924cc028 \
     getrandom                       0.1.14  7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb \
     git2                            0.11.0  77519ef7c5beee314d0804d4534f01e0f9e8d9acdee2b7a48627e590b27e0ec4 \
     h2                               0.2.1  b9433d71e471c1736fd5a61b671fc0b148d7a2992f666c958d03cd8feb3b88d1 \
     heck                             0.3.1  20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205 \
-    hermit-abi                       0.1.6  eff2656d88f158ce120947499e971d743c05dbcbed62e5bd2f38f1698bbc3772 \
+    hermit-abi                       0.1.7  e2c55f143919fbc0bc77e427fe2d74cf23786d7c1875666f2fde3ac3c659bb67 \
     http                             0.2.0  b708cc7f06493459026f53b9a61a7a121a5d1ec6238dee58ea4941132b30156b \
     http-body                        0.3.1  13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b \
     httparse                         1.3.4  cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9 \
@@ -108,7 +108,7 @@ cargo.crates \
     log                              0.4.8  14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7 \
     mach                             0.2.3  86dd2487cdfea56def77b88438a2c915fb45113c5319bfe7e14306ca4cd0b0e1 \
     matches                          0.1.8  7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
-    memchr                           2.3.0  3197e20c7edb283f87c071ddfc7a2cca8f8e0b888c242959846a6fce03c72223 \
+    memchr                           2.3.2  53445de381a1f436797497c61d851644d0e8e88e6140f22872ad33a704933978 \
     memoffset                        0.5.3  75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9 \
     mime                            0.3.16  2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d \
     mime_guess                       2.0.1  1a0ed03949aef72dbdf3116a383d7b38b4768e6f960528cd6a6044aa9ed68599 \
@@ -124,9 +124,9 @@ cargo.crates \
     num-traits                      0.2.11  c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096 \
     num_cpus                        1.12.0  46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6 \
     once_cell                        1.3.1  b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b \
-    open                             1.3.3  3dfa632621d66502e1e9298c038d903090fc810a33cc1e6a02958fa0be65e3fb \
+    open                             1.3.4  e02989ecc31ed50c00e2b0edc25ab1f5e7bd81e8baa52b7c4a89180580b4ed08 \
     openssl-probe                    0.1.2  77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de \
-    os_info                          1.3.3  46c6031e9373f6942a00933638731c7f4543f265b4bd920a1230fbcd62dfdf0c \
+    os_info                          2.0.0  4c44df6cf2c8efe99e1539a636c16af6e9e8bededa1d9b97aed47e9b63b659c2 \
     path-slash                       0.1.1  a0858af4d9136275541f4eac7be1af70add84cf356d901799b065ac1b8ff6e2f \
     percent-encoding                 2.1.0  d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
     pin-project                      0.4.8  7804a463a8d9572f13453c516a5faea534a2403d7ced2f0c7e100eeff072772c \
@@ -160,7 +160,7 @@ cargo.crates \
     rustls-native-certs              0.1.0  51ffebdbb48c14f84eba0b715197d673aff1dd22cc1007ca647e28483bbcc307 \
     ryu                              1.0.2  bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8 \
     schannel                        0.1.17  507a9e6e8ffe0a4e0ebb9a10293e62fdf7657c06f1b8bb07a8fcf697d2abf295 \
-    scopeguard                       1.0.0  b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d \
+    scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
     sct                              0.6.0  e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c \
     security-framework               0.3.4  8ef2429d7cefe5fd28bd1d2ed41c944547d4ff84776f5935b456da44593a16df \
     security-framework-sys           0.3.3  e31493fc37615debb8c5090a7aeb4a9730bc61e77ab10b9af59f1a202284f895 \
@@ -168,7 +168,7 @@ cargo.crates \
     semver-parser                    0.7.0  388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
     serde                          1.0.104  414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449 \
     serde_derive                   1.0.104  128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64 \
-    serde_json                      1.0.46  21b01d7f0288608a01dca632cf1df859df6fd6ffa885300fc275ce2ba6221953 \
+    serde_json                      1.0.48  9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25 \
     serde_urlencoded                 0.6.1  9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97 \
     slab                             0.4.2  c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8 \
     smallvec                         1.2.0  5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc \
@@ -177,7 +177,7 @@ cargo.crates \
     static_assertions                0.3.4  7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3 \
     strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
     syn                             1.0.14  af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5 \
-    sysinfo                         0.10.5  b8834e42be61ae4f6338b216fbb69837c7f33c3d4d3a139fb073735b25af4d9e \
+    sysinfo                         0.11.2  1569849bee47c8094d7bece5d1b57f3fdda279136ef616cac04b926787514289 \
     tempfile                         3.1.0  7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9 \
     term_size                        0.3.1  9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327 \
     termcolor                        1.1.0  bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
