### PR TITLE
julia: update to version 1.4.1

### DIFF
--- a/lang/julia/Portfile
+++ b/lang/julia/Portfile
@@ -8,7 +8,7 @@ PortGroup           compilers 1.0
 compilers.choose    fc f77 f90
 compilers.setup     require_fortran -g95
 
-github.setup        JuliaLang julia 1.3.1 v
+github.setup        JuliaLang julia 1.4.1 v
 revision            0
 categories-append   lang math science
 maintainers         {ieee.org:s.t.smith @essandess} openmaintainer
@@ -26,9 +26,9 @@ github.tarball_from releases
 distfiles           ${name}-${version}-full${extract.suffix}
 
 checksums           ${name}-${version}-full${extract.suffix} \
-                    rmd160  545114fe79296ab1e56ce842adbb89464238f4ab \
-                    sha256  053908ec2706eb76cfdc998c077de123ecb1c60c945b4b5057aa3be19147b723 \
-                    size    129120361 \
+                    rmd160  7e2b390d24c77f717b8eecbe3a5285dae7e9ea4a \
+                    sha256  b21585db55673ac0668c163678fcf2aad11eb7c64bb2aa03a43046115fab1553 \
+                    size    132815888 \
 
 gpg_verify.use_gpg_verification \
                     yes


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [] enhancement
- [ ] security fix
- [x] software version update

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.12.6 16G2136
Xcode 9.2 9C40b
variant: +gcc8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
I followed the instructions in https://trac.macports.org/wiki/howto/Upgrade, but `port lint` returns 
`Warning: julia-1.4.1-full.tar.gz.asc - missing recommended checksum type: rmd160
  Warning: julia-1.4.1-full.tar.gz.asc - missing recommended checksum type: sha256`
although  these are specified in the Portfile.

- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->