### PR TITLE
spring-boot-cli: update to 2.2.6

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            spring-boot-cli
-version         2.2.4
+version         2.2.6
 revision        0
 
 categories      java
@@ -30,9 +30,9 @@ master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/
 
 distname        ${name}-${version}.RELEASE-bin
 
-checksums       rmd160  80aea8034b91d5024fb440fc385b6153c0e9d3b0 \
-                sha256  6cdb94163728f338f0d1773a75f46b144a8f06348d52715e3f9789f89a45f039 \
-                size    11380514
+checksums       rmd160  473203e0a268cba55156dc062cf412f3d3616539 \
+                sha256  f2594c453f7a066e8c058f2a078dfd05e9ec0caeb19f58f72a49760a300b014e \
+                size    11410321
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
#### Description

Update to Spring Boot CLI 2.2.6.RELEASE.

###### Tested on

macOS 10.15.4 19E266
Xcode 11.4 11E146

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?