### PR TITLE
noah, noahstrap: New ports

### DIFF
--- a/emulators/noah/Portfile
+++ b/emulators/noah/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               cmake 1.1
+PortGroup               github 1.0
+
+github.setup            linux-noah noah 0.5.1
+revision                0
+checksums               rmd160  85823bb389f84a17a573584cb8d1b82beee98267 \
+                        sha256  452c00b1baeafca73e6566b552c9d63dc304504be95296f6568274cd74073660 \
+                        size    49644147
+
+categories              emulators
+maintainers             nomaintainer
+platforms               darwin
+license                 {MIT GPL-2+}
+# Per the Portfile included in the upstream repository.
+supported_archs         x86_64
+
+description             Linux ABI implementation for macOS
+
+long_description        Noah is a Darwin subsystem for Linux. Noah is \
+                        implemented as a hypervisor that traps Linux \
+                        system calls and translates them into Darwin \
+                        system calls. Noah also has an interpreter of \
+                        ELF files so that Linux binary executables run \
+                        directly and flawlessly without any \
+                        modifications. It's effectively a macOS Linux \
+                        execution flavor, similar to that of FreeBSD \
+                        Linuxolator, a.k.a. Linux emulation, a.k.a. \
+                        Linux ABI. In other words, it's the reverse of \
+                        the Linux Darling project.
+
+github.tarball_from     archive
+
+depends_run             port:noahstrap
+
+patchfiles              noah.in.patch
+
+# Noah uses the Hypervisor framework introduced in OS X Yosemite but the
+# readme says it requires Sierra or later. (This has not been verified.)
+if {${os.platform} ne "darwin" || ${os.major} < 16} {
+    known_fail          yes
+    pre-configure {
+        ui_error "${name} @${version} requires macOS Sierra or later"
+        return -code error "unsupported OS"
+    }
+}

--- a/emulators/noah/files/noah.in.patch
+++ b/emulators/noah/files/noah.in.patch
@@ -1,0 +1,12 @@
+Use MacPorts noahstrap.
+--- bin/noah.in.orig	2018-03-04 22:20:42.000000000 -0600
++++ bin/noah.in	2020-05-01 00:07:50.000000000 -0500
+@@ -34,7 +34,7 @@
+   $root = "$noahdir/tree";
+   if (! -d $root) {
+     prompt_yn("Noah is installing the initial filesystem in ~/.noah/tree. Proceed? [Y/n]", "y") or exit 1;
+-    system "sudo noahstrap -p ubuntu $root";
++    system "sudo @CMAKE_INSTALL_PREFIX@/bin/noahstrap -p ubuntu $root";
+   }
+ }
+ 

--- a/emulators/noahstrap/Portfile
+++ b/emulators/noahstrap/Portfile
@@ -1,0 +1,43 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+
+github.setup            linux-noah noahstrap 2.0.0
+revision                0
+checksums               rmd160  80471dd6693ed06406dfc34f29fcbc70f1fac1b9 \
+                        sha256  16213a3069418ca722c14bac8f92a905ee943b5827c5b4a78c3a7e8c3814733f \
+                        size    1940
+
+categories              emulators
+maintainers             nomaintainer
+platforms               darwin
+# The project does not indicate its license. The source contains a
+# Portfile that claims to be under these licenses, but the Portfile was
+# clearly copied from noah and then modified. Request for clarification:
+# https://github.com/linux-noah/noahstrap/issues/2
+license                 {MIT GPL-2+}
+supported_archs         noarch
+
+description             bootstrap a Linux ABI implementation for macOS
+
+long_description        noahstrap bootstraps a Linux system for noah
+
+github.tarball_from     archive
+
+depends_run             port:gnutar \
+                        port:pv
+
+patchfiles              noahstrap.patch
+
+post-patch {
+    reinplace "s|@PREFIX@|${prefix}|g" ${worksrcpath}/noahstrap
+}
+
+use_configure           no
+
+build {}
+
+# Request for DESTDIR support:
+# https://github.com/linux-noah/noahstrap/issues/3
+destroot.destdir        PREFIX=${destroot}${prefix}

--- a/emulators/noahstrap/files/noahstrap.patch
+++ b/emulators/noahstrap/files/noahstrap.patch
@@ -1,0 +1,12 @@
+Use MacPorts pv and gnutar.
+--- noahstrap.orig	2017-01-16 00:27:30.000000000 -0600
++++ noahstrap	2020-05-01 00:02:49.000000000 -0500
+@@ -62,7 +62,7 @@
+ 
+ my ($fh, $archive) = tempfile();
+ system "curl -o $archive $suites{$suite}" and die "could not fetch the suite";
+-system "pv $archive | gtar xzf - -C $target --strip-components=1" and die "could not extract fs tree from suite";
++system "@PREFIX@/bin/pv $archive | @PREFIX@/bin/gnutar xzf - -C $target --strip-components=1" and die "could not extract fs tree from suite";
+ 
+ print "$suite is successfully installed into $target\n";
+ 


### PR DESCRIPTION
#### Description

New ports for noah (as requested in https://trac.macports.org/ticket/60417) and its dependency noahstrap.

See ticket for further discussion.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G12034
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
