### PR TITLE
poppler: Revert "poppler: update to version 0.86.1"

### DIFF
--- a/graphics/poppler/Portfile
+++ b/graphics/poppler/Portfile
@@ -9,7 +9,7 @@ PortGroup           legacysupport 1.0
 
 name                poppler
 conflicts           xpdf-tools
-version             0.86.1
+version             0.85.0
 license             GPL-2+
 maintainers         {devans @dbevans} openmaintainer
 categories          graphics
@@ -23,9 +23,9 @@ master_sites        ${homepage}
 
 use_xz              yes
 
-checksums           rmd160  ac2662621df73630e939d29b752f3c3e7f36b1e6 \
-                    sha256  af630a277c8e194c31339c5446241834aed6ed3d4b4dc7080311e51c66257f6c \
-                    size    1593856
+checksums           rmd160  9d2e5fd162ee0126afa1c47977ff7119af7eabf2 \
+                    sha256  2bc875eb323002ae6b287e09980473518e2b2ed6b5b7d2e1089e36a6cd00d94b \
+                    size    1588616
 
 depends_build-append \
                     port:pkgconfig


### PR DESCRIPTION
#### Description

This reverts commit 467c4dd30aaca1f36b10809153735118adc0f6e4.

Poppler 0.86.1 breaks pdfpc (see [poppler issue #893](https://gitlab.freedesktop.org/poppler/poppler/issues/893), [MacPorts issue #60180](https://trac.macports.org/ticket/60180) and [Homebrew issue #51133](https://github.com/Homebrew/homebrew-core/issues/51133)).

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6 17G11023 
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
