### PR TITLE
gh: update to 0.6.2

### DIFF
--- a/devel/gh/Portfile
+++ b/devel/gh/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        cli cli 0.6.1 v
+github.setup        cli cli 0.6.2 v
 name                gh
 categories          devel
 platforms           darwin
@@ -21,9 +21,9 @@ homepage            https://cli.github.com/
 github.tarball_from releases
 distname            gh_${version}_macOS_amd64
 
-checksums           rmd160  c0eabffcdc850ce6127c2f76e156d4332f303b4e \
-                    sha256  a7ffd358476958541687da8108d7b2fc7adedbcb046ad7faa37ad4d7f381c314 \
-                    size    6194802
+checksums           rmd160  a321816e5ab4c516bf3ae5e07b44bb9de0f978f0 \
+                    sha256  03568f685bd118b7a8bae77dfceaa2c35d89b328a07a4f2bc73675ea1e2ad985 \
+                    size    6206110
 
 use_configure       no
 


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
