### PR TITLE
directory-studio: update to 2.0.0.v20200411-M15

### DIFF
--- a/databases/directory-studio/Portfile
+++ b/databases/directory-studio/Portfile
@@ -4,7 +4,7 @@ PortSystem                  1.0
 PortGroup                   java 1.0
 
 name                        directory-studio
-version                     2.0.0.v20180908-M14
+version                     2.0.0.v20200411-M15
 categories                  databases
 platforms                   darwin
 supported_archs             x86_64
@@ -26,9 +26,9 @@ master_sites                https://www-eu.apache.org/dist/directory/studio/${ve
 distname                    ApacheDirectoryStudio-${version}-macosx.cocoa.x86_64
 extract.suffix              .dmg
 
-checksums                   rmd160  055ec155ae83cfd9edc1aa84c353fc4ff0207ebd \
-                            sha256  845392529c86e52697c1edac1f0603261324ff2a649e697dbdf566ee5f5f8e5e \
-                            size    147573082
+checksums                   rmd160  fdfdd845e9ccded41dea4c76d3241a08f77c5475 \
+                            sha256  1e3208fcdf42ae107796a06a00240c08b9f0c24c8b07a61e94b968112657fda8 \
+                            size    139258350
 
 extract                     {
                             file mkdir /tmp/${distname}


### PR DESCRIPTION
###### Tested on

macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?