### PR TITLE
git: update to 2.26.0

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 name                git
-version             2.25.1
+version             2.26.0
 revision            0
 
 description         A fast version control system
@@ -23,13 +23,13 @@ distfiles           git-${version}${extract.suffix} \
                     git-manpages-${version}${extract.suffix}
 
 checksums           git-${version}.tar.xz \
-                    rmd160  a8ab476982440c2cc94c7d21f619320d74f117d2 \
-                    sha256  222796cc6e3bf2f9fd765f8f097daa3c3999bb7865ac88a8c974d98182e29f26 \
-                    size    5875548 \
+                    rmd160  5c8ae74bb7a3ca053e4a678debdaf1ff459b8081 \
+                    sha256  9ece0dcb07a5e0d7366a92b613b201cca11ae368ab7687041364b3e756e495d6 \
+                    size    6005104 \
                     git-manpages-${version}.tar.xz \
-                    rmd160  eb79be5e0bb08e2819d6776fc6e90d210458d1ca \
-                    sha256  30886372c1962a5e087f919998b02f816605368201b564d3f519614ee4a9ee96 \
-                    size    457408 \
+                    rmd160  1088258b1732f8a4629a4212e409c53f048eee0c \
+                    sha256  387e46a0b67c148be7ef80759b1930a3b64ac77782630c18afc784f35ed93426 \
+                    size    462092
 
 perl5.require_variant   yes
 perl5.conflict_variants yes
@@ -145,9 +145,9 @@ variant pcre description {Use pcre} {
 variant doc description {Install HTML and plaintext documentation} {
     distfiles-append        git-htmldocs-${version}${extract.suffix}
     checksums-append        git-htmldocs-${version}.tar.xz \
-                            rmd160  0873984c4fa6f683e02a7e863de14551c4de4061 \
-                            sha256  2d8f206f12bfd7d9edd74dea25bc457e4bc9ca6eb1a14e09104b549342fcc377 \
-                            size    1295708
+                            rmd160  32dce2790de766d1d2d950c22cfda6dd745fba95 \
+                            sha256  5be14d0835177f8ada0310c98b0248c7caaea0a302b7b58f1ccc0c0f7ece2466 \
+                            size    1303968
 
     patchfiles-append       patch-git-subtree.html.diff
 


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3 19D76
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
