### PR TITLE
qBittorrent: Use correct case for qbittorrent.app

### DIFF
--- a/net/qBittorrent/Portfile
+++ b/net/qBittorrent/Portfile
@@ -6,7 +6,7 @@ PortGroup       qt5 1.0
 PortGroup       compiler_blacklist_versions 1.0
 
 github.setup    qbittorrent qBittorrent 4.2.2 release-
-revision        0
+revision        1
 categories      net
 maintainers     {@i0ntempest me.com:szf1234} openmaintainer
 platforms       darwin
@@ -43,7 +43,7 @@ configure.args-append \
 
 destroot {
         if {[variant_isset gui]} {
-            set appname "qBittorrent.app"
+            set appname "qbittorrent.app"
         } else {
             set appname "qbittorrent-nox.app"
         }


### PR DESCRIPTION
[qBittorrent fails to destroot on case-sensitive filesystems](https://build.macports.org/builders/ports-10.13_x86_64-builder/builds/80830/steps/install-port/logs/stdio):

```
DEBUG: Executing org.macports.destroot (qBittorrent)
--->  Patching qt.conf: s|Plugins = PlugIns|Plugins = /opt/local/libexec/qt5/plugins|g
DEBUG: Executing reinplace: /usr/bin/sed {s|Plugins = PlugIns|Plugins = /opt/local/libexec/qt5/plugins|g} </opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_net_qBittorrent/qBittorrent/work/qBittorrent-4.2.2/src/qBittorrent.app/Contents/Resources/qt.conf >@file11
DEBUG: couldn't read file "/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_net_qBittorrent/qBittorrent/work/qBittorrent-4.2.2/src/qBittorrent.app/Contents/Resources/qt.conf": no such file or directory
```

This is because the build has created an app called qbittorrent.app but the portfile is referring to it as qBittorrent.app. macOS file systems can be case-sensitive, and are on our buildbot workers.

This PR provides one possible fix for this issue.
