### PR TITLE
lilypond: Synchronize Portfile with 'lilypond-devel' Portfile.

### DIFF
--- a/textproc/lilypond/Portfile
+++ b/textproc/lilypond/Portfile
@@ -1,10 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           cxx11 1.1
 
 name                lilypond
 version             2.20.0
-revision            0
+revision            1
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          textproc
 maintainers         {snc @nerdling} openmaintainer
@@ -26,7 +27,8 @@ checksums           rmd160  030ebe2074ad647269c7f8aca40eaee671ddb77f \
 platforms           darwin
 universal_variant   no
 
-depends_build       port:autoconf \
+depends_build-append \
+                    port:autoconf \
                     port:bison \
                     port:dblatex \
                     port:flex \
@@ -50,7 +52,7 @@ depends_build       port:autoconf \
                     port:texlive-xetex \
                     port:urw-core35-fonts
 
-depends_lib         port:extractpdfmark \
+depends_lib-append  port:extractpdfmark \
                     port:ghostscript \
                     port:guile18 \
                     port:python38
@@ -59,9 +61,80 @@ build.type          gnu
 configure.cmd       autoconf -f && ./configure
 configure.python    ${prefix}/bin/python3.8
 
+set lilypond.texgyredir \
+    "${prefix}/share/texmf-texlive/fonts/opentype/public/tex-gyre"
+set lilypond.mactex_bin   ""
+set lilypond.temp         ""
+set lilypond.have_texgyre false
+
+notes-append "\
+    Pre-installation note for 'mactex' variant:
+
+    MacTeX or another external TeXLive distribution gets used for\
+    installation instead of MacPorts's texlive packages; the path to\
+    the TeX distribution's binary directory (for example\
+    '/Library/TeX/texbin') must be added to 'binpath' in\
+    'macports.conf' *before* installing this port.
+
+    Note that TeX is not needed after installation."
+
+variant mactex description {Use MacTeX or non-MacPorts TeX; see\
+    "port notes" for more information} {
+
+    # Find the binary directory of the external TeX distribution by
+    # searching the kpsewhich program in the path.  We assume that all
+    # other binaries of the distribution are in this directory, too.
+    if {[auto_execok kpsewhich] ne ""} {
+        set lilypond.temp {*}[auto_execok kpsewhich]
+    }
+    set lilypond.mactex_bin \
+        [file dirname [file normalize ${lilypond.temp}]]
+    if {${lilypond.mactex_bin} eq "."} {
+        pre-fetch {
+            return -code error "Cannot find MacTeX or external TeXLive\
+                installation; aborting.  Have you added the path to\
+                your TeX distribution's binary directory to 'binpath'\
+                in 'macports.conf'?"
+        }
+    } elseif {${lilypond.mactex_bin} eq \
+                  [file dirname [file normalize "${prefix}/bin/kpsewhich"]]} {
+        pre-fetch {
+            return -code error "Variant 'mactex' doesn't work with\
+                installed MacPorts TeXLive packages.  Either\
+                uninstall them or don't use the 'mactex' variant of\
+                lilypond."
+        }
+    } else {
+        set lilypond.have_texgyre \
+            [regexp -line {installed: *Yes} \
+                 [exec ${lilypond.mactex_bin}/tlmgr info --only-installed tex-gyre]]
+    }
+
+    if {${lilypond.have_texgyre}} {
+        set lilypond.texgyredir \
+            [file dirname \
+                [exec ${lilypond.mactex_bin}/kpsewhich texgyreschola-regular.otf]]
+    } else {
+        pre-fetch {
+            return -code error "TeXLive package 'tex-gyre' not\
+                installed; aborting.  Please install it, then\
+                try again"
+        }
+    }
+
+    depends_build-delete port:texlive-fonts-recommended \
+                         port:texlive-lang-cyrillic \
+                         port:texlive-metapost \
+                         port:texlive-xetex
+
+    configure.args-append --with-texgyre-dir=${lilypond.texgyredir}
+}
+
 configure.args-append   --disable-documentation
-configure.args-append   --with-texgyre-dir=${prefix}/share/texmf-texlive/fonts/opentype/public/tex-gyre
 configure.args-append   --with-urwotf-dir=${prefix}/share/fonts/urw-core35-fonts
+if {![variant_isset mactex]} {
+    configure.args-append  --with-texgyre-dir=${lilypond.texgyredir}
+}
 
 configure.env-append    GUILE=${prefix}/bin/guile18
 configure.env-append    GUILE_CONFIG=${prefix}/bin/guile18-config


### PR DESCRIPTION
#### Description
Add variant 'mactex'.

Other, minor adjustments.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.7.5 11G63
Xcode 4.6.3 4H1503 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
