### PR TITLE
mm-common: ensure MacPorts Python 3.8 is used

### DIFF
--- a/gnome/mm-common/Portfile
+++ b/gnome/mm-common/Portfile
@@ -5,7 +5,7 @@ PortGroup           meson 1.0
 
 name                mm-common
 version             1.0.0
-revision            1
+revision            2
 license             GPL-2
 set branch          [join [lrange [split ${version} .] 0 1] .]
 
@@ -38,12 +38,18 @@ depends_build-append \
                     port:curl \
                     port:wget
 
-depends_lib-append  port:python37
+depends_lib-append  port:python38
 
 patchfiles          patch-use-our-python3.diff
 
 post-patch {
-    reinplace "s|@@PYTHON3_BIN@@|${prefix}/bin/python3.7|" ${worksrcpath}/meson.build
+    reinplace "s|@@PYTHON3_BIN@@|${prefix}/bin/python3.8|" \
+                    ${worksrcpath}/meson.build \
+                    ${worksrcpath}/util/mm-common-get.in \
+                    ${worksrcpath}/util/build_scripts/dist-build-scripts.py \
+                    ${worksrcpath}/util/build_scripts/doc-reference.py \
+                    ${worksrcpath}/util/build_scripts/dist-changelog.py \
+                    ${worksrcpath}/util/build_scripts/generate-binding.py
 }
 
 livecheck.type      gnome

--- a/gnome/mm-common/files/patch-use-our-python3.diff
+++ b/gnome/mm-common/files/patch-use-our-python3.diff
@@ -9,3 +9,43 @@
  python_version = python3.language_version()
  python_version_req = '>= 3.5'
  if not python_version.version_compare(python_version_req)
+--- util/mm-common-get.in.orig	2019-10-29 10:37:45.000000000 -0700
++++ util/mm-common-get.in	2020-03-27 14:49:11.000000000 -0700
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!@@PYTHON3_BIN@@
+ 
+ # Copyright (C) 2019 The gtkmm Development Team
+ #
+--- util/build_scripts/dist-build-scripts.py.orig	2019-10-29 10:37:45.000000000 -0700
++++ util/build_scripts/dist-build-scripts.py	2020-03-27 14:50:31.000000000 -0700
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!@@PYTHON3_BIN@@
+ 
+ # External command, intended to be called with meson.add_dist_script() in meson.build
+ 
+--- util/build_scripts/doc-reference.py.orig	2019-10-29 10:37:45.000000000 -0700
++++ util/build_scripts/doc-reference.py	2020-03-27 14:51:40.000000000 -0700
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!@@PYTHON3_BIN@@
+ 
+ # External command, intended to be called with custom_target(),
+ # meson.add_install_script() or meson.add_dist_script() in meson.build.
+--- util/build_scripts/dist-changelog.py.orig	2019-10-29 10:37:45.000000000 -0700
++++ util/build_scripts/dist-changelog.py	2020-03-27 14:52:47.000000000 -0700
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!@@PYTHON3_BIN@@
+ 
+ # External command, intended to be called with meson.add_dist_script() in meson.build
+ 
+--- util/build_scripts/generate-binding.py.orig	2019-10-29 10:37:45.000000000 -0700
++++ util/build_scripts/generate-binding.py	2020-03-27 14:53:35.000000000 -0700
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!@@PYTHON3_BIN@@
+ 
+ # External command, intended to be called with run_command(), custom_target(),
+ # meson.add_install_script() and meson.add_dist_script().


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3
Xcode 11.4 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
