### PR TITLE
icu: Fix possibly-conflicting macro invocation

### DIFF
--- a/devel/icu/Portfile
+++ b/devel/icu/Portfile
@@ -122,7 +122,7 @@ subport ${name}-lx {
 }
 
 if {${subport} eq ${name}} {
-    revision                1
+    revision                2
 }
 
 if { ${subport} ne "${name}-docs" } {
@@ -136,6 +136,9 @@ if { ${subport} ne "${name}-docs" } {
         patchfiles-append   max_align_t.patch
         # https://trac.macports.org/ticket/59723
         patchfiles-append   umachine.h.patch
+
+        patchfiles-append patch-declspec-conflict.patch
+        # https://trac.macports.org/ticket/60325
     }
 
     # ICU has three mechanisms to aid other projects in building properly

--- a/devel/icu/files/patch-declspec-conflict.patch
+++ b/devel/icu/files/patch-declspec-conflict.patch
@@ -1,0 +1,37 @@
+--- common/unicode/platform.h.orig	2020-04-05 22:01:04.000000000 -0400
++++ common/unicode/platform.h	2020-04-05 22:01:39.000000000 -0400
+@@ -814,16 +814,16 @@
+     /* Use the predefined value. */
+ #elif defined(U_STATIC_IMPLEMENTATION)
+ #   define U_EXPORT
+-#elif defined(_MSC_VER) || (UPRV_HAS_DECLSPEC_ATTRIBUTE(dllexport) && \
+-                            UPRV_HAS_DECLSPEC_ATTRIBUTE(dllimport))
+-#   define U_EXPORT __declspec(dllexport)
++#elif defined(_MSC_VER) || (UPRV_HAS_DECLSPEC_ATTRIBUTE(__dllexport__) && \
++                            UPRV_HAS_DECLSPEC_ATTRIBUTE(__dllimport__))
++#   define U_EXPORT __declspec(__dllexport__)
+ #elif defined(__GNUC__)
+ #   define U_EXPORT __attribute__((visibility("default")))
+ #elif (defined(__SUNPRO_CC) && __SUNPRO_CC >= 0x550) \
+    || (defined(__SUNPRO_C) && __SUNPRO_C >= 0x550) 
+ #   define U_EXPORT __global
+ /*#elif defined(__HP_aCC) || defined(__HP_cc)
+-#   define U_EXPORT __declspec(dllexport)*/
++#   define U_EXPORT __declspec(__dllexport__)*/
+ #else
+ #   define U_EXPORT
+ #endif
+@@ -839,10 +839,10 @@
+ 
+ #ifdef U_IMPORT
+     /* Use the predefined value. */
+-#elif defined(_MSC_VER) || (UPRV_HAS_DECLSPEC_ATTRIBUTE(dllexport) && \
+-                            UPRV_HAS_DECLSPEC_ATTRIBUTE(dllimport))
++#elif defined(_MSC_VER) || (UPRV_HAS_DECLSPEC_ATTRIBUTE(__dllexport__) && \
++                            UPRV_HAS_DECLSPEC_ATTRIBUTE(__dllimport__))
+     /* Windows needs to export/import data. */
+-#   define U_IMPORT __declspec(dllimport)
++#   define U_IMPORT __declspec(__dllimport__)
+ #else
+ #   define U_IMPORT 
+ #endif


### PR DESCRIPTION
#### Description

This is a potential bug introduced in icu65.1. I’ve already reported it upstream, but who knows when it’ll get fixed.

As of now, this was producing a conflict with at least CppRestSdk

See more complete explanation in https://trac.macports.org/ticket/60325

P.S. I know I shouldn't open tickets for new PRs, but I did because this is something I expect will eventually be fixed, making my patch obsolete.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
