### PR TITLE
gsmartcontrol: update to 1.1.3

### DIFF
--- a/sysutils/gsmartcontrol/Portfile
+++ b/sysutils/gsmartcontrol/Portfile
@@ -1,10 +1,9 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cxx11 1.1
 
 name                gsmartcontrol
-version             1.1.0
+version             1.1.3
 maintainers         {cal @neverpanic} openmaintainer
 
 categories          sysutils gnome
@@ -22,8 +21,14 @@ homepage            http://gsmartcontrol.sourceforge.net/
 master_sites        sourceforge:project/${name}/${version}/
 use_bzip2           yes
 
-checksums           rmd160  9187d326d94892fe5b45d17e329692c199aad874 \
-                    sha256  90c9ead852255f5e1a74a3ff6c265d1cbcba19ad2fc77059c60737c13a3cd2c8
+checksums           rmd160  13c4ca733e652cc40de14e3115b0dfa363e19ec5 \
+                    sha256  b64f62cffa4430a90b6d06cd52ebadd5bcf39d548df581e67dfb275a673b12a9 \
+                    size    677998
+
+compiler.cxx_standard 2011
+
+# uses a file called "version" during build that conflicts with c++ header
+compiler.blacklist-append {macports-clang-[8-9].0}
 
 depends_build       port:pkgconfig
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.6.8 10K549
Xcode 4.2 4C199 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
