### PR TITLE
gnuplot: move to qt5 as default

### DIFF
--- a/math/gnuplot/Portfile
+++ b/math/gnuplot/Portfile
@@ -126,7 +126,14 @@ variant old_bitmap_terminals description "Enable PBM (Portable Bit Map) and othe
     configure.args-replace      --without-bitmap-terminals --with-bitmap-terminals
 }
 
-default_variants                +aquaterm +luaterm +pangocairo +wxwidgets +x11
+default_variants                +luaterm +pangocairo
+
+# qt5 requires macOS 10.8 or later
+if { ${os.platform} eq "darwin" && ${os.major} < 12 } {
+    default_variants            +wxwidgets
+} else {
+    default_variants            +qt5
+}
 
 if {[variant_isset pangocairo] || [variant_isset wxwidgets]} {
     depends_lib-append          path:lib/pkgconfig/pango.pc:pango


### PR DESCRIPTION
#### Description

seems the default on most Linux distributions and it offers more
features like saving formats

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.4 19E287
Xcode 11.4 11E146

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
