### PR TITLE
crossgcc: Add 9.3.0

### DIFF
--- a/_resources/port1.0/group/crossgcc-1.0.tcl
+++ b/_resources/port1.0/group/crossgcc-1.0.tcl
@@ -66,6 +66,11 @@ array set crossgcc.versions_info {
         sha256  ea6ef08f121239da5695f76c9b33637a118dcf63e24164422231917fa61fb206 \
         size    70607648
     }}
+    9.3.0 {xz {
+        rmd160  e0ade31726b8fbb1eb308e2b1383a79633aef996 \
+        sha256  71e197867611f6054aa1119b13a0c0abac12834765fe2d81f35ac57f84f742d1 \
+        size    70533868
+    }}
 }
 
 array set newlib.versions_info {


### PR DESCRIPTION
#### Description

I really actually want a new arm-none-eabi-gcc; is this the correct thing to bump first? Should I update all the cross compilers together?

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F53f
Xcode 11.4 11E146 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
