### PR TITLE
virt-manager: update to 2.2.1

### DIFF
--- a/gnome/virt-manager/Portfile
+++ b/gnome/virt-manager/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        virt-manager virt-manager 2.1.0 v
+github.setup        virt-manager virt-manager 2.2.1 v
 categories          gnome emulators
 supported_archs     noarch
 maintainers         {danchr @danchr} openmaintainer
@@ -27,9 +27,9 @@ long_description \
     \
     The primary use on macOS is for remote administration of Linux boxes.
 
-checksums           rmd160  2e9190ca7d04146650ef9dee832300a4c852a2cc \
-                    sha256  34ea069a6565f1f1860a0741e5a5029e8b45c779e81f16d27fb4d767fd4403d4 \
-                    size    2617988
+checksums           rmd160  9c06e912feb3f44f0ba4b50d94b22118106d380e \
+                    sha256  cfd88d66e834513e067b4d3501217e21352fadb673103bacb9e646da9f029a1b \
+                    size    2623754
 
 platforms           darwin
 
@@ -53,7 +53,8 @@ depends_run \
     port:libvirt-glib \
     port:vte \
     port:gtk-vnc \
-    port:gtk2 \
+    port:gtk3 \
+    port:gtksourceview4 \
     port:spice-gtk \
     port:libosinfo
 


### PR DESCRIPTION
###### Description

* version push to 2.2.1
* update gtk dependency
* add missing gtksourceview dependency

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
