### PR TITLE
Update beancount dependencies, support Python 3.8

### DIFF
--- a/python/fava/Portfile
+++ b/python/fava/Portfile
@@ -5,11 +5,11 @@ PortGroup               python 1.0
 
 name                    fava
 categories-append       finance
-version                 1.10
-revision                1
-checksums               rmd160  15c187e8f5a852a3850cb4a5c79e078dfc532c64 \
-                        sha256  5207d0ee49f86b5f7520ea7d556e769321853bb8eaa760acc606e4f76d49a990 \
-                        size    617036
+version                 1.14
+revision                0
+checksums               rmd160  3584157fff58977d2586b58214065a37f145935e \
+                        sha256  1eb7638252ba110840a94fca5a88fbd3c35057efb0146dce1258a97305be3ea0 \
+                        size    1367651
 
 license                 MIT
 platforms               darwin
@@ -23,7 +23,8 @@ homepage                https://beancount.github.io/fava/
 master_sites            pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname                ${python.rootname}-${version}
 
-python.default_version  37
+python.versions         37 38
+python.default_version  38
 
 depends_build-append    port:py${python.version}-setuptools_scm
 

--- a/python/py-beancount-import/Portfile
+++ b/python/py-beancount-import/Portfile
@@ -6,6 +6,7 @@ PortGroup           python 1.0
 name                py-beancount-import
 categories-append   finance
 version             1.3.0
+revision            1
 checksums           rmd160  2c574b08a3c2083678f3b42997892fbb38e4e5e0 \
                     sha256  b4f8020d68e249933633365c620859079bcacef0b4e7a2b3c3c20eefbdf8cac5 \
                     size    321899
@@ -27,7 +28,7 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 use_zip             yes
 
-python.versions     37
+python.versions     37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-beancount/Portfile
+++ b/python/py-beancount/Portfile
@@ -5,10 +5,10 @@ PortGroup           python 1.0
 
 name                py-beancount
 categories-append   finance
-version             2.2.1
-checksums           rmd160  60650715322a8f302455f3028400281f23d850d2 \
-                    sha256  ebcb59bd7c0e18a858c55d6c30eacee3fa949ee5d2c452a7aa80690e36ae2f77 \
-                    size    597196
+version             2.2.3
+checksums           rmd160  706810f10713aeb835266d11f05066b32805bb40 \
+                    sha256  1554adfd773d12cb88fd7f4da67fcb608665a9bdedc7e44834e059d1b3a08e5d \
+                    size    604034
 
 license             GPL-2
 platforms           darwin
@@ -24,7 +24,7 @@ homepage            http://furius.ca/beancount/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-python.versions     37
+python.versions     37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-bottle/Portfile
+++ b/python/py-bottle/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-bottle
 version             0.12.18
-revision            0
+revision            1
 
 categories-append   devel
 platforms           darwin
@@ -26,7 +26,7 @@ checksums           rmd160  a34d7d5c77e3a65a9763323c5fe94edc85fc2c97 \
                     sha256  0819b74b145a7def225c0e83b16a4d5711fde751cd92bae467a69efce720f69e \
                     size    71557
 
-python.versions     27 37
+python.versions     27 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-flask-babel/Portfile
+++ b/python/py-flask-babel/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-flask-babel
 python.rootname     Flask-Babel
-version             0.12.2
+version             1.0.0
 revision            0
 categories-append   www
 maintainers         nomaintainer
@@ -20,11 +20,11 @@ homepage            https://github.com/python-babel/flask-babel
 master_sites        pypi:F/${python.rootname}/
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  826fd8df10aa7d6634c46c41f58c660adbaecaf9 \
-                    sha256  316ad183e42003f3922957fa643d0a1e8e34a0f0301a88c3a8f605bc37ba5c86 \
-                    size    44567
+checksums           rmd160  85d6e2de03cd98e09e0a1177774ba7465ea5323d \
+                    sha256  d6a70468f9a8919d59fba2a291a003da3a05ff884275dddbd965f3b98b09ab3e \
+                    size    49680
 
-python.versions     27 37
+python.versions     27 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-google-auth/Portfile
+++ b/python/py-google-auth/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-google-auth
-version             1.7.1
+version             1.11.2
 revision            0
 
 categories-append   www devel
@@ -21,9 +21,9 @@ homepage            https://pypi.python.org/pypi/${python.rootname}
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  483cbb630c62e7c3339465010022ec22591d423f \
-                    sha256  baf1b3f8b29a5f96f66753ad848473699322b63f4d68964e510554b12d002443 \
-                    size    81126
+checksums           rmd160  bc2c6821b62b5f4a8321f7be1933d2234dbaefab \
+                    sha256  1ee22e22f35d6e00f068d7b3999b2ce24ecb5d0dcbd485aa6896d2b83c8907d6 \
+                    size    88031
 
 python.versions     27 35 36 37 38
 


### PR DESCRIPTION
#### Description

This adds Python 3.8 support for beancount, and fixes some errors introduced in dependencies in the process.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
