### PR TITLE
ghc: Update to version 8.10.1

### DIFF
--- a/lang/ghc/Portfile
+++ b/lang/ghc/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           gpg_verify 1.0
 
 name                ghc
-version             8.8.3
+version             8.10.1
 revision            0
 categories          lang haskell
 maintainers         {ieee.org:s.t.smith @essandess} openmaintainer
@@ -38,14 +38,15 @@ use_xz              yes
 master_sites        https://downloads.haskell.org/~${name}/${version}
 distfiles           ${distname}-x86_64-apple-darwin${extract.suffix} \
                     ${distname}-testsuite${extract.suffix}
+
 checksums           ${distname}-x86_64-apple-darwin${extract.suffix} \
-                    rmd160  0c50b7e11babbbf6ba0d5d0c8e6ebfec3f3246f7 \
-                    sha256  7016de90dd226b06fc79d0759c5d4c83c2ab01d8c678905442c28bd948dbb782 \
-                    size    190133108 \
+                    rmd160  5798ed5082418e20603ea022228a3a1015253848 \
+                    sha256  65b1ca361093de4804a7e40b3e68178e1ef720f84f743641ec8d95e56a45b3a8 \
+                    size    192889416 \
                     ${distname}-testsuite${extract.suffix} \
-                    rmd160  b474fa937aaadc2bc6b38ff31de3e55d84ae7310 \
-                    sha256  f9caa452f458e3b540e323bf8216e2712ed21576e205acddd4e2504ad2ad62d0 \
-                    size    1965236 \
+                    rmd160  225d1aba26458102330a730b96ae4500cf00d0bc \
+                    sha256  37cf67b04bcf00ae78914e4612db9d959bc5bd455a27ea5f6461100137c0b800 \
+                    size    2091988
 
 gpg_verify.use_gpg_verification \
                     yes
@@ -99,9 +100,9 @@ if { [variant_isset "prebuilt"] } {
                     ${distname}-src${extract.suffix}
     checksums-append \
                     ${distname}-src${extract.suffix} \
-                    rmd160  3945b5e40a90bdd6d7531791087e485e8b4605e5 \
-                    sha256  e0dcc0aaf3e234c5978f29e6df62947e97720ab404ec0158343df211c5480f89 \
-                    size    19343672
+                    rmd160  99cd5da02c02364bdfb9b171f14012bea32b843a \
+                    sha256  4e3b07f83a266b3198310f19f71e371ebce97c769b14f0d688f4cbf2a2a1edf5 \
+                    size    19781652
 
     depends_build-append \
                     port:alex \


### PR DESCRIPTION
ghc: Update to version 8.10.1

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
