### PR TITLE
pdfpc: enable video playback also in quartz variant 

### DIFF
--- a/gnome/gstreamer1-gst-plugins-good/Portfile
+++ b/gnome/gstreamer1-gst-plugins-good/Portfile
@@ -10,6 +10,7 @@ name                gstreamer1-gst-plugins-good
 set my_name         gst-plugins-good
 # please only commit stable updates (even numbered releases)
 version             1.16.1
+revision            1
 description         A set of good-quality plug-ins for GStreamer under GStreamer's preferred \
                     license, LGPL.
 long_description    GStreamer Good Plug-ins is a set of plug-ins that GStreamer's developers \
@@ -91,16 +92,10 @@ platform darwin {
     }
 }
 
-variant gtk3 requires x11 description {Enable GTK3 X11/GL windowing elements} {
+variant gtk3 description {Enable GTK3 windowing elements} {
     depends_lib-append      port:gtk3
     configure.args-replace  --disable-gtk3 \
                             --enable-gtk3
-}
-
-# gtk3 elements require gtk3 +x11
-
-if {[variant_isset gtk3]} {
-    require_active_variants gtk3 x11
 }
 
 variant jack description {Enable Jack plugin} {

--- a/gnome/gstreamer1-gst-plugins-good/Portfile
+++ b/gnome/gstreamer1-gst-plugins-good/Portfile
@@ -10,7 +10,6 @@ name                gstreamer1-gst-plugins-good
 set my_name         gst-plugins-good
 # please only commit stable updates (even numbered releases)
 version             1.16.1
-revision            1
 description         A set of good-quality plug-ins for GStreamer under GStreamer's preferred \
                     license, LGPL.
 long_description    GStreamer Good Plug-ins is a set of plug-ins that GStreamer's developers \

--- a/graphics/pdfpc/Portfile
+++ b/graphics/pdfpc/Portfile
@@ -40,7 +40,8 @@ checksums               rmd160  ae78dbb12ec2f639705a09ecd67055b17599ea0e \
                         sha256  04de35626c415ad4105dd9fb75e92b3f05c5e83a3728b1676ee1ef2e6581d03c \
                         size 7733169
 
-configure.args          -DMOVIES=off
+configure.args          -DCMAKE_INSTALL_SYSCONFDIR=${prefix}/etc \
+                        -DMOVIES=off
 
 pre-configure {
     if {![variant_isset quartz] && ![variant_isset x11]} {

--- a/graphics/pdfpc/Portfile
+++ b/graphics/pdfpc/Portfile
@@ -6,7 +6,7 @@ PortGroup               active_variants 1.1
 PortGroup               cmake 1.1
 
 github.setup            pdfpc pdfpc 4.4.0 v
-revision                0
+revision                1
 
 maintainers             {gmx.de:Torsten.Maehne @maehne} openmaintainer
 
@@ -39,6 +39,8 @@ checksums               rmd160  ae78dbb12ec2f639705a09ecd67055b17599ea0e \
                         sha256  04de35626c415ad4105dd9fb75e92b3f05c5e83a3728b1676ee1ef2e6581d03c \
                         size 7733169
 
+configure.args          -DMOVIES=off
+
 pre-configure {
     if {![variant_isset quartz] && ![variant_isset x11]} {
         error "Either +x11 or +quartz is required"
@@ -47,19 +49,25 @@ pre-configure {
 
 variant quartz conflicts x11 {
     require_active_variants     port:gtk3 quartz
-    configure.args-append       -DMOVIES=off
 }
 
 variant x11 conflicts quartz {
     require_active_variants     port:gtk3 x11
+}
+
+variant video description {Enable video playback using gstreamer1} {
     depends_lib-append          port:gstreamer1 \
                                 port:gstreamer1-gst-plugins-base \
                                 port:gstreamer1-gst-plugins-good
     require_active_variants     port:gstreamer1-gst-plugins-good gtk3
+
+    configure.args-delete       -DMOVIES=off
 }
 
 if {![variant_isset quartz]} {
-    default_variants +x11
+    default_variants +x11 +video
+} else {
+    default_variants +video
 }
 
 livecheck.type          regex

--- a/graphics/pdfpc/Portfile
+++ b/graphics/pdfpc/Portfile
@@ -31,7 +31,8 @@ depends_build-append    port:vala \
                         port:pkgconfig
 depends_lib-append      port:gtk3 \
                         port:poppler \
-                        port:libgee
+                        port:libgee \
+                        port:librsvg
 
 cmake.out_of_source     yes
 


### PR DESCRIPTION
#### Description

This PR enables video playback also in the quartz variant of pdfpc. This is done in two steps:

1. Commit cb7d749 makes the `gtk3` variant of port `gstreamer1-gst-plugins-good` not automatically to depend on the `x11` variant, as this is not needed when using the `gtksink` for video playback using gstreamer1.

2. Commit b48e78b moves dependencies for video playback into a new `video` variant, which can be enabled for `quartz` or `x11`.

These modifications have been tested with the pdfpc +quartz variant on macOS High Sierra using poppler 0.85. Be aware that poppler 0.86.1 currently breaks pdfpc causing a segfault when opening any new PDF file (cf. to [issue #60180](https://trac.macports.org/ticket/60180)).

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6 17G11023 
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
