### PR TITLE
Update of Port ehcache to version 3.8.1

### DIFF
--- a/java/ehcache/Portfile
+++ b/java/ehcache/Portfile
@@ -1,53 +1,56 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
+PortGroup               java 1.0
+PortGroup               github 1.0
 
-name				ehcache
-version				1.1
+github.setup            ehcache ehcache3 3.8.1 v
+github.tarball_from releases
+name                    ehcache
+distname                ${name}-${version}
 
-categories			java
-maintainers			nomaintainer
-platforms			darwin
+categories              java
+maintainers             nomaintainer
+platforms               darwin
+license                 Apache-2
 
-description			Ehcache is a pure Java, in-process object cache.
-long_description	Ehcache is a pure Java, in-process cache with the following features: \
-	1.	Fast \
-	2.	Simple \
-	3.	Acts as a pluggable cache for Hibernate \
-	4.	Small foot print. Both in terms of size and memory requirements. \
-	5.	Minimal dependencies. \
-	6.	Fully documented. See the online Documentation, FAQ and the online JavaDoc. \
-	7.	Comprehensively Test Coverage. See the clover test report. \
-	8.	Scalable to hundreds of caches and large multi-cpu servers. \
-	9.	Provides LRU, LFU and FIFO cache eviction policies. \
-	10.	Available under the Apache 1.1 license. Ehcache's copyright and licensing has been reviewed and approved by the Apache Software Foundation, making ehcache suitable for use in Apache projects. \
-	11.	Production tested. All final versions of ehcache are production tested for several weeks on a large and very busy eCommerce site before release.
+description             Ehcache is a pure Java, in-process object cache.
+long_description        Ehcache is a pure Java, in-process cache with the \
+    following features: \
+    1.  Fast \
+    2.  Simple \
+    3.  Acts as a pluggable cache for Hibernate \
+    4.  Small foot print. Both in terms of size and memory requirements. \
+    5.  Minimal dependencies. \
+    6.  Fully documented. See the online Documentation, FAQ and the online JavaDoc. \
+    7.  Comprehensively Test Coverage. See the clover test report. \
+    8.  Scalable to hundreds of caches and large multi-cpu servers. \
+    9.  Provides LRU, LFU and FIFO cache eviction policies. \
+    10. Available under the Apache 1.1 license. Ehcache's copyright and licensing has \
+    been reviewed and approved by the Apache Software Foundation, making ehcache \
+    suitable for use in Apache projects. \
+    11. Production tested. All final versions of ehcache are production tested for \
+    several weeks on a large and very busy eCommerce site before release.
 
-homepage			http://ehcache.sourceforge.net/
+extract.suffix          .jar
+extract.only
 
-master_sites		sourceforge
+supported_archs         noarch
 
-extract.suffix		.tgz
-worksrcdir			${name}
-fetch.type			cvs
-cvs.module			${name}
-cvs.root			:pserver:anonymous@cvs.sourceforge.net:/cvsroot/ehcache
-cvs.tag				RELEASE_[string map { . _ } ${version}]
+checksums               md5 a6f66597f5aca8104972a79e72d62a04 \
+                        sha256 95ed983b906d5d292ea41f561c09e58e9c22574a4fd73958bd9956a645365cfc \
+                        rmd160 858c91550036b2687b481c06eeb927c497f85e42 \
+                        size 1796698
 
-checksums			md5 1cc46d376838b9d4a99b1a83ebabb88c
+use_configure           no
 
-depends_build		bin:ant:apache-ant
-depends_lib			bin:java:kaffe
+build                   {}
 
-use_configure		no
+pre-destroot {
+    xinstall -m 644 ${distpath}/${distfiles} ${distpath}
+}
 
-build.cmd			ant
-build.target		clean dist
-
-destroot	{
-	xinstall -m 755 -d ${destroot}${prefix}/share/java \
-		${destroot}${prefix}/share/doc/${name}
-	xinstall -m 644 \
-		${worksrcpath}/build/dist/${name}-${version}.jar \
-		${destroot}${prefix}/share/java/${name}.jar
-	file copy ${worksrcpath}/build/javadoc \
-		${destroot}${prefix}/share/doc/${name}
+destroot {
+    xinstall -m 755 -d ${destroot}${prefix}/share/java ${destroot}${prefix}/share/doc/${name}
+    file copy ${distpath}/${distfiles} ${destroot}${prefix}/share/doc/${name}
 }


### PR DESCRIPTION
Resolution of issue #60219 - [https://trac.macports.org/ticket/60219]

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.3 19D76

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?