### PR TITLE
ecCodes: update to 2.17.0

### DIFF
--- a/science/ecCodes/Portfile
+++ b/science/ecCodes/Portfile
@@ -5,7 +5,7 @@ PortGroup cmake     1.1
 PortGroup compilers 1.0
 
 name                ecCodes
-version             2.16.0
+version             2.17.0
 revision            0
 platforms           darwin
 maintainers         {takeshi @tenomoto}
@@ -15,9 +15,9 @@ description         API and tools for decoding and encoding GRIB, BUFR and GTS f
 homepage            https://confluence.ecmwf.int/display/ECC
 master_sites        https://confluence.ecmwf.int/download/attachments/45757960
 distname            eccodes-${version}-Source
-checksums           rmd160  cb366378da4316e1581a38a2f012cb7bc908c67f \
-                    sha256  141406b724d531fde5ca908a00f9382e1426e32b24d3d96dc31cb2392e7ff8a3 \
-                    size    11258869
+checksums           rmd160  0f1af591bcdcf7561d49a5c1d3f3b0ddd1197675 \
+                    sha256  762d6b71993b54f65369d508f88e4c99e27d2c639c57a5978c284c49133cc335 \
+                    size    11370790
 long_description \
     ecCodes is a package developed by ECMWF which provides an application programming interface and \
     a set of tools for decoding and encoding messages in the following formats: \


### PR DESCRIPTION
#### Description

Simple upstream update to version 2.17.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3
Xcode 10.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
