### PR TITLE
google-cloud-sdk: update to 285.0.1

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             284.0.0
+version             285.0.1
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  846ea9f88cbd2fbff34b8c86032d3dbc7469c512 \
-                    sha256  443ce5230a86335a3df2b04662a008e3a95d3d06d9e976dd98238eda37a3dbeb \
-                    size    48490724
+    checksums       rmd160  4636de6233951cf05a2ad9d5d4a68a8f75ccba16 \
+                    sha256  84989e6b614bdecd22fc56b5e6a20186b49b58b88b72b11de323b12f19e08039 \
+                    size    48683108
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  7587156aed1401762ba2c0664498ee7f61086cad \
-                    sha256  117e1b106fce6946ffcdd9e3c668eed8eae6525d025fe8394f756c622725f00e \
-                    size    49534906
+    checksums       rmd160  f12c460ef2f4b72e8258cf7d8c011634ff949444 \
+                    sha256  05c6cd008b7d946891a0e804c4f68ff3a1bfd1ddefb1992fb6f0c10dfe6327f0 \
+                    size    49726584
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 285.0.1.

###### Tested on

macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?