### PR TITLE
Lazarus: Update to new upstream version (2.0.8)

### DIFF
--- a/devel/lazarus/Portfile
+++ b/devel/lazarus/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                lazarus
-version             2.0.6
+version             2.0.8
 revision            0
 categories          devel
 platforms           darwin
@@ -25,9 +25,9 @@ long_description    Lazarus is an open-source development system that builds \
 homepage            https://wiki.freepascal.org/Main_Page
 master_sites        sourceforge:lazarus
 
-checksums           rmd160  717506ed9f82f5618d7e1c16ce15cf0beca07b41 \
-                    sha256  82cdafb0f0c05cf1ebb8e52b58bf980a08a866b6df1003f55ca2da3480e92a6c \
-                    size    65558951
+checksums           rmd160  d49c83c4207283d8ba27978c6df38b5f8d175fcc \
+                    sha256  90b037280e5c63265bc25a63e6e78c9cb979fc4b45aa84606e3856b09ac791c5 \
+                    size    65602475
 
 depends_lib         port:fpc port:fpc-sources
 supported_archs     x86_64


### PR DESCRIPTION
The update only needed to update the checksums. The rest still works.

#### Description

The update only required to update the version and the checksum. Building, installing and running was fine

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [*] bugfix
- [*] enhancement
- [*] security fix

###### Tested on

macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [*] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [*] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [*] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [*] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [*] checked your Portfile with `port lint`?
- [*] tried existing tests with `sudo port test`?
- [*] tried a full install with `sudo port -vst install`?
- [*] tested basic functionality of all binary files?
