### PR TITLE
jq: Replace oniguruma5 with oniguruma6

### DIFF
--- a/sysutils/jq/Portfile
+++ b/sysutils/jq/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        stedolan jq 1.6 jq-
-revision            1
+revision            2
 categories          sysutils
 platforms           darwin
 maintainers         {raimue @raimue} \
@@ -20,7 +20,7 @@ long_description\
 homepage            https://stedolan.github.io/jq/
 github.tarball_from releases
 
-depends_lib         port:oniguruma5
+depends_lib         port:oniguruma6
 
 checksums           rmd160  7ae650c881fa14ade87569b7e9cd25a62ee6e4e3 \
                     sha256  5de8c8e29aaa3fb9cc6b47bb27299f271354ebb72514e3accadc7d38b5bbaa72 \


### PR DESCRIPTION
This update will cause a disruption for users and will not have
a straight-forward upgrade path as oniguruma5 and oniguruma6 are
conflicting. As other ports use oniguruma5 as a dependency, I do not
think there will be any better way to handle this.

In case of an error on upgrade, uninstall oniguruma5 first:
```
sudo port uninstall oniguruma5
```

Closes: https://trac.macports.org/ticket/60363

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.12.6 16G2136
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?