### PR TITLE
openjdk8: update OpenJ9 subports to .2 releases

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -18,7 +18,7 @@ subport openjdk8-graalvm {
 
 subport openjdk8-openj9 {
     version      8u252
-    revision     1
+    revision     2
 
     set build    09
     set major    8
@@ -27,7 +27,7 @@ subport openjdk8-openj9 {
 
 subport openjdk8-openj9-large-heap {
     version      8u252
-    revision     1
+    revision     2
 
     set build    09
     set major    8
@@ -59,7 +59,7 @@ subport openjdk11-graalvm {
 
 subport openjdk11-openj9 {
     version      11.0.7
-    revision     1
+    revision     2
 
     set build    10
     set major    11
@@ -68,7 +68,7 @@ subport openjdk11-openj9 {
 
 subport openjdk11-openj9-large-heap {
     version      11.0.7
-    revision     1
+    revision     2
 
     set build    10
     set major    11
@@ -137,7 +137,7 @@ subport openjdk14 {
 
 subport openjdk14-openj9 {
     version      14.0.1
-    revision     1
+    revision     2
 
     set build    7
     set major    14
@@ -146,7 +146,7 @@ subport openjdk14-openj9 {
 
 subport openjdk14-openj9-large-heap {
     version      14.0.1
-    revision     1
+    revision     2
 
     set build    7
     set major    14
@@ -215,14 +215,14 @@ if {${subport} eq "openjdk8"} {
 
     homepage     https://www.graalvm.org
 } elseif {${subport} eq "openjdk8-openj9"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}.1_openj9-${openj9_version}/
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}.2_openj9-${openj9_version}/
 
     # Stealth update
-    dist_subdir  ${name}/${version}_1
+    dist_subdir  ${name}/${version}_2
 
-    checksums    rmd160  ca64741a8fa3deb79961657667b6d88e3a337ba6 \
-                 sha256  b695f8e95ee548f354fe647abd45612be8318063ea14dfd410b4bc22000fa095 \
-                 size    159487269
+    checksums    rmd160  b0f23be9c2f7df5ee0438b726bcb53a207d31762 \
+                 sha256  f522061a23290bce3423e49025a95b6e78d6f30e2741817e83c8fdba4c0c4ae7 \
+                 size    113265117
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}b${build}_openj9-${openj9_version}
     worksrcdir   jdk${version}-b${build}
@@ -235,14 +235,14 @@ if {${subport} eq "openjdk8"} {
                  VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
                  suitable for running all workloads.
 } elseif {${subport} eq "openjdk8-openj9-large-heap"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}.1_openj9-${openj9_version}/
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}.2_openj9-${openj9_version}/
 
     # Stealth update
-    dist_subdir  ${name}/${version}_1
+    dist_subdir  ${name}/${version}_2
 
-    checksums    rmd160  7d07bf50bb3c06639bb65c89f530fcbf62b87ffa \
-                 sha256  b7fa56aa38d3478023b4e5666a514a07696c56ed945b79a9a8d8abf73db1e6e7 \
-                 size    159582180
+    checksums    rmd160  3e9394986bc60248d4bb267261cda0c52b87d41b \
+                 sha256  79ab9e7f745201a353b2f95856ada555b4b844bcf64e825e3c7b73cd4f1641b4 \
+                 size    113908307
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}b${build}_openj9-${openj9_version}
     worksrcdir   jdk${version}-b${build}
@@ -300,14 +300,14 @@ if {${subport} eq "openjdk8"} {
 
     homepage     https://www.graalvm.org
 } elseif {${subport} eq "openjdk11-openj9"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.1_openj9-${openj9_version}/
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.2_openj9-${openj9_version}/
 
     # Stealth update
-    dist_subdir  ${name}/${version}_1
+    dist_subdir  ${name}/${version}_2
 
-    checksums    rmd160  e8da36a2996f8cbc96833908cb7897558039832e \
-                 sha256  7e017209063c673a82c4d6047c9165b0fb66054c2bcd6b1f6389ed54f692b0b5 \
-                 size    248496881
+    checksums    rmd160  9f852323878d78c838acce77f77ce04811ad1f3e \
+                 sha256  a0de749c37802cc233ac58ffde68191a4dc985c71b626e7c0ff53944f743427f \
+                 size    194540776
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
     worksrcdir   jdk-${version}+${build}
@@ -320,14 +320,14 @@ if {${subport} eq "openjdk8"} {
                  VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
                  suitable for running all workloads.
 } elseif {${subport} eq "openjdk11-openj9-large-heap"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.1_openj9-${openj9_version}/
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.2_openj9-${openj9_version}/
 
     # Stealth update
-    dist_subdir  ${name}/${version}_1
+    dist_subdir  ${name}/${version}_2
 
-    checksums    rmd160  51431040a8ae6dc2665929b5ae2a8396af53b6fb \
-                 sha256  801b6e52300cf67617009b8a48039ae0bc02ab68710cd67334db8262cbe63c33 \
-                 size    248578484
+    checksums    rmd160  b4b3aa8c4f639f8f874df2ec6f4e4d642967956a \
+                 sha256  96518b3a9b303bed5ab7bd697a4fbd0ea8525df7e581543830ca7e1e0d7ed90b \
+                 size    193760354
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
     worksrcdir   jdk-${version}+${build}
@@ -441,15 +441,15 @@ if {${subport} eq "openjdk8"} {
 
     worksrcdir   jdk-${version}+${build}
 } elseif {${subport} eq "openjdk14-openj9"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.1_openj9-${openj9_version}/
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.2_openj9-${openj9_version}/
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
 
     # Stealth update
-    dist_subdir  ${name}/${version}_1
+    dist_subdir  ${name}/${version}_2
 
-    checksums    rmd160  613d7709e8fb6925d06cf6ab2327d1f9d70114af \
-                 sha256  8d0f8f56284add84c02a9ba359d7cc4c8b9a3cd912b8a1e98bba234664fb4d72 \
-                 size    254646126
+    checksums    rmd160  0600f3cba4e925c94b3a5b7b1f944c7d34190f4b \
+                 sha256  4203f1939704de50d4fae4b98fdd0c63f154aab804eb1ebd5cd6bbcbf0811a1d \
+                 size    200744726
 
     worksrcdir   jdk-${version}+${build}
 
@@ -461,15 +461,15 @@ if {${subport} eq "openjdk8"} {
                  VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
                  suitable for running all workloads.
 } elseif {${subport} eq "openjdk14-openj9-large-heap"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.1_openj9-${openj9_version}/
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.2_openj9-${openj9_version}/
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
 
     # Stealth update
-    dist_subdir  ${name}/${version}_1
+    dist_subdir  ${name}/${version}_2
 
-    checksums    rmd160  52ac161558b0999e303ccd01852cdf6d5cf7f768 \
-                 sha256  6d2973221513c2cf23567982d42c2468a23e16f6aba6025892c9fa4e11b4742d \
-                 size    254742826
+    checksums    rmd160  21789f13b72e62370ec7d926c5998cc8d1c6fc1f \
+                 sha256  eb5f8708e586afc80054c8c16946dc27c86113185cccced4b8f0a2c4992b999c \
+                 size    200741041
 
     worksrcdir   jdk-${version}+${build}
 


### PR DESCRIPTION
#### Description

Update AdoptOpenJDK builds with OpenJ9 VM to the .2 releases.

###### Tested on

macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?