### PR TITLE
py-apptools: update to 4.5.0, add py38 subport

### DIFF
--- a/python/py-apptools/Portfile
+++ b/python/py-apptools/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        enthought apptools 4.4.0
+github.setup        enthought apptools 4.5.0
 
 name                py-apptools
 categories-append   devel
@@ -19,10 +19,11 @@ long_description    The Enthought Tool Suite includes a set of packages\
     These packages are distributed together as the AppTools project.
 platforms           darwin
 
-checksums           rmd160  004958cc00d28caf83045497c813880cdbf7f1ee \
-                    sha256  eb80e3ba421de2c3665a7f83bd3e3588d291013b3dd1d46e816124d62a53e163
+checksums           rmd160  4afafbe5a5115b92567ef9675d36be5e249048f5 \
+                    sha256  c46fc598f02a1a70bfb37538853c1acf8c4b344cad41766b812219d83a99481d \
+                    size    305783
 
-python.versions     27 35 36 37
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6
Xcode 11.3.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [ x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
