### PR TITLE
osquery: new port

### DIFF
--- a/sysutils/osquery/Portfile
+++ b/sysutils/osquery/Portfile
@@ -1,0 +1,143 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        osquery osquery 4.3.0
+
+description         SQL powered operating system instrumentation, monitoring, \
+                    and analytics.
+
+long_description    osquery exposes an operating system as a high-performance \
+                    relational database. This allows you to write SQL-based \
+                    queries to explore operating system data. With osquery, \
+                    SQL tables represent abstract concepts such as running \
+                    processes, loaded kernel modules, open network \
+                    connections, browser plugins, hardware events or file \
+                    hashes.
+
+maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
+
+homepage            https://osquery.io
+
+categories          sysutils
+
+license             Apache-2 \
+                    GPL-2
+
+platforms           darwin
+
+# The osquery build process requires the git repository as it pulls in a
+# large amount of its dependencies as git submodules.
+fetch.type          git
+
+configure.args-append \
+    -DOSQUERY_VERSION="${version}"
+
+depends_build-append \
+    port:python38
+
+patchfiles \
+    patch-default_paths.h.diff \
+    patch-lenses-path-augeas.cpp.diff \
+    patch-macports-cmake-packaging.cmake.diff
+
+set osq_data_dir    ${prefix}/var/db/${name}
+set osq_conf_dir    ${prefix}/etc/${name}
+set osq_log_dir     ${prefix}/var/log/${name}
+set osq_run_dir     ${prefix}/var/run/${name}
+set osq_share_dir   ${prefix}/share/${name}
+set osq_plist_dir   org.macports.${name}
+set osq_plist_file  org.macports.${name}.plist
+set osq_flags_file  ${name}.flags
+
+
+destroot.keepdirs-append \
+    ${osq_data_dir} \
+    ${osq_conf_dir} \
+    ${osq_log_dir} \
+    ${osq_run_dir}
+
+post-patch {
+
+    reinplace "s|@SHAREPATH@|${osq_share_dir}|g" \
+        ${worksrcpath}/osquery/tables/system/posix/augeas.cpp
+
+    reinplace "s|@CONFPATH@|${osq_conf_dir}|g" \
+        ${worksrcpath}/osquery/utils/config/default_paths.h
+
+    reinplace "s|@DATAPATH@|${osq_data_dir}|g" \
+        ${worksrcpath}/osquery/utils/config/default_paths.h
+
+    reinplace "s|@RUNPATH@|${osq_run_dir}|g" \
+        ${worksrcpath}/osquery/utils/config/default_paths.h
+
+    reinplace "s|@LOGPATH@|${osq_log_dir}|g" \
+        ${worksrcpath}/osquery/utils/config/default_paths.h
+
+    reinplace "s|@SHAREPATH@|${osq_share_dir}|g" \
+        ${worksrcpath}/osquery/utils/config/default_paths.h
+
+    copy ${filespath}/${osq_plist_file} ${workpath}/
+
+    reinplace "s|@PREFIX@|${prefix}|g"          ${workpath}/${osq_plist_file}
+    reinplace "s|@CONFPATH@|${osq_conf_dir}|g"  ${workpath}/${osq_plist_file}
+
+    copy ${filespath}/${osq_flags_file} ${workpath}/
+
+    reinplace "s|@CONFPATH@|${osq_conf_dir}|g"  ${workpath}/${osq_flags_file}
+}
+
+post-destroot {
+
+    xinstall -m 755 -o root -g wheel -d ${destroot}${osq_conf_dir}
+    xinstall -m 755 -o root -g wheel -d ${destroot}${osq_data_dir}
+    xinstall -m 755 -o root -g wheel -d ${destroot}${osq_log_dir}
+    xinstall -m 755 -o root -g wheel -d ${destroot}${osq_run_dir}
+
+    copy ${workpath}/${osq_flags_file}  ${destroot}${osq_share_dir}/
+
+    xinstall -d -m 755 ${destroot}${prefix}/etc/LaunchDaemons/${osq_plist_dir}
+
+    xinstall -m 0644 -o root -W ${workpath} ${osq_plist_file} \
+        ${destroot}${prefix}/etc/LaunchDaemons/${osq_plist_dir}/
+
+    xinstall -d -m 755 ${destroot}/Library/LaunchDaemons
+
+    ln -s ${prefix}/etc/LaunchDaemons/${osq_plist_dir}/${osq_plist_file} \
+        ${destroot}/Library/LaunchDaemons/${osq_plist_file}
+}
+
+post-activate {
+
+    if {![file exists ${osq_conf_dir}/osquery.conf]} {
+        copy ${osq_share_dir}/osquery.example.conf ${osq_conf_dir}/osquery.conf
+    }
+
+    if {![file exists ${osq_conf_dir}/${osq_flags_file}]} {
+        copy ${osq_share_dir}/${osq_flags_file} ${osq_conf_dir}/
+    }
+}
+
+notes "
+osquery's configuration can be found in:
+
+    ${osq_conf_dir}
+
+...and query packs can be found in:
+
+    ${osq_share_dir}/packs
+
+To enable the osquery service, use `port load`:
+
+\$ sudo port load osquery
+
+...and use `port unload` to disable:
+
+\$ sudo port unload osquery
+
+Once running, logs can be found in:
+
+    ${osq_log_dir}
+"

