### PR TITLE
clew: Update to version 20170324

### DIFF
--- a/devel/clew/Portfile
+++ b/devel/clew/Portfile
@@ -4,9 +4,19 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 
-github.setup        martijnberger clew 50751dd62c05a03b2b9c001b9eb6e29e392ee9db
-
-version             20160912
+name                clew
+set commit_versions [list 20170324          20160912]
+set commit_authors  [list OpenCLWrangler    martijnberger]
+set commit_names    [list \
+    ${name}_[lindex $commit_versions 0] \
+    ${name}_[lindex $commit_versions 1] \
+]
+set commit_hashes   [list \
+    27a6867076c44f7be1620f0a768931de6264b97c \
+    50751dd62c05a03b2b9c001b9eb6e29e392ee9db \
+]
+github.setup        [lindex $commit_authors 0] ${name} [lindex $commit_hashes 0]
+version             [lindex $commit_versions 0]
 categories          devel
 platforms           darwin
 license             BSD
@@ -16,5 +26,55 @@ maintainers         {stromnov @stromnov} openmaintainer
 description         The OpenCL Extension Wrangler Library
 long_description    {*}${description}
 
-checksums           rmd160  727600bf740976003a8947c873453ae597f6f1bc \
-                    sha256  c3bf2d15eacec229b5752a1158a9212cda64f85dfb39c8971aeb8677eba0d964
+foreach n $commit_names {
+    set idx [lsearch -exact $commit_names $n]
+    if {[regexp ${version} $n result]} {
+        set ${n}.master_site \
+            ${github.homepage}/${github.tarball_from}/${git.branch}
+    } else {
+        set ${n}.master_site \
+            https://github.com/[lindex $commit_authors $idx]/${name}/${github.tarball_from}/${git.branch}
+    }
+    set ${n}.distfile ${name}-[lindex $commit_hashes $idx]${extract.suffix}
+}
+github.master_sites ${clew_20170324.master_site}:clew_20170324 \
+                    ${clew_20160912.master_site}:clew_20160912
+distfiles           ${clew_20170324.distfile}:clew_20170324 \
+                    ${clew_20160912.distfile}:clew_20160912
+
+checksums           ${clew_20170324.distfile} \
+                    rmd160  65bd3235592df7975ebc161449d9fffd7b25770d \
+                    sha256  6e442642503d53f9d59240a35c2338d2b2a9ddc7e345b386dfed16af3e908362 \
+                    size    23772 \
+                    ${clew_20160912.distfile} \
+                    rmd160  727600bf740976003a8947c873453ae597f6f1bc \
+                    sha256  c3bf2d15eacec229b5752a1158a9212cda64f85dfb39c8971aeb8677eba0d964 \
+                    size    27303
+
+worksrcdir [lindex $commit_authors 0]-${name}-[string range [lindex $commit_hashes 0] 0 6]
+
+pre-patch {
+    set oldsrcpath ${workpath}/[lindex $commit_authors 1]-${name}-[string range [lindex $commit_hashes 1] 0 6]
+
+    # Copy certain files from the martijnberger source
+    # into the OpenCLWrangler source tree.
+    foreach d [list "" include src] {
+        copy -force \
+             ${oldsrcpath}/$d/CMakeLists.txt \
+             ${worksrcpath}/$d/
+    }
+    foreach f [glob -directory ${oldsrcpath}/clewTest *] {
+        copy -force $f ${worksrcpath}/clewTest/
+    }
+
+    # Build both static and dynamic libraries
+    reinplace "/add_library.*SHARED/a\\
+\\  add_library( clew_static STATIC clew.c )\\
+\\  set_target_properties(clew_static PROPERTIES OUTPUT_NAME clew)\\
+\\  install(TARGETS clew_static\\
+\\    LIBRARY DESTINATION \${CMAKE_INSTALL_PREFIX}/lib\${LIB_SUFFIX})\\
+" \
+        ${worksrcpath}/src/CMakeLists.txt
+}
+
+configure.args      -DBUILD_SHARED_LIBRARY=ON


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
The newer version of CLEW adds some new preprocessor directives for AMD GPUs.

I made some modifications, and this one seems to be much better, as opposed to pull request #7019. At the very least, the compiled library is getting put in the same location as the previous version.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.11.6 15G22010
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->