### PR TITLE
wtfutil: update to 0.27.0

### DIFF
--- a/sysutils/wtfutil/Portfile
+++ b/sysutils/wtfutil/Portfile
@@ -1,9 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
+PortGroup           golang 1.0
 
-github.setup        wtfutil wtf 0.26.0 v
+go.setup            github.com/wtfutil/wtf 0.27.0 v
+
 homepage            https://wtfutil.com
 
 name                wtfutil
@@ -17,28 +18,17 @@ description         A personal terminal-based dashboard utility, designed for \
                     data.
 long_description    ${description}
 
-fetch.type          git
+checksums           rmd160  9814f46f9f72633f31a0d23361f4e1118dbe76b5 \
+                    sha256  046a1f9f3b266c897845ae1ee5c0f33805d5f91f71fcd79b89e59b9da00bf001 \
+                    size    2226528
 
-depends_build       port:go
+set build_date      [exec date +%FT%T%z]
 
-use_configure       no
-use_parallel_build  no
-
-build.env           GOPATH=${workpath} \
-                    PATH=$env(PATH):${workpath}/bin
-
-build.target        install
-
-post-extract {
-    reinplace "s|~/go|\$\${GOPATH}|g" ${worksrcpath}/Makefile
-}
-
-post-build {
-    exec go clean
-}
+build.args          -o ${name} -ldflags \
+                        '-X main.version=${version} -X main.date=${build_date}'
 
 destroot {
-    xinstall -m 755 ${workpath}/bin/${name} ${destroot}${prefix}/bin/${name}
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}
     xinstall -d -m 0755 ${destroot}${prefix}/share/${name}
     xinstall -d -m 0755 ${destroot}${prefix}/share/${name}/sample_configs
 


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
