### PR TITLE
knock: new port

### DIFF
--- a/net/knock/Portfile
+++ b/net/knock/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        jvinet knock 258a27e5a47809f97c2b9f2751a88c2f94aae891
+version             0.7.8-20151227
+#name               knock
+categories          net
+platforms           darwin
+maintainers         nomaintainer
+license             GPL-2
+description         A port-knocking implementation
+long_description    ${description}
+homepage            https://www.zeroflux.org/projects/knock
+checksums           rmd160  a95443251191b26f96fead78e8e25eceb29ae7f0 \
+                    sha256  33640a796b338f07a28de7e31578c06bfabea52256ce14933776680a3074f85a \
+                    size    31054
+
+depends_lib-append  port:libpcap
+
+use_autoreconf      yes


### PR DESCRIPTION
#### Description

Simple port knocking client and daemon.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.3 19D76
Xcode (CLI only)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
