### PR TITLE
grass7: fix trac issues

### DIFF
--- a/gis/grass7/Portfile
+++ b/gis/grass7/Portfile
@@ -82,7 +82,7 @@ configure.args-append \
 build.target            default
 
 # Python 3 variants
-set python_suffixes {34 35 36 37 38}
+set python_suffixes {35 36 37 38}
 set python_variants {}
 
 foreach pyver ${python_suffixes} {

--- a/gis/grass7/files/patch-Install_make.diff
+++ b/gis/grass7/files/patch-Install_make.diff
@@ -9,6 +9,15 @@
  		echo "ERROR: Directory $$INST_PATH is a parent directory of your" >&2 ; \
  		echo "  install directory $(INST_DIR) and is not writable." >&2 ; \
  		echo "  Perhaps you need root access." >&2 ; \
+@@ -63,7 +63,7 @@
+ 	fi
+ 
+ install-check-writable:
+-	@ if [ -d "$(INST_DIR)" -a ! -w "$(INST_DIR)" ] ; then \
++	@ if [ -d "$(DESTDIR)$(INST_DIR)" -a ! -w "$(DESTDIR)$(INST_DIR)" ] ; then \
+ 		echo "ERROR: Your install directory $(INST_DIR) is not writable." >&2 ; \
+ 		echo "  Perhaps you need root access." >&2 ; \
+ 		echo "  Installation aborted, exiting Make." >&2 ; \
 @@ -71,7 +71,7 @@
  	fi
  


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
This PR addresses two trac issues:

**_Upgradability_**

Fixes bug introduced with update to 7.8.3, making upgrading fail.

https://trac.macports.org/ticket/60445

**_python34 variant_**

Removes the python34 variant, see https://trac.macports.org/ticket/59953, which depends on sub-ports that have been removed.

```
$ port lint grass7 +python34
--->  Verifying Portfile for grass7
Error: Unknown dependency: py34-Pillow
Error: Unknown dependency: py34-numpy
Error: Unknown dependency: py34-psycopg2
--->  3 errors and 0 warnings found.
```

See also comment on original commit:
https://github.com/macports/macports-ports/commit/216ccac434fb61d04a79762b82d3059c96d75c63#commitcomment-36480013
and subsequent reply by original author.

I'm not sure, should I bump revision too with this?

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6
Xcode 10.2.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
