### PR TITLE
rust: update to 1.43.0, drop i686 support

### DIFF
--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -1,15 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=portfile:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           muniversal 1.0
-PortGroup           active_variants 1.1
 
 name                rust
-version             1.42.0
+version             1.43.0
 revision            0
 categories          lang devel
 platforms           darwin
-supported_archs     i386 x86_64
+supported_archs     x86_64
 license             {MIT Apache-2} BSD zlib NCSA Permissive
 maintainers         {g5pw @g5pw} openmaintainer
 
@@ -27,9 +25,9 @@ long_description    Rust is a curly-brace, block-structured expression \
 homepage            https://www.rust-lang.org/
 
 # Get from src/stage0.txt
-set ruststd_version 1.41.1
-set rustc_version   1.41.1
-set cargo_version   0.42.0
+set ruststd_version 1.42.0
+set rustc_version   1.42.0
+set cargo_version   0.43.0
 set llvm_version    9.0
 
 # can use cmake or cmake-devel; default to cmake.
@@ -44,61 +42,28 @@ distname            ${name}c-${version}-src
 
 patchfiles          patch-src-librustc-llvm-lib.diff
 
-if {![variant_isset universal]} {
-    if {${build_arch} eq "i386"} {
-        set architectures i686
-    } else {
-        set architectures ${build_arch}
-    }
-} else {
-    set architectures {}
-    foreach arch ${universal_archs} {
-        if {${arch} eq "i386"} {
-            lappend architectures i686
-        } else {
-            lappend architectures ${arch}
-        }
-    }
-}
-
-foreach arch ${architectures} {
-    distfiles-append rust-std-${ruststd_version}-${arch}-apple-${os.platform}${extract.suffix} \
-                     rustc-${rustc_version}-${arch}-apple-${os.platform}${extract.suffix} \
-                     cargo-${cargo_version}-${arch}-apple-${os.platform}${extract.suffix}
-}
+distfiles-append    rust-std-${ruststd_version}-${build_arch}-apple-${os.platform}${extract.suffix} \
+                    rustc-${rustc_version}-${build_arch}-apple-${os.platform}${extract.suffix} \
+                    cargo-${cargo_version}-${build_arch}-apple-${os.platform}${extract.suffix}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  3b35f1542ef4eee65403f90194d92745acecdd29 \
-                    sha256  d2e8f931d16a0539faaaacd801e0d92c58df190269014b2360c6ab2a90ee3475 \
-                    size    135735490
-
-checksums-append \
-                    rust-std-${ruststd_version}-i686-apple-${os.platform}${extract.suffix} \
-                    rmd160  289028f8a0b68b91e01681d579bbee2d4186e136 \
-                    sha256  f76796588fb5dd3b070bff005ed190d3053be5c77f245985d43406b8891016d7 \
-                    size    21329270 \
-                    rustc-${rustc_version}-i686-apple-${os.platform}${extract.suffix} \
-                    rmd160  36de99d7358b40e87a1ac8b662cff7177092e312 \
-                    sha256  e4732fb1f8b0a44690573e26b81fce01eb6a993ba66f05e6c79d4c1b3565a47d \
-                    size    80109236 \
-                    cargo-${cargo_version}-i686-apple-${os.platform}${extract.suffix} \
-                    rmd160  545f39de16b7e7ae987dee80dfeb48d0588917fa \
-                    sha256  62f5219792a27de6c5d141c59f05dee252424b7ce9671cefbb1227cab15da91e \
-                    size    5241962
+                    rmd160  994ef055d958f38d23a70575884e2fcb058003f9 \
+                    sha256  75f6ac6c9da9f897f4634d5a07be4084692f7ccc2d2bb89337be86cfc18453a1 \
+                    size    136038757
 
 checksums-append \
                     rust-std-${ruststd_version}-x86_64-apple-${os.platform}${extract.suffix} \
-                    rmd160  6b90224938a5d54ae7f1814732cb9dd9ec0615ad \
-                    sha256  6f4058d48027c1a0b8c04f1de3d86c8695b470850b60555b659f8f06adc2c447 \
-                    size    21405237 \
+                    rmd160  b6a5f43438bedda5415722acd87cd93871c43116 \
+                    sha256  1d61e9ed5d29e1bb4c18e13d551c6d856c73fb8b410053245dc6e0d3b3a0e92c \
+                    size    22972985 \
                     rustc-${rustc_version}-x86_64-apple-${os.platform}${extract.suffix} \
-                    rmd160  ae50678e13778051ae6455ac79e1b1cc659e2f8f \
-                    sha256  ec3e8b3fc11cb4e781724f0556c4e64c46a50bfb014b104ee7f200169804df0c \
-                    size    82763438 \
+                    rmd160  9cdf25b0b539943b752563c67a4467cf710baf8e \
+                    sha256  778dea93d7e46261e2c06cadec35b68f9857604f279ce6fbd1b37c1a89634625 \
+                    size    83826769 \
                     cargo-${cargo_version}-x86_64-apple-${os.platform}${extract.suffix} \
