### PR TITLE
p5-tcl-ptk: update to version 1.06

### DIFF
--- a/perl/p5-tcl-ptk/Portfile
+++ b/perl/p5-tcl-ptk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28 5.30
-perl5.setup         Tcl-pTk 1.02
+perl5.setup         Tcl-pTk 1.06 ../../authors/id/C/CA/CAC
 
 platforms           darwin
 maintainers         {@chrstphrchvz gmx.us:chrischavez} openmaintainer
@@ -25,9 +25,9 @@ long_description    Tcl::pTk interfaces perl to an existing Tcl/Tk \
                     features (for example native-looking widgets using the \
                     Tile package).\n
 
-checksums           rmd160  b4da7e43be2cf83eec61b615d86e97740c19cf20 \
-                    sha256  4b85eb48e036c4bb8bfeb93da968f69fa684cc8c5e990f8f7d33bf8141646b0c \
-                    size    540855
+checksums           rmd160  a935d40d50687409c026d465fadf7e974a0d7fdf \
+                    sha256  adeb01e5fcf58ad91cd49c7dd308a867586fbdd369da8e1556ca4a98c7b7d6b9 \
+                    size    532699
 
 if {${perl5.major} != ""} {
     depends_lib-append \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Tested using tk +x11. 

To test, the following procedure is recommended.

```
sudo port build p5.30-tcl-ptk
cd work/Tcl-pTk-1.06
sudo make test

```
This gets around the issue that the MacPorts X11 Server is typically installed for the local user only
and is not easily accessible during the traditional  MacPorts test phase.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3 19D76
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
