### PR TITLE
py-sip: update to 4.19.22

### DIFF
--- a/python/py-sip/Portfile
+++ b/python/py-sip/Portfile
@@ -20,7 +20,7 @@ long_description \
 
 homepage            https://www.riverbankcomputing.com/software/sip/intro
 
-version             4.19.21
+version             4.19.22
 
 # bumped the epoch to revert from 4.19.10 to 4.19.8. The former caused
 # configuration errors in py*-qscitilla-qt5 and py*-pyqt4, and
@@ -70,10 +70,10 @@ if {${name} ne ${subport}} {
         distname        sip-${version}
     }
 
-    checksums           rmd160 e52170c8ac2c80a42b73fd4d5178e8d85bfd39e2 \
-                        sha256 6af9979ab41590e8311b8cc94356718429ef96ba0e3592bdd630da01211200ae \
-                        size   1050654
-    revision            1
+    checksums           rmd160 48255d2fd0dfad19be73011c296bd79f40f91ea9 \
+                        sha256 e1b768824ec1a2ee38dd536b6b6b3d06de27b00a2f5f55470d1b512306e3be45 \
+                        size   1050805
+    revision            0
 
     patchfiles          patch-siputils.py.diff \
                         patch-specs_macx-g++.diff \


### PR DESCRIPTION
#### Description
Verified SIP API is still at 12.7.
From ChangeLog:
```
2020-03-12  Phil Thompson  <phil@riverbankcomputing.com>

	* sipgen/metasrc/parser.y:
	Fixed the handling of keyword argument names in imported class
	templates.
	[1510ce7f5463] <4.19-maint>
```
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode command line tools 11.4.1
Python 3.8.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
