### PR TITLE
chezmoi: update to 1.8.1

### DIFF
--- a/sysutils/chezmoi/Portfile
+++ b/sysutils/chezmoi/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/twpayne/chezmoi 1.8.0 v
+go.setup            github.com/twpayne/chezmoi 1.8.1 v
 
 categories          sysutils
 license             MIT
@@ -11,9 +11,9 @@ installs_libs       no
 
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
 
-checksums           rmd160  c67021cbdda94dcab7097640f18e25667dcd6099 \
-                    sha256  484de97033cba85ab09384a8783190f8da20d5ce7e76d44218b981ab862403ae \
-                    size    2082823
+checksums           rmd160  9f05c1261867e38d3a5ca7222fc455013c3b70f1 \
+                    sha256  759deceb78c4b8a073d39f6f64bb575623b0fed60e39752cb2fb8aa5dafd36a5 \
+                    size    2217165
 
 homepage            https://chezmoi.io/
 
@@ -21,6 +21,8 @@ description         Manage your dotfiles across multiple machines, securely.
 
 long_description    chezmoi helps you manage your personal configuration \
                     files (dotfiles, like ~/.bashrc) across multiple machines.
+
+build.args          -ldflags \"-X main.version=${version} -X main.builtBy=macports\"
 
 set cm_doc_dir      ${prefix}/share/doc/${name}
 


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
