### PR TITLE
cctools: Remove rsrc forks from manpages.

### DIFF
--- a/devel/cctools/Portfile
+++ b/devel/cctools/Portfile
@@ -6,7 +6,7 @@ name                    cctools
 # Xcode 10.2
 version                 927.0.2
 set ld64_version        450.3
-revision                2
+revision                3
 categories              devel
 platforms               darwin
 maintainers             {jeremyhu @jeremyhu} {kencu @kencu} openmaintainer
@@ -191,6 +191,16 @@ post-patch {
             set try_system_clang 0
         }
         reinplace "s:__TRY_SYSTEM_CLANG__:${try_system_clang}:" ${worksrcpath}/as/driver.c
+
+        foreach file [glob ${worksrcpath}/man/*] {
+            ui_debug "deleting stray rsrc fork from ${file}"
+            if {${os.major} >= 9} {
+                system "cp -X  ${file} ${file}.tmp"
+                system "mv ${file}.tmp ${file}"
+            } else {
+                system "cp /dev/null ${file}/rsrc"
+            }
+        }
 
         foreach file [glob ${worksrcpath}/{*/,}Makefile] {
 


### PR DESCRIPTION
See https://trac.macports.org/ticket/60176

Adding manpages to the list of files that need stray resource forks stripped.