### PR TITLE
terragrunt: fix terraform binary used

### DIFF
--- a/sysutils/terragrunt/Portfile
+++ b/sysutils/terragrunt/Portfile
@@ -5,22 +5,30 @@ PortGroup           golang 1.0
 
 name                terragrunt
 version             0.23.4
-depends_run         port:terraform-0.12
+revision            1
 
 categories          sysutils
 platforms           darwin linux
 license             MIT
 maintainers         {mjrc.nl:macports @mjrc} openmaintainer
 
-description         Terragrunt
-long_description    Terragrunt is a thin wrapper for Terraform that provides extra tools for working with multiple Terraform modules.
-homepage            https://terragrunt.gruntwork.io
+description         Terragrunt is a thin wrapper for Terraform
+long_description    ${description} that provides extra tools for working with multiple Terraform modules.
 
 go.setup            github.com/gruntwork-io/terragrunt ${version} v
+homepage            https://terragrunt.gruntwork.io
 
 checksums           rmd160  f072990cea4a0d0d2a814e32ab233ec64a93825e \
                     sha256  3b4ddc07684eba41e1d3ad8b33464e8e9aeea6d2adb29aab6799a00f48988a52 \
                     size    1963542
+
+patchfiles          patch-options.go.diff
+
+post-patch {
+    reinplace "s|@@TERRAFORM_BIN@@|terraform0.12|g" ${worksrcpath}/options/options.go
+}
+
+depends_run         port:terraform-0.12
 
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
@@ -28,14 +36,3 @@ destroot {
 
 set go_ldflags      "-X main.VERSION=${version}"
 build.args          -ldflags \"${go_ldflags}\" ${go.package}
-
-notes "
-Note that terragrunt requires the terraform0.12 port to be installed.  
-Also, it looks for terraform on the path. In order create a link, run: 
-
-sudo port select --set terraform terraform0.12
-
-Alternatively, use the TERRAGRUNT_TFPATH environment variable or the 
---terragrunt-tfpath command line argument to specify a specific version 
-of terraform to use.   
-"

--- a/sysutils/terragrunt/files/patch-options.go.diff
+++ b/sysutils/terragrunt/files/patch-options.go.diff
@@ -1,0 +1,11 @@
+--- options/options.go.orig	2020-04-09 12:07:58.000000000 -0400
++++ options/options.go	2020-04-09 12:08:19.000000000 -0400
+@@ -22,7 +22,7 @@
+ const DEFAULT_MAX_FOLDERS_TO_CHECK = 100
+ 
+ // TERRAFORM_DEFAULT_PATH just takes terraform from the path
+-const TERRAFORM_DEFAULT_PATH = "terraform"
++const TERRAFORM_DEFAULT_PATH = "@@TERRAFORM_BIN@@"
+ 
+ const TerragruntCacheDir = ".terragrunt-cache"
+ 


### PR DESCRIPTION
#### Description
This PR makes sure that `terragrunt` is by default using the `terraform` binary installed by MacPorts, which is named `terraform0.12`. 

Closes: https://trac.macports.org/ticket/60333
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G4032
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
