### PR TITLE
unzip: Enable LARGE_FILE_SUPPORT for 32-bit

### DIFF
--- a/archivers/unzip/Portfile
+++ b/archivers/unzip/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                unzip
 version             6.0
-revision            3
+revision            4
 maintainers         {gregfiumara.com:greg @gfiumara} openmaintainer
 categories          archivers sysutils
 platforms           darwin freebsd
@@ -74,7 +74,7 @@ build.args          -f unix/Makefile \
 
 pre-build {
     # have to add this here so variants can modify it
-    build.args-append LOCAL_UNZIP="${localflags}"
+    build.args-append LOCAL_UNZIP="-DLARGE_FILE_SUPPORT ${localflags}"
 }
 
 destroot.args       {*}${build.args} \
@@ -90,10 +90,6 @@ post-destroot {
 
 platform darwin 8 {
     append localflags " -DNO_LCHMOD"
-}
-
-if {${build_arch} eq "x86_64"} {
-    append localflags " -DLARGE_FILE_SUPPORT"
 }
 
 variant iconv description {Add iconv support} {


### PR DESCRIPTION
`LARGE_FILE_SUPPORT` is supported as long as `sizeof(off_t) >= 8` or `sizeof(long) >= 8`, which is true going back to at least 10.5.

Closes: https://trac.macports.org/ticket/60396

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.5.8 9L31a
Xcode 3.1.3 DevToolsSupport-1186.0 9M2736 

and

macOS 10.15.4 19E287
Xcode 11.4.1 11E503a 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
