### PR TITLE
python38: fix build on older systems

### DIFF
--- a/lang/python38/Portfile
+++ b/lang/python38/Portfile
@@ -37,7 +37,9 @@ patchfiles          patch-setup.py.diff \
                     patch-Lib-ctypes-macholib-dyld.py.diff \
                     patch-libedit.diff \
                     patch-configure-xcode4bug.diff \
-                    patch-_osx_support.py.diff
+                    patch-_osx_support.py.diff \
+                    patch-no-copyfile-on-Tiger.diff \
+                    patch-threadid-older-systems.diff
 
 depends_build       port:pkgconfig
 depends_lib         port:bzip2 \

--- a/lang/python38/files/patch-no-copyfile-on-Tiger.diff
+++ b/lang/python38/files/patch-no-copyfile-on-Tiger.diff
@@ -1,0 +1,68 @@
+posix.copyfile does not exist on Tiger. 
+
+Python 3.8's posix._fcopyfile implementation unconditionally uses <copyfile.h>, 
+which only exists on Leopard ane newer. This patch removes posix._fcopyfile 
+on Tiger - this is okay because the rest of the stdlib uses posix._fcopyfile 
+only conditionally after checking that the function exists 
+(non-Apple systems don't have posix._fcopyfile either).
+
+
+thanks to @dgelessus
+https://github.com/macports/macports-ports/pull/5987
+
+
+--- Lib/test/test_shutil.py.orig
++++ Lib/test/test_shutil.py
+@@ -2393,7 +2393,7 @@
+             shutil._USE_CP_SENDFILE = True
+ 
+ 
+-@unittest.skipIf(not MACOS, 'macOS only')
++@unittest.skipIf(not MACOS or not hasattr(posix, "_fcopyfile"), 'macOS with posix._fcopyfile only')
+ class TestZeroCopyMACOS(_ZeroCopyFileTest, unittest.TestCase):
+     PATCHPOINT = "posix._fcopyfile"
+ 
+diff --git Modules/clinic/posixmodule.c.h Modules/clinic/posixmodule.c.h
+index c0d1d4d..7052678 100644
+--- Modules/clinic/posixmodule.c.h
++++ Modules/clinic/posixmodule.c.h
+@@ -4975,7 +4975,7 @@ exit:
+     return return_value;
+ }
+ 
+-#if defined(__APPLE__)
++#if defined(__APPLE__) && MACOSX_VERSION_MAX_ALLOWED >= 1050
+ 
+ PyDoc_STRVAR(os__fcopyfile__doc__,
+ "_fcopyfile($module, infd, outfd, flags, /)\n"
+diff --git Modules/posixmodule.c Modules/posixmodule.c
+index b09204d..78b2909 100644
+--- Modules/posixmodule.c
++++ Modules/posixmodule.c
+@@ -109,7 +109,7 @@ corresponding Unix manual entries for more information on calls.");
+ #include <sys/sendfile.h>
+ #endif
+ 
+-#if defined(__APPLE__)
++#if defined(__APPLE__) && MACOSX_VERSION_MAX_ALLOWED >= 1050
+ #include <copyfile.h>
+ #endif
+ 
+@@ -9153,7 +9153,7 @@ done:
+ #endif /* HAVE_SENDFILE */
+ 
+ 
+-#if defined(__APPLE__)
++#if defined(__APPLE__) && MACOSX_VERSION_MAX_ALLOWED >= 1050
+ /*[clinic input]
+ os._fcopyfile
+ 
+@@ -14222,7 +14222,7 @@ all_ins(PyObject *m)
+ #endif
+ #endif
+ 
+-#if defined(__APPLE__)
++#if defined(__APPLE__) && MACOSX_VERSION_MAX_ALLOWED >= 1050
+     if (PyModule_AddIntConstant(m, "_COPYFILE_DATA", COPYFILE_DATA)) return -1;
+ #endif
+ 

--- a/lang/python38/files/patch-threadid-older-systems.diff
+++ b/lang/python38/files/patch-threadid-older-systems.diff
@@ -1,0 +1,22 @@
+Older systems (< 10.6) don't have the kernel support for pthread_threadid_np.
+But they do have pthread_mach_thread_np, which is a similar function, if not quite
+as ideal in scope. kencu@macports.org
+
+diff --git Python/thread_pthread.h Python/thread_pthread.h
+index 5678b05..5cfdd17 100644
+--- Python/thread_pthread.h
++++ Python/thread_pthread.h
+@@ -325,9 +327,12 @@ PyThread_get_thread_native_id(void)
+ {
+     if (!initialized)
+         PyThread_init_thread();
+-#ifdef __APPLE__
++#if defined(__APPLE__) && MACOSX_VERSION_MAX_ALLOWED >= 1060
+     uint64_t native_id;
+     (void) pthread_threadid_np(NULL, &native_id);
++#elif defined(__APPLE__) && MACOSX_VERSION_MAX_ALLOWED < 1060
++    uint64_t native_id;
++    native_id = pthread_mach_thread_np(pthread_self());
+ #elif defined(__linux__)
+     pid_t native_id;
+     native_id = syscall(SYS_gettid);


### PR DESCRIPTION
there is no copyfile on Tiger
work around lack of pthread_threadid_np on < 10.6

closes: https://trac.macports.org/ticket/59827
closes: https://trac.macports.org/ticket/59772

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.4, 5, 14
Xcode various

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
