### PR TITLE
dpkg: update to 1.20.0. Disable update-alternatives.

### DIFF
--- a/sysutils/dpkg/Portfile
+++ b/sysutils/dpkg/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 name                dpkg
-version             1.19.7
+version             1.20.0
 revision            0
 
 platforms           darwin
@@ -22,9 +22,9 @@ worksrcdir          ${name}-${version}
 use_xz              yes
 extract.asroot      yes
 
-checksums           rmd160  f649124d61386dc2d81b0532900ec5ed384c75cd \
-                    sha256  4c27fededf620c0aa522fff1a48577ba08144445341257502e7730f2b1a296e8 \
-                    size    4716724
+checksums           rmd160  e0a2ca3232723d4e0927e6ae1a7f92648cc917da \
+                    sha256  b633cc2b0e030efb61e11029d8a3fb1123f719864c9992da2e52b471c96d0900 \
+                    size    4738556
 
 perl5.branches      5.28
 
@@ -62,7 +62,8 @@ configure.args-append \
                     --disable-linker-optimizations \
                     --disable-silent-rules \
                     --disable-start-stop-daemon \
-                    --disable-dselect
+                    --disable-dselect \
+                    --disable-update-alternatives
 
 compiler.blacklist-append cc gcc-3.3 gcc-4.0 apple-gcc-4.0
 


### PR DESCRIPTION
#### Description

* Update `dpkg` from `1.19.7` to `1.20.0`
* Disable `update-alternatives` command

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.15
Xcode 11.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
