### PR TITLE
wgrib2: Use legacysupport for strnlen

### DIFF
--- a/science/wgrib2/Portfile
+++ b/science/wgrib2/Portfile
@@ -2,6 +2,10 @@
 
 PortSystem          1.0
 PortGroup compilers 1.0
+PortGroup legacysupport 1.0
+
+# strnlen
+legacysupport.newest_darwin_requires_legacy 10
 
 name                wgrib2
 version             2.0.8


### PR DESCRIPTION
Use legacysupport for Darwin 10 and earlier attempting to fix [build failure due to missing strnlen](https://build.macports.org/builders/ports-10.6_x86_64-builder/builds/25849/steps/install-port/logs/stdio).

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
not tested

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
