### PR TITLE
py-panedr: new port version 0.5.2

### DIFF
--- a/python/py-panedr/Portfile
+++ b/python/py-panedr/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim: fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-panedr
+version             0.5.2
+revision            0
+categories-append   science
+platforms           darwin
+license             LGPL-2.1+
+supported_archs     noarch
+
+python.versions     37 38
+
+maintainers         {gmail.com:giovanni.bussi @GiovanniBussi} openmaintainer
+
+description         Panedr reads a Gromacs EDR file and returns its content as a pandas dataframe.
+long_description    ${description} \
+                    The library exposes one function—the edr_to_df function—that gets the path \
+                    to an EDR file and returns a pandas dataframe.
+
+homepage            https://github.com/jbarnoud/panedr
+
+checksums           rmd160  aab8bda18f35abdd33bde44e962c5b0c5cef2314 \
+                    sha256  45eb926a1176789998f041be4d2bea2ed5b70c6540cbaf8903d82473cfd886b2 \
+                    size    15642174
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools
+    depends_lib-append      port:py${python.version}-pandas \
+                            port:py${python.version}-pbr
+    livecheck.type          none
+
+    depends_test-append     port:py${python.version}-pytest \
+                            port:py${python.version}-six
+    test.run                yes
+    test.cmd                py.test-${python.branch}
+    test.target
+    test.env                PYTHONPATH=${worksrcpath}/build/lib
+}


### PR DESCRIPTION
#### Description

New port. It also supports python 2.7, I am not sure if I should include it or not here.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G4032
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
