### PR TITLE
mpfr: Rebuild with newer Xcode 11

### DIFF
--- a/devel/mpfr/Portfile
+++ b/devel/mpfr/Portfile
@@ -11,6 +11,7 @@ PortGroup           compiler_blacklist_versions 1.0
 name                mpfr
 # The actual version is generated below, after patchfiles is defined.
 set base_version    4.0.2
+revision            1
 categories          devel math
 platforms           darwin
 license             LGPL-3+
@@ -56,6 +57,12 @@ if {${patch_level} > 0} {
 # any project that requires a thread-safe mpfr library, therefore the Xcode 4.2 compiler is
 # blacklisted here
 compiler.blacklist  {clang == 211.10.1}
+
+# Early versions of Xcode 11 seem to miscompile mpfr such that compiling
+# i686-w64-mingw32-gcc-nothreads crashes. Xcode 11.3.1 and later seem to
+# be ok. See https://trac.macports.org/ticket/60091
+compiler.blacklist-append \
+                    {clang >= 1100 < 1100.0.33.17}
 
 test.run            yes
 test.target         check


### PR DESCRIPTION
#### Description

mpfr built with early Xcode 11 on Catalina results in some ports including i686-w64-mingw32-gcc-nothreads being unbuildable, so rebuild mpfr and ensure old Xcode 11 clang versions aren't used.

Don't know whether it's early Xcode 11's clang that's the problem or its SDK, but assuming for now it's the former.

Closes: https://trac.macports.org/ticket/60091

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.4 19E287
Command line tools (no Xcode)

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
