### PR TITLE
Update sysutils/blueutil to v2.6.0

### DIFF
--- a/sysutils/blueutil/Portfile
+++ b/sysutils/blueutil/Portfile
@@ -3,7 +3,7 @@
 PortSystem                  1.0
 PortGroup                   github 1.0
 
-github.setup                toy blueutil 2.5.1 v
+github.setup                toy blueutil 2.6.0 v
 categories                  sysutils
 platforms                   darwin
 maintainers                 {dons.net.au:darius @DanielO}
@@ -16,10 +16,10 @@ long_description            Command line interface for Bluetooth on OSX, \
                             devices, pair new devices, connect and disconnect \
                             devices, and check if a device is connected.
 
-checksums                   sha1    6507cd58bbc22632350dd903ed453a024ead46f9 \
-                            rmd160  d661423901f4b5b922be87658a55a94c542c389b \
-                            sha256  b207ea049a748fa949a9532ae2691e9e800ea7ac6f29f3cbffa7efb2bbd27055 \
-                            size    10831
+checksums                   sha1    c06665f0564fa686cb60037ad9fe21b4d3033128 \
+                            rmd160  2c79a34420a5854d23a5cdaa3aa3697769ca78a7 \
+                            sha256  45a418781eb71174965a47b2aa7f606fcbff5fbeea71d20e6eff88ee1f4e6721 \
+                            size    16760
 
 if { ${os.platform} eq "darwin" && ${os.major} <= 12} {
     pre-fetch {
@@ -38,7 +38,7 @@ use_configure               no
 
 post-destroot {
     xinstall -d -m 0755 ${destroot}${prefix}/share/${name}
-    xinstall -m 0644 -W ${worksrcpath} README.md LICENSE.txt \
+    xinstall -m 0644 -W ${worksrcpath} README.md LICENSE.txt CHANGELOG.md \
         ${destroot}${prefix}/share/${name}/
 }
 

--- a/sysutils/blueutil/files/blueutil-Makefile.diff
+++ b/sysutils/blueutil/files/blueutil-Makefile.diff
@@ -1,7 +1,7 @@
 --- Makefile.orig	2019-02-11 22:54:03.000000000 +1030
 +++ Makefile	2019-02-11 22:55:56.000000000 +1030
-@@ -1,11 +1,12 @@
- CFLAGS = -Wall -Wextra -Werror -framework Foundation -framework IOBluetooth
+@@ -1,7 +1,7 @@
+ CFLAGS = -Wall -Wextra -Werror -mmacosx-version-min=10.9 -framework Foundation -framework IOBluetooth
  
  DESTDIR =
 -prefix = /usr/local
@@ -9,8 +9,3 @@
  bindir = $(prefix)/bin
  INSTALL = install
  INSTALL_PROGRAM = $(INSTALL) -m 755
- 
-+all: blueutil
- build: blueutil
- 
- test: build


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G3020
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

As for [previous update](https://github.com/macports/macports-ports/pull/6035#issuecomment-568270783), tests fail when ran using `sudo port test` probably caused by different user.
