### PR TITLE
yabasic: update to 2.86.7 and enable libffi

### DIFF
--- a/lang/yabasic/Portfile
+++ b/lang/yabasic/Portfile
@@ -1,25 +1,31 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+PortSystem          1.0
 
-name			yabasic
-version			2.763
-revision                1
-categories		lang
-platforms		darwin
-license			{Artistic-1 GPL-2}
-maintainers		nomaintainer
-description		yet another basic language
-long_description	Yabasic implements the most common and simple elements \
-				of the basic language. It comes with goto/gosub, with \
-				various loops, with user defined subroutines and Libraries. \
-				Yabasic does monochrome line graphics and printing.
+name                yabasic
+version             2.86.7
+revision            0
+categories          lang
+platforms           darwin
+license             {Artistic-1 GPL-2}
+maintainers         nomaintainer
+description         yet another basic language
+long_description    Yabasic implements the most common and simple elements \
+                    of the basic language. It comes with goto/gosub, with \
+                    various loops, with user defined subroutines and Libraries. \
+                    Yabasic does monochrome line graphics and printing.
 
-homepage		http://www.yabasic.de/
-master_sites	${homepage}/download/
-checksums		md5 98f0cb59db973b89753abcc24b2c5ec2
+homepage            http://www.yabasic.de/
+master_sites        ${homepage}/download/
+checksums           rmd160 40368320d20971acd3f9b08439003035d6f9b6e2 \
+                    sha256 e3871f293e82d82861b9c884b2745038d164d6c38e436aed61b5d6cfd7256c23 \
+                    size 711695
 
-depends_lib \
-	port:xorg-libsm \
-	port:xorg-libX11
+depends_build       port:pkgconfig
 
-configure.args	--mandir=${prefix}/share/man
+depends_lib         port:xorg-libsm \
+                    port:xorg-libX11 \
+                    port:xorg-libXt \
+                    port:libffi
+
+configure.args      --mandir=${prefix}/share/man
 


### PR DESCRIPTION
This obsoletes a [previous pull request](https://github.com/macports/macports-ports/pull/6735)
for yabasic 2.86.6 which worked around a problem in finding libffi.
Upstream has added pkgconfig support and can now find libffi without intervention.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G4032
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
