### PR TITLE
cfm: respect MacPorts settings

### DIFF
--- a/sysutils/cfm/Portfile
+++ b/sysutils/cfm/Portfile
@@ -2,8 +2,10 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           makefile 1.0
 
 github.setup        willeccles cfm 0.6.0 v
+revision            1
 categories          sysutils
 platforms           darwin
 license             MPL-2
@@ -15,8 +17,10 @@ checksums           rmd160  8d479a155a4c7560b6c37519baa2548bb3761cfe \
                     sha256  9b7faaf28f4a0f9c53c1e02ea042e58737dc20f6c11da54b3adc705abb1761d7 \
                     size    71274
 
-destroot.args       PREFIX=${prefix}
+# Makefile sets optimization flag
+configure.optflags
 
-use_configure       no
+# https://github.com/WillEccles/cfm/pull/15
+patchfiles-append   patch-Makefile.diff
 
 compiler.c_standard 2011

--- a/sysutils/cfm/files/patch-Makefile.diff
+++ b/sysutils/cfm/files/patch-Makefile.diff
@@ -1,0 +1,13 @@
+--- Makefile.orig	2020-02-27 12:06:22.000000000 -0700
++++ Makefile	2020-05-04 01:15:38.000000000 -0700
+@@ -5,8 +5,8 @@
+ MANPAGE = cfm.1
+ PREFIX ?= /usr/local
+ 
+-CFLAGS = -O3 -std=c11 -Wall -W -pedantic
+-CPPFLAGS = -D_XOPEN_SOURCE=700
++CFLAGS += -O3 -std=c11 -Wall -W -pedantic
++CPPFLAGS += -D_XOPEN_SOURCE=700
+ 
+ .PHONY: install uninstall clean
+ 


### PR DESCRIPTION
My using the makefile PG, more MacPorts settings are respected.
Fixes https://trac.macports.org/ticket/60428

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4
Xcode 11.4.1 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
