### PR TITLE
xorg-server: add xcsecurity variant to enable the security extension

### DIFF
--- a/x11/xorg-server/Portfile
+++ b/x11/xorg-server/Portfile
@@ -137,6 +137,10 @@ platform macosx {
         }
 }
 
+variant xcsecurity description "Enable Security Extensions" {
+    configure.args-append  --enable-xcsecurity
+}
+
 variant docs description "Install extra documentation" {
         depends_build-append \
                 port:doxygen \


### PR DESCRIPTION
#### Description

Adds optional variant to enable the security extension. Disabled by default (as it is by upstream), as effectively replaced by XACE, but perhaps useful to some to have option to enable it.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G12034
Xcode 10.1 10B61
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
