### PR TITLE
gdb: Support +python38 variant

### DIFF
--- a/devel/gdb/Portfile
+++ b/devel/gdb/Portfile
@@ -87,7 +87,7 @@ post-destroot {
     }
 }
 
-set pythons_suffixes {27 35 36 37}
+set pythons_suffixes {27 35 36 37 38}
 
 set pythons_ports {}
 foreach s ${pythons_suffixes} {


### PR DESCRIPTION
#### Description

Adds support for Python 3.8. For example,

```
$ gdb
(gdb) python-interactive
>>> import sys
>>> print(sys.version)
3.8.2 (default, Feb 27 2020, 19:56:42)
[Clang 10.0.1 (clang-1001.0.46.4)]
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G103
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? **There are no related tickets.**
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? **gdb has no tests turned on.**
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?