### PR TITLE
New port: Redwax modules - cryptographic support for apache

### DIFF
--- a/www/mod_ca/Portfile
+++ b/www/mod_ca/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                mod_ca
+version             0.2.2
+categories          www security
+platforms           darwin
+maintainers         {redwax.org:dirkx @dirkx} openmaintainer
+license             Apache-2
+
+description         base modules for redwax.eu
+
+long_description    Core mod_ca modules which provide cryptographic and PKI services to other \
+                    redwax modules.
+
+homepage            https://redwax.eu/
+master_sites        https://redwax.eu/dist/rs \
+                    freebsd
+
+checksums           sha256  1af9e7fdbb9e22e229d3f74ac220d1778a9f8334b6bbf87322e74535f232463f \
+                    rmd160  d99c00654a7a84ebb4c101ab468b27615341662d \
+                    size    130093
+
+depends_lib         port:apache2 port:pkgconfig path:lib/libssl.dylib:openssl
+
+pre-build {
+    system "echo > ${worksrcpath}/mod_ca_ldap.c"
+    system "echo > ${worksrcpath}/mod_ca_ldap.h"
+}

--- a/www/mod_crl/Portfile
+++ b/www/mod_crl/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                mod_crl
+version             0.2.2
+categories          www security
+platforms           darwin
+maintainers         {redwax.org:dirkx @dirkx} openmaintainer
+license             Apache-2
+
+description         Redwax apache module - serve CRLs from your webserver
+
+long_description    Apache module that servers CRL files from your webserver.
+
+homepage            https://redwax.eu/
+master_sites        https://redwax.eu/dist/rs \
+                    freebsd
+
+checksums           sha256  ab6167366c7f5a15550144106634c458a67f206e542460463e7deccd89159631 \
+                    rmd160  b3a91b47c0e27bc682ab883c6447dc2f2fdc42f3 \
+                    size    92482
+
+depends_lib         port:apache2 port:mod_ca path:lib/libssl.dylib:openssl

--- a/www/mod_csr/Portfile
+++ b/www/mod_csr/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                mod_csr
+version             0.2.3
+categories          www security
+platforms           darwin
+maintainers         {redwax.org:dirkx @dirkx} openmaintainer
+license             Apache-2
+
+description         Redwax apache module - handle CSRs
+
+long_description    Redwax.eu Apache module that handles Certificate Signing Requests from your webserver.
+
+homepage            https://redwax.eu/
+master_sites        https://redwax.eu/dist/rs \
+                    freebsd
+
+checksums           sha256  fdf0d4c97bbdebe725c9c3ff1fe7ed92ac03800dd93eccf7e5a31040306092dc \
+                    rmd160  89cd2940a25be3b1e2577ff42079741471b4a46f \
+                    size    99657
+
+depends_lib         port:apache2 port:mod_ca path:lib/libssl.dylib:openssl

--- a/www/mod_ocsp/Portfile
+++ b/www/mod_ocsp/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                mod_ocsp
+version             0.2.2
+categories          www security
+platforms           darwin
+maintainers         {redwax.org:dirkx @dirkx} openmaintainer
+license             Apache-2
+
+description         Redwax apache module to serve OCSP requests
+
+long_description    Apache module that Exposes an endpoint to respond to \
+                    RFC6960 Online Certificate Status Protocol requests \
+                    from your normal apache webserver.
+
+homepage            https://redwax.eu/
+master_sites        https://redwax.eu/dist/rs \
+                    freebsd
+
+checksums           sha256  365b7c915d6f27f968ca17214ba9fd761591a01e4b781b11e0013f528719c573 \
+                    rmd160  5007988d5ea71ff7b55d31f781d5d73dc08a4409 \
+                    size    97966
+
+depends_lib         port:apache2 port:mod_ca path:lib/libssl.dylib:openssl

