### PR TITLE
prometheus: set the USER env var in environments where it isn't set.

### DIFF
--- a/net/prometheus/Portfile
+++ b/net/prometheus/Portfile
@@ -50,8 +50,12 @@ add_users           ${prom_user} \
                     group=${prom_user} \
                     realname=Prometheus
 
-pre-build {
-  system "env"
+
+# promu will fail if it cannot capture the current user using the USER
+# environment variable.  So if USER is not currently set in the environment,
+# we'll set it here for purposes of the build.
+if {! [info exists env(USER)]} {
+    build.env-append USER="${macportsuser}"
 }
 
 post-extract {


### PR DESCRIPTION
Attempted fix for https://trac.macports.org/ticket/58709

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E266
Xcode 11.4 11E146

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
