### PR TITLE
cloog-devel: Remove obsolete port

### DIFF
--- a/devel/cloog/Portfile
+++ b/devel/cloog/Portfile
@@ -34,7 +34,8 @@ depends_lib         port:gmp path:lib/pkgconfig/isl.pc:isl
 
 master_sites        http://www.bastoul.net/cloog/pages/download/count.php3?url=./
 checksums           rmd160  12d7a27442fc95f01f7c6445b5559579f8f614cc \
-                    sha256  325adf3710ce2229b7eeb9e84d3b539556d093ae860027185e7af8a8b00a750e
+                    sha256  325adf3710ce2229b7eeb9e84d3b539556d093ae860027185e7af8a8b00a750e \
+                    size    4796456
 
 # prevent -L/lib from being added to LDFLAGS
 # see https://groups.google.com/group/isl-development/t/37ad876557e50f2c

--- a/devel/cloog/Portfile
+++ b/devel/cloog/Portfile
@@ -1,9 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-if {${subport} eq "cloog"} {
 PortGroup           muniversal 1.0
-}
 
 name                cloog
 epoch               1
@@ -51,14 +49,12 @@ configure.args-append   --disable-silent-rules \
                         --with-isl=system \
                         --with-osl=no
 
-subport cloog {
 variant osl description {Build with OpenScop support (causes tests to fail)} {
     pre-test {
         ui_warn "osl variant causes tests to fail"
     }
     depends_lib-append      port:openscop
     configure.args-replace  --with-osl=no --with-osl=system
-}
 }
 
 test.run            yes
@@ -67,13 +63,3 @@ test.target         check
 livecheck.type      regex
 livecheck.url       [lindex ${master_sites} 0]
 livecheck.regex     ${name}-(\[0-9.\]+)${extract.suffix}
-
-subport cloog-devel {
-    replaced_by         cloog
-    PortGroup           obsolete 1.0
-    version             0.18.3
-    revision            1
-    maintainers         {larryv @larryv}
-    long_description    "This port has been replaced by ${replaced_by}."
-    homepage            http://www.cloog.org
-}


### PR DESCRIPTION
Removes the obsolete cloog-devel subport from the cloog portfile.

Has been obsolete for years (since 81ac64c95cc0dbd7c687c3089aadeb62657d5605).
