### PR TITLE
fd: Update to 8.0.0

### DIFF
--- a/sysutils/fd/Portfile
+++ b/sysutils/fd/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        sharkdp fd 7.3.0 v
+github.setup        sharkdp fd 8.0.0 v
 categories          sysutils
 platforms           darwin
 maintainers         {saagarjha.com:saagar @saagarjha} \
@@ -18,69 +18,72 @@ long_description    fd is a simple, fast and user-friendly alternative to find. 
                     for 80% of the use cases.
 
 checksums           fd-${version}.tar.gz \
-                    rmd160  41c9af67dfb384d08216037d664e8aa2f48cfa7d \
-                    sha256  5a37bd04cce61acd3f0cd8635eca9ae0fc621545d0cacf03acbcf4392d8d9bd5 \
-                    size    57703
+                    rmd160  c66c368d7b76068dd7c8be3ab40f713d65115df9 \
+                    sha256  df7ba250958c81899055225716e289e2c5568afdad93da0f0b5ea6ee5fdd66e2 \
+                    size    71480
+
+patchfiles          patch-disable-jemallocator.diff
 
 cargo.crates \
-    aho-corasick                     0.6.9  1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e \
+    aho-corasick                    0.7.10  8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada \
+    ansi_term                       0.12.1  d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2 \
     ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
-    atty                            0.2.11  9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652 \
-    bitflags                         1.0.4  228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12 \
-    cc                              1.0.29  4390a3b5f4f6bce9c1d0c00128379df433e53777fdd30e92f16a529332baec4e \
-    cfg-if                           0.1.6  082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4 \
-    clap                            2.32.0  b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e \
-    crossbeam-channel                0.3.8  0f0ed1a4de2235cabda8558ff5840bffb97fcb64c97827f354a451307df5f72b \
-    crossbeam-utils                  0.6.5  f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c \
-    ctrlc                            3.1.1  630391922b1b893692c6334369ff528dcc3a9d8061ccf4c803aa8f83cb13db5e \
-    diff                            0.1.11  3c2b69f912779fbb121ceb775d74d51e915af17aaebc38d28a592843a2dd0a3a \
-    filetime                         0.2.4  a2df5c1a8c4be27e7707789dc42ae65976e60b394afd293d1419ab915833e646 \
+    anyhow                          1.0.28  d9a60d744a80c30fcb657dfe2c1b22bcb3e814c1a1e3674f32bf5820b570fbff \
+    atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+    autocfg                          1.0.0  f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d \
+    bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
+    bstr                            0.2.12  2889e6d50f394968c8bf4240dc3f2a7eb4680844d27308f798229ac9d4725f41 \
+    cc                              1.0.50  95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd \
+    cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
+    clap                            2.33.0  5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9 \
+    crossbeam-channel                0.4.2  cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061 \
+    crossbeam-utils                  0.7.2  c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8 \
+    ctrlc                            3.1.4  7a4ba686dff9fa4c1c9636ce1010b0cf98ceb421361b0bb3d6faeec43bd217a7 \
+    diff                            0.1.12  0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499 \
+    filetime                         0.2.9  f59efc38004c988e4201d11d263b8171f49a2e7ec0bdbb71773433f271504a5e \
     fnv                              1.0.6  2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3 \
+    fs_extra                         1.1.0  5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674 \
     fuchsia-cprng                    0.1.1  a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba \
-    globset                          0.4.2  4743617a7464bbda3c8aec8558ff2f9429047e025771037df561d383337ff865 \
-    humantime                        1.2.0  3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114 \
-    ignore                           0.4.6  ad03ca67dc12474ecd91fdb94d758cbd20cb4e7a78ebe831df26a9b7511e1162 \
+    globset                          0.4.5  7ad1da430bd7281dde2576f44c84cc3f0f7b475e7202cd503042dff01a8c8120 \
+    hermit-abi                      0.1.11  8a0d737e0f947a1864e93d33fdef4af8445a00d1ed8dc0c8ddb73139ea6abf15 \
+    humantime                        2.0.0  b9b6c53306532d3c8e8087b44e6580e10db51a023cf9b433cea2ac38066b92da \
+    ignore                          0.4.14  ddf60d063dbe6b75388eec66cfc07781167ae3d34a09e0c433e6c5de0511f7fb \
+    jemalloc-sys                     0.3.2  0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45 \
+    jemallocator                     0.3.2  43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69 \
     kernel32-sys                     0.2.2  7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d \
