### PR TITLE
google-cloud-sdk: update to 290.0.1

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             290.0.0
+version             290.0.1
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  373784b28d569da1f9eb9d0f224bf99af2998383 \
-                    sha256  8f63d6a5e0873d7e6d308166f1a6e49197b780342cfb3b0d9653d217ab156221 \
-                    size    50129282
+    checksums       rmd160  90b9b128e3d9005e0534776ab8e3523b44eb1d14 \
+                    sha256  51b650528d64bfbc3666dff4bb41d3df09db769455b58ae40f28e49a2acf5de4 \
+                    size    50123330
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  1f5f4d11f5d1082e4686b9b45a9a59dfe03e2909 \
-                    sha256  97420bf912fd21403b874079170e71da1e742e490602deb54d48f79134d67474 \
-                    size    51219215
+    checksums       rmd160  a3f63a37667bbac961cc3464fe6f1a22cc38745e \
+                    sha256  6df652b728bf6b7b74addb0b407e09c28e9caccd93b586b536cb60293477191a \
+                    size    51211263
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 290.0.1.

###### Tested on

macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?