### PR TITLE
gqrx: update version and commit

### DIFF
--- a/science/gqrx/Portfile
+++ b/science/gqrx/Portfile
@@ -19,12 +19,10 @@ dist_subdir         gqrx
 
 if {${subport} eq ${name}} {
 
-    github.setup    csete gqrx 2.11.5 v
-    revision        1
-    checksums       \
-        rmd160 b22320ee122d428ff7accc3053796d8ff303ae63 \
-        sha256 e3e98ac8d0cccdb26122a0b8030e40bae99fe76ab188918bbcc9e2cc5639ea37 \
-        size   1329109
+    github.setup    csete gqrx 2.12.1 v
+    checksums       rmd160  0cef770c446df9be17837d57f60df6687697c6f3 \
+                    sha256  9b12c64f98892781b45b83d8d145fc8bcb44cdecec759326a3f3cbf90a52c7d9 \
+                    size    1334901
 
     patchfiles-append   patch-gqrx.pro.release.diff
 

--- a/science/gqrx/Portfile
+++ b/science/gqrx/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
 name                gqrx
-maintainers         {michaelld @michaelld} openmaintainer
+maintainers         {michaelld @michaelld} {ra1nb0w @ra1nb0w} openmaintainer
 
 description         Gqrx is a software defined radio (SDR) receiver using GNU Radio, OSMOSDR, and Qt5.
 long_description {Gqrx is a software defined radio receiver for Funcube Dongle (FCD), RTL2832U-based DVB-T devices (RTL-SDR), Universal Software Radio Peripherals (USRP) and Osmo SDR devices.  Gqrx is powered by GNU Radio and the Qt5 GUI toolkit.  Gqrx is free and open source software and anyone is invited to hack the source code to suit their needs.}

--- a/science/gqrx/Portfile
+++ b/science/gqrx/Portfile
@@ -39,11 +39,11 @@ provides the release version, which is typically updated every month or so.
 
 subport gqrx-devel {
 
-    github.setup csete gqrx 6e92a6a76ea623c62feb4b437137e5fa649e794c
-    version      20190413-[string range ${github.version} 0 7]
-    checksums    rmd160 726d46ba0df820577549cf7fbf5669f59082bc15 \
-                 sha256 7dcf542e7b37e57481153e4b7651a2165f83f1b9be29c347dcb37d16c9e515d4 \
-                 size   1329304
+    github.setup csete gqrx 7f0c1d92f5de3a52d778004001be6f0d5d5d96f7
+    version      20200222-[string range ${github.version} 0 7]
+    checksums    rmd160  b5780a0ba2fdf41cec4225a374d03f3a1786d2ef \
+                 sha256  1613dfadc0e13235a2d7c6cae2f526b1ad48d47243b480303ac714e57b32c0d1 \
+                 size    1336002
     revision     0
 
     patchfiles-append   patch-gqrx.pro.devel.diff

--- a/science/gqrx/Portfile
+++ b/science/gqrx/Portfile
@@ -4,9 +4,6 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-# Qt5.7 requires C++11 support
-PortGroup           cxx11 1.1
-
 name                gqrx
 maintainers         {michaelld @michaelld} openmaintainer
 
@@ -56,6 +53,8 @@ subport gqrx-devel {
     conflicts           gqrx
 
 }
+
+compiler.cxx_standard 2011
 
 # allow gqrx to work with gnuradio, gnuradio-devel, and gnuradio-next
 

--- a/science/gqrx/files/patch-gqrx.pro.devel.diff
+++ b/science/gqrx/files/patch-gqrx.pro.devel.diff
@@ -1,12 +1,12 @@
---- gqrx.pro.orig
-+++ gqrx.pro
+--- gqrx.pro.orig	2020-02-22 18:20:58.000000000 +0100
++++ gqrx.pro	2020-03-02 13:39:20.000000000 +0100
 @@ -61,10 +61,11 @@
      PREFIX=/usr/local
  }
  
 -target.path  = $$PREFIX/bin
 +target.path  = @APPSDIR@
- INSTALLS    += target 
+ INSTALLS    += target
  
 -#CONFIG += debug
 +CONFIG -= debug

--- a/science/gqrx/files/patch-gqrx.pro.release.diff
+++ b/science/gqrx/files/patch-gqrx.pro.release.diff
@@ -1,12 +1,12 @@
---- gqrx.pro.orig
-+++ gqrx.pro
+--- gqrx.pro.orig	2020-02-22 18:20:58.000000000 +0100
++++ gqrx.pro	2020-03-02 13:39:20.000000000 +0100
 @@ -61,10 +61,11 @@
      PREFIX=/usr/local
  }
  
 -target.path  = $$PREFIX/bin
 +target.path  = @APPSDIR@
- INSTALLS    += target 
+ INSTALLS    += target
  
 -#CONFIG += debug
 +CONFIG -= debug


### PR DESCRIPTION
#### Description

- retire cxx11 portgroup
- gqrx: update version to 2.12.2
- gqrx-devel: update to the latest commit
- add myself as co-maintainer

both versions work fine on my bench (GR3.7 and Soapy backend)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
