### PR TITLE
Py quantities: update version to 0.12.4 and add python 3.7 and 3.8 support

### DIFF
--- a/python/py-quantities/Portfile
+++ b/python/py-quantities/Portfile
@@ -3,10 +3,10 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        python-quantities python-quantities 0.10.1 v
+github.setup        python-quantities python-quantities 0.12.4 v
 
 name                py-quantities
-revision            1
+revision            0
 categories-append   science
 
 platforms           darwin
@@ -23,8 +23,9 @@ long_description    \
     features and API are stable, test coverage is incomplete so the package is \
     not suggested for mission-critical applications.
 
-checksums           rmd160  a9be07abc6ceb746e3648cafa11e5762778a25c6 \
-                    sha256  d31e55a150a207c68c999611d459b93fc8b501863de993ef7efa47766c84eabd
+checksums           rmd160  592d0babf8deaafde1cf666898e36000943f650b \
+                    sha256  404f54ead6f8ba0016cf4215825e267c47be7f86d700fac0e2160d91690d210e \
+                    size    104099
 python.versions     27 35 36
 
 if {${name} ne ${subport}} {

--- a/python/py-quantities/Portfile
+++ b/python/py-quantities/Portfile
@@ -26,7 +26,8 @@ long_description    \
 checksums           rmd160  592d0babf8deaafde1cf666898e36000943f650b \
                     sha256  404f54ead6f8ba0016cf4215825e267c47be7f86d700fac0e2160d91690d210e \
                     size    104099
-python.versions     27 35 36
+
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

- bump version to 0.12.4
- added python 3.7 and 3.8

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
