### PR TITLE
signing-party: Use Python 3.8

### DIFF
--- a/mail/signing-party/Portfile
+++ b/mail/signing-party/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                signing-party
 version             2.10
-revision            1
+revision            2
 checksums           rmd160  6ce5b02719ca25096daecfee3534c6ab3ba1d0f1 \
                     sha256  e19416cbd2bc723593334e2471d311f413794faa751b8b2e452e0792fc0431eb \
                     size    222778
@@ -46,7 +46,7 @@ depends_lib         port:perl${perl5.major} \
                     port:libmd
 depends_run         path:bin/gpg:gnupg2 \
                     port:dialog \
-                    port:python27
+                    port:python38
 
 # The build scripts assume that DEB_VERSION_UPSTREAM is set to the version
 # number, which is presumably true in Debian but is not true elsewhere.
@@ -79,7 +79,7 @@ pre-build {
         ${worksrcpath}/keylookup/keylookup \
         ${worksrcpath}/sig2dot/sig2dot \
         ${worksrcpath}/springgraph/springgraph
-    reinplace "s|/usr/bin/python|${prefix}/bin/python2.7|g" \
+    reinplace "s|/usr/bin/python3|${prefix}/bin/python3.8|g" \
         ${worksrcpath}/keyart/keyart \
         ${worksrcpath}/gpgparticipants/gpgparticipants-prefill
 }


### PR DESCRIPTION
#### Description

Upstream changed the shebang to python3, which caused our reinplace to
produce python2.73, which is broken.

Closes: https://trac.macports.org/ticket/60297

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G4032
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
