### PR TITLE
opencv: update to 3.4.10

### DIFF
--- a/graphics/opencv/Portfile
+++ b/graphics/opencv/Portfile
@@ -6,7 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 PortGroup           legacysupport 1.0
 
 name                opencv
-version             3.4.8
+version             3.4.10
 revision            0
 categories          graphics science
 platforms           darwin
@@ -33,9 +33,9 @@ distfiles           ${distname}${extract.suffix}:opencv
 
 # don't forget to also update the checksums under the contrib variant.
 checksums           ${distname}${extract.suffix} \
-                    rmd160  40652271f410d9d48904a7df428465296f71d874 \
-                    sha256  f0901648a1db3dc3af30e65082665921dbe998673137380450bdd91e8251b567 \
-                    size    87343996
+                    rmd160  a5b32f3d6ebeedb34d32a9f397d5b00d36c5162a \
+                    sha256  1ed6f5b02a7baf14daca04817566e7c98ec668cec381e0edf534fa49f10f58a2 \
+                    size    87430332
 
 worksrcdir          opencv-${version}
 
@@ -275,8 +275,8 @@ variant qt5 conflicts qt4 description {Build with Qt5 Backend support.} {
 
 variant java description {Add Java bindings.} {
     PortGroup               java 1.0
-    java.version            12
-    java.fallback           openjdk12
+    java.version            1.6+
+    java.fallback           openjdk11
     depends_build-append    port:apache-ant
     configure.args-replace  -DBUILD_opencv_java=OFF \
                             -DBUILD_opencv_java=ON


### PR DESCRIPTION
Lower required Java version for `+java` variant
Fixes: https://trac.macports.org/ticket/60193

Use latest LTS Java as fallback instead of a non-LTS version

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Untested.
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
