### PR TITLE
google-cloud-sdk: update to 288.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             287.0.0
+version             288.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  68865c22eaec75c4d88de36ca8a21f691ea1d1c2 \
-                    sha256  cdfe1212b4b8d7cd29983380338ebf660ecc3a705d9992c2f188b5c0e18045a8 \
-                    size    48838500
+    checksums       rmd160  045e9c4cd93001311682be74f880a7ba3307d370 \
+                    sha256  ad7491a4fe98a18a4bf35941045c7abccd7cf5f4706b0daaeb1258b302f3d1bc \
+                    size    48879120
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  0498555a2530b9316426bcfc0af50ef33fbab32a \
-                    sha256  2dafe2afc453781a8010aaaacb6631b5dbbeac8ae67a71cd9376bdd53fdddfd6 \
-                    size    49881178
+    checksums       rmd160  84c654619ce466ca6db3ddd97171a8677fe0092b \
+                    sha256  716b6412bc875c9319d6d77d7f0a125924ba8b90625dad7258446f4ca6a3f488 \
+                    size    49920798
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 288.0.0.

###### Tested on

macOS 10.15.4 19E266
Xcode 11.4 11E146

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?