### PR TITLE
google-cloud-sdk: update to 286.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             285.0.1
+version             286.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  4636de6233951cf05a2ad9d5d4a68a8f75ccba16 \
-                    sha256  84989e6b614bdecd22fc56b5e6a20186b49b58b88b72b11de323b12f19e08039 \
-                    size    48683108
+    checksums       rmd160  581f34bd11f172e67ad089cb566c60a2c43541d3 \
+                    sha256  0955a050d94ff54157e778f1719fa50b6ca67cef106dcf40dbf672c243da1857 \
+                    size    48779568
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  f12c460ef2f4b72e8258cf7d8c011634ff949444 \
-                    sha256  05c6cd008b7d946891a0e804c4f68ff3a1bfd1ddefb1992fb6f0c10dfe6327f0 \
-                    size    49726584
+    checksums       rmd160  d9690fb5e2ceb6502df01069a2c7bf8facf8a7b3 \
+                    sha256  14a7559466df485b1d42dcc95075efe2ed43f51a6c56a60630dd7209be72036d \
+                    size    49827668
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 286.0.0.

###### Tested on

macOS 10.15.4 19E266
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?