### PR TITLE
starship: update to 0.40.1

### DIFF
--- a/sysutils/starship/Portfile
+++ b/sysutils/starship/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        starship starship 0.39.0 v
+github.setup        starship starship 0.40.1 v
 categories          sysutils
 platforms           darwin
 maintainers         {gmail.com:herby.gillot @herbygillot} \
@@ -16,9 +16,9 @@ description         a minimal, blazing fast, and extremely customizable prompt f
 long_description    Starship is ${description}.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  99dcc90ab17e822bfc5acc03f89f995baf4fd462 \
-                    sha256  55b7c09b6830cef58bae0e6ffc503cfea66399bc9a506c7ab502595632f94b0b \
-                    size    5111268
+                    rmd160  d701a26f4e9b9ac4f7111ac231e07c789c932d1a \
+                    sha256  71f0104ec42da1449cfd7a0c591119272c98a0eb1186aaadcca67010c14ed56f \
+                    size    5129187
 
 # For crate:openssl-sys
 depends_build       port:pkgconfig
@@ -42,7 +42,11 @@ cargo.crates \
     battery                          0.7.5  36a698e449024a5d18994a815998bf5e2e4bc1883e35a7d7ba95b6b69ee45907 \
     bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
     blake2b_simd                    0.5.10  d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a \
+    block-buffer                     0.7.3  c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b \
+    block-padding                    0.1.5  fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5 \
+    byte-tools                       0.3.1  e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7 \
     byte-unit                        3.0.3  6894a79550807490d9f19a138a6da0f8830e70c83e83402dd23f16fd6c479056 \
+    byteorder                        1.3.4  08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de \
     bytes                            0.5.4  130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1 \
     cc                              1.0.50  95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd \
     cfg-if                           0.1.9  b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33 \
@@ -57,22 +61,26 @@ cargo.crates \
     crossbeam-epoch                  0.8.2  058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace \
     crossbeam-queue                  0.2.1  c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db \
     crossbeam-utils                  0.7.2  c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8 \
+    digest                           0.8.1  f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5 \
     dirs                             2.0.2  13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3 \
     dirs-sys                         0.3.4  afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b \
     doc-comment                      0.3.3  fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10 \
     dtoa                             0.4.5  4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3 \
     either                           1.5.3  bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3 \
     env_logger                       0.7.1  44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36 \
+    fake-simd                        0.1.2  e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed \
     fnv                              1.0.6  2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3 \
     foreign-types                    0.3.2  f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1 \
     foreign-types-shared             0.1.1  00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b \
+    generic-array                   0.12.3  c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec \
     gethostname                      0.2.1  e692e296bfac1d2533ef168d0b60ff5897b8b70a4009276834014dd8924cc028 \
     getrandom                       0.1.14  7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb \
-    git2                            0.13.1  ef222034f2069cfc5af01ce423574d3d9a3925bd4052912a14e5bcfd7ca9e47a \
-    hermit-abi                       0.1.8  1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8 \
-    http                             0.2.0  b708cc7f06493459026f53b9a61a7a121a5d1ec6238dee58ea4941132b30156b \
+    git2                            0.13.2  2cfb93ca10f2934069c3aaafb753fbe0663f08ee009a01b6d62e062391447b15 \
+    hermit-abi                      0.1.10  725cf19794cf90aa94e65050cb4191ff5d8fa87a498383774c47b332e3af952e \
+    http                             0.2.1  28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9 \
     humantime                        1.3.0  df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f \
     idna                             0.2.0  02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9 \
+    indexmap                         1.3.2  076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292 \
     itoa                             0.4.5  b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e \
     jobserver                       0.1.21  5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2 \
     kernel32-sys                     0.2.2  7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d \
@@ -80,11 +88,12 @@ cargo.crates \
     lazycell                         1.2.1  b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f \
     lexical-core                     0.6.7  f86d66d380c9c5a685aaac7a11818bdfa1f733198dfd9ec09c70b762cd12ad6f \
     libc                            0.2.68  dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0 \
-    libgit2-sys                   0.12.2+1.0.0  a12c878ccc1a49ff71e264233a66d2114cdcc7fdc44c0ebe2b54075240831238 \
+    libgit2-sys                   0.12.3+1.0.0  7637dc15e7f05a16011723e0448655081fc01a374bcd368e2c9b9c7f5c5ab3ea \
     libz-sys                        1.0.25  2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe \
     linked-hash-map                  0.5.2  ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83 \
     log                              0.4.8  14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7 \
     mach                             0.2.3  86dd2487cdfea56def77b88438a2c915fb45113c5319bfe7e14306ca4cd0b0e1 \
+    maplit                           1.0.2  3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d \
     matches                          0.1.8  7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
     maybe-uninit                     2.0.0  60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00 \
     memchr                           2.3.3  3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400 \
@@ -98,18 +107,23 @@ cargo.crates \
     num-traits                      0.2.11  c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096 \
     num_cpus                        1.12.0  46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6 \
     once_cell                        1.3.1  b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b \
+    opaque-debug                     0.2.3  2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c \
     open                             1.4.0  7c283bf0114efea9e42f1a60edea9859e8c47528eae09d01df4b29c1e489cc48 \
-    openssl                        0.10.28  973293749822d7dd6370d6da1e523b0d1db19f06c459134c658b2a4261378b52 \
+    openssl                        0.10.29  cee6d85f4cb4c4f59a6a85d5b68a233d280c82e29e822913b9c8b129fbf20bdd \
     openssl-probe                    0.1.2  77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de \
