### PR TITLE
php-mysql-xdevapi: fix parse error on Mac OS X Lion

### DIFF
--- a/php/php-mysql-xdevapi/Portfile
+++ b/php/php-mysql-xdevapi/Portfile
@@ -45,7 +45,7 @@ if {${name} ne ${subport}} {
     configure.args      --with-boost=${prefix}/include
 
     platform darwin 11 {
-        if {[vercmp ${branch} 7.1] >= 0 && [vercmp ${branch} 7.4] < 0} {
+        if {[vercmp ${php.branch} 7.1] >= 0 && [vercmp ${php.branch} 7.4] < 0} {
             # Need to investigate how this was fixed for php 7.4 and
             # possibly backport the fix.
             # https://bugs.php.net/bug.php?id=76826


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.7.5
Xcode 4.6.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
