### PR TITLE
google-cloud-sdk: update to 282.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             281.0.0
+version             282.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  a72547640506b006c8b326b8497e99c40746b876 \
-                    sha256  1ee756ffeedabc4f6caa8959f2f38a53650fc2cfb03f09f8aa872e157f2b4cfc \
-                    size    48154129
+    checksums       rmd160  0e7454f6a4f86054a6f3088093ac38a8fbb624d6 \
+                    sha256  40a95817a046249e0c8394d33d53b4ddbf75c94fff5e7415c3ba76b3c9d317c2 \
+                    size    48219710
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  8cf19e1740aaa8bd67e672ae9037f90b1d729c2f \
-                    sha256  d9c4a987e64ab4f1ac2ce641be6ab2bd3113352f20b7043154c959da8640e441 \
-                    size    49202100
+    checksums       rmd160  80d364f8b71ffd6d794ea554f3b89960b660bd44 \
+                    sha256  2b6f96113a9a5cca3ef96ed0e8ba1f7754da1851e623aa2ae933b917bf713738 \
+                    size    49266008
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 282.0.0.

###### Tested on

macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?