### PR TITLE
bandwhich: update to 0.13.0

### DIFF
--- a/net/bandwhich/Portfile
+++ b/net/bandwhich/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        imsnif bandwhich 0.12.0
+github.setup        imsnif bandwhich 0.13.0
 categories          net
 platforms           darwin
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
@@ -24,9 +24,9 @@ long_description    bandwhich sniffs a given network interface and records IP \
 github.tarball_from archive
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  5fab2e8ecf87a88002831e728f6180f208f3312f \
-                    sha256  195693dccff3f5104376c2aa83340583440ac2c40c4f4289fe07b6948ca5d363 \
-                    size    2992421
+                    rmd160  84f77f48344164bd856d537b3e5b335b1e95369c \
+                    sha256  42b0411c0a9df0b51fa5bedaa5f04fb001fdf46cd2d7ea9a58c98f4f6e7a15d3 \
+                    size    2994854
 
 destroot {
     xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E266
Xcode 11.4 11E146

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
