### PR TITLE
libomp: Use canonical llvm-project github account.

### DIFF
--- a/lang/libomp/Portfile
+++ b/lang/libomp/Portfile
@@ -22,73 +22,64 @@ platforms               darwin
 supported_archs         i386 x86_64
 license                 {MIT NCSA}
 
+# Moved to epoch 1 for svn # -> version # change.
+epoch                   1
+
 subport                 libomp-devel {}
 
-if { ${subport} eq "libomp-devel" } {
-    if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} eq "libstdc++"} {
+if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} ne "libstdc++"} {
+    if { ${subport} eq "libomp-devel" } {
+        version                 10.0.0-rc3
+        checksums \
+            rmd160  24b50ccf7264748452154a4c9a5c728a8844f350 \
+            sha256  4b56ff1cff324cc69c783a3dd56305078c8cb92fc59fee494e736714b2eaad2b \
+            size    958880
+
+        livecheck.regex         {"llvmorg-([0-9.rc-]+)".*}
+    } else {
+        version                 9.0.1
+        checksums \
+            rmd160  e5562fce183a9838d412d4e60c5afb41607b0c37 \
+            sha256  5c94060f846f965698574d9ce22975c0e9f04c9b14088c3af5f03870af75cace \
+            size    938360
+
+        livecheck.regex         {"llvmorg-([0-9.]+)".*}
+    }
+
+    if {${os.major} <= 12} {
+        # kmp_alloc.c includes <atomic> but libc++ is not the default on
+        # these systems. https://trac.macports.org/ticket/52554
+        configure.cflags-append -stdlib=libc++
+    }
+
+    master_sites \
+        https://github.com/llvm/llvm-project/releases/download/llvmorg-${version} \
+        https://releases.llvm.org/${version}
+    distname                openmp-[strsed ${version} {s/-//}].src
+    use_xz                  yes
+    dist_subdir             openmp-release
+    worksrcdir              ${distname}
+    set rtpath              "runtime/"
+    patchfiles-append       patch-libomp-use-gettid-on-Leopard.diff
+    livecheck.url           https://api.github.com/repos/llvm/llvm-project/tags
+} else {
+    if { ${subport} eq "libomp-devel" } {
         version                 291764
         replaced_by             libomp
     } else {
-        conflicts               libomp
-        # Moved to official llvm github project. It would be a very large 
-        # (100MB+) download, so use the svn interface (!) to github to 
-        # download just the openmp directory. Not using LLVM's own SVN since
-        # they are in the process of migrating to github.
-        fetch.type              svn
-        svn.url                 https://github.com/llvm/llvm-project/trunk/openmp
-        svn.revision            327229
-        worksrcdir              openmp
-        # llvm-svn revision; also used for livecheck
-        version                 367070
-        revision                0
-        name                    ${subport}
-        livecheck.url \
-            https://llvm.org/viewvc/llvm-project/openmp/trunk/?view=log
-        livecheck.version       ${version}
-        livecheck.regex         revision=(\[0-9\]+)
-        set rtpath              "runtime/"
-        patchfiles-append       patch-libomp-use-gettid-on-Leopard.diff
-    }
-} else {
-    PortGroup               github 1.0
-    conflicts               libomp-devel
-    if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} ne "libstdc++"} {
-        if {${os.major} <= 12} {
-            # kmp_alloc.c includes <atomic> but libc++ is not the default on
-            # these systems. https://trac.macports.org/ticket/52554
-            configure.cflags-append -stdlib=libc++
-        }
-        version                 9.0.0
-        revision                0
-        master_sites            https://github.com/llvm/llvm-project/releases/download/llvmorg-${version} \
-                                https://releases.llvm.org/${version}
-        distname                openmp-${version}.src
-        use_xz                  yes
-        dist_subdir             openmp-release
-        checksums               rmd160  43db5865294f92a8c724ec3e83d500263b32ff59 \
-                                sha256  9979eb1133066376cc0be29d1682bc0b0e7fb541075b391061679111ae4d3b5b \
-                                size    939036
-
-        worksrcdir              ${distname}
-        set rtpath              "runtime/"
-        patchfiles-append       patch-libomp-use-gettid-on-Leopard.diff
-    } else {
+        PortGroup               github 1.0
         # Last version working on libstdc++
         github.setup            llvm-mirror openmp 381 svn-tags/RELEASE_
+        name                    libomp
+
         worksrcdir              openmp-${version}/final/runtime
         version                 3.8.1
-        revision                3
         checksums \
             rmd160  a41054068a127ef84610afef8090109078cb6c46 \
             sha256  4c46b5946fe9b2a701661746d11c7c85c51a7f18673194a7ebd2a43470948a34
         set rtpath              "./"
     }
-    # Moved to epoch 1 for svn # -> version # change.
-    epoch                   1
-    name                    libomp
-    livecheck.version       [strsed ${version} {g/\.//}]
-    livecheck.url           https://github.com/llvm-mirror/openmp/branches
-    livecheck.regex         svn-tags/RELEASE_(\[0-9\]+)
+    livecheck.type          none
 }
 
 depends_build-append    port:perl5
@@ -123,7 +114,7 @@ configure.args-delete   -DCMAKE_INSTALL_RPATH=${prefix}/lib \
 # final destination we move them to
 configure.args-append   -DCMAKE_INSTALL_RPATH=${prefix}/lib/libomp \
                         -DCMAKE_INSTALL_NAME_DIR=${prefix}/lib/libomp \
-                        -DLIBOMP_OMPT_SUPPORT=FALSE 
+                        -DLIBOMP_OMPT_SUPPORT=FALSE
 
 variant top_level description \
     "Install (links to) omp.h and libs into ${prefix}/(include|lib)" {}
@@ -140,9 +131,11 @@ post-destroot {
     xinstall -d ${instdest}/include/libomp
     move ${instdest}/tmp/include/omp.h ${instdest}/include/libomp/
     xinstall -d ${instdest}/lib/libomp
+
     foreach p {libiomp5.dylib libomp.dylib libgomp.dylib} {
         move ${instdest}/tmp/lib/${p} ${instdest}/lib/libomp/
     }
+
     if [variant_isset top_level] {
         system -W ${instdest}/include \
           "ln -s libomp/omp.h"
@@ -152,11 +145,10 @@ post-destroot {
         }
     }
 
-
     set fpath ${worksrcpath}/${rtpath}
     file copy ${fpath}/README.txt ${fpath}/../LICENSE.txt \
         ${fpath}/../www ${instdest}/share/doc/libomp/
-    
+
 }
 
 notes "


### PR DESCRIPTION
Maintainer update.

Since libomp is used by all the clang-4+ versions, I'd like to see some others test this out, too.

Primarily a reorganization of the Portfile to reduce duplication; also moves libomp-devel to using the llvm-project/llvm github sources.