### PR TITLE
automake: update to 1.16.2

### DIFF
--- a/devel/automake/Portfile
+++ b/devel/automake/Portfile
@@ -9,8 +9,8 @@ name                automake
 # Otherwise glibtoolize will provide an incompatible version of aclocal.m4
 # from the older version of automake.
 # cf: ${prefix}/share/libtool/aclocal.m4
-version             1.16.1
-revision            1
+version             1.16.2
+revision            0
 
 categories          devel
 platforms           darwin freebsd
@@ -32,8 +32,9 @@ depends_build       port:autoconf
 installs_libs       no
 
 master_sites        gnu
-checksums           rmd160  3bada190697e5683d5a0353e1a39bfc24e883061 \
-                    sha256  608a97523f97db32f1f5d5615c98ca69326ced2054c9f82e65bade7fc4c9dea8
+checksums           rmd160  b1ca498336cfe960086a470be42ed3e70d027a0c \
+                    sha256  b2f361094b410b4acbf4efba7337bdb786335ca09eb2518635a09fb7319ca5c1 \
+                    size    2311642
 
 patchfiles          test-glibtool.patch \
                     patch-issue57329.diff
@@ -47,6 +48,7 @@ configure.args      --disable-silent-rules
 test.run            yes
 test.env            CC=${configure.cc}
 test.target         check
+test.args           -j${build.jobs}
 
 post-destroot {
     set docdir ${destroot}${prefix}/share/doc/${name}


### PR DESCRIPTION
#### Description
I tested this via the `port test` command.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
macOS 10.13.6 17G11023
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
