### PR TITLE
sqlitebrowser: set compiler.cxx_standard to 2011

### DIFF
--- a/databases/sqlitebrowser/Portfile
+++ b/databases/sqlitebrowser/Portfile
@@ -57,6 +57,8 @@ if {[info procs cmake.save_configure_cmd] ne ""} {
     cmake.save_configure_cmd "log too"
 }
 
+compiler.cxx_standard 2011
+
 configure.args-append \
                     -DQSCINTILLA_INCLUDE_DIR=${qt_includes_dir} \
                     -DQT_LIBRARY_DIR=${qt_frameworks_dir}


### PR DESCRIPTION
#### Description

According to [BUILDING.md](https://github.com/sqlitebrowser/sqlitebrowser/blob/v3.11.2/BUILDING.md) from the sqlitebrowser repo, versions after 3.9.1 require a C++11-capable compiler.

This change fixes the build on systems where the default compiler does not (properly) support C++11.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.7
Xcode 4.6.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
