### PR TITLE
npm6: default to nodejs14

### DIFF
--- a/devel/npm6/Portfile
+++ b/devel/npm6/Portfile
@@ -32,11 +32,11 @@ checksums           sha1    50a1c6274fb451ca18f6ff472d2a73f006adbd66 \
 
 worksrcdir          "package"
 
-depends_lib         path:bin/node:nodejs10
+depends_lib         path:bin/node:nodejs14
 
 platform darwin {
     if {${os.major} < 13} {
-        depends_lib-replace path:bin/node:nodejs12 path:bin/node:nodejs8
+        depends_lib-replace path:bin/node:nodejs14 path:bin/node:nodejs8
     }
 }
 


### PR DESCRIPTION
###### Type(s)

- [x] enhancement

###### Tested on
macOS 10.15.4 19E287
Xcode 11.4 11E146

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?