### PR TITLE
py-jupytext: new port

### DIFF
--- a/python/py-jupytext/Portfile
+++ b/python/py-jupytext/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
+
+github.setup        mwouts jupytext 1.4.0
+
+name                py-jupytext
+revision            0
+categories-append   devel
+maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
+platforms           darwin
+license             MIT
+supported_archs     noarch
+
+description         Jupyter Notebooks as Markdown Documents, Julia, Python or R Scripts
+
+long_description    Jupytext can save Jupyter notebooks as Markdown and R \
+                    Markdown documents and Scripts in many languages. It can \
+                    also convert these documents **into** Jupyter Notebooks, \
+                    allowing you to synchronize content in both directions.
+
+checksums           rmd160  9502fef40d095a2c5f04a882ce2aea1b179cd78a \
+                    sha256  8184375aa68d8b3be1e1664aa9b49f418376471ffadadc3e617b96f2575a9511 \
+                    size    4322795
+
+python.versions     36 37 38
+
+if {${name} ne ${subport}} {
+    depends_lib-append      port:py${python.version}-setuptools \
+                            port:py${python.version}-nbformat \
+                            port:py${python.version}-yaml 
+
+    livecheck.type      none
+}


### PR DESCRIPTION
* new port py-jupytext at version 1.4.0

#### Description

https://github.com/mwouts/jupytext

I tested the dropdown menu feature in a jupyter notebook, and it seems to work. I have not tested the terminal command.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G3020
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
