### PR TITLE
MacPass: new port

### DIFF
--- a/security/MacPass/Portfile
+++ b/security/MacPass/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        MacPass MacPass 0.7.12
+
+categories          security
+platforms           darwin
+license             GPL-3
+maintainers         {@sikmir gmail.com:sikmir} openmaintainer
+
+description         A native OS X KeePass client
+long_description    MacPass is an attempt to create a native macOS port of KeePass \
+                    on a solid open source foundation with a vibrant community \
+                    pushing it further to become the best KeePass client for macOS.
+
+homepage            https://macpassapp.org/
+
+checksums           rmd160  733dffa7083ff8132ba88a5260492874b5cb2b30 \
+                    sha256  acde7f51fd0b6529553e1e4ad4a7cbc137096bd355987bb5f4fb869f578f33be \
+                    size    6384553
+
+master_sites        ${github.homepage}/releases/download/${version}
+
+extract.mkdir       yes
+
+use_configure       no
+use_zip             yes
+
+build {}
+
+destroot {
+    copy ${worksrcpath}/MacPass.app ${destroot}${applications_dir}
+}


### PR DESCRIPTION
#### Description

[MacPass](https://github.com/MacPass/MacPass) - a native OS X KeePass client.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
