### PR TITLE
searchfs: fix fspatch workaround for older systems

### DIFF
--- a/sysutils/searchfs/Portfile
+++ b/sysutils/searchfs/Portfile
@@ -25,6 +25,9 @@ variant universal {}
 
 use_configure       no
 
+# this patch should be upstreamed
+patchfiles          patch-searchfs-fsgetpath-availability.diff
+
 build.args          CC="${configure.cc} [get_canonical_archflags cc]"
 
 destroot {

--- a/sysutils/searchfs/files/patch-searchfs-fsgetpath-availability.diff
+++ b/sysutils/searchfs/files/patch-searchfs-fsgetpath-availability.diff
@@ -1,0 +1,26 @@
+--- main.m.orig	2019-09-28 16:15:32.000000000 -0700
++++ main.m	2019-09-28 16:16:19.000000000 -0700
+@@ -43,7 +43,13 @@
+ #include <sys/param.h>
+ #include <sys/attr.h>
+ #include <sys/vnode.h>
++
++#if defined(__has_include)
++#if __has_include(<sys/fsgetpath.h>)
+ #include <sys/fsgetpath.h>
++#endif
++#endif
++
+ #include <sys/mount.h>
+ 
+ struct packed_name_attr {
+--- main.m.orig	2019-09-28 16:23:18.000000000 -0700
++++ main.m	2019-09-28 16:26:51.000000000 -0700
+@@ -471,6 +471,7 @@
+ static ssize_t fsgetpath_compat(char *buf, size_t buflen, fsid_t *fsid, uint64_t obj_id) {
+ #pragma clang diagnostic push
+ #pragma clang diagnostic ignored "-Wpartial-availability"
++#pragma clang diagnostic ignored "-Wimplicit-function-declaration"
+     if (fsgetpathAvailable) {
+         ssize_t size = fsgetpath(buf, buflen, fsid, obj_id);
+         if (size > -1) {


### PR DESCRIPTION
include the header only if it exists
fixes build on older SDKs without the fswatch.h header
don't warn about the implicit function definition

closes: https://trac.macports.org/ticket/59124

this fixes the build on 10.7+
to get 10.6, we'd need the legacysupport fix added as well -- perhaps later?