### PR TITLE
openjdk8: OpenJ9 updates for openjdk11 and openjdk14 subports

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -58,21 +58,21 @@ subport openjdk11-graalvm {
 }
 
 subport openjdk11-openj9 {
-    version      11.0.6
-    revision     1
+    version      11.0.7
+    revision     0
 
     set build    10
     set major    11
-    set openj9_version 0.18.1
+    set openj9_version 0.20.0
 }
 
 subport openjdk11-openj9-large-heap {
-    version      11.0.6
-    revision     1
+    version      11.0.7
+    revision     0
 
     set build    10
     set major    11
-    set openj9_version 0.18.1
+    set openj9_version 0.20.0
 }
 
 subport openjdk12 {
@@ -136,21 +136,21 @@ subport openjdk14 {
 }
 
 subport openjdk14-openj9 {
-    version      14
+    version      14.0.1
     revision     0
 
-    set build    36
+    set build    7
     set major    14
-    set openj9_version 0.19.0
+    set openj9_version 0.20.0
 }
 
 subport openjdk14-openj9-large-heap {
-    version      14
+    version      14.0.1
     revision     0
 
-    set build    36
+    set build    7
     set major    14
-    set openj9_version 0.19.0
+    set openj9_version 0.20.0
 }
 
 categories       java devel
@@ -293,9 +293,9 @@ if {${subport} eq "openjdk8"} {
 } elseif {${subport} eq "openjdk11-openj9"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
 
-    checksums    rmd160  a20f46cf19d34e4b489b5bffb1755d2465fc7cd9 \
-                 sha256  9a5c5b3bb51a82e666c46b2d1bbafa8c2bbc3aae50194858c8f96c5d43a96f64 \
-                 size    196636566
+    checksums    rmd160  554f47d5163d79ae213df4028b883033952b85a9 \
+                 sha256  1be24fb479afcc6d4452eb5cf8aa7f2642941889dfcfcc853e4ccb6648529dcc \
+                 size    248388099
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
     worksrcdir   jdk-${version}+${build}
@@ -310,9 +310,9 @@ if {${subport} eq "openjdk8"} {
 } elseif {${subport} eq "openjdk11-openj9-large-heap"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
 
-    checksums    rmd160  e134ac760608708bab54ac9fdc863cf5a1ccafa2 \
-                 sha256  bb6eec01ebd74a85c178a13d3568d3d657eb48d583d6602627c8237355b801cf \
-                 size    196630490
+    checksums    rmd160  d9da7f31a2ae48e17f172495f65ff4a2be63d564 \
+                 sha256  c58b615d08dcfa4aa2573c4db3e416e30b5202da4aaf24dc879c13c2064af8cd \
+                 size    248479495
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
     worksrcdir   jdk-${version}+${build}
@@ -427,11 +427,11 @@ if {${subport} eq "openjdk8"} {
     worksrcdir   jdk-${version}+${build}
 } elseif {${subport} eq "openjdk14-openj9"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
-    distname     OpenJDK${major}-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
+    distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
 
-    checksums    rmd160  939ca5002a6b7bf1fbe3f6097452afe3f9c81b03 \
-                 sha256  171279c0514e102796fec894e7760ec61c7c8e826aeb0d19c1578759fc81f583 \
-                 size    205221842
+    checksums    rmd160  e0995c6d3e8965887871df35b09ec35437dfdbc1 \
+                 sha256  0e89551bce50dae3723516e8cd77c9769cd7364a8d5004a0a8c25bce43a99c4e \
+                 size    254540861
 
     worksrcdir   jdk-${version}+${build}
 
@@ -444,11 +444,11 @@ if {${subport} eq "openjdk8"} {
                  suitable for running all workloads.
 } elseif {${subport} eq "openjdk14-openj9-large-heap"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
-    distname     OpenJDK${major}-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
+    distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
 
-    checksums    rmd160  59d9ae1f1a4891c4584509508e5f6f99e658db7e \
-                 sha256  603aa1e2cd4f5db53fec75b6f033653d0621c720844147bc9a15ef6ea603401e \
-                 size    205221731
+    checksums    rmd160  7a5a28d075028137f490d6f79bd3697530806531 \
+                 sha256  02f37d60d611833848d7cf1e4fa5b5e4f901a26cc51dc6638070ae70d28e2bd8 \
+                 size    254638749
 
     worksrcdir   jdk-${version}+${build}
 


### PR DESCRIPTION
#### Description

OpenJ9 updates for openjdk11 and openjdk14 subports.

###### Tested on

macOS 10.15.4 19E287
Xcode 11.4 11E146

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?