### PR TITLE
softhsm: add myself as primary maintainer

### DIFF
--- a/security/softhsm/Portfile
+++ b/security/softhsm/Portfile
@@ -8,7 +8,7 @@ revision            0
 categories          security
 platforms           darwin
 license             BSD
-maintainers         {NLnetLabs.nl:jaap @Jakker} openmaintainer
+maintainers         {iay.org.uk:ian @iay} {NLnetLabs.nl:jaap @Jakker} openmaintainer
 
 description         Software implementation of a Hardware Security Module (HSM)
 long_description    SoftHSM is an implementation of a cryptographic store accessible \


### PR DESCRIPTION
#### Description

* Add @iay as maintainer
* Retain @Jakker as backup
* As discussed in https://github.com/macports/macports-ports/pull/6707

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.4 19E266
Xcode 11.4 11E146

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
   * n/a
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
   * `Failed to test softhsm: softhsm has no tests turned on.`
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
