### PR TITLE
ripgrep: update to 12.0.1

### DIFF
--- a/textproc/ripgrep/Portfile
+++ b/textproc/ripgrep/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        BurntSushi ripgrep 12.0.0
+github.setup        BurntSushi ripgrep 12.0.1
 categories          textproc
 platforms           darwin
 maintainers         {raimue @raimue} \
@@ -35,12 +35,12 @@ cargo.crates \
     fnv                           1.0.6    2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3  \
     fs_extra                      1.1.0    5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674  \
     glob                          0.3.0    9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574  \
-    hermit-abi                    0.1.8    1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8  \
+    hermit-abi                    0.1.9    0ebe6e23502442c4c9cd80fcb8bdf867dc5f4a9e9f1d882499fa49c5ed83e559  \
     itoa                          0.4.5    b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e  \
     jemalloc-sys                  0.3.2    0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45  \
     jemallocator                  0.3.2    43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69  \
     lazy_static                   1.4.0    e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646  \
-    libc                          0.2.67   eb147597cdf94ed43ab7a9038716637d2d1bf2bc571da995d0028dec06bd3018  \
+    libc                          0.2.68   dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0  \
     log                           0.4.8    14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7  \
     maybe-uninit                  2.0.0    60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00  \
     memchr                        2.3.3    3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400  \
@@ -52,16 +52,16 @@ cargo.crates \
     pkg-config                    0.3.17   05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677  \
     proc-macro2                   1.0.9    6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435  \
     quote                         1.0.3    2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f  \
-    regex                         1.3.5    8900ebc1363efa7ea1c399ccc32daed870b4002651e0bed86e72d501ebbe0048  \
+    regex                         1.3.6    7f6946991529684867e47d86474e3a6d0c0ab9b82d5821e314b1ede31fa3a4b3  \
     regex-automata                0.1.9    ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4  \
     regex-syntax                  0.6.17   7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae  \
     ryu                           1.0.3    535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76  \
     same-file                     1.0.6    93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502  \
-    serde                         1.0.104  414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449  \
-    serde_derive                  1.0.104  128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64  \
-    serde_json                    1.0.48   9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25  \
+    serde                         1.0.105  e707fbbf255b8fc8c3b99abb91e7257a622caeb20a9818cbadbeeede4e0932ff  \
+    serde_derive                  1.0.105  ac5d00fc561ba2724df6758a17de23df5914f20e41cb00f94d5b7ae42fffaff8  \
+    serde_json                    1.0.50   78a7a12c167809363ec3bd7329fc0a3369056996de43c4b37ef3cd54a6ce4867  \
     strsim                        0.8.0    8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a  \
-    syn                           1.0.16   123bd9499cfb380418d509322d7a6d52e5315f064fe4b3ad18a53d6b92c07859  \
+    syn                           1.0.17   0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03  \
     termcolor                     1.1.0    bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f  \
     textwrap                      0.11.0   d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060  \
     thread_local                  1.0.1    d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14  \
@@ -74,9 +74,9 @@ cargo.crates \
     winapi-x86_64-pc-windows-gnu  0.4.0    712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f
 
 checksums-append    ${distname}${extract.suffix} \
-                    rmd160  796a71e3a40061b9a7c6dd607e7690a615224586 \
-                    sha256  ddd3f688ed89f6c5b54da98c8e119ab2bbd629d23e1dce96b8f7739569246075 \
-                    size    475100
+                    rmd160  fef612f8f637008d288990018689b3a05f1e3061 \
+                    sha256  8462e8f42885bd4c1452d6225536ee89bc5eccdac3ebc23bd3a65cd78a66fc0a \
+                    size    475166 \
 
 depends_build-append \
                     port:asciidoc \


### PR DESCRIPTION
#### Description
update

tested with a grep across the Portfile repository

###### Type(s)
- [x] bugfix
- [x] enhancement
- [x] security fix

###### Tested on
macOS 10.13.6 17G11023
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
