### PR TITLE
py-traitsui: update to 6.1.3, add py38 subport

### DIFF
--- a/python/py-traitsui/Portfile
+++ b/python/py-traitsui/Portfile
@@ -4,7 +4,7 @@ PortSystem	        1.0
 PortGroup	        python 1.0
 PortGroup           github 1.0
 
-github.setup        enthought traitsui 6.0.0
+github.setup        enthought traitsui 6.1.3
 
 name                py-traitsui
 categories-append   devel
@@ -17,11 +17,11 @@ long_description    The traitsui project contains a toolkit-independent GUI\
                     "visualization" features of the Traits package.
 platforms           darwin
 
-checksums           rmd160  005d298238b5dd2da76f0a536063654ddb5a9894 \
-                    sha256  c075336d32c9e8aba92cdcbfba4f05416828b944ce1712ac3d97f65574a92a09 \
-                    size    5064024
+checksums           rmd160  a616786cd6594ad7037b71bc8bb8c188e3f5d366 \
+                    sha256  b7a843192c8e4584c91b9119e5297d4a86da6fba7335aa767c62e9e288c21a1f \
+                    size    5120702
 
-python.versions     27 35 36 37
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6
Xcode 11.3.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
