### PR TITLE
nano: Update to 4.9.1

### DIFF
--- a/editors/nano/Portfile
+++ b/editors/nano/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 
 name            nano
-version         4.9
+version         4.9.1
 categories      editors
 platforms       darwin freebsd
 license         GPL-3
@@ -19,9 +19,9 @@ long_description \
 homepage        https://www.nano-editor.org
 master_sites    ${homepage}/dist/v[strsed ${version} {/\.[0-9]*$//}]/ gnu
 
-checksums           rmd160  045f94ed679ab415521a129c34a656ac7a3733de \
-                    sha256  20fab3ba591eb04d6baea55dd1274d8558ea0f3e59470e25d15cf06dda760e58 \
-                    size    3000427
+checksums           rmd160  33a243c237b5e66b30a618dc696bc5c6b928fa31 \
+                    sha256  85fe5d70ff24be1020de9d16c2a452d908f2614065be7845482ac2d08cbdfeec \
+                    size    2995183
 
 depends_lib     port:gettext \
                 port:libiconv \


### PR DESCRIPTION
#### Description

I'm running through `port livecheck installed` and trying to update things that have an open maintainer or no maintainer.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E266
Xcode 11.4 11E146 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
