### PR TITLE
Add ghostpdl variant to ghostscript port

### DIFF
--- a/print/ghostscript/Portfile
+++ b/print/ghostscript/Portfile
@@ -25,17 +25,19 @@ master_sites        https://github.com/ArtifexSoftware/ghostpdl-downloads/releas
 set mappingresources_commit \
                     a709991e67196a87af053e2c16d7a65108613a41
 
+distname            ghostpdl-${version}
 distfiles           ${distname}.tar.gz:source \
                     ghostscript-fonts-other-6.0.tar.gz:fonts \
                     ghostscript-fonts-std-8.11.tar.gz:fonts \
                     ${mappingresources_commit}.zip:misc
 
-patchfiles          patch-base_unix-dll.mak.diff
+patchfiles          patch-base_unix-dll.mak.diff \
+                    patch-base_unixinst.mak.diff
 
 checksums           ${distname}.tar.gz \
-                    rmd160  0e345d2ce7122aa973882738210a88a4f8736f36 \
-                    sha256  0f53e89fd647815828fc5171613e860e8535b68f7afbc91bf89aee886769ce89 \
-                    size    44597668 \
+                    rmd160  9498a55e842736fac6a4f3477b37e5a20da44271 \
+                    sha256  dd94c5a06c03c58b47b929d03260f491d4807eaf5be83abd283278927b11c9ee \
+                    size    53564956 \
                     ghostscript-fonts-other-6.0.tar.gz \
                     rmd160  ab60dbf71e7d91283a106c3df381cadfe173082f \
                     sha256  4fa051e341167008d37fe34c19d241060cd17b13909932cd7ca7fe759243c2de \
@@ -106,10 +108,14 @@ configure.cppflags-replace \
                     -I${prefix}/include \
                     -isystem${prefix}/include
 
-configure.args      --disable-compile-inits \
+configure.args      --enable-gpdl \
+                    --disable-compile-inits \
                     --disable-cups \
                     --disable-dbus \
                     --disable-gtk \
+                    --without-pcl \
+                    --without-xps \
+                    --without-gpdl \
                     --without-x \
                     --without-luratech \
                     --with-system-libtiff
@@ -119,6 +125,34 @@ build.target        so
 destroot.target     soinstall
 post-destroot {
     ln -s gsc ${destroot}${prefix}/bin/gs
+
+    if {[variant_isset ghostpdl]} {
+        ln -s gpcl6c ${destroot}/${prefix}/bin/gpcl6
+        ln -s gxpsc ${destroot}/${prefix}/bin/gxps
+        ln -s gpdlc ${destroot}/${prefix}/bin/gpdl
+    }
+
+    xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 0644 -W ${worksrcpath} \
+        LICENSE DroidSansFallback.NOTICE \
+        ${destroot}/${prefix}/share/doc/${name}
+
+    if {[variant_isset ghostpdl]} {
+        xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}/pcl
+        xinstall -m 0644 -W ${worksrcpath}/pcl \
+            COPYING.AFPL LICENSE NEWS README.txt \
+            ${destroot}${prefix}/share/doc/${name}/pcl
+
+        xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}/pcl/pcl
+        xinstall -m 0644 -W ${worksrcpath}/pcl/pcl \
+            Anomalies.txt \
+            ${destroot}${prefix}/share/doc/${name}/pcl/pcl
+
+        xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}/pcl/pxl
+        xinstall -m 0644 -W ${worksrcpath}/pcl/pxl \
+            pxcet.txt pxdiff.txt pxfts.txt pxlib.txt pxspec.txt \
+            ${destroot}${prefix}/share/doc/${name}/pcl/pxl
+    }
 
     # std fonts - install into FontCache-compatible directory.
     # Check: could break on case-sensitive file systems...
