### PR TITLE
igraph: update to 0.8.1

### DIFF
--- a/math/igraph/Portfile
+++ b/math/igraph/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        igraph igraph 0.8.0
+github.setup        igraph igraph 0.8.1
 github.tarball_from releases
 
 categories          math science devel
@@ -18,14 +18,14 @@ platforms           darwin
 depends_lib         port:gmp \
                     port:libxml2
 
-checksums           rmd160  0622c01766132fdacd4ee0a032b7efeeb9b869ca \
-                    sha256  72637335600cf4758fd718009b16d92489b58a2f5dd96d884740d20cd5769649 \
-                    size    3597881
+checksums           rmd160  3d7c1b0f4216532cffb8e5b7dd3c0ba5b058a09f \
+                    sha256  266e1bf9e81305b368fbaa2218a8416c51ae85ea164e3657c574dc3898ca7b71 \
+                    size    3625101
 
 test.run            yes
 test.target         check
 
-# igraph 0.8.0 embeds GLPK 4.45. Currently GLPK is at version 4.65.
+# igraph 0.8.1 embeds GLPK 4.45. Currently GLPK is at version 4.65.
 # Some igraph functions perform better with this new GLPK version.
 
 variant external_glpk description {Build with external GLPK} {


### PR DESCRIPTION
#### Description

igraph: update to 0.8.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] security fix
- [ ] enhancement

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G3020
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
