### PR TITLE
swig-python3: make it obsolete

### DIFF
--- a/devel/swig/Portfile
+++ b/devel/swig/Portfile
@@ -63,7 +63,6 @@ array set bindings {
     php         {port:php73             "php=${prefix}/bin/php73"}
     pike        {port:pike              pike}
     python      {port:python_select     python}
-    python3     {port:python3_select    python3}
     r           {port:R                 r}
     ruby        {port:ruby23            "ruby=${prefix}/bin/ruby2.3"}
     tcl         {port:tcl               tcl}
@@ -71,7 +70,7 @@ array set bindings {
 array set prettynames {chicken Chicken clisp CLISP csharp "C#"
     d D gcj GCJ go Go guile Guile java Java lua Lua
     ocaml "Objective Caml" octave Octave perl5 Perl php "PHP 7" pike Pike
-    python Python python3 "Python 3" r R ruby Ruby tcl Tcl}
+    python Python r R ruby Ruby tcl Tcl}
 
 options         swig.lang
 default         swig.lang ""
@@ -89,12 +88,6 @@ foreach lang [lsort [array names bindings]] {
     if {${swig.lang} != $arg_name} {
         configure.args-append --without-${arg_name}
     }
-}
-
-# swig3 has no subport for python3
-# this feature was added as of swig4
-subport swig-python3 {
-    depends_lib-delete port:swig3-python3
 }
 
 subport swig-php {
@@ -298,4 +291,14 @@ if {${swig.lang} eq ""} {
             }
         }
     }
+}
+
+# 20200414
+# make it obsolete since Python3 folder
+# doesn't exist and swig has only Python
+subport swig-python3 {
+    PortGroup       obsolete 1.0
+    replaced_by     swig-python
+    version         4.0.1
+    revision        2
 }


### PR DESCRIPTION


#### Description

make it obsolete since Python3 folder doesn't exist
and swig has only the Python one

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.4 19E287
Xcode 11.4 11E146

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