-                    rmd160  095c410db6434c1efbf297068426c74a2bc6db9d \
-                    sha256  9633707ec7d83c02664e74040601e4d78488d8521de4400e9881d7c57594e49f \
-                    size    5371783
+                    rmd160  be99fef6ddeb53590b0f3976ff2d60d6c01b0923 \
+                    sha256  92d4c9fb4747dce158cdfb773651aea8eac894277f3a2de5aa2c3b9d92439d8e \
+                    size    5375241
 
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
     known_fail yes
@@ -109,105 +74,28 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
 }
 
 post-extract {
-    foreach arch ${architectures} {
-        set rust_root     ${worksrcpath}/build/stage0-${arch}
-        set rust_platform ${arch}-apple-${os.platform}
-        file mkdir ${rust_root}
-        system "cp -r ${workpath}/rust-std-${ruststd_version}-${rust_platform}/rust-std-${rust_platform}/* ${rust_root}"
-        system "cp -r ${workpath}/rustc-${rustc_version}-${rust_platform}/rustc/* ${rust_root}"
-        system "cp -r ${workpath}/cargo-${cargo_version}-${rust_platform}/cargo/* ${rust_root}"
-    }
+    set rust_root     ${worksrcpath}/build/stage0-${build_arch}
+    set rust_platform ${build_arch}-apple-${os.platform}
+    file mkdir ${rust_root}
+    system "cp -r ${workpath}/rust-std-${ruststd_version}-${rust_platform}/rust-std-${rust_platform}/* ${rust_root}"
+    system "cp -r ${workpath}/rustc-${rustc_version}-${rust_platform}/rustc/* ${rust_root}"
+    system "cp -r ${workpath}/cargo-${cargo_version}-${rust_platform}/cargo/* ${rust_root}"
 }
 
-configure.args      --enable-vendor \
-                    --default-linker=${configure.cc} \
-                    --disable-codegen-tests \
-                    --disable-docs \
-                    --release-channel=stable
+set rust_platform       ${build_arch}-apple-${os.platform}
+set rust_root           ${worksrcpath}/build/stage0-${build_arch}
 
