### PR TITLE
xephem: use bundled motif

### DIFF
--- a/science/xephem/Portfile
+++ b/science/xephem/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                xephem
 version             3.7.7
+revision            1
 categories          science
 maintainers         nomaintainer
 license             Restrictive/Distributable
@@ -19,15 +20,24 @@ homepage            http://www.clearskyinstitute.com/xephem/
 platforms           darwin
 master_sites        http://www.clearskyinstitute.com/xephem/
 checksums           rmd160  8cda6208a8d6990703c1fc49c371ff9a5bb710d2 \
-                    sha256  fb0b889218322c1cc0b994da7125e624e4f0112d9da1c468936600d1179e55de
+                    sha256  fb0b889218322c1cc0b994da7125e624e4f0112d9da1c468936600d1179e55de \
+                    size    18128521
 extract.suffix      .tgz
-depends_lib         lib:libXm:openmotif
+depends_lib         port:xorg-libXp \
+                    port:xorg-libXt \
+                    port:xorg-libXext \
+                    port:xorg-libXmu \
+                    port:xorg-libX11
 worksrcdir          ${distname}/GUI/xephem
 
 patchfiles          patch-Makefile.diff
 
+# we need to use the included libpng as the included motif is built against it
+# the included libpng is not reliably built in time with parallel building
+use_parallel_build  no
+
 use_configure       no
-build.args          MOTIFI=${prefix}/include MOTIFL=${prefix}/lib \
+build.args          MOTIF=../../libXm/osx \
                     CC=${configure.cc}
 build.target
 

--- a/science/xephem/files/patch-Makefile.diff
+++ b/science/xephem/files/patch-Makefile.diff
@@ -1,5 +1,14 @@
 --- Makefile.orig	2015-08-09 16:36:50.000000000 -0500
 +++ Makefile	2016-12-26 15:26:20.000000000 -0600
+@@ -12,7 +12,7 @@
+ # These -I and -L flags point to the supporting XEphem libraries
+ LIBINC = -I../../libastro -I../../libip -I../../liblilxml -I../../libjpegd -I../../libpng -I../../libz
+ LIBLNK = -L../../libastro -L../../libip -L../../liblilxml -L../../libjpegd -L../../libpng -L../../libz
+-LIBLIB = -lastro -lip -llilxml -ljpegd -lpng -lz
++LIBLIB = -lastro -lip -llilxml -ljpegd ../../libpng/libpng.a -lz
+ 
+ # MOTIFI is the directory containing the Xm directory of include files.
+ # MOTIFL is the directory containing the libXm.a library.
 @@ -32,8 +32,8 @@
  # for linux and Apple OS X
  CC = gcc


### PR DESCRIPTION
the current openmotif in MacPorts uses a two-level namespace
which causes some ports to fail to run

use the bundled motif library (and the bundled libpng)
until xephem is updated to work with the current openmotif

closes: https://trac.macports.org/ticket/60122

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->

macOS 10.14.6 18G3020, 10.6.8
Xcode 11.3.1 11C504 , 4.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
