### PR TITLE
gitlab-runner: update to 12.8.0

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 12.7.1 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 12.8.0 v
 
 categories          devel
 platforms           darwin
@@ -23,9 +23,9 @@ homepage            https://docs.gitlab.com/runner/
 master_sites        https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v${version}/
 distname            gitlab-runner-v${version}
 
-checksums           rmd160  3b00c5487096225edfcf6e96e9c58524921c9d3b \
-                    sha256  6582d7a654ca99119de33f6b29280b859de12487f8dc7b3f35e49e7d2c415bf5 \
-                    size    6963046
+checksums           rmd160  e3f83e6c9b57fa8960faeef63eece8dc28f312d7 \
+                    sha256  5ed0ee8e5b7c5134d1232cae36ed9d2e21b0f9a7c780d5854cb73c6d9f14ac40 \
+                    size    7144428
 
 # Reproduce the "build_simple" target from the upstream Makefile
 set go_ldflags      "-X ${go.package}/common.NAME=${go.package} \


### PR DESCRIPTION
#### Description

Update to GitLab Runner 12.8.0.

###### Tested on

macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?