### PR TITLE
keepassxc: update to 2.5.4

### DIFF
--- a/security/KeePassXC/Portfile
+++ b/security/KeePassXC/Portfile
@@ -20,7 +20,7 @@ platforms               darwin
 license                 GPL-2+
 license_noconflict      openssl
 
-github.setup            keepassxreboot keepassxc 2.5.1
+github.setup            keepassxreboot keepassxc 2.5.4
 github.tarball_from     releases
 distname                keepassxc-${version}-src
 use_xz                  yes
@@ -28,10 +28,12 @@ distfiles-append        ${distname}${extract.suffix}.sig
 
 # See keepassxc-${version}-src.tar.xz.DIGEST on upstream GitHub releases page for SHA256 sums
 checksums               ${distname}${extract.suffix} \
-                        rmd160  4b3c639ec001fec15f16560f795dbbfd9a79ab9c \
-                        sha256  ef33258b859a7b996af007113613b0f6210f2341e8f5fb3a005564262c2caf30 \
-                        size    6798880 \
+                        rmd160  635c4eff7769c3edf80af1e3070d535157487ee6 \
+                        sha256  a55e0801c318b02b1ac4e16e9b7a87ccfa7b039ea60d2c62610bd1bbbdd6cd4a \
+                        size    6839396 \
                         ${distname}${extract.suffix}.sig \
+                        rmd160  44153573ac36bc47b97e58b845bfee2a91db0c6a \
+                        sha256  fc527280cfa05c2ed75529c280432ab8d301f69911f2d74c56fe8061f2b0d2f1 \
                         size    488
 
 gpg_verify.use_gpg_verification \

--- a/security/KeePassXC/files/patch-no-deployqt.diff
+++ b/security/KeePassXC/files/patch-no-deployqt.diff
@@ -1,6 +1,6 @@
---- CMakeLists.txt	2018-02-28 05:38:05.000000000 +0800
-+++ CMakeLists.txt	2018-03-02 16:51:27.000000000 +0800
-@@ -306,12 +306,6 @@
+--- CMakeLists.txt	2020-04-23 12:59:39.000000000 +0200
++++ CMakeLists.txt	2020-04-23 13:06:45.000000000 +0200
+@@ -397,12 +397,6 @@
  
  if(APPLE)
      set(CMAKE_MACOSX_RPATH TRUE)
@@ -13,9 +13,9 @@
  elseif(MINGW)
      find_program(WINDEPLOYQT_EXE windeployqt HINTS ${Qt5_PREFIX}/bin ENV PATH)
      if(NOT WINDEPLOYQT_EXE)
---- src/CMakeLists.txt	2018-02-28 05:38:05.000000000 +0800
-+++ src/CMakeLists.txt	2018-03-02 16:47:48.000000000 +0800
-@@ -319,11 +319,6 @@
+--- src/CMakeLists.txt	2020-04-09 18:24:20.000000000 +0200
++++ src/CMakeLists.txt	2020-04-23 13:07:45.000000000 +0200
+@@ -380,11 +380,6 @@
      set(CPACK_PACKAGE_FILE_NAME "${PROGNAME}-${KEEPASSXC_VERSION}")
      include(CPack)
  
@@ -27,9 +27,9 @@
  endif()
  
  install(TARGETS ${PROGNAME}
---- src/autotype/mac/CMakeLists.txt	2018-02-28 05:38:05.000000000 +0800
-+++ src/autotype/mac/CMakeLists.txt	2018-03-02 16:48:26.000000000 +0800
-@@ -13,8 +13,8 @@
+--- src/autotype/mac/CMakeLists.txt	2020-04-09 18:24:20.000000000 +0200
++++ src/autotype/mac/CMakeLists.txt	2020-04-23 13:09:07.000000000 +0200
+@@ -7,8 +7,8 @@
  if(WITH_APP_BUNDLE)
      add_custom_command(TARGET keepassx-autotype-cocoa
              POST_BUILD

--- a/security/KeePassXC/files/patch-old-mac.diff
+++ b/security/KeePassXC/files/patch-old-mac.diff
@@ -1,19 +1,6 @@
-diff --git src/gui/macutils/AppKitImpl.mm src/gui/macutils/AppKitImpl.mm
-index 44137ee7..a09ffda8 100644
---- src/gui/macutils/AppKitImpl.mm
-+++ src/gui/macutils/AppKitImpl.mm
-@@ -22,10 +22,6 @@
- #import <CoreVideo/CVPixelBuffer.h>
- #import <Availability.h>
- 
--#if __MAC_OS_X_VERSION_MAX_ALLOWED < 101200
--static const NSEventMask NSEventMaskKeyDown = NSKeyDownMask;
--#endif
--
- @implementation AppKitImpl
- 
- - (id) initWithObject:(AppKit*)appkit
-@@ -139,6 +135,7 @@ - (bool) enableAccessibility
+--- src/gui/macutils/AppKitImpl.mm	2020-04-09 18:24:20.000000000 +0200
++++ src/gui/macutils/AppKitImpl.mm.new	2020-04-23 13:24:04.000000000 +0200
+@@ -134,6 +134,7 @@
  //
  - (bool) enableScreenRecording
  {
@@ -21,7 +8,7 @@ index 44137ee7..a09ffda8 100644
      if (@available(macOS 10.15, *)) {
          // Request screen recording permission on macOS 10.15+
          // This is necessary to get the current window title
-@@ -156,6 +153,7 @@ - (bool) enableScreenRecording
+@@ -151,6 +152,7 @@
              return NO;
          }
      }


### PR DESCRIPTION
* update to 2.5.4
* new patches

#### Description
Updated KeePassXC to 2.5.4 (current).

###### Type(s)
Update
- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
