### PR TITLE
vgrep: update to 2.3.0

### DIFF
--- a/textproc/vgrep/Portfile
+++ b/textproc/vgrep/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/vrothberg/vgrep 2.2.0 v
+go.setup            github.com/vrothberg/vgrep 2.3.0 v
 
 categories          textproc
 license             GPL-3
@@ -14,9 +14,9 @@ build.target        release
 
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
 
-checksums           rmd160  443dde781d2a87ba9be0f9ee1054a750881fc464 \
-                    sha256  d824487534fc297141ac9c57a37ccd52ac3cfb48f19d96d0f580613ebaabdb98 \
-                    size    1637926
+checksums           rmd160  b943f1f04a58ae4ca18df1db98e3968d0e5166df \
+                    sha256  308b75e6b132a2a964ad167dae31a422dba036e8a5cdd5ea180becd754c5aa7a \
+                    size    1149415
 
 description         an easy to use front-end for (git) grep
 


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
