### PR TITLE
bandwhich: update to 0.14.0

### DIFF
--- a/net/bandwhich/Portfile
+++ b/net/bandwhich/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        imsnif bandwhich 0.13.0
+github.setup        imsnif bandwhich 0.14.0
 categories          net
 platforms           darwin
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
@@ -24,9 +24,9 @@ long_description    bandwhich sniffs a given network interface and records IP \
 github.tarball_from archive
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  84f77f48344164bd856d537b3e5b335b1e95369c \
-                    sha256  42b0411c0a9df0b51fa5bedaa5f04fb001fdf46cd2d7ea9a58c98f4f6e7a15d3 \
-                    size    2994854
+                    rmd160  d57f757bc0c362efd270aabbeaf287efac9d459a \
+                    sha256  9b9eec854bc9fe5ee8e563d3f65b0acd2cb0ae1b014e51f77cbabf990aaa1398 \
+                    size    2993511
 
 destroot {
     xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/${name} ${destroot}${prefix}/bin/
@@ -36,7 +36,6 @@ destroot {
 cargo.crates \
     adler32                          1.0.4  5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2 \
     aho-corasick                     0.7.6  58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d \
-    aho-corasick                    0.6.10  81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5 \
     ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
     arc-swap                         0.4.3  f1a1eca3195b729bbd64e292ef2f5fff6b1c28504fed762ce2b1013dde4d8e92 \
     async-trait                     0.1.21  8b6dd385bb33043b833ba049048d57bdbb4d654a121ed68c71871ca51ff67070 \
@@ -98,8 +97,8 @@ cargo.crates \
     insta                           0.11.0  23f83ab4ee86f38b292f0420c27fd412690a4baa9ea0ad4e3fa624bf34379b76 \
     iovec                            0.1.4  b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e \
     ipconfig                         0.2.1  aa79fa216fbe60834a9c0737d7fcd30425b32d1c58854663e24d4c4b328ed83f \
-    ipnetwork                       0.15.0  bf7762e2b430ad80cbef992a1d4f15a15d9d4068bdd8e57acb0a3d21d0cf7f40 \
     ipnetwork                       0.12.8  70783119ac90828aaba91eae39db32c6c1b8838deea3637e5238efa0130801ab \
+    ipnetwork                       0.16.0  b8eca9f51da27bc908ef3dd85c21e1bbba794edaf94d7841e37356275b82d31e \
     itertools                        0.8.1  87fa75c9dea7b07be3138c49abbb83fd4bea199b5cdc76f9804458edc5da0d6e \
     itoa                             0.4.4  501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f \
     kernel32-sys                     0.2.2  7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d \
@@ -122,7 +121,7 @@ cargo.crates \
     num-traits                       0.2.8  6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32 \
     numtoa                           0.1.0  b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef \
     opaque-debug                     0.2.3  2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c \
-    packet-builder                   0.4.0  c3a4c42f976f5e39b18002d165d238fadb0a897e1252cf96e39109f515e85aa8 \
+    packet-builder                   0.5.0  369f20d8356b3f1cfd362c5b3775d3ca71e0290f259eeff6154420fd06d578d6 \
     parking_lot                      0.9.0  f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252 \
     parking_lot_core                 0.6.2  b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b \
     percent-encoding                 2.1.0  d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
@@ -132,18 +131,14 @@ cargo.crates \
     pest_meta                        2.1.2  df43fd99896fd72c485fe47542c7b500e4ac1e8700bf995544d1317a60ded547 \
     pin-project-lite                 0.1.1  f0af6cbca0e6e3ce8692ee19fb8d734b641899e07b68eb73e9bbbd32f1703991 \
     pin-utils                     0.1.0-alpha.4  5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587 \
-    pnet                            0.23.0  5cf9ef46222a90a9d1e35bb4fa208e1076c6663a02d8ecf3e264fd5001ab6e8e \
-    pnet_bandwhich_fork             0.23.1  e146697b998acfb2491f2524d1570f81f650a017402ce45b99539c5a5935a605 \
-    pnet_base                       0.23.0  f7d818b94d0897cd22f7a18f6c2a94f7ae1dfcedc194bf1665880f6c1155e051 \
-    pnet_base_bandwhich_fork        0.23.0  f0886cdc1878c06687cbee7d3ed5045380e57b164bf69f036570559c07f6de88 \
-    pnet_datalink                   0.23.0  557ff7deb5ad2b35ac17a495d629d64dfeacf02e7f4834974dceb5e2cc544d55 \
-    pnet_datalink_bandwhich_fork    0.23.1  697cdb8110661cb4eea5aa08684ab50b0b2ab9b0ca88e9bcef2aa232f7c41369 \
-    pnet_macros                     0.21.0  5d228096fd739d4e3e60dee9e1e4f07d9ae0f3f309c876834192538748e561e4 \
-    pnet_macros_support             0.23.0  d6158bbc3627b9ce01526f5ff8b9895224a0dc96c27baaf79cda0f703a4898ea \
-    pnet_packet                     0.23.0  7efa93f5572ed735852737232ba7539977799861642aaba05de87b6a03dc0f74 \
-    pnet_sys                        0.23.0  ab2f8311f738773513fc8192a77e8f77461d97333184c23597a23cb9eb0bd0eb \
-    pnet_sys_bandwhich_fork         0.23.0  019c5cdc431afe23ae950d145cdf6cc321a8ef4ece501a4cb92c79c3ed4cdabf \
-    pnet_transport                  0.23.0  40851df523364df420e1c85e4885319656904a189a9352657ececcb3c2314fc0 \
+    pnet                            0.26.0  c62df42dcd72f6f2a658bcf38509f1027df1440ac85f1af4badbe034418302dc \
+    pnet_base                       0.26.0  b7cd5f7e15220afa66b0a9a62841ea10089f39dcaa1c29752c0b22dfc03111b5 \
+    pnet_datalink                   0.26.0  7318ae1d6e0b7fa1e49933233c9473f2b72d3d18b97e70e2716c6415dde5f915 \
+    pnet_macros                     0.26.0  bbbd5c52c6e04aa720400f9c71cd0e8bcb38cd13421d5caabd9035e9efa47de9 \
+    pnet_macros_support             0.26.0  daf9c5c0c36766d0a4da9ab268c0700771b8ec367b9463fd678109fa28463c5b \
+    pnet_packet                     0.26.0  89e26a864d71d0ac51a549cf40283c44ed1b8f98168545638a4730ef9f560283 \
+    pnet_sys                        0.26.0  73f0de0c52609f157b25d79ce24d9016ab1bbf10cde761397200d634a833872c \
+    pnet_transport                  0.26.0  6712ab76534340494d849e3c51c64a6261e4b451337b7c05bd3681e384c48b10 \
     ppv-lite86                       0.2.6  74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b \
     proc-macro-error                 0.2.6  aeccfe4d5d8ea175d5f0e4a2ad0637e0f4121d63bd99d356fb1f39ab2e7c6097 \
     proc-macro-hack                 0.5.11  ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5 \
@@ -171,10 +166,8 @@ cargo.crates \
     rdrand                           0.4.0  678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2 \
     redox_syscall                   0.1.56  2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84 \
     redox_termios                    0.1.1  7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76 \
-    regex                           0.2.11  9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384 \
     regex                            1.3.1  dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd \
     regex-syntax                    0.6.12  11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716 \
-    regex-syntax                     0.5.6  7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7 \
     resolv-conf                      0.6.2  b263b4aa1b5de9ffc0054a2386f96992058bb6870aab516f8cdeb8a667d56dcb \
     rle-decode-fast                  1.0.1  cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac \
     rustc-demangle                  0.1.16  4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783 \
@@ -221,7 +214,6 @@ cargo.crates \
     tui                              0.5.1  4ff64c925f5e20d7a393c598a33b6afc9c9942e7ebc530085588f5b7667ea559 \
     typenum                         1.11.2  6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9 \
     ucd-trie                         0.1.2  8f00ed7be0c1ff1e24f46c3d2af4859f7e863672ba3a6e92e7cff702bf9f06c2 \
-    ucd-util                         0.1.5  fa9b3b49edd3468c0e6565d85783f51af95212b6fa3986a5500954f00b460874 \
     unicode-bidi                     0.3.4  49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5 \
     unicode-normalization            0.1.9  09c8070a9942f5e7cfccd93f490fdebd230ee3c3c9f107cb25bad5351ef671cf \
     unicode-segmentation             1.6.0  e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0 \
@@ -230,7 +222,6 @@ cargo.crates \
     unicode-xid                      0.0.3  36dff09cafb4ec7c8cf0023eb0b686cb6ce65499116a12201c9e11840ca01beb \
     unicode-xid                      0.1.0  fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc \
     url                              2.1.0  75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61 \
-    utf8-ranges                      1.0.4  b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba \
     uuid                             0.8.1  9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11 \
     uuid                             0.7.4  90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a \
     vec_map                          0.8.1  05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
