### PR TITLE
opencv +java: lower required Java version (again)

### DIFF
--- a/graphics/opencv/Portfile
+++ b/graphics/opencv/Portfile
@@ -275,8 +275,12 @@ variant qt5 conflicts qt4 description {Build with Qt5 Backend support.} {
 
 variant java description {Add Java bindings.} {
     PortGroup               java 1.0
-    java.version            12
-    java.fallback           openjdk12
+    # OpenCV appears to support older Java versions,
+    # and MacPorts users have requested Java 8 support:
+    # see https://trac.macports.org/ticket/60193
+    java.version            1.6+
+    # Use latest LTS Java version as fallback
+    java.fallback           openjdk11
     depends_build-append    port:apache-ant
     configure.args-replace  -DBUILD_opencv_java=OFF \
                             -DBUILD_opencv_java=ON


### PR DESCRIPTION
Unintentionally raised during update to 3.4.10 (d98d7d7369)
Use latest LTS Java as fallback
See: https://trac.macports.org/ticket/60193

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Untested

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
