### PR TITLE
libsoundio: update version to 2.0.0

### DIFF
--- a/audio/libsoundio/Portfile
+++ b/audio/libsoundio/Portfile
@@ -8,8 +8,7 @@ name                        libsoundio
 version                     2.0.0
 license                     MIT
 categories                  audio
-maintainers                 {darkcog.com:casr+macports @casr} \
-                            openmaintainer
+maintainers                 nomaintainer
 homepage                    http://libsound.io/
 platforms                   darwin
 

--- a/audio/libsoundio/Portfile
+++ b/audio/libsoundio/Portfile
@@ -1,10 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem                  1.0
-PortGroup                   cmake 1.0
+PortGroup                   cmake 1.1
+PortGroup                   github 1.0
 
 name                        libsoundio
-version                     1.1.0
+version                     2.0.0
 license                     MIT
 categories                  audio
 maintainers                 {darkcog.com:casr+macports @casr} \
@@ -21,27 +22,24 @@ long_description            libsoundio is a lightweight abstraction over \
                             behalf\; instead exposing the raw power of the \
                             underlying backend.
 
-master_sites                http://libsound.io/release/
+github.setup                andrewrk libsoundio 2.0.0
+checksums                   rmd160  1e1c2c350137174593d84a32c6aa45fb18744367 \
+                            sha256  f19e120d09b1b2aa80d5cb0c224e38d6854149fe55665665ea89a0bd97e300e6 \
+                            size    120456
+revision                    0
 
-checksums                   rmd160 61b8416e3feb9d6299b443c3e455cb2b0a2de350 \
-                            sha256 ba0b21397cb3e29dc8f51ed213ae27625f05398c01aefcfbaa860fab42a84281
-
-configure.args-append       -DBUILD_EXAMPLE_PROGRAMS=Off \
-                            -DBUILD_TESTS=Off \
-                            -DENABLE_JACK=Off \
-                            -DENABLE_PULSEAUDIO=Off \
-                            -DENABLE_ALSA=Off \
-                            -DENABLE_WASAPI=Off
+configure.args-append       -DBUILD_EXAMPLE_PROGRAMS=OFF \
+                            -DBUILD_TESTS=OFF \
+                            -DENABLE_JACK=OFF \
+                            -DENABLE_PULSEAUDIO=OFF \
+                            -DENABLE_ALSA=OFF \
+                            -DENABLE_WASAPI=OFF \
+                            -DENABLE_COREAUDIO=ON
 
 variant pulseaudio description {Enable PulseAudio support} {
-    depends_build-append        port:pulseaudio
-
-    configure.args-replace      -DENABLE_PULSEAUDIO=Off -DENABLE_PULSEAUDIO=On
+    depends_build-append    port:pulseaudio
+    configure.args-replace  -DENABLE_PULSEAUDIO=OFF -DENABLE_PULSEAUDIO=ON
 }
-
-# As PulseAudio is a build time only dependency we may as well let the
-# buildbot take care of this
-default_variants            +pulseaudio
 
 pre-fetch {
     if {${os.platform} eq "darwin" && ${os.major} < 14} {
@@ -49,7 +47,3 @@ pre-fetch {
         return -code error "incompatible macOS version"
     }
 }
-
-
-livecheck.type              regex
-livecheck.regex             ${name}-(\[0-9.\]+)${extract.suffix}


### PR DESCRIPTION


#### Description

- move to github
- remove pulseaudio as default variant (not needed at build time)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.4 19E287
Xcode 11.4 11E146

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
