### PR TITLE
prometheus: update to 2.17.1

### DIFF
--- a/net/prometheus/Portfile
+++ b/net/prometheus/Portfile
@@ -1,7 +1,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        prometheus prometheus 2.17.0 v
+github.setup        prometheus prometheus 2.17.1 v
 github.tarball_from archive
 
 description         The Prometheus monitoring system and time series database
@@ -42,13 +42,17 @@ set prom_share_dir  ${prefix}/share/${name}
 set prom_log_dir    ${prefix}/var/log/${name}
 set prom_log_file   ${prom_log_dir}/${name}.log
 
-checksums   rmd160  f631fa9b637a30186902d838fe0d3c5e9e2f14bd \
-            sha256  b5e508f1c747aaf50dd90a48e5e2a3117fec2e9702d0b1c7f97408b87a073009 \
-            size    12820441
+checksums   rmd160  f18d4e10b2f34ee2721e7cdee5c83f46ad52511e \
+            sha256  d0b53411ea0295c608634ca7ef1d43fa0f5559e7ad50705bf4d64d052e33ddaf \
+            size    12822668
 
 add_users           ${prom_user} \
                     group=${prom_user} \
                     realname=Prometheus
+
+pre-build {
+  system "env"
+}
 
 post-extract {
     # Link promu into the workpath


### PR DESCRIPTION
Adding `env` command to help troubleshoot an issue with building prometheus in MacPorts buildbot[1]

1: https://trac.macports.org/ticket/58709

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3 19D76
Xcode 11.4 11E146

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
