### PR TITLE
jtc: update to 1.76

### DIFF
--- a/textproc/jtc/Portfile
+++ b/textproc/jtc/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 
-github.setup        ldn-softdev jtc 1.75d
+github.setup        ldn-softdev jtc 1.76
 github.tarball_from archive
 revision            0
 
@@ -24,9 +24,9 @@ long_description    jtc stand for: JSON test console, but it's a legacy name, \
                     insert new elements, remove, copy, move, compare, \
                     transform and swap around).
 
-checksums           rmd160  2d9829a134299d5730c4ffaf27c8c8658d8b5bc5 \
-                    sha256  e490a754be493660ef4f2e764ea121b5c39b280adf9b4c55d73e4876e8618f04 \
-                    size    206457
+checksums           rmd160  1704af5fb08d4986afbe8a33293117ee79cd479b \
+                    sha256  8524ba3c67364719196ffc8c81078ea9c1ccfa629fff5e57441edd09f1950052 \
+                    size    228445
 
 compiler.cxx_standard 2014
 


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