@@ -141,6 +175,13 @@ post-destroot {
             COPYING ChangeLog README README.tweaks TODO \
             ${destroot}${prefix}/share/doc/${name}/fonts
 
+    if {[variant_isset ghostpdl]} {
+        # Install PCL base fonts into urwfonts directory
+        xinstall -m 755 -d ${destroot}${prefix}/share/${name}/urwfonts
+        xinstall -m 644 {*}[glob -directory ${worksrcpath}/pcl/urwfonts *.ttf] \
+            ${destroot}${prefix}/share/${name}/urwfonts
+    }
+
     # install missing header
     xinstall -m 0644 ${worksrcpath}/base/gserrors.h \
             ${destroot}${prefix}/include/ghostscript/
@@ -160,6 +201,23 @@ variant x11 {
 
 variant cups description {Enable CUPS driver} {
     configure.args-replace  --disable-cups --enable-cups
+}
+
+variant ghostpdl description {Install GhostPDL} {
+    license-append          noncommercial
+    configure.args-replace  --without-pcl --with-pcl=gpcl6
+    configure.args-replace  --without-xps --with-xps=gxps
+    configure.args-replace  --without-gpdl --with-gpdl=gpdl
+    notes "
+    GhostPCL requires a set of truetype fonts to function properly. To use
+    the default URW font set, add the following to your shell profile:
+
+        export PCLFONTSOURCE='${prefix}/share/${name}/urwfonts/'
+
+    These fonts are distributed under the Aladdin Free Public License which
+    bars commercial use. For more information see
+    ${prefix}/share/doc/${name}/pcl/LICENSE
+    "
 }
 
 default_variants    +x11

--- a/print/ghostscript/files/patch-base_unix-dll.mak.diff
+++ b/print/ghostscript/files/patch-base_unix-dll.mak.diff
@@ -1,6 +1,6 @@
---- base/unix-dll.mak.orig	2013-08-30 19:37:28.000000000 +0900
-+++ base/unix-dll.mak	2013-09-10 14:06:01.000000000 +0900
-@@ -91,12 +91,12 @@
+--- base/unix-dll.mak.orig	2019-01-16 17:24:24.000000000 +0000
++++ base/unix-dll.mak	2020-04-24 02:39:18.000000000 -0700
+@@ -91,13 +91,26 @@
  
  
  # MacOS X
@@ -8,13 +8,73 @@
 -#GS_SONAME=$(GS_SONAME_BASE).$(GS_SOEXT)
 -#GS_SONAME_MAJOR=$(GS_SONAME_BASE).$(GS_VERSION_MAJOR).$(GS_SOEXT)
 -#GS_SONAME_MAJOR_MINOR=$(GS_SONAME_BASE).$(GS_VERSION_MAJOR).$(GS_VERSION_MINOR).$(GS_SOEXT)
+-#LDFLAGS_SO=-dynamiclib -flat_namespace
+-#LDFLAGS_SO_MAC=-dynamiclib -install_name $(GS_SONAME_MAJOR_MINOR)
+-#LDFLAGS_SO=-dynamiclib -install_name $(FRAMEWORK_NAME)
 +GS_SOEXT=dylib
 +GS_SONAME=$(GS_SONAME_BASE).$(GS_SOEXT)
 +GS_SONAME_MAJOR=$(GS_SONAME_BASE).$(GS_VERSION_MAJOR).$(GS_SOEXT)
 +GS_SONAME_MAJOR_MINOR=$(GS_SONAME_BASE).$(GS_VERSION_MAJOR).$(GS_VERSION_MINOR).$(GS_SOEXT)
- #LDFLAGS_SO=-dynamiclib -flat_namespace
--#LDFLAGS_SO_MAC=-dynamiclib -install_name $(GS_SONAME_MAJOR_MINOR)
 +GS_LDFLAGS_SO=-dynamiclib -install_name __PREFIX__/lib/$(GS_SONAME_MAJOR_MINOR)
- #LDFLAGS_SO=-dynamiclib -install_name $(FRAMEWORK_NAME)
++
++PCL_SONAME=$(PCL_SONAME_BASE).$(GS_SOEXT)
++PCL_SONAME_MAJOR=$(PCL_SONAME_BASE).$(GS_VERSION_MAJOR).$(GS_SOEXT)
++PCL_SONAME_MAJOR_MINOR=$(PCL_SONAME_BASE).$(GS_VERSION_MAJOR).$(GS_VERSION_MINOR).$(GS_SOEXT)
++PCL_LDFLAGS_SO=-dynamiclib -install_name __PREFIX__/lib/$(PCL_SONAME_MAJOR_MINOR)
++
++XPS_SONAME=$(XPS_SONAME_BASE).$(GS_SOEXT)
++XPS_SONAME_MAJOR=$(XPS_SONAME_BASE).$(GS_VERSION_MAJOR).$(GS_SOEXT)
++XPS_SONAME_MAJOR_MINOR=$(XPS_SONAME_BASE).$(GS_VERSION_MAJOR).$(GS_VERSION_MINOR).$(GS_SOEXT)
++XPS_LDFLAGS_SO=-dynamiclib -install_name __PREFIX__/lib/$(XPS_SONAME_MAJOR_MINOR)
++
++GPDL_SONAME=$(GPDL_SONAME_BASE).$(GS_SOEXT)
++GPDL_SONAME_MAJOR=$(GPDL_SONAME_BASE).$(GS_VERSION_MAJOR).$(GS_SOEXT)
++GPDL_SONAME_MAJOR_MINOR=$(GPDL_SONAME_BASE).$(GS_VERSION_MAJOR).$(GS_VERSION_MINOR).$(GS_SOEXT)
++PDL_LDFLAGS_SO=-dynamiclib -install_name __PREFIX__/lib/$(GPDL_SONAME_MAJOR_MINOR)
  
  GS_SO=$(BINDIR)/$(GS_SONAME)
+ GS_SO_MAJOR=$(BINDIR)/$(GS_SONAME_MAJOR)
+@@ -301,7 +314,7 @@
+ install-sodebug:
+ 	$(MAKE) $(SUB_MAKE_OPTION) install-so-subtarget GENOPT='-DDEBUG' BUILDDIRPREFIX=$(SODEBUGDIRPREFIX)
+ 
+-install-so-subtarget: so-subtarget
++install-so-subtarget: so-subtarget install-so-subtarget-$(PCL_TARGET) install-so-subtarget-$(XPS_TARGET) install-so-subtarget-$(GPDL_TARGET)
+ 	-mkdir -p $(DESTDIR)$(prefix)
+ 	-mkdir -p $(DESTDIR)$(datadir)
+ 	-mkdir -p $(DESTDIR)$(gsdir)
+@@ -321,6 +334,34 @@
+ 	$(INSTALL_DATA) $(GLSRC)gserrors.h $(DESTDIR)$(gsincludedir)gserrors.h
+ 	$(INSTALL_DATA) $(DEVSRC)gdevdsp.h $(DESTDIR)$(gsincludedir)gdevdsp.h
+ 
++install-so-subtarget-gpcl6:
++	$(INSTALL_PROGRAM) $(PCLSOC) $(DESTDIR)$(bindir)/$(PCLSOC_XENAME)
++	$(INSTALL_PROGRAM) $(BINDIR)/$(PCL_SONAME_MAJOR_MINOR) $(DESTDIR)$(libdir)/$(PCL_SONAME_MAJOR_MINOR)
++	$(RM_) $(DESTDIR)$(libdir)/$(PCL_SONAME)
++	ln -s $(PCL_SONAME_MAJOR_MINOR) $(DESTDIR)$(libdir)/$(PCL_SONAME)
++	$(RM_) $(DESTDIR)$(libdir)/$(PCL_SONAME_MAJOR)
++	ln -s $(PCL_SONAME_MAJOR_MINOR) $(DESTDIR)$(libdir)/$(PCL_SONAME_MAJOR)
++
++install-so-subtarget-gxps:
++	$(INSTALL_PROGRAM) $(XPSSOC) $(DESTDIR)$(bindir)/$(XPSSOC_XENAME)
++	$(INSTALL_PROGRAM) $(BINDIR)/$(XPS_SONAME_MAJOR_MINOR) $(DESTDIR)$(libdir)/$(XPS_SONAME_MAJOR_MINOR)
++	$(RM_) $(DESTDIR)$(libdir)/$(XPS_SONAME)
++	ln -s $(XPS_SONAME_MAJOR_MINOR) $(DESTDIR)$(libdir)/$(XPS_SONAME)
++	$(RM_) $(DESTDIR)$(libdir)/$(XPS_SONAME_MAJOR)
++	ln -s $(XPS_SONAME_MAJOR_MINOR) $(DESTDIR)$(libdir)/$(XPS_SONAME_MAJOR)
++
++install-so-subtarget-gpdl:
++	$(INSTALL_PROGRAM) $(GPDLSOC) $(DESTDIR)$(bindir)/$(GPDLSOC_XENAME)
++	$(INSTALL_PROGRAM) $(BINDIR)/$(GPDL_SONAME_MAJOR_MINOR) $(DESTDIR)$(libdir)/$(GPDL_SONAME_MAJOR_MINOR)
++	$(RM_) $(DESTDIR)$(libdir)/$(GPDL_SONAME)
++	ln -s $(GPDL_SONAME_MAJOR_MINOR) $(DESTDIR)$(libdir)/$(GPDL_SONAME)
++	$(RM_) $(DESTDIR)$(libdir)/$(GPDL_SONAME_MAJOR)
++	ln -s $(GPDL_SONAME_MAJOR_MINOR) $(DESTDIR)$(libdir)/$(GPDL_SONAME_MAJOR)
++
++# Dummy target if PCL / XPS / PDL not enabled
++install-so-subtarget-:
++	$(NO_OP)
++
+ soinstall:
+ 	$(MAKE) $(SUB_MAKE_OPTION) soinstall-subtarget BUILDDIRPREFIX=$(SODIRPREFIX)
+ 

--- a/print/ghostscript/files/patch-base_unixinst.mak.diff
+++ b/print/ghostscript/files/patch-base_unixinst.mak.diff
@@ -1,0 +1,75 @@
+--- base/unixinst.mak.orig	2019-03-26 09:13:42.000000000 +0000
++++ base/unixinst.mak	2020-04-28 01:05:01.000000000 -0700
+@@ -78,6 +78,8 @@
+ PSEXDIR=$(PSLIBDIR)/../examples
+ PSMANDIR=$(PSLIBDIR)/../man
+ 
++PCLEXDIR=$(PSLIBDIR)/../pcl/examples
++
+ install-data: install-libdata install-resdata$(COMPILE_INITS) install-iccdata$(COMPILE_INITS) install-doc install-man
+ 
+ # There's no point in providing a complete dependency list: we include
+@@ -157,7 +159,9 @@
+ 
+ DOC_PAGE_IMAGES=Artifex_logo.png  favicon.png  ghostscript_logo.png  hamburger-light.png  x-light.png
+ 
+-install-doc: $(PSDOCDIR)/News.htm
++GPDL_DOC_PAGES=ghostpdl.pdf ghostpdl.txt
++
++install-doc: $(PSDOCDIR)/News.htm install-doc-$(PCL_TARGET) install-doc-$(XPS_TARGET) install-doc-$(GPDL_TARGET)
+ 	-mkdir -p $(DESTDIR)$(docdir)
+ 	-mkdir -p $(DESTDIR)$(docdir)/images
+ 	$(SH) -c 'for f in $(DOC_PAGES) ;\
+@@ -167,6 +171,22 @@
+ 	do if ( test -f $(PSDOCDIR)/images/$$f ); then $(INSTALL_DATA) $(PSDOCDIR)/images/$$f $(DESTDIR)$(docdir)/images; fi;\
+ 	done'
+ 
++install-doc-gpcl6: install-doc-gpdl
++	$(NO_OP)
++
++install-doc-gxps: install-doc-gpdl
++	$(NO_OP)
++
++install-doc-gpdl:
++	-mkdir -p $(DESTDIR)$(docdir)/pclxps
++	$(SH) -c 'for f in $(GPDL_DOC_PAGES) ;\
++	do if ( test -f $(PSDOCDIR)/pclxps/$$f ); then $(INSTALL_DATA) $(PSDOCDIR)/pclxps/$$f $(DESTDIR)$(docdir)/pclxps; fi;\
++	done'
++
++# Dummy target
++install-doc-:
++	$(NO_OP)
++
+ # install the man pages for each locale
+ MAN_LCDIRS=. de
+ MAN1_LINKS_PS2PS=eps2eps
+@@ -201,7 +221,7 @@
+ 	done'
+ 
+ # install the example files
+-install-examples:
++install-examples: install-examples-$(PCL_TARGET)
+ 	-mkdir -p $(DESTDIR)$(exdir)
+ 	for f in \
+         alphabet.ps colorcir.ps escher.ps grayalph.ps snowflak.ps \
+@@ -217,6 +237,20 @@
+ 	do $(INSTALL_DATA) $(PSEXDIR)/cjk/$$f $(DESTDIR)$(exdir)/cjk ;\
+ 	done
+ 
++install-examples-gpcl6:
++	-mkdir -p $(DESTDIR)$(exdir)/pcl
++	for f in \
++	    bitfont.pcl bitfonts.pxl fills.pcl fontpage.pcl fonts.pcl fonts.pxl \
++	    frs96.pxl gl-chars.pcl grashopp.pcl grid.pcl label.tst \
++	    lineprinter.pcl null.pxl opaque.pcl origins.pcl owl.pcl owl2.pcl \
++	    pattern.pcl pattern.pxl tiger.px3 tiger.xps .px3;\
++	do $(INSTALL_DATA) $(PCLEXDIR)/$$f $(DESTDIR)$(exdir)/pcl ;\
++	done
++
++# Dummy target
++install-examples-:
++	$(NO_OP)
++
+ install-shared: $(GS_SHARED_OBJS)
+ 	-mkdir -p $(DESTDIR)$(gssharedir)
+ 	$(SH) -c 'for obj in $(GS_SHARED_OBJS); do \


### PR DESCRIPTION
#### Description

Add a variant to the ghostscript port to install the full GhostPDL suite rather than just Ghostscript.  This adds the gpcl6, gxps, and gpdl binaries.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.13.6 17G12034
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!--- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?-->
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
<!--- [ ] tried existing tests with `sudo port test`?-->
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
