### PR TITLE
nodejs14: add missing libuv include files

### DIFF
--- a/devel/nodejs14/Portfile
+++ b/devel/nodejs14/Portfile
@@ -126,6 +126,7 @@ destroot {
     xinstall -d ${libndir}
     xinstall -d ${libddir}
     xinstall -d ${incdir}
+    xinstall -d ${incdir}/uv
     xinstall -d ${docdir}
 
     # install binaries
@@ -137,6 +138,7 @@ destroot {
     xinstall -m 644 {*}[glob ${worksrcpath}/src/*.h]                ${incdir}
     xinstall -m 644 {*}[glob ${worksrcpath}/deps/v8/include/*.h]    ${incdir}
     xinstall -m 644 {*}[glob ${worksrcpath}/deps/uv/include/*.h]    ${incdir}
+    xinstall -m 644 {*}[glob ${worksrcpath}/deps/uv/include/uv/*.h] ${incdir}/uv
     xinstall -m 644 {*}[glob ${worksrcpath}/deps/cares/include/*.h] ${incdir}
 
     # install dtrace script


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/60361

Revision isn't incremented because builds take forever and Node.js updates are frequent anyway.

###### Type(s)

- [x] bugfix

###### Tested on
macOS 10.15.4 19E287
Xcode 11.4 11E146

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?