### PR TITLE
lilypond: docs variant is broken

### DIFF
--- a/textproc/lilypond/Portfile
+++ b/textproc/lilypond/Portfile
@@ -129,10 +129,10 @@ post-destroot {
         ${destroot}${prefix}/bin/lilypond
 }
 
-variant docs description {Build documentation files} {
-    configure.args-delete   --disable-documentation
-    configure.args-append   --enable-documentation
-}
+#variant docs description {Build documentation files} {
+#    configure.args-delete   --disable-documentation
+#    configure.args-append   --enable-documentation
+#}
 
 livecheck.type  regex
 livecheck.url   ${homepage}/source.html


### PR DESCRIPTION
it requires texi2html 1.82

probably broken since about 2010, when
texi2html was updated to >= 5

I am not sure how many of the deps can be tied
to the docs variant, but no doubt some of them
can be deleted if there is no docs variant

alternatively, port would have to figure out a
way to use texi2html 1.82 during the build.

closes: https://trac.macports.org/ticket/60167
