### PR TITLE
py-netcdf4: update to 1.5.3

### DIFF
--- a/python/py-cftime/Portfile
+++ b/python/py-cftime/Portfile
@@ -1,0 +1,53 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
+
+github.setup        Unidata cftime 1.1.0 v rel
+name                py-cftime
+revision            0
+
+categories-append   devel
+platforms           darwin
+license             GPL-3
+maintainers         {reneeotten @reneeotten} openmaintainer
+
+description         Time-handling functionality from netcdf4-python
+long_description    ${description}
+
+checksums           rmd160  ec58750d775efc3c8bcfe09df208ed5a73b60a16 \
+                    sha256  638e0c1c083423b2270118e02d75f4fd1a6062d874397f9b4687e7b646cf124f \
+                    size    605899
+
+python.versions     27 35 36 37 38
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-cython \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-numpy
+
+    pre-test {
+        test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
+    }
+
+    depends_test-append \
+                    port:py${python.version}-pytest
+
+    test.run        yes
+    test.cmd        py.test-${python.branch}
+    test.args       -o addopts=''
+    test.target
+
+    post-destroot {
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} README.md Changelog \
+            COPYING ${destroot}${docdir}
+    }
+
+    livecheck.type  none
+}

--- a/python/py-netcdf4/Portfile
+++ b/python/py-netcdf4/Portfile
@@ -6,13 +6,13 @@ PortGroup           mpi 1.0
 
 name                py-netcdf4
 python.rootname     netCDF4
-version             1.2.9
-revision            4
+version             1.5.3
+revision            0
+
 categories-append   science
 platforms           darwin
-maintainers         {fastmail.fm:jswhit @jswhit} \
-                    openmaintainer
 license             MIT
+maintainers         {fastmail.fm:jswhit @jswhit} openmaintainer
 
 description         Python/numpy interface to netCDF
 long_description    netCDF version 4 has many features not found in \
@@ -21,14 +21,12 @@ long_description    netCDF version 4 has many features not found in \
                     in both the new netCDF 4 and the old netCDF \
                     3 format, and can create files that are readable by \
                     HDF5 clients.
+
 homepage            https://unidata.github.io/netcdf4-python/
 
-master_sites        pypi:n/netCDF4
-distname            netCDF4-${version}
-
-checksums           rmd160  232de81a67802e90c21117e32c2b549d184470d2 \
-                    sha256  259edab1f03b1c1b93bdbaa804d50211a0c9d8a15eee4f23988b5685c6c0d2c0 \
-                    size    538450
+checksums           rmd160  b855fcb0cc51bf349824ada5129feab9f3911728 \
+                    sha256  2a3ca855848f4bbf07fac366da77a681fcead18c0a8813d91d46302f562dc3be \
+                    size    790343
 
 mpi.enforce_variant netcdf
 mpi.setup
@@ -36,21 +34,39 @@ mpi.setup
 build.env-append    USE_NCCONFIG=1
 destroot.env-append USE_NCCONFIG=1
 
-python.versions     27 35 36 37
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
-    depends_lib-append  port:netcdf \
-                        port:py${python.version}-numpy \
-                        port:py${python.version}-cython
+    depends_build-append \
+                    port:py${python.version}-cython
 
-    post-patch {
-        reinplace -W ${worksrcpath} "s,@@PREFIX@@,${prefix}," setup.py
-    }
+    depends_lib-append \
+                    port:netcdf \
+                    port:py${python.version}-cftime \
+                    port:hdf5 \
+                    port:py${python.version}-numpy \
+                    port:py${python.version}-setuptools
 
     pre-configure {
         # py-netcdf4's setup.py uses nc-config for flags and libs but not compiler
         configure.cc    {*}[exec ${prefix}/bin/nc-config --cc]
     }
 
-    livecheck.type      none
+    pre-test {
+        test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
+    }
+
+    test.run        yes
+    test.dir        ${build.dir}/test
+    test.cmd        ${python.bin} run_all.py
+    test.target
+
+    post-destroot {
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} COPYING Changelog \
+           README.md ${destroot}${docdir}
+    }
+
+    livecheck.type  none
 }


### PR DESCRIPTION
#### Description
This PR update ```py-netcdf4``` to its latest version and adds the new dependency ```py-cftime```.

###### Tested on
macOS 10.14.6 18G3020
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
