### PR TITLE
tmux: update to 3.1a

### DIFF
--- a/sysutils/tmux/Portfile
+++ b/sysutils/tmux/Portfile
@@ -3,14 +3,14 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    tmux tmux 3.1
+github.setup    tmux tmux 3.1a
 if {${subport} eq ${name}} {
     revision        0
     conflicts       tmux-devel
 }
 subport tmux-devel {
-    github.setup    tmux tmux e67d65064e5541482990402fef85342f8cb4996b
-    version         20200424-[string range ${github.version} 0 6]
+    github.setup    tmux tmux 5af694394018940819c0734be9b5fd44df1bf857
+    version         20200429-[string range ${github.version} 0 6]
     revision        0
     conflicts       tmux
 }
@@ -30,14 +30,14 @@ depends_lib     port:libevent port:ncurses
 
 if {${subport} eq ${name}} {
     github.tarball_from     releases
-    checksums               rmd160  1283b1b1908e90ae6b3459cb8da439ab4ef7152d \
-                            sha256  979bf38db2c36193de49149aaea5c540d18e01ccc27cf76e2aff5606bd186722 \
-                            size    561086
+    checksums               rmd160  b0cb14a79e078ec9ce4f3d6c6a99be57452109d8 \
+                            sha256  10687cbb02082b8b9e076cf122f1b783acc2157be73021b4bedb47e958f4e484 \
+                            size    561121
 }
 subport tmux-devel {
-    checksums               rmd160  ec8d99801f88b90cdd60ac0cccd4547a5d6fe099 \
-                            sha256  1b31ee63a5553c8d49f7e63a797daeb6678a1d10affae24b8972753705d83554 \
-                            size    745230
+    checksums               rmd160  43c16b4483a7dc1b238ff2543d154a12371f1b15 \
+                            sha256  709687fc170b765aa376913224af0ab6e83bb184edbca43390ea21beb18c327c \
+                            size    748493
 
     use_autoreconf          yes
     autoreconf.cmd          ./autogen.sh


### PR DESCRIPTION
tmux: update to 3.1a
tmux: update tmux-devel to latest commit (5af694394018940819c0734be9b5fd44df1bf857)

#### Description

###### Type(s)

- [x] update

###### Tested on

macOS 10.14.6 18G4032
Xcode 11.3.1 11C504

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?