### PR TITLE
poppler: Fix upstream issue #893

### DIFF
--- a/graphics/poppler/Portfile
+++ b/graphics/poppler/Portfile
@@ -10,6 +10,7 @@ PortGroup           legacysupport 1.0
 name                poppler
 conflicts           xpdf-tools
 version             0.86.1
+revision            1
 license             GPL-2+
 maintainers         {devans @dbevans} openmaintainer
 categories          graphics
@@ -65,7 +66,11 @@ patchfiles-append   patch-bug106417.diff
 
 # https://trac.macports.org/ticket/57167
 patchfiles-append   patch-trac-57167.diff
-  
+
+# https://gitlab.freedesktop.org/poppler/poppler/issues/893
+# patch based on upstream commit 68b6dd2e by Adam Reichold
+patchfiles-append   patch-upstream-issue-893.diff
+
 configure.args-append \
                     -DENABLE_UNSTABLE_API_ABI_HEADERS=ON \
                     -DENABLE_QT5=OFF \

--- a/graphics/poppler/files/patch-upstream-issue-893.diff
+++ b/graphics/poppler/files/patch-upstream-issue-893.diff
@@ -1,0 +1,64 @@
+diff --git glib/poppler-action.cc.orig glib/poppler-action.cc
+--- glib/poppler-action.cc.orig
++++ glib/poppler-action.cc
+@@ -627,39 +627,39 @@ _poppler_action_new (PopplerDocument *document,
+ 	switch (link->getKind ()) {
+ 	case actionGoTo:
+ 		action->type = POPPLER_ACTION_GOTO_DEST;
+-		build_goto_dest (document, action, dynamic_cast <const LinkGoTo *> (link));
++		build_goto_dest (document, action, static_cast <const LinkGoTo *> (link));
+ 		break;
+ 	case actionGoToR:
+ 		action->type = POPPLER_ACTION_GOTO_REMOTE;
+-		build_goto_remote (action, dynamic_cast <const LinkGoToR *> (link));
++		build_goto_remote (action, static_cast <const LinkGoToR *> (link));
+ 		break;
+ 	case actionLaunch:
+ 		action->type = POPPLER_ACTION_LAUNCH;
+-		build_launch (action, dynamic_cast <const LinkLaunch *> (link));
++		build_launch (action, static_cast <const LinkLaunch *> (link));
+ 		break;
+ 	case actionURI:
+ 		action->type = POPPLER_ACTION_URI;
+-		build_uri (action, dynamic_cast <const LinkURI *> (link));
++		build_uri (action, static_cast <const LinkURI *> (link));
+ 		break;
+ 	case actionNamed:
+ 		action->type = POPPLER_ACTION_NAMED;
+-		build_named (action, dynamic_cast <const LinkNamed *> (link));
++		build_named (action, static_cast <const LinkNamed *> (link));
+ 		break;
+ 	case actionMovie:
+ 		action->type = POPPLER_ACTION_MOVIE;
+-		build_movie (document, action, dynamic_cast<const LinkMovie*> (link));
++		build_movie (document, action, static_cast<const LinkMovie*> (link));
+ 		break;
+ 	case actionRendition:
+ 		action->type = POPPLER_ACTION_RENDITION;
+-		build_rendition (action, dynamic_cast<const LinkRendition*> (link));
++		build_rendition (action, static_cast<const LinkRendition*> (link));
+ 		break;
+ 	case actionOCGState:
+ 		action->type = POPPLER_ACTION_OCG_STATE;
+-		build_ocg_state (document, action, dynamic_cast<const LinkOCGState*> (link));
++		build_ocg_state (document, action, static_cast<const LinkOCGState*> (link));
+ 		break;
+ 	case actionJavaScript:
+ 		action->type = POPPLER_ACTION_JAVASCRIPT;
+-		build_javascript (action, dynamic_cast<const LinkJavaScript*> (link));
++		build_javascript (action, static_cast<const LinkJavaScript*> (link));
+ 		break;
+ 	case actionUnknown:
+ 	default:
+diff --git a/utils/HtmlOutputDev.cc.orig b/utils/HtmlOutputDev.cc
+--- utils/HtmlOutputDev.cc.orig
++++ utils/HtmlOutputDev.cc
+@@ -1839,7 +1839,7 @@ int HtmlOutputDev::getOutlinePageNum(OutlineItem *item)
+     if (!action || action->getKind() != actionGoTo)
+         return pagenum;
+ 
+-    link = dynamic_cast<const LinkGoTo*>(action);
++    link = static_cast<const LinkGoTo*>(action);
+ 
+     if (!link || !link->isOk())
+         return pagenum;


### PR DESCRIPTION
#### Description

This commit adds a patch to the poppler port for [upstream issue #893](https://gitlab.freedesktop.org/poppler/poppler/issues/893). It is based on upstream commit 68b6dd2e by Adam Reichold. With this fix, pdfpc works also with poppler 0.86.1.

Fixes: https://trac.macports.org/ticket/60180

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6 17G11023  
Xcode 10.1 10B61  

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
