### PR TITLE
pgcli: update to 2.2.0

### DIFF
--- a/databases/pgcli/Portfile
+++ b/databases/pgcli/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        dbcli pgcli 2.1.1 v
-revision            1
+github.setup        dbcli pgcli 2.2.0 v
+revision            0
 
 categories          databases python
 maintainers         {g5pw @g5pw} {@xeron gmail.com:xeron.oskom} openmaintainer
@@ -17,11 +17,9 @@ long_description    {*}${description}
 
 homepage            https://pgcli.com
 
-checksums           rmd160  50bee637da3cef3d993d353c6349dbe1def3eebc \
-                    sha256  14ee789ae2f8b6e7173dca42362213361da88a46b1853507c4bcde58b02feb5e \
-                    size    435790
-
-patchfiles          postgresql12_support.diff
+checksums           rmd160  b21661497897b26408db6d5b452cdacbf2449c34 \
+                    sha256  349db982139d6dd7c05989d66313e98d2184724464679b12fdb61ef96be13fc6 \
+                    size    437034
 
 variant python27 conflicts python36 python37 python38 description "Use Python 2.7" {}
 variant python36 conflicts python27 python37 python38 description "Use Python 3.6" {}
@@ -46,7 +44,8 @@ if {[variant_isset python27]} {
                     sha256  2c30dd068afdc8a0b15460d49b27962c55642154bb4cb4279e86b36d607c9590 \
                     size    430226
 
-    patchfiles-append   setup-1.11.0.py.diff
+    patchfiles      postgresql12_support.diff \
+                    setup-1.11.0.py.diff
 }
 
 depends_lib-append  port:py${python.version}-cli-helpers \

--- a/python/py-pgspecial/Portfile
+++ b/python/py-pgspecial/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pgspecial
-version             1.11.7
+version             1.11.9
 license             BSD
 platforms           darwin
 supported_archs     noarch
@@ -19,9 +19,9 @@ homepage            https://pypi.python.org/pypi/${python.rootname}/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  a3f10c64081e48231a0a09d5ae101982fc6ac530 \
-                    sha256  f7501681e276b07cb260e665ce578ff5c64bcd1bc58bde27a01b78425afdc173 \
-                    size    62884
+checksums           rmd160  c80cd446308553b564a322de2555a892f0fa428a \
+                    sha256  77f8651450ccbde7d3036cfe93486a4eeeb5ade28d1ebc4b2ba186fea0023c56 \
+                    size    63047
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

Update pgcli to 2.2.0.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3 19D76
Xcode 11.3.1 11C504 