### PR TITLE
py-mayavi: update to 4.7.1, add py38 subport

### DIFF
--- a/python/py-mayavi/Portfile
+++ b/python/py-mayavi/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           active_variants 1.1
 PortGroup           github 1.0
 
-github.setup        enthought mayavi 4.6.2
+github.setup        enthought mayavi 4.7.1
 
 name                py-mayavi
 categories-append   devel graphics math
@@ -17,12 +17,11 @@ long_description    3D Scientific Data Visualization and Plotting using VTK as t
 license             BSD
 platforms           darwin
 
-checksums           rmd160  e1228d368978b5abde4ee4946306b82e3431e087 \
-                    sha256  27d8f02cf8f40afce2b6e4dec7de740fbcbcd25d1bb69e26069adb4ab9f4a9a9 \
-    size    9051159
+checksums           rmd160  a78fee221fa1243096101cf088dc26dd14567d5f \
+                    sha256  5dff720e2d3342697d2f6b22621a9a7cf4a34134aceb9bf22446eea2257e4789 \
+                    size    9066423
 
-python.versions     27 35 36 37
-python.default_version      36
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools \


### PR DESCRIPTION
Note that the py38 subport depends on VTK being built with Python 3.8, but that appears broken for now.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6
Xcode 11.3.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
