### PR TITLE
py-numpy: update to 1.18.2 and 1.16.4 (PY27)

### DIFF
--- a/python/py-numpy/Portfile
+++ b/python/py-numpy/Portfile
@@ -13,10 +13,10 @@ maintainers             {michaelld @michaelld} openmaintainer
 description             The core utilities for the scientific library scipy for Python
 long_description        ${description}
 
-github.setup            numpy numpy 1.18.1 v
-checksums               rmd160 19f68392436cbecc8aad8cd15758e11b7dc276e6 \
-                        sha256 d73a59e762f6820aeeec1f47613625e3e399f604d7f3e09b2543bb66045ffb86 \
-                        size   5160417
+github.setup            numpy numpy 1.18.2 v
+checksums               rmd160  ba58a89eb7c1112541e8037dd66774d9b5747ca8 \
+                        sha256  5f684cf7b31f725c121f94dc1c6cd5a8af910ead9e71cddf4af4f16d7ce4d78b \
+                        size    5161709
 revision                0
 
 if {${name} ne ${subport}} {
@@ -37,10 +37,10 @@ python.consistent_destroot yes
 
 if {${name} ne ${subport}} {
     if {${python.version} == 27} {
-        github.setup        numpy numpy 1.16.4 v
-        checksums           rmd160 a5a18f70e57962b9691eeef28bae9f0c3851279f \
-                            sha256 86e12b00ca36643c63184b5e45373727603a9e073177f24ce2c4b5a4a9dabc04 \
-                            size   4676166
+        github.setup        numpy numpy 1.16.6 v
+        checksums           rmd160  cbb34cf0981ea142ff45722d05a9daad20a134ea \
+                            sha256  2dce87065d5de1a83485cfb3de5e4e793787890f5c1dcc3536a9cabf2e1620af \
+                            size    4691852
         revision            0
         patchfiles-append   patch-numpy_core_setup.py.27.diff \
                             patch-numpy_tests_test_scripts.py.27.diff \


### PR DESCRIPTION
#### Description
This updates ```py-numpy``` to the latest versions: 1.18.2 and 1.16.4 (for PY27). Version 1.18.2 contains the new CPU detection code, which hopefully avoids many failures on the 10.12 buildbot for (Python) ports that use ```py-numpy```. 

See: https://trac.macports.org/ticket/59022 and several others (once we can confirm this updated fixes it, we can re-start the builds and close tickets accordingly).

###### Tested on
macOS 10.14.6 18G3020
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
