### PR TITLE
cfm: new Portfile

### DIFF
--- a/sysutils/cfm/Portfile
+++ b/sysutils/cfm/Portfile
@@ -1,0 +1,21 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        willeccles cfm 0.5.5 v
+categories          sysutils
+platforms           darwin
+license             MPL-2
+maintainers         {eccles.dev:will @willeccles}
+description         Cactus File Manager
+long_description    Cactus File Manager is a simple and fast TUI file manager
+homepage            https://github.com/willeccles/cfm
+
+checksums           rmd160  e864a6d96f170f5013df61496440bfd0597a7950 \
+                    sha256  22c52896986883e0d831b75d7b1c01217cac04043357c3fab2527eb363d0600d \
+                    size    70980
+
+destroot.args       DESTDIR=${destdir} PREFIX=${prefix}
+
+use_configure       no


### PR DESCRIPTION
#### Description

[cfm](https://cfm.atinycact.us) is a simple and fast TUI file manager with no dependencies.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.4 18E226
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->