### PR TITLE
swig: move as default

### DIFF
--- a/devel/swig/Portfile
+++ b/devel/swig/Portfile
@@ -1,10 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
+PortSystem      1.0
 
 name            swig
 version         4.0.1
-revision        0
+revision        1
 checksums       rmd160 8dfb658742824cf47f5528d08f88c77e7aa79a35 \
                 sha256 7a00b4d0d53ad97a14316135e2d702091cd5f193bb58bcfcd8bc59d41e7887a9 \
                 size   8062962
@@ -254,7 +254,8 @@ subport swig-ruby {
 if {${swig.lang} eq ""} {
     depends_lib     port:pcre
 
-    # temporary workaround until we are sure all ports build with SWIG 4.
+    # REMOVE next revision/version bump
+    # used to force the binary renaming
     depends_lib-append port:swig3
 
     set docdir      ${prefix}/share/doc/${name}-${version}
@@ -278,12 +279,6 @@ if {${swig.lang} eq ""} {
     livecheck.type      regex
     livecheck.url       http://swig.org/download.html
     livecheck.regex     The latest release is <.*>${name}-(\\d+(?:\\.\\d+)*)
-
-    # temporary workaround until we are sure all ports build with SWIG 4.
-    post-destroot {
-        move ${destroot}${prefix}/bin/swig        ${destroot}${prefix}/bin/swig4
-        move ${destroot}${prefix}/bin/ccache-swig ${destroot}${prefix}/bin/ccache-swig4
-    }
 
 } else {
 

--- a/devel/swig3/Portfile
+++ b/devel/swig3/Portfile
@@ -1,10 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
+PortSystem      1.0
 
 name            swig3
 version         3.0.12
-revision        0
+revision        1
 checksums       rmd160 41877e9de3ff598731ef36161f77fa66dec3c301 \
                 sha256 7cf9f447ae7ed1c51722efc45e7f14418d15d7a1e143ac9f09a668999f4fc94d
 
@@ -297,6 +297,12 @@ if {${swig.lang} eq ""} {
             xinstall -m 0644 {*}[glob ${worksrcpath}/Doc/Manual/*.{css,html,pdf,png}] \
                 ${destroot}${docdir}/html
         }
+    }
+
+    # rename the swig binary to avoid conflict
+    post-destroot {
+        move ${destroot}${prefix}/bin/swig        ${destroot}${prefix}/bin/swig3
+        move ${destroot}${prefix}/bin/ccache-swig ${destroot}${prefix}/bin/ccache-swig3
     }
 
     livecheck.type      regex

--- a/science/lal/Portfile
+++ b/science/lal/Portfile
@@ -140,8 +140,6 @@ subport octave-${name} {
   # do not prepend ${prefix} to Octave directory
   patchfiles-append     patch-configure.diff
 
-  configure.env-append  SWIG=${prefix}/bin/swig4
-
   configure.args-replace --disable-swig-octave --enable-swig-octave
 
   # Only install SWIG bindings, Python libraries, and Python scripts

--- a/science/lalburst/Portfile
+++ b/science/lalburst/Portfile
@@ -142,8 +142,6 @@ subport octave-${name} {
   # do not prepend ${prefix} to Octave directory
   patchfiles-append     patch-configure.diff
 
-  configure.env-append  SWIG=${prefix}/bin/swig4
-
   configure.args-replace --disable-swig-octave --enable-swig-octave
 
   # Only install SWIG bindings, Python libraries, and Python scripts

--- a/science/lalframe/Portfile
+++ b/science/lalframe/Portfile
@@ -139,8 +139,6 @@ subport octave-${name} {
   # do not prepend ${prefix} to Octave directory
   patchfiles-append     patch-configure.diff
 
-  configure.env-append  SWIG=${prefix}/bin/swig4
-
   configure.args-replace --disable-swig-octave --enable-swig-octave
 
   # Only install SWIG bindings, Python libraries, and Python scripts

--- a/science/lalinference/Portfile
+++ b/science/lalinference/Portfile
@@ -166,8 +166,6 @@ subport octave-${name} {
   # do not prepend ${prefix} to Octave directory
   patchfiles-append     patch-configure.diff
 
-  configure.env-append  SWIG=${prefix}/bin/swig4
-
   configure.args-replace --disable-swig-octave --enable-swig-octave
 
   # Only install SWIG bindings, Python libraries, and Python scripts

--- a/science/lalinspiral/Portfile
+++ b/science/lalinspiral/Portfile
@@ -144,8 +144,6 @@ subport octave-${name} {
   # do not prepend ${prefix} to Octave directory
   patchfiles-append     patch-configure.diff
 
-  configure.env-append  SWIG=${prefix}/bin/swig4
-
   configure.args-replace --disable-swig-octave --enable-swig-octave
 
   # Only install SWIG bindings, Python libraries, and Python scripts

--- a/science/lalmetaio/Portfile
+++ b/science/lalmetaio/Portfile
@@ -138,8 +138,6 @@ subport octave-${name} {
   # do not prepend ${prefix} to Octave directory
   patchfiles-append     patch-configure.diff
 
-  configure.env-append  SWIG=${prefix}/bin/swig4
-
   configure.args-replace --disable-swig-octave --enable-swig-octave
 
   # Only install SWIG bindings, Python libraries, and Python scripts

--- a/science/lalpulsar/Portfile
+++ b/science/lalpulsar/Portfile
@@ -144,8 +144,6 @@ subport octave-${name} {
   # do not prepend ${prefix} to Octave directory
   patchfiles-append     patch-configure.diff
 
-  configure.env-append  SWIG=${prefix}/bin/swig4
-
   configure.args-replace --disable-swig-octave --enable-swig-octave
 
   # Only install SWIG bindings, Python libraries, and Python scripts

--- a/science/lalsimulation/Portfile
+++ b/science/lalsimulation/Portfile
@@ -143,8 +143,6 @@ subport octave-${name} {
   # do not prepend ${prefix} to Octave directory
   patchfiles-append     patch-configure.diff
 
-  configure.env-append  SWIG=${prefix}/bin/swig4
-
   configure.args-replace --disable-swig-octave --enable-swig-octave
 
   # Only install SWIG bindings, Python libraries, and Python scripts

--- a/science/plplot/Portfile
+++ b/science/plplot/Portfile
@@ -121,7 +121,6 @@ configure.args-append   -DBUILD_SHARED_LIBS=ON \
                         -DBUILD_TEST=OFF \
                         -DHAVE_SHAPELIB=ON \
                         -DHAVE_AGG=ON \
-                        -DSWIG_EXECUTABLE=${prefix}/bin/swig4 \
                         -Dhpdf_INCLUDE_DIR=${prefix}/include
 
 post-configure {


### PR DESCRIPTION
#### Description

move swig(4) as default and clear ports that forced the usage

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.4 19E287
Xcode 11.4 11E146

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
