### PR TITLE
python38: fix build on older systems - second try

### DIFF
--- a/lang/python38/Portfile
+++ b/lang/python38/Portfile
@@ -37,7 +37,9 @@ patchfiles          patch-setup.py.diff \
                     patch-Lib-ctypes-macholib-dyld.py.diff \
                     patch-libedit.diff \
                     patch-configure-xcode4bug.diff \
-                    patch-_osx_support.py.diff
+                    patch-_osx_support.py.diff \
+                    patch-no-copyfile-on-Tiger.diff \
+                    patch-threadid-older-systems.diff
 
 depends_build       port:pkgconfig
 depends_lib         port:bzip2 \

--- a/lang/python38/files/patch-no-copyfile-on-Tiger.diff
+++ b/lang/python38/files/patch-no-copyfile-on-Tiger.diff
@@ -1,0 +1,72 @@
+posix.copyfile does not exist on Tiger. 
+
+Python 3.8's posix._fcopyfile implementation unconditionally uses <copyfile.h>, 
+which only exists on Leopard ane newer. This patch removes posix._fcopyfile 
+on Tiger - this is okay because the rest of the stdlib uses posix._fcopyfile 
+only conditionally after checking that the function exists 
+(non-Apple systems don't have posix._fcopyfile either).
+
+
+thanks to @dgelessus
+https://github.com/macports/macports-ports/pull/5987
+
+
+--- Lib/test/test_shutil.py.orig
++++ Lib/test/test_shutil.py
+@@ -2393,7 +2393,7 @@
+             shutil._USE_CP_SENDFILE = True
+ 
+ 
+-@unittest.skipIf(not MACOS, 'macOS only')
++@unittest.skipIf(not MACOS or not hasattr(posix, "_fcopyfile"), 'macOS with posix._fcopyfile only')
+ class TestZeroCopyMACOS(_ZeroCopyFileTest, unittest.TestCase):
+     PATCHPOINT = "posix._fcopyfile"
+ 
+--- Modules/clinic/posixmodule.c.h.orig
++++ Modules/clinic/posixmodule.c.h
+@@ -4975,7 +4975,7 @@ exit:
+     return return_value;
+ }
+ 
+-#if defined(__APPLE__)
++#if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED >= 1050
+ 
+ PyDoc_STRVAR(os__fcopyfile__doc__,
+ "_fcopyfile($module, infd, outfd, flags, /)\n"
+--- ./Modules/posixmodule.c.orig
++++ ./Modules/posixmodule.c
+@@ -11,6 +11,7 @@
+ 
+ 
+ #ifdef __APPLE__
++#include <AvailabilityMacros.h>
+    /*
+     * Step 1 of support for weak-linking a number of symbols existing on
+     * OSX 10.4 and later, see the comment in the #ifdef __APPLE__ block
+@@ -109,7 +110,7 @@
+ #include <sys/sendfile.h>
+ #endif
+ 
+-#if defined(__APPLE__)
++#if defined(__APPLE__) && MAC_OS_X_VERSION_MAX_ALLOWED >= 1050
+ #include <copyfile.h>
+ #endif
+ 
+@@ -9266,7 +9267,7 @@
+ #endif /* HAVE_SENDFILE */
+ 
+ 
+-#if defined(__APPLE__)
++#if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED >= 1050
+ /*[clinic input]
+ os._fcopyfile
+ 
+@@ -14368,7 +14369,7 @@
+ #endif
+ #endif
+ 
+-#if defined(__APPLE__)
++#if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED >= 1050
+     if (PyModule_AddIntConstant(m, "_COPYFILE_DATA", COPYFILE_DATA)) return -1;
+ #endif
+ 

--- a/lang/python38/files/patch-threadid-older-systems.diff
+++ b/lang/python38/files/patch-threadid-older-systems.diff
@@ -1,0 +1,23 @@
+--- Python/thread_pthread.h.orig	2020-03-07 12:42:06.000000000 -0800
++++ Python/thread_pthread.h	2020-03-07 12:48:22.000000000 -0800
+@@ -325,9 +325,19 @@
+ {
+     if (!initialized)
+         PyThread_init_thread();
+ #ifdef __APPLE__
+     uint64_t native_id;
+-    (void) pthread_threadid_np(NULL, &native_id);
++#if MAC_OS_X_VERSION_MAX_ALLOWED < 1060
++    native_id = pthread_mach_thread_np(pthread_self());
++#elif MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++    if (&pthread_threadid_np) {
++        (void) pthread_threadid_np(NULL, &native_id);
++    } else {
++        native_id = pthread_mach_thread_np(pthread_self());
++    }
++#else
++    (void) pthread_threadid_np(NULL, &native_id);
++#endif
+ #elif defined(__linux__)
+     pid_t native_id;
+     native_id = syscall(SYS_gettid);


### PR DESCRIPTION
Second attempt to get this right. I think this is right now...

no copyfile on Tiger
work around lack of pthread_threadid_np on < 10.6

closes: https://trac.macports.org/ticket/59827
closes: https://trac.macports.org/ticket/59772

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.4, 5, 24
Xcode 2.5 to 111.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
