### PR TITLE
caf: allow build on older systems

### DIFF
--- a/devel/caf/Portfile
+++ b/devel/caf/Portfile
@@ -20,15 +20,6 @@ checksums           rmd160  4758b0632f08a5008c3cb48d9d4a911065df99a5 \
                     sha256  aacdd9137358cb251ef2ce92e7de23e728eab2c96caeba4ca76880f2add4cdc4 \
                     size    2683575
 
-pre-fetch {
-    platform darwin {
-        if {${os.major} < 12} {
-            ui_error "${name} @${version} requires at least macOS 10.8 Mountain Lion"
-            return -code error "imcompatible macOS version"
-        }
-    }
-}
-
 # (Soon) We need C++17
 compiler.cxx_standard   2017
 
@@ -40,4 +31,9 @@ variant docs description {Build documentation} {
 
 if {![variant_isset docs]} {
     patchfiles      patch-doc-CMakeLists.txt.diff
+}
+
+if {${os.platform} eq "darwin" && ${os.major} < 12} {
+    # see https://trac.macports.org/ticket/60212
+    configure.args-append   -DCAF_NO_OPENCL=yes
 }


### PR DESCRIPTION
See https://trac.macports.org/ticket/60212

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.7.5
Xcode 4.6.3 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
