### PR TITLE
welle.io: update welle.io-devel to 20200405

### DIFF
--- a/multimedia/welle.io/Portfile
+++ b/multimedia/welle.io/Portfile
@@ -109,15 +109,15 @@ if {${subport} eq ${name}} {
         -DGIT_COMMIT_HASH=${version}
 } else {
     # devel
-    github.setup            AlbrechtL welle.io db596b30c59b39761b7e626c4ad12b68a4a71fc4
+    github.setup            AlbrechtL welle.io 36276f4217c02a81a0e9d41cfb61f9b56eec31fe
     set githash             [string range ${github.version} 0 6]
-    version                 20200204+git${githash}
+    version                 20200405+git${githash}
 
     conflicts               welle.io
 
-    checksums               rmd160  975121c0a10fff8e7863280e9f4c7076b8e0dacd \
-                            sha256  f3ddcbaf5e826b6f4ad23d88dbc99cfba2fcad8edbdf89411f121a66b6d01ae6 \
-                            size    1646546
+    checksums               rmd160  936bc8415d8156823e48770fb662eff1e51f2886 \
+                            sha256  4bc710e6852004ac356731f37508126dae75cced1b6207b1c5a0b19fd377cbf9 \
+                            size    1646154
 
     configure.pre_args-append \
         -DGIT_COMMIT_HASH=${githash}


### PR DESCRIPTION
#### Description

welle.io: update welle.io-devel to 20200405

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
