### PR TITLE
gcc7: roll back to 7.4.0 if not libc++

### DIFF
--- a/lang/gcc7/Portfile
+++ b/lang/gcc7/Portfile
@@ -30,12 +30,29 @@ master_sites        ftp://ftp.funet.fi/pub/mirrors/sources.redhat.com/pub/gcc/re
                     ftp://gcc.gnu.org/pub/gcc/releases/gcc-${version}/ \
                     gnu:gcc/gcc-${version}
 
-distname            gcc-${version}
-use_xz              yes
 
 checksums           rmd160  91d46ec088badec75f41a2ad2a0ba228a6715107 \
                     sha256  b81946e7f01f90528a1f7352ab08cc602b9ccc05d4e44da4bd501c5a189ee661 \
                     size    62783088
+
+if { ${os.platform} eq "darwin" && ${os.major} < 10 } {
+
+    # roll gcc7 back to version 7.4.0 as 7.5.0 does not play nicely with
+    # the system /usr/lib/libstdc++.dylib at present. This is being looked at upstream.
+    # we bump the epoch to roll back, but will also bump the revisions to 4 for clarity
+    # https://trac.macports.org/ticket/59832
+
+    epoch           4
+    version         7.4.0
+    revision        4
+    subport libgcc7 {revision 4}
+    checksums       rmd160  77d3cdafe7df748fa484a300e9513acb3ee2c2e1 \
+                    sha256  eddde28d04f334aec1604456e536416549e9b1aa137fc69204e65eb0c009fe51 \
+                    size    62601888
+}
+
+distname            gcc-${version}
+use_xz              yes
 
 # Check if this is the last supported gcc version for this system.
 # If it is, libgcc7 installs a full runtime, otherwise it only installs
@@ -368,6 +385,17 @@ build.env-append \
 # see https://trac.macports.org/ticket/59706
 # we probably also want to clear out the rest of the configure.XYZ flags
 configure.optflags
+
+# gcc i386 misconfigures if our cctools as modification sends it to clang for assembly
+# export suitable ENVVARS to the build to force the traditional expected gas behaviour
+# have gcc build pass these ENVARS to the build process where it is needed
+if {${build_arch} eq "i386"} {
+    configure.env-append   DISABLE_MACPORTS_AS_CLANG_SEARCH
+    build.env-append       DISABLE_MACPORTS_AS_CLANG_SEARCH
+    configure.env-append   DISABLE_XCODE_AS_CLANG_SEARCH
+    build.env-append       DISABLE_XCODE_AS_CLANG_SEARCH
+    patchfiles-append      patch-gcc-set-envvars-to-force-gas-assembler.diff
+}
 
 configure.cc-append [get_canonical_archflags]
 configure.cc_archflags

--- a/lang/gcc7/files/patch-gcc-set-envvars-to-force-gas-assembler.diff
+++ b/lang/gcc7/files/patch-gcc-set-envvars-to-force-gas-assembler.diff
@@ -1,0 +1,26 @@
+--- Makefile.in.orig	2020-03-12 23:19:11.000000000 -0700
++++ Makefile.in	2020-03-12 23:20:05.000000000 -0700
+@@ -140,7 +140,9 @@
+ 	M4="$(M4)"; export M4; \
+ 	SED="$(SED)"; export SED; \
+ 	AWK="$(AWK)"; export AWK; \
+-	MAKEINFO="$(MAKEINFO)"; export MAKEINFO;
++	MAKEINFO="$(MAKEINFO)"; export MAKEINFO; \
++	DISABLE_MACPORTS_AS_CLANG_SEARCH="$(DISABLE_MACPORTS_AS_CLANG_SEARCH)"; export DISABLE_MACPORTS_AS_CLANG_SEARCH; \
++	DISABLE_XCODE_AS_CLANG_SEARCH="$(DISABLE_XCODE_AS_CLANG_SEARCH)"; export DISABLE_XCODE_AS_CLANG_SEARCH;
+ 
+ # This is the list of variables to export in the environment when
+ # configuring subdirectories for the build system.
+--- Makefile.tpl.orig	2020-03-12 22:51:59.000000000 -0700
++++ Makefile.tpl	2020-03-12 22:55:39.000000000 -0700
+@@ -143,7 +143,9 @@
+ 	M4="$(M4)"; export M4; \
+ 	SED="$(SED)"; export SED; \
+ 	AWK="$(AWK)"; export AWK; \
+-	MAKEINFO="$(MAKEINFO)"; export MAKEINFO;
++	MAKEINFO="$(MAKEINFO)"; export MAKEINFO; \
++	DISABLE_MACPORTS_AS_CLANG_SEARCH="$(DISABLE_MACPORTS_AS_CLANG_SEARCH)"; export DISABLE_MACPORTS_AS_CLANG_SEARCH; \
++	DISABLE_XCODE_AS_CLANG_SEARCH="$(DISABLE_XCODE_AS_CLANG_SEARCH)"; export DISABLE_XCODE_AS_CLANG_SEARCH;
+ 
+ # This is the list of variables to export in the environment when
+ # configuring subdirectories for the build system.


### PR DESCRIPTION
also fix build when clang >= 5.0 is installed, needed at the same time