### PR TITLE
gloomhaven-helper: New port.

### DIFF
--- a/games/gloomhaven-helper/Portfile
+++ b/games/gloomhaven-helper/Portfile
@@ -1,0 +1,47 @@
+PortSystem      1.0
+PortGroup       java 1.0
+
+java.version    1.8
+java.fallback   openjdk8
+
+name            gloomhaven-helper
+version         8.3.1
+categories      games
+platforms       macosx
+license         Restrictive
+maintainers     eborisch
+
+description     Helper application for Gloomhaven board game.
+long_description Gloomhaven Helper is the officially licensed companion \
+                application for playing the Gloomhaven board game and \
+                Forgotten Circles expansion, without losing the board game \
+                feel. It tracks initiative, monsters, and characters so you \
+                can focus on playing the game rather than bookkeeping. \
+                Playing the game becomes faster, as does setup and tear \
+                down. \
+
+homepage        http://esotericsoftware.com/gloomhaven-helper#Desktop
+master_sites    http://esotericsoftware.com/files/ghh/
+distname        GloomhavenHelper-${version}
+use_zip         true
+
+checksums \
+    rmd160  fa1660dd363ba19e2403adacaa0269e4765d1602 \
+    sha256  c937fa37bdbe72e65c780aefb9c3de741a16140f26b701c2d8a192bd8196dcce \
+    size    32712586
+
+use_configure   no
+
+build {
+    reinplace "s^java^cd ${prefix}/libexec/${name} ; ${java.home}/bin/java^g" run.sh
+}
+
+destroot {
+    xinstall -d ${destroot}${prefix}/bin
+    xinstall -d ${destroot}${prefix}/libexec/${name}
+    xinstall ${worksrcpath}/ghh.jar ${destroot}${prefix}/libexec/${name}/
+    xinstall ${worksrcpath}/run.sh ${destroot}${prefix}/bin/${name}
+}
+
+livecheck.type  regex
+livecheck.regex {Gloomhavenhelper-([\d.]+)\.zip}


### PR DESCRIPTION
New port: Gloomhaven Helper is the officially licensed companion application for playing the Gloomhaven board game and Forgotten Circles expansion, without losing the board game feel. It tracks initiative, monsters, and characters so you can focus on playing the game rather than bookkeeping. Playing the game becomes faster, as does setup and tear down.

Never used the java portgroup before, but it appears to be working...