### PR TITLE
gh: update to 0.7.0

### DIFF
--- a/devel/gh/Portfile
+++ b/devel/gh/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        cli cli 0.6.4 v
+github.setup        cli cli 0.7.0 v
 name                gh
 categories          devel
 platforms           darwin
@@ -21,9 +21,9 @@ homepage            https://cli.github.com/
 github.tarball_from releases
 distname            gh_${version}_macOS_amd64
 
-checksums           rmd160  f7b49e4414527fdbcdc3df18236a4c93313b887c \
-                    sha256  d240d3ba78dbaefdba9edf573010b6b814768c67f7b826f74072eb8e4acfd739 \
-                    size    6228181
+checksums           rmd160  d8ad93d44aca68e1e2068f4c19242100ea464001 \
+                    sha256  88a22c7421510a2e8f64ee6e78048d51382f9abd07ca4d275b0fb5fcd3871173 \
+                    size    6231965
 
 use_configure       no
 


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
