### PR TITLE
flyway: use Java portgroup

### DIFF
--- a/java/flyway/Portfile
+++ b/java/flyway/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           select 1.0
+PortGroup           java 1.0
 
 name                flyway
 version             6.3.1
@@ -27,7 +28,8 @@ checksums           rmd160  d30549f7cbe20ecd2181945b9b8916c5592abc9e \
                     sha256  ff91611330f6f993a3c02f4102ea8e136b39248aed47b4da91936680b975c984 \
                     size    49882528
 
-depends_run         bin:java:kaffe
+java.version        1.8+
+java.fallback       openjdk11
 
 use_configure       no
 


### PR DESCRIPTION
Use latest Java LTS (Java 11) as fallback

Remove fallback dependency on deprecated port kaffe
See: https://trac.macports.org/ticket/60206
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
~~macOS 10.x~~
~~Xcode 8.x~~

Untested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
