### PR TITLE
bind9: use legacysupport PortGroup

### DIFF
--- a/net/bind9/Portfile
+++ b/net/bind9/Portfile
@@ -1,4 +1,5 @@
 PortSystem 1.0
+PortGroup  legacysupport 1.0
 
 name			bind9
 version			9.16.0


### PR DESCRIPTION
Requires clock_gettime as of version 9.16.0.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Mac OS X 10.6.8
Xcode 3.2.6
