### PR TITLE
transmission: fix build on mojave and catalina

### DIFF
--- a/net/transmission/Portfile
+++ b/net/transmission/Portfile
@@ -53,6 +53,12 @@ post-patch {
         ${worksrcpath}/Transmission.xcodeproj/project.pbxproj
 }
 
+pre-build {
+    if {${os.platform} eq "darwin" && ${os.version} >= 18} {
+        system -W ${worksrcpath}/macosx "/usr/bin/codesign --sign - Sparkle.framework"
+    }
+}
+
 destroot {
     file copy ${worksrcpath}/build/${xcode.configuration}/Transmission.app \
         ${destroot}${applications_dir}/Transmission.app
@@ -74,4 +80,10 @@ if {([vercmp $xcodeversion 7.0] < 0) || ([vercmp ${macosx_deployment_target} 10.
         ui_error "Consider installing transmission-x11 instead."
         return -code error "incompatible OS X version"
     }
+}
+
+# this port has not yet been updated to build with the new build system Xcode 10+
+if {${os.platform} eq "darwin" && ([vercmp $xcodeversion 10.0] > 0)} {
+    build.pre_args-append -UseModernBuildSystem=NO
+    destroot.pre_args-append -UseModernBuildSystem=NO
 }


### PR DESCRIPTION
#### Description
Closes: https://trac.macports.org/ticket/57213
Part of the fix is taken from the ticket above.
Another part is for signing the sparkles bundle.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E266
Xcode 11.4 11E146

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
