### PR TITLE
k9s: update to 0.17.4

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.17.3 v
+go.setup            github.com/derailed/k9s 0.17.4 v
 
 categories          sysutils
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -19,9 +19,9 @@ platforms           darwin
 supported_archs     x86_64
 license             Apache-2
 
-checksums           rmd160  16ef3e009e75adfeb94c8a39766500cffa013556 \
-                    sha256  16e5e6e03d169e6c1235a40c6933e9c326d1a785e6d3d96ee2ba6daf5a47d057 \
-                    size    14514269
+checksums           rmd160  30f1085987da9ce12836158bb0f2f7742daef60b \
+                    sha256  dcb153fa5445400776266721285ab07095a140c14b6e37883c771903ae535505 \
+                    size    15198150
 
 # Reproduce the "build" target from the upstream Makefile
 set go_ldflags      "-w -X ${go.package}/cmd.version=${version} \


### PR DESCRIPTION
#### Description

Update to k9s 0.17.4.

###### Tested on

macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?