### PR TITLE
wtfutil: update to 0.29.0

### DIFF
--- a/sysutils/wtfutil/Portfile
+++ b/sysutils/wtfutil/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/wtfutil/wtf 0.28.0 v
+go.setup            github.com/wtfutil/wtf 0.29.0 v
 
 homepage            https://wtfutil.com
 
@@ -18,9 +18,9 @@ description         A personal terminal-based dashboard utility, designed for \
                     data.
 long_description    ${description}
 
-checksums           rmd160  3513e0b4a65182bb6c89b4eef10be3e2ccc9b3ca \
-                    sha256  6e031fd5df4cdc6aea565e8f2452759250aa7b3214dbe79b6ee71a9ef454bfa5 \
-                    size    2227205
+checksums           rmd160  2ffde16002927522a94f7b28e4eaff8342c17d87 \
+                    sha256  0c7f73d40e86a8dc925b12bf57f0971b59ad2c0fbc8225c87ab09f4028e77851 \
+                    size    2233215
 
 set build_date      [exec date +%FT%T%z]
 


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
