### PR TITLE
py-ansible: update to 2.9.5, add py38 support

### DIFF
--- a/python/py-ansible/Portfile
+++ b/python/py-ansible/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-ansible
-version             2.9.2
+version             2.9.5
 license             GPL-3+
 
 categories-append   sysutils
@@ -19,9 +19,9 @@ homepage            https://github.com/ansible/ansible
 description         SSH-based configuration management and deployment system
 
 distname            ansible-${version}
-checksums           rmd160  b906eb46a19d61abeff8a841e6f8721040e890ef \
-                    sha256  2f83f8ccc50640aa41a24f6e7757ac06b0ee6189fdcaacab68851771d3b42f3a \
-                    size    14157188
+checksums           rmd160  8945e1235d2e843decf4433594d1519fba568618 \
+                    sha256  51ae50d33264eb644ecb79a0208a20569a1127ec3440e8de60eda3a2b3d9caa5 \
+                    size    14186885
 
 conflicts           ansible
 
@@ -33,7 +33,7 @@ long_description \
     be written in any language and are transferred to managed machines \
     automatically.
 
-python.versions 27 35 36 37
+python.versions 27 35 36 37 38
 
 if {${name} ne ${subport}} {
     patch {

--- a/python/py-ansible/files/py38-ansible
+++ b/python/py-ansible/files/py38-ansible
@@ -1,0 +1,10 @@
+bin/ansible-3.8
+bin/ansible-config-3.8
+bin/ansible-connection-3.8
+bin/ansible-console-3.8
+bin/ansible-doc-3.8
+bin/ansible-galaxy-3.8
+bin/ansible-inventory-3.8
+bin/ansible-playbook-3.8
+bin/ansible-pull-3.8
+bin/ansible-vault-3.8


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
simple update

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3
Xcode 11.3.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
