### PR TITLE
go: backport upstream fix for AVX

### DIFF
--- a/lang/go/Portfile
+++ b/lang/go/Portfile
@@ -66,6 +66,9 @@ build.env           GOROOT_BOOTSTRAP=${prefix}/lib/go-1.4 \
                     GOROOT_FINAL=${GOROOT_FINAL} \
                     CC=${configure.cc}
 
+# backport upstream patch to test for AVX before using it
+patchfiles-append   go-141-avx-fix.patch
+
 if {${os.platform} eq "darwin" && ${os.major} <= ${legacysupport.newest_darwin_requires_legacy}} {
     # The legacy support PG will not actually change anything in this port directly,
     # since go doesn't use the standard CFLAGS/CXXFLAGS.

--- a/lang/go/files/go-141-avx-fix.patch
+++ b/lang/go/files/go-141-avx-fix.patch
@@ -1,0 +1,98 @@
+go / go / 4d6efad6506ac40d3f6530d5e6f1a5a94431639c^! / .
+commit	4d6efad6506ac40d3f6530d5e6f1a5a94431639c	[log] [tgz]
+author	Cherry Zhang <cherryyz@google.com>	Tue Feb 25 20:30:37 2020 -0500
+committer	Cherry Zhang <cherryyz@google.com>	Wed Feb 26 19:59:07 2020 +0000
+tree	54ba05f663696962a5f731a2cfba5acc92a1de6a
+parent	99f8de733936785d0e5c0d1271539d3f2f26d009 [diff]
+[release-branch.go1.14] runtime: guard VZEROUPPER on CPU feature
+
+In CL 219131 we inserted a VZEROUPPER instruction on darwin/amd64.
+The instruction is not available on pre-AVX machines. Guard it
+with CPU feature.
+
+Updates #37459.
+Fixes #37478.
+
+Change-Id: I9a064df277d091be4ee594eda5c7fd8ee323102b
+Reviewed-on: https://go-review.googlesource.com/c/go/+/221057
+Run-TryBot: Cherry Zhang <cherryyz@google.com>
+TryBot-Result: Gobot Gobot <gobot@golang.org>
+Reviewed-by: Keith Randall <khr@golang.org>
+(cherry picked from commit c46ffdd2eca339918ed30b6ba9d4715ba769d35d)
+diff --git src/runtime/cpuflags.go src/runtime/cpuflags.go
+index 94f9331..4bd894d 100644
+--- src/runtime/cpuflags.go
++++ src/runtime/cpuflags.go
+@@ -11,6 +11,7 @@
+ 
+ // Offsets into internal/cpu records for use in assembly.
+ const (
++	offsetX86HasAVX  = unsafe.Offsetof(cpu.X86.HasAVX)
+ 	offsetX86HasAVX2 = unsafe.Offsetof(cpu.X86.HasAVX2)
+ 	offsetX86HasERMS = unsafe.Offsetof(cpu.X86.HasERMS)
+ 	offsetX86HasSSE2 = unsafe.Offsetof(cpu.X86.HasSSE2)
+diff --git src/runtime/mkpreempt.go src/runtime/mkpreempt.go
+index 31b6f5c..c26406e 100644
+--- src/runtime/mkpreempt.go
++++ src/runtime/mkpreempt.go
+@@ -244,15 +244,6 @@
+ 
+ 	// TODO: MXCSR register?
+ 
+-	// Apparently, the signal handling code path in darwin kernel leaves
+-	// the upper bits of Y registers in a dirty state, which causes
+-	// many SSE operations (128-bit and narrower) become much slower.
+-	// Clear the upper bits to get to a clean state. See issue #37174.
+-	// It is safe here as Go code don't use the upper bits of Y registers.
+-	p("#ifdef GOOS_darwin")
+-	p("VZEROUPPER")
+-	p("#endif")
+-
+ 	p("PUSHQ BP")
+ 	p("MOVQ SP, BP")
+ 	p("// Save flags before clobbering them")
+@@ -261,6 +252,18 @@
+ 	p("ADJSP $%d", l.stack)
+ 	p("// But vet doesn't know ADJSP, so suppress vet stack checking")
+ 	p("NOP SP")
++
++	// Apparently, the signal handling code path in darwin kernel leaves
++	// the upper bits of Y registers in a dirty state, which causes
++	// many SSE operations (128-bit and narrower) become much slower.
++	// Clear the upper bits to get to a clean state. See issue #37174.
++	// It is safe here as Go code don't use the upper bits of Y registers.
++	p("#ifdef GOOS_darwin")
++	p("CMPB internal∕cpu·X86+const_offsetX86HasAVX(SB), $0")
++	p("JE 2(PC)")
++	p("VZEROUPPER")
++	p("#endif")
++
+ 	l.save()
+ 	p("CALL ·asyncPreempt2(SB)")
+ 	l.restore()
+diff --git src/runtime/preempt_amd64.s src/runtime/preempt_amd64.s
+index 0f2fd7d..4765e9f 100644
+--- src/runtime/preempt_amd64.s
++++ src/runtime/preempt_amd64.s
+@@ -4,9 +4,6 @@
+ #include "textflag.h"
+ 
+ TEXT ·asyncPreempt(SB),NOSPLIT|NOFRAME,$0-0
+-	#ifdef GOOS_darwin
+-	VZEROUPPER
+-	#endif
+ 	PUSHQ BP
+ 	MOVQ SP, BP
+ 	// Save flags before clobbering them
+@@ -15,6 +12,11 @@
+ 	ADJSP $368
+ 	// But vet doesn't know ADJSP, so suppress vet stack checking
+ 	NOP SP
++	#ifdef GOOS_darwin
++	CMPB internal∕cpu·X86+const_offsetX86HasAVX(SB), $0
++	JE 2(PC)
++	VZEROUPPER
++	#endif
+ 	MOVQ AX, 0(SP)
+ 	MOVQ CX, 8(SP)
+ 	MOVQ DX, 16(SP)


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/60133

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.13.6 17G11023
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
