### PR TITLE
Fix pipx deps

### DIFF
--- a/python/pipx/Portfile
+++ b/python/pipx/Portfile
@@ -1,4 +1,4 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8::et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
 PortGroup           python 1.0
@@ -18,9 +18,25 @@ checksums           rmd160  64b198d937c3c7b12531a81828c7b813fa9a597a \
                     sha256  af7f4cf388bfdae6547117a6be222d1d7b7edd3bccd3a77e2c96b8c858ac791f \
                     size    356746
 
-python.default_version 37
-python.versions     36 37 38
-depends_lib         port:py${python.version}-argcomplete \
-                    port:py${python.version}-setuptools
-
 github.livecheck.regex  {([\d\.]+)}
+
+variant python36 conflicts python37 python38 description {Use Python 3.6} {
+    python.default_version 36
+}
+
+variant python37 conflicts python36 python38 description {Use Python 3.7} {
+    python.default_version 37
+}
+
+variant python38 conflicts python36 python37 description {Use Python 3.8} {
+    python.default_version 38
+}
+
+if {![variant_isset python36] && ![variant_isset python37] && ![variant_isset python38]} {
+    default_variants +python38
+}
+
+depends_lib-append \
+                    port:py${python.version}-argcomplete \
+                    port:py${python.version}-setuptools \
+                    port:py${python.version}-userpath

--- a/python/py-userpath/Portfile
+++ b/python/py-userpath/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-userpath
+version             1.3.0
+categories-append   devel
+license             {MIT Apache-2}
+maintainers         {@0az 0az@afzhou.com} openmaintainer
+supported_archs     noarch
+platforms           darwin
+
+description         A tool and library for adding locations to user PATH
+long_description    ${description}
+homepage            https://github.com/ofek/userpath
+
+checksums           rmd160  d3997f6d4d9502637e173d9f31006b8e27ec5361 \
+                    sha256  dd0b8ba650732c614c5e6b709e51be321c596566422d99a443d545401a965468 \
+                    size    19056
+
+python.versions     36 37 38
+
+if {${name} ne ${subport}} {
+                        
+    depends_run-append \
+                        port:py${python.version}-click
+    depends_lib-append \
+                        port:py${python.version}-setuptools
+
+    livecheck.type      none
+}


### PR DESCRIPTION
#### Description

- Fixes the missing `userpath` dep in `pipx`
- Adds variants for alternative Python versions

###### Type(s)

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G2022
Xcode 11.0 11A420a 

###### Verification

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
