### PR TITLE
jsch: update to 0.1.55

### DIFF
--- a/java/jsch/Portfile
+++ b/java/jsch/Portfile
@@ -1,9 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
+PortGroup               java 1.0
 
 name                    jsch
-version                 0.1.54
+version                 0.1.55
 categories              java security
 platforms               darwin
 maintainers             {gmail.com:ndiscreet @chicagotripp} \
@@ -19,12 +20,14 @@ homepage                http://www.jcraft.com/jsch/
 master_sites            sourceforge:project/jsch/jsch/${version}/
 use_zip                 yes
 
-checksums               md5     0b9312909fe542f6e662d40ec676f6b5 \
-                        sha1    c4252657c7caad9c8482836ddb1fa2abcf080357 \
-                        rmd160  cc0d72d817829c434dfcba845d2ff0d43243417c \
-                        sha256  ab71e1e5ff665213b7d892ebd0829b3da835538a73409fe11bb006ec5b6b3909
+checksums               md5     6409f5c38840b053d946fb17cc3f2400 \
+                        sha1    5e7b17414533005c4f163bec8be41d023b1f0810 \
+                        rmd160  d1ce73ff32e2e644a5fa02fc5d6b0fdd55d54416 \
+                        sha256  063bf66e163f43b7d7897ac14efe1e80ed094d4016afe1181fe2285e3797bed3 \
+                        size    369664
 
-depends_lib             bin:java:kaffe
+java.version            1.7+
+java.fallback           openjdk8
 depends_build           bin:ant:apache-ant
 
 patchfiles              patch-build.xml.diff


### PR DESCRIPTION
Use Java portgroup + LTS OpenJDK fallback instead of `kaffe` (deprecated)
See https://trac.macports.org/ticket/60206

Add size to checksums

#### Description

See upstream changelog: http://www.jcraft.com/jsch/ChangeLog
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
~~macOS 10.x~~
~~Xcode 8.x~~

Untested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on Trac with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
