### PR TITLE
gtk3 +quartz: Fix building on case-sensitive file systems

### DIFF
--- a/gnome/gtk3/Portfile
+++ b/gnome/gtk3/Portfile
@@ -51,7 +51,8 @@ depends_lib-append  port:mesa
 depends_run         port:shared-mime-info \
                     port:hicolor-icon-theme
 
-patchfiles          O_CLOEXEC-10.6-and-earlier.patch
+patchfiles          O_CLOEXEC-10.6-and-earlier.patch \
+                    patch-gdkquartz-gtk-only.diff
 
 # use autoreconf to deal with dependency tracking issues in configure
 use_autoreconf      yes

--- a/gnome/gtk3/files/patch-gdkquartz-gtk-only.diff
+++ b/gnome/gtk3/files/patch-gdkquartz-gtk-only.diff
@@ -1,0 +1,11 @@
+--- gdk/quartz/gdkquartz-gtk-only.h.orig	2020-03-10 16:14:40.000000000 +0100
++++ gdk/quartz/gdkquartz-gtk-only.h	2020-03-10 16:15:05.000000000 +0100
+@@ -23,7 +23,7 @@
+ #error "This API is for use only in Gtk internal code."
+ #endif
+ 
+-#include <Appkit/Appkit.h>
++#include <AppKit/AppKit.h>
+ #include <gdk/gdk.h>
+ #include <gdk/quartz/gdkquartz.h>
+ 


### PR DESCRIPTION
#### Description

* Add patch to fix typo `Appkit` -> `AppKit` in header `gdk/quartz/gdkquartz-gtk-only.h`.

The header `gdk/quartz/gdkquartz-gtk-only.h` includes in line 26 the
framework AppKit using `<Appkit/Appkit.h>` instead of
`<AppKit/AppKit.h>`, which works on case-insensitive file systems, but
not on case-sensitive ones.

References: https://gitlab.gnome.org/GNOME/gtk/issues/2503
Fixes: https://trac.macports.org/ticket/60168

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6 17G11023
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
