### PR TITLE
dbvis: update to 11.0

### DIFF
--- a/databases/dbvis/Portfile
+++ b/databases/dbvis/Portfile
@@ -4,7 +4,7 @@ PortSystem                  1.0
 PortGroup                   java 1.0
 
 name                        dbvis
-version                     10.0.26
+version                     11.0
 categories                  databases
 platforms                   darwin
 supported_archs             x86_64
@@ -22,9 +22,9 @@ master_sites                ${homepage}/product_download/dbvis-${version}/media/
 distname                    dbvis_macos_[strsed $version g/\\./_/]
 extract.suffix              .tgz
 
-checksums                   rmd160  a76ac42b44398d1dacc9200686f181a9d17e2d71 \
-                            sha256  16b841d19f12afbd554aa98b99a22fd74b4600fc1b9b6d47cc58e4a706a4feb6 \
-                            size    80414843
+checksums                   rmd160  54fe0db3506ab573ec5423be27169f3112548342 \
+                            sha256  2cae8a5e54971e8fca8db364470c83dd2ede1d3443b6e062ba3ebde05be3e2bc \
+                            size    89370363
 
 java.version                1.8+
 java.fallback               openjdk11
@@ -40,5 +40,5 @@ destroot {
 }
 
 livecheck.type              regex
-livecheck.url               ${homepage}/CheckForUpdate/?dbvisVersion=10.0.0&dbvisEdition=Free&channels=feature&channels=maintenance
+livecheck.url               ${homepage}/CheckForUpdate/?dbvisVersion=11.0.0&dbvisEdition=Free&channels=feature&channels=maintenance
 livecheck.regex             "www.dbvis.com/download/(\[0-9.\]+)"


### PR DESCRIPTION
###### Tested on

macOS 10.15.4 19E266
Xcode 11.4 11E146

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?