### PR TITLE
k9s: update to 0.17.0

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.16.1 v
+go.setup            github.com/derailed/k9s 0.17.0 v
 
 categories          sysutils
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -19,9 +19,9 @@ platforms           darwin
 supported_archs     x86_64
 license             Apache-2
 
-checksums           rmd160  095adda7e225140abfdc3eefabd685b584dcc233 \
-                    sha256  7a8ae8fe9de9cf09655aaf701ca381934dccbea661de41875caee6c27844e8eb \
-                    size    3166686
+checksums           rmd160  9c5c0907f4be535c41cc0f63156c59547a6d6d57 \
+                    sha256  9cf1268e02986e55cd5591e3acd2175f940c520cdbd6254f998243346cfa98c2 \
+                    size    14513187
 
 # Reproduce the "build" target from the upstream Makefile
 set go_ldflags      "-w -X ${go.package}/cmd.version=${version} \


### PR DESCRIPTION
#### Description

Update to k9s 0.17.0.

###### Tested on

macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?