### PR TITLE
auto-multiple-choice-devel: update to version 1.4.0-201912050859

### DIFF
--- a/x11/auto-multiple-choice/Portfile
+++ b/x11/auto-multiple-choice/Portfile
@@ -40,15 +40,16 @@ if {${subport} eq ${name}} {
     conflicts               auto-multiple-choice-devel
 } else {
     # devel
-    set gitlab.commit       "adb638a014e0a1da2419ee092d1a19210b16d3c9"
-    set amc_revision        "201911160924"
-    set amc_date            "201911160924"
+    set gitlab.commit       "fc646f9d08f9b1fc5d680de7ec84a8cdbf34aeb8"
+    set amc_revision        "201912050859"
+    set amc_date            "201912050859"
     version                 1.4.0-${amc_revision}
-    checksums               rmd160  0b48d68161f1bace705a2fa1508e3946dd5d6d36 \
-                            sha256  a2b0ac4b9599939e8c51d05ac7528bdab0cd91ccd67dd0c08b8b86373522fbff \
-                            size    5768018
+    checksums               rmd160  5c43a192632b08ae022f861d0ee1cd71efb2a05e \
+                            sha256  f4406c246c8eb44c870539c5e7a45e422f51dd243465afe7750d15ca2aad1da2 \
+                            size    5770205
     build.cmd               ${prefix}/bin/gmake
     conflicts               auto-multiple-choice
+    patchfiles              patch-cupslp-pm-684.diff
 }
 
 master_sites            https://gitlab.com/jojo_boulix/auto-multiple-choice/repository/archive.tar.gz?ref=${gitlab.commit}&dummy=
@@ -98,6 +99,8 @@ configure {
     }
     system -W ${worksrcpath} "${build.cmd} version_files AMCCONF=macports BASEPATH=${prefix} PERLPATH=${perl5.bin} PERLDIR=${perl5.lib} SYSTEM_TYPE=macports TEXDIR=${amc.texmflocal}/tex/latex/AMC TEXDOCDIR=${amc.texmflocal}/doc/latex/AMC"
 }
+
+build.env-append        AMCCONF=macports BASEPATH=${prefix}
 
 pre-destroot {
     destroot.args-append PERLDIR=${perl5.lib}

--- a/x11/auto-multiple-choice/files/patch-cupslp-pm-684.diff
+++ b/x11/auto-multiple-choice/files/patch-cupslp-pm-684.diff
@@ -1,0 +1,42 @@
+--- AMC-perl/AMC/Print/cupslp.pm.orig	2019-12-05 09:59:42.000000000 +0100
++++ AMC-perl/AMC/Print/cupslp.pm	2020-01-09 15:22:00.000000000 +0100
+@@ -65,14 +65,32 @@
+ sub printers_list {
+     my ($self) = @_;
+     my @list = ();
+-    open( PL, "-|", "lpstat", "-e" )
+-      or die "Can't exec lpstat: $!";
+-    while (<PL>) {
+-        chomp;
+-        push @list, { name => $_, description => "" };
+-    }
++    
++    # Verify if lpstat -e output to stderr
++    open( PL, "-|", "lpstat -e 2>&1 1>/dev/null" )
++        or die "Can't exec lpstat: $!";
++    my $err = <PL>;
+     close PL;
+-    return (@list);
++    if($err) {
++        # lpstat -e outputted to stderr so try lpstat -a
++        open(PL,"-|","lpstat","-a")
++           or die "Can't exec lpstat: $!";
++        while(<PL>) {
++            push @list,{name=>$1,description=>$1}
++              if(/^([^\s]+)\s+accept/);
++        }
++        close PL;
++	} else {
++        # lpstat -e outputted nothing to stderr so use it
++        open( PL, "-|", "lpstat", "-e" )
++            or die "Can't exec lpstat: $!";
++        while (<PL>) {
++            chomp;
++            push @list, { name => $_, description => "" };
++        }
++        close PL;
++    }
++    return(@list);
+ }
+ 
+ sub default_printer {


### PR DESCRIPTION
auto-multiple-choice-devel: update to version 1.4.0-201912050859

* update to version 1.4.0-201912050859
* solve printer access with old version of CUPS https://project.auto-multiple-choice.net/issues/688

Close https://trac.macports.org/ticket/59521

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3 19D76
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
