### PR TITLE
JOSM: new port

### DIFF
--- a/gis/JOSM/Portfile
+++ b/gis/JOSM/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                JOSM
+version             16239
+categories          gis editors java
+platforms           darwin
+license             GPL-2+
+supported_archs     i386 x86_64
+
+maintainers         {@sikmir gmail.com:sikmir} openmaintainer
+
+description         An extensible editor for OpenStreetMap
+long_description    ${name} is a feature-rich editor for the \
+                    experienced OSM mappers.
+homepage            https://josm.openstreetmap.de
+
+master_sites        ${homepage}/download/macosx/
+distname            josm-macosx-${version}
+
+checksums           rmd160  d80e13f48a71f8b484b08282a54946e7101badd4 \
+                    sha256  0c008bce6fa4f0e8dfc616282dcc3c0b824afd45914adf3584e1bac6770e9cda \
+                    size    14296718
+
+extract.mkdir       yes
+
+use_configure       no
+use_zip             yes
+
+build {}
+
+destroot {
+    copy ${worksrcpath}/JOSM.app ${destroot}${applications_dir}
+}


### PR DESCRIPTION
#### Description
[JOSM](https://josm.openstreetmap.de/) - extensible editor for OpenStreetMap.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