--- a/sysutils/osquery/files/org.macports.osquery.plist
+++ b/sysutils/osquery/files/org.macports.osquery.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>KeepAlive</key>
+  <true/>
+  <key>Disabled</key>
+  <false/>
+  <key>Label</key>
+  <string>org.macports.osquery</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>@PREFIX@/bin/osqueryd</string>
+    <string>--flagfile=@CONFPATH@/osquery.flags</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>60</integer>
+</dict>
+</plist>

--- a/sysutils/osquery/files/osquery.flags
+++ b/sysutils/osquery/files/osquery.flags
@@ -1,0 +1,1 @@
+--config_path=@CONFPATH@/osquery.conf

--- a/sysutils/osquery/files/patch-default_paths.h.diff
+++ b/sysutils/osquery/files/patch-default_paths.h.diff
@@ -1,0 +1,19 @@
+--- osquery/utils/config/default_paths.h	2020-04-30 20:41:20.000000000 -0400
++++ osquery/utils/config/default_paths.h	2020-04-30 23:57:42.000000000 -0400
+@@ -41,10 +41,10 @@
+ #define OSQUERY_LOG_HOME "/var/log/osquery/"
+ #define OSQUERY_CERTS_HOME "/etc/ssl/"
+ #else
+-#define OSQUERY_HOME "/var/osquery/"
+-#define OSQUERY_DB_HOME OSQUERY_HOME
+-#define OSQUERY_SOCKET OSQUERY_DB_HOME
+-#define OSQUERY_PIDFILE OSQUERY_DB_HOME
+-#define OSQUERY_LOG_HOME "/var/log/osquery/"
+-#define OSQUERY_CERTS_HOME OSQUERY_HOME "certs/"
++#define OSQUERY_HOME "@CONFPATH@/"
++#define OSQUERY_DB_HOME "@DATAPATH@/"
++#define OSQUERY_SOCKET "@RUNPATH@/"
++#define OSQUERY_PIDFILE "@RUNPATH@/"
++#define OSQUERY_LOG_HOME "@LOGPATH@/"
++#define OSQUERY_CERTS_HOME "@SHAREPATH@/" "certs/"
+ #endif

