### PR TITLE
k9s: update to 0.19.1

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.19.0 v
+go.setup            github.com/derailed/k9s 0.19.1 v
 
 categories          sysutils
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -19,9 +19,9 @@ platforms           darwin
 supported_archs     x86_64
 license             Apache-2
 
-checksums           rmd160  b4bc6ecc82a0b2d2b19ed96a40f264d4eb6cee85 \
-                    sha256  a4b86b1519085d27f876208330f4dc5a93aec3176a6a66d8782e6b27b1867cc9 \
-                    size    17387766
+checksums           rmd160  4a9c42168a91a1bf35635b274e0d96e4ae4f663f \
+                    sha256  a0c7af76bdadae54566936209e2e61291beaf3f44d7c3e52581f3aee01f50a5a \
+                    size    17388336
 
 # Reproduce the "build" target from the upstream Makefile
 set go_ldflags      "-w -X ${go.package}/cmd.version=${version} \


### PR DESCRIPTION
#### Description

Update to k9s 0.19.1.

###### Tested on

macOS 10.15.4 19E266
Xcode 11.4 11E146

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?