### PR TITLE
gptfdisk: fix up makefile

### DIFF
--- a/sysutils/gptfdisk/Portfile
+++ b/sysutils/gptfdisk/Portfile
@@ -8,6 +8,8 @@ checksums               rmd160  ada1fa96849dc2654b8cb4b970c47066d8f00463 \
                         sha256  0e7d3987cd0488ecaf4b48761bc97f40b1dc089e5ff53c4b37abe30bc67dcb2f \
                         size    205973
 
+revision                1
+
 categories              sysutils
 platforms               darwin
 license                 GPL-2+
@@ -25,6 +27,8 @@ depends_lib             port:ncurses \
                         port:popt
 
 use_configure           no
+
+patchfiles              patch-gptfdisk-makefile.diff
 
 variant universal {}
 

--- a/sysutils/gptfdisk/files/patch-gptfdisk-makefile.diff
+++ b/sysutils/gptfdisk/files/patch-gptfdisk-makefile.diff
@@ -1,0 +1,33 @@
+--- Makefile.mac.orig	2020-05-08 12:55:24.000000000 -0700
++++ Makefile.mac	2020-05-08 12:57:52.000000000 -0700
+@@ -1,11 +1,11 @@
+ CC=gcc
+ CXX=c++
+ # FATBINFLAGS=-arch x86_64 -arch i386 -mmacosx-version-min=10.9
+-FATBINFLAGS=-arch x86_64 -mmacosx-version-min=10.9
+-THINBINFLAGS=-arch x86_64 -mmacosx-version-min=10.9
+-CFLAGS=$(FATBINFLAGS) -O2 -D_FILE_OFFSET_BITS=64 -g
++FATBINFLAGS=
++THINBINFLAGS=
++CFLAGS=$(FATBINFLAGS) -D_FILE_OFFSET_BITS=64 -g
+ #CXXFLAGS=-O2 -Wall -D_FILE_OFFSET_BITS=64 -D USE_UTF16 -I/opt/local/include -I/usr/local/include -I/opt/local/include -g
+-CXXFLAGS=$(FATBINFLAGS) -O2 -Wall -D_FILE_OFFSET_BITS=64 -stdlib=libc++ -I/opt/local/include -I /usr/local/include -I/opt/local/include -g
++CXXFLAGS=$(FATBINFLAGS) -Wall -D_FILE_OFFSET_BITS=64 -I/opt/local/include -g
+ LIB_NAMES=crc32 support guid gptpart mbrpart basicmbr mbr gpt bsd parttypes attributes diskio diskio-unix
+ MBR_LIBS=support diskio diskio-unix basicmbr mbrpart
+ #LIB_SRCS=$(NAMES:=.cc)
+@@ -21,12 +21,12 @@
+ #	$(CXX) $(LIB_OBJS) -L/usr/lib -licucore gpttext.o gdisk.o -o gdisk
+ 
+ cgdisk: $(LIB_OBJS) cgdisk.o gptcurses.o
+-	$(CXX) $(LIB_OBJS) cgdisk.o gptcurses.o /usr/lib/libncurses.dylib $(LDFLAGS) $(FATBINFLAGS) -o cgdisk
++	$(CXX) $(LIB_OBJS) cgdisk.o gptcurses.o -lncurses $(LDFLAGS) $(FATBINFLAGS) -o cgdisk
+ #	$(CXX) $(LIB_OBJS) cgdisk.o gptcurses.o $(LDFLAGS) -licucore -lncurses -o cgdisk
+ 
+ sgdisk: $(LIB_OBJS) gptcl.o sgdisk.o
+ #	$(CXX) $(LIB_OBJS) gptcl.o sgdisk.o /opt/local/lib/libiconv.a /opt/local/lib/libintl.a /opt/local/lib/libpopt.a $(FATBINFLAGS) -o sgdisk
+-	$(CXX) $(LIB_OBJS) gptcl.o sgdisk.o -L/usr/local/lib -lpopt $(THINBINFLAGS) -o sgdisk
++	$(CXX) $(LIB_OBJS) gptcl.o sgdisk.o -lpopt $(THINBINFLAGS) -o sgdisk
+ #	$(CXX) $(LIB_OBJS) gptcl.o sgdisk.o -L/sw/lib -licucore -lpopt -o sgdisk
+ 
+ fixparts: $(MBR_LIB_OBJS) fixparts.o


### PR DESCRIPTION
stop hard-coding libraries in /usr/lib
stop hard-coding deployement target
stop hard-coding optflags
stop hard-coding archflags
actually use macports ncurses

fixes builds on older systems, and makes
proper builds on all systems

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.6.8
Xcode 4.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
