### PR TITLE
k9s: update to 0.19.3

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,8 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.19.2 v
+go.setup            github.com/derailed/k9s 0.19.3 v
+homepage            https://k9scli.io
 
 categories          sysutils devel
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -19,9 +20,9 @@ platforms           darwin
 supported_archs     x86_64
 license             Apache-2
 
-checksums           rmd160  9cab79cf0cf2067b05403fd75bea9e5704a6e7c0 \
-                    sha256  94381d4daf88997c56259174d2198f74c291f3105e6f9f2f3021c2a40753c490 \
-                    size    17389658
+checksums           rmd160  b711122f3a1e7316a353c98591bb47033b1daa87 \
+                    sha256  873f707765712ba28028cb17ad62d9e816e2b43457cbc8ce21338768a5afbf9a \
+                    size    6058705
 
 # Reproduce the "build" target from the upstream Makefile
 set go_ldflags      "-w -X ${go.package}/cmd.version=${version} \


### PR DESCRIPTION
#### Description

Update to k9s 0.19.3.

###### Tested on

macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?