### PR TITLE
softhsm: implement 'port test'

### DIFF
--- a/security/softhsm/Portfile
+++ b/security/softhsm/Portfile
@@ -28,6 +28,7 @@ patchfiles          patch-const-535.diff
 depends_build       port:libtool
 depends_lib         path:lib/libssl.dylib:openssl \
                     port:sqlite3
+depends_test        port:cppunit
 
 configure.args      --with-sqlite3=${prefix} \
                     --with-objectstore-backend-db \
@@ -36,6 +37,9 @@ configure.args      --with-sqlite3=${prefix} \
 build.type          gnu
 
 destroot.keepdirs   ${destroot}${prefix}/var/lib/softhsm/tokens
+
+test.run            yes
+test.target         check
 
 livecheck.type      regex
 livecheck.url       [lindex ${master_sites} 0]


### PR DESCRIPTION
#### Description

Implement "port test" functionality.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E266
Xcode 11.4 11E146 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
  * n/a
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
