### PR TITLE
openjdk8: update to AdoptOpenJDK .1 releases

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -4,7 +4,7 @@ PortSystem       1.0
 
 name             openjdk8
 version          8u252
-revision         0
+revision         1
 
 set build        09
 set major        8
@@ -18,7 +18,7 @@ subport openjdk8-graalvm {
 
 subport openjdk8-openj9 {
     version      8u252
-    revision     0
+    revision     1
 
     set build    09
     set major    8
@@ -27,7 +27,7 @@ subport openjdk8-openj9 {
 
 subport openjdk8-openj9-large-heap {
     version      8u252
-    revision     0
+    revision     1
 
     set build    09
     set major    8
@@ -59,7 +59,7 @@ subport openjdk11-graalvm {
 
 subport openjdk11-openj9 {
     version      11.0.7
-    revision     0
+    revision     1
 
     set build    10
     set major    11
@@ -68,7 +68,7 @@ subport openjdk11-openj9 {
 
 subport openjdk11-openj9-large-heap {
     version      11.0.7
-    revision     0
+    revision     1
 
     set build    10
     set major    11
@@ -137,7 +137,7 @@ subport openjdk14 {
 
 subport openjdk14-openj9 {
     version      14.0.1
-    revision     0
+    revision     1
 
     set build    7
     set major    14
@@ -146,7 +146,7 @@ subport openjdk14-openj9 {
 
 subport openjdk14-openj9-large-heap {
     version      14.0.1
-    revision     0
+    revision     1
 
     set build    7
     set major    14
@@ -186,11 +186,14 @@ if {${os.platform} eq "darwin" && ${os.major} < 14} {
 }
 
 if {${subport} eq "openjdk8"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}/
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}.1/
+
+    # Stealth update
+    dist_subdir  ${name}/${version}_1
     
-    checksums    rmd160  845f0d7678b40e00615a7b4571b2c17c22a502ec \
-                 sha256  6e267893aae127a4bccfedb56d9893a891213a93de593a97f248629eaa0594ba \
-                 size    100177346
+    checksums    rmd160  7e63fa413519502a03d1fa80774c96afa43443e4 \
+                 sha256  2caed3ec07d108bda613f9b4614b22a8bdd196ccf2a432a126161cd4077f07a5 \
+                 size    100518315
 
     distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}b${build}
     worksrcdir   jdk${version}-b${build}
@@ -212,11 +215,14 @@ if {${subport} eq "openjdk8"} {
 
     homepage     https://www.graalvm.org
 } elseif {${subport} eq "openjdk8-openj9"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}.1_openj9-${openj9_version}/
 
-    checksums    rmd160  2b77e821ad37276ff9ab28b79c3cb3f9732ef7b8 \
-                 sha256  119ffa095367dd236758fd2bebcaeb3ac60560fad85bd522f7a96af49db163af \
-                 size    140934091
+    # Stealth update
+    dist_subdir  ${name}/${version}_1
+
+    checksums    rmd160  ca64741a8fa3deb79961657667b6d88e3a337ba6 \
+                 sha256  b695f8e95ee548f354fe647abd45612be8318063ea14dfd410b4bc22000fa095 \
+                 size    159487269
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}b${build}_openj9-${openj9_version}
     worksrcdir   jdk${version}-b${build}
@@ -229,11 +235,14 @@ if {${subport} eq "openjdk8"} {
                  VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
                  suitable for running all workloads.
 } elseif {${subport} eq "openjdk8-openj9-large-heap"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}.1_openj9-${openj9_version}/
 
-    checksums    rmd160  4ce7e449a0fb2e4c333dec459d3bfad463b5cf07 \
-                 sha256  0aa1be10afb5df50bfb218d466c857f1d6b8e2817600927380977fc75f2b5646 \
-                 size    140899873
+    # Stealth update
+    dist_subdir  ${name}/${version}_1
+
+    checksums    rmd160  7d07bf50bb3c06639bb65c89f530fcbf62b87ffa \
+                 sha256  b7fa56aa38d3478023b4e5666a514a07696c56ed945b79a9a8d8abf73db1e6e7 \
+                 size    159582180
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}b${build}_openj9-${openj9_version}
     worksrcdir   jdk${version}-b${build}
@@ -291,11 +300,14 @@ if {${subport} eq "openjdk8"} {
 
     homepage     https://www.graalvm.org
 } elseif {${subport} eq "openjdk11-openj9"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.1_openj9-${openj9_version}/
 
-    checksums    rmd160  554f47d5163d79ae213df4028b883033952b85a9 \
-                 sha256  1be24fb479afcc6d4452eb5cf8aa7f2642941889dfcfcc853e4ccb6648529dcc \
-                 size    248388099
+    # Stealth update
+    dist_subdir  ${name}/${version}_1
+
+    checksums    rmd160  e8da36a2996f8cbc96833908cb7897558039832e \
+                 sha256  7e017209063c673a82c4d6047c9165b0fb66054c2bcd6b1f6389ed54f692b0b5 \
+                 size    248496881
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
     worksrcdir   jdk-${version}+${build}
@@ -308,11 +320,14 @@ if {${subport} eq "openjdk8"} {
                  VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
                  suitable for running all workloads.
 } elseif {${subport} eq "openjdk11-openj9-large-heap"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.1_openj9-${openj9_version}/
 
-    checksums    rmd160  d9da7f31a2ae48e17f172495f65ff4a2be63d564 \
-                 sha256  c58b615d08dcfa4aa2573c4db3e416e30b5202da4aaf24dc879c13c2064af8cd \
-                 size    248479495
+    # Stealth update
+    dist_subdir  ${name}/${version}_1
+
+    checksums    rmd160  51431040a8ae6dc2665929b5ae2a8396af53b6fb \
+                 sha256  801b6e52300cf67617009b8a48039ae0bc02ab68710cd67334db8262cbe63c33 \
+                 size    248578484
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
     worksrcdir   jdk-${version}+${build}
@@ -426,12 +441,15 @@ if {${subport} eq "openjdk8"} {
 
     worksrcdir   jdk-${version}+${build}
 } elseif {${subport} eq "openjdk14-openj9"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.1_openj9-${openj9_version}/
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
 
-    checksums    rmd160  e0995c6d3e8965887871df35b09ec35437dfdbc1 \
-                 sha256  0e89551bce50dae3723516e8cd77c9769cd7364a8d5004a0a8c25bce43a99c4e \
-                 size    254540861
+    # Stealth update
+    dist_subdir  ${name}/${version}_1
+
+    checksums    rmd160  613d7709e8fb6925d06cf6ab2327d1f9d70114af \
+                 sha256  8d0f8f56284add84c02a9ba359d7cc4c8b9a3cd912b8a1e98bba234664fb4d72 \
+                 size    254646126
 
     worksrcdir   jdk-${version}+${build}
 
@@ -443,12 +461,15 @@ if {${subport} eq "openjdk8"} {
                  VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
                  suitable for running all workloads.
 } elseif {${subport} eq "openjdk14-openj9-large-heap"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.1_openj9-${openj9_version}/
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
 
-    checksums    rmd160  7a5a28d075028137f490d6f79bd3697530806531 \
-                 sha256  02f37d60d611833848d7cf1e4fa5b5e4f901a26cc51dc6638070ae70d28e2bd8 \
-                 size    254638749
+    # Stealth update
+    dist_subdir  ${name}/${version}_1
+
+    checksums    rmd160  52ac161558b0999e303ccd01852cdf6d5cf7f768 \
+                 sha256  6d2973221513c2cf23567982d42c2468a23e16f6aba6025892c9fa4e11b4742d \
+                 size    254742826
 
     worksrcdir   jdk-${version}+${build}
 


### PR DESCRIPTION
#### Description

Update to .1 releases for AdoptOpenJDK 8u252, 11.0.7 and 14.0.1.

###### Tested on

macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?