### PR TITLE
dblatex: Update to 0.3.11

### DIFF
--- a/textproc/dblatex/Portfile
+++ b/textproc/dblatex/Portfile
@@ -5,8 +5,8 @@ PortGroup           python 1.0
 PortGroup           texlive 1.0
 
 name                dblatex
-version             0.3.10
-revision            3
+version             0.3.11
+revision            0
 categories          textproc tex
 maintainers         {cal @neverpanic} openmaintainer
 license             GPL-2+
@@ -31,8 +31,9 @@ long_description    Dblatex transforms a DocBook XML/SGML document to LaTeX. \
 homepage            http://dblatex.sourceforge.net
 master_sites        sourceforge:project/dblatex/dblatex/dblatex-${version}
 
-checksums           sha256  6fd696b740e0044ae1caf843d225d98c01b6ed916550384544e7e31c0c6a2cfa \
-                    rmd160  b113dc1a04180704e36558039ef1cc9d13900105
+checksums           sha256  7b7e97e275075fa275670b4ed368ef5d352c9aebffc480997e51c747055be166 \
+                    rmd160  dc20fbbe999131b5ce850d7ebd75fe570aadf2d6 \
+                    size    1668043
 
 use_bzip2           yes
 
@@ -47,8 +48,7 @@ depends_lib         port:texlive-latex-extra \
 python.link_binaries no
 python.default_version 27
 
-# this gets assigned before python.bin is set to the version selected by the variant
-#destroot.cmd        ${python.bin} setup.py
+default destroot.cmd {${python.bin} setup.py}
 destroot.destdir    --root=${destroot} \
                     --catalogs=${destroot}${prefix}/etc/xml/catalog
 


### PR DESCRIPTION
#### Description
Update to 0.3.11

Unfortunately this still does not support Python 3.x, but somebody out
there seems to be working on it, so fingers crossed!

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G4032
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
