### PR TITLE
xrmc +openmp: use compiler.openmp_version

### DIFF
--- a/science/xrmc/Portfile
+++ b/science/xrmc/Portfile
@@ -42,14 +42,14 @@ test.target         check
 # It is good to offer them since the default clang on Yosemite works but default on other OSX versions might not.
 compilers.choose    cc cxx
 compilers.setup     
-compiler.blacklist  gcc-4.2
-# COLLAPSE is a new clause that has been added in OpenMP 3.0, which is supported only in GCC 4.4 and later
-# so gcc 4.2 will give errors like this:
-# detector.cpp:187: error: expected '#pragma omp' clause before 'collapse'
-# detector.cpp:279: error: expected '#pragma omp' clause before 'collapse'
-# llvm-gcc-4.2 is fine though because the configure script correctly detects that OpenMP is not supported; same for default clang
 
-variant openmp description {Build with OpenMP. Might cause trouble for some compilers.} {
+variant openmp description {Build with OpenMP} {
+    # COLLAPSE is a new clause that has been added in OpenMP 3.0, which is supported only in GCC 4.4 and later
+    # so gcc 4.2 will give errors like this:
+    # detector.cpp:187: error: expected '#pragma omp' clause before 'collapse'
+    # detector.cpp:279: error: expected '#pragma omp' clause before 'collapse'
+    # llvm-gcc-4.2 is fine though because the configure script correctly detects that OpenMP is not supported; same for default clang
+    compiler.openmp_version 3.0
     configure.args-delete  --disable-openmp
     configure.args-append  --enable-openmp
 }


### PR DESCRIPTION
…instead of compiler blacklisting

Option was introduced in MacPorts 2.6.0:
https://trac.macports.org/wiki/CompilerSelection

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Untested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
