### PR TITLE
openjdk8: update to 8u252

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -3,10 +3,10 @@
 PortSystem       1.0
 
 name             openjdk8
-version          8u242
+version          8u252
 revision         0
 
-set build        08
+set build        09
 set major        8
 
 subport openjdk8-graalvm {
@@ -17,21 +17,21 @@ subport openjdk8-graalvm {
 }
 
 subport openjdk8-openj9 {
-    version      8u242
+    version      8u252
     revision     0
 
-    set build    08
+    set build    09
     set major    8
-    set openj9_version 0.18.1
+    set openj9_version 0.20.0
 }
 
 subport openjdk8-openj9-large-heap {
-    version      8u242
+    version      8u252
     revision     0
 
-    set build    08
+    set build    09
     set major    8
-    set openj9_version 0.18.1
+    set openj9_version 0.20.0
 }
 
 subport openjdk10 {
@@ -188,9 +188,9 @@ if {${os.platform} eq "darwin" && ${os.major} < 14} {
 if {${subport} eq "openjdk8"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}/
     
-    checksums    rmd160  8127d78a0a6455d7a5cbb1e2de5b498389678a6a \
-                 sha256  06675b7d65bce0313ee1f2e888dd44267e8afeced75e0b39b5ad1f5fdff54e0b \
-                 size    102535673
+    checksums    rmd160  845f0d7678b40e00615a7b4571b2c17c22a502ec \
+                 sha256  6e267893aae127a4bccfedb56d9893a891213a93de593a97f248629eaa0594ba \
+                 size    100177346
 
     distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}b${build}
     worksrcdir   jdk${version}-b${build}
@@ -214,9 +214,9 @@ if {${subport} eq "openjdk8"} {
 } elseif {${subport} eq "openjdk8-openj9"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
 
-    checksums    rmd160  6db70061a643d19c2bbe41637e085293a94aab7e \
-                 sha256  665dc9c8239b7270b007ab9dd7522570e2686e327d89caf57a6aa6e5c6450078 \
-                 size    114579018
+    checksums    rmd160  2b77e821ad37276ff9ab28b79c3cb3f9732ef7b8 \
+                 sha256  119ffa095367dd236758fd2bebcaeb3ac60560fad85bd522f7a96af49db163af \
+                 size    140934091
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}b${build}_openj9-${openj9_version}
     worksrcdir   jdk${version}-b${build}
@@ -231,9 +231,9 @@ if {${subport} eq "openjdk8"} {
 } elseif {${subport} eq "openjdk8-openj9-large-heap"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
 
-    checksums    rmd160  3b319be42f052139b6432b6f89ba667a13aa4e08 \
-                 sha256  e1f8e053899a5d4eba9de8928d4744041b1d127a98959bc9683e4b31868b25cc \
-                 size    114576741
+    checksums    rmd160  4ce7e449a0fb2e4c333dec459d3bfad463b5cf07 \
+                 sha256  0aa1be10afb5df50bfb218d466c857f1d6b8e2817600927380977fc75f2b5646 \
+                 size    140899873
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}b${build}_openj9-${openj9_version}
     worksrcdir   jdk${version}-b${build}


### PR DESCRIPTION
#### Description

Update to OpenJDK 8u252.

###### Tested on

macOS 10.15.4 19E287
Xcode 11.4 11E146

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?