### PR TITLE
k9s: update to 0.18.1

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.17.7 v
+go.setup            github.com/derailed/k9s 0.18.1 v
 
 categories          sysutils
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -19,9 +19,9 @@ platforms           darwin
 supported_archs     x86_64
 license             Apache-2
 
-checksums           rmd160  d028a6a3b1d3473356fce094faa77952dca2ceaf \
-                    sha256  16ae83a33ba3c6476db4eca3218df78c9b1976fb83cc2d1ed8b520ad4bad07f8 \
-                    size    15193358
+checksums           rmd160  acbdcfe7742f6ddc75b76a352a8cb7da5593d891 \
+                    sha256  4009c1313495a17ffbfde3f2120a350320d94e01242b6c4187f915dd519a7049 \
+                    size    16075292
 
 # Reproduce the "build" target from the upstream Makefile
 set go_ldflags      "-w -X ${go.package}/cmd.version=${version} \


### PR DESCRIPTION
#### Description

Update to k9s 0.18.1.

###### Tested on

macOS 10.15.4 19E266
Xcode 11.4 11E146

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?