--- a/www/mod_pkcs12/Portfile
+++ b/www/mod_pkcs12/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                mod_pkcs12
+version             0.2.1
+categories          www security
+platforms           darwin
+maintainers         {redwax.org:dirkx @dirkx} openmaintainer
+license             Apache-2
+
+description         Redwax apache module to issue signed certificates in PKCS12 format
+
+long_description    Redwax.eu apache module that exposes an enpoint that can generate \
+                    a certificate and key returned as PKCS12 from your normal apache webserver.
+
+homepage            https://redwax.eu/
+master_sites        https://redwax.eu/dist/rs \
+                    freebsd
+
+checksums           sha256  51199d09f5ddc4c4be04eac92ab619bb791323c2ee2bfeab0218a9a1a5c3c42f \
+                    rmd160  7a1f7696578d54244612e5ad2ff593b779615b02 \
+                    size    96524
+
+depends_lib         port:apache2 port:mod_ca path:lib/libssl.dylib:openssl

--- a/www/mod_scep/Portfile
+++ b/www/mod_scep/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                mod_scep
+version             0.2.3
+categories          www security
+platforms           darwin
+license             Apache-2
+maintainers         {redwax.org:dirkx @dirkx} openmaintainer
+
+description         Redwax apache module to handle SCEP requests
+
+long_description    Redwax.eu module that Exposes an endpoint that can process \
+                    a traditional SCEP request and return a certificate from \
+                    your normal apache webserver.
+
+homepage            https://redwax.eu/
+master_sites        https://redwax.eu/dist/rs \
+                    freebsd
+
+checksums           sha256  2c3fc5985a2a48d45795d9b52ce37b6258ee414ebdd94dd5068906143d6eadc6 \
+                    rmd160  5ce2f9326efa2cdd4b63be4e7bde017ca0959aa2 \
+                    size    110733
+
+depends_lib         port:apache2 port:mod_ca path:lib/libssl.dylib:openssl

--- a/www/mod_spkac/Portfile
+++ b/www/mod_spkac/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                mod_spkac
+version             0.2.2
+categories          www security
+platforms           darwin
+maintainers         {redwax.org:dirkx @dirkx} openmaintainer
+license             Apache-2
+
+description         Redwax apache module to handle SPKAC requests
+
+long_description    Redwax.eu Apache module that exposes an endpoint that can \
+                    process a Signed Public Key and Challenge request and return \
+                    a certificate from your normal apache webserver.
+
+homepage            https://redwax.eu/
+master_sites        https://redwax.eu/dist/rs \
+                    freebsd
+
+checksums           sha256  10c8c39a4c3cc9c31bfb3a2d4525d10141a22d524258a9410d22aeaf3c2af942 \
+                    rmd160  9a796f2b09f1b96e3c272efd497aedb0b0008654 \
+                    size    97792
+
+depends_lib         port:apache2 port:mod_ca path:lib/libssl.dylib:openssl

--- a/www/mod_timestamp/Portfile
+++ b/www/mod_timestamp/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                mod_timestamp
+version             0.2.1
+categories          www security
+platforms           darwin
+maintainers         redwax.eu:dirkx  @dirkx openmaintainer
+maintainers         {redwax.org:dirkx @dirkx} openmaintainer
+license             Apache-2
+
+description         Redwax apache module to serve signed timestamps
+
+long_description    Redwax.eu apache module that exposes an RFC3161 \
+                    Time Stamp Protocol endpoint for document timestamping \
+                    from your normal apache webserver.
+
+homepage            https://redwax.eu/
+master_sites        https://redwax.eu/dist/rs \
+                    freebsd
+
+checksums           sha256  ee98fbf7607e9640a70e28426898e10b83882d0535a9369c53c9f2b61a018b48 \
+                    rmd160  34af0517be4b97a439405e57bf3497a1f10e32d4 \
+                    size    94222
+
+depends_lib         port:apache2 port:mod_ca path:lib/libssl.dylib:openssl


### PR DESCRIPTION
Set of new modules - done in one pull request as there are interdependencies.

Replaces #6587 

tested on
macOS 10.13, 10.14, 10.15
XCode 8 until 10.3.1

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)? 

yes - one for each port.

- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
