### PR TITLE
Adds initial version of the terragrunt port

### DIFF
--- a/sysutils/terragrunt/Portfile
+++ b/sysutils/terragrunt/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+name                terragrunt
+version             0.23.4
+depends_run         port:terraform-0.12
+
+categories          sysutils
+platforms           darwin linux
+license             MIT
+maintainers         mjrc.nl:macports
+
+description         Terragrunt
+long_description    Terragrunt is a thin wrapper for Terraform that provides extra tools for working with multiple Terraform modules.
+homepage            https://terragrunt.gruntwork.io
+
+go.setup            github.com/gruntwork-io/terragrunt ${version} v
+
+checksums           rmd160  f072990cea4a0d0d2a814e32ab233ec64a93825e \
+                    sha256  3b4ddc07684eba41e1d3ad8b33464e8e9aeea6d2adb29aab6799a00f48988a52 \
+                    size    1963542
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}
+
+set go_ldflags      "-X main.VERSION=${version}"
+build.args          -ldflags \"${go_ldflags}\" ${go.package}

--- a/sysutils/terragrunt/Portfile
+++ b/sysutils/terragrunt/Portfile
@@ -10,7 +10,7 @@ depends_run         port:terraform-0.12
 categories          sysutils
 platforms           darwin linux
 license             MIT
-maintainers         mjrc.nl:macports
+maintainers         {mjrc.nl:macports @mjrc} openmaintainer
 
 description         Terragrunt
 long_description    Terragrunt is a thin wrapper for Terraform that provides extra tools for working with multiple Terraform modules.
@@ -28,3 +28,14 @@ destroot {
 
 set go_ldflags      "-X main.VERSION=${version}"
 build.args          -ldflags \"${go_ldflags}\" ${go.package}
+
+notes "
+Note that terragrunt requires the terraform0.12 port to be installed.  
+Also, it looks for terraform on the path. In order create a link, run: 
+
+sudo port select --set terraform terraform0.12
+
+Alternatively, use the TERRAGRUNT_TFPATH environment variable or the 
+--terragrunt-tfpath command line argument to specify a specific version 
+of terraform to use.   
+"


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E266
Xcode 11.4 11E146 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
