### PR TITLE
mingw-gcc: update to 9.3.0

### DIFF
--- a/cross/i686-w64-mingw32-gcc/Portfile
+++ b/cross/i686-w64-mingw32-gcc/Portfile
@@ -8,10 +8,10 @@ set mingw_name      w64-mingw32
 set mingw_arch      i686
 set mingw_target    ${mingw_arch}-${mingw_name}
 
-crossgcc.setup      ${mingw_target} 9.2.0
+crossgcc.setup      ${mingw_target} 9.3.0
 crossgcc.languages  {c c++ fortran objc obj-c++}
 dist_subdir         gcc[lindex [split ${version} .] 0]
-revision            2
+revision            0
 
 maintainers         {mojca @mojca} openmaintainer
 

--- a/cross/x86_64-w64-mingw32-gcc/Portfile
+++ b/cross/x86_64-w64-mingw32-gcc/Portfile
@@ -8,10 +8,10 @@ set mingw_name      w64-mingw32
 set mingw_arch      x86_64
 set mingw_target    ${mingw_arch}-${mingw_name}
 
-crossgcc.setup      ${mingw_target} 9.2.0
+crossgcc.setup      ${mingw_target} 9.3.0
 crossgcc.languages  {c c++ fortran objc obj-c++}
 dist_subdir         gcc[lindex [split ${version} .] 0]
-revision            2
+revision            0
 
 maintainers         {mojca @mojca} openmaintainer
 


### PR DESCRIPTION
#### Description
Update mingw-gcc ports to using gcc-9.3.0

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Blocked by https://github.com/macports/macports-ports/pull/6817

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G4032
Xcode 10.3 10G8 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
