### PR TITLE
pew and pipenv: Add python38 support

### DIFF
--- a/python/pipenv/Portfile
+++ b/python/pipenv/Portfile
@@ -38,7 +38,6 @@ checksums           rmd160  d38fa3755744a6788d30494547c933bb079d6537 \
                     sha256  81862314929e3e532502e25bab3c6ba969c0cf67dcaa9d63c2c931ee2d61541c \
                     size    5150047
 
-
 python.default_version 38
 
 depends_lib-append \

--- a/python/pipenv/Portfile
+++ b/python/pipenv/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                pipenv
-version             2020.5.28
+version             2020.6.2
 revision            0
 categories-append   devel
 platforms           darwin
@@ -34,9 +34,9 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  d38fa3755744a6788d30494547c933bb079d6537 \
-                    sha256  81862314929e3e532502e25bab3c6ba969c0cf67dcaa9d63c2c931ee2d61541c \
-                    size    5150047
+checksums           rmd160  d0e5b85c0b58486325dedfa15841e525a2f7bc65 \
+                    sha256  7dd49a7345fa5da7843907bab42a996dece474e45dd309dbd7619739dc60478b \
+                    size    5153157
 
 python.default_version 38
 

--- a/python/py-pew/Portfile
+++ b/python/py-pew/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           github 1.0
 PortGroup           select 1.0
 
-revision            1
+revision            2
 
 github.setup        berdario pew 1.2.0
 github.tarball_from releases
@@ -19,7 +19,7 @@ categories          python
 platforms           darwin
 license             MIT
 
-python.versions     35 36 37
+python.versions     35 36 37 38
 
 maintainers         openmaintainer {gmail.com:esafak @esafak}
 description         A tool to manage multiple virtual environments written in pure python

--- a/python/py-pew/files/pew38
+++ b/python/py-pew/files/pew38
@@ -1,0 +1,1 @@
+${frameworks_dir}/Python.framework/Versions/3.8/bin/pew

--- a/python/py-pythonz/Portfile
+++ b/python/py-pythonz/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     35 36 37
+python.versions     35 36 37 38
 
 maintainers         {gmail.com:rubendibattista @rubendibattista} openmaintainer
 description         Python installation manager supporting CPython, Stackless, PyPy and Jython

--- a/python/py-resumable-urlretrieve/Portfile
+++ b/python/py-resumable-urlretrieve/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     35 36 37
+python.versions     35 36 37 38
 
 maintainers         {gmail.com:rubendibattista @rubendibattista} openmaintainer
 description         Small library to fetch files over HTTP and resuming their download


### PR DESCRIPTION
#### Description

Add python38 support to `pew` and its deps
Use `python38` by default for `pipenv`

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
