### PR TITLE
vtk: Fix compatibility issues with python38

### DIFF
--- a/graphics/vtk/Portfile
+++ b/graphics/vtk/Portfile
@@ -15,14 +15,14 @@ compiler.blacklist-append {clang < 900}
 
 name                vtk
 version             8.2.0
-revision            0
+revision            1
 categories          graphics devel
 platforms           darwin
 license             BSD
 
 set branch          [join [lrange [split ${version} .] 0 1] .]
 
-maintainers         {stromnov @stromnov} openmaintainer
+maintainers         {stromnov @stromnov} {rubendibattista gmail.com:rubendibattista} openmaintainer
 
 description         Visualization Toolkit (VTK)
 
@@ -65,8 +65,14 @@ mpi.enforce_variant hdf5
 patchfiles          patch-pugixml.diff \
                     patch-IOMovie-module.cmake.diff
 
-configure.args-delete \
-                    -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON
+if {[variant_isset python38]} {
+    # https://gitlab.kitware.com/vtk/vtk/-/commit/257b9d7b18d5f3db3fe099dc18f230e23f7dfbab
+    # Remove this when upgrading the version, because it was merged for VTK9
+    patchfiles-append  patch-python38-tp_print.diff  
+}
+
+configure.pre_args-delete \
+                    -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON
 
 configure.args-append \
                     ../${distname}/ \

