### PR TITLE
py-pyobjc: update to 6.2, moved to GitHub

### DIFF
--- a/python/py-pyobjc/Portfile
+++ b/python/py-pyobjc/Portfile
@@ -2,14 +2,14 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
-PortGroup           bitbucket 1.0
+PortGroup           github 1.0
 
-bitbucket.setup     ronaldoussoren pyobjc 6.1 pyobjc-
-revision            2
+github.setup        ronaldoussoren pyobjc 6.2 v
+revision            0
 
-checksums           rmd160  93a213137223054789e42c198d3daad5a962c937 \
-                    sha256  d46d061b6156df60db4562c6bb4dd886ada54c41c0463f290b3ee2650d56b3cd \
-                    size    12915723
+checksums           rmd160  290ae501ed3c6d6959f4e955511664b4eaa4dac3 \
+                    sha256  0835402fdc831d19cb02d6c6faab9e27a4930f452ffc8eeaeeb7f2f31c192624 \
+                    size    12971644
 
 name                py-pyobjc
 categories-append   devel

--- a/python/py-pyobjc/files/patch-docs-conf.py.diff
+++ b/python/py-pyobjc/files/patch-docs-conf.py.diff
@@ -1,11 +1,10 @@
-diff --git docs/conf.py docs/conf.py
---- docs/conf.py
-+++ docs/conf.py
-@@ -33,7 +33,6 @@ extensions = [
+--- docs/conf.py.orig	2020-04-01 07:47:09.000000000 -0400
++++ docs/conf.py	2020-04-01 07:47:25.000000000 -0400
+@@ -34,7 +34,6 @@
      "sphinx.ext.ifconfig",
      "sphinx.ext.extlinks",
      "examples",
 -    "sphinx_sitemap",
  ]
  
- extlinks = {"issue": ("https://bitbucket.org/ronaldoussoren/pyobjc/issues/%s", "issue ")}
+ extlinks = {"issue": ("https://github.com/ronaldoussoren/pyobjc/issues/%s", "issue ")}

--- a/python/py-pyobjc/files/patch-install.py.diff
+++ b/python/py-pyobjc/files/patch-install.py.diff
@@ -1,7 +1,6 @@
-diff --git install.py install.py
---- install.py
-+++ install.py
-@@ -186,17 +186,6 @@ def sorted_framework_wrappers():
+--- install.py.orig	2020-03-25 12:26:08.000000000 -0400
++++ install.py	2020-04-01 07:49:00.000000000 -0400
+@@ -187,17 +187,6 @@
  def build_project(project, extra_args):
      proj_dir = os.path.join(TOPDIR, project)
  

--- a/python/py-pyobjc/files/pyobjc_setup.py.patch
+++ b/python/py-pyobjc/files/pyobjc_setup.py.patch
@@ -1,13 +1,17 @@
+see @jmroot his patch submitted upstream:
 https://bitbucket.org/ronaldoussoren/pyobjc/pull-requests/22/pyobjc_setuppy-sdk-detection-fixes/diff
-
-diff --git a/pyobjc-core/Tools/pyobjc_setup.py b/pyobjc-core/Tools/pyobjc_setup.py
---- a/pyobjc-core/Tools/pyobjc_setup.py
-+++ b/pyobjc-core/Tools/pyobjc_setup.py
-@@ -219,25 +219,46 @@ def get_os_level():
-     v = pl["ProductVersion"]
+--- pyobjc-core/Tools/pyobjc_setup.py.orig	2020-03-25 12:26:08.000000000 -0400
++++ pyobjc-core/Tools/pyobjc_setup.py	2020-04-01 08:00:49.000000000 -0400
+@@ -203,23 +203,45 @@
      return ".".join(v.split(".")[:2])
- 
- 
+
+
+-def get_sdk_level():
+-    cflags = get_config_var("CFLAGS")
+-    cflags = shlex.split(cflags)
+-    for i, val in enumerate(cflags):
+-        if val == "-isysroot":
+-            sdk = cflags[i + 1]
 +def get_sdk():
 +    env_cflags = os.environ.get("CFLAGS", "")
 +    config_cflags = get_config_var("CFLAGS")
@@ -22,26 +26,21 @@ diff --git a/pyobjc-core/Tools/pyobjc_setup.py b/pyobjc-core/Tools/pyobjc_setup.
 +                sdk = val[len("-isysroot"):]
 +                break
 +        if sdk:
-+            break
+             break
+-    else:
 +
 +    return sdk
 +
- def get_sdk_level():
--    cflags = get_config_var("CFLAGS")
--    cflags = shlex.split(cflags)
--    for i, val in enumerate(cflags):
--        if val == "-isysroot":
--            sdk = cflags[i + 1]
--            break
--    else:
++
++def get_sdk_level():
 +    sdk = get_sdk()
 +
 +    if not sdk:
          return None
- 
+
      if sdk == "/":
          return get_os_level()
- 
+
 -    sdk = os.path.basename(sdk)
 -    assert sdk.startswith("MacOSX")
 -    assert sdk.endswith(".sdk")
@@ -57,15 +56,13 @@ diff --git a/pyobjc-core/Tools/pyobjc_setup.py b/pyobjc-core/Tools/pyobjc_setup.
 +            raise SystemExit("Cannot determine SDK version")
 +    else:
 +        return sdkname[6:-4]
- 
- 
+
+
  class pyobjc_install_lib(install_lib.install_lib):
-     def get_exclusions(self):
-@@ -411,17 +432,16 @@ def Extension(*args, **kwds):
-     ldflags = []
+@@ -394,15 +416,14 @@
      if "clang" in get_config_var("CC"):
          cflags.append("-Wno-deprecated-declarations")
- 
+
 -    CFLAGS = get_config_var("CFLAGS")
 -    if "-isysroot" not in CFLAGS:  # and os.path.exists('/usr/include/stdio.h'):
 -        # We're likely on a system with de Xcode Command Line Tools.
@@ -75,11 +72,10 @@ diff --git a/pyobjc-core/Tools/pyobjc_setup.py b/pyobjc-core/Tools/pyobjc_setup.
 +        # We're likely on a system with the Xcode Command Line Tools.
 +        # Explicitly use the most recent SDK to avoid compile problems.
          data = subprocess.check_output(
-                 ["/usr/bin/xcrun", "-sdk", "macosx", "--show-sdk-path"],
-                 universal_newlines=True,
-             ).strip()
+             ["/usr/bin/xcrun", "-sdk", "macosx", "--show-sdk-path"],
+             universal_newlines=True,
+         ).strip()
 -        data = data.strip()
          if data:
              cflags.append("-isysroot")
              cflags.append(data)
-             cflags.append(


### PR DESCRIPTION
#### Description
The project has moved to GitHub and the latest release is version 6.2. 

###### Tested on
macOS 10.14.6 18G4032
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
