### PR TITLE
dbeaver-community: update to 7.0.0

### DIFF
--- a/databases/dbeaver-community/Portfile
+++ b/databases/dbeaver-community/Portfile
@@ -2,9 +2,8 @@
 
 PortSystem                  1.0
 PortGroup                   github 1.0
-PortGroup                   java 1.0
 
-github.setup                dbeaver dbeaver 6.3.4
+github.setup                dbeaver dbeaver 7.0.0
 github.tarball_from         releases
 distname                    dbeaver-ce-${version}-macosx.cocoa.x86_64
 name                        dbeaver-community
@@ -28,14 +27,15 @@ long_description            Free multi-platform database tool for developers, SQ
 
 homepage                    https://dbeaver.io/
 
-checksums                   rmd160  7a00e527c67a293991059e0668f0e62fea75c5f5 \
-                            sha256  695d598561076df7c8b2173bc79e4972af38d70ab82ed67f1b553b612c892b2b \
-                            size    59188289
+checksums                   rmd160  cfb0b13fe573938af48dff00d7453d9e7aee661b \
+                            sha256  8b1353aba203233140c3b5e6b83168ed811f03122d091f2e2a9e4f126b3650fb \
+                            size    59248087
 
-java.version                1.8+
-java.fallback               openjdk11
+depends_lib-append          port:openjdk8
 
 extract.mkdir               yes
+
+patchfiles                  openjdk8.patch
 
 use_configure               no
 

--- a/databases/dbeaver-community/files/openjdk8.patch
+++ b/databases/dbeaver-community/files/openjdk8.patch
@@ -1,0 +1,10 @@
+--- DBeaver.app/Contents/Info.plist.orig	2020-03-22 20:26:19.000000000 +0100
++++ DBeaver.app/Contents/Info.plist	2020-03-22 20:27:18.000000000 +0100
+@@ -55,6 +55,7 @@
+ 				<string>-vm</string><string>/System/Library/Frameworks/JavaVM.framework/Versions/1.4.2/Commands/java</string>
+ 				<string>-vm</string><string>/System/Library/Frameworks/JavaVM.framework/Versions/1.5.0/Commands/java</string>
+ 			-->
++			<string>-vm</string><string>/Library/Java/JavaVirtualMachines/openjdk8/Contents/Home/bin/java</string>
+ 			<string>-keyring</string><string>~/.eclipse_keyring</string>
+ 			<!-- WARNING:
+ 				If you try to add a single VM argument (-vmargs) here,


### PR DESCRIPTION
#### Description

Update to 7.0.0  and force OpenJDK8, since it is known to work and there are open issues with several other JDK versions.

###### Tested on

macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?