### PR TITLE
meson: switch to python 3.8

### DIFF
--- a/devel/meson/Portfile
+++ b/devel/meson/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 PortGroup           github 1.0
 
 github.setup        mesonbuild meson 0.53.1
+revision            1
 
 github.tarball_from releases
 license             Apache-2
@@ -28,8 +29,8 @@ checksums           rmd160  e15d73b1d10249365da4562d3cef3bfb4a1a56df \
 
 # as of verison 0.45.0,requires python 3.5 or better
 
-python.versions         37
-python.default_version  37
+python.versions         38
+python.default_version  38
 python.link_binaries    no
 
 depends_build-append \
@@ -59,7 +60,7 @@ post-destroot {
 # doing a file test for ${prefix}/bin/python3 and requiring this
 # to be honest would have been much simpler, but not the "MacPorts way"
 pre-test {
-    reinplace "s|/usr/bin/env python3$|/usr/bin/env python3.7|" \
+    reinplace "s|/usr/bin/env python3$|${python.bin}|" \
         ${worksrcpath}/run_tests.py \
         ${worksrcpath}/run_cross_test.py \
         ${worksrcpath}/run_meson_command_tests.py \
@@ -69,7 +70,7 @@ pre-test {
     set testpath "${worksrcpath}/test\\ cases"
     fs-traverse f ${testpath} {
         if { [string match *.py ${f}] } {
-            reinplace "s|/usr/bin/env python3$|/usr/bin/env python3.7|" ${f}
+            reinplace "s|/usr/bin/env python3$|${python.bin}|" ${f}
         }
     }
 }


### PR DESCRIPTION
#### Description

Switches to python 3.8 and improves deterministic handling of the correct python version.

When running unit tests I'm still getting
```
test_meson_uninstalled (__main__.CommandTests) ... env: python3: No such file or directory
```
but I didn't have time to investigate any further.

###### Tested on

macOS 10.13

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
  - (some tests seem broken, some test for software that's not dependency of meson, like `mercurial`, `cmake`, ...). It also looks as if `ninja` isn't seen as a dependency during the test.
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
