### PR TITLE
update gnuplot and py-enum34

### DIFF
--- a/math/gnuplot/Portfile
+++ b/math/gnuplot/Portfile
@@ -6,7 +6,7 @@ PortGroup           xcodeversion    1.0
 PortGroup           wxWidgets       1.0
 
 name                gnuplot
-version             5.2.7
+version             5.2.8
 categories          math science
 # the license has some inconvenient requirements that we're not meeting
 # to be allowed to distribute binaries
@@ -29,9 +29,9 @@ homepage            http://gnuplot.sourceforge.net/
 master_sites        sourceforge:project/gnuplot/gnuplot/${version}
 dist_subdir         ${name}/${version}
 
-checksums           rmd160  59a3d9fbcd5856b123b4e8eb9ecde753ab252060 \
-                    sha256  97fe503ff3b2e356fe2ae32203fc7fd2cf9cef1f46b60fe46dc501a228b9f4ed \
-                    size    5335673
+checksums           rmd160  1048f333f14be3f27bd8a6fa866371c6308f4f5d \
+                    sha256  60a6764ccf404a1668c140f11cc1f699290ab70daa1151bb58fed6139a28ac37 \
+                    size    5340677
 
 depends_build       port:pkgconfig
 

--- a/python/py-enum34/Portfile
+++ b/python/py-enum34/Portfile
@@ -4,20 +4,23 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-enum34
-version             1.1.9
+version             1.1.10
+revision            0
+
 categories          python
 platforms           darwin
+supported_archs     noarch
 license             BSD
 maintainers         {mojca @mojca} openmaintainer
+
 description         Python 3.4 Enum backported to 3.3, 3.2, 3.1, 2.7, 2.6, 2.5, and 2.4
 long_description    ${description}
-homepage            https://pypi.python.org/pypi/enum34
-master_sites        pypi:e/enum34
-distname            enum34-${version}
 
-checksums           rmd160  1373e781ce0ba075e692247d4042f443813f6fe3 \
-                    sha256  13ef9a1c478203252107f66c25b99b45b1865693ca1284aab40dafa7e1e7ac17 \
-                    size    28191
+homepage            https://pypi.python.org/pypi/enum34
+
+checksums           rmd160  39ef0739737338df46960a3ffa436aa38394ae88 \
+                    sha256  cce6a7477ed816bd2542d03d53db9f0db935dd013b70f336a95c73979289f248 \
+                    size    28187
 
 # works in 24 25 26 27 31 32 33
 python.versions     27
@@ -25,9 +28,11 @@ python.versions     27
 if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
+
+    test.run        yes
+    test.cmd        ${python.bin} enum/test.py
+    test.target
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
+
     livecheck.type  none
-} else {
-    livecheck.type  regex
-    livecheck.url   ${homepage}
-    livecheck.regex {enum34 (\d+(?:\.\d+)*)}
 }


### PR DESCRIPTION
#### Description
Update ```gnuplot``` to version 5.2.8 and ```py-enum34``` to version 1.1.10. 

###### Tested on
macOS 10.14.6 18G3020
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
