### PR TITLE
libsdl2: bugfix sdl2-config.cmake file

### DIFF
--- a/devel/libsdl2/Portfile
+++ b/devel/libsdl2/Portfile
@@ -7,6 +7,7 @@ PortGroup       xcodeversion 1.0
 name            libsdl2
 set my_name     SDL2
 version         2.0.12
+revision        1
 categories      devel multimedia
 platforms       macosx freebsd
 license         zlib
@@ -25,7 +26,8 @@ distname        ${my_name}-${version}
 checksums       rmd160 0f2c979da6151b622a6445e7fc8d4e3ea8987105 \
                 sha256 349268f695c02efbc9b9148a70b85e58cefbbf704abd3e91be654db7f1e2c863
 
-patchfiles      NSOperatingSystemVersion.patch
+patchfiles      NSOperatingSystemVersion.patch \
+                sdl2-config.cmake.in-fix.patch
 
 configure.args  --without-x
 build.args      V=1

--- a/devel/libsdl2/files/sdl2-config.cmake.in-fix.patch
+++ b/devel/libsdl2/files/sdl2-config.cmake.in-fix.patch
@@ -1,0 +1,11 @@
+--- sdl2-config.cmake.in.orig    2020-03-10 21:36:18.000000000 -0400
++++ sdl2-config.cmake.in         2020-03-16 19:57:15.000000000 -0400
+@@ -22,7 +22,7 @@
+   set_target_properties(SDL2::SDL2 PROPERTIES
+     INTERFACE_INCLUDE_DIRECTORIES "@includedir@/SDL2"
+     IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+-    IMPORTED_LOCATION "@libdir@/libSDL2.so"
++    IMPORTED_LOCATION "@libdir@/libSDL2${CMAKE_SHARED_LIBRARY_SUFFIX}"
+     INTERFACE_LINK_LIBRARIES "${SDL2_EXTRA_LINK_FLAGS}")
+ 
+   add_library(SDL2::SDL2-static STATIC IMPORTED)


### PR DESCRIPTION
sdl2-config.cmake now passes libsdl2.so instead of dylib due to hardcoded changes within the file, removing this resolves cmake project builds that use sdl2

The change was to resolve upstream bug 4970

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G3020
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
