### PR TITLE
junit: update to 4.13

### DIFF
--- a/java/junit/Portfile
+++ b/java/junit/Portfile
@@ -2,10 +2,9 @@
 
 PortSystem      1.0
 PortGroup       java 1.0
-PortGroup       github 1.0
 
 name            junit
-github.setup    junit-team junit4 4.12 r
+version         4.13
 categories      java devel
 license         CPL-1
 platforms       darwin
@@ -19,14 +18,13 @@ long_description \
     It is an instance of the xUnit architecture for unit \
     testing frameworks.
 
-homepage        http://www.junit.org/
+homepage        https://junit.org/junit4/
+master_sites    https://repo1.maven.org/maven2/junit/junit/${version}/
 distfiles       ${name}-${version}.jar
 
-github.tarball_from releases
-
-checksums   rmd160  cac965767259d6112bd72f2aaad37eebb7e930aa \
-            sha256  59721f0805e223d84b90677887d9ff567dc534d7c502ca903c0c2b17f05c116a \
-            size    314932
+checksums   rmd160  45b1bcd0fbe3e069989be2dff0f8f2f2a72b9d76 \
+            sha256  4b8532f63bdc0e0661507f947eb324a954d1dbac631ad19c8aa9a00feed1d863 \
+            size    381765
 
 use_configure   no
 # don't extract anything


### PR DESCRIPTION
.jar for 4.13 not published to GitHub releases; use Central Repository instead (as suggested by upstream project)

Update homepage to JUnit4-specific page

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Complete release notes:
https://github.com/junit-team/junit4/blob/master/doc/ReleaseNotes4.13.md

###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
~~macOS 10.x~~
~~Xcode 8.x~~

Untested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
