### PR TITLE
gerbil: Update to latest master

### DIFF
--- a/science/gerbil/Portfile
+++ b/science/gerbil/Portfile
@@ -3,12 +3,13 @@
 PortSystem          1.0
 PortGroup           cmake 1.0
 PortGroup           github 1.0
+PortGroup           qt5 1.0
 
-github.setup        gerbilvis gerbil 94f704447b5ce2dcd77019a641d96382dcb174a7
-version             2017-02-19-94f7044
-checksums           rmd160  0f56728d486d366ab9bac90bc4057007a5b4bca2 \
-                    sha256  a7fb37313dbacac0fb580296183aa92563bfaa39e11a518965e58320c16270c0 \
-                    size    2304146
+github.setup        gerbilvis gerbil 5a7705fe1170f812a6cd0e79a1a853f4d8aec2cf
+version             2020-05-06-5a7705f
+checksums           rmd160  9b3f9ac2589a4f3b2ae12db6b02fdcd924886ec4 \
+                    sha256  1eb67522c0629a885f940ce333880982528c0ef23ee5a3b27aaddf9facf72d6f \
+                    size    2301204
 
 categories          science
 license             GPL-3
@@ -23,8 +24,7 @@ long_description    \
 
 homepage            http://gerbilvis.org/
 
-depends_lib         port:qt5 \
-                    port:opencv \
+depends_lib         port:opencv4 \
                     port:boost \
                     port:gdal \
                     port:tbb


### PR DESCRIPTION
#### Description

While at it, switch to the qt5 PortGroup to improve support for older
platforms of macOS.

Closes: https://trac.macports.org/ticket/56884

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G4032
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
