### PR TITLE
submission: mod_ca: new port - redwax.eu apache module for pki, signing, ...

### DIFF
--- a/www/mod_ca/Portfile
+++ b/www/mod_ca/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                mod_ca
+version             0.2.2
+categories          www security
+platforms           darwin
+maintainers         redwax.org:dirkx
+license             Apache-2
+
+description         base modules for redwax.eu
+
+long_description    Core mod_ca modules which provide cryptographic and PKI services to other \
+                    redwax modules.
+
+homepage            https://redwax.eu/
+master_sites        https://redwax.eu/dist/rs \
+                    freebsd
+
+checksums           sha256  1af9e7fdbb9e22e229d3f74ac220d1778a9f8334b6bbf87322e74535f232463f \
+                    rmd160  d99c00654a7a84ebb4c101ab468b27615341662d \
+                    size    130093
+
+depends_lib         port:apache2 port:pkgconfig
+
+use_configure       yes
+
+pre-build {
+    system "echo > ${worksrcpath}/mod_ca_ldap.c"
+    system "echo > ${worksrcpath}/mod_ca_ldap.h"
+}
+


### PR DESCRIPTION
mod_ca: new port - redwax.eu apache module for pki, signing, timestamping, etc.

This is the port of the core module of redwax (the other modules will follow; but require this module as a dependency - so the CI will fail until this port is merged).

Originally part of PR#6587 (that passes CI, as it has all modules combined).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] enhancement

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.13, 10.14, 10.15
Xcode 8.x, 10.X, 11.3.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
== yes there is - PR#6587 -- but this PR contains the modules one by one as requested by @ra1nb0w.
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
== there are no tickets open.
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
