### PR TITLE
py-envisage: update to 4.9.2, add py38 subport

### DIFF
--- a/python/py-envisage/Portfile
+++ b/python/py-envisage/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        enthought envisage 4.7.0
+github.setup        enthought envisage 4.9.2
 
 name                py-envisage
 categories-append   devel
@@ -19,11 +19,11 @@ license             BSD
 platforms           darwin
 supported_archs     noarch
 
-checksums           rmd160  f36190f621a30540a91b13b415fdf0538e269e05 \
-                    sha256  f4b926f961f11381c162b256c21b22dfdb51ddb422841e8c28ee95eff7dac90d \
-                    size    551110
+checksums           rmd160  2c95a0299c38b13a7a1491528edbbcef39d64159 \
+                    sha256  98770c290633e3dcb09f1cc2ae4b776541380e18cdb052a42d2ecfd43bc5a2e0 \
+                    size    497046
 
-python.versions     27 35 36 37
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build   port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6
Xcode 11.3.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [ x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
