### PR TITLE
rust: update to 1.42.0

### DIFF
--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -5,7 +5,7 @@ PortGroup           muniversal 1.0
 PortGroup           active_variants 1.1
 
 name                rust
-version             1.41.1
+version             1.42.0
 revision            0
 categories          lang devel
 platforms           darwin
@@ -27,9 +27,9 @@ long_description    Rust is a curly-brace, block-structured expression \
 homepage            https://www.rust-lang.org/
 
 # Get from src/stage0.txt
-set ruststd_version 1.40.0
-set rustc_version   1.40.0
-set cargo_version   0.41.0
+set ruststd_version 1.41.1
+set rustc_version   1.41.1
+set cargo_version   0.42.0
 set llvm_version    9.0
 
 # can use cmake or cmake-devel; default to cmake.
@@ -68,37 +68,37 @@ foreach arch ${architectures} {
 }
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  f825400c722a36c71cc46892bcb4c915a1fdf8ab \
-                    sha256  38c93d016e6d3e083aa15e8f65511d3b4983072c0218a529f5ee94dd1de84573 \
-                    size    135341149
+                    rmd160  3b35f1542ef4eee65403f90194d92745acecdd29 \
+                    sha256  d2e8f931d16a0539faaaacd801e0d92c58df190269014b2360c6ab2a90ee3475 \
+                    size    135735490
 
 checksums-append \
                     rust-std-${ruststd_version}-i686-apple-${os.platform}${extract.suffix} \
-                    rmd160  b0d33fbff6d6a396570c817304eea2d35dde0751 \
-                    sha256  5812c8a1a89afd0e348a87c9e0f87956e2c1688738a03b5e3adcd3b3846c6809 \
-                    size    22442282 \
+                    rmd160  289028f8a0b68b91e01681d579bbee2d4186e136 \
+                    sha256  f76796588fb5dd3b070bff005ed190d3053be5c77f245985d43406b8891016d7 \
+                    size    21329270 \
                     rustc-${rustc_version}-i686-apple-${os.platform}${extract.suffix} \
-                    rmd160  79d84b7bd1287c5af1c4f6e3f4a0754ebab19cc9 \
-                    sha256  8fa281d23b2c251ca3ada1b85ee2f2550670eb56cd0d322504dbfd6e4596407c \
-                    size    80595214 \
+                    rmd160  36de99d7358b40e87a1ac8b662cff7177092e312 \
+                    sha256  e4732fb1f8b0a44690573e26b81fce01eb6a993ba66f05e6c79d4c1b3565a47d \
+                    size    80109236 \
                     cargo-${cargo_version}-i686-apple-${os.platform}${extract.suffix} \
-                    rmd160  d1172497536db584763440acf7100dc310f01d26 \
-                    sha256  57533f5188933cf0d0d196526918b2f158f91aa0716f0e996f436b1913a2d25b \
-                    size    5238160
+                    rmd160  545f39de16b7e7ae987dee80dfeb48d0588917fa \
+                    sha256  62f5219792a27de6c5d141c59f05dee252424b7ce9671cefbb1227cab15da91e \
+                    size    5241962
 
 checksums-append \
                     rust-std-${ruststd_version}-x86_64-apple-${os.platform}${extract.suffix} \
-                    rmd160  5646ba5fe5c25bb95614e4a64938d2a863e57ee5 \
-                    sha256  1eff41b353403cc284a09debb00cfd41d663447eabf5ad2d4cf736c8c8db0458 \
-                    size    22509207 \
+                    rmd160  6b90224938a5d54ae7f1814732cb9dd9ec0615ad \
+                    sha256  6f4058d48027c1a0b8c04f1de3d86c8695b470850b60555b659f8f06adc2c447 \
+                    size    21405237 \
                     rustc-${rustc_version}-x86_64-apple-${os.platform}${extract.suffix} \
-                    rmd160  dc0c4e8afe25c87b31be763be26b0b5ed210a105 \
-                    sha256  f45bb00a9a59ca819a8266e9de77f7232f4b704d64f1c45d3870e2db4f646a77 \
-                    size    83133251 \
+                    rmd160  ae50678e13778051ae6455ac79e1b1cc659e2f8f \
+                    sha256  ec3e8b3fc11cb4e781724f0556c4e64c46a50bfb014b104ee7f200169804df0c \
+                    size    82763438 \
                     cargo-${cargo_version}-x86_64-apple-${os.platform}${extract.suffix} \
-                    rmd160  9d3e946459d6993087771ab531d2c8f904e812fd \
-                    sha256  1ef77a6be5e697bb7dde40854651fc67e91f119d5a9ddf747a25e30c1179fbe1 \
-                    size    5371818
+                    rmd160  095c410db6434c1efbf297068426c74a2bc6db9d \
+                    sha256  9633707ec7d83c02664e74040601e4d78488d8521de4400e9881d7c57594e49f \
+                    size    5371783
 
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
     known_fail yes


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
