### PR TITLE
redis: update to 5.0.8

### DIFF
--- a/databases/redis/Portfile
+++ b/databases/redis/Portfile
@@ -5,7 +5,7 @@ PortGroup           muniversal 1.0
 PortGroup           xcode_workaround 1.0
 
 name                redis
-version             5.0.7
+version             5.0.8
 categories          databases
 platforms           darwin
 license             BSD
@@ -18,9 +18,9 @@ long_description    {*}${description}
 homepage            https://redis.io/
 master_sites        http://download.redis.io/releases/
 
-checksums           rmd160  0490b980daaba10d5697af8b8b719c6ab54a821c \
-                    sha256  61db74eabf6801f057fd24b590232f2f337d422280fd19486eca03be87d3a82b \
-                    size    1984203
+checksums           rmd160  91bb5a283b0a040aeb67dcab954a7c1b85490e3b \
+                    sha256  f3c7eac42f433326a8d981b50dba0169fdfaf46abb23fcda2f933a7552ee4ed7 \
+                    size    1985757
 
 patchfiles          patch-redis.conf.diff
 


### PR DESCRIPTION
#### Description
Tested by spinning up the server locally and running some queries with redis-cli.

###### Type(s)
- [x] enhancement

###### Tested on
macOS 10.13.6 17G11023
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
