### PR TITLE
httpie: add python variants

### DIFF
--- a/net/httpie/Portfile
+++ b/net/httpie/Portfile
@@ -20,7 +20,18 @@ platforms           darwin
 license             BSD
 homepage            http://httpie.org
 
-python.default_version      37
+variant python36 conflicts python37 python38 description "Use Python 3.6" {}
+variant python37 conflicts python36 python38 description "Use Python 3.7" {}
+variant python38 conflicts python36 python37 description "Use Python 3.8" {}
+
+if {[variant_isset python36]} {
+    python.default_version 36
+} elseif {[variant_isset python37]} {
+    python.default_version 37
+} else {
+    default_variants +python38
+    python.default_version 38
+}
 
 depends_lib-append  port:py${python.version}-requests \
                     port:py${python.version}-pygments


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
httpie supports Python 3.6+, added variants for python36, python37 and python38

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3
Xcode 11.3.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
