### PR TITLE
broot: update to 0.13.5b

### DIFF
--- a/sysutils/broot/Portfile
+++ b/sysutils/broot/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        Canop broot 0.13.4 v
+github.setup        Canop broot 0.13.5b v
 categories          sysutils
 platforms           darwin
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
@@ -20,12 +20,13 @@ long_description    broot is a new way to see and navigate directory trees. \
                     via regular expressions, and more.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  71728d0ed1a584c86bb937424a31ca556596a0fb \
-                    sha256  85cc6ed343f5e9df28b54c5e842de1ca8351eebe384bea1faa0e54483707bc4d \
-                    size    1681528
+                    rmd160  fd504f540c4a2fbd574a831b8cbffd93c4087115 \
+                    sha256  aa0ecf6f5a25ac6af027ee627118f323467b9fe0f36fba5a3086219fbdceef1a \
+                    size    2090581
 
 destroot {
     xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/${name} ${destroot}${prefix}/bin/
+    xinstall -m 644 ${worksrcpath}/man/page ${destroot}${prefix}/share/man/man1/broot.1
 }
 
 cargo.crates \
@@ -105,7 +106,7 @@ cargo.crates \
     num-integer                     0.1.41  b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09 \
     num-traits                       0.2.8  6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32 \
     num_cpus                        1.11.1  76dac5ed2a876980778b8b85f75a71b6cbf0db0b1232ee12f826bccb00d09d72 \
-    open                             1.3.2  94b424e1086328b0df10235c6ff47be63708071881bead9e76997d9291c0134b \
+    open                             1.4.0  7c283bf0114efea9e42f1a60edea9859e8c47528eae09d01df4b29c1e489cc48 \
     parking_lot                     0.10.0  92e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc \
     parking_lot_core                 0.7.0  7582838484df45743c8434fbff785e8edf260c28748353d44bc0da32e0ceabf1 \
     pathdiff                         0.1.0  a3bf70094d203e07844da868b634207e71bfab254fe713171fae9a6e751ccf31 \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E266
Xcode 11.4 11E146

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
