### PR TITLE
new port: gore

### DIFF
--- a/devel/gore/Portfile
+++ b/devel/gore/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/motemen/gore 0.5.0 v
+
+categories          devel
+license             MIT
+installs_libs       no
+
+build.target        github.com/motemen/gore/cmd/gore
+
+maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
+
+checksums           rmd160  e538328c2e0e10dbb74b582019ece8d9f617b03d \
+                    sha256  1ec26685f1429faa8bc954f113a6431e16fe6264104930318fe088cf9e0eadc1 \
+                    size    434710
+
+description         gore is yet another Go REPL with line editing, code \
+                    completion, and more.
+
+long_description    gore is a Go REPL featuring line editing with history, \
+                    multi-line input, package importing with completion, \
+                    auto-importing (gore -autoimport) and more.
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description
New port for [gore](https://github.com/motemen/gore), a Go REPL.

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
