### PR TITLE
wgrib2: use compiler.openmp_version

### DIFF
--- a/science/wgrib2/Portfile
+++ b/science/wgrib2/Portfile
@@ -131,12 +131,7 @@ destroot {
 }
 
 variant openmp description {Add support for OpenMP} {
-    compiler.whitelist      macports-clang-7.0 macports-clang-6.0 macports-clang-5.0 \
-                            macports-clang-3.7 \
-                            macports-gcc-8 macports-gcc-7 macports-gcc-6 macports-gcc-5 \
-                            macports-gcc-4.8 macports-gcc-4.7 macports-gcc-4.6 macports-gcc-4.5 \
-                            macports-gcc-4.4 macports-gcc-4.3
-    compiler.fallback       macports-clang-7.0
+    compiler.openmp_version 2.5
 }
 
 livecheck.url       http://www.ftp.cpc.ncep.noaa.gov/wd51we/wgrib2/


### PR DESCRIPTION
…instead of compiler whitelisting

Option was introduced in MacPorts 2.6.0:
https://trac.macports.org/wiki/CompilerSelection

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Untested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
