### PR TITLE
google-cloud-sdk: update to 287.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             286.0.0
+version             287.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  581f34bd11f172e67ad089cb566c60a2c43541d3 \
-                    sha256  0955a050d94ff54157e778f1719fa50b6ca67cef106dcf40dbf672c243da1857 \
-                    size    48779568
+    checksums       rmd160  68865c22eaec75c4d88de36ca8a21f691ea1d1c2 \
+                    sha256  cdfe1212b4b8d7cd29983380338ebf660ecc3a705d9992c2f188b5c0e18045a8 \
+                    size    48838500
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  d9690fb5e2ceb6502df01069a2c7bf8facf8a7b3 \
-                    sha256  14a7559466df485b1d42dcc95075efe2ed43f51a6c56a60630dd7209be72036d \
-                    size    49827668
+    checksums       rmd160  0498555a2530b9316426bcfc0af50ef33fbab32a \
+                    sha256  2dafe2afc453781a8010aaaacb6631b5dbbeac8ae67a71cd9376bdd53fdddfd6 \
+                    size    49881178
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 287.0.0.

###### Tested on

macOS 10.15.4 19E266
Xcode 11.4 11E146

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?