### PR TITLE
cfm: Don't set duplicate DESTDIR arg; indicate C language requirement

### DIFF
--- a/sysutils/cfm/Portfile
+++ b/sysutils/cfm/Portfile
@@ -15,6 +15,6 @@ checksums           rmd160  8d479a155a4c7560b6c37519baa2548bb3761cfe \
                     sha256  9b7faaf28f4a0f9c53c1e02ea042e58737dc20f6c11da54b3adc705abb1761d7 \
                     size    71274
 
-destroot.args       DESTDIR=${destdir} PREFIX=${prefix}
+destroot.args       PREFIX=${prefix}
 
 use_configure       no

--- a/sysutils/cfm/Portfile
+++ b/sysutils/cfm/Portfile
@@ -18,3 +18,5 @@ checksums           rmd160  8d479a155a4c7560b6c37519baa2548bb3761cfe \
 destroot.args       PREFIX=${prefix}
 
 use_configure       no
+
+compiler.c_standard 2011


### PR DESCRIPTION
#### Description

This PR makes a couple minor changes to the cfm port:

* Don't set a duplicate DESTDIR arg; MacPorts base already sets it for you in destroot.destdir
* Indicate the C language requirement, matching the flag the build system already adds

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G12034
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
