### PR TITLE
lazygit: update to 0.20

### DIFF
--- a/devel/lazygit/Portfile
+++ b/devel/lazygit/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/jesseduffield/lazygit 0.19 v
+go.setup            github.com/jesseduffield/lazygit 0.20 v
 categories          devel
 license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
@@ -11,9 +11,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
 description         A simple terminal UI for git commands, written in Go
 long_description    {*}$description
 
-checksums           rmd160  83b8949f5c104bc7c788cc2d3210e596d6d51ba3 \
-                    sha256  ba8809e630b0b5f914929e10fb302c6188ac67bca328042251308470125c1029 \
-                    size    9193801
+checksums           rmd160  3e009db299ac089114424075fd34bf854f073264 \
+                    sha256  11f26b9ffd37c7a977703759b9f20527a2a68b86da8850c460e2b1d595e0ba6a \
+                    size    9194817
 
 set build_date      [exec date +%FT%T%z]
 build.args          -ldflags \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
