### PR TITLE
chezmoi: update to 1.8.0

### DIFF
--- a/sysutils/chezmoi/Portfile
+++ b/sysutils/chezmoi/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/twpayne/chezmoi 1.7.19 v
+go.setup            github.com/twpayne/chezmoi 1.8.0 v
 
 categories          sysutils
 license             MIT
@@ -11,9 +11,9 @@ installs_libs       no
 
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
 
-checksums           rmd160  c46ad26ea3b66fb271c2739ec1af0d4401efa5f8 \
-                    sha256  52ae29511a3568183e3bcaa3ddd132b938a2e5c0b05cac9d8d3ffa64e2999186 \
-                    size    2074060
+checksums           rmd160  c67021cbdda94dcab7097640f18e25667dcd6099 \
+                    sha256  484de97033cba85ab09384a8783190f8da20d5ce7e76d44218b981ab862403ae \
+                    size    2082823
 
 homepage            https://chezmoi.io/
 


### PR DESCRIPTION

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
