### PR TITLE
uni: update to 1.1.0

### DIFF
--- a/textproc/uni/Portfile
+++ b/textproc/uni/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/arp242/uni 1.0.0 v
+go.setup            github.com/arp242/uni 1.1.0 v
 
 categories          textproc
 license             MIT
@@ -11,9 +11,9 @@ installs_libs       no
 
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
 
-checksums           rmd160  e0e5b5808aaaf83d1dac90d73921f79451b3fc90 \
-                    sha256  2afd697b9291ce8fa60725f26164fe37ba754e9b2e3a611a98ea4d9dd51a8b9f \
-                    size    395367
+checksums           rmd160  8000e7a32ad639aa3ca33d0066d26418798631e0 \
+                    sha256  5fd01ff5dc98529150401de3bfbdd553213af6ee4b5d3ca0da32939a37d8f0ff \
+                    size    412258
 
 description         uni queries the Unicode database from the commandline.
 long_description    Query the Unicode database from the commandline, with \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
