### PR TITLE
py-plumbum: update to version 1.6.9, license

### DIFF
--- a/python/py-plumbum/Portfile
+++ b/python/py-plumbum/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        tomerfiliba plumbum 1.6.8 v
+github.setup        tomerfiliba plumbum 1.6.9 v
 name                py-${name}
 
 maintainers         {g5pw @g5pw} openmaintainer
@@ -18,19 +18,19 @@ long_description    ${description} The motto of the library is \"Never write \
                     shell syntax (\"shell combinators\") where it makes sense, \
                     while keeping it all pythonic and cross-platform.
 
-license             X11
+license             MIT
 platforms           darwin
 
 homepage            https://plumbum.readthedocs.org
 
-python.versions     27 35 36 37
+python.versions     27 35 36 37 38
 
 if { ${subport} ne ${name} } {
     depends_lib         port:py${python.version}-six
 
-    checksums           rmd160  3b32a03745caf0c7a8db7886bd7db62c13c39be7 \
-                        sha256  39e7bc02d2f3bb070374c958727ce9a33229c571db0238c6633cc138a5cc192c \
-                        size    309482
+    checksums           rmd160  0021b2544e15f9f50bd6899f014776313a1b3880 \
+                        sha256  854fd30b0cac65e83727939cfc4f0199b36b218d1c6d59712953698a9cf615d7 \
+                        size    311259
 
     livecheck.type      none
 }


### PR DESCRIPTION
Add py38 subport.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
