### PR TITLE
py-docker: add missing dependency

### DIFF
--- a/python/py-docker/Portfile
+++ b/python/py-docker/Portfile
@@ -29,6 +29,7 @@ if {${subport} ne ${name}} {
 
     depends_lib-append  \
                     port:py${python.version}-dockerpy-creds \
+                    port:py${python.version}-paramiko \
                     port:py${python.version}-requests \
                     port:py${python.version}-six \
                     port:py${python.version}-websocket-client


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G3020
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

The `py-docker` package has an additional (`extra_require`) dependency, as listed in `setup.py`:

```
    # Only required when connecting using the ssh:// protocol
    'ssh': ['paramiko>=2.4.2'],
```

This extra dependency is required by another port which I'm updating (`docker-compose`).