### PR TITLE
kotlin: update to 1.3.70

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           java 1.0
 
-github.setup        JetBrains kotlin 1.3.61 v
+github.setup        JetBrains kotlin 1.3.70 v
 revision            0
 github.tarball_from releases
 distname            ${name}-compiler-${version}
@@ -23,9 +23,9 @@ long_description    Kotlin is a pragmatic programming language for JVM \
 
 homepage            https://kotlinlang.org/
 
-checksums           rmd160  3fc7f1ad53a0c8b7efd0bdbeded3d61700896880 \
-                    sha256  3901151ad5d94798a268d1771c6c0b7e305a608c2889fc98a674802500597b1c \
-                    size    53125546
+checksums           rmd160  5e705805702f52a384f6f5ea975d813dae1f27b1 \
+                    sha256  709d782ff707a633278bac4c63bab3026b768e717f8aaf62de1036c994bc89c7 \
+                    size    54791049
 
 java.version        1.8+
 java.fallback       openjdk8


### PR DESCRIPTION
#### Description

Update to Kotlin 1.3.70.

###### Tested on

macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?