### PR TITLE
upt: switch to python3.8

### DIFF
--- a/python/py-upt-cpan/Portfile
+++ b/python/py-upt-cpan/Portfile
@@ -23,7 +23,7 @@ checksums           sha256  624b58e05edb9539e4972222d72d8ca991def512cd2bed833e29
                     rmd160  500051bcef096b4498d808f0bf3efb8c5be4fd72 \
                     size    5439
 
-python.versions     37
+python.versions     37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-upt-macports/Portfile
+++ b/python/py-upt-macports/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  dfe4b11250a7918bd3492c809ea88a3baea3c1e2 \
                     sha256  3d3ac6c65fb3159f28a1d04a553aedc1a604059a35c9635355008c8533462363 \
                     size    11817
 
-python.versions     37
+python.versions     37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-upt-pypi/Portfile
+++ b/python/py-upt-pypi/Portfile
@@ -23,7 +23,7 @@ checksums           sha256  6cfe91ab916ab190d4d6440b829c2c13d42855724f681c39483e
                     rmd160  283c92efd5bef46ce74f1b467ea017b40e7341cf \
                     size    12414
 
-python.versions     37
+python.versions     37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-upt-rubygems/Portfile
+++ b/python/py-upt-rubygems/Portfile
@@ -23,7 +23,7 @@ checksums           sha256  4bf9988ae2d42d30e50cb85e34f3b8a4a0ef298c9710561fb0ec
                     rmd160  fa8accf7092b44a05273932de18df0282586976e \
                     size    5795
 
-python.versions     37
+python.versions     37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/sysutils/upt/Portfile
+++ b/sysutils/upt/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                upt
 version             0.11
-revision            0
+revision            1
 
 categories-prepend  sysutils
 platforms           darwin
@@ -24,7 +24,7 @@ checksums           rmd160  c0cfd7c4121eb87beef442957b471f589c7d224d \
                     sha256  65ef84ec7d8ba5f563bd6e2d522f055b80b143063f7cd96663bf8ad2c424df79 \
                     size    29366
 
-python.default_version  37
+python.default_version  38
 
 depends_lib-append \
                 port:py${python.version}-colorlog \


### PR DESCRIPTION
#### Description

Switches to python 3.8. The 3.7 subports could probably be removed as they likely don't serve anyone else outside of the `upt` port anyway.

Running unit tests before `upt` itself is installed is problematic (`py-upt-cpan` tests require `upt` to be installed, but the dependencies are reverse), but I believe you know this already.

###### Tested on

macOS 10.13

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
