### PR TITLE
py-spyder:  add py38-spyder subport

### DIFF
--- a/python/py-language-server/Portfile
+++ b/python/py-language-server/Portfile
@@ -22,8 +22,7 @@ checksums           rmd160  4eaee0d0d89ba0f90468acf4be481ee307a14d25 \
                     sha256  59e85f6dbebf43f247f60291b2c48ab36f4b920a5b4cc1b63a6f2041d88f5240 \
                     size    454668
 
-# no support yet for Python 3.8
-python.versions     27 35 36 37
+python.versions     27 35 36 37 38
 
 if {${subport} ne ${name}} {
     depends_lib-append \

--- a/python/py-language-server/files/py38-pyls
+++ b/python/py-language-server/files/py38-pyls
@@ -1,0 +1,1 @@
+${frameworks_dir}/Python.framework/Versions/3.8/bin/pyls

--- a/python/py-python-jsonrpc-server/Portfile
+++ b/python/py-python-jsonrpc-server/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  900bb755841932f6105be186d652aa82c6a7f54f \
                     sha256  c73bf5495c9dd4d2f902755bedeb6da5afe778e0beee82f0e195c4655352fe37 \
                     size    26123
 
-python.versions     27 35 36 37
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-rope/Portfile
+++ b/python/py-rope/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  1475de6cc38de7e1db5644d1423d90cb2a7b1af3 \
                     sha256  55028271ccff9fbea73d90bef28a8575f629815acdcd46f4f8eb14c7890c9542 \
                     size    244571
 
-python.versions     27 35 36 37
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-spyder/Portfile
+++ b/python/py-spyder/Portfile
@@ -34,7 +34,7 @@ checksums           rmd160  8cd2e3c3167563ed3d245e712e5e607d980da7e6 \
                     sha256  469755bc4e023a40507071d4bb613a17eebd18fddfc15306f2ab215340cb3657 \
                     size    11125301
 
-python.versions     27 35 36 37
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
     if {${python.version} in "36 37"} {

--- a/python/py-spyder/files/spyder-38
+++ b/python/py-spyder/files/spyder-38
@@ -1,0 +1,1 @@
+bin/spyder-3.8


### PR DESCRIPTION
* add py38-spyder subport
* add py38 subports for py-language-server, py-python-jsonrpc-server, and py-rope

Closes:  https://trac.macports.org/ticket/60215

#### Description

Although I don't know much about python-language-server, it seems to be working now with python 3.8. I tested py38-spyder, and the iPython console shows help balloons.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
