### PR TITLE
2048.cpp: fix user data overwritting and data store failure

### DIFF
--- a/games/2048.cpp/Portfile
+++ b/games/2048.cpp/Portfile
@@ -7,7 +7,7 @@ PortGroup               cmake 1.1
 
 github.setup            plibither8 2048.cpp 81c0eebaa2e575c7c7943c01958b88896c9da852
 version                 2019-12-12
-revision                0
+revision                1
 categories              games
 maintainers             {mails.ucas.ac.cn:chenguokai17 @chenguokai} openmaintainer
 
@@ -23,8 +23,24 @@ checksums               rmd160  3f1b6aae943e70ac79d107dd899762313ff2ce66 \
                         sha256  e5746f6505220d62f1c250456731c632d6d2e820f6a66313bc2940dbd2e1dcbd \
                         size    4205777
 
-notes "
-If you run 2048 binary from a directory other than ${prefix}/bin, it is\
-likely that this game fails to save scores. It is expected, since upstream\
-code takes a relative path. Wait for any upstream updates.
-"
+post-destroot {
+    move ${destroot}${prefix}/var/2048.cpp/data/scores.txt \
+         ${destroot}${prefix}/var/2048.cpp/data/scores.txt.ori
+    move ${destroot}${prefix}/var/2048.cpp/data/statistics.txt \
+         ${destroot}${prefix}/var/2048.cpp/data/statistics.txt.ori
+    move ${destroot}${prefix}/bin/2048 \
+         ${destroot}${prefix}/bin/_2048
+    system "echo '#!/bin/sh' >> ${destroot}${prefix}/bin/2048"
+    system "echo 'cd ${prefix}/bin ' >> ${destroot}${prefix}/bin/2048"
+    system "echo './_2048' >> ${destroot}${prefix}/bin/2048"
+    system "chmod a+x ${destroot}${prefix}/bin/2048"
+}
+
+post-activate {
+    if {![file exists ${prefix}/var/2048.cpp/data/scores.txt]} {
+        move ${prefix}/var/2048.cpp/data/scores.txt.ori ${prefix}/var/2048.cpp/data/scores.txt
+    }
+    if {![file exists ${prefix}/var/2048.cpp/data/statistics.txt]} {
+        move ${prefix}/var/2048.cpp/data/statistics.txt.ori ${prefix}/var/2048.cpp/data/statistics.txt
+    }
+}


### PR DESCRIPTION
* fix user data overwritting during upgarde
* fix data store failure on most paths

Closes https://trac.macports.org/ticket/60401
Closes https://trac.macports.org/ticket/60402

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G4032
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
