### PR TITLE
libpcl: fix build with Boost 1.70+, use compiler.openmp_version

### DIFF
--- a/gis/libpcl/Portfile
+++ b/gis/libpcl/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 PortGroup           active_variants 1.1
 
 github.setup        PointCloudLibrary pcl 1.9.1 pcl-
-revision            1
+revision            2
 checksums           rmd160  223b36b48c9a77a1092bf0cbe8ed15e843c46386 \
                     sha256  943c618003c0a57046bca7c3b8e9a1e9a51b5f44545ffff9e1e744dd9304cf19 \
                     size    67161112
@@ -37,6 +37,8 @@ depends_test        port:gtest
 
 require_active_variants vtk qt5
 
+patchfiles-append   boost170.patch
+
 configure.args-replace -DCMAKE_BUILD_TYPE=MacPorts -DCMAKE_BUILD_TYPE=Release
 
 configure.args-append -DBUILD_apps=ON \
@@ -44,10 +46,9 @@ configure.args-append -DBUILD_apps=ON \
                       -DWITH_DOCS=OFF \
                       -DWITH_QT=ON
 
-variant openmp description {Build with macports-clang >= 5.0 to enable OpenMP for speed} {
-    depends_lib-append      port:libomp
-    compiler.blacklist-append *gcc* {clang}
-    compiler.blacklist-append macports-clang-3.3 macports-clang-3.4 macports-clang-3.7
+variant openmp description {Enable OpenMP for speed} {
+    # TODO: verify OpenMP version required
+    compiler.openmp_version 3.1
 }
 
 variant test description {Configure to run unit tests} {

--- a/gis/libpcl/files/boost170.patch
+++ b/gis/libpcl/files/boost170.patch
@@ -1,0 +1,17 @@
+Patch to fix build with Boost 1.70 obtained from
+https://github.com/PointCloudLibrary/pcl/files/2975614/patch.txt
+See issue https://github.com/PointCloudLibrary/pcl/issues/2931
+
+diff --git a/segmentation/include/pcl/segmentation/supervoxel_clustering.h b/segmentation/include/pcl/segmentation/supervoxel_clustering.h
+index 0fad772..bed6c1a 100644
+--- segmentation/include/pcl/segmentation/supervoxel_clustering.h
++++ segmentation/include/pcl/segmentation/supervoxel_clustering.h
+@@ -524,7 +524,7 @@ namespace pcl
+       };
+ 
+       //Make boost::ptr_list can access the private class SupervoxelHelper
+-      friend void boost::checked_delete<> (const typename pcl::SupervoxelClustering<PointT>::SupervoxelHelper *);
++      friend void boost::checked_delete<> (const typename pcl::SupervoxelClustering<PointT>::SupervoxelHelper *) BOOST_NOEXCEPT;
+ 
+       typedef boost::ptr_list<SupervoxelHelper> HelperListT;
+       HelperListT supervoxel_helpers_;


### PR DESCRIPTION
…instead of compiler blacklisting

Option was introduced in MacPorts 2.6.0:
https://trac.macports.org/wiki/CompilerSelection

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5
Xcode command line tools 11.5
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
