### PR TITLE
mkvtoolnix: update to 45.0.0 and address xsltproc err in new versions

### DIFF
--- a/multimedia/mkvtoolnix/Portfile
+++ b/multimedia/mkvtoolnix/Portfile
@@ -6,11 +6,11 @@ PortGroup           muniversal 1.0
 
 # The developer does not accept macOS-specific bug reports, but does
 # accept pull requests.
-github.setup        mbunkus mkvtoolnix 41.0.0 release-
+github.setup        mbunkus mkvtoolnix 45.0.0 release-
 revision            0
-checksums           rmd160  17b2f3b7d6eb87e9d9d4aac536b66705c18d497f \
-                    sha256  7cdd6ad9144324162604172b7e96cb13cdbb7913e07c4ad7633344aac20e4103 \
-                    size    7401548
+checksums           rmd160  a94a0848c7185befd5ce136f545728fea8d5f050 \
+                    sha256  995208f38e5d77da326ec2718a820357219856d8e375081e5d8d7ab9239b6d66 \
+                    size    7500448
 
 categories          multimedia
 platforms           darwin
@@ -61,6 +61,12 @@ post-patch {
     }
 }
 
+# This is now in the upstream, remove when updating to v46
+pre-configure {
+    reinplace "s|XSLTPROC_FLAGS=--nonet|XSLTPROC_FLAGS=\"--nonet --maxdepth 10000\"|g" ${worksrcpath}/configure
+    reinplace "s|\"\$XSLTPROC\" \"\$XSLTPROC_FLAGS\"|\"\$XSLTPROC\" \$XSLTPROC_FLAGS|g" ${worksrcpath}/configure
+}
+
 compiler.cxx_standard 2017
 
 set cxx_stdlibflags {}
@@ -91,8 +97,10 @@ test.target         tests:unit
 
 variant qtgui description {Build with the qt5 GUI} {
     PortGroup       app 1.0
+
     PortGroup       qt5 1.0
-    
+
+
     app.name        MKVToolNix
     app.executable  mkvtoolnix-gui
     app.icon        ${worksrcpath}/share/icons/256x256/mkvtoolnix-gui.png


### PR DESCRIPTION
About the reinplaces: 
It seems that xsltproc has different recursion limits on different platforms. So for mkvtoolnix, it works on other platforms but not macOS (where limit is 3000). The first reinplace increases the limit, and the second one enables word splitting for the args.
I actually reported this long ago to upstream but the dev didn't want to help, so I decided to investigate. See: https://gitlab.com/mbunkus/mkvtoolnix/issues/2754

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E266
Xcode 11.4 11E146

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
