### PR TITLE
qt4 PortGroup: wrap platform error in pre-fetch block

### DIFF
--- a/_resources/port1.0/group/qt4-1.0.tcl
+++ b/_resources/port1.0/group/qt4-1.0.tcl
@@ -169,7 +169,9 @@ if {![info exists building_qt4]} {
         }
 
     } else {
-        return -code error "MacPorts does not support qt4 on platforms other than darwin"
+        pre-fetch {
+            return -code error "MacPorts does not support qt4 on platforms other than darwin"
+        }
     }
 }
 


### PR DESCRIPTION
running portindex on non-darwin OSs generates parse errors in all the ports that include this PortGroup.

Is this the right way to accomplish fixing this? I think so -- any port that includes this portgroup should produce this error pre-fetch this way

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.13.6 17G12034
Xcode 10.1 10B61 

Ubuntu Linux 20.04

