### PR TITLE
alacritty: new port

### DIFF
--- a/aqua/alacritty/Portfile
+++ b/aqua/alacritty/Portfile
@@ -1,0 +1,293 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo 1.0
+
+github.setup        alacritty alacritty 0.4.2 v
+categories          aqua shells
+platforms           darwin
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+license             Apache-2
+
+description         A cross-platform, GPU-accelerated terminal emulator
+
+long_description    Alacritty is the fastest terminal emulator in existence. \
+                    Using the GPU for rendering enables optimizations that \
+                    simply aren't possible without it. Alacritty currently \
+                    supports macOS, Linux, BSD, and Windows.
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  78f3f6d98edb35ff4890033a284bf3ef2d7102e2 \
+                    sha256  9810c4d64fef72f2871c1c7e3cc0aca72cb1b79a97149f834ab9a947a00ee637 \
+                    size    1486955
+
+set al_app_name     Alacritty.app
+set al_app_dir      "${applications_dir}/${al_app_name}"
+set al_app_template "extra/osx/${al_app_name}"
+set al_app_bindir   "${al_app_dir}/Contents/MacOS"
+set al_target_dir   "target/${build_arch}-apple-${platforms}/release"
+
+destroot {
+
+    file mkdir "${destroot}${applications_dir}"
+
+    copy "${worksrcpath}/${al_app_template}/" "${destroot}${applications_dir}"
+
+    file mkdir "${destroot}/${al_app_bindir}"
+
+    move "${worksrcpath}/${al_target_dir}/${name}" \
+        "${destroot}${al_app_bindir}"
+}
+
+cargo.crates \
+    adler32                          1.0.4  5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2 \
+    aho-corasick                     0.7.9  d5e63fd144e18ba274ae7095c0197a870a7b9468abc801dd62f190d80817d2ec \
+    andrew                           0.2.1  9b7f09f89872c2b6b29e319377b1fbe91c6f5947df19a25596e121cf19a7b35e \
+    android_glue                     0.2.3  000444226fcff248f2bc4c7625be32c63caccfecc2723a2b9f78a7487a49c407 \
+    ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
+    approx                           0.3.2  f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3 \
+    arc-swap                         0.4.4  d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff \
+    arrayref                         0.3.6  a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544 \
+    arrayvec                         0.5.1  cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8 \
+    arrayvec                        0.4.12  cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9 \
+    atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+    autocfg                          1.0.0  f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d \
+    base64                          0.11.0  b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7 \
+    bindgen                         0.53.1  99de13bb6361e01e493b3db7928085dcc474b7ba4f5481818e53a89d76b8393f \
+    bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
+    blake2b_simd                    0.5.10  d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a \
+    block                            0.1.6  0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a \
+    byteorder                        1.3.4  08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de \
+    bzip2                            0.3.3  42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b \
+    bzip2-sys                     0.1.8+1.0.8  05305b41c5034ff0e93937ac64133d109b5a2660114ec45e9760bc6816d83038 \
+    c2-chacha                        0.2.3  214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb \
+    calloop                          0.4.4  7aa2097be53a00de9e8fc349fea6d76221f398f5c4fa550d420669906962d160 \
+    cc                              1.0.50  95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd \
+    cexpr                            0.3.6  fce5b5fb86b0c57c20c834c1b412fd09c77c8a59b9473f86272709e78874cd1d \
+    cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
+    cgl                              0.3.2  0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff \
+    clang-sys                       0.28.1  81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853 \
+    clap                            2.33.0  5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9 \
+    clipboard-win                    2.2.0  e3a093d6fed558e5fe24c3dfc85a68bb68f1c824f440d3ba5aca189e2998786b \
+    cloudabi                         0.0.3  ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
+    cmake                           0.1.42  81fb25b677f8bf1eb325017cb6bb8452f87969db0fedb4f757b297bee78a7c62 \
+    cocoa                           0.19.1  f29f7768b2d1be17b96158e3285951d366b40211320fb30826a76cb7a0da6400 \
+    constant_time_eq                 0.1.5  245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc \
+    copypasta                        0.6.3  865e9675691e2a7dfc806b16ef2dd5dd536e26ea9b8046519767d79be03aeb6a \
+    core-foundation                  0.6.4  25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d \
+    core-foundation-sys              0.6.2  e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b \
+    core-graphics                   0.17.3  56790968ab1c8a1202a102e6de05fc6e1ec87da99e4e93e9a7d13efbfc1e95a9 \
+    core-text                       13.3.2  db84654ad95211c082cf9795f6f83dc17d0ae6c985ac1b906369dc7384ed346d \
+    core-video-sys                   0.1.3  8dc065219542086f72d1e9f7aadbbab0989e980263695d129d502082d063a9d0 \
+    crc32fast                        1.2.0  ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1 \
+    crossbeam-utils                  0.7.2  c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8 \
+    deflate                         0.7.20  707b6a7b384888a70c8d2e8650b3e60170dfc6a67bb4aa67b6dfca57af4bedb4 \
+    dirs                             2.0.2  13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3 \
+    dirs-sys                         0.3.4  afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b \
+    dispatch                         0.2.0  bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b \
+    dlib                             0.4.1  77e51249a9d823a4cb79e3eca6dcd756153e8ed0157b6c04775d04bf1b13b76a \
+    downcast-rs                      1.1.1  52ba6eb47c2131e784a38b726eb54c1e1484904f013e576a25354d0124161af6 \
+    dtoa                             0.4.5  4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3 \
+    dwrote                           0.9.0  0bd1369e02db5e9b842a9b67bce8a2fcc043beafb2ae8a799dd482d46ea1ff0d \
+    embed-resource                   1.3.1  bbaba4684ab0af1cbb3ef0b1f540ddc4b57b31940c920ea594efe09ab86e2a6c \
+    env_logger                       0.7.1  44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36 \
+    euclid                          0.20.7  3f852d320142e1cceb15dccef32ed72a9970b83109d8a4e24b1ab04d579f485d \
+    expat-sys                        2.1.6  658f19728920138342f68408b7cf7644d90d4784353d8ebc32e7e8663dbe45fa \
+    filetime                         0.2.8  1ff6d4dab0aa0c8e6346d46052e93b13a16cf847b54ed357087c35011048cc7d \
+    flate2                          1.0.13  6bd6d6f4752952feb71363cffc9ebac9411b75b87c6ab6058c40c8900cf43c0f \
+    fnv                              1.0.6  2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3 \
+    foreign-types                    0.3.2  f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1 \
+    foreign-types                    0.5.0  d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965 \
+    foreign-types-macros             0.2.1  63f713f8b2aa9e24fec85b0e290c56caee12e3b6ae0aeeda238a75b28251afd6 \
+    foreign-types-shared             0.1.1  00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b \
+    foreign-types-shared             0.3.0  7684cf33bb7f28497939e8c7cf17e3e4e3b8d9a0080ffa4f8ae2f515442ee855 \
+    freetype-rs                     0.23.0  ad4e4ba31012a428040fde05907b42ee7d62b093457f4b2280a0294e0835d61b \
+    freetype-sys                     0.9.0  7dc687b58f0c77150b0aca7d9a1dc93522303570458e1aa36b4fb367584f60c4 \
+    fsevent                          0.4.0  5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6 \
+    fsevent-sys                      2.0.1  f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0 \
+    fuchsia-zircon                   0.3.3  2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
+    fuchsia-zircon-sys               0.3.3  3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
+    getrandom                       0.1.14  7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb \
+    gl_generator                    0.14.0  1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d \
+    gl_generator                    0.13.1  ca98bbde17256e02d17336a6bdb5a50f7d0ccacee502e191d3e3d0ec2f96f84a \
+    glob                             0.3.0  9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574 \
+    glutin                          0.24.0  611023dea5047f3e9047aecb9e361852dcfd0881129daf5d110106ca2b14f3f3 \
+    glutin_egl_sys                   0.1.4  772edef3b28b8ad41e4ea202748e65eefe8e5ffd1f4535f1219793dbb20b3d4c \
+    glutin_emscripten_sys            0.1.1  80de4146df76e8a6c32b03007bc764ff3249dcaeb4f675d68a06caf1bac363f1 \
+    glutin_gles2_sys                 0.1.4  07e853d96bebcb8e53e445225c3009758c6f5960d44f2543245f6f07b567dae0 \
+    glutin_glx_sys                   0.1.6  08c243de74d6cf5ea100c788826d2fb9319de315485dd4b310811a663b3809c3 \
+    glutin_wgl_sys                   0.1.4  a93dba7ee3a0feeac0f437141ff25e71ce2066bcf1a706acab1559ffff94eb6a \
+    hermit-abi                       0.1.8  1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8 \
+    http_req                         0.5.5  ef9a6b5b2cd80630d9c6bda175408a86908d8a9c1eb5b2857206529d88d063a3 \
+    humantime                        1.3.0  df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f \
+    idna                             0.2.0  02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9 \
+    image                           0.22.5  08ed2ada878397b045454ac7cfb011d73132c59f31a955d230bd1f1c2e68eb4a \
+    inflate                          0.4.5  1cdb29978cc5797bd8dcc8e5bf7de604891df2a8dc576973d71a281e916db2ff \
+    inotify                          0.7.0  24e40d6fd5d64e2082e0c796495c8ef5ad667a96d03e5aaa0becfd9d47bcbfb8 \
+    inotify-sys                      0.1.3  e74a1aa87c59aeff6ef2cc2fa62d41bc43f54952f55652656b18a02fd5e356c0 \
+    instant                          0.1.2  6c346c299e3fe8ef94dc10c2c0253d858a69aac1245157a3bf4125915d528caf \
+    iovec                            0.1.4  b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e \
+    itoa                             0.4.5  b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e \
+    jobserver                       0.1.21  5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2 \
+    kernel32-sys                     0.2.2  7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d \
+    khronos_api                      3.1.0  e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    lazycell                         1.2.1  b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f \
+    lexical-core                     0.6.2  d7043aa5c05dd34fb73b47acb8c3708eac428de4545ea3682ed2f11293ebd890 \
+    libc                            0.2.67  eb147597cdf94ed43ab7a9038716637d2d1bf2bc571da995d0028dec06bd3018 \
+    libloading                       0.5.2  f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753 \
+    libz-sys                        1.0.25  2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe \
+    line_drawing                     0.7.0  5cc7ad3d82c845bdb5dde34ffdcc7a5fb4d2996e1e1ee0f19c33bc80e15196b9 \
+    linked-hash-map                  0.5.2  ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83 \
+    lock_api                         0.3.3  79b2de95ecb4691949fea4716ca53cdbcfccb2c612e19644a8bad05edcf9f47b \
+    log                              0.4.8  14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7 \
+    malloc_buf                       0.0.6  62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb \
+    matches                          0.1.8  7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
+    maybe-uninit                     2.0.0  60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00 \
+    memchr                           2.3.3  3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400 \
+    memmap                           0.7.0  6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b \
+    miniz_oxide                      0.3.6  aa679ff6578b1cddee93d7e82e263b94a575e0bfced07284eb0c037c1d2416a5 \
+    mio                             0.6.21  302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f \
+    mio-anonymous-pipes              0.1.0  f8c274c3c52dcd1d78c5d7ed841eca1e9ea2db8353f3b8ec25789cc62c471aaf \
+    mio-extras                       2.0.6  52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19 \
+    mio-named-pipes                  0.1.6  f5e374eff525ce1c5b7687c4cef63943e7686524a387933ad27ca7ec43779cb3 \
+    miow                             0.2.1  8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919 \
+    miow                             0.3.3  396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226 \
+    native-tls                       0.2.3  4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e \
+    net2                            0.2.33  42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88 \
+    nix                             0.14.1  6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce \
+    nix                             0.16.1  dd0eaf8df8bab402257e0a5c17a254e4cc1f72a93588a1ddfb5d356c801aa7cb \
+    nodrop                          0.1.14  72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb \
+    nom                              4.2.3  2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6 \
+    nom                              5.1.1  0b471253da97532da4b61552249c521e01e736071f71c1a4f7ebbfbf0a06aad6 \
+    notify                          4.0.15  80ae4a7688d1fab81c5bf19c64fc8db920be8d519ce6336ed4e7efe024724dbd \
+    num-integer                     0.1.42  3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba \
+    num-iter                        0.1.40  dfb0800a0291891dd9f4fe7bd9c19384f98f7fbe0cd0f39a2c6b88b9868bbc00 \
+    num-rational                     0.2.3  da4dc79f9e6c81bef96148c8f6b8e72ad4541caa4a24373e900a36da07de03a3 \
+    num-traits                      0.2.11  c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096 \
+    objc                             0.2.7  915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1 \
+    objc-foundation                  0.1.1  1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9 \
+    objc_id                          0.1.1  c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b \
+    openssl                        0.10.28  973293749822d7dd6370d6da1e523b0d1db19f06c459134c658b2a4261378b52 \
+    openssl-probe                    0.1.2  77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de \
+    openssl-sys                     0.9.54  1024c0a59774200a555087a6da3f253a9095a5f344e353b212ac4c8b8e450986 \
+    ordered-float                    1.0.2  18869315e81473c951eb56ad5558bbc56978562d3ecfb87abb7a1e944cea4518 \
+    osmesa-sys                       0.1.2  88cfece6e95d2e717e0872a7f53a8684712ad13822a7979bc760b9c77ec0013b \
+    parking_lot                      0.9.0  f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252 \
+    parking_lot                     0.10.0  92e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc \
+    parking_lot_core                 0.7.0  7582838484df45743c8434fbff785e8edf260c28748353d44bc0da32e0ceabf1 \
+    parking_lot_core                 0.6.2  b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b \
+    peeking_take_while               0.1.2  19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099 \
+    percent-encoding                 2.1.0  d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
+    phf                              0.8.0  3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12 \
+    phf_codegen                      0.8.0  cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815 \
+    phf_generator                    0.8.0  17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526 \
+    phf_shared                       0.8.0  c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7 \
+    pkg-config                      0.3.17  05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677 \
+    png                             0.15.3  ef859a23054bbfee7811284275ae522f0434a3c8e7f4b74bd4a35ae7e1c4a283 \
+    podio                            0.1.6  780fb4b6698bbf9cf2444ea5d22411cef2953f0824b98f33cf454ec5615645bd \
+    ppv-lite86                       0.2.6  74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b \
+    proc-macro2                     0.4.30  cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759 \
+    proc-macro2                      1.0.9  6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435 \
+    quick-error                      1.2.3  a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0 \
+    quote                           0.6.13  6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1 \
+    quote                            1.0.3  2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f \
+    rand                             0.7.3  6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
+    rand_chacha                      0.2.1  03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853 \
+    rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
+    rand_hc                          0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
+    rand_pcg                         0.2.1  16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429 \
+    raw-window-handle                0.3.3  0a441a7a6c80ad6473bd4b74ec1c9a4c951794285bf941c2126f607c72e48211 \
+    redox_syscall                   0.1.56  2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84 \
+    redox_users                      0.3.4  09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431 \
+    regex                            1.3.4  322cf97724bea3ee221b78fe25ac9c46114ebb51747ad5babd51a2fc6a8235a8 \
+    regex-syntax                    0.6.15  7246cd0a0a6ec2239a5405b2b16e3f404fa0dcc6d28f5f5b877bf80e33e0f294 \
+    remove_dir_all                   0.5.2  4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e \
+    rust-argon2                      0.7.0  2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017 \
+    rustc-hash                       1.1.0  08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2 \
+    rustc_tools_util                 0.2.0  b725dadae9fabc488df69a287f5a99c5eaf5d10853842a8a3dfac52476f544ee \
+    rustc_version                    0.2.3  138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a \
+    rusttype                         0.7.9  310942406a39981bed7e12b09182a221a29e0990f3e7e0c971f131922ed135d5 \
+    rusttype                         0.8.2  14a911032fb5791ccbeec9f28fdcb9bf0983b81f227bafdfd227c658d0731c8a \
+    ryu                              1.0.2  bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8 \
+    same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
+    schannel                        0.1.17  507a9e6e8ffe0a4e0ebb9a10293e62fdf7657c06f1b8bb07a8fcf697d2abf295 \
+    scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
+    security-framework               0.3.4  8ef2429d7cefe5fd28bd1d2ed41c944547d4ff84776f5935b456da44593a16df \
+    security-framework-sys           0.3.3  e31493fc37615debb8c5090a7aeb4a9730bc61e77ab10b9af59f1a202284f895 \
+    semver                           0.9.0  1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403 \
+    semver-parser                    0.7.0  388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
+    serde                          1.0.104  414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449 \
+    serde_derive                   1.0.104  128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64 \
+    serde_json                      1.0.48  9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25 \
+    serde_yaml                      0.8.11  691b17f19fc1ec9d94ec0b5864859290dff279dbd7b03f017afda54eb36c3c35 \
+    servo-fontconfig                 0.4.0  a088f8d775a5c5314aae09bd77340bc9c67d72b9a45258be34c83548b4814cd9 \
+    servo-fontconfig-sys             4.0.9  62b3e166450f523f4db06c14f02a2d39e76d49b5d8cbd224338d93e3595c156c \
+    shared_library                   0.1.9  5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11 \
+    shlex                            0.1.1  7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2 \
+    signal-hook                     0.1.13  10b9f3a1686a29f53cfd91ee5e3db3c12313ec02d33765f02c1a9645a1811e2c \
+    signal-hook-registry             1.2.0  94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41 \
+    siphasher                        0.3.1  83da420ee8d1a89e640d0948c646c1c088758d3a3c538f943bfa97bdac17929d \
+    slab                             0.4.2  c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8 \
+    smallvec                         1.2.0  5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc \
+    smallvec                        0.6.13  f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6 \
+    smithay-client-toolkit           0.6.6  421c8dc7acf5cb205b88160f8b4cc2c5cfabe210e43b2f80f009f4c1ef910f1d \
+    smithay-clipboard                0.4.0  917e8ec7f535cd1a6cbf749c8866c24d67c548a80ac48c8e88a182eab5c07bd1 \
+    socket2                         0.3.11  e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85 \
+    spsc-buffer                      0.1.1  be6c3f39c37a4283ee4b43d1311c828f2e1fb0541e76ea0cb1a2abd9ef2f5b3b \
+    static_assertions                0.3.4  7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3 \
+    stb_truetype                     0.3.1  f77b6b07e862c66a9f3e62a07588fee67cd90a9135a2b942409f195507b4fb51 \
+    strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
+    syn                             1.0.16  123bd9499cfb380418d509322d7a6d52e5315f064fe4b3ad18a53d6b92c07859 \
+    tempfile                         3.1.0  7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9 \
+    termcolor                        1.1.0  bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f \
+    terminfo                         0.7.1  98d3e0d7e9382dc58238ca33e9a945242409fd6f90b06958638787355a9da03d \
+    textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
+    thread_local                     1.0.1  d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14 \
+    time                            0.1.42  db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f \
+    unicase                          2.6.0  50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6 \
+    unicode-bidi                     0.3.4  49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5 \
+    unicode-normalization           0.1.12  5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4 \
+    unicode-width                    0.1.7  caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479 \
+    unicode-xid                      0.2.0  826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c \
+    unicode-xid                      0.1.0  fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc \
+    url                              2.1.1  829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb \
+    urlocator                        0.1.3  317bb1e85e87e72c11cb9cda7cb8909ca174a21d0abeb0f6955b8f6b0178b164 \
+    utf8parse                        0.2.0  936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372 \
+    vcpkg                            0.2.8  3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168 \
+    vec_map                          0.8.1  05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a \
+    version_check                    0.9.1  078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce \
+    version_check                    0.1.5  914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd \
+    void                             1.0.2  6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d \
+    vswhom                           0.1.0  be979b7f07507105799e854203b470ff7c78a1639e330a58f183b5fea574608b \
+    vswhom-sys                       0.1.0  fc2f5402d3d0e79a069714f7b48e3ecc60be7775a2c049cb839457457a239532 \
+    vte                              0.7.1  8299f6cd1505d50a633aa31b4088aeffe511099d8c7bc38e5d3669379a08a2b8 \
+    vte_generate_state_changes       0.1.1  d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff \
+    walkdir                          2.3.1  777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d \
+    wasi                          0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
+    wayland-client                  0.23.6  af1080ebe0efabcf12aef2132152f616038f2d7dcbbccf7b2d8c5270fe14bcda \
+    wayland-commons                 0.23.6  bb66b0d1a27c39bbce712b6372131c6e25149f03ffb0cd017cf8f7de8d66dbdb \
+    wayland-protocols               0.23.6  6cc286643656742777d55dc8e70d144fa4699e426ca8e9d4ef454f4bf15ffcf9 \
+    wayland-scanner                 0.23.6  93b02247366f395b9258054f964fe293ddd019c3237afba9be2ccbe9e1651c3d \
+    wayland-sys                     0.23.6  d94e89a86e6d6d7c7c9b19ebf48a03afaac4af6bc22ae570e9a24124b75358f4 \
+    which                            3.1.0  5475d47078209a02e60614f7ba5e645ef3ed60f771920ac1906d7c1cc65024c8 \
+    winapi                           0.3.8  8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6 \
+    winapi                           0.2.8  167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
+    winapi-build                     0.1.1  2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                      0.1.3  4ccfbf554c6ad11084fb7517daca16cfdcaccbdadba4fc336f032a8b12c2ad80 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    winit                           0.22.0  02e9092b71b48ad6a0d98835a786308d10760cc09369d02e4a166608327f1f26 \
+    winpty                           0.2.0  92c5a39bb2408a307dd5ab774039ec3f2c68d052970ae4dacc346101abe202b2 \
+    winpty-sys                       0.5.0  ed8a179a59760dc51d30b5e6eaf1bd6da88461f72f2616e962ddebef7e413210 \
+    winreg                           0.6.2  b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9 \
+    ws2_32-sys                       0.2.1  d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e \
+    x11-clipboard                    0.5.1  e5e937afd03b64b7be4f959cc044e09260a47241b71e56933f37db097bf7859d \
+    x11-dl                          2.18.5  2bf981e3a5b3301209754218f962052d4d9ee97e478f4d26d4a6eced34c1fef8 \
+    xcb                              0.9.0  62056f63138b39116f82a540c983cc11f1c90cd70b3d492a70c25eaa50bd22a6 \
+    xdg                              2.2.0  d089681aa106a86fade1b0128fb5daf07d5867a509ab036d99988dec80429a57 \
+    xml-rs                           0.8.0  541b12c998c5b56aa2b4e6f18f03664eef9a4fd0a246a55594efae6cc2d964b5 \
+    yaml-rust                        0.4.3  65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d \
+    zip                              0.5.5  6df134e83b8f0f8153a094c7b0fd79dfebe437f1d76e7715afa18ed95ebe2fd7


### PR DESCRIPTION
#### Description

New port for [Alacritty](https://github.com/alacritty/alacritty)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
