### PR TITLE
 py-oct2py: add Python 3.8 subport; enable testing; set no arch

### DIFF
--- a/python/py-oct2py/Portfile
+++ b/python/py-oct2py/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 
 name                py-oct2py
 
-python.versions     27 36 37
+python.versions     27 36 37 38
 python.default_version 27
 
 github.setup        blink1073 oct2py 5.0.4 v

--- a/python/py-oct2py/Portfile
+++ b/python/py-oct2py/Portfile
@@ -28,6 +28,15 @@ if {${name} ne ${subport}} {
         port:octave \
         port:py${python.version}-metakernel \
         port:py${python.version}-octave_kernel
+
+    test.run            yes
+    depends_test-append \
+        port:py${python.version}-pytest \
+        port:octave-signal
+    # from Makefile
+    test.cmd            py.test-[join [split ${python.version} {}] {.}]
+    test.target
+    test.env            PYTHONPATH=${worksrcpath}/build/lib
 }
 
 foreach {old new} {34 36 35 36} {

--- a/python/py-oct2py/Portfile
+++ b/python/py-oct2py/Portfile
@@ -21,6 +21,8 @@ description         Python to GNU Octave bridge --> run m-files from Python.
 long_description    ${description}
 platforms           darwin
 
+supported_archs     noarch
+
 if {${name} ne ${subport}} {
     depends_lib-append \
         port:octave \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3
Xcode 11.4 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