-    openssl-src                   111.6.1+1.1.1d  c91b04cb43c1a8a90e934e0cd612e2a5715d976d2d6cff4490278a0cddf35005 \
-    openssl-sys                     0.9.54  1024c0a59774200a555087a6da3f253a9095a5f344e353b212ac4c8b8e450986 \
+    openssl-src                   111.8.1+1.1.1f  f04f0299a91de598dde58d2e99101895498dcf3d58896a3297798f28b27c8b72 \
+    openssl-sys                     0.9.55  7717097d810a0f2e2323f9e5d11e71608355e24828410b55b9d4f18aa5f9a5d8 \
     os_info                          2.0.2  0ecb53e7b83e5016bf4ac041e15e02b0d240cb27072b19b651b0b4d8cd6bbda9 \
     path-slash                       0.1.1  a0858af4d9136275541f4eac7be1af70add84cf356d901799b065ac1b8ff6e2f \
     percent-encoding                 2.1.0  d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
+    pest                             2.1.3  10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53 \
+    pest_derive                      2.1.0  833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0 \
+    pest_generator                   2.1.3  99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55 \
+    pest_meta                        2.1.3  54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d \
     pkg-config                      0.3.17  05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677 \
     ppv-lite86                       0.2.6  74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b \
     pretty_env_logger                0.4.0  926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d \
-    proc-macro2                      1.0.9  6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435 \
+    proc-macro2                     1.0.10  df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3 \
     quick-error                      1.2.3  a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0 \
     quote                            1.0.3  2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f \
     rand                             0.7.3  6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
@@ -126,21 +140,22 @@ cargo.crates \
     rust-argon2                      0.7.0  2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017 \
     rustc_version                    0.2.3  138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a \
     ryu                              1.0.3  535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76 \
-    schannel                        0.1.17  507a9e6e8ffe0a4e0ebb9a10293e62fdf7657c06f1b8bb07a8fcf697d2abf295 \
+    schannel                        0.1.18  039c25b130bd8c1321ee2d7de7fde2659fa9c2744e4bb29711cfc852ea53cd19 \
     scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
-    security-framework               0.4.1  97bbedbe81904398b6ebb054b3e912f99d55807125790f3198ac990d98def5b0 \
-    security-framework-sys           0.4.1  06fd2f23e31ef68dd2328cc383bd493142e46107a3a0e24f7d734e3f3b80fe4c \
+    security-framework               0.4.2  572dfa3a0785509e7a44b5b4bebcf94d41ba34e9ed9eb9df722545c3b3c4144a \
+    security-framework-sys           0.4.2  8ddb15a5fec93b7021b8a9e96009c5d8d51c15673569f7c0f6b7204e5b7b404f \
     semver                           0.9.0  1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403 \
     semver-parser                    0.7.0  388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
-    serde                          1.0.105  e707fbbf255b8fc8c3b99abb91e7257a622caeb20a9818cbadbeeede4e0932ff \
-    serde_derive                   1.0.105  ac5d00fc561ba2724df6758a17de23df5914f20e41cb00f94d5b7ae42fffaff8 \
+    serde                          1.0.106  36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399 \
+    serde_derive                   1.0.106  9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c \
     serde_json                      1.0.51  da07b57ee2623368351e9a0488bb0b261322a15a6e0ae53e243cbdc0f4208da9 \
     serde_urlencoded                 0.6.1  9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97 \
-    smallvec                         1.2.0  5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc \
+    sha-1                            0.8.2  f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df \
+    smallvec                         1.3.0  05720e22615919e4734f6a99ceae50d00226c3c5aca406e102ebc33298214e0a \
     static_assertions                0.3.4  7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3 \
     strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
-    syn                             1.0.16  123bd9499cfb380418d509322d7a6d52e5315f064fe4b3ad18a53d6b92c07859 \
-    sysinfo                         0.12.0  7ccb41798287e8e299a701b5560d886d6ca2c3e7115e9ea2cb68c123aec339b7 \
+    syn                             1.0.17  0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03 \
+    sysinfo                         0.13.1  8edb5068ab4f00d7f7e78cae194235a4f45671fb5a19b344731b9ab5478e0a6f \
     tempfile                         3.1.0  7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9 \
     term_size                        0.3.1  9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327 \
     termcolor                        1.1.0  bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f \
@@ -149,6 +164,7 @@ cargo.crates \
     time                            0.1.42  db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f \
     toml                             0.5.6  ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a \
     typenum                         1.11.2  6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9 \
+    ucd-trie                         0.1.3  56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c \
     unicode-bidi                     0.3.4  49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5 \
     unicode-normalization           0.1.12  5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4 \
     unicode-segmentation             1.6.0  e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0 \
@@ -166,6 +182,6 @@ cargo.crates \
     winapi                           0.2.8  167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
     winapi-build                     0.1.1  2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
-    winapi-util                      0.1.3  4ccfbf554c6ad11084fb7517daca16cfdcaccbdadba4fc336f032a8b12c2ad80 \
+    winapi-util                      0.1.4  fa515c5163a99cc82bab70fd3bfdd36d827be85de63737b40fcef2ce084a436e \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
     yaml-rust                        0.4.3  65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4 11E146

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
