### PR TITLE
kotlin: update to 1.3.72

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           java 1.0
 
-github.setup        JetBrains kotlin 1.3.71 v
+github.setup        JetBrains kotlin 1.3.72 v
 revision            0
 github.tarball_from releases
 distname            ${name}-compiler-${version}
@@ -23,9 +23,9 @@ long_description    Kotlin is a pragmatic programming language for JVM \
 
 homepage            https://kotlinlang.org/
 
-checksums           rmd160  d92d30f7bba1881976ec83852cb5fd082c544301 \
-                    sha256  7adb77dad99c6d2f7bde9f8bafe4c6244a04587a8e36e62b074d00eda9f8e74a \
-                    size    54798562
+checksums           rmd160  0eefb9d603a0284646ac234e7f3e43f08aa84c14 \
+                    sha256  ccd0db87981f1c0e3f209a1a4acb6778f14e63fe3e561a98948b5317e526cc6c \
+                    size    54804925
 
 java.version        1.8+
 java.fallback       openjdk8


### PR DESCRIPTION
#### Description

Update to Kotlin 1.3.72.

###### Tested on

macOS 10.15.4 19E287
Xcode 11.4 11E146

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?