### PR TITLE
k9s: update to 0.19.2

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,9 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.19.1 v
+go.setup            github.com/derailed/k9s 0.19.2 v
 
-categories          sysutils
+categories          sysutils devel
 maintainers         {breun.nl:nils @breun} openmaintainer
 description         K9s
 long_description    K9s provides a curses based terminal UI to interact with \
@@ -19,9 +19,9 @@ platforms           darwin
 supported_archs     x86_64
 license             Apache-2
 
-checksums           rmd160  4a9c42168a91a1bf35635b274e0d96e4ae4f663f \
-                    sha256  a0c7af76bdadae54566936209e2e61291beaf3f44d7c3e52581f3aee01f50a5a \
-                    size    17388336
+checksums           rmd160  9cab79cf0cf2067b05403fd75bea9e5704a6e7c0 \
+                    sha256  94381d4daf88997c56259174d2198f74c291f3105e6f9f2f3021c2a40753c490 \
+                    size    17389658
 
 # Reproduce the "build" target from the upstream Makefile
 set go_ldflags      "-w -X ${go.package}/cmd.version=${version} \


### PR DESCRIPTION
#### Description

Update to k9s 0.19.2 and added the port to the devel category.

###### Tested on

macOS 10.15.4 19E287
Xcode 11.4 11E146

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [d] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [d] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?