### PR TITLE
texlive-bin: provide TeXDist directory structure

### DIFF
--- a/tex/texlive-bin/Portfile
+++ b/tex/texlive-bin/Portfile
@@ -15,7 +15,7 @@ PortGroup       muniversal 1.0
 
 name            texlive-bin
 version         2019.50896
-revision        2
+revision        3
 
 categories      tex
 maintainers     {dports @drkp}
@@ -253,6 +253,20 @@ if {[string match *clang* ${configure.cxx}]} {
     configure.cxxflags-append -Wno-reserved-user-defined-literal
 }
 
+destroot.violate_mtree  yes
+
+# Useful variables to set up the TeXDist directory structure.
+# See below in post-destroot and pre-activate.
+set td_root         /Library/TeX/Distributions
+set td_fd           /.FactoryDefaults
+if {[string equal ${prefix} {/opt/local}]} {
+    set td_name     MacPorts-TeXLive
+} else {
+    regsub -all {/} [string trim ${prefix} {/}] {_} prefix_
+    set td_name     MacPorts-${prefix_}-TeXLive
+}
+set td_mp           ${td_root}/${td_name}.texdist
+set td_mpfd         ${td_root}${td_fd}/${td_name}/Contents
 
 post-destroot   {
     # Anything that gets installed into texmf-dist will be installed
@@ -289,6 +303,145 @@ post-destroot   {
     }
     ln -s ${texlive_mactex_texdistdir}-${version} \
           ${destroot}${texlive_mactex_texdistdir}
+
+    # Install the TeXDist directory structure describing MacPorts' TeX Live.
+    #
+    # It is used to switch between TeX distribution on macOS by tools such as
+    # the TeX Live Utility, the texdist script, the TeX Distribution
+    # Preference Pane, and the LocalTeX Preference Pane.
+    # For more details, see
+    #   - the file TeXDist-description.rtf (installed by MacTeX/BasicTeX in
+    #     /Library/TeX/Distributions),
+    #   - MacTeX/BasicTeX's postinstall script,
+    #   - the postinstall script in https://github.com/TeXLive-M/TeXDist, and
+    #   - http://www.tug.org/mactex/multipletexdistributions.html .
+    #
+    # With respect to TeXDist-description.rtf and the postinstall scripts,
+    # we do not install
+    #   - /usr/texbin,
+    #   - /Library/TeX/Distributions/.DefaultTeX,
+    #   - anything in /Library/TeX outside /Library/TeX/Distributions.
+    # In fact they are useful only when other distributions are installed,
+    # and they install those missing pieces.
+    #
+    # MacTeX/BasicTeX's postinstall (but not the other one) install also
+    # symlinks Local/TEXMF{HOME,VAR,CONFIG} inside Contents, but they are not
+    # documented in TeXDist-description.rtf: we do not install them.
+    #
+    # The directories MacPorts-TeXLive.texdist and MacPorts-teTeX.texdist in
+    # /Library/TeX/Distributions/ and MacPorts-TeXLive and MacPorts-teTeX in
+    # /Library/TeX/Distributions/.FactoryDefaults/ are considered by
+    # TeX Live / MacTeX developers as owned by MacPorts.
+    #
+    # From a private email exchange with Richard Koch (April 2015):
+    #
+    #    "Do you have direct contact with the MacPorts people. If so, you
+    #     might propose that
+    #     [...]
+    #     b) From now on, they install the data structure themselves.
+    #     Surely b) is the correct option, and I follow it for all
+    #     distributions except Fink-tetex, MacPorts-teTeX, and
+    #     MacPorts-TeXLive."
+    #
+    #    "> I'm willing to help improving this (e.g. I could prepare a port
+    #     > for the data structure in MacPorts), [...]
+    #     AHA. Then it is great that you wrote. Go ahead and write your own
+    #     data, and reuse the names I used, because then MacTeX will not
+    #     overwrite it."
+    #
+    #    "From now on, these entries will not be created by MacTeX. If the
+    #     entries already exist, either because we wrote them or because you
+    #     changed them, MacTeX won't change them. If you remove the entries
+    #     entirely, then new versions of MacTeX won't add them back, but the
+    #     rare use of old install packages will."
+    #
+    # Moreover, they are useful only if MacPorts' TeX Live is installed, so
+    # removing the old ones here and not restoring them in post-deactivate
+    # does no harm to the user. Consider also that teTeX does not exist
+    # anymore in MacPorts.
+
+    xinstall -d ${destroot}${td_mp}
+    ln -s ..${td_fd}/${td_name}/Contents ${destroot}${td_mp}/Contents
+
+    xinstall -d ${destroot}${td_mpfd}/AllTexmf
+    ln -s ${texlive_texmfports} ${destroot}${td_mpfd}/AllTexmf/texmf
+    ln -s ${texlive_texmfdist} ${destroot}${td_mpfd}/AllTexmf/texmf-dist
+    ln -s ${texlive_texmfdist}/doc ${destroot}${td_mpfd}/AllTexmf/texmf-doc
+    ln -s ${texlive_texmflocal} ${destroot}${td_mpfd}/AllTexmf/texmf-local
+    ln -s ${texlive_texmfsysvar} ${destroot}${td_mpfd}/AllTexmf/texmf-var
+
+    xinstall -d ${destroot}${td_mpfd}/Doc
+    ln -s ${texlive_texmfdist}/doc ${destroot}${td_mpfd}/Doc/texmf-dist-doc
+    ln -s ${texlive_texmfports}/doc ${destroot}${td_mpfd}/Doc/texmf-doc
+    ln -s ${texlive_texmfdist}/doc ${destroot}${td_mpfd}/Doc/texmf-doc-doc
+    ln -s ${texlive_texmfdist}/doc ${destroot}${td_mpfd}/Doc/texmf-var-doc
+
+    ln -s ${prefix}/share/info ${destroot}${td_mpfd}/Info
+    ln -s ${prefix}/share/man ${destroot}${td_mpfd}/Man
+
+    # The texdist script determines if a TeX distribution is usable
+    # by testing the binaries in the directory called `uname -p`.
+    # `uname -p` outputs i386 also for x86_64 systems.
+    xinstall -d ${destroot}${td_mpfd}/Programs
+    if {[variant_isset universal]} {
+        if {[string match "*ppc*" ${configure.universal_archs}]} {
+            ln -s ${texlive_mactex_texbindir} ${destroot}${td_mpfd}/Programs/powerpc
+            ln -s ${texlive_mactex_texbindir} ${destroot}${td_mpfd}/Programs/ppc
+        }
+        if {"x86_64" in ${configure.universal_archs} || "i386" in ${configure.universal_archs}} {
+            ln -s ${texlive_mactex_texbindir} ${destroot}${td_mpfd}/Programs/i386
+        }
+        if {"x86_64" in ${configure.universal_archs}} {
+            ln -s ${texlive_mactex_texbindir} ${destroot}${td_mpfd}/Programs/x86_64
+        }
+    } else {
+        if {[string match "ppc*" ${configure.build_arch}]} {
+            ln -s ${texlive_mactex_texbindir} ${destroot}${td_mpfd}/Programs/powerpc
+            ln -s ${texlive_mactex_texbindir} ${destroot}${td_mpfd}/Programs/ppc
+        } else {
+            if {${configure.build_arch} eq "x86_64"} {
+                ln -s ${texlive_mactex_texbindir} ${destroot}${td_mpfd}/Programs/i386
+            }
+            ln -s ${texlive_mactex_texbindir} ${destroot}${td_mpfd}/Programs/${configure.build_arch}
+        }
+    }
+    ln -s ${texlive_mactex_texbindir} ${destroot}${td_mpfd}/Programs/texbin
+
+    xinstall -d ${destroot}${td_mpfd}/Resources/English.lproj
+    xinstall -m 644 ${filespath}/Description.rtf \
+        ${destroot}${td_mpfd}/Resources/English.lproj/Description.rtf
+    reinplace "s|%%PREFIX%%|${prefix}|g" \
+        ${destroot}${td_mpfd}/Resources/English.lproj/Description.rtf
+    reinplace "s|%%VERSION%%|${version}|g" \
+        ${destroot}${td_mpfd}/Resources/English.lproj/Description.rtf
+
+    ln -s ${prefix}/share ${destroot}${td_mpfd}/Root
+
+    set td_vfile [open ${destroot}${td_mpfd}/TeXDistVersion w]
+    puts ${td_vfile} "1"
+    close ${td_vfile}
+
+    ln -s ${texlive_texmflocal} ${destroot}${td_mpfd}/TexmfLocal
+    ln -s ${texlive_texmfsysvar} ${destroot}${td_mpfd}/TexmfSysVar
+}
+
+pre-activate {
+    # Delete leftover MacPorts-related TeXDist directories.
+    # See comment above in post-destroot for the rationale.
+    if {[string equal ${prefix} {/opt/local}]} {
+        if {[file exists ${td_root}/MacPorts-TeXLive.texdist]} {
+            delete file ${td_root}/MacPorts-TeXLive.texdist
+        }
+        if {[file exists ${td_root}${td_fd}/MacPorts-TeXLive]} {
+            delete file ${td_root}${td_fd}/MacPorts-TeXLive
+        }
+        if {[file exists ${td_root}/MacPorts-teTeX.texdist]} {
+            delete file ${td_root}/MacPorts-teTeX.texdist
+        }
+        if {[file exists ${td_root}${td_fd}/MacPorts-teTeX]} {
+            delete file ${td_root}${td_fd}/MacPorts-teTeX
+        }
+    }
 }
 
 post-activate {

--- a/tex/texlive-bin/Portfile
+++ b/tex/texlive-bin/Portfile
@@ -257,16 +257,16 @@ destroot.violate_mtree  yes
 
 # Useful variables to set up the TeXDist directory structure.
 # See below in post-destroot and pre-activate.
-set td_root         /Library/TeX/Distributions
-set td_fd           /.FactoryDefaults
+set texdist_root         /Library/TeX/Distributions
+set texdist_fd           .FactoryDefaults
 if {[string equal ${prefix} {/opt/local}]} {
-    set td_name     MacPorts-TeXLive
+    set texdist_name     MacPorts-TeXLive
 } else {
     regsub -all {/} [string trim ${prefix} {/}] {_} prefix_
-    set td_name     MacPorts-${prefix_}-TeXLive
+    set texdist_name     MacPorts-${prefix_}-TeXLive
 }
-set td_mp           ${td_root}/${td_name}.texdist
-set td_mpfd         ${td_root}${td_fd}/${td_name}/Contents
+set texdist_mp           ${texdist_root}/${texdist_name}.texdist
+set texdist_mpfd         ${texdist_root}/${texdist_fd}/${texdist_name}/Contents
 
 post-destroot   {
     # Anything that gets installed into texmf-dist will be installed
@@ -331,115 +331,94 @@ post-destroot   {
     # The directories MacPorts-TeXLive.texdist and MacPorts-teTeX.texdist in
     # /Library/TeX/Distributions/ and MacPorts-TeXLive and MacPorts-teTeX in
     # /Library/TeX/Distributions/.FactoryDefaults/ are considered by
-    # TeX Live / MacTeX developers as owned by MacPorts.
-    #
-    # From a private email exchange with Richard Koch (April 2015):
-    #
-    #    "Do you have direct contact with the MacPorts people. If so, you
-    #     might propose that
-    #     [...]
-    #     b) From now on, they install the data structure themselves.
-    #     Surely b) is the correct option, and I follow it for all
-    #     distributions except Fink-tetex, MacPorts-teTeX, and
-    #     MacPorts-TeXLive."
-    #
-    #    "> I'm willing to help improving this (e.g. I could prepare a port
-    #     > for the data structure in MacPorts), [...]
-    #     AHA. Then it is great that you wrote. Go ahead and write your own
-    #     data, and reuse the names I used, because then MacTeX will not
-    #     overwrite it."
-    #
-    #    "From now on, these entries will not be created by MacTeX. If the
-    #     entries already exist, either because we wrote them or because you
-    #     changed them, MacTeX won't change them. If you remove the entries
-    #     entirely, then new versions of MacTeX won't add them back, but the
-    #     rare use of old install packages will."
+    # TeX Live / MacTeX developers as owned by MacPorts (see
+    # https://github.com/macports/macports-ports/pull/6755#issuecomment-613055213).
     #
     # Moreover, they are useful only if MacPorts' TeX Live is installed, so
     # removing the old ones here and not restoring them in post-deactivate
     # does no harm to the user. Consider also that teTeX does not exist
     # anymore in MacPorts.
 
-    xinstall -d ${destroot}${td_mp}
-    ln -s ..${td_fd}/${td_name}/Contents ${destroot}${td_mp}/Contents
+    xinstall -d ${destroot}${texdist_mp}
+    ln -s ../${texdist_fd}/${texdist_name}/Contents ${destroot}${texdist_mp}/Contents
 
-    xinstall -d ${destroot}${td_mpfd}/AllTexmf
-    ln -s ${texlive_texmfports} ${destroot}${td_mpfd}/AllTexmf/texmf
-    ln -s ${texlive_texmfdist} ${destroot}${td_mpfd}/AllTexmf/texmf-dist
-    ln -s ${texlive_texmfdist}/doc ${destroot}${td_mpfd}/AllTexmf/texmf-doc
-    ln -s ${texlive_texmflocal} ${destroot}${td_mpfd}/AllTexmf/texmf-local
-    ln -s ${texlive_texmfsysvar} ${destroot}${td_mpfd}/AllTexmf/texmf-var
+    xinstall -d ${destroot}${texdist_mpfd}/AllTexmf
+    ln -s ${texlive_texmfports} ${destroot}${texdist_mpfd}/AllTexmf/texmf
+    ln -s ${texlive_texmfdist} ${destroot}${texdist_mpfd}/AllTexmf/texmf-dist
+    ln -s ${texlive_texmfdist}/doc ${destroot}${texdist_mpfd}/AllTexmf/texmf-doc
+    ln -s ${texlive_texmflocal} ${destroot}${texdist_mpfd}/AllTexmf/texmf-local
+    ln -s ${texlive_texmfsysvar} ${destroot}${texdist_mpfd}/AllTexmf/texmf-var
 
-    xinstall -d ${destroot}${td_mpfd}/Doc
-    ln -s ${texlive_texmfdist}/doc ${destroot}${td_mpfd}/Doc/texmf-dist-doc
-    ln -s ${texlive_texmfports}/doc ${destroot}${td_mpfd}/Doc/texmf-doc
-    ln -s ${texlive_texmfdist}/doc ${destroot}${td_mpfd}/Doc/texmf-doc-doc
-    ln -s ${texlive_texmfdist}/doc ${destroot}${td_mpfd}/Doc/texmf-var-doc
+    xinstall -d ${destroot}${texdist_mpfd}/Doc
+    ln -s ${texlive_texmfdist}/doc ${destroot}${texdist_mpfd}/Doc/texmf-dist-doc
+    ln -s ${texlive_texmfports}/doc ${destroot}${texdist_mpfd}/Doc/texmf-doc
+    ln -s ${texlive_texmfdist}/doc ${destroot}${texdist_mpfd}/Doc/texmf-doc-doc
+    ln -s ${texlive_texmfdist}/doc ${destroot}${texdist_mpfd}/Doc/texmf-var-doc
 
-    ln -s ${prefix}/share/info ${destroot}${td_mpfd}/Info
-    ln -s ${prefix}/share/man ${destroot}${td_mpfd}/Man
+    ln -s ${prefix}/share/info ${destroot}${texdist_mpfd}/Info
+    ln -s ${prefix}/share/man ${destroot}${texdist_mpfd}/Man
 
     # The texdist script determines if a TeX distribution is usable
     # by testing the binaries in the directory called `uname -p`.
     # `uname -p` outputs i386 also for x86_64 systems.
-    xinstall -d ${destroot}${td_mpfd}/Programs
+    xinstall -d ${destroot}${texdist_mpfd}/Programs
     if {[variant_isset universal]} {
         if {[string match "*ppc*" ${configure.universal_archs}]} {
-            ln -s ${texlive_mactex_texbindir} ${destroot}${td_mpfd}/Programs/powerpc
-            ln -s ${texlive_mactex_texbindir} ${destroot}${td_mpfd}/Programs/ppc
+            ln -s ${texlive_mactex_texbindir} ${destroot}${texdist_mpfd}/Programs/powerpc
+            ln -s ${texlive_mactex_texbindir} ${destroot}${texdist_mpfd}/Programs/ppc
         }
         if {"x86_64" in ${configure.universal_archs} || "i386" in ${configure.universal_archs}} {
-            ln -s ${texlive_mactex_texbindir} ${destroot}${td_mpfd}/Programs/i386
+            ln -s ${texlive_mactex_texbindir} ${destroot}${texdist_mpfd}/Programs/i386
         }
         if {"x86_64" in ${configure.universal_archs}} {
-            ln -s ${texlive_mactex_texbindir} ${destroot}${td_mpfd}/Programs/x86_64
+            ln -s ${texlive_mactex_texbindir} ${destroot}${texdist_mpfd}/Programs/x86_64
         }
     } else {
         if {[string match "ppc*" ${configure.build_arch}]} {
-            ln -s ${texlive_mactex_texbindir} ${destroot}${td_mpfd}/Programs/powerpc
-            ln -s ${texlive_mactex_texbindir} ${destroot}${td_mpfd}/Programs/ppc
+            ln -s ${texlive_mactex_texbindir} ${destroot}${texdist_mpfd}/Programs/powerpc
+            ln -s ${texlive_mactex_texbindir} ${destroot}${texdist_mpfd}/Programs/ppc
         } else {
             if {${configure.build_arch} eq "x86_64"} {
-                ln -s ${texlive_mactex_texbindir} ${destroot}${td_mpfd}/Programs/i386
+                ln -s ${texlive_mactex_texbindir} ${destroot}${texdist_mpfd}/Programs/i386
             }
-            ln -s ${texlive_mactex_texbindir} ${destroot}${td_mpfd}/Programs/${configure.build_arch}
+            ln -s ${texlive_mactex_texbindir} ${destroot}${texdist_mpfd}/Programs/${configure.build_arch}
         }
     }
-    ln -s ${texlive_mactex_texbindir} ${destroot}${td_mpfd}/Programs/texbin
+    ln -s ${texlive_mactex_texbindir} ${destroot}${texdist_mpfd}/Programs/texbin
 
-    xinstall -d ${destroot}${td_mpfd}/Resources/English.lproj
+    xinstall -d ${destroot}${texdist_mpfd}/Resources/English.lproj
     xinstall -m 644 ${filespath}/Description.rtf \
-        ${destroot}${td_mpfd}/Resources/English.lproj/Description.rtf
+        ${destroot}${texdist_mpfd}/Resources/English.lproj/Description.rtf
     reinplace "s|%%PREFIX%%|${prefix}|g" \
-        ${destroot}${td_mpfd}/Resources/English.lproj/Description.rtf
+        ${destroot}${texdist_mpfd}/Resources/English.lproj/Description.rtf
     reinplace "s|%%VERSION%%|${version}|g" \
-        ${destroot}${td_mpfd}/Resources/English.lproj/Description.rtf
+        ${destroot}${texdist_mpfd}/Resources/English.lproj/Description.rtf
 
-    ln -s ${prefix}/share ${destroot}${td_mpfd}/Root
+    ln -s ${prefix}/share ${destroot}${texdist_mpfd}/Root
 
-    set td_vfile [open ${destroot}${td_mpfd}/TeXDistVersion w]
-    puts ${td_vfile} "1"
-    close ${td_vfile}
+    set texdist_vfile [open ${destroot}${texdist_mpfd}/TeXDistVersion w]
+    puts ${texdist_vfile} "1"
+    close ${texdist_vfile}
 
-    ln -s ${texlive_texmflocal} ${destroot}${td_mpfd}/TexmfLocal
-    ln -s ${texlive_texmfsysvar} ${destroot}${td_mpfd}/TexmfSysVar
+    ln -s ${texlive_texmflocal} ${destroot}${texdist_mpfd}/TexmfLocal
+    ln -s ${texlive_texmfsysvar} ${destroot}${texdist_mpfd}/TexmfSysVar
 }
 
 pre-activate {
     # Delete leftover MacPorts-related TeXDist directories.
     # See comment above in post-destroot for the rationale.
     if {[string equal ${prefix} {/opt/local}]} {
-        if {[file exists ${td_root}/MacPorts-TeXLive.texdist]} {
-            delete file ${td_root}/MacPorts-TeXLive.texdist
-        }
-        if {[file exists ${td_root}${td_fd}/MacPorts-TeXLive]} {
-            delete file ${td_root}${td_fd}/MacPorts-TeXLive
-        }
-        if {[file exists ${td_root}/MacPorts-teTeX.texdist]} {
-            delete file ${td_root}/MacPorts-teTeX.texdist
-        }
-        if {[file exists ${td_root}${td_fd}/MacPorts-teTeX]} {
-            delete file ${td_root}${td_fd}/MacPorts-teTeX
+        set texdist_delete_dist [list TeXLive teTeX]
+        foreach dist ${texdist_delete_dist} {
+            set texdist_delete_dir [list \
+                ${texdist_root}/MacPorts-${dist}.texdist \
+                ${texdist_root}/${texdist_fd}/MacPorts-${dist} \
+            ]
+            foreach dir ${texdist_delete_dir} {
+                if {[file exists ${dir}]} {
+                    delete file ${dir}
+                }
+            }
         }
     }
 }

--- a/tex/texlive-bin/files/Description.rtf
+++ b/tex/texlive-bin/files/Description.rtf
@@ -1,0 +1,10 @@
+{\rtf1\ansi\ansicpg1252\cocoartf1038\cocoasubrtf360
+{\fonttbl\f0\fswiss\fcharset0 Helvetica;}
+{\colortbl;\red255\green255\blue255;}
+\margl1440\margr1440\vieww9000\viewh8400\viewkind0
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\ql\qnatural\pardirnatural
+
+\f0\fs24 \cf0 MacPorts TeX Live %%VERSION%% distribution.\
+(MacPorts prefix: %%PREFIX%%)\
+\
+}


### PR DESCRIPTION
Closes https://trac.macports.org/ticket/51668

#### Description

With TeX Live 2020 approaching, I decided to revive my proposal.

The TeXDist directory structure is used by MacTeX's texdist utility and TeX Distribution Preference Pane to switch between TeX distributions.

This change deletes and writes files outside `${prefix}`: the rationale is explained in the comments.

Instead of `/Library/TeX/Distributions/.FactoryDefaults`, I think that it would be appropriate for the MacPorts' TeXDist to live in `${texlive_mactex_texdistdir}` (`TeXDist-description.rtf` suggests that distributions keep their TeXDist inside).
However, currently that directory contains symlinks to `${texlive_mactex_texbindir}` and the relevant comment in the Portfile states that “it seems that future versions of the prefpane will want these”, so I didn’t use it.
@drkp: if you decide that in fact you prefer to use `${texlive_mactex_texbindir}`, let me know and I can update the pull request.

@mojca might be interested, too.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.13.6 17G11023
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`? **(It gives two errors for hardcoded `/opt/local` but they refer to lines where I am testing if `${prefix}` equals `/opt/local`: is there a way to suppress the lint errors?)**
- [x] tried a full install with `sudo port -vst install`? **(I actually tested it with empty configure, build and destroot phases to avoid building all the binaries and to test only the part I added.)**
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
