### PR TITLE
FAudio: Update to 20.04

### DIFF
--- a/audio/FAudio/Portfile
+++ b/audio/FAudio/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cmake 1.1
 
-github.setup            FNA-XNA FAudio 20.03
+github.setup            FNA-XNA FAudio 20.04
 revision                0
 
 license                 zlib
@@ -18,12 +18,22 @@ long_description        an XAudio reimplementation that focuses solely on develo
 
 depends_lib-append      port:libsdl2
 
-checksums               rmd160  c3a00ea95ac9f34e5011ba1aa1b4553f47b0526c \
-                        sha256  654500c4adac47fdd4885877c2496d8b4c313af7a6b59f7cfca76e03297d28f6 \
-                        size    908871
+checksums               rmd160  b22854b0b36c1041b68bf1edb0fdaea4b042bfa4 \
+                        sha256  92cafeaf7b61e6165f632c0d4564704b9cf326525639298eedc3ae2454a2bf3c \
+                        size    909352
 
-# remove set deployment target
-patchfiles              patch-faudio-remove-deployment-target.diff
+# Bump macOS minimum to 10.9, per cert requirements
+# https://github.com/FNA-XNA/FAudio/commit/30b692372a81189cf57f013e8252e53edd57dcf1
+# So fallback to 20.3 for systems below 10.9
+if {${os.major} < 13} {
+    github.setup            FNA-XNA FAudio 20.03
+    checksums               rmd160  c3a00ea95ac9f34e5011ba1aa1b4553f47b0526c \
+                            sha256  654500c4adac47fdd4885877c2496d8b4c313af7a6b59f7cfca76e03297d28f6 \
+                            size    908871
+                            
+    # remove set deployment target
+    patchfiles              patch-faudio-remove-deployment-target.diff
+}
 
 configure.args          -DFFMPEG=OFF \
                         -DBUILD_UTILS=OFF \


### PR DESCRIPTION
- Updated FAudio to the current release.
- Added fallback to support systems below 10.9

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G4032
Xcode 10.3 10G8 

macOS 10.7.5 11G63
Xcode 4.3.3 4E3002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
