### PR TITLE
py-pyqt5: update to 5.14.2

### DIFF
--- a/python/py-pyqt5/Portfile
+++ b/python/py-pyqt5/Portfile
@@ -6,7 +6,7 @@ PortGroup               python 1.0
 name                    py-pyqt5
 python.rootname         PyQt5
 # we the next bump check --allow-sip-warnings if needed
-version                 5.14.1
+version                 5.14.2
 revision                0
 categories-append       devel
 platforms               darwin
@@ -16,9 +16,9 @@ long_description        ${description}. The bindings \
                         are implemented as a set of Python modules and contain over 620 classes.
 homepage                https://www.riverbankcomputing.com/software/pyqt/intro
 license                 GPL-3
-checksums               rmd160  3cb6fbdc9e83dffe2972125c56afe858a6e1f66c \
-                        sha256  2f230f2dbd767099de7a0cb915abdf0cbc3256a0b5bb910eb09b99117db7a65b \
-                        size    3241571
+checksums               rmd160  9f4672ff0a2165a7557216ac3a14fadbb9db9375 \
+                        sha256  bd230c6fd699eabf1ceb51e13a8b79b74c00a80272c622427b80141a22269eb0 \
+                        size    3246557
 
 python.versions 27 35 36 37 38
 subport "${name}-common" {}
@@ -157,14 +157,6 @@ if {${subport} eq "${name}-common"} {
             move ${destroot}${qt_data_dir}/qsci/api/python/PyQt5.api \
                 ${destroot}${qt_data_dir}/qsci/api/python/PyQt5-Python${python.branch}.api
         }
-    }
-
-    # variant is obsolete since py-pyqt5 version 5.12.1, remove after March 26, 2020
-    variant webengine description {Build QtWebEngine module (obsolete, use the py-pyqt5-webengine port)} {
-        notes "
-        The +webengine variant is obsolete because PyQtWebEngine is not included anymore in the PyQt5 bindings.\
-        If you need PyQtWebEngine, please install the py-pyqt5-webengine port.
-        "
     }
 
     variant webkit description {Build QtWebKit module} {


### PR DESCRIPTION
Remove `+webengine` variant (obsoleted in cacb2fa1f7)

#### Description
From ChangeLog:
```
2020-04-02  Phil Thompson  <phil@riverbankcomputing.com>

[…]

	* PyQt5.msp:
	Added the missing QTextCodec.convertFromUnicode() so that QTextCodec
	can now be instantiated from Python.
	[71aabcec4eb4] <5.14-maint>

2020-03-15  Phil Thompson  <phil@riverbankcomputing.com>

	* qpy/QtCore/qjsonarray.sip, qpy/QtCore/qpycore_qjsonvalue.cpp:
	Fixed a regression introduced when QJsonValue became iterable.
	[b03590b430ce] <5.14-maint>

[…]

2020-02-05  Phil Thompson  <phil@riverbankcomputing.com>

	* PyQt5.msp:
	Fixed glReadPixels() in the ES2 support.
	[c104737f6f05] <5.14-maint>

2020-02-04  Phil Thompson  <phil@riverbankcomputing.com>

	* PyQt5.msp:
	Enabled the OpenGL ES bindings.
	[d15fbceb7632] <5.14-maint>

2020-01-19  Phil Thompson  <phil@riverbankcomputing.com>

	* PyQt5.msp:
	Implement QFlags.__index__() to replicate the behaviour of Python's
	enum.IntFlag type and avoid a deprecation warning in Python v3.8.
	[541f2dcf2b27] <5.14-maint>

```
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 (19E287)
Xcode command line tools 11.4.1
Python 3.8.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
```
--->  Verifying Portfile for py-pyqt5
Error: Line 96 repeats inclusion of PortGroup qmake5
--->  1 errors and 0 warnings found.
```
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
