### PR TITLE
openttd: Update to 1.10.1

### DIFF
--- a/games/openttd/Portfile
+++ b/games/openttd/Portfile
@@ -13,13 +13,13 @@ maintainers         {cal @neverpanic} openmaintainer
 if {${name} eq ${subport}} {
 
     PortGroup           cxx11 1.1
-    
-    version             1.9.2
-    revision            1
-  
-    checksums           rmd160  f8f6c2d99cc741522615c35269e3f8f38943cfab \
-                        sha256  f9ff8c255145a1dd617798a9413179cc740a0cc91709455990880a15eeb7564a \
-                        size    6666860
+
+    version             1.10.1
+    revision            0
+
+    checksums           rmd160  d5549e42fc8c79af68f22c4bb5660724e4d6d588 \
+                        sha256  0d22a3c50f7a321f4f211594f4987ac16c381e8e3e40f116848e63e91e7fbb9b \
+                        size    6741548
 
     license             GPL-2
 
@@ -30,8 +30,8 @@ if {${name} eq ${subport}} {
         mimic the original game as closely as possible while extending it with new \
         features.
 
-    homepage            http://www.openttd.org/en/
-    master_sites        https://proxy.binaries.openttd.org/openttd-releases/${version}
+    homepage            https://www.openttd.org/en/
+    master_sites        https://cdn.openttd.org/openttd-releases/${version}
     distfiles           openttd-${version}-source.tar.xz
     use_xz              yes
 
@@ -85,10 +85,10 @@ if {${name} eq ${subport}} {
 }
 
 subport openttd-opengfx {
-    version             0.5.5
-    checksums           rmd160  7c5f7180f806d520593565e3a0243975d2317183 \
-                        sha256  c648d56c41641f04e48873d83f13f089135909cc55342a91ed27c5c1683f0dfe \
-                        size    3548368
+    version             0.6.0
+    checksums           rmd160  6ef0cbd399b3a4e117a70e723c072ed694b7517f \
+                        sha256  d419c0f5f22131de15f66ebefde464df3b34eb10e0645fe218c59cbc26c20774 \
+                        size    3551230
 
     supported_archs     noarch
     license             GPL-2
@@ -99,13 +99,13 @@ subport openttd-opengfx {
         graphics so that OpenTTD can be shipped finally fully functional \
         without the need for additional downloads.
 
-    homepage            http://dev.openttdcoop.org/projects/opengfx
-    master_sites        https://binaries.openttd.org/extra/opengfx/${version}
+    homepage            https://github.com/OpenTTD/OpenGFX
+    master_sites        https://cdn.openttd.org/opengfx-releases/${version}
     distfiles           opengfx-${version}-all.zip
     worksrcdir          opengfx-${version}
     use_zip             yes
 
-    # for some reason, the opengfx-0.5.0-all.zip file contains a tarball
+    # for some reason, the opengfx-${version}-all.zip file contains a tarball
     post-extract {
         system -W ${workpath} "tar xf opengfx-${version}.tar"
     }
@@ -143,8 +143,8 @@ subport openttd-opensfx {
         so that OpenTTD can be shipped finally fully functional without the \
         need for non-free files.
 
-    homepage            http://dev.openttdcoop.org/projects/opensfx
-    master_sites        https://binaries.openttd.org/extra/opensfx/${version}
+    homepage            https://github.com/OpenTTD/OpenSFX
+    master_sites        https://cdn.openttd.org/opensfx-releases/${version}
     distfiles           opensfx-${version}-all.zip
     worksrcdir          opensfx-${version}
     use_zip             yes
@@ -181,8 +181,8 @@ subport openttd-openmsx {
         so that OpenTTD can be shipped finally fully functional without the \
         need for non-free files.
 
-    homepage            http://dev.openttdcoop.org/projects/openmsx
-    master_sites        https://binaries.openttd.org/extra/openmsx/${version}
+    homepage            https://github.com/OpenTTD/OpenMSX
+    master_sites        https://cdn.openttd.org/openmsx-releases/${version}
     distfiles           openmsx-${version}-all.zip
     worksrcdir          openmsx-${version}
     use_zip             yes

--- a/games/openttd/files/patch-name_conflict.diff
+++ b/games/openttd/files/patch-name_conflict.diff
@@ -1,6 +1,6 @@
---- src/string.cpp.orig	2019-07-07 13:57:48.000000000 -0700
-+++ src/string.cpp	2019-10-04 03:42:57.000000000 -0700
-@@ -33,10 +33,6 @@
+--- ./src/string.cpp.orig	2020-04-13 21:02:12.000000000 +0200
++++ ./src/string.cpp	2020-05-09 22:43:02.000000000 +0200
+@@ -31,10 +31,6 @@
  #include "os/windows/string_uniscribe.h"
  #endif
  
@@ -8,12 +8,12 @@
 -#include "os/macosx/string_osx.h"
 -#endif
 -
- #ifdef WITH_ICU_SORT
+ #ifdef WITH_ICU_I18N
  /* Required by strnatcmp. */
  #include <unicode/ustring.h>
-@@ -44,6 +40,10 @@
+@@ -42,6 +38,10 @@
  #include "gfx_func.h"
- #endif /* WITH_ICU_SORT */
+ #endif /* WITH_ICU_I18N */
  
 +#if defined(WITH_COCOA)
 +#include "os/macosx/string_osx.h"


### PR DESCRIPTION
#### Description

openttd-opengfx: Update to 0.6.0
Modernize all URLs.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G4032
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?