### PR TITLE
mod_csr: new port - redwax.eu apache module for CSR Signing

### DIFF
--- a/www/mod_csr/Portfile
+++ b/www/mod_csr/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                mod_csr
+version             0.2.3
+categories          www security
+platforms           darwin
+maintainers         redwax.org:dirkx
+license             Apache-2
+
+description         Redwax apache module - handle CSRs
+
+long_description    Redwax.eu Apache module that handles Certificate Signing Requests from your webserver.
+
+homepage            https://redwax.eu/
+master_sites        https://redwax.eu/dist/rs \
+                    freebsd
+
+checksums           sha256  fdf0d4c97bbdebe725c9c3ff1fe7ed92ac03800dd93eccf7e5a31040306092dc \
+                    rmd160  89cd2940a25be3b1e2577ff42079741471b4a46f \
+                    size    99657
+
+depends_lib         port:apache2 port:mod_ca
+use_configure       yes
+


### PR DESCRIPTION
new port - redwax.eu apache module for CSR signing

This port requires PR#6607 as a dependency. Originally part of PR#6587 (that passes CI, as it has all modules combined).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->a

- [X] enhancement

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.13, 10.14, 10.15
Xcode 8.x, 10.X, 11.3.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
== yes there is - PR#6587 -- but this PR contains the modules one by one as requested by @ra1nb0w.
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
== there are no tickets open.
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
