### PR TITLE
py-graph-tool: update to 2.31

### DIFF
--- a/python/py-graph-tool/Portfile
+++ b/python/py-graph-tool/Portfile
@@ -6,13 +6,13 @@ PortGroup           active_variants 1.1
 
 set realname        graph-tool
 name                py-${realname}
-version             2.29
+version             2.31
 revision            0
 epoch               20190711
 categories          python science
 platforms           darwin
 license             GPL-3
-maintainers         skewed.de:tiago
+maintainers         {skewed.de:tiago @count0}
 description         Efficient python graph module
 long_description    graph-tool is an efficient python module for manipulation \
                     and statistical analysis of graphs. The internal data \
@@ -21,12 +21,12 @@ long_description    graph-tool is an efficient python module for manipulation \
 homepage            http://graph-tool.skewed.de
 master_sites        http://downloads.skewed.de/graph-tool/
 use_bzip2           yes
-checksums           rmd160  ad784fc2ffe7dd745d8cadfd90bae2a03eef3116 \
-                    sha256  6c0c4336bed6e2f79c91ace6d6914145ee03d0bd5025473b5918aec2b0657f7a \
-                    size    15068583
+checksums           rmd160  cb156f194e9ef3ffa015f9a3aec4ef64d9858d22 \
+                    sha256  fbb4a7aee8baa9a9f7ded082e4976ebb3035f04bdf504eb3f9e7fbb2664fd67c \
+                    size    15104602
 distname            ${realname}-${version}
 
-python.versions     27 35 36 37
+python.versions     27 35 36 37 38
 python.default_version 27
 
 if {${os.major} <= 12 && ${os.platform} eq "darwin"} {
@@ -42,21 +42,10 @@ if {${os.major} <= 12 && ${os.platform} eq "darwin"} {
         compiler.cxx_standard   2017
 
         variant openmp description "Enable OpenMP" {
-            # make sure libomp is installed at runtime, even if the compiler gets uninstalled
-            depends_lib-append    lib:${prefix}/lib/libomp/libomp:libomp
+            compiler.openmp_version 2.5
             configure.args-append --enable-openmp
         }
-
-        variant clang60 requires openmp conflicts clang70 description "Use clang-6.0 and enable OpenMP" {
-            configure.compiler  macports-clang-6.0
-        }
-        variant clang70 requires openmp conflicts clang60 description "Use clang-7.0 and enable OpenMP" {
-            configure.compiler  macports-clang-7.0
-        }
         default_variants +openmp
-        if {![variant_isset clang60]} {
-            default_variants-append +clang70
-        }
     }
 }
 
@@ -82,37 +71,21 @@ if {${name} ne ${subport}} {
 
     # PYTHON_EXTRA_LDFLAGS is set to work around incorrect detection of
     # link flags by configure
-    if {[vercmp [macports_version] 2.5.99] >= 0} {
     configure.env-append PYTHON=${python.bin} \
                          PYTHON_VERSION=${python.branch} \
                          PYTHON_CPPFLAGS=-I${python.include} \
                          "PYTHON_LDFLAGS=-L${python.libdir}/.. -lpython${python.branch}" \
                          "PYTHON_EXTRA_LDFLAGS=-L${python.libdir}/.. -lpython${python.branch}"
-    } else {
-    configure.env-append PYTHON=${python.bin} \
-                         PYTHON_VERSION=${python.branch} \
-                         PYTHON_CPPFLAGS=-I${python.include} \
-                         PYTHON_LDFLAGS="-L${python.libdir}/.. -lpython${python.branch}" \
-                         PYTHON_EXTRA_LDFLAGS="-L${python.libdir}/.. -lpython${python.branch}"
-    }
     # With python2.7 PYTHON_EXTRA_LIBS is determined to be
     # '-u _PyMac_Error Python.framework/Versions/2.7/Python'. Not clear whether
     # python2.7 or py-graph-tool's configure script is to blame, but we can easily
     # work around this:
     if {${python.version} eq "27"} {
-        if {[vercmp [macports_version] 2.5.99] >= 0} {
         configure.env-append "PYTHON_EXTRA_LIBS=-u _PyMac_Error"
-        } else {
-        configure.env-append PYTHON_EXTRA_LIBS="-u _PyMac_Error"
-        }
     }
     # Something similar is happening with python3.6
     if {${python.version} eq "36"} {
-        if {[vercmp [macports_version] 2.5.99] >= 0} {
         configure.env-append "PYTHON_EXTRA_LIBS=-Wl,-stack_size,1000000 -framework CoreFoundation ${python.lib}"
-        } else {
-        configure.env-append PYTHON_EXTRA_LIBS="-Wl,-stack_size,1000000 -framework CoreFoundation ${python.lib}"
-        }
     }
     configure.cppflags-append -I${prefix}/include -I${python.include}/..
     configure.ldflags-append -L${prefix}/lib
@@ -123,12 +96,11 @@ if {${name} ne ${subport}} {
         --with-expat-inc=${prefix}/include \
         --with-expat-lib="-L${prefix}/lib -lexpat"
 
-    # Clang uses the old libstc++ from gcc 4.2 before OS X 10.9. Boost doesn't
+    # Clang uses the old libstdc++ from gcc 4.2 before OS X 10.9. Boost doesn't
     # include some of the tr1 headers in libstdc++ and defines its own tr1
     # classes. This causes conflicts with sparsehash which insists on using
     # the old tr1 headers.
-    if {[string match *gcc* ${configure.compiler}] ||
-        ${os.major} >= 13 && ${os.platform} eq "darwin"} {
+    if {${configure.cxx_stdlib} ne "libstdc++"} {
         depends_lib-append port:sparsehash
     } else {
         configure.args-append --disable-sparsehash


### PR DESCRIPTION
Add GitHub handle for maintainer

Use `compiler.openmp_version` option introduced in MacPorts 2.6.0
See https://trac.macports.org/wiki/CompilerSelection
Remove unneeded +clang* variants

Cleanup pre-2.6.0 handling in portfile

Use `configure.cxx_stdlib` to check for libstdc++
Fixes: https://trac.macports.org/ticket/59890

Add py38 subport

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Untested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
