### PR TITLE
wireguard-go: update to 0.0.20200320

### DIFF
--- a/net/wireguard-go/Portfile
+++ b/net/wireguard-go/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-go
-version             0.0.20200121
+version             0.0.20200320
 revision            0
-checksums           rmd160  d0e7a84545088fe5df207ec7e8d21f15a46b75bf \
-                    sha256  d790697df58bcd1d890f126d8a4f0b9aa11ad6f847a692e9c638a4b7b0454c14 \
-                    size    80532
+checksums           rmd160  acb5defeb676ae02cadada7be13d274b1fc4bc83 \
+                    sha256  c8262da949043976d092859843d3c0cdffe225ec6f1398ba119858b6c1b3552f \
+                    size    80556
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
###### Tested on
macOS 10.13.6 17G11023
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?