### PR TITLE
dar: don't opportunistically try to build Python bindings

### DIFF
--- a/archivers/dar/Portfile
+++ b/archivers/dar/Portfile
@@ -42,3 +42,6 @@ compiler.cxx_standard 2011
 compiler.blacklist-append {clang < 800}
 
 universal_variant   no
+
+# don't opportunistically try to build Python bindings
+configure.args      --disable-python-binding


### PR DESCRIPTION
#### Description

When building dar I got

> :info:build Making all in python
> :info:build make[3]: Entering directory `/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_release_tarballs_ports_archivers_dar/dar/work/dar-2.6.9/src/python'
> :info:build /usr/bin/clang++ -c -fPIC -DLIBDAR_MODE=64 -I../libdar -DDAR_LOCALEDIR=\"/opt/local/share/locale\" -DDAR_SYS_DIR=\"\"     -std=c++11 -I/opt/local/Library/Frameworks/Python.framework/Versions/3.8/include/python3.8 -I/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_release_tarballs_ports_archivers_dar/dar/work/.home/Library/Python/3.8/include/python3.8 pybind11_libdar.cpp -o pybind11_libdar.o
> :info:build /usr/bin/clang++ -shared  -L/opt/local/lib -lcurl  -std=c++11 ../libdar/.libs/libdar64.so pybind11_libdar.o  -o libdar.cpython-38-darwin.so
> :info:build clang: error: no such file or directory: '../libdar/.libs/libdar64.so'

Closes: https://trac.macports.org/ticket/59966

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
macOS 10.14.6 18G4032
Xcode 10.3 10G8 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
