### PR TITLE
gobject-introspection: update to 1.60.2

### DIFF
--- a/gnome/gobject-introspection/Portfile
+++ b/gnome/gobject-introspection/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           active_variants 1.1
 
 name                gobject-introspection
-version             1.58.3
-revision            3
+version             1.60.2
+revision            0
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          gnome
 platforms           darwin
@@ -20,9 +20,9 @@ homepage            https://wiki.gnome.org/Projects/GObjectIntrospection
 master_sites        gnome:sources/${name}/${branch}/
 use_xz              yes
 
-checksums           rmd160  0c443e36b5860278de2bb77fa99997aabbda3513 \
-                    sha256  025b632bbd944dcf11fc50d19a0ca086b83baf92b3e34936d008180d28cdc3c8 \
-                    size    1378068
+checksums           rmd160  6455f1b5e4427b8f0a26efb94597a476ed9ca96e \
+                    sha256  ffdfe2368fb2e34a547898b01aac0520d52d8627fdeb1c306559bcb503ab5e9c \
+                    size    1285000
 
 depends_build       port:pkgconfig \
                     port:autoconf-archive
@@ -35,7 +35,8 @@ depends_lib         path:lib/pkgconfig/cairo.pc:cairo \
 
 depends_run         bin:glibtool:libtool
 
-patchfiles          no-env-shebang.patch
+patchfiles          no-env-shebang.patch \
+                    patch-fix-rpath-gir-typelib.diff
 
 post-patch {
     reinplace "s|libcairo-gobject.2.dylib|${prefix}/lib/libcairo-gobject.2.dylib|g" ${worksrcpath}/configure.ac

--- a/gnome/gobject-introspection/files/no-env-shebang.patch
+++ b/gnome/gobject-introspection/files/no-env-shebang.patch
@@ -4,8 +4,8 @@
  	tools/g-ir-tool-template.in \
  	tools/meson.build
  
--TOOL_SUBSTITUTIONS = -e s,@libdir\@,$(libdir), -e s,@datarootdir\@,$(datarootdir), -e s,@PYTHON_CMD\@,\/usr\/bin\/env\ $(PYTHON),
-+TOOL_SUBSTITUTIONS = -e s,@libdir\@,$(libdir), -e s,@datarootdir\@,$(datarootdir), -e s,@PYTHON_CMD\@,$(PYTHON),
+-TOOL_SUBSTITUTIONS = -e s,@libdir\@,$(libdir), -e s,@datarootdir\@,$(datarootdir), -e s,@PYTHON_CMD\@,\/usr\/bin\/env\ $(PYTHON), -e s,@GIR_DIR\@,$(GIR_DIR),g
++TOOL_SUBSTITUTIONS = -e s,@libdir\@,$(libdir), -e s,@datarootdir\@,$(datarootdir), -e s,@PYTHON_CMD\@,$(PYTHON), -e s,@GIR_DIR\@,$(GIR_DIR),g
  
  g-ir-scanner: tools/g-ir-tool-template.in _giscanner.la Makefile
  	$(AM_V_GEN) sed $(TOOL_SUBSTITUTIONS) -e s,@TOOL_MODULE\@,scannermain, -e s,@TOOL_FUNCTION\@,scanner_main, $< > $@.tmp && mv $@.tmp $@

--- a/gnome/gobject-introspection/files/patch-fix-rpath-gir-typelib.diff
+++ b/gnome/gobject-introspection/files/patch-fix-rpath-gir-typelib.diff
@@ -1,0 +1,61 @@
+--- giscanner/shlibs.py.orig
++++ giscanner/shlibs.py
+@@ -19,7 +19,6 @@
+ #
+ 
+ import os
+-import sys
+ import platform
+ import re
+ import subprocess
+@@ -104,24 +103,40 @@
+         output = subprocess.check_output(args)
+         if isinstance(output, bytes):
+             output = output.decode("utf-8", "replace")
+-
+         shlibs = resolve_from_ldd_output(libraries, output)
+-        return list(map(sanitize_shlib_path, shlibs))
+-
+-
+-def sanitize_shlib_path(lib):
++        libdir = ''
++        # for Darwin purposes, assume libraries get installed into
++        # the first non-build library path
++        if platform.system() == 'Darwin':
++            for lpath in options.library_paths:
++                if not lpath.startswith (os.getcwd()):
++                    libdir = lpath
++                    break
++            if libdir == '':
++                # no way to resolve @rpath and the like, since we can't
++                # make a reasonable assumpion of the install libdir
++                print("warning: unknown install library directory! GObject Introspection GIR and TYPELIB files might not work!")
++            else:
++                libdir = libdir + '/'
++        outlibs = []
++        for lib in shlibs:
++            outlibs.append(sanitize_shlib_path(lib,libdir))
++        return list (outlibs)
++
++def sanitize_shlib_path(lib,libdir):
+     # Use absolute paths on OS X to conform to how libraries are usually
+     # referenced on OS X systems, and file names everywhere else.
+     # In case we get relative paths on macOS (like @rpath) then we fall
+     # back to the basename as well:
+     # https://gitlab.gnome.org/GNOME/gobject-introspection/issues/222
+-    if sys.platform == "darwin":
++    if platform.system() == 'Darwin':
+         if not os.path.isabs(lib):
+-            return os.path.basename(lib)
+-        return lib
++            lib = os.path.basename(lib)
++            # prepend the libdir
++            lib = libdir + lib
+     else:
+-        return os.path.basename(lib)
+-
++        lib = os.path.basename(lib)
++    return lib
+ 
+ def resolve_from_ldd_output(libraries, output):
+     patterns = {}

--- a/gnome/gobject-introspection/files/patch-girscanner-tiger-no-rpath.diff
+++ b/gnome/gobject-introspection/files/patch-girscanner-tiger-no-rpath.diff
@@ -2,7 +2,7 @@ diff --git giscanner/ccompiler.py giscanner/ccompiler.py
 index c003828..87f98d2 100644
 --- giscanner/ccompiler.py
 +++ giscanner/ccompiler.py
-@@ -126,7 +126,7 @@ class CCompiler(object):
+@@ -191,7 +191,7 @@ class CCompiler(object):
  
              if not libtool:
                  # https://bugzilla.gnome.org/show_bug.cgi?id=625195
@@ -11,7 +11,7 @@ index c003828..87f98d2 100644
  
                  # Ensure libraries are always linked as we are going to use ldd to work
                  # out their names later
-@@ -152,12 +152,12 @@ class CCompiler(object):
+@@ -206,12 +206,12 @@ class CCompiler(object):
                  args.append('-libpath:' + library_path)
              else:
                  args.append('-L' + library_path)


### PR DESCRIPTION
#### Description

Add patch to minimally address @rpath introspection issue from https://trac.macports.org/ticket/60149 and, it looks like (now that I poke around more) https://trac.macports.org/ticket/60024 . It's a bit of a hack, but it will generally work for MacPorts needs.

GI 1.60.2 is the final version using autotools to build, which is why I chose to update to it instead of the latest (which requires meson). I know https://github.com/macports/macports-ports/pull/5759 is trying to update to 1.62.0 ... this PR is hopefully a nice intermediate step to get the rpath issue fixed, while minimally changing the actual Portfile, while providing an update to the port.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G3020
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->