### PR TITLE
wireshark3: Make the python variants conflict

### DIFF
--- a/net/wireshark3/Portfile
+++ b/net/wireshark3/Portfile
@@ -127,15 +127,15 @@ variant chmodbpf description {Enable Wireshark to acces macOS capture devices} {
     depends_run             port:wireshark-chmodbpf
 }
 
-variant python35 description {Use python35 during build} {
+variant python35 conflicts python36 python37 description {Use python35 during build} {
     depends_build-append    port:python35
 }
 
-variant python36 description {Use python36 during build} {
+variant python36 conflicts python35 python37 description {Use python36 during build} {
     depends_build-append    port:python36
 }
 
-variant python37 description {Use python37 during build} {
+variant python37 conflicts python35 python36 description {Use python37 during build} {
     depends_build-append    port:python37
 }
 


### PR DESCRIPTION
Make the python variants conflict.
