### PR TITLE
gimp-lqr-plugin: fixed invalid parameter name - plugin crashed gimp 2.10.18

### DIFF
--- a/graphics/gimp-lqr-plugin/Portfile
+++ b/graphics/gimp-lqr-plugin/Portfile
@@ -5,7 +5,7 @@ PortGroup       active_variants 1.1
 
 name            gimp-lqr-plugin
 version         0.7.2
-revision        2
+revision        3 
 license         GPL-2
 maintainers     {devans @dbevans} openmaintainer
 categories      graphics
@@ -36,7 +36,8 @@ depends_build   port:pkgconfig \
 depends_lib     port:liblqr \
                 path:lib/pkgconfig/gimp-2.0.pc:gimp2
 
-patchfiles      patch-autogen.sh.diff
+patchfiles      patch-autogen.sh.diff \
+                patch-invalid-parameter-name-fix.diff
 
 # reconfigure using upstream autogen.sh for intltool 0.51 compatibility
 

--- a/graphics/gimp-lqr-plugin/files/patch-invalid-parameter-name-fix.diff
+++ b/graphics/gimp-lqr-plugin/files/patch-invalid-parameter-name-fix.diff
@@ -1,0 +1,11 @@
+--- src/main.c.orig	2020-04-13 22:54:08.000000000 +0200
++++ src/main.c	2020-04-13 22:55:19.000000000 +0200
+@@ -179,7 +179,7 @@
+   {GIMP_PDB_INT32, "resize_aux_layers",
+    "Whether to resize auxiliary layers"},
+   {GIMP_PDB_INT32, "resize_canvas", "Whether to resize canvas"},
+-  {GIMP_PDB_INT32, "output target", "Output target (same layer, new layer, new image)"},
++  {GIMP_PDB_INT32, "output_target", "Output target (same layer, new layer, new image)"},
+   {GIMP_PDB_INT32, "seams", "Whether to output the seam map"},
+   {GIMP_PDB_INT32, "nrg_func", "Energy function to use"},
+   {GIMP_PDB_INT32, "res_order", "Resize order"},


### PR DESCRIPTION
#### Description
The current gimp-lqr-plugin has a wrong parameter name "output target".
That crashes the current gimp 2.10.18 version. The change is already in upstream:

https://github.com/carlobaldassi/gimp-lqr-plugin/commit/8600fa6c7c611215c3cd282b8092ca5bec64f2fb

I took exactly the patch from upstream and added it to the
current build. Then it works with gimp 2.10.18.

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G12034
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
