### PR TITLE
cmake: Use gitlab PortGroup

### DIFF
--- a/devel/cmake/Portfile
+++ b/devel/cmake/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           muniversal 1.0
 PortGroup           xcodeversion 1.0
+PortGroup           gitlab 1.0
 PortGroup           legacysupport 1.1
 
 # Cmake is a depedency of clang
@@ -22,6 +23,7 @@ set base_long_description \
     used in conjunction with the native build environment."
 homepage            https://cmake.org
 platforms           darwin freebsd
+gitlab.instance     https://gitlab.kitware.com
 
 # require C++11
 compiler.cxx_standard 2011
@@ -48,13 +50,14 @@ if {${subport} eq ${name}} {
 
     # release
 
-    version   ${branch}.0
-    checksums rmd160 9373c0524092bec9db3bd8e9259c7cb545c5a0d6 \
-              sha256 b74c05b55115eacc4fa2b77a814981dbda05cdc95a53e279fe16b7b272f00847 \
-              size   9466484
-    revision  0
+    gitlab.setup    cmake cmake ${branch}.0 v
+    gitlab.livecheck.regex  {([0-9.]+)}
 
-    master_sites    ${homepage}/files/v${branch}/
+    checksums rmd160 bc8af0a1638c1d21333f162e133c22203e44dd35 \
+              sha256 c8ee2d53f4aad3987d8a3cb138d12c772c1ad6b65b2b69c74421b21ea8d6fb79 \
+              size   7411593
+    revision  1
+
     conflicts       cmake-devel
 
     long_description ${base_long_description} \
@@ -69,26 +72,16 @@ if {${subport} eq ${name}} {
         patch-fix-system-prefix-path.release.diff \
         patch-cmake-leopard-tiger.release.diff \
         patch-fix-clock_gettime-test.release.diff
-
-    livecheck.type  regex
-    livecheck.regex ${name}-(\[0-9.\]+)${extract.suffix}
-    livecheck.url   https://cmake.org/files/LatestRelease/
-
 } else {
 
     # devel
 
-    set commit 8638c49f2a0b87c131be8f4d3147a2617938e30a
-    version   20200323-[string range ${commit} 0 7]
-    checksums rmd160 3dcc07bbc4166bdfc5ed3ed0c63738c62c22cdf6 \
-              sha256 9827cc7ea13654e7f2819e76f239018edfdb6abbdb2b6580a300445329d3c70d \
-              size   6732894
-    revision  0
-
-    use_bzip2       yes
-    master_sites    https://gitlab.kitware.com/cmake/cmake/repository/archive${extract.suffix}?ref=${commit}&
-    distname        ${name}-${commit}
-    worksrcdir      ${name}-${commit}-${commit}
+    gitlab.setup     cmake cmake 8638c49f
+    version   20200323-${gitlab.version}
+    checksums rmd160 e2b2fb0728376283ef35dd15a6f01de8540272e1 \
+              sha256 849ed895f1a8d2efd2ff5bd66ba414e28ab9aa43942a701e5a95eae7fdc32b23 \
+              size   6692910
+    revision  1
 
     conflicts       cmake
     long_description ${base_long_description} \
@@ -103,12 +96,6 @@ if {${subport} eq ${name}} {
         patch-fix-system-prefix-path.devel.diff \
         patch-cmake-leopard-tiger.devel.diff \
         patch-fix-clock_gettime-test.devel.diff
-
-    livecheck.type  regex
-    livecheck.regex data-clipboard-text=\"(\[0-9a-g\]+)\"
-    livecheck.version ${commit}
-    livecheck.url   https://gitlab.kitware.com/cmake/cmake/tree/master
-
 }
 
 depends_lib-append  port:curl \


### PR DESCRIPTION
Move to using the gitlab PortGroup for cmake.

Take it or leave it. ;)