### PR TITLE
mod_ocsp: new port - redwax.eu apache module for OCSP

### DIFF
--- a/www/mod_ocsp/Portfile
+++ b/www/mod_ocsp/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                mod_ocsp
+version             0.2.2
+categories          www security
+platforms           darwin
+maintainers         redwax.eu:dirkx
+license             Apache-2
+
+description         Redwax apache module to serve OCSP requests
+
+long_description    Apache module that Exposes an endpoint to respond to \
+                    RFC6960 Online Certificate Status Protocol requests \
+                    from your normal apache webserver.
+
+homepage            https://redwax.eu/
+master_sites        https://redwax.eu/dist/rs \
+                    freebsd
+
+checksums           sha256  365b7c915d6f27f968ca17214ba9fd761591a01e4b781b11e0013f528719c573 \
+                    rmd160  5007988d5ea71ff7b55d31f781d5d73dc08a4409 \
+                    size    97966
+
+depends_lib         port:apache2 port:mod_ca
+use_configure       yes
+


### PR DESCRIPTION
new port - redwax.eu apache module for OCSP services.

This port requires PR#6607 as a dependency. Originally part of PR#6587 (that passes CI, as it has all modules combined).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->a

- [X] enhancement

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.13, 10.14, 10.15
Xcode 8.x, 10.X, 11.3.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
== yes there is - PR#6587 -- but this PR contains the modules one by one as requested by @ra1nb0w.
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
== there are no tickets open.
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
