### PR TITLE
tmux: update to 3.1

### DIFF
--- a/sysutils/tmux/Portfile
+++ b/sysutils/tmux/Portfile
@@ -3,14 +3,14 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    tmux tmux 3.0a
+github.setup    tmux tmux 3.1
 if {${subport} eq ${name}} {
     revision        0
     conflicts       tmux-devel
 }
 subport tmux-devel {
-    github.setup    tmux tmux 533c5ee7ad8c6d6e4eb2d05d8fc61c1e11a2705e
-    version         20200414-[string range ${github.version} 0 6]
+    github.setup    tmux tmux e67d65064e5541482990402fef85342f8cb4996b
+    version         20200424-[string range ${github.version} 0 6]
     revision        0
     conflicts       tmux
 }
@@ -30,14 +30,14 @@ depends_lib     port:libevent port:ncurses
 
 if {${subport} eq ${name}} {
     github.tarball_from     releases
-    checksums               rmd160  2b781a3632c11098184f787774742b5e5af761ce \
-                            sha256  4ad1df28b4afa969e59c08061b45082fdc49ff512f30fc8e43217d7b0e5f8db9 \
-                            size    546377
+    checksums               rmd160  1283b1b1908e90ae6b3459cb8da439ab4ef7152d \
+                            sha256  979bf38db2c36193de49149aaea5c540d18e01ccc27cf76e2aff5606bd186722 \
+                            size    561086
 }
 subport tmux-devel {
-    checksums               rmd160  5cec69527b0d62f2ec4eeb14235eca783ae3028c \
-                            sha256  f46c672994429b25fc489454ff10c59b84a25ced5572681fae93239dddf4dce0 \
-                            size    738066
+    checksums               rmd160  ec8d99801f88b90cdd60ac0cccd4547a5d6fe099 \
+                            sha256  1b31ee63a5553c8d49f7e63a797daeb6678a1d10affae24b8972753705d83554 \
+                            size    745230
 
     use_autoreconf          yes
     autoreconf.cmd          ./autogen.sh


### PR DESCRIPTION
tmux: update to 3.1
tmux: update tmux-devel to latest commit (e67d65064e5541482990402fef85342f8cb4996b)

#### Description

###### Type(s)

- [x] update

###### Tested on

macOS 10.14.6 18G4032
Xcode 11.3.1 11C504

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?