### PR TITLE
py-[upt-macports|semver]: update to latest version

### DIFF
--- a/python/py-semver/Portfile
+++ b/python/py-semver/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-semver
-version             2.9.0
+version             2.9.1
 revision            0
 
 platforms           darwin
@@ -16,12 +16,10 @@ description         Python helper for Semantic Versioning (http://semver.org/)
 long_description    ${description}
 
 homepage            https://github.com/k-bx/python-semver
-master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
-distname            ${python.rootname}-${version}
 
-checksums           sha256  ed1edeaa0c27f68feb74f09f715077fd07b728446dc2bb7fc470fc0f737873a0 \
-                    rmd160  49416bb7a2deedd7157b6c95b372a52ab6e5dc03 \
-                    size    13239
+checksums           sha256  723be40c74b6468861e0e3dbb80a41fc3b171a2a45bf956c245304773dc06055 \
+                    rmd160  d376c882ee915ed254152bcc732fe2f91f42fa49 \
+                    size    34508
 
 python.versions     37 38
 

--- a/python/py-upt-macports/Portfile
+++ b/python/py-upt-macports/Portfile
@@ -4,9 +4,9 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-set git_hash        39d5324bbd4d9fe40da1a8fbaeeee5db9352e46f
+set git_hash        3808070e5884f1c71f748630ffbbc913e68208d9
 github.setup        macports upt-macports ${git_hash}
-version             0.1-20200209
+version             0.1-20200224
 name                py-${github.project}
 revision            0
 
@@ -18,9 +18,9 @@ maintainers         {@korusuke somaiya.edu:karan.sheth} openmaintainer
 description         MacPorts backend for upt.
 long_description    ${description}
 
-checksums           rmd160  dfe4b11250a7918bd3492c809ea88a3baea3c1e2 \
-                    sha256  3d3ac6c65fb3159f28a1d04a553aedc1a604059a35c9635355008c8533462363 \
-                    size    11817
+checksums           rmd160  d5eb30099c03d80a4506d8688f0ea9e878f3eaf9 \
+                    sha256  248b51e02bfc0bfc7f529711ee52032f9798cc55fe2cccc9d6d6ea66790e1c7b \
+                    size    11825
 
 python.versions     37 38
 


### PR DESCRIPTION
#### Description
This PR updates py-upt-macports to its latest commit and py-semver to version 2.9.1

###### Tested on
macOS 10.14.6 18G3020
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
