### PR TITLE
grafana: new port

### DIFF
--- a/net/grafana/Portfile
+++ b/net/grafana/Portfile
@@ -1,0 +1,148 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        grafana grafana 6.7.3 v
+
+description         The tool for beautiful monitoring and metric analytics & \
+                    dashboards for Graphite, InfluxDB & Prometheus & More
+
+long_description    Grafana allows you to query, visualize, alert on and \
+                    understand your metrics no matter where they are stored. \
+                    Create, explore, and share dashboards with your team and \
+                    foster a data driven culture.
+
+homepage            https://grafana.com/
+
+platforms           darwin
+categories          net sysutils
+license             Apache-2
+
+maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
+
+depends_build       port:go \
+                    port:nodejs12 \
+                    port:yarn
+
+build.env           GOPATH=${workpath} PATH=${workpath}/bin:$env(PATH)
+
+build.target        all
+
+use_configure       no
+installs_libs       no
+use_parallel_build  no
+
+set grafana_user        ${name}
+set grafana_conf_dir    ${prefix}/etc/${name}
+set grafana_conf_file   ${grafana_conf_dir}/${name}.ini
+set grafana_data_dir    ${prefix}/var/db/${name}
+set grafana_share_dir   ${prefix}/share/${name}
+set grafana_log_dir     ${prefix}/var/log/${name}
+set grafana_conf_tpl    ${grafana_share_dir}/conf/${name}.ini
+set grafana_plist       org.macports.${name}.plist
+set grafana_plist_dir   ${prefix}/etc/LaunchDaemons/org.macports.${name}
+
+add_users               ${grafana_user} group=${grafana_user} realname=Grafana
+
+checksums   rmd160  832cafba00e6269ba2ec3b432f15adbb44ff24e5 \
+            sha256  fba8eaf5f32715ccdc65d75434ec7675de67f2af881b3dfab3072ead04ac7d27 \
+            size    15983800
+
+
+post-extract {
+
+    copy ${filespath}/${grafana_plist} ${workpath}
+
+    reinplace "s|@USER@|${grafana_user}|g"          ${workpath}/${grafana_plist}
+    reinplace "s|@GROUP@|${grafana_user}|g"         ${workpath}/${grafana_plist}
+    reinplace "s|@PREFIX@|${prefix}|g"              ${workpath}/${grafana_plist}
+    reinplace "s|@CONFFILE@|${grafana_conf_file}|g" ${workpath}/${grafana_plist}
+    reinplace "s|@SHAREDIR@|${grafana_share_dir}|g" ${workpath}/${grafana_plist}
+}
+
+
+destroot.keepdirs-append \
+    ${destroot}${grafana_conf_dir} \
+    ${destroot}${grafana_data_dir} \
+    ${destroot}${grafana_log_dir}
+
+
+destroot {
+    set goos ${os.platform}
+
+    switch ${build_arch} {
+        i386    { set goarch 386 }
+        x86_64  { set goarch amd64 }
+        default { set goarch {} }
+    }
+
+    xinstall -m 755 ${worksrcpath}/bin/${goos}-${goarch}/${name}-cli \
+        ${destroot}${prefix}/bin/
+
+    xinstall -m 755 ${worksrcpath}/bin/${goos}-${goarch}/${name}-server \
+        ${destroot}${prefix}/bin/
+
+    xinstall -d -m 755 ${destroot}${grafana_conf_dir}
+    xinstall -d -m 755 ${destroot}${grafana_share_dir}
+
+    xinstall -m 755 -o ${grafana_user} -g ${grafana_user} -d \
+        ${destroot}${grafana_data_dir}
+
+    xinstall -m 755 -o ${grafana_user} -g ${grafana_user} -d \
+        ${destroot}${grafana_log_dir}
+
+    xinstall -d -m 755 ${destroot}${grafana_share_dir}/conf
+    xinstall -d -m 755 ${destroot}${grafana_share_dir}/public
+
+    copy {*}[glob ${worksrcpath}/conf/*] \
+        ${destroot}${grafana_share_dir}/conf/
+    copy {*}[glob ${worksrcpath}/public/*] \
+        ${destroot}${grafana_share_dir}/public/
+
+    copy ${destroot}${grafana_share_dir}/conf/defaults.ini \
+         ${destroot}${grafana_conf_tpl}
+
+     system -W ${destroot}${grafana_share_dir}/conf/ \
+         "patch -p0 < ${filespath}/grafana.ini.diff"
+
+     reinplace "s|@CONFPATH@|${grafana_conf_dir}|g" \
+         ${destroot}${grafana_conf_tpl}
+     reinplace "s|@DATAPATH@|${grafana_data_dir}|g" \
+         ${destroot}${grafana_conf_tpl}
+     reinplace "s|@LOGPATH@|${grafana_log_dir}|g"   \
+         ${destroot}${grafana_conf_tpl}
+
+    xinstall -d -m 755 ${destroot}${grafana_plist_dir}
+
+    xinstall -m 0644 -o root -W ${workpath} ${grafana_plist} \
+        ${destroot}${grafana_plist_dir}
+
+    xinstall -d -m 755 ${destroot}/Library/LaunchDaemons
+
+    ln -s ${grafana_plist_dir}/${grafana_plist} \
+        ${destroot}/Library/LaunchDaemons/${grafana_plist}
+
+}
+
+
+post-activate {
+    if {![file exists ${grafana_conf_file}]} {
+        copy ${grafana_conf_tpl} ${grafana_conf_file}
+    }
+}
+
+notes "
+Grafana's configuration file is available at:
+
+ ${grafana_conf_file}
+
+To enable the Grafana service, use `port load`, as follows:
+
+\$ sudo port load ${name}
+
+Grafana will listen by default on: http://localhost:3900
+
+Once enabled, the service will log to:
+ ${grafana_log_dir}
+"

--- a/net/grafana/files/grafana.ini.diff
+++ b/net/grafana/files/grafana.ini.diff
@@ -1,0 +1,35 @@
+--- grafana.ini	2020-04-29 04:31:29.000000000 -0400
++++ grafana.ini	2020-04-29 04:36:44.000000000 -0400
+@@ -12,19 +12,19 @@
+ #################################### Paths ###############################
+ [paths]
+ # Path to where grafana can store temp files, sessions, and the sqlite3 db (if that is used)
+-data = data
++data = @DATAPATH@
+ 
+ # Temporary files in `data` directory older than given duration will be removed
+ temp_data_lifetime = 24h
+ 
+ # Directory where grafana can store logs
+-logs = data/log
++logs = @LOGPATH@
+ 
+ # Directory where grafana will automatically scan and look for plugins
+-plugins = data/plugins
++plugins = @DATAPATH@/plugins
+ 
+ # folder that contains provisioning config files that grafana will apply on startup and while running.
+-provisioning = conf/provisioning
++provisioning = @CONFPATH@/provisioning
+ 
+ #################################### Server ##############################
+ [server]
+@@ -35,7 +35,7 @@
+ http_addr =
+ 
+ # The http port to use
+-http_port = 3000
++http_port = 3900
+ 
+ # The public facing domain name used to access grafana from a browser
+ domain = localhost

--- a/net/grafana/files/org.macports.grafana.plist
+++ b/net/grafana/files/org.macports.grafana.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>org.macports.grafana</string>
+    <key>ProcessType</key>
+    <string>Interactive</string>
+    <key>Disabled</key>
+    <false/>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>SessionCreate</key>
+    <true/>
+    <key>LaunchOnlyOnce</key>
+    <false/>
+    <key>UserName</key>
+    <string>@USER@</string>
+    <key>GroupName</key>
+    <string>@GROUP@</string>
+    <key>ExitTimeOut</key>
+    <integer>600</integer>
+    <key>ProgramArguments</key>
+        <array>
+            <string>@PREFIX@/bin/grafana-server</string>
+            <string>-config=@CONFFILE@</string>
+            <string>-homepath=@SHAREDIR@</string>
+        </array>
+</dict>
+</plist>


### PR DESCRIPTION
#### Description

New port for [Grafana](https://www.grafana.com)

Addresses: https://trac.macports.org/ticket/59421

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
