### PR TITLE
openjdk8: update openjdk14 subport to 14.0.1

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -128,10 +128,10 @@ subport openjdk13-openj9-large-heap {
 }
 
 subport openjdk14 {
-    version      14
+    version      14.0.1
     revision     0
 
-    set build    36
+    set build    7
     set major    14
 }
 
@@ -420,9 +420,9 @@ if {${subport} eq "openjdk8"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}/
     distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}_${build}
 
-    checksums    rmd160  7e2467e9f3ba520836508fff2be8fb3bc899c75e \
-                 sha256  aabc3aebb0abf1ba64d9bd5796d0c7eb7239983f6e4c0f015b5b88be5616e4bd \
-                 size    201087797
+    checksums    rmd160  bc4afe3ada4aceaab7d4e00d83a325a9f5ebbdb9 \
+                 sha256  b11cb192312530bcd84607631203d0c1727e672af12813078e6b525e3cce862d \
+                 size    195769653
 
     worksrcdir   jdk-${version}+${build}
 } elseif {${subport} eq "openjdk14-openj9"} {


### PR DESCRIPTION
#### Description

Update to AdoptOpenJDK HotSpot 14.0.1.

###### Tested on

macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?