### PR TITLE
tk +quartz: add patch to fix unresponsive menus

### DIFF
--- a/x11/tk/Portfile
+++ b/x11/tk/Portfile
@@ -5,7 +5,7 @@ PortGroup           muniversal 1.0
 
 name                tk
 version             8.6.10
-revision            0
+revision            1
 categories          x11
 license             Tcl/Tk
 maintainers         {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
@@ -40,6 +40,11 @@ patchfiles          patch-unix-Makefile.in.diff
 
 # see https://trac.macports.org/ticket/57594
 patchfiles-append   patch-dyld_fallback_library_path.diff
+
+# Fix for unresponsive menus at startup on 10.15 Catalina (+quartz)
+# see https://core.tcl-lang.org/tk/info/5bb1439eeb
+# Remove when updating to 8.6.11
+patchfiles-append   patch-macosx-tkMacOSXInit.c.diff
 
 configure.args      --mandir=${prefix}/share/man --with-tcl=${prefix}/lib
 # see https://trac.macports.org/ticket/58447

--- a/x11/tk/files/patch-macosx-tkMacOSXInit.c.diff
+++ b/x11/tk/files/patch-macosx-tkMacOSXInit.c.diff
@@ -1,0 +1,47 @@
+Upstream-Status: Backport (taken from https://core.tcl-lang.org/tk/info/5bb1439eeb)
+
+Index: macosx/tkMacOSXInit.c
+==================================================================
+--- macosx/tkMacOSXInit.c
++++ macosx/tkMacOSXInit.c
+@@ -118,18 +118,16 @@
+ {
+     /*
+      * It is not safe to force activation of the NSApp until this method is
+      * called. Activating too early can cause the menu bar to be unresponsive.
+      * The call to activateIgnoringOtherApps was moved here to avoid this.
+-     * However, with the release of macOS 10.15 (Catalina) this was no longer
+-     * sufficient.  (See ticket bf93d098d7.)  Apparently apps were being
+-     * activated automatically, and this was sometimes being done too early.
+-     * As a workaround we deactivate and then reactivate the app, even though
+-     * Apple says that "Normally, you shouldn’t invoke this method".
++     * However, with the release of macOS 10.15 (Catalina) that was no longer
++     * sufficient.  (See ticket bf93d098d7.)  The call to setActivationPolicy
++     * needed to be moved into this function as well.
+      */
+ 
+-    [NSApp deactivate];
++    [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+     [NSApp activateIgnoringOtherApps: YES];
+ 
+     /*
+      * Process events to ensure that the root window is fully initialized. See
+      * ticket 56a1823c73.
+@@ -176,16 +174,10 @@
+      * Be our own delegate.
+      */
+ 
+     [self setDelegate:self];
+ 
+-    /*
+-     * Make sure we are allowed to open windows.
+-     */
+-
+-    [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+-
+     /*
+      * If no icon has been set from an Info.plist file, use the Wish icon from
+      * the Tk framework.
+      */
+ 
+


### PR DESCRIPTION
Backport fix for unresponsive menu bar when Tk Aqua is started on 10.15 Catalina

Patch taken from https://core.tcl-lang.org/tk/info/5bb1439eeb
Fix will appear in Tk 8.6.11; patch can be dropped then

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3
Xcode 11.3.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
