### PR TITLE
opencv +java: lower required Java version

### DIFF
--- a/graphics/opencv/Portfile
+++ b/graphics/opencv/Portfile
@@ -275,8 +275,8 @@ variant qt5 conflicts qt4 description {Build with Qt5 Backend support.} {
 
 variant java description {Add Java bindings.} {
     PortGroup               java 1.0
-    java.version            12
-    java.fallback           openjdk12
+    java.version            1.6+
+    java.fallback           openjdk11
     depends_build-append    port:apache-ant
     configure.args-replace  -DBUILD_opencv_java=OFF \
                             -DBUILD_opencv_java=ON


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/60193

Use latest LTS Java as fallback

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Untested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
