### PR TITLE
wireshark3: add +python38 variant and make it the default

### DIFF
--- a/net/wireshark3/Portfile
+++ b/net/wireshark3/Portfile
@@ -139,6 +139,10 @@ variant python37 description {Use python37 during build} {
     depends_build-append    port:python37
 }
 
+variant python38 description {Use python38 during build} {
+    depends_build-append    port:python38
+}
+
 default_variants +zlib +libsmi +gnutls +geoip +kerberos5 +chmodbpf
 
 if {![variant_isset qt5] && ![variant_isset no_gui]} {
@@ -149,11 +153,11 @@ if {![variant_isset adns] && ![variant_isset cares]} {
     default_variants-append +cares
 }
 
-## if no python3* variant is specified, add +python37
+## if no python3* variant is specified, add +python38
 ## XYZZY: it would be better to detect which python3* is already installed and use that...
 if {![variant_isset python35] && ![variant_isset python36] && \
-    ![variant_isset python37]} {
-    default_variants-append +python37
+    ![variant_isset python37] && ![variant_isset python38]} {
+    default_variants-append +python38
 }
 
 post-destroot {


### PR DESCRIPTION
#### Description

Update wireshark3 to enable +python38 variant and use it by default if no Python variant is specified.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G3020
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
