### PR TITLE
bazel: switch to Python 3.8.

### DIFF
--- a/devel/bazel/Portfile
+++ b/devel/bazel/Portfile
@@ -215,7 +215,7 @@ set bazel_min_xcode   9.0
 use_xcode             yes
 
 # python versions. Build needs both 'python2' and 'python3'
-set py3ver 3.7
+set py3ver 3.8
 set py2ver 2.7
 
 depends_lib-append    port:cctools


### PR DESCRIPTION
#### Description

Update to using Python 3.8 instead of Python 3.7.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G12034
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

I built py38-tensorflow1 with bazel25 using Python 3.8.
