### PR TITLE
tig: update to 2.5.1

### DIFF
--- a/devel/tig/Portfile
+++ b/devel/tig/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        jonas tig 2.5.0 tig-
+github.setup        jonas tig 2.5.1 tig-
 github.tarball_from releases
-checksums           rmd160  d0235e03aab2c564e4857048f9a9979affd969f1 \
-                    sha256  ff537c67af9201e7e7276ce8a0ff9961e9d9c6a8a78790f5817124bd7755aef4 \
-                    size    1143004
+checksums           rmd160  2bc115eeecdcca3fe5014d2b544b2ddce349fd96 \
+                    sha256  500d5d34524f6b856edd5cae01f1404d14f3b51a9a53fd7357f4cebb3d4c9e64 \
+                    size    1144666
 
 categories          devel
 maintainers         {cal @neverpanic} \
@@ -19,11 +19,6 @@ homepage            https://jonas.github.io/tig/
 license             GPL-2+
 platforms           darwin
 
-depends_build       port:automake \
-                    port:autoconf \
-                    port:asciidoc \
-                    port:xmlto
-
 depends_lib         bin:git:git \
                     port:libiconv \
                     port:ncurses
@@ -33,17 +28,14 @@ license_noconflict  git asciidoc
 # -E, -S, -save-temps and -M options are not allowed with multiple -arch flags
 universal_variant   no
 
-# We need to create the configure file,
-# the github version does not contain it.
-pre-configure {
-    system -W ${worksrcpath} "make configure"
+destroot.target-append install-doc-man
+
+variant doc description {Install HTML documentation} {
+    depends_build-append port:asciidoc
+    depends_build-append port:xmlto
+
+    build.target-append doc-html
+    destroot.target-append install-doc-html
 }
 
-build.target-append doc-man doc-html
-# for some reason, the XML tools fail to find and use ${prefix}/etc/catalog,
-# where these paths are configured
-build.target-append XMLTO=\"${prefix}/bin/xmlto \
-                    --searchpath ${prefix}/share/xml/docbook/4.5/ \
-                    --searchpath ${prefix}/share/xsl/docbook-xsl-nons/manpages\"
-destroot.target-append \
-                    install-doc-man install-doc-html
+default_variants    +doc


### PR DESCRIPTION
The installation of the HTML documentation is now controlled by the
'doc' variant.
