### PR TITLE
py-xdis: update to 4.2.4

### DIFF
--- a/python/py-xdis/Portfile
+++ b/python/py-xdis/Portfile
@@ -4,8 +4,9 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-xdis
-version             4.2.2
+version             4.2.4
 platforms           darwin
+supported_archs     noarch
 license             GPL-2
 maintainers         {khindenburg @kurthindenburg} openmaintainer
 
@@ -20,25 +21,24 @@ long_description \
     (NYU) called ACOR that estimates the autocorrelation time \
     of time series data very quickly.
 
-homepage            https://pypi.python.org/pypi/${python.rootname}/
-master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
-distname            ${python.rootname}-${version}
+homepage            https://github.com/rocky/python-xdis
 
-checksums           rmd160  e3b0ef97ced1fc90daffdd947b312476f006c22d \
-                    sha256  096b9f70d1ee77181cd6153db630f6f390d59dc588540b0b856c4220d61d91f2 \
-                    size    205819
+checksums           rmd160  637d96825749f31ecf2f624c51e37308f2612ab7 \
+                    sha256  f1a615442b46075152fe3d5f8c5c0ddb1496a5a02405d9618dfe17506a3001eb \
+                    size    206721
 
 python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
-    depends_build-append    port:py${python.version}-setuptools \
-                            port:py${python.version}-pytest-runner
+    depends_lib-append  port:py${python.version}-click \
+                        port:py${python.version}-setuptools \
+                        port:py${python.version}-six
 
-    depends_lib-append  port:py${python.version}-click
+    depends_test-append port:py${python.version}-pytest
 
-    depends_test-append port:py${python.version}-py \
-                        port:py${python.version}-pytest
     test.run            yes
+    test.cmd            py.test-${python.branch}
+    test.target
     test.env            PYTHONPATH=${worksrcpath}/build/lib
 
     livecheck.type  none


### PR DESCRIPTION
#### Description
This PR update `py-xdis` to its latest version, with a few additional fixes:
- add noarch
- update homepage
- update dependencies and fix type for `py-setuptools`; also needed at runtime due to console_scipts

the newer version is required for an update of `py-uncompyle6` I've been working on.
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
macOS 10.14.6 18G4032
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