-# see https://trac.macports.org/ticket/56351
-# see https://github.com/rust-lang/rust/issues/50220
-if {[variant_isset universal]} {
-    # LLVM is or will need to be universal
-    set copy_llvm 1
-} else {
-    if {![catch {set result [active_variants llvm-${llvm_version} "universal" ""]}] && $result} {
-        # LLVM was installed with universal variant
-        set copy_llvm 1
-    } else {
-        set copy_llvm 0
-    }
-}
-
-if {!${copy_llvm}} {
-    # LLVM is NOT universal, so use installed version
-    configure.args-append \
-        --llvm-root=${prefix}/libexec/llvm-${llvm_version}
-} else {
-    # copy LLVM and thin static libraries
-    # see https://trac.macports.org/ticket/56351
-    # see https://github.com/rust-lang/rust/issues/50220
-    if {[variant_isset universal]} {
-        set archs ${universal_archs}
-        foreach arch ${universal_archs} {
-            lappend merger_configure_args(${arch}) \
-                --llvm-root=${workpath}/llvm-${llvm_version}-${arch}
-        }
-    } else {
-        set archs ${build_arch}
-        configure.args-append \
-            --llvm-root=${workpath}/llvm-${llvm_version}-${build_arch}
-    }
-
-    depends_extract-append  port:llvm-${llvm_version}
-
-    post-extract {
-        foreach arch ${archs} {
-            system -W ${workpath} "cp -R ${prefix}/libexec/llvm-${llvm_version} ${workpath}/llvm-${llvm_version}-${arch}"
-            fs-traverse f ${workpath}/llvm-${llvm_version}-${arch} {
-                if {[file isfile $f] && [file type $f]!="link" && [file extension $f]==".a"} {
-                    catch {system "lipo -thin ${arch} ${f} -o ${f}"}
-                }
-            }
-        }
-    }
-}
-
-if {![variant_isset universal]} {
-    if {${build_arch} eq "i386"} {
-        set arch_name i686
-    } else {
-        set arch_name ${build_arch}
-    }
-    set rust_platform ${arch_name}-apple-${os.platform}
-    set rust_root     ${worksrcpath}/build/stage0-${arch_name}
-    configure.args-append \
-                   --build=${rust_platform} \
-                   --local-rust-root=${rust_root}
-} else {
-    foreach arch ${universal_archs} {
-        if {${arch} eq "i386"} {
-            set arch_name i686
-        } else {
-            set arch_name ${build_arch}
-        }
-        set rust_platform ${arch_name}-apple-${os.platform}
-        set rust_root     ${worksrcpath}/build/stage0-${arch_name}
-        lappend merger_configure_args(${arch}) \
-                  --build=${rust_platform} \
-                  --local-rust-root=${rust_root}
-    }
-}
-
-foreach arch ${architectures} {
-    set rust_platform ${arch}-apple-${os.platform}
-    configure.args-append \
-                    --set=target.${rust_platform}.cc=${configure.cc} \
-                    --set=target.${rust_platform}.cxx=${configure.cxx} \
-                    --set=target.${rust_platform}.linker=${configure.cc}
-}
-
-configure.universal_args-delete --disable-dependency-tracking
+configure.args          --enable-vendor \
+                        --default-linker=${configure.cc} \
+                        --disable-codegen-tests \
+                        --disable-docs \
+                        --release-channel=stable \
+                        --llvm-root=${prefix}/libexec/llvm-${llvm_version} \
+                        --build=${rust_platform} \
+                        --local-rust-root=${rust_root} \
+                        --set=target.${rust_platform}.cc=${configure.cc} \
+                        --set=target.${rust_platform}.cxx=${configure.cxx} \
+                        --set=target.${rust_platform}.linker=${configure.cc}
 
 post-configure {
     # the bootstrap call to rustc uses cc for the linker
@@ -215,11 +103,11 @@ post-configure {
     # see https://trac.macports.org/wiki/UsingTheRightCompiler
     xinstall -d -m 0755 ${workpath}/.home/.cargo
     set config [open ${workpath}/.home/.cargo/config w]
-    foreach arch ${architectures} {
-        set rust_platform ${arch}-apple-${os.platform}
-        puts ${config} "\[target.${rust_platform}\]"
-        puts ${config} "linker = \"${configure.cc}\""
-    }
+
+    set rust_platform ${build_arch}-apple-${os.platform}
+    puts ${config} "\[target.${rust_platform}\]"
+    puts ${config} "linker = \"${configure.cc}\""
+
     close ${config}
 }
 
@@ -230,34 +118,15 @@ test.target         check
 test.args           VERBOSE=1
 
 destroot.args       VERBOSE=1
-if {${subport} eq ${name}} {
-    if {![variant_isset universal]} {
-        post-destroot {
-            if {${build_arch} eq "i386"} {
-                set arch_name i686
-            } else {
-                set arch_name ${build_arch}
-            }
 
+if {${subport} eq ${name}} {
+
+    post-destroot {
         xinstall -d ${destroot}${prefix}/share/${name}
         xinstall -m 644 ${worksrcpath}/src/etc/ctags.rust \
             ${destroot}${prefix}/share/${name}
     }
-    } else {
-        merger-post-destroot {
-            foreach arch ${universal_archs} {
-                if {${arch} eq "i386"} {
-                    set arch_name i686
-                } else {
-                    set arch_name ${arch}
-                }
 
-                xinstall -d ${destroot}-${arch}${prefix}/share/${name}
-                xinstall -m 644 ${worksrcpath}-${arch}/src/etc/ctags.rust \
-                    ${destroot}-${arch}${prefix}/share/${name}
-            }
-        }
-    }
 }
 
 livecheck.type      regex


### PR DESCRIPTION
#### Description

As we had already seen in https://trac.macports.org/ticket/60237 for `cargo`, **i686-darwin** support in Rust has been dropped down to `Tier 3`.

https://forge.rust-lang.org/release/platform-support.html

`
Tier 3 platforms are those which the Rust codebase has support for, but which are not built or tested automatically, and may not work. Official builds are not available.
`

The Rust team announced that they would do this back in early January of this year: https://blog.rust-lang.org/2020/01/03/reducing-support-for-32-bit-apple-targets.html

As a result we already removed `i686` support in `cargo`: https://github.com/macports/macports-ports/pull/6700

Now with the release of 1.43.0, the same decision needs to be made for Rust.

It appears that `i686` downloadables are no longer available. https://static.rust-lang.org/dist is not serving **i686-darwin** `rustc`, `rust-std` and `cargo` tarballs with the versions that 1.43.0 needs in order to build.  While according to the Rust announcements, it should be possible for build for i686 in theory, this is no longer covered under Rust's official test profile.

This PR takes the simple way and provides Rust version 1.43.0, while removing `i686` and `universal` support. I'd like to know if we are OK with this.

Tests were run between the current version of Rust in ports, and this PR:

**current version: 1.42.0**:
```
failures:
    [ui] ui/issues/issue-69225-SCEVAddExpr-wrap-flag.rs
    [ui] ui/macros/restricted-shadowing-legacy.rs
    [ui] ui/wait-forked-but-failed-child.rs

test result: FAILED. 9508 passed; 3 failed; 57 ignored; 0 measured; 0 filtered out
```

**this PR: 1.43.0**:
```
failures:
    [ui] ui/macros/restricted-shadowing-legacy.rs
    [ui] ui/wait-forked-but-failed-child.rs

test result: FAILED. 9694 passed; 2 failed; 63 ignored; 0 measured; 0 filtered out
```

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
