### PR TITLE
mpfr: use xcode_workaround PG

### DIFF
--- a/devel/mpfr/Portfile
+++ b/devel/mpfr/Portfile
@@ -7,10 +7,12 @@ PortSystem          1.0
 # due to the variable HAVE_LDOUBLE_IEEE_EXT_LITTLE.
 PortGroup           muniversal 1.0
 PortGroup           compiler_blacklist_versions 1.0
+PortGroup           xcode_workaround 1.0
 
 name                mpfr
 # The actual version is generated below, after patchfiles is defined.
 set base_version    4.0.2
+revision            1
 categories          devel math
 platforms           darwin
 license             LGPL-3+
@@ -36,6 +38,9 @@ checksums           ${distname}${extract.suffix} \
                         rmd160  14fb12027e7be8d4aa84b8cb8d8dc8769c35b899 \
                         sha256  1d3be708604eae0e42d578ba93b390c2a145f17743a744d8f3f8c2ad5855a38a \
                         size    1441996
+
+# see https://trac.macports.org/ticket/60091
+xcode_workaround.fixed_xcode_version 11.2
 
 # Upstream patch names are not qualified with the base version.
 dist_subdir         ${name}/${base_version}


### PR DESCRIPTION
Closes https://trac.macports.org/ticket/60091

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.2
Xcode 11.2 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
