### PR TITLE
mingw32-binutils: skip libbfd resolves issue with shared files

### DIFF
--- a/cross/i686-w64-mingw32-binutils/Portfile
+++ b/cross/i686-w64-mingw32-binutils/Portfile
@@ -8,9 +8,15 @@ set mingw_name      w64-mingw32
 set mingw_arch      i686
 set mingw_target    ${mingw_arch}-${mingw_name}
 crossbinutils.setup ${mingw_target} 2.34
+revision            1
 
 maintainers         {mojca @mojca} openmaintainer
 
 configure.args-append \
                     --disable-multilib \
                     --disable-werror
+
+# Remove due to commit;
+# libctf: installable libctf as a shared library
+configure.args-delete \
+                    --enable-install-libbfd

--- a/cross/x86_64-w64-mingw32-binutils/Portfile
+++ b/cross/x86_64-w64-mingw32-binutils/Portfile
@@ -8,9 +8,15 @@ set mingw_name      w64-mingw32
 set mingw_arch      x86_64
 set mingw_target    ${mingw_arch}-${mingw_name}
 crossbinutils.setup ${mingw_target} 2.34
+revision            1
 
 maintainers         {mojca @mojca} openmaintainer
 
 configure.args-append \
                     --disable-multilib \
                     --disable-werror
+                    
+# Remove due to commit;
+# libctf: installable libctf as a shared library
+configure.args-delete \
+                    --enable-install-libbfd


### PR DESCRIPTION
The upgrade to 2.34 caused includes conflicts when installing both i686 & x86_64

#### Description
The recent binutils version bump causes a conflict when `i686-w64-mingw32-binutils` & then `x86_64-w64-mingw32-binutils` is install like when installing `mingw-w64` meta Portfile the following error happens; 

```
Error: Failed to activate x86_64-w64-mingw32-binutils: Image error: /opt/local/include/ctf-api.h is being used by the active i686-w64-mingw32-binutils port.  Please deactivate this port first, or use 'port -f activate x86_64-w64-mingw32-binutils' to force the activation.
DEBUG: Error code: registry::image-error
DEBUG: Backtrace: Image error: /opt/local/include/ctf-api.h is being used by the active i686-w64-mingw32-binutils port.  Please deactivate this port first, or use 'port -f activate x86_64-w64-mingw32-binutils' to force the activation.
```
This resolves the build errors from https://github.com/macports/macports-ports/pull/6449

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3 19D76
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
