### PR TITLE
py-[xdis|uncompyle6]: update to latest versions

### DIFF
--- a/python/py-uncompyle6/Portfile
+++ b/python/py-uncompyle6/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-uncompyle6
-version             3.6.5
+version             3.6.7
 revision            0
 
 categories-append   devel
@@ -18,9 +18,9 @@ long_description    ${description}
 
 homepage            https://github.com/rocky/python-uncompyle6/
 
-checksums           rmd160  a22662d0bdf7daa8362484e4c62e5666281ff39a \
-                    sha256  ddbb2f9919464215fba4a7cc5522d1417e1e252d4940a11a6b3a888790d102ea \
-                    size    2365335
+checksums           rmd160  c76455245c009dba62cd9052b3b8a660816abe0a \
+                    sha256  6f5ae93cfb0ccf22b6b10b608c982bc0fa9bed2481ead57242c02ac64a573db7 \
+                    size    2375402
 
 python.versions     27 35 36 37 38
 

--- a/python/py-xdis/Portfile
+++ b/python/py-xdis/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-xdis
-version             4.3.2
+version             4.5.1
 platforms           darwin
 supported_archs     noarch
 license             GPL-2
@@ -23,9 +23,9 @@ long_description \
 
 homepage            https://github.com/rocky/python-xdis
 
-checksums           rmd160  ee1f951c35255c569c68bc06021ec669a27d67af \
-                    sha256  0efc601c13a3cd9e70aba369a7380da051427c5a1d502fd42e90d9e397cf20d9 \
-                    size    219750
+checksums           rmd160  0d2900fe6543f7f760586d0c2dd35b2c64afe4d6 \
+                    sha256  2cbdbff1325a78b2f825bc065ccd1d3c827cd5188963ec87a2f89576eb5867bd \
+                    size    224393
 
 python.versions     27 35 36 37 38
 
@@ -34,12 +34,15 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-setuptools \
                         port:py${python.version}-six
 
-    depends_test-append port:py${python.version}-pytest
+    post-patch {
+        reinplace "s|PYTHON ?= python|PYTHON ?= ${python.bin}|g" ${worksrcpath}/test/Makefile
+    }
 
-    test.run            yes
-    test.cmd            py.test-${python.branch}
-    test.target
-    test.env            PYTHONPATH=${worksrcpath}/build/lib
+    test.run        yes
+    test.dir        ${build.dir}/test
+    test.cmd        make
+    test.target     check-full
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     livecheck.type  none
 }


### PR DESCRIPTION
#### Description
This PR updates `py-uncompyle6` and its dependency `py-xdis` to their latest versions.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
macOS 10.14.6 18G4032
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->