### PR TITLE
sysutils/ntp: add PortGroup legacysupport

### DIFF
--- a/sysutils/ntp/Portfile
+++ b/sysutils/ntp/Portfile
@@ -8,6 +8,7 @@ maintainers	{geeklair.net:dluke @danielluke}
 description	NTP is a protocol designed to synchronize the clocks of computers over a network.
 #license	NTP (http://www.eecis.udel.edu/~mills/ntp/html/copyright.html), see http://opensource.org/licenses/NTP
 license		Permissive
+PortGroup	legacysupport 1.0
 
 long_description	NTP is an implementation of RFC-5905. It is widely \
 			used to synchronize a computer to Internet time \


### PR DESCRIPTION

#### Description

Fixes build on Snow Leopard
Closes: https://trac.macports.org/ticket/60240

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.6.8 10K549
Xcode 3.2.1 DevToolsSupport-1591.0 10M2020 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
