### PR TITLE
lazygit: update to 0.16.2

### DIFF
--- a/devel/lazygit/Portfile
+++ b/devel/lazygit/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/jesseduffield/lazygit 0.16 v
+go.setup            github.com/jesseduffield/lazygit 0.16.2 v
 categories          devel
 license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
@@ -11,9 +11,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
 description         A simple terminal UI for git commands, written in Go
 long_description    {*}$description
 
-checksums           rmd160  8a8aa0ad17f43872ddee9121ef133ca55d08c759 \
-                    sha256  384f1474801ad81567f8fcaa6c88c47768515a4d7e9a6998d472d8c0fd5ee700 \
-                    size    7135103
+checksums           rmd160  15bcbe0325b0b0187ec385ef4012ae36368897cc \
+                    sha256  90bf5ab022ec4f5087e80a794226fc2303e901696e2eb902a9d46765f2ff70a9 \
+                    size    7133904
 
 set build_date      [exec date +%FT%T%z]
 build.args          -ldflags \


### PR DESCRIPTION

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
