### PR TITLE
librsvg: add missing ldflag

### DIFF
--- a/graphics/librsvg/Portfile
+++ b/graphics/librsvg/Portfile
@@ -93,6 +93,7 @@ gobject_introspection yes
 configure.args      --enable-vala=yes \
                     --disable-silent-rules \
                     --disable-Bsymbolic
+configure.ldflags-append    -lobjc
 
 test.run            yes
 test.dir            ${worksrcpath}/tests


### PR DESCRIPTION
Fixes https://trac.macports.org/ticket/60220

#### Description

The flag fixes the build on 10.13.
I think that it shouldn't hurt in newer systems, so I applied the change unconditionally, but I cannot test it.
Let's see wait for the Azure builds: if they fail I can make it conditional on the OS version.

`sudo port test` fails on 10.13 with a message about undefined symbols, similar to https://trac.macports.org/ticket/60220 but for different symbols.
The library seems to work so I think it shouldn't block this pull request.
I'll open a ticket to track the problem.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.13.6 17G11023
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
