### PR TITLE
mafft|muscle|cdhit: new ports

### DIFF
--- a/science/cdhit/Portfile
+++ b/science/cdhit/Portfile
@@ -1,0 +1,56 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        weizhongli cdhit 4.8.1 V
+github.tarball_from archive
+name                cdhit
+revision            0
+
+categories          science
+platforms           darwin
+license             GPL-2
+maintainers         {reneeotten @reneeotten} openmaintainer
+
+description         A program for clustering and comparing protein or nucleotide sequences
+long_description    ${description}
+
+homepage            http://weizhongli-lab.org/cd-hit/
+
+checksums           rmd160  d45a8d8567c3ab02d4dc2a80af613b3df4597400 \
+                    sha256  f8bc3cdd7aebb432fcd35eed0093e7a6413f1e36bbd2a837ebc06e57cdb20b70 \
+                    size    945639
+
+depends_lib         port:zlib
+
+depends_run         bin:perl:perl5
+
+patchfiles          patch-Makefile.diff
+
+post-patch {
+    reinplace "s|@@PREFIX@@|${prefix}|g" ${worksrcpath}/Makefile
+    reinplace "s|#!/usr/bin/perl|#!${prefix}/bin/perl|g" {*}[glob ${worksrcpath}/*.pl]
+}
+
+variant openmp description "enable OpenMP parallel acceleration" {}
+
+if {[variant_isset openmp]} {
+    compiler.openmp_version 2.5
+} else {
+    build.args-append   openmp=no
+}
+
+use_configure       no
+
+build.env           CXX=${configure.cxx} \
+                    CXXFLAGS=${configure.cxxflags}
+
+post-destroot {
+    set docdir ${prefix}/share/doc/${name}
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} license.txt README \
+        ChangeLog ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath}/doc cdhit-user-guide.pdf \
+        ${destroot}${docdir}
+}

--- a/science/cdhit/files/patch-Makefile.diff
+++ b/science/cdhit/files/patch-Makefile.diff
@@ -1,0 +1,30 @@
+Patch to fix two issues:
+- upstream does: CC = g++
+In order to keep the Makefile the same we set CC = $(CXX)
+- install target  
+Add DESTDIR so that the destroot phase works properly
+
+--- Makefile.orig	2020-03-04 21:45:27.000000000 -0500
++++ Makefile	2020-03-04 21:50:00.000000000 -0500
+@@ -1,6 +1,4 @@
+-CC = g++ -Wall -ggdb
+-CC = g++ -pg
+-CC = g++
++CC = $(CXX)
+ 
+ # default with OpenMP
+ # with OpenMP
+@@ -99,10 +97,10 @@
+ cdhit-454.o: cdhit-454.c++ cdhit-common.h
+ 	$(CC) $(CCFLAGS) cdhit-454.c++ -c
+ 
+-PREFIX ?= /usr/local/bin
++PREFIX ?= @@PREFIX@@
+ 
+ install:
+ 	for prog in $(PROGS); do \
+-		install -m 0755 $$prog $(PREFIX); \
++		install -m 0755 $$prog $(DESTDIR)$(PREFIX)/bin; \
+ 	done
+-	install -m 0755 *.pl $(PREFIX);
++	install -m 0755 *.pl $(DESTDIR)$(PREFIX)/bin;

--- a/science/mafft/Portfile
+++ b/science/mafft/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                mafft
+version             7.453
+revision            0
+
+categories          science
+platforms           darwin
+license             BSD
+maintainers         {reneeotten @reneeotten} openmaintainer
+
+description         Multiple alignment program for amino acid or nucleotide sequences
+long_description    ${description}
+
+homepage            https://mafft.cbrc.jp/alignment/software/
+master_sites        ${homepage}
+distname            mafft-${version}-without-extensions-src
+
+checksums           rmd160  82fecc871866986215cbdb93c59b58f8357b407a \
+                    sha256  4c05dfc4d173c9a139fcaa9373fbc2c8d6a59f410a7971f7acc6268be628b1f9 \
+                    size    612421
+
+extract.suffix      .tgz
+
+post-patch {
+    reinplace "s|PREFIX = /usr/local|PREFIX = ${prefix}|g" ${worksrcpath}/core/Makefile
+    reinplace "s|DESTDIR =|#DESTDIR =|g" ${worksrcpath}/core/Makefile
+    reinplace "s|CC =|#CC =|g" ${worksrcpath}/core/Makefile
+}
+
+use_configure       no
+
+build.dir           ${worksrcpath}/core
+build.env           CC=${configure.cc}
+
+destroot.env        DESTDIR=${destroot}${prefix}
+
+post-destroot {
+    set docdir ${prefix}/share/doc/${name}
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} license readme ${destroot}${docdir}
+}
+
+livecheck.type      regex
+livecheck.url       ${homepage}/source.html
+livecheck.regex     mafft-(\[0-9.\]+)-without-extensions-src${extract.suffix}

--- a/science/muscle/Portfile
+++ b/science/muscle/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                muscle
+version             3.8.1551
+revision            0
+
+categories          science
+platforms           darwin
+license             public-domain
+maintainers         {reneeotten @reneeotten} openmaintainer
+
+description         A program for multiple sequence alignment with high accuracy and high throughput
+long_description    ${description}
+
+homepage            https://drive5.com/muscle
+master_sites        ${homepage}
+distname            muscle_src_${version}
+
+checksums           rmd160  3fe31297b1aed972fc95f0c238129e918e4d0197 \
+                    sha256  c70c552231cd3289f1bad51c9bd174804c18bb3adcf47f501afec7a68f9c482e \
+                    size    190019
+
+extract.mkdir       yes
+
+patchfiles          patch-Makefile.diff
+
+use_configure       no
+
+build.env           CXX=${configure.cxx}
+
+destroot {
+    xinstall -m 0755 -W ${worksrcpath} muscle ${destroot}${prefix}/bin
+}
+
+livecheck.type      regex
+livecheck.url       ${homepage}/downloads.htm
+livecheck.regex     ${name}_src_(\[0-9.\]+)${extract.suffix}

--- a/science/muscle/files/patch-Makefile.diff
+++ b/science/muscle/files/patch-Makefile.diff
@@ -1,0 +1,26 @@
+--- Makefile.orig	2020-03-02 22:27:18.000000000 -0500
++++ Makefile	2020-03-02 22:27:24.000000000 -0500
+@@ -9,9 +9,8 @@
+ # On OSX, using -static gives the error "ld: can't locate file for: -lcrt0.o",
+ # this is fixed by deleting "-static" from the LDLIBS line.
+ 
+-CFLAGS = -O3 -funroll-loops -Winline -DNDEBUG=1
+-LDLIBS = -lm -static
+-# LDLIBS = -lm
++CFLAGS += -O3 -funroll-loops -Winline -DNDEBUG=1
++LDLIBS = -lm
+ 
+ OBJ = .o
+ EXE =
+@@ -19,9 +18,9 @@
+ RM = rm -f
+ CP = cp
+ 
+-GPP = g++
++GPP = $(CXX)
+ LD = $(GPP) $(CFLAGS)
+-CPP = $(GPP) -c $(CFLAGS) 
++CPP = $(GPP) -c $(CFLAGS)
+ 
+ all: muscle
+ 


### PR DESCRIPTION
#### Description
This PR adds three new ports:
- muscle: version 3.8.1551
- mafft: version 7.453
- cdhit: version 4.8.1

It all builds for me locally, a quick PR to see if that's also the case on older macOS/Xcode combinations.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
macOS 10.14.6 18G3020
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?