### PR TITLE
groovy: update to 3.0.2

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            groovy
-version         3.0.1
+version         3.0.2
 revision        0
 
 categories      lang java
@@ -41,9 +41,9 @@ master_sites    https://dl.bintray.com/${name}/maven/
 distname        apache-${name}-binary-${version}
 use_zip         yes
 
-checksums       rmd160  104a618288b39927c12e05e7ec97d00e766c4476 \
-                sha256  528ae6b5e651ea68e1ecc4d5e7604c71b3b7f521c7486c7dac83f91bc6a61405 \
-                size    42902791
+checksums       rmd160  de52d7eafb8aa969d990c02262bbe0ccafe373ca \
+                sha256  3ce9d9097f3bc42cc23b80cb5bd7e3790c5ca12493bd6ebee104f29ab11bbcb5 \
+                size    42939074
 
 worksrcdir      ${name}-${version}
 


### PR DESCRIPTION
#### Description

Update to Groovy 3.0.2.

###### Tested on

macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?