### PR TITLE
git-delta: new port

### DIFF
--- a/textproc/git-delta/Portfile
+++ b/textproc/git-delta/Portfile
@@ -1,0 +1,162 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo 1.0
+
+github.setup        dandavison delta 0.1.1
+name                git-delta
+categories          textproc
+platforms           darwin
+maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
+license             MIT
+
+description         A syntax-highlighter for git and diff output
+
+long_description    Delta provides language syntax-highlighting, within-line \
+                    insertion/deletion detection, and restructured diff \
+                    output for git on the command line.
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  9b4a4fe29970b340b262ec88c1ac57de41d81697 \
+                    sha256  95adcef0e0c9b2ad5f43a17aa50ca6d48735fbca8c3db28e8e11a500da6440e7 \
+                    size    801541
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/delta \
+        ${destroot}${prefix}/bin/
+}
+
+notes "
+To install delta for git if it isn't installed already, you can use `git config`:
+
+    git config --global core.pager delta
+
+If you are using a light terminal theme, then you may prefer:
+
+    git config --global core.pager 'delta --light'
+
+"
+
+cargo.crates \
+    adler32                          1.0.3  7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c \
+    aho-corasick                     0.7.6  58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d \
+    ansi_colours                     1.0.1  1d0f302a81afc6a7f4350c04f0ba7cfab529cc009bca3324b3fb5764e6add8b6 \
+    ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
+    arrayref                         0.3.5  0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee \
+    arrayvec                         0.5.1  cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8 \
+    atty                            0.2.13  1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90 \
+    autocfg                          1.0.0  f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d \
+    autocfg                          0.1.5  22130e92352b948e7e82a49cdb0aa94f2211761117f29e052dd397c1ac33542b \
+    backtrace                       0.3.40  924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea \
+    backtrace-sys                   0.1.32  5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491 \
+    base64                          0.10.1  0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e \
+    bincode                          1.1.4  9f04a5e50dc80b3d5d35320889053637d15011aed5e66b66b37ae798c65da6f7 \
+    bindgen                         0.50.1  cb0e5a5f74b2bafe0b39379f616b5975e08bcaca4e779c078d5c31324147e9ba \
+    bitflags                         1.1.0  3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd \
+    blake2b_simd                     0.5.9  b83b7baab1e671718d78204225800d6b170e648188ac7dc992e9d6bddf87d0c0 \
+    box_drawing                      0.1.2  ea27d8d5fd867b17523bf6788b1175fa9867f34669d057e9adaf76e27bcea44b \
+    byteorder                        1.3.2  a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5 \
+    cc                              1.0.38  ce400c638d48ee0e9ab75aef7997609ec57367ccfe1463f21bf53c3eca67bf46 \
+    cexpr                            0.3.6  fce5b5fb86b0c57c20c834c1b412fd09c77c8a59b9473f86272709e78874cd1d \
+    cfg-if                           0.1.9  b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33 \
+    clang-sys                       0.28.1  81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853 \
+    clap                            2.33.0  5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9 \
+    clicolors-control                1.0.0  73abfd4c73d003a674ce5d2933fca6ce6c42480ea84a5ffe0a2dc39ed56300f9 \
+    cloudabi                         0.0.3  ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
+    console                          0.7.7  8ca57c2c14b8a2bf3105bc9d15574aad80babf6a9c44b1058034cdf8bd169628 \
+    constant_time_eq                 0.1.4  995a44c877f9212528ccc74b21a232f66ad69001e40ede5bcee2ac9ef2657120 \
+    crc32fast                        1.2.0  ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1 \
+    crossbeam-utils                  0.6.6  04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6 \
+    dirs                             2.0.2  13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3 \
+    dirs-sys                         0.3.4  afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b \
+    either                           1.5.2  5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b \
+    encode_unicode                   0.3.5  90b2c9496c001e8cb61827acdefad780795c42264c137744cae6f7d9e3450abd \
+    env_logger                       0.6.2  aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3 \
+    error-chain                     0.12.1  3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9 \
+    failure                          0.1.6  f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9 \
+    failure_derive                   0.1.6  0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08 \
+    flate2                           1.0.9  550934ad4808d5d39365e5d61727309bf18b3b02c6c56b729cb92e7dd84bc3d8 \
+    fnv                              1.0.6  2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3 \
+    fuchsia-cprng                    0.1.1  a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba \
+    fxhash                           0.2.1  c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c \
+    glob                             0.3.0  9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574 \
+    heck                             0.3.1  20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205 \
+    humantime                        2.0.0  b9b6c53306532d3c8e8087b44e6580e10db51a023cf9b433cea2ac38066b92da \
+    humantime                        1.2.0  3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114 \
+    indexmap                         1.3.2  076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292 \
+    itertools                        0.8.0  5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358 \
+    itoa                             0.4.4  501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    lazycell                         1.2.1  b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f \
+    libc                            0.2.60  d44e80633f007889c7eff624b709ab43c92d708caad982295768a7b13ca3b5eb \
+    libloading                       0.5.2  f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753 \
+    line-wrap                        0.1.1  f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9 \
+    linked-hash-map                  0.5.2  ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83 \
+    lock_api                         0.3.1  f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc \
+    log                              0.4.8  14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7 \
+    memchr                           2.2.1  88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e \
+    miniz-sys                       0.1.12  1e9e3ae51cea1576ceba0dde3d484d30e6e5b86dee0b2d412fe3a16a15c98202 \
+    miniz_oxide                      0.2.2  b6c3756d66cf286314d5f7ebe74886188a9a92f5eee68b06f31ac2b4f314c99d \
+    miniz_oxide_c_api                0.2.2  5b78ca5446dd9fe0dab00e058731b6b08a8c1d2b9cdb8efb10876e24e9ae2494 \
+    nom                              4.2.3  2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6 \
+    onig                             5.0.0  e4e723fc996fff1aeab8f62205f3e8528bf498bdd5eadb2784d2d31f30077947 \
+    onig_sys                        69.2.0  0a8d4efbf5f59cece01f539305191485b651acb3785b9d5eef05749f0496514e \
+    parking_lot                      0.9.0  f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252 \
+    parking_lot_core                 0.6.2  b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b \
+    peeking_take_while               0.1.2  19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099 \
+    pkg-config                      0.3.15  a7c1d2cfa5a714db3b5f24f0915e74fcdf91d09d496ba61329705dda7774d2af \
+    plist                            0.5.4  50ce7c785e06e3a9e6f546c1a30d3d59111a31a21bc294fb1496241a572c9a00 \
+    proc-macro2                      1.0.6  9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27 \
+    proc-macro2                     0.4.30  cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759 \
+    quick-error                      1.2.2  9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0 \
+    quote                            1.0.2  053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe \
+    quote                           0.6.13  6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1 \
+    rand_core                        0.4.2  9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc \
+    rand_core                        0.3.1  7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b \
+    rand_os                          0.1.3  7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071 \
+    rdrand                           0.4.0  678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2 \
+    redox_syscall                   0.1.56  2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84 \
+    redox_users                      0.3.1  4ecedbca3bf205f8d8f5c2b44d83cd0690e39ee84b951ed649e9f1841132b66d \
+    regex                            1.2.1  88c3d9193984285d544df4a30c23a4e62ead42edf70a4452ceb76dac1ce05c26 \
+    regex-syntax                    0.6.11  b143cceb2ca5e56d5671988ef8b15615733e7ee16cd348e064333b251b89343f \
+    rust-argon2                      0.5.1  4ca4eaef519b494d1f2848fc602d18816fed808a981aedf4f1f00ceb7c9d32cf \
+    rustc-demangle                  0.1.16  4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783 \
+    rustc_version                    0.2.3  138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a \
+    ryu                              1.0.0  c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997 \
+    safemem                          0.3.1  e133ccc4f4d1cd4f89cc8a7ff618287d56dc7f638b8e38fc32c5fdcadc339dd5 \
+    same-file                        1.0.5  585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421 \
+    scopeguard                       1.0.0  b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d \
+    semver                           0.9.0  1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403 \
+    semver-parser                    0.7.0  388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
+    serde                           1.0.98  7fe5626ac617da2f2d9c48af5515a21d5a480dbd151e01bb1c355e26a3e68113 \
+    serde_derive                    1.0.98  01e69e1b8a631f245467ee275b8c757b818653c6d704cdbcaeb56b56767b529c \
+    serde_json                      1.0.40  051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704 \
+    shell-words                      0.1.0  39acde55a154c4cd3ae048ac78cc21c25f3a0145e44111b523279113dce0d94a \
+    shlex                            0.1.1  7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2 \
+    smallvec                        0.6.10  ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7 \
+    strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
+    structopt                       0.2.18  16c2cdbf9cc375f15d1b4141bc48aeef444806655cd0e904207edc8d68d86ed7 \
+    structopt-derive                0.2.18  53010261a84b37689f9ed7d395165029f9cc7abb9f56bbfe86bee2597ed25107 \
+    syn                             1.0.11  dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238 \
+    syn                            0.15.43  ee06ea4b620ab59a2267c6b48be16244a3389f8bfa0986bdd15c35b890b00af3 \
+    synstructure                    0.12.3  67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545 \
+    syntect                          4.1.0  274f5e6be6e730e919e4e371dba490cd35cf7401fad41dac4a39a8d88884c731 \
+    termcolor                        1.1.0  bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f \
+    termios                          0.3.1  72b620c5ea021d75a735c943269bb07d30c9b77d6ac6b236bc8b5c496ef05625 \
+    textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
+    thread_local                     0.3.6  c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b \
+    unicode-segmentation             1.3.0  1967f4cdfc355b37fd76d2a954fb2ed3871034eb4f26d60537d88795cfc332a9 \
+    unicode-width                    0.1.6  7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20 \
+    unicode-xid                      0.2.0  826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c \
+    unicode-xid                      0.1.0  fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc \
+    vec_map                          0.8.1  05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a \
+    version_check                    0.1.5  914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd \
+    walkdir                          2.2.9  9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e \
+    which                            2.0.1  b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164 \
+    winapi                           0.3.7  f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770 \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                      0.1.4  fa515c5163a99cc82bab70fd3bfdd36d827be85de63737b40fcef2ce084a436e \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    xml-rs                           0.8.0  541b12c998c5b56aa2b4e6f18f03664eef9a4fd0a246a55594efae6cc2d964b5 \
+    yaml-rust                        0.4.3  65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d


### PR DESCRIPTION
#### Description

Adds new port for [delta](https://github.com/dandavison/delta), a syntax-highlighter for git and diff output.

Addresses https://trac.macports.org/ticket/60131

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
