### PR TITLE
openjdk8: add OpenJDK 14 subports

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -127,6 +127,32 @@ subport openjdk13-openj9-large-heap {
     set openj9_version 0.18.0
 }
 
+subport openjdk14 {
+    version      14
+    revision     0
+
+    set build    36
+    set major    14
+}
+
+subport openjdk14-openj9 {
+    version      14
+    revision     0
+
+    set build    36
+    set major    14
+    set openj9_version 0.19.0
+}
+
+subport openjdk14-openj9-large-heap {
+    version      14
+    revision     0
+
+    set build    36
+    set major    14
+    set openj9_version 0.19.0
+}
+
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
 platforms        darwin
@@ -390,6 +416,51 @@ if {${subport} eq "openjdk8"} {
                  suitable for running all workloads. \
                  \
                  This version uses non-compressed references and should be used for applications which require heaps that are over ~57 GB.
+} elseif {${subport} eq "openjdk14"} {
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}/
+    distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}_${build}
+
+    checksums    rmd160  7e2467e9f3ba520836508fff2be8fb3bc899c75e \
+                 sha256  aabc3aebb0abf1ba64d9bd5796d0c7eb7239983f6e4c0f015b5b88be5616e4bd \
+                 size    201087797
+
+    worksrcdir   jdk-${version}+${build}
+} elseif {${subport} eq "openjdk14-openj9"} {
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
+    distname     OpenJDK${major}-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
+
+    checksums    rmd160  939ca5002a6b7bf1fbe3f6097452afe3f9c81b03 \
+                 sha256  171279c0514e102796fec894e7760ec61c7c8e826aeb0d19c1578759fc81f583 \
+                 size    205221842
+
+    worksrcdir   jdk-${version}+${build}
+
+    description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM
+    long_description AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully \
+                 open-source set of build scripts and infrastructure. \
+                 \
+                 OpenJ9 is the virtual machine from the Eclipse community. It is an enterprise-grade \
+                 VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
+                 suitable for running all workloads.
+} elseif {${subport} eq "openjdk14-openj9-large-heap"} {
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
+    distname     OpenJDK${major}-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
+
+    checksums    rmd160  59d9ae1f1a4891c4584509508e5f6f99e658db7e \
+                 sha256  603aa1e2cd4f5db53fec75b6f033653d0621c720844147bc9a15ef6ea603401e \
+                 size    205221731
+
+    worksrcdir   jdk-${version}+${build}
+
+    description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM for large heap sizes
+    long_description AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully \
+                 open-source set of build scripts and infrastructure. \
+                 \
+                 OpenJ9 is the virtual machine from the Eclipse community. It is an enterprise-grade \
+                 VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
+                 suitable for running all workloads. \
+                 \
+                 This version uses non-compressed references and should be used for applications which require heaps that are over ~57 GB.
 }
 
 variant Applets \
@@ -429,15 +500,15 @@ destroot {
 
 notes "
 If you have more than one JDK installed you can make JDK ${major} the default
-by adding the following line to your Bash shell profile (~/.bash_profile):
+by adding the following line to your shell profile:
 
     export JAVA_HOME=${target}/Contents/Home
 "
 
-if {${subport} eq "openjdk10" || [string match openjdk12* ${subport}]} {
+if {${subport} eq "openjdk10" || [string match openjdk12* ${subport}] || [string match openjdk13* ${subport}]} {
     notes-append "
     Warning: Support for OpenJDK ${major} has reached end of life and there will be no more updates.
              Please consider migrating to a supported OpenJDK version.
-             Currently OpenJDK 8, 11 and 13 are supported.
+             Currently OpenJDK 8, 11 and 14 are supported.
     "
 }


### PR DESCRIPTION
#### Description

Add subports for OpenJDK 14 based on the AdoptOpenJDK builds. Indicate that OpenJDK 13 is no longer supported.

###### Tested on

macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?