--- a/sysutils/osquery/files/patch-lenses-path-augeas.cpp.diff
+++ b/sysutils/osquery/files/patch-lenses-path-augeas.cpp.diff
@@ -1,0 +1,11 @@
+--- osquery/tables/system/posix/augeas.cpp	2020-04-30 22:18:48.000000000 -0400
++++ osquery/tables/system/posix/augeas.cpp	2020-04-30 22:19:13.000000000 -0400
+@@ -29,7 +29,7 @@
+ #ifdef __APPLE__
+ FLAG(string,
+      augeas_lenses,
+-     "/private/var/osquery/lenses",
++     "@SHAREPATH@/lenses",
+      "Directory that contains augeas lenses files");
+ #else
+ FLAG(string,

--- a/sysutils/osquery/files/patch-macports-cmake-packaging.cmake.diff
+++ b/sysutils/osquery/files/patch-macports-cmake-packaging.cmake.diff
@@ -1,0 +1,37 @@
+--- cmake/packaging.cmake	2020-05-01 01:01:46.000000000 -0400
++++ cmake/packaging.cmake	2020-05-01 01:02:40.000000000 -0400
+@@ -232,28 +232,23 @@
+     file(COPY "${CMAKE_SOURCE_DIR}/tools/deployment/osqueryctl" DESTINATION "${CMAKE_BINARY_DIR}/package/pkg")
+     install(PROGRAMS "${CMAKE_BINARY_DIR}/package/pkg/osqueryctl" DESTINATION bin COMPONENT osquery)
+ 
+-    # /private/var
+-    install(DIRECTORY COMPONENT osquery DESTINATION /private/var/log/osquery)
+-    install(DIRECTORY COMPONENT osquery DESTINATION /private/var/osquery)
++    install(DIRECTORY COMPONENT osquery DESTINATION share/osquery)
+ 
+     install(DIRECTORY "${augeas_lenses_path}" COMPONENT osquery
+-            DESTINATION /private/var/osquery/lenses
++            DESTINATION share/osquery/lenses
+             FILES_MATCHING PATTERN "*.aug"
+             PATTERN "tests" EXCLUDE)
+ 
+     file(COPY "${CMAKE_SOURCE_DIR}/packs" DESTINATION "${CMAKE_BINARY_DIR}/package/pkg")
+-    install(DIRECTORY "${CMAKE_BINARY_DIR}/package/pkg/packs" COMPONENT osquery DESTINATION /private/var/osquery)
++    install(DIRECTORY "${CMAKE_BINARY_DIR}/package/pkg/packs" COMPONENT osquery DESTINATION share/osquery)
+ 
+-    install(FILES "${CMAKE_SOURCE_DIR}/tools/deployment/certs.pem" COMPONENT osquery DESTINATION /private/var/osquery/certs)
++    install(FILES "${CMAKE_SOURCE_DIR}/tools/deployment/certs.pem" COMPONENT osquery DESTINATION share/osquery/certs)
+ 
+     file(COPY "${CMAKE_SOURCE_DIR}/tools/deployment/com.facebook.osqueryd.conf" DESTINATION "${CMAKE_BINARY_DIR}/package/pkg")
+-    install(FILES "${CMAKE_BINARY_DIR}/package/pkg/com.facebook.osqueryd.conf" DESTINATION /private/var/osquery COMPONENT osquery)
+-
+-    file(COPY "${CMAKE_SOURCE_DIR}/tools/deployment/com.facebook.osqueryd.plist" DESTINATION "${CMAKE_BINARY_DIR}/package/pkg")
+-    install(FILES "${CMAKE_BINARY_DIR}/package/pkg/com.facebook.osqueryd.plist" DESTINATION /private/var/osquery COMPONENT osquery)
++    install(FILES "${CMAKE_BINARY_DIR}/package/pkg/com.facebook.osqueryd.conf" DESTINATION share/osquery COMPONENT osquery)
+ 
+     file(COPY "${CMAKE_SOURCE_DIR}/tools/deployment/osquery.example.conf" DESTINATION "${CMAKE_BINARY_DIR}/package/pkg")
+-    install(FILES "${CMAKE_BINARY_DIR}/package/pkg/osquery.example.conf" DESTINATION /private/var/osquery COMPONENT osquery)
++    install(FILES "${CMAKE_BINARY_DIR}/package/pkg/osquery.example.conf" DESTINATION share/osquery COMPONENT osquery)
+   endif()
+ 
+   file(COPY "${CMAKE_SOURCE_DIR}/LICENSE" DESTINATION "${CMAKE_BINARY_DIR}/package")


### PR DESCRIPTION
#### Description
Adds a new port for [osquery](https://osquery.io/)

Addresses: https://trac.macports.org/ticket/59036

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
