### PR TITLE
skaffold: update to 1.9.1

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -1,9 +1,9 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 
-name                skaffold
-version             1.7.0
+github.setup        GoogleContainerTools skaffold 1.9.1 v
 revision            0
 
 categories          devel
@@ -21,21 +21,40 @@ long_description    Skaffold is a command line tool that facilitates continuous 
 
 homepage            https://skaffold.dev
 
-master_sites        https://github.com/GoogleContainerTools/${name}/releases/download/v${version}/
-distfiles           ${name}-${os.platform}-amd64
+github.tarball_from archive
 
-checksums           rmd160  f3380ad37b8dbb010652e6930444c9a9c548a2f1 \
-                    sha256  3302914e3e59ee84f86b1520fd57ec7afbc2e22b6c20e1ea7ae8f648fd2b260f \
-                    size    43120524
+checksums           rmd160  a050dc600e299ba21f3fc379ab3a0dd3be83b61d \
+                    sha256  2fa0d499e253fa5bf3ec2f812ee1e94319227b7065be0aa37afd278ffadb0273 \
+                    size    27061491
 
-worksrcdir          .
+depends_build       port:go
+
 use_configure       no
-extract {
-    file copy ${distpath}/${distfiles} ${workpath}
-}
 
-build {}
+build.env-append    VERSION=${version}
+build.target
 
 destroot {
-    xinstall -m 0755 ${worksrcpath}/${distfiles} ${destroot}${prefix}/bin/${name}
+    xinstall -m 0755 ${worksrcpath}/out/${name} ${destroot}${prefix}/bin/${name}
+
+    # bash completion
+    xinstall -d ${destroot}${prefix}/etc/bash_completion.d
+    system "${destroot}${prefix}/bin/${name} completion bash > ${destroot}${prefix}/etc/bash_completion.d/${name}"
+
+    # zsh completion
+    xinstall -d ${destroot}${prefix}/share/zsh/site-functions
+    system "${destroot}${prefix}/bin/${name} completion zsh > ${destroot}${prefix}/share/zsh/site-functions/_${name}"
 }
+
+# Disable update check: https://skaffold.dev/docs/references/privacy/#update-check
+notes "
+To disable automatic update checks, you have two options:
+
+  1. set the SKAFFOLD_UPDATE_CHECK environment variable to false, e.g. in your shell profile:
+
+     export SKAFFOLD_UPDATE_CHECK=false
+
+  2. turn it off in skaffold’s config (~/.skaffold/config) with:
+
+     skaffold config set -g update-check false
+"


### PR DESCRIPTION
#### Description

Update to skaffold 1.9.1. Also switched to building from source, added completion files and a note about disabling the automatic update check.

###### Tested on

macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?