### PR TITLE
prometheus: update to 2.18.1

### DIFF
--- a/net/prometheus/Portfile
+++ b/net/prometheus/Portfile
@@ -1,7 +1,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        prometheus prometheus 2.18.0 v
+github.setup        prometheus prometheus 2.18.1 v
 github.tarball_from archive
 
 description         The Prometheus monitoring system and time series database
@@ -42,9 +42,9 @@ set prom_share_dir  ${prefix}/share/${name}
 set prom_log_dir    ${prefix}/var/log/${name}
 set prom_log_file   ${prom_log_dir}/${name}.log
 
-checksums   rmd160  60461ea95fb82cc5f973c68938a7341e38e63bed \
-            sha256  5eaffd8017309c61e37752599cd53821a4f204a489524e9e520a237d9c471a5c \
-            size    13276295
+checksums   rmd160  299e241601364f0b4c88d342d14bc4e2f107090c \
+            sha256  fffb2e7f1f112b91d5ea7330cf6b5c5270374ea2c7c51beab464c10b9886a699 \
+            size    13277342
 
 add_users           ${prom_user} \
                     group=${prom_user} \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
