### PR TITLE
borgbackup: move llfuse dependency into a variant.

### DIFF
--- a/sysutils/borgbackup/Portfile
+++ b/sysutils/borgbackup/Portfile
@@ -35,7 +35,6 @@ depends_build-append    port:py${python.version}-setuptools_scm \
                         port:py${python.version}-sphinx_rtd_theme
 depends_lib-append      path:lib/libssl.dylib:openssl \
                         port:lz4 \
-                        port:py${python.version}-llfuse \
                         port:py${python.version}-msgpack \
                         port:py${python.version}-setuptools
 
@@ -68,4 +67,14 @@ post-destroot {
     xinstall -d ${destroot}${zsh_compl_path}
     xinstall -m 0644 ${worksrcpath}/scripts/shell_completions/zsh/_borg \
         ${destroot}${zsh_compl_path}
+}
+
+variant fuse description {Add FUSE mounting support} {
+    depends_lib-append  port:py${python.version}-llfuse
+}
+
+platform darwin {
+    if {${os.major} < 19} {
+        default_variants +fuse
+    }
 }


### PR DESCRIPTION
This dependency causes trouble on MacOS 10.15 and above, as there is
no longer an open source version of OSXFUSE compatible with MacOS 10.15.

Borg backup gracefully handles the missing dependency, giving a useful
error message. Indeed, borg backup is designed to work on platforms that
do not have any kind of FUSE support. The FUSE dependency is only used
for the `borg mount` command and does not affect borg's core backup and
restore functionality.

It could be reasonable to make -fuse the default on MacOS 10.15, but I haven't done that here.