### PR TITLE
google-cloud-sdk: update to 284.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             283.0.0
+version             284.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  973b2202a43e5ce7679d8d071592c598114a65bd \
-                    sha256  59c49d6cf8b45b0a11fb0876e4ac6be4269e9e516501baef8be7dd078ef4d9d6 \
-                    size    48278974
+    checksums       rmd160  846ea9f88cbd2fbff34b8c86032d3dbc7469c512 \
+                    sha256  443ce5230a86335a3df2b04662a008e3a95d3d06d9e976dd98238eda37a3dbeb \
+                    size    48490724
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  330c4dad83707b498644181ad87a11fe50d99596 \
-                    sha256  1a7278d2001fdf8586b7161325359e20e38cf2a8e656d7c776d319a0bb60a59c \
-                    size    49328776
+    checksums       rmd160  7587156aed1401762ba2c0664498ee7f61086cad \
+                    sha256  117e1b106fce6946ffcdd9e3c668eed8eae6525d025fe8394f756c622725f00e \
+                    size    49534906
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 284.0.0.

###### Tested on

macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?