### PR TITLE
softhsm: update to 2.6.0 and make compatible with latest compiler

### DIFF
--- a/security/softhsm/Portfile
+++ b/security/softhsm/Portfile
@@ -23,6 +23,8 @@ checksums           rmd160  5149b87c0428702b55de77c0e0cb3ff4a40fee0b \
                     sha256  19c2500f22c547b69d314fda55a91c40b0d2a9c269496a5da5d32ae1b835d6d1 \
                     size 1061748
 
+patchfiles          patch-const-535.diff
+
 depends_build       port:libtool
 depends_lib         path:lib/libssl.dylib:openssl \
                     port:sqlite3

--- a/security/softhsm/Portfile
+++ b/security/softhsm/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 
 name                softhsm
-version             2.4.0
-revision            1
+version             2.6.0
+revision            0
 categories          security
 platforms           darwin
 license             BSD
@@ -19,9 +19,9 @@ long_description    SoftHSM is an implementation of a cryptographic store access
 homepage            https://www.opendnssec.org/softhsm
 master_sites        http://dist.opendnssec.org/source/
 
-checksums           rmd160  de04f7902a2885526d6cbc04cca6e2c9c961f288 \
-                    sha256  26aac12bdeaacd15722dc0a24a5a1981a3b711e61d10ac687a23ff0b7075da07 \
-                    size 1042566
+checksums           rmd160  5149b87c0428702b55de77c0e0cb3ff4a40fee0b \
+                    sha256  19c2500f22c547b69d314fda55a91c40b0d2a9c269496a5da5d32ae1b835d6d1 \
+                    size 1061748
 
 depends_build       port:libtool
 depends_lib         path:lib/libssl.dylib:openssl \

--- a/security/softhsm/files/patch-const-535.diff
+++ b/security/softhsm/files/patch-const-535.diff
@@ -1,0 +1,22 @@
+--- src/lib/crypto/PrivateKey.h.orig	2020-03-26 12:58:40.000000000 +0000
++++ src/lib/crypto/PrivateKey.h	2020-03-26 13:06:15.000000000 +0000
+@@ -68,7 +68,7 @@
+ 	virtual bool PKCS8Decode(const ByteString& ber) = 0;
+ 
+ 	// Assignment
+-	constexpr PrivateKey& operator=(const PrivateKey&) { return *this; }
++	constexpr const PrivateKey& operator=(const PrivateKey&) const { return *this; }
+ };
+ 
+ #endif // !_SOFTHSM_V2_PRIVATEKEY_H
+--- src/lib/crypto/PublicKey.h.orig	2020-03-26 12:58:48.000000000 +0000
++++ src/lib/crypto/PublicKey.h	2020-03-26 13:06:15.000000000 +0000
+@@ -61,7 +61,7 @@
+ 	virtual ByteString serialise() const = 0;
+ 
+ 	// Assignment
+-	constexpr PublicKey& operator=(const PublicKey&) { return *this; }
++	constexpr const PublicKey& operator=(const PublicKey&) const { return *this; }
+ };
+ 
+ #endif // !_SOFTHSM_V2_PUBLICKEY_H


### PR DESCRIPTION
#### Description

Two changes:

* update to latest upstream release
* patch that to compile under latest macOS/Xcode, see https://trac.macports.org/ticket/60235

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.4 19E266
Xcode 11.4 11E146 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
    * (two separate changes for same port, related but not identical)
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
    * `Error: Failed to test softhsm: softhsm has no tests turned on. see 'test.run' in portfile(7)`
    * I have run the package's internal checks, though: `make check`
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
