### PR TITLE
tmux: update to 3.1b

### DIFF
--- a/sysutils/tmux/Portfile
+++ b/sysutils/tmux/Portfile
@@ -3,14 +3,14 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    tmux tmux 3.1a
+github.setup    tmux tmux 3.1b
 if {${subport} eq ${name}} {
     revision        0
     conflicts       tmux-devel
 }
 subport tmux-devel {
-    github.setup    tmux tmux 5af694394018940819c0734be9b5fd44df1bf857
-    version         20200429-[string range ${github.version} 0 6]
+    github.setup    tmux tmux a08f1c8c59787408529463c985929e5ae1c67211
+    version         20200504-[string range ${github.version} 0 6]
     revision        0
     conflicts       tmux
 }
@@ -30,14 +30,14 @@ depends_lib     port:libevent port:ncurses
 
 if {${subport} eq ${name}} {
     github.tarball_from     releases
-    checksums               rmd160  b0cb14a79e078ec9ce4f3d6c6a99be57452109d8 \
-                            sha256  10687cbb02082b8b9e076cf122f1b783acc2157be73021b4bedb47e958f4e484 \
-                            size    561121
+    checksums               rmd160  10bd0c871da3fd9c450408c96bbc7231257e40e4 \
+                            sha256  d93f351d50af05a75fe6681085670c786d9504a5da2608e481c47cf5e1486db9 \
+                            size    561152
 }
 subport tmux-devel {
-    checksums               rmd160  43c16b4483a7dc1b238ff2543d154a12371f1b15 \
-                            sha256  709687fc170b765aa376913224af0ab6e83bb184edbca43390ea21beb18c327c \
-                            size    748493
+    checksums               rmd160  c379f7faa81473a610380261d0110ab580c053de \
+                            sha256  6ea3edc022326df0d902b3260c8f568bb0eae49b13e9952338ee8dc700e8e85c \
+                            size    751410
 
     use_autoreconf          yes
     autoreconf.cmd          ./autogen.sh


### PR DESCRIPTION
tmux: update to 3.1b
tmux: update tmux-devel to latest commit (a08f1c8c59787408529463c985929e5ae1c67211)

#### Description

###### Type(s)

- [x] update

###### Tested on

macOS 10.14.6 18G4032
Xcode 11.3.1 11C504

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?