-    lazy_static                      1.2.0  a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1 \
-    libc                            0.2.48  e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047 \
-    log                              0.4.6  c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6 \
-    lscolors                         0.5.0  e9938fd8c379393454f73ec4c9c5b40f3d8332d80b25a29da05e41ee0ecbb559 \
-    memchr                           2.2.0  2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39 \
-    nix                             0.11.0  d37e713a259ff641624b6cb20e3b12b2952313ba36b6823c0f16e6cfd9e5de17 \
-    num_cpus                        1.10.0  1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba \
-    quick-error                      1.2.2  9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0 \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    libc                            0.2.69  99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005 \
+    log                              0.4.8  14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7 \
+    lscolors                         0.7.0  1f77452267149eac960ded529fe5f5460ddf792845a1d71b5d0cfcee5642e47e \
+    maybe-uninit                     2.0.0  60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00 \
+    memchr                           2.3.3  3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400 \
+    nix                             0.17.0  50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363 \
+    num_cpus                        1.13.0  05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3 \
     rand                             0.4.6  552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293 \
+    rand_core                        0.4.2  9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc \
     rand_core                        0.3.1  7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b \
-    rand_core                        0.4.0  d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0 \
     rdrand                           0.4.0  678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2 \
-    redox_syscall                   0.1.51  423e376fffca3dfa06c9e9790a9ccd282fafb3cc6e6397d01dbf64f9bacc6b85 \
-    redox_termios                    0.1.1  7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76 \
-    regex                            1.1.0  37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f \
-    regex-syntax                     0.6.5  8c2f35eedad5295fdf00a63d7d4b238135723f92b434ec06774dad15c7ab0861 \
-    remove_dir_all                   0.5.1  3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5 \
-    same-file                        1.0.4  8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267 \
-    smallvec                         0.6.8  88aea073965ab29f6edb5493faf96ad662fb18aa9eeb186a3b7057951605ed15 \
-    strsim                           0.7.0  bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550 \
+    redox_syscall                   0.1.56  2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84 \
+    regex                            1.3.6  7f6946991529684867e47d86474e3a6d0c0ab9b82d5821e314b1ede31fa3a4b3 \
+    regex-syntax                    0.6.17  7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae \
+    remove_dir_all                   0.5.2  4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e \
+    same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
+    strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
     tempdir                          0.3.7  15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8 \
     term_size                        0.3.1  9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327 \
-    termion                          1.5.1  689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096 \
-    textwrap                        0.10.0  307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6 \
-    thread_local                     0.3.6  c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b \
-    ucd-util                         0.1.3  535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86 \
-    unicode-width                    0.1.5  882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526 \
-    unreachable                      1.0.0  382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56 \
-    utf8-ranges                      1.0.2  796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737 \
+    textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
+    thread_local                     1.0.1  d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14 \
+    unicode-width                    0.1.7  caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479 \
     vec_map                          0.8.1  05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a \
-    version_check                    0.1.5  914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd \
+    version_check                    0.9.1  078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce \
     void                             1.0.2  6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d \
-    walkdir                          2.2.7  9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1 \
+    walkdir                          2.3.1  777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d \
+    winapi                           0.3.8  8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6 \
     winapi                           0.2.8  167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
-    winapi                           0.3.6  92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0 \
     winapi-build                     0.1.1  2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
-    winapi-util                      0.1.2  7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9 \
+    winapi-util                      0.1.4  fa515c5163a99cc82bab70fd3bfdd36d827be85de63737b40fcef2ce084a436e \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f
-
 
 pre-build {
     file mkdir ${worksrcpath}/shell_completions

--- a/sysutils/fd/files/patch-disable-jemallocator.diff
+++ b/sysutils/fd/files/patch-disable-jemallocator.diff
@@ -1,0 +1,22 @@
+--- Cargo.toml.orig	2020-04-23 10:40:47.000000000 -0700
++++ Cargo.toml	2020-04-23 14:44:57.000000000 -0700
+@@ -54,7 +54,7 @@
+ [target.'cfg(all(unix, not(target_os = "redox")))'.dependencies]
+ libc = "0.2"
+ 
+-[target.'cfg(all(not(windows), not(target_env = "musl")))'.dependencies]
++[target.'cfg(all(not(windows), not(target_os = "macos"), not(target_env = "musl")))'.dependencies]
+ jemallocator = "0.3.0"
+ 
+ [dev-dependencies]
+--- src/main.rs.orig	2020-04-23 10:41:24.000000000 -0700
++++ src/main.rs	2020-04-23 14:44:51.000000000 -0700
+@@ -30,7 +30,7 @@
+ use crate::regex_helper::pattern_has_uppercase_char;
+ 
+ // We use jemalloc for performance reasons, see https://github.com/sharkdp/fd/pull/481
+-#[cfg(all(not(windows), not(target_env = "musl")))]
++#[cfg(all(not(windows), not(target_os = "macos"), not(target_env = "musl")))]
+ #[global_allocator]
+ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+ 


### PR DESCRIPTION
#### Description

Update to one of my ports. See #5609 for some discussion about the jemallocator patch.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F62f
Xcode 11.4.1 11E503a 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
