### PR TITLE
gitlab-runner: update to 12.10.2

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 12.10.1 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 12.10.2 v
 
 categories          devel
 platforms           darwin
@@ -23,9 +23,9 @@ homepage            https://docs.gitlab.com/runner/
 master_sites        https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v${version}/
 distname            gitlab-runner-v${version}
 
-checksums           rmd160  59a33082fa6c5967a0b1b97992a1a9f0ee991d07 \
-                    sha256  2b60061d7c671ae525c97ae7c714cb2de5d979b983455a3f64603835cf32acb5 \
-                    size    7304161
+checksums           rmd160  8c62001231ae5bce79ff9e30b34c112874061935 \
+                    sha256  993a737185b691bfe2ce29827d3329287afdaf3bd17248f5bd7e3447ddad6089 \
+                    size    7307295
 
 # Reproduce the "build_simple" target from the upstream Makefile
 set go_ldflags      "-X ${go.package}/common.NAME=${go.package} \


### PR DESCRIPTION
#### Description

Update to GitLab Runner 12.10.2.

###### Tested on

macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?