### PR TITLE
micronaut: update to 1.3.3

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       java 1.0
 
-github.setup    micronaut-projects micronaut-core 1.3.2 v
+github.setup    micronaut-projects micronaut-core 1.3.3 v
 revision        0
 name            micronaut
 categories      java
@@ -43,8 +43,8 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        ${name}-${version}
 
-checksums       rmd160  d8792a970f025d0d3bd0f665d5ad076e38ee3eac \
-                sha256  05b61a19b74fa4edc0e29d17211ff39711ed7767944392b8cce04b7f35f7826e \
+checksums       rmd160  4c3d8b372eda35d17ff69afa73a2dd9797ec783c \
+                sha256  143c044ce11856188a43a95eff82f84f32b2b17548a8fb263a6b0cd5cd518e9c \
                 size    13037978
 
 use_zip         yes


### PR DESCRIPTION
#### Description

Update to Micronaut 1.3.3.

###### Tested on

macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
