### PR TITLE
micronaut: update to 1.3.5

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       java 1.0
 
-github.setup    micronaut-projects micronaut-core 1.3.4 v
+github.setup    micronaut-projects micronaut-core 1.3.5 v
 revision        0
 name            micronaut
 categories      java
@@ -43,9 +43,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        ${name}-${version}
 
-checksums       rmd160  edf49590443fa6cac414e2719867ddafbfc20cf0 \
-                sha256  0a02d9b49b8a41b00fdeb55f4a62664b8aff6f63a1785acbcff1695451551724 \
-                size    13037985
+checksums       rmd160  58f1176f6ebbe6babc44b02819f6ef80b3a73707 \
+                sha256  456ae4f241772465bfafa4e589fb572a761476186f182ec365fcfb0f486b235e \
+                size    13043095
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 1.3.5.

###### Tested on

macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?