### PR TITLE
pango: fix broken x11 variant.

### DIFF
--- a/x11/pango/Portfile
+++ b/x11/pango/Portfile
@@ -11,7 +11,7 @@ conflicts               pango-devel
 set my_name             pango
 epoch                   1
 version                 1.42.4
-revision                1
+revision                2
 checksums               rmd160  e91880e0e9a459bbc2c280ac747ab31f80352000 \
                         sha256  1d2b74cd63e8bd41961f2f8d952355aa0f9be6002b52c8aa7699d9f5da597c9d \
                         size    833876
@@ -49,7 +49,7 @@ patchfiles-append       fix-pango_layout_get_pixel_extents-crash.patch
 
 configure.args          --enable-static \
                         --disable-silent-rules \
-                        --without-x
+                        --without-xft
 
 gobject_introspection   yes
 
@@ -75,7 +75,7 @@ platform macosx {
 
 variant x11 {
     depends_lib-append      port:Xft2
-    configure.args-delete   --without-x
+    configure.args-delete   --without-xft
     configure.args-append   --x-include=${prefix}/include \
                             --x-lib=${prefix}/lib
 }


### PR DESCRIPTION
I have no idea when but I assume this must have changed at some point upstream. I don’t know, however, whether the x-lib and x-include flags are still valid or not but at least configure’s not complaining about them.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
