### PR TITLE
BlackHole: new port

### DIFF
--- a/audio/BlackHole/Portfile
+++ b/audio/BlackHole/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           xcode 1.0
+PortGroup           xcode_workaround 1.0
+
+github.setup        ExistentialAudio BlackHole 0.2.6 v
+categories          audio
+platforms           darwin
+maintainers         nomaintainer
+license             GPL-3.0
+
+description         macOS virtual audio driver.  
+long_description    BlackHole is a modern macOS virtual audio driver that \
+                    allows applications to pass audio to other applications \
+                    with zero additional latency.
+
+xcode.configuration Debug
+xcode.build.settings    CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO
+xcode.destroot.settings {*}${xcode.build.settings}
+xcode.destroot.path /Library/Audio/Plug-Ins/HAL
+post-activate {
+  system "sudo launchctl kickstart -kp system/com.apple.audio.coreaudiod"
+}
+
+# BlackHole violates the mtree layout by placing the driver in
+# /Library/Audio/Plug-Ins/HAL
+destroot.violate_mtree yes
+
+checksums           rmd160  3c1e6747ccc9be81f2fe707b43b6a18e8ebbd651 \
+                    sha256  da0ce2754cfb2edcc1e02542e25b5682fc45cc17be0ec256e5183b89e23e5396 \
+                    size    5602801
+notes "\
+To fully uninstall BlackHole, you will need to run the following command after
+running 'port uninstall blackhole':
+
+  sudo launchctl kickstart -kp system/com.apple.audio.coreaudiod    
+
+"


### PR DESCRIPTION
#### Description

This PR adds a new port, BlackHole, which is a macOS virtual audio driver

###### Tested on

macOS 10.15.2 19C57
Xcode 11.4 11E146

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
