### PR TITLE
ncurses: add support for modules infrastructure

### DIFF
--- a/devel/ncurses/Portfile
+++ b/devel/ncurses/Portfile
@@ -3,6 +3,7 @@ PortGroup  clang_dependency 1.0
 
 name            ncurses
 version         6.2
+revision        1
 categories      devel
 platforms       darwin freebsd
 license         MIT
@@ -79,6 +80,9 @@ post-destroot {
     ln -s ncurses6-config ${destroot}${prefix}/bin/ncursesw6-config
     reinplace "s|-Wl,-syslibroot,${configure.sdkroot}||" ${destroot}${prefix}/bin/ncurses6-config
     reinplace "s|${archflags}||" ${destroot}${prefix}/bin/ncurses6-config
+
+    # see https://trac.macports.org/ticket/59992
+    xinstall -m 0644 ${filespath}/module.modulemap ${destroot}${prefix}/include
 }
 
 livecheck.regex ${name}-(\[\\d.-\]+)${extract.suffix}

--- a/devel/ncurses/files/module.modulemap
+++ b/devel/ncurses/files/module.modulemap
@@ -1,0 +1,3 @@
+module unctrl {
+ textual header "unctrl.h"
+}


### PR DESCRIPTION
See https://trac.macports.org/ticket/59992

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3
Xcode 11.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
