### PR TITLE
llvm*: fix wrapper

### DIFF
--- a/lang/llvm-5.0/files/llvm-bin
+++ b/lang/llvm-5.0/files/llvm-bin
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-if [ -x /usr/bin/xcrun ] ; then
-    exec /usr/bin/xcrun EXEC_PATH "${@}"
-else
-    exec EXEC_PATH "${@}"
-fi
+if [ -x /usr/bin/xcrun ] ; then exec /usr/bin/xcrun EXEC_PATH "${@}"; fi
+
+if [ ! -x /usr/bin/xcrun ] ; then exec EXEC_PATH "${@}"; fi

--- a/lang/llvm-6.0/files/llvm-bin
+++ b/lang/llvm-6.0/files/llvm-bin
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-if [ -x /usr/bin/xcrun ] ; then
-    exec /usr/bin/xcrun EXEC_PATH "${@}"
-else
-    exec EXEC_PATH "${@}"
-fi
+if [ -x /usr/bin/xcrun ] ; then exec /usr/bin/xcrun EXEC_PATH "${@}"; fi
+
+if [ ! -x /usr/bin/xcrun ] ; then exec EXEC_PATH "${@}"; fi

--- a/lang/llvm-7.0/files/llvm-bin
+++ b/lang/llvm-7.0/files/llvm-bin
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-if [ -x /usr/bin/xcrun ] ; then
-    exec /usr/bin/xcrun EXEC_PATH "${@}"
-else
-    exec EXEC_PATH "${@}"
-fi
+if [ -x /usr/bin/xcrun ] ; then exec /usr/bin/xcrun EXEC_PATH "${@}"; fi
+
+if [ ! -x /usr/bin/xcrun ] ; then exec EXEC_PATH "${@}"; fi

--- a/lang/llvm-8.0/files/llvm-bin
+++ b/lang/llvm-8.0/files/llvm-bin
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-if [ -x /usr/bin/xcrun ] ; then
-    exec /usr/bin/xcrun EXEC_PATH "${@}"
-else
-    exec EXEC_PATH "${@}"
-fi
+if [ -x /usr/bin/xcrun ] ; then exec /usr/bin/xcrun EXEC_PATH "${@}"; fi
+
+if [ ! -x /usr/bin/xcrun ] ; then exec EXEC_PATH "${@}"; fi

--- a/lang/llvm-9.0/files/llvm-bin
+++ b/lang/llvm-9.0/files/llvm-bin
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-if [ -x /usr/bin/xcrun ] ; then
-    exec /usr/bin/xcrun EXEC_PATH "${@}"
-else
-    exec EXEC_PATH "${@}"
-fi
+if [ -x /usr/bin/xcrun ] ; then exec /usr/bin/xcrun EXEC_PATH "${@}"; fi
+
+if [ ! -x /usr/bin/xcrun ] ; then exec EXEC_PATH "${@}"; fi

--- a/lang/llvm-devel/files/llvm-bin
+++ b/lang/llvm-devel/files/llvm-bin
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-if [ -x /usr/bin/xcrun ] ; then
-    exec /usr/bin/xcrun EXEC_PATH "${@}"
-else
-    exec EXEC_PATH "${@}"
-fi
+if [ -x /usr/bin/xcrun ] ; then exec /usr/bin/xcrun EXEC_PATH "${@}"; fi
+
+if [ ! -x /usr/bin/xcrun ] ; then exec EXEC_PATH "${@}"; fi


### PR DESCRIPTION
#### Description

The current wrapper is incorrect, if xcrun is missing from a system the else fallback section is never called.

Without this change OS X 10.7 when calling an llvm port from macports results in a unusable compiler, with this change I was able to again compile

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.7.5 11G63
Xcode 4.3.3 4E3002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