--- a/graphics/vtk/files/patch-python38-tp_print.diff
+++ b/graphics/vtk/files/patch-python38-tp_print.diff
@@ -1,0 +1,176 @@
+From 257b9d7b18d5f3db3fe099dc18f230e23f7dfbab Mon Sep 17 00:00:00 2001
+From: David Gobbi <david.gobbi@gmail.com>
+Date: Tue, 20 Aug 2019 17:02:24 -0600
+Subject: [PATCH] Compatibility for Python 3.8
+
+The PyTypeObject struct was modified in Python 3.8, this change is
+required to avoid compile errors.
+---
+ .../PythonInterpreter/vtkPythonStdStreamCaptureHelper.h   | 6 ++++++
+ Wrapping/PythonCore/PyVTKMethodDescriptor.cxx             | 2 +-
+ Wrapping/PythonCore/PyVTKNamespace.cxx                    | 2 +-
+ Wrapping/PythonCore/PyVTKReference.cxx                    | 8 ++++----
+ Wrapping/PythonCore/PyVTKTemplate.cxx                     | 2 +-
+ Wrapping/PythonCore/vtkPythonCompatibility.h              | 8 +++++++-
+ Wrapping/Tools/vtkWrapPythonClass.c                       | 2 +-
+ Wrapping/Tools/vtkWrapPythonEnum.c                        | 2 +-
+ Wrapping/Tools/vtkWrapPythonType.c                        | 2 +-
+ 9 files changed, 23 insertions(+), 11 deletions(-)
+
+diff --git Utilities/PythonInterpreter/vtkPythonStdStreamCaptureHelper.h Utilities/PythonInterpreter/vtkPythonStdStreamCaptureHelper.h
+index b1c12c83de..14ccfbe928 100644
+--- Utilities/PythonInterpreter/vtkPythonStdStreamCaptureHelper.h
++++ Utilities/PythonInterpreter/vtkPythonStdStreamCaptureHelper.h
+@@ -140,6 +140,12 @@ static PyTypeObject vtkPythonStdStreamCaptureHelperType = {
+ #if PY_VERSION_HEX >= 0x03040000
+   0, // tp_finalize
+ #endif
++#if PY_VERSION_HEX >= 0x03080000
++  0, // tp_vectorcall
++#if PY_VERSION_HEX < 0x03090000
++  0, // tp_print
++#endif
++#endif
+ };
+ 
+ static PyObject* vtkWrite(PyObject* self, PyObject* args)
+diff --git Wrapping/PythonCore/PyVTKMethodDescriptor.cxx Wrapping/PythonCore/PyVTKMethodDescriptor.cxx
+index 2b0d443537..3840038498 100644
+--- Wrapping/PythonCore/PyVTKMethodDescriptor.cxx
++++ Wrapping/PythonCore/PyVTKMethodDescriptor.cxx
+@@ -186,7 +186,7 @@ PyTypeObject PyVTKMethodDescriptor_Type = {
+   sizeof(PyMethodDescrObject),           // tp_basicsize
+   0,                                     // tp_itemsize
+   PyVTKMethodDescriptor_Delete,          // tp_dealloc
+-  nullptr,                               // tp_print
++  0,                                     // tp_vectorcall_offset
+   nullptr,                               // tp_getattr
+   nullptr,                               // tp_setattr
+   nullptr,                               // tp_compare
+diff --git Wrapping/PythonCore/PyVTKNamespace.cxx Wrapping/PythonCore/PyVTKNamespace.cxx
+index 71ee2a3516..5cf5bfbe6b 100644
+--- Wrapping/PythonCore/PyVTKNamespace.cxx
++++ Wrapping/PythonCore/PyVTKNamespace.cxx
+@@ -49,7 +49,7 @@ PyTypeObject PyVTKNamespace_Type = {
+   0,                                     // tp_basicsize
+   0,                                     // tp_itemsize
+   PyVTKNamespace_Delete,                 // tp_dealloc
+-  nullptr,                               // tp_print
++  0,                                     // tp_vectorcall_offset
+   nullptr,                               // tp_getattr
+   nullptr,                               // tp_setattr
+   nullptr,                               // tp_compare
+diff --git Wrapping/PythonCore/PyVTKReference.cxx Wrapping/PythonCore/PyVTKReference.cxx
+index 943ac71080..b7104091c0 100644
+--- Wrapping/PythonCore/PyVTKReference.cxx
++++ Wrapping/PythonCore/PyVTKReference.cxx
+@@ -1010,7 +1010,7 @@ PyTypeObject PyVTKReference_Type = {
+   sizeof(PyVTKReference),                // tp_basicsize
+   0,                                     // tp_itemsize
+   PyVTKReference_Delete,                 // tp_dealloc
+-  nullptr,                               // tp_print
++  0,                                     // tp_vectorcall_offset
+   nullptr,                               // tp_getattr
+   nullptr,                               // tp_setattr
+   nullptr,                               // tp_compare
+@@ -1067,7 +1067,7 @@ PyTypeObject PyVTKNumberReference_Type = {
+   sizeof(PyVTKReference),                // tp_basicsize
+   0,                                     // tp_itemsize
+   PyVTKReference_Delete,                 // tp_dealloc
+-  nullptr,                               // tp_print
++  0,                                     // tp_vectorcall_offset
+   nullptr,                               // tp_getattr
+   nullptr,                               // tp_setattr
+   nullptr,                               // tp_compare
+@@ -1124,7 +1124,7 @@ PyTypeObject PyVTKStringReference_Type = {
+   sizeof(PyVTKReference),                // tp_basicsize
+   0,                                     // tp_itemsize
+   PyVTKReference_Delete,                 // tp_dealloc
+-  nullptr,                               // tp_print
++  0,                                     // tp_vectorcall_offset
+   nullptr,                               // tp_getattr
+   nullptr,                               // tp_setattr
+   nullptr,                               // tp_compare
+@@ -1181,7 +1181,7 @@ PyTypeObject PyVTKTupleReference_Type = {
+   sizeof(PyVTKReference),                // tp_basicsize
+   0,                                     // tp_itemsize
+   PyVTKReference_Delete,                 // tp_dealloc
+-  nullptr,                               // tp_print
++  0,                                     // tp_vectorcall_offset
+   nullptr,                               // tp_getattr
+   nullptr,                               // tp_setattr
+   nullptr,                               // tp_compare
+diff --git Wrapping/PythonCore/PyVTKTemplate.cxx Wrapping/PythonCore/PyVTKTemplate.cxx
+index be200985b3..340fe7953b 100644
+--- Wrapping/PythonCore/PyVTKTemplate.cxx
++++ Wrapping/PythonCore/PyVTKTemplate.cxx
+@@ -268,7 +268,7 @@ PyTypeObject PyVTKTemplate_Type = {
+   0,                                     // tp_basicsize
+   0,                                     // tp_itemsize
+   nullptr,                               // tp_dealloc
+-  nullptr,                               // tp_print
++  0,                                     // tp_vectorcall_offset
+   nullptr,                               // tp_getattr
+   nullptr,                               // tp_setattr
+   nullptr,                               // tp_compare
+diff --git Wrapping/PythonCore/vtkPythonCompatibility.h Wrapping/PythonCore/vtkPythonCompatibility.h
+index 4a767844a6..be208faeef 100644
+--- Wrapping/PythonCore/vtkPythonCompatibility.h
++++ Wrapping/PythonCore/vtkPythonCompatibility.h
+@@ -64,7 +64,13 @@
+ #endif
+ 
+ // PyTypeObject compatibility
+-#if PY_VERSION_HEX >= 0x03040000
++#if PY_VERSION_HEX >= 0x03090000
++#define VTK_WRAP_PYTHON_SUPPRESS_UNINITIALIZED \
++  0, 0, 0, 0,
++#elif PY_VERSION_HEX >= 0x03080000
++#define VTK_WRAP_PYTHON_SUPPRESS_UNINITIALIZED \
++  0, 0, 0, 0, 0,
++#elif PY_VERSION_HEX >= 0x03040000
+ #define VTK_WRAP_PYTHON_SUPPRESS_UNINITIALIZED \
+   0, 0, 0,
+ #else
+diff --git Wrapping/Tools/vtkWrapPythonClass.c Wrapping/Tools/vtkWrapPythonClass.c
+index b1e45f8e80..4d558ea081 100644
+--- Wrapping/Tools/vtkWrapPythonClass.c
++++ Wrapping/Tools/vtkWrapPythonClass.c
+@@ -521,7 +521,7 @@ void vtkWrapPython_GenerateObjectType(
+     "  sizeof(PyVTKObject), // tp_basicsize\n"
+     "  0, // tp_itemsize\n"
+     "  PyVTKObject_Delete, // tp_dealloc\n"
+-    "  nullptr, // tp_print\n"
++    "  0, // tp_vectorcall_offset\n"
+     "  nullptr, // tp_getattr\n"
+     "  nullptr, // tp_setattr\n"
+     "  nullptr, // tp_compare\n"
+diff --git Wrapping/Tools/vtkWrapPythonEnum.c Wrapping/Tools/vtkWrapPythonEnum.c
+index b933702242..1249362854 100644
+--- Wrapping/Tools/vtkWrapPythonEnum.c
++++ Wrapping/Tools/vtkWrapPythonEnum.c
+@@ -145,7 +145,7 @@ void vtkWrapPython_GenerateEnumType(
+     "  sizeof(PyIntObject), // tp_basicsize\n"
+     "  0, // tp_itemsize\n"
+     "  nullptr, // tp_dealloc\n"
+-    "  nullptr, // tp_print\n"
++    "  0, // tp_vectorcall_offset\n"
+     "  nullptr, // tp_getattr\n"
+     "  nullptr, // tp_setattr\n"
+     "  nullptr, // tp_compare\n"
+diff --git Wrapping/Tools/vtkWrapPythonType.c Wrapping/Tools/vtkWrapPythonType.c
+index 744cb1b9d3..0a1375e541 100644
+--- Wrapping/Tools/vtkWrapPythonType.c
++++ Wrapping/Tools/vtkWrapPythonType.c
+@@ -709,7 +709,7 @@ void vtkWrapPython_GenerateSpecialType(
+     "  sizeof(PyVTKSpecialObject), // tp_basicsize\n"
+     "  0, // tp_itemsize\n"
+     "  Py%s_Delete, // tp_dealloc\n"
+-    "  nullptr, // tp_print\n"
++    "  0, // tp_vectorcall_offset\n"
+     "  nullptr, // tp_getattr\n"
+     "  nullptr, // tp_setattr\n"
+     "  nullptr, // tp_compare\n"
+-- 
+GitLab
+


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
