### PR TITLE
syncthing: update to 1.5.0

### DIFF
--- a/net/syncthing/Portfile
+++ b/net/syncthing/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/syncthing/syncthing 1.4.2 v
+go.setup            github.com/syncthing/syncthing 1.5.0 v
 categories          net
 platforms           darwin
 license             MPL-2
@@ -17,9 +17,9 @@ long_description    Syncthing replaces proprietary sync and cloud services \
                     and how it's transmitted over the Internet.
 homepage            https://syncthing.net
 
-checksums           rmd160  0d8ff5d0a1765f161819070f604e90c7712d9a1e \
-                    sha256  672391ae9968b0cd66de6741eef4efa11d3dfd1334b6563de0a2324cf66ffa57 \
-                    size    4792697
+checksums           rmd160  31be3981d663e91c75251348a5825ee53260dbed \
+                    sha256  3ad58fac4449594648f51ac9a01036fc12dd19de4003132d41b56c78af86254b \
+                    size    4797753
 
 build.env-append    GO111MODULE=on
 build.cmd           ${go.bin} run build.go


### PR DESCRIPTION
#### Description
Update syncthing to 1.5.0
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
