### PR TITLE
py-traits: update to 6.0.0, add py38 subport

### DIFF
--- a/python/py-traits/Portfile
+++ b/python/py-traits/Portfile
@@ -4,7 +4,7 @@ PortSystem	        1.0
 PortGroup	        python 1.0
 PortGroup           github 1.0
 
-github.setup        enthought traits 4.6.0
+github.setup        enthought traits 6.0.0
 
 name                py-traits
 categories-append   devel
@@ -17,11 +17,11 @@ long_description    A trait is a type definition that can be used for normal\
     some additional characteristics.
 platforms           darwin
 
-checksums           rmd160  207668489ea23343b37f60705961b28733fb428f \
-                    sha256  d213210af3dc7467d0f70bf12188ab371098f1baca0ec67ec3df573ed3ea6819 \
-                    size    437845
+checksums           rmd160  52b3ef50370d4c6ddf1da661e6250f9996550642 \
+                    sha256  82097d159370ce6b864376675cab97e16ef0cb75dbf767d137f92acb92d2fa8f \
+                    size    435847
 
-python.versions     27 35 36 37
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6
Xcode 11.3.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [ x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
