### PR TITLE
WIP:py-gacode:Update to version 0.50

### DIFF
--- a/python/py-gacode/Portfile
+++ b/python/py-gacode/Portfile
@@ -5,7 +5,9 @@ PortGroup           python 1.0
 PortGroup           compilers 1.0
 
 name                py-gacode
-version             0.40
+version             0.50
+python.rootname     pygacode
+
 
 compilers.setup     default_fortran
 
@@ -20,11 +22,23 @@ long_description    ${description}
 license             MIT
 homepage            https://gacode.io
 
-checksums           rmd160  f60a9ce677c528f67543390b25898f863047a4bf \
-                    sha256  831345b6efaa95616f3230107ad27f96157de8034c77778de98f05989179cc67 \
-                    size    18889
+checksums           rmd160  aa48614c5a90755e6763c9e712b20c822aa93920 \
+                    sha256  90603c244172f1d4f1a424603c6500361a623d046f7da9d7c221616af62caced \
+                    size    29258
+
+patchfiles          patch-setup.py.diff
 
 if {${name} ne ${subport}} {
-    livecheck.type       none
-    depends_lib-append   port:py${python.version}-numpy
+    depends_lib-append \
+                    port:py${python.version}-numpy
+
+    pre-test {
+        test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
+    }
+
+    test.run        yes
+    test.cmd        ${python.bin} -c 'from pygacode.test import test_install'
+    test.target
+
+    livecheck.type  none
 }

--- a/python/py-gacode/files/patch-setup.py.diff
+++ b/python/py-gacode/files/patch-setup.py.diff
@@ -1,0 +1,10 @@
+--- setup.py.orig	2020-02-27 23:24:57.000000000 -0800
++++ setup.py	2020-02-27 23:25:03.000000000 -0800
+@@ -20,7 +20,3 @@
+       packages=['pygacode.test'],
+       ext_modules=[wrapper]
+       )
+-
+-# only run tests when installing
+-if 'install' in sys.argv:
+-    from pygacode.test import test_install


### PR DESCRIPTION
#### Description

Update to pygacode version 0.50
Upstream changed its location to pygacode as well

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G87
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

When trying with a fresh install, this fails, as upstream tries to test during the install (destroot) phase, and there seems to be some name mangling going on before the final installation.