### PR TITLE
chromedriver: Update to version 81, provide support for recent versions

### DIFF
--- a/www/chromedriver/Portfile
+++ b/www/chromedriver/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                chromedriver
-version             78.0.3904.70
+version             81.0.4044.20
 categories          www
 platforms           darwin
 maintainers         nomaintainer
@@ -25,10 +25,6 @@ dist_subdir         ${name}/${version}
 
 use_zip             yes
 
-checksums           rmd160  0be0c41da777153ea7859be8dd0fb33b0d85ceb4 \
-                    sha256  f04501f36af92ab869111137a66c84612e69ec729caa29b25fa4c305614cfe37 \
-                    size    7488025
-
 extract.mkdir       yes
 
 use_configure       no
@@ -36,7 +32,65 @@ use_configure       no
 build {}
 
 destroot {
-    xinstall -m 755 ${worksrcpath}/chromedriver ${destroot}${prefix}/bin/
+    xinstall -m 755 \
+        ${worksrcpath}/chromedriver \
+        ${destroot}${prefix}/bin/${subport}
+}
+
+# most recent versions via
+# https://sites.google.com/a/chromium.org/chromedriver/downloads
+set latest_major_version \
+                    [lindex [split ${version} .] 0]
+
+checksums           rmd160  f977e91ba9599e51cf46425fc570c2dc1460852a \
+                    sha256  e1e884c4ddb41711defedd4e5c65b512eb2f8a20d084ef3c4cafbc824481b770 \
+                    size    7018740
+
+if {${subport} eq ${name}} {
+    conflicts       ${name}-${latest_major_version}
+}
+
+subport ${name}-${latest_major_version} {
+    conflicts       ${name}
+    post-destroot {
+        ln -s \
+            ${prefix}/bin/${name}-${latest_major_version} \
+            ${destroot}${prefix}/bin/chromedriver
+    }
+}
+
+subport ${name}-80 {
+    version         80.0.3987.106
+
+    checksums       rmd160  90479d8f2a8e60daf8a49b7c79123a3003470be3 \
+                    sha256  4e74140a26a9eea5a5ca1e9bdc9ab2997f18ad2978a278a199a6204fb03b2b09 \
+                    size    7004832
+
+    master_sites    https://chromedriver.storage.googleapis.com/${version}/
+    dist_subdir     ${name}/${version}
+    livecheck.type  none
+}
+
+subport ${name}-79 {
+    version         79.0.3945.36
+
+    checksums       rmd160  5db9b224fd2acf7a2edf076739496bf9a3c33b61 \
+                    sha256  c3bbd1139ace81268fe6d2e74fc815a2fc86d95b3c617eca4a70c92d7cba1b1c \
+                    size    6908371
+
+    master_sites    https://chromedriver.storage.googleapis.com/${version}/
+    dist_subdir     ${name}/${version}
+    livecheck.type  none
+}
+
+subport ${name}-78 {
+    version         78.0.3904.70
+
+    # This subport can be removed on September 8, 2020. 
+    PortGroup       obsolete 1.0
+
+    distfiles
+    livecheck.type      none
 }
 
 livecheck.type      regex


### PR DESCRIPTION
chromedriver: Update to version 81, provide support for recent versions
* Update to version 81
* Add subports for the most recent versions
    * `chromedriver` version must match Google Chrome.app's version,
      which may be fixed 1-2 versions behind the most recent

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
