### PR TITLE
vault: update to 1.4.1

### DIFF
--- a/security/vault/Portfile
+++ b/security/vault/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        hashicorp vault 1.4.0 v
+github.setup        hashicorp vault 1.4.1 v
 homepage            https://www.vaultproject.io/
 
 platforms           darwin
@@ -61,7 +61,7 @@ destroot {
 
 variant ui description {Enable the Web UI} {
     build.post_args    static-dist dev-ui
-    depends_lib-append port:nodejs10 \
+    depends_lib-append port:nodejs12 \
                        port:npm6 \
                        port:yarn
 


### PR DESCRIPTION
- use NodeJS12 for JS dependencies

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
