### PR TITLE
yarn: use nodejs12 instead of nodejs10

### DIFF
--- a/devel/yarn/Portfile
+++ b/devel/yarn/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        yarnpkg yarn 1.22.4 v
-revision            1
+revision            2
 
 categories          devel
 
@@ -32,11 +32,11 @@ checksums           rmd160  78fa03d13631d7560a34aba42c6b17f9087c3cac \
                     sha256  bc5316aa110b2f564a71a3d6e235be55b98714660870c5b6b2d2d3f12587fb58 \
                     size    1244785
 
-depends_run         path:bin/node:nodejs10
+depends_run         path:bin/node:nodejs12
 
 platform darwin {
     if {${os.major} < 13} {
-        depends_run-replace path:bin/node:nodejs10 path:bin/node:nodejs6
+        depends_run-replace path:bin/node:nodejs12 path:bin/node:nodejs6
     }
 }
 


### PR DESCRIPTION
#### Description

Changes `yarn` to require and use `nodejs12` instead of `nodejs10`, as 10 is about to enter Maintenance on May 19.  NodeJS 12 is the most recent Active LTS version of Node.

https://nodejs.org/en/about/releases/

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
