### PR TITLE
ykpers: don't opportunistically link to (incompatible) json-c

### DIFF
--- a/security/ykpers/Portfile
+++ b/security/ykpers/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                ykpers
 version             1.20.0
+revision            1
 categories          security
 license             BSD
 maintainers         {cal @neverpanic} {snc @nerdling} openmaintainer
@@ -21,6 +22,9 @@ checksums           rmd160  398bdf2048def28e4b07e05b164be04f4c9c4b08 \
                     size    523134
 
 depends_lib         port:libyubikey
+
+# Not compatible with json-c 0.14-20200419
+configure.args      --without-json
 
 if {{$os.major} < 11} {
     patchfiles          patch-pre-Lion-strnlen.diff


### PR DESCRIPTION
#### Description

ykpers was opportunistically linking with the json-c library; the recent update of same is not compatible (build errors out). This fix simply prevents linking with json-c.

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->