### PR TITLE
nano: Update to 4.9.2

### DIFF
--- a/editors/nano/Portfile
+++ b/editors/nano/Portfile
@@ -1,14 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem      1.0
+PortSystem          1.0
 
-name            nano
-version         4.9.2
-categories      editors
-platforms       darwin freebsd
-license         GPL-3
-maintainers     {grimreaper @grimreaper} openmaintainer
-description     Nano is ANOther editor - enhanced free Pico Clone
+name                nano
+version             4.9.2
+categories          editors
+platforms           darwin freebsd
+license             GPL-3
+maintainers         {grimreaper @grimreaper} openmaintainer
+description         Nano is ANOther editor - enhanced free Pico Clone
 
 long_description \
     GNU nano is a small and friendly text editor. Besides basic text \
@@ -16,24 +16,24 @@ long_description \
     and replace, goto line number, auto-indentation, feature toggles, \
     internationalization support, and filename tab completion.
 
-homepage        https://www.nano-editor.org
-master_sites    ${homepage}/dist/v[strsed ${version} {/\.[0-9]*$//}]/ gnu
+homepage            https://www.nano-editor.org
+master_sites        ${homepage}/dist/v[strsed ${version} {/\.[0-9]*$//}]/ gnu
 
 checksums           rmd160  15ed91e7958306f48cacd56f4ee2b99ec6782d50 \
                     sha256  31186eab2c266575a049d73216d422f3ad035304e071a82a9f34560b1cfee320 \
                     size    2996106
 
-depends_lib     port:gettext \
-                port:libiconv \
-                port:libmagic \
-                port:ncurses \
-                port:zlib
+depends_lib         port:gettext \
+                    port:libiconv \
+                    port:libmagic \
+                    port:ncurses \
+                    port:zlib
 
-configure.args  --enable-utf8
+configure.args      --enable-utf8
 
 use_parallel_build  yes
 
-set docdir      ${prefix}/share/doc/${name}
+set docdir          ${prefix}/share/doc/${name}
 
 post-destroot {
     xinstall -d $destroot$docdir/html
@@ -46,6 +46,6 @@ notes "
 A sample configuration file is available at ${docdir}/sample.nanorc.
 "
 
-livecheck.url   ${homepage}/download.php
-livecheck.type  regex
-livecheck.regex "${name}-(\\d+\\.\\d+(\\.\\d+)?)"
+livecheck.url       ${homepage}/download.php
+livecheck.type      regex
+livecheck.regex     "${name}-(\\d+\\.\\d+(\\.\\d+)?)"

--- a/editors/nano/Portfile
+++ b/editors/nano/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 
 name            nano
-version         4.9.1
+version         4.9.2
 categories      editors
 platforms       darwin freebsd
 license         GPL-3
@@ -19,9 +19,9 @@ long_description \
 homepage        https://www.nano-editor.org
 master_sites    ${homepage}/dist/v[strsed ${version} {/\.[0-9]*$//}]/ gnu
 
-checksums           rmd160  33a243c237b5e66b30a618dc696bc5c6b928fa31 \
-                    sha256  85fe5d70ff24be1020de9d16c2a452d908f2614065be7845482ac2d08cbdfeec \
-                    size    2995183
+checksums           rmd160  15ed91e7958306f48cacd56f4ee2b99ec6782d50 \
+                    sha256  31186eab2c266575a049d73216d422f3ad035304e071a82a9f34560b1cfee320 \
+                    size    2996106
 
 depends_lib     port:gettext \
                 port:libiconv \
@@ -48,4 +48,4 @@ A sample configuration file is available at ${docdir}/sample.nanorc.
 
 livecheck.url   ${homepage}/download.php
 livecheck.type  regex
-livecheck.regex "${name}-(\\d+\\.\\d+(\\.\d+)?)"
+livecheck.regex "${name}-(\\d+\\.\\d+(\\.\\d+)?)"


### PR DESCRIPTION
#### Description

I'm running through `port livecheck installed` and trying to update things that have an open maintainer or no maintainer.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F53f
Xcode 11.4 11E146 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
