### PR TITLE
lazygit: update to 0.15.3

### DIFF
--- a/devel/lazygit/Portfile
+++ b/devel/lazygit/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/jesseduffield/lazygit 0.14.4 v
+go.setup            github.com/jesseduffield/lazygit 0.15.3 v
 categories          devel
 license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
@@ -11,12 +11,15 @@ maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
 description         A simple terminal UI for git commands, written in Go
 long_description    {*}$description
 
-checksums           rmd160  cf3591c7723041b84f9004032d9294d30fc1873e \
-                    sha256  7c8b314f26a0f66bdd130a9d25cb6a8e0e7adfc51d05415d9fadfaf80d2774cd \
-                    size    7127518
+checksums           rmd160  635f00e75a3b5797acec7c2cd6a1efdf7216f640 \
+                    sha256  cd9c1fa289b8ba66a0cbdcf9d5fd8f5987013f0847c6239f5e134a60ab3f1844 \
+                    size    7131080
 
+set build_date      [exec date +%FT%T%z]
 build.args          -ldflags \
-                      '-X main.version=${version} -X main.buildSource=macports'
+                      '-X main.date=${build_date} \
+                       -X main.version=${version} \
+                       -X main.buildSource=macports'
 
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
