### PR TITLE
logcat-colorize: update to 0.8.2

### DIFF
--- a/devel/logcat-colorize/Portfile
+++ b/devel/logcat-colorize/Portfile
@@ -2,9 +2,10 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           cxx11 1.1
 
-github.setup        carlonluca logcat-colorize 0.8.1 v
-github.tarball_from releases
+github.setup        carlonluca logcat-colorize 0.8.2 v
+github.tarball_from archive
 license             Apache-2
 categories          devel
 platforms           darwin
@@ -14,11 +15,15 @@ long_description    logcat-colorize is a parser for the output of the \
                     Android Debug Bridge logcat output. It accepts the \
                     logcat output from stdin and produces a formatted \
                     output, optimised for reading in a console.
-checksums           rmd160  a7f465551403929f73c5b76649a73e043e33105a \
-                    sha256  4f9c8a71b5f90b6448e6f57e7f2349b37513ed8e42878a640403e966b62a4048 \
-                    size    14518
+checksums           rmd160  1eb98b47415072f5da8512e3f6a75e40522bf572 \
+                    sha256  556c163512aaadd5cfc0a206a2818f06d5321a24ee5ebf37c66597cecba08c27 \
+                    size    787826
 depends_lib         port:boost
 use_configure       no
 build.target
 destroot.args       PREFIX=${prefix}
 universal_variant   no
+supported_archs     x86_64
+build.args-append   CC=${configure.cc} \
+                    CXX=${configure.cxx} \
+                    CPP=${configure.cpp}


### PR DESCRIPTION
limit supported archs to x86_64
require c++11 support
use the right compiler

closes: https://trac.macports.org/ticket/60357

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.3
Xcode 11.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
