### PR TITLE
qri: update to 0.9.5

### DIFF
--- a/devel/qri/Portfile
+++ b/devel/qri/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        qri-io qri 0.9.4 v
+github.setup        qri-io qri 0.9.5 v
 
 categories          devel net
 license             GPL-3
@@ -11,9 +11,9 @@ platforms           darwin
 
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
 
-checksums           rmd160  4cdc9db70f4b3d20ce49d3d162afca69fae3ff2e \
-                    sha256  5f3ac6445890d3efd310ba7f7eb476b8261df60c678436fcd7e9b8a7c1e1b611 \
-                    size    4472249
+checksums           rmd160  833d6b586978e2402b0200fda96ba5a8050ac021 \
+                    sha256  2551df588b4fe34a700f9640997b7ee8efcda444189b4c9facb46da267ba2a7a \
+                    size    4512311
 
 description         A global dataset version control system (GDVCS) built on \
                     the distributed web.


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
