### PR TITLE
fribidi: update to 1.0.9

### DIFF
--- a/textproc/fribidi/Portfile
+++ b/textproc/fribidi/Portfile
@@ -3,7 +3,8 @@
 PortSystem      1.0
 
 PortGroup       github 1.0
-github.setup    fribidi fribidi 1.0.8 v
+github.setup    fribidi fribidi 1.0.9 v
+github.tarball_from releases
 revision        0
 
 categories      textproc
@@ -19,34 +20,15 @@ long_description \
 
 homepage        http://fribidi.org/
 
-checksums       rmd160  c8d45104684a3093deced1961654e6c31ef02149 \
-                sha256  9e30a05d4691622bd5dd3f34cdff8fa323b3b425e50d1968d5ed6da35f894e9f \
-                size    2087866
+checksums       rmd160  2bd97363d956db9bfe7f552ba13b390c3330a1e2 \
+                sha256  c5e47ea9026fb60da1944da9888b4e0a18854a0e2410bbfe7ad90a054d36e0c7 \
+                size    1141684
+use_xz          yes
 
-depends_build   port:pkgconfig
+depends_build   port:automake \
+                port:pkgconfig
 
-use_autoreconf  yes
-autoreconf.args -fvi
-
-patchfiles      gen.tab_Makefile.am.patch 
-
-post-patch {
-    # git.mk seems to trigger a ./config.status --recheck, which is unnecessary
-    # and additionally fails due to quoting
-    delete ${worksrcpath}/git.mk
-}
-
-# Parallel builds fail because gen.tab/packtab.o is built multiple times:
-# /usr/bin/clang -DHAVE_CONFIG_H -I. -I..  -I../lib -I../lib -I../charset -I/opt/local/include/glib-2.0 -I/opt/local/lib/glib-2.0/include -I/opt/local/include  -pipe -Os -arch x86_64 -Wall -ansi  -MT packtab.o -MD -MP -MF .deps/packtab.Tpo -c -o packtab.o packtab.c
-# /usr/bin/clang -DHAVE_CONFIG_H -I. -I..  -I../lib -I../lib -I../charset -I/opt/local/include/glib-2.0 -I/opt/local/lib/glib-2.0/include -I/opt/local/include  -pipe -Os -arch x86_64 -Wall -ansi  -MT packtab.o -MD -MP -MF .deps/packtab.Tpo -c -o packtab.o packtab.c
-# /usr/bin/clang -DHAVE_CONFIG_H -I. -I..  -I../lib -I../lib -I../charset -I/opt/local/include/glib-2.0 -I/opt/local/lib/glib-2.0/include -I/opt/local/include  -pipe -Os -arch x86_64 -Wall -ansi  -MT packtab.o -MD -MP -MF .deps/packtab.Tpo -c -o packtab.o packtab.c
-# [...]
-# mv -f .deps/packtab.Tpo .deps/packtab.Po
-# mv -f .deps/packtab.Tpo .deps/packtab.Po
-# mv -f .deps/packtab.Tpo .deps/packtab.Po
-# [...]
-# mv: rename .deps/packtab.Tpo to .deps/packtab.Po: No such file or directory
-use_parallel_build no
+patchfiles      gen.tab_Makefile.am.patch
 
 configure.env   CC_FOR_BUILD=${configure.cc} \
                 CPP_FOR_BUILD=${configure.cpp}
@@ -58,7 +40,7 @@ post-destroot {
     set docdir ${prefix}/share/doc/${name}
     xinstall -d ${destroot}${docdir}
     xinstall -m 0644 -W ${worksrcpath} AUTHORS COPYING ChangeLog.old \
-        HISTORY NEWS README THANKS TODO ${destroot}${docdir}
+        NEWS README THANKS TODO ${destroot}${docdir}
 }
 
 test.run        yes

--- a/textproc/fribidi/files/gen.tab_Makefile.am.patch
+++ b/textproc/fribidi/files/gen.tab_Makefile.am.patch
@@ -1,12 +1,12 @@
---- gen.tab/Makefile.am.orig	2018-07-23 07:09:31.000000000 +1000
-+++ gen.tab/Makefile.am	2019-02-09 10:54:31.000000000 +1100
+--- gen.tab/Makefile.am.orig	2020-03-24 21:49:33.864576589 -0400
++++ gen.tab/Makefile.am	2020-03-24 21:49:51.680898782 -0400
 @@ -23,9 +23,7 @@
  gen_brackets_tab_CPPFLAGS = $(AM_CPPFLAGS)
  gen_brackets_type_tab_CPPFLAGS = $(AM_CPPFLAGS)
- 
+
 -CFLAGS_FOR_BUILD += -DHAVE_CONFIG_H -I$(top_builddir) -I$(top_builddir)/lib -I$(top_srcdir)/lib
  CC = $(CC_FOR_BUILD)
 -CFLAGS = $(CFLAGS_FOR_BUILD)
- 
+ LDFLAGS = $(LDFLAGS_FOR_BUILD)
+
  CLEANFILES = $(EXTRA_PROGRAMS)
- DISTCLEANFILES =


### PR DESCRIPTION
#### Description
Updated the Portfile to take advantage of changes that have been made upstream. Also tested with "port test" successfully.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G2022
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
