### PR TITLE
bedtools: rename "version" to avoid clash with STL

### DIFF
--- a/science/bedtools/Portfile
+++ b/science/bedtools/Portfile
@@ -35,6 +35,8 @@ build.args-append   CC=${configure.cc} \
 
 use_parallel_build  yes
 
+patchfiles          patch-rename-version.diff
+
 post-build {
     system -W ${worksrcpath}/docs "${build.cmd} SPHINXBUILD=${prefix}/bin/sphinx-build-3.8 html man"
 }

--- a/science/bedtools/files/patch-rename-version.diff
+++ b/science/bedtools/files/patch-rename-version.diff
@@ -1,0 +1,14 @@
+diff --git src/utils/gzstream/version src/utils/gzstream/version
+deleted file mode 100644
+index 511137de..00000000
+--- src/utils/gzstream/version
++++ /dev/null
+@@ -1 +0,0 @@
+-1.5 (08 Jan 2003)
+diff --git src/utils/gzstream/version.txt src/utils/gzstream/version.txt
+new file mode 100644
+index 00000000..511137de
+--- /dev/null
++++ src/utils/gzstream/version.txt
+@@ -0,0 +1 @@
++1.5 (08 Jan 2003)


### PR DESCRIPTION
With C++20 version.h is part of STL; rename local version to avoid
clash. I've submitted a pull request upstream for this: https://github.com/arq5x/bedtools2/pull/830

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
