### PR TITLE
clew: Update to version 20170324

### DIFF
--- a/devel/clew/Portfile
+++ b/devel/clew/Portfile
@@ -4,9 +4,9 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 
-github.setup        martijnberger clew 50751dd62c05a03b2b9c001b9eb6e29e392ee9db
+github.setup        OpenCLWrangler clew 27a6867076c44f7be1620f0a768931de6264b97c
 
-version             20160912
+version             20170324
 categories          devel
 platforms           darwin
 license             BSD
@@ -16,5 +16,6 @@ maintainers         {stromnov @stromnov} openmaintainer
 description         The OpenCL Extension Wrangler Library
 long_description    {*}${description}
 
-checksums           rmd160  727600bf740976003a8947c873453ae597f6f1bc \
-                    sha256  c3bf2d15eacec229b5752a1158a9212cda64f85dfb39c8971aeb8677eba0d964
+checksums           rmd160  65bd3235592df7975ebc161449d9fffd7b25770d \
+                    sha256  6e442642503d53f9d59240a35c2338d2b2a9ddc7e345b386dfed16af3e908362 \
+                    size    23772


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
The newer version of CLEW adds some new preprocessor directives for AMD GPUs.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.11.6 15G22010
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
