### PR TITLE
k9s: update to 0.17.7

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.17.6 v
+go.setup            github.com/derailed/k9s 0.17.7 v
 
 categories          sysutils
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -19,9 +19,9 @@ platforms           darwin
 supported_archs     x86_64
 license             Apache-2
 
-checksums           rmd160  98b6c37820442af45c1c6bced71abd11c38df399 \
-                    sha256  a726950ae180282e9276f00c655a1851c3eb772b03d6da04ad7c30f34fc163d8 \
-                    size    15196236
+checksums           rmd160  d028a6a3b1d3473356fce094faa77952dca2ceaf \
+                    sha256  16ae83a33ba3c6476db4eca3218df78c9b1976fb83cc2d1ed8b520ad4bad07f8 \
+                    size    15193358
 
 # Reproduce the "build" target from the upstream Makefile
 set go_ldflags      "-w -X ${go.package}/cmd.version=${version} \


### PR DESCRIPTION
#### Description

Update to k9s 0.17.7.

###### Tested on

macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?