### PR TITLE
crossbinutils: bugfix - disable libbfd

### DIFF
--- a/_resources/port1.0/group/crossbinutils-1.0.tcl
+++ b/_resources/port1.0/group/crossbinutils-1.0.tcl
@@ -147,8 +147,7 @@ proc crossbinutils.setup {target version} {
     configure.args \
         --target=${target} \
         --program-prefix=${target}- \
-        --enable-install-libiberty=${prefix}/${crossbinutils.target}/host  \
-        --enable-install-libbfd
+        --enable-install-libiberty=${prefix}/${crossbinutils.target}/host
 
     build.dir ${workpath}/build
 

--- a/cross/arm-elf-binutils/Portfile
+++ b/cross/arm-elf-binutils/Portfile
@@ -5,6 +5,7 @@ PortGroup           crossbinutils 1.0
 
 crossbinutils.setup arm-elf 2.34
 maintainers         nomaintainer
+revision            1
 
 # Fix build problems on powerpc, #29925
 configure.args-append --disable-werror

--- a/cross/arm-none-eabi-binutils/Portfile
+++ b/cross/arm-none-eabi-binutils/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
 crossbinutils.setup arm-none-eabi 2.34
+revision            1
 maintainers         nomaintainer
 
 configure.args-append --disable-werror

--- a/cross/arm-none-linux-gnueabi-binutils/Portfile
+++ b/cross/arm-none-linux-gnueabi-binutils/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
 crossbinutils.setup arm-none-linux-gnueabi 2.34
+revision            1
 maintainers         nomaintainer
 
 # description       FSF Binutils for arm-none-linux-gnueabi cross development, with Code Sourcery patches (for Nokia Internet Tablet)

--- a/cross/avr-binutils/Portfile
+++ b/cross/avr-binutils/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
 crossbinutils.setup avr 2.34
+revision            1
 maintainers         {g5pw @g5pw} openmaintainer
 
 # configure.args-append --disable-werror

--- a/cross/i386-elf-binutils/Portfile
+++ b/cross/i386-elf-binutils/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
 crossbinutils.setup i386-elf 2.34
+revision            1
 maintainers         nomaintainer
 
 configure.args-append --disable-werror

--- a/cross/i686-w64-mingw32-binutils/Portfile
+++ b/cross/i686-w64-mingw32-binutils/Portfile
@@ -8,6 +8,7 @@ set mingw_name      w64-mingw32
 set mingw_arch      i686
 set mingw_target    ${mingw_arch}-${mingw_name}
 crossbinutils.setup ${mingw_target} 2.34
+revision            1
 
 maintainers         {mojca @mojca} openmaintainer
 

--- a/cross/m68k-elf-binutils/Portfile
+++ b/cross/m68k-elf-binutils/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
 crossbinutils.setup m68k-elf 2.34
+revision            1
 
 configure.args-append \
                     --disable-werror

--- a/cross/mips-elf-binutils/Portfile
+++ b/cross/mips-elf-binutils/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
 crossbinutils.setup mips-elf 2.34
+revision            1
 
 configure.args-append \
                     --disable-werror

--- a/cross/ppc-linux-binutils/Portfile
+++ b/cross/ppc-linux-binutils/Portfile
@@ -4,4 +4,5 @@ PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
 crossbinutils.setup ppc-linux 2.34
+revision            1
 maintainers         nomaintainer

--- a/cross/spu-binutils/Portfile
+++ b/cross/spu-binutils/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
 crossbinutils.setup spu 2.34
+revision            1
 maintainers         nomaintainer
 
 configure.args-append   --disable-werror

--- a/cross/x86_64-elf-binutils/Portfile
+++ b/cross/x86_64-elf-binutils/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
 crossbinutils.setup x86_64-elf 2.34
+revision            1
 maintainers         nomaintainer
 
 configure.args-append --disable-werror

--- a/cross/x86_64-w64-mingw32-binutils/Portfile
+++ b/cross/x86_64-w64-mingw32-binutils/Portfile
@@ -8,6 +8,7 @@ set mingw_name      w64-mingw32
 set mingw_arch      x86_64
 set mingw_target    ${mingw_arch}-${mingw_name}
 crossbinutils.setup ${mingw_target} 2.34
+revision            1
 
 maintainers         {mojca @mojca} openmaintainer
 

--- a/devel/binutils/Portfile
+++ b/devel/binutils/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                binutils
-version             2.32
+version             2.34
 
-checksums           rmd160  cfff50aae6534512a51fbb720e30f37484f8193e \
-                    sha256  0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04 \
-                    size    20774880
+checksums           rmd160  8ee249f7c98c925ef650eaca3b4d1710d75be4e7 \
+                    sha256  f00b0e8803dc9bab1e2165bd568528135be734df3fabf8d0161828cd56028952 \
+                    size    21637796
 
 description         FSF Binutils for native development.
 long_description    Free Software Foundation development toolchain ("binutils") \
@@ -28,7 +28,8 @@ configure.args      --infodir='${prefix}/share/info' \
                     --mandir='${prefix}/share/man' \
                     --disable-werror \
                     --program-prefix=g \
-                    --enable-shared
+                    --enable-shared \
+                    --enable-install-libbfd
 
 # The Makefile runs configure again in subdirectories.
 # It correcty passes along most configure variables (CFLAGS, LDFLAGS, ...),


### PR DESCRIPTION
binutils 2.34 when libbfd is enabled installs sharded files that cause conflicts ports that use this never version to have conflicts.

An example of this is mingw-w64, as both i686-w64-mingw32-binutils & x86_64-w64-mingw32-binutils will now both install these shared files.
```
Error: Failed to activate x86_64-w64-mingw32-binutils: Image error: /opt/local/include/ctf-api.h is being used by the active i686-w64-mingw32-binutils port.  Please deactivate this port first, or use 'port -f activate x86_64-w64-mingw32-binutils' to force the activation.
DEBUG: Error code: registry::image-error
DEBUG: Backtrace: Image error: /opt/local/include/ctf-api.h is being used by the active i686-w64-mingw32-binutils port.  Please deactivate this port first, or use 'port -f activate x86_64-w64-mingw32-binutils' to force the activation.
```

Also see https://github.com/macports/macports-ports/pull/6460 the alternative is doing that to all affected Portfiles instead of making the chage within crossbinutils

All affected Ports had a revision bump and binutils now adds `--enable-install-libbfd` to keep the expected functionality.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G4032
Xcode 10.3 10G8 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
