### PR TITLE
OpenBLAS: update to version 0.3.9

### DIFF
--- a/math/OpenBLAS/Portfile
+++ b/math/OpenBLAS/Portfile
@@ -76,17 +76,16 @@ if {[string first "-devel" $subport] > 0} {
 
 } else {
 
-    github.setup    xianyi OpenBLAS 0.3.8 v
-    checksums       rmd160 f13b757446293fde3e5c2a0bd2195425f509c48d \
-                    sha256 69b6351db7821354164d1c513691bbb252d2c5eccdbd4632853766ba4348f638 \
-                    size   12180349
+    github.setup    xianyi OpenBLAS 0.3.9 v
+checksums           rmd160  98c9d2569c5111e10724a1ef901eec7df168a04c \
+                    sha256  8393c9dab141d5de65d4d525afb7b01fbc470eab244982e4e3b1a7956d4f3f92 \
+                    size    12189745
     revision        0
 
     conflicts       OpenBLAS-devel
 
     patchfiles      patch-libnoarch.release.diff \
-                    patch-OpenBLAS-i386-Apple.diff \
-                    patch-revert-5f6206fa-c_check-only.diff
+                    patch-OpenBLAS-i386-Apple.diff
 
     if {![variant_isset native]} {
         notes "


### PR DESCRIPTION
#### Description

Update OpenBLAS to version 0.3.9.
Required to remove patch that got committed upstream.

Also adding kencu as reviewer considering all the contributions he made for older platforms.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G3020
Xcode 10.3 10G8 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
