### PR TITLE
cargo: remove i686 support

### DIFF
--- a/devel/cargo/Portfile
+++ b/devel/cargo/Portfile
@@ -16,7 +16,7 @@ PortGroup           cargo 1.0
 revision            0
 categories          devel
 platforms           darwin
-supported_archs     i386 x86_64
+supported_archs     x86_64
 license             {MIT Apache-2}
 maintainers         nomaintainer
 
@@ -105,35 +105,14 @@ if {${subport} ne "${name}-bootstrap"} {
     master_sites-append https://static.rust-lang.org/dist/:stage0
 
     checksums-append \
-        ${name}-${version}-i686-apple-darwin${extract.suffix} \
-                    rmd160  545f39de16b7e7ae987dee80dfeb48d0588917fa \
-                    sha256  62f5219792a27de6c5d141c59f05dee252424b7ce9671cefbb1227cab15da91e \
-                    size    5241962
-
-    checksums-append \
         ${name}-${version}-x86_64-apple-darwin${extract.suffix} \
                     rmd160  be99fef6ddeb53590b0f3976ff2d60d6c01b0923 \
                     sha256  92d4c9fb4747dce158cdfb773651aea8eac894277f3a2de5aa2c3b9d92439d8e \
                     size    5375241
 
-    if {![variant_isset universal]} {
-        set rust_platform [cargo.rust_platform ${build_arch}]
-        distfiles  ${name}-${version}-${rust_platform}${extract.suffix}:stage0
-        worksrcdir ${name}-${version}-${rust_platform}
-    } else {
-        distfiles
-        foreach arch ${universal_archs} {
-            set rust_platform [cargo.rust_platform ${arch}]
-            distfiles-append  ${name}-${version}-${rust_platform}${extract.suffix}:stage0
-        }
-        post-extract {
-            xinstall -d -m 0755 ${workpath}/${name}-${version}
-            foreach arch ${universal_archs} {
-                set rust_platform [cargo.rust_platform ${arch}]
-                move ${workpath}/${name}-${version}-${rust_platform} ${workpath}/${name}-${version}-${arch}
-            }
-        }
-    }
+    set rust_platform [cargo.rust_platform ${build_arch}]
+    distfiles  ${name}-${version}-${rust_platform}${extract.suffix}:stage0
+    worksrcdir ${name}-${version}-${rust_platform}
 
     build {}
 


### PR DESCRIPTION
  Darwin x86 is considered a Tier 3 platform as per Rust official docs:
  https://forge.rust-lang.org/release/platform-support.html

> Tier 3 platforms are those which the Rust codebase has support for, but which are not built or tested automatically, and may not work. Official builds are not available.

Addresses https://trac.macports.org/ticket/60237

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3 19D76
Xcode 11.4 11E146

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
