### PR TITLE
2048.cpp: new port

### DIFF
--- a/games/2048.cpp/Portfile
+++ b/games/2048.cpp/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+
+PortGroup               github 1.0
+PortGroup               cmake 1.1
+
+github.setup            plibither8 2048.cpp 81c0eebaa2e575c7c7943c01958b88896c9da852
+version                 2019-12-12
+revision                0
+categories              games
+maintainers             {mails.ucas.ac.cn:chenguokai17 @chenguokai} openmaintainer
+
+platforms               darwin
+license                 MIT
+description             Fully featured terminal version of the game "2048" written in C++
+
+long_description        Fully featured terminal version of the game "2048" written in C++ \
+                        which is made to run natively on the GNU/Linux and MacOS platforms.
+
+patchfiles              data_path.diff
+checksums               rmd160  3f1b6aae943e70ac79d107dd899762313ff2ce66 \
+                        sha256  e5746f6505220d62f1c250456731c632d6d2e820f6a66313bc2940dbd2e1dcbd \
+                        size    4205777
+
+notes "
+If you run 2048 binary from a directory other than ${prefix}/bin, 
+it is likely that this game fails to save scores. It is expected, since upstream 
+code takes a relative path. Wait for any upstream updates.
+"

--- a/games/2048.cpp/files/data_path.diff
+++ b/games/2048.cpp/files/data_path.diff
@@ -1,0 +1,111 @@
++++ CMakeLists.txt	2020-04-03 14:36:08.000000000 +0800
+@@ -31,4 +31,13 @@
+   RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+ 
+ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/data
+-        DESTINATION ${CMAKE_INSTALL_PREFIX})
++        DESTINATION ${CMAKE_INSTALL_PREFIX}/var/2048.cpp/
++        DIRECTORY_PERMISSIONS
++          OWNER_WRITE OWNER_READ OWNER_EXECUTE
++          GROUP_WRITE GROUP_READ GROUP_EXECUTE
++          WORLD_WRITE WORLD_READ WORLD_EXECUTE
++        PATTERN "data/*"
++        PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE
++                    GROUP_WRITE GROUP_READ GROUP_EXECUTE
++                    WORLD_WRITE WORLD_READ WORLD_EXECUTE
++        )
+
+
+--- src/game-pregamemenu.cpp.ori	2020-03-31 17:44:45.000000000 +0800
++++ src/game-pregamemenu.cpp	2020-03-31 17:41:34.000000000 +0800
+@@ -127,8 +127,8 @@
+ 
+ load_gameboard_status_t initialiseContinueBoardArray() {
+   using namespace Loader;
+-  constexpr auto gameboard_data_filename = "../data/previousGame";
+-  constexpr auto game_stats_data_filename = "../data/previousGameStats";
++  constexpr auto gameboard_data_filename = "../var/2048.cpp/data/previousGame";
++  constexpr auto game_stats_data_filename = "../var/2048.cpp/data/previousGameStats";
+   auto loaded_gameboard{false};
+   auto loaded_game_stats{false};
+   auto tempGBoard = GameBoard{1};
+
+--- src/menu.cpp.ori	2020-03-31 17:44:46.000000000 +0800
++++ src/menu.cpp	2020-03-31 17:41:55.000000000 +0800
+@@ -44,7 +44,7 @@
+   // bool loaded_scorelist;
+   // Warning: Does not care if file exists or not!
+   std::tie(std::ignore, scoreList) =
+-      Scoreboard::loadFromFileScore("../data/scores.txt");
++      Scoreboard::loadFromFileScore("../var/2048.cpp/data/scores.txt");
+ 
+   auto counter{1};
+   const auto convert_to_display_list_t = [&counter](const Scoreboard::Score s) {
+@@ -68,7 +68,7 @@
+   Statistics::total_game_stats_t stats;
+   bool stats_file_loaded{};
+   std::tie(stats_file_loaded, stats) =
+-      Statistics::loadFromFileStatistics("../data/statistics.txt");
++      Statistics::loadFromFileStatistics("../var/2048.cpp/data/statistics.txt");
+ 
+   const auto tsdd = std::make_tuple(
+       stats_file_loaded, std::to_string(stats.bestScore),
+
+--- src/saveresource.cpp.ori	2020-03-31 17:44:46.000000000 +0800
++++ src/saveresource.cpp	2020-03-31 17:42:02.000000000 +0800
+@@ -35,8 +35,8 @@
+ void saveGamePlayState(GameBoard gb) {
+   // Currently two datafiles for now.
+   // Will be merged into one datafile in a future PR.
+-  constexpr auto filename_game_data_state = "../data/previousGame";
+-  constexpr auto filename_game_data_statistics = "../data/previousGameStats";
++  constexpr auto filename_game_data_state = "../var/2048.cpp/data/previousGame";
++  constexpr auto filename_game_data_statistics = "../var/2048.cpp/data/previousGameStats";
+   std::remove(filename_game_data_state);
+   std::remove(filename_game_data_statistics);
+
+
+--- src/scores.cpp.ori	2020-03-31 17:44:47.000000000 +0800
++++ src/scores.cpp	2020-03-31 17:42:13.000000000 +0800
+@@ -45,7 +45,7 @@
+ }
+ 
+ void saveScore(Score finalscore) {
+-  saveToFileScore("../data/scores.txt", finalscore);
++  saveToFileScore("../var/2048.cpp/data/scores.txt", finalscore);
+ }
+ 
+ } // namespace Scoreboard
+
+
+--- src/statistics.cpp.ori	2020-03-31 17:44:48.000000000 +0800
++++ src/statistics.cpp	2020-03-31 17:42:27.000000000 +0800
+@@ -58,7 +58,7 @@
+   bool stats_file_loaded{};
+   ull tempscore{0};
+   std::tie(stats_file_loaded, stats) =
+-      loadFromFileStatistics("../data/statistics.txt");
++      loadFromFileStatistics("../var/2048.cpp/data/statistics.txt");
+   if (stats_file_loaded) {
+     tempscore = stats.bestScore;
+   }
+@@ -70,7 +70,7 @@
+   // Need some sort of stats data values only.
+   // No need to care if file loaded successfully or not...
+   std::tie(std::ignore, stats) =
+-      loadFromFileStatistics("../data/statistics.txt");
++      loadFromFileStatistics("../var/2048.cpp/data/statistics.txt");
+   stats.bestScore =
+       stats.bestScore < finalscore.score ? finalscore.score : stats.bestScore;
+   stats.gameCount++;
+@@ -78,7 +78,7 @@
+   stats.totalMoveCount += finalscore.moveCount;
+   stats.totalDuration += finalscore.duration;
+ 
+-  saveToFileEndGameStatistics("../data/statistics.txt", stats);
++  saveToFileEndGameStatistics("../var/2048.cpp/data/statistics.txt", stats);
+ }
+ 
+ void CreateFinalScoreAndEndGameDataFile(std::ostream &os, std::istream &is,
+
+


### PR DESCRIPTION
* add 2048.cpp as a new port
* selfassign maintainer

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G4032
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
