### PR TITLE
vgrep: new port

### DIFF
--- a/textproc/vgrep/Portfile
+++ b/textproc/vgrep/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/vrothberg/vgrep 2.2.0 v
+
+categories          textproc
+license             GPL-3
+installs_libs       no
+
+build.cmd           make
+build.target        release
+
+maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
+
+checksums           rmd160  443dde781d2a87ba9be0f9ee1054a750881fc464 \
+                    sha256  d824487534fc297141ac9c57a37ccd52ac3cfb48f19d96d0f580613ebaabdb98 \
+                    size    1637926
+
+description         an easy to use front-end for (git) grep
+
+long_description    vgrep is a command-line tool to search textual patterns \
+                    in directories. It serves as a front-end to grep and \
+                    git-grep and allows to open the indexed matching lines \
+                    in a user-specified editor. vgrep is inspired by the \
+                    ancient cgvg scripts but extended to perform further \
+                    operations such as listing statistics of files and \
+                    directory trees or showing the context lines before and \
+                    after the matches.
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/build/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4 11E146

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
