### PR TITLE
itstool: add python38 variant

### DIFF
--- a/textproc/itstool/Portfile
+++ b/textproc/itstool/Portfile
@@ -32,7 +32,7 @@ depends_build       port:gawk
 
 patchfiles          patch-configure.diff
 
-variant python27 conflicts python37 description {Use Python 2.7} {
+variant python27 conflicts python37 python38 description {Use Python 2.7} {
     configure.python \
                     ${prefix}/bin/python2.7
 
@@ -40,7 +40,7 @@ variant python27 conflicts python37 description {Use Python 2.7} {
                     port:py27-libxml2
 }
 
-variant python37 conflicts python27 description {Use Python 3.7 (experimental, still a few bugs)} {
+variant python37 conflicts python27 python38 description {Use Python 3.7 (experimental, still a few bugs)} {
     configure.python \
                     ${prefix}/bin/python3.7
     
@@ -48,7 +48,15 @@ variant python37 conflicts python27 description {Use Python 3.7 (experimental, s
                     port:py37-libxml2
 }
 
-if {![variant_isset python27] && ![variant_isset python37]} {
+variant python38 conflicts python27 python37 description {Use Python 3.8 (experimental, still a few bugs)} {
+    configure.python \
+                    ${prefix}/bin/python3.8
+
+    depends_lib-append \
+                    port:py38-libxml2
+}
+
+if {![variant_isset python27] && ![variant_isset python37] && ![variant_isset python38]} {
     default_variants +python27
 }
 


### PR DESCRIPTION
#### Description

Added python38 variant for itstool. Prior to this, it was broken on my system, which had python38 installed and set as python3, and had 'none' set for both python2 and python.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
