### PR TITLE
py-[pytest|qtconsole]: update to latest version

### DIFF
--- a/python/py-pytest/Portfile
+++ b/python/py-pytest/Portfile
@@ -5,8 +5,9 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-pytest
-version             5.3.5
+version             5.4.1
 revision            0
+
 categories-append   devel
 platforms           darwin
 license             MIT
@@ -24,9 +25,9 @@ long_description    The pytest framework makes it easy to write small tests, \
 
 homepage            https://pytest.org
 
-checksums           rmd160  e03742f5e3e73277ef5bcd49b6373bf70e98657f \
-                    sha256  0d5fe9189a148acc3c3eb2ac8e1ac0742cb7618c084f3d228baaec0c254b318d \
-                    size    990935
+checksums           rmd160  6672e7c8e37b48829c8aa9a18ce02f49ec149e99 \
+                    sha256  84dde37075b8805f3d1f392cc47e38a0e59518fb46a431cfdaf7cf1ce805f970 \
+                    size    1017924
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -37,7 +38,6 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-packaging \
                         port:py${python.version}-attrs \
                         port:py${python.version}-more-itertools \
-                        port:py${python.version}-atomicwrites \
                         port:py${python.version}-pluggy \
                         port:py${python.version}-wcwidth
 
@@ -55,7 +55,8 @@ if {${name} ne ${subport}} {
                             sha256  4a784f1d4f2ef198fe9b7aef793e9fa1a3b2f84e822d9b3a64a181293a572d45 \
                             size    949947
 
-        depends_lib-append  port:py${python.version}-six \
+        depends_lib-append  port:py${python.version}-atomicwrites \
+                            port:py${python.version}-six \
                             port:py${python.version}-funcsigs
     }
 

--- a/python/py-qtconsole/Portfile
+++ b/python/py-qtconsole/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-qtconsole
-version             4.6.0
+version             4.7.1
 revision            0
 
 categories-append   devel
@@ -20,13 +20,10 @@ description         Jupyter QtConsole
 long_description    ${description}
 
 homepage            https://jupyter.org
-master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
-distname            ${python.rootname}-${version}
-
-checksums           rmd160  36b4a57f9a121e4b13ca36a00fa69e5965b7aa0e \
-                    sha256  654f423662e7dfe6a9b26fac8ec76aedcf742c339909ac49f1f0c1a1b744bcd1 \
-                    size    426936
+checksums           rmd160  e52f2549eaeb4d6be12a87f78f510f6b3be72af2 \
+                    sha256  d51c1c51c81fbd1fac62b2d4bdc8b54fb6b7cbe6cbf70c3baeea11516525c956 \
+                    size    423720
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-setuptools \
@@ -35,7 +32,8 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-jupyter_core \
                         port:py${python.version}-jupyter_client \
                         port:py${python.version}-pygments \
-                        port:py${python.version}-ipykernel
+                        port:py${python.version}-ipykernel \
+                        port:py${python.version}-qtpy
 
     # Note: depends on one of py-pyqt4, py-pyqt5 or py-pyside (first available at runtime)
     notes-append        "Please do not forget to install one of Qt backends: py${python.version}-pyside, py${python.version}-pyqt5 or py${python.version}-pyqt4."


### PR DESCRIPTION
#### Description
This PR updates the following ports to their latest versions:
- py-pytest: update to 5.4.1
- py-qtconsole: update to 4.7.1 

###### Tested on
macOS 10.14.6 18G3020
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
