### PR TITLE
skim: new port

### DIFF
--- a/sysutils/skim/Portfile
+++ b/sysutils/skim/Portfile
@@ -1,0 +1,135 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo 1.0
+
+github.setup        lotabout skim 0.8.1 v
+categories          sysutils
+platforms           darwin
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+license             MIT
+
+description         Fuzzy Finder in Rust
+
+long_description    Skim is a general fuzzy finder that saves you time. It \
+                    works on files, lines and commands.  It is blazingly fast \
+                    as it reads the data source asynchronously.
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  1a3bdf78bcf4d7c9aeba6a1e67efe0a094067b28 \
+                    sha256  de870ca224c83b49a9d36b50e0490a0aa397dee4a2928e0272f26af53cdde3c0 \
+                    size    102612
+
+set sk_share_dir    ${prefix}/share/${name}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/sk ${destroot}${prefix}/bin/
+    xinstall -m 755 ${worksrcpath}/bin/sk-tmux ${destroot}${prefix}/bin/
+
+    copy {*}[glob ${worksrcpath}/man/man1/*] ${destroot}${prefix}/share/man/man1/
+
+    file mkdir ${destroot}${sk_share_dir}
+    copy ${worksrcpath}/shell ${destroot}${sk_share_dir}
+}
+
+notes "
+skim's shell completions can be found in:
+
+    ${sk_share_dir}/shell
+"
+
+cargo.crates \
+    aho-corasick                     0.7.3  e6f484ae0c99fec2e858eb6134949117399f222608d84cadb3f58c1f97c2364c \
+    ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
+    arrayref                         0.3.6  a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544 \
+    arrayvec                        0.4.10  92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71 \
+    arrayvec                         0.5.1  cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8 \
+    atty                            0.2.11  9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652 \
+    autocfg                          0.1.7  1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2 \
+    base64                          0.11.0  b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7 \
+    bitflags                         1.0.4  228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12 \
+    blake2b_simd                    0.5.10  d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a \
+    cc                              1.0.31  c9ce8bb087aacff865633f0bd5aeaed910fe2fe55b55f4739527f2e023a2e53d \
+    cfg-if                           0.1.7  11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4 \
+    chrono                           0.4.6  45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878 \
+    clap                            2.32.0  b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e \
+    constant_time_eq                 0.1.5  245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc \
+    crossbeam                        0.7.3  69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e \
+    crossbeam-channel                0.4.0  acec9a3b0b3559f15aee4f90746c4e5e293b701c0f7d3925d24e01645267b68c \
+    crossbeam-deque                  0.2.0  f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3 \
+    crossbeam-deque                  0.7.2  c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca \
+    crossbeam-epoch                  0.8.0  5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac \
+    crossbeam-epoch                  0.3.1  927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150 \
+    crossbeam-queue                  0.2.1  c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db \
+    crossbeam-utils                  0.7.0  ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4 \
+    crossbeam-utils                  0.2.2  2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9 \
+    darling                         0.10.2  0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858 \
+    darling_core                    0.10.2  f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b \
+    darling_macro                   0.10.2  d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72 \
+    derive_builder                   0.9.0  a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0 \
+    derive_builder_core              0.9.0  2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef \
+    dirs                             2.0.2  13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3 \
+    dirs-sys                         0.3.4  afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b \
+    either                           1.5.1  c67353c641dc847124ea1902d69bd753dee9bb3beff9aa3662ecf86c971d1fac \
+    env_logger                       0.6.1  b61fa891024a945da30a9581546e8cfaf5602c7b3f4c137a2805cf388f92075a \
+    fnv                              1.0.6  2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3 \
+    fuzzy-matcher                    0.3.4  75a03d6d8629fcd151ece9d3a7f59a87fc38a620ab0290bf2888c2ad73821170 \
+    getrandom                        0.1.6  e65cce4e5084b14874c4e7097f38cab54f47ee554f9194673456ea379dcc4c55 \
+    humantime                        1.2.0  3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114 \
+    ident_case                       1.0.1  b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39 \
+    lazy_static                      1.3.0  bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14 \
+    libc                            0.2.58  6281b86796ba5e4366000be6e9e18bf35580adf9e63fbe2294aadb587613a319 \
+    log                              0.4.6  c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6 \
+    memchr                           2.2.0  2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39 \
+    memoffset                        0.2.1  0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3 \
+    memoffset                        0.5.3  75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9 \
+    nix                             0.14.0  0d10caafde29a846a82ae0af70414e4643e072993441033b2c93217957e2f867 \
+    nodrop                          0.1.13  2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945 \
+    num-integer                     0.1.39  e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea \
+    num-traits                       0.2.6  0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1 \
+    num_cpus                        1.10.0  1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba \
+    proc-macro2                      1.0.6  9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27 \
+    quick-error                      1.2.2  9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0 \
+    quote                            1.0.2  053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe \
+    rayon                            1.0.3  373814f27745b2686b350dd261bfd24576a6fb0e2c5919b3a2b6005f820b0473 \
+    rayon-core                       1.4.1  b055d1e92aba6877574d8fe604a63c8b5df60f60e5982bf7ccbb1338ea527356 \
+    redox_syscall                   0.1.51  423e376fffca3dfa06c9e9790a9ccd282fafb3cc6e6397d01dbf64f9bacc6b85 \
+    redox_termios                    0.1.1  7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76 \
+    redox_users                      0.3.4  09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431 \
+    regex                            1.1.6  8f0a0bcab2fd7d1d7c54fa9eae6f43eddeb9ce2e7352f8518a814a4f65d60c58 \
+    regex-syntax                     0.6.6  dcfd8681eebe297b81d98498869d4aae052137651ad7b96822f09ceb690d0a96 \
+    rust-argon2                      0.7.0  2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017 \
+    rustc_version                    0.2.3  138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a \
+    scopeguard                       0.3.3  94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27 \
+    scopeguard                       1.0.0  b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d \
+    semver                           0.9.0  1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403 \
+    semver-parser                    0.7.0  388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
+    shlex                            0.1.1  7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2 \
+    spin                             0.5.2  6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d \
+    strsim                           0.9.3  6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c \
+    strsim                           0.7.0  bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550 \
+    syn                             1.0.11  dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238 \
+    term                             0.6.1  c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5 \
+    termcolor                        1.0.4  4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f \
+    termion                          1.5.1  689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096 \
+    textwrap                        0.10.0  307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6 \
+    thread_local                     1.0.0  88ddf1ad580c7e3d1efff877d972bcc93f995556b9087a5a259630985c88ceab \
+    thread_local                     0.3.6  c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b \
+    time                            0.1.42  db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f \
+    timer                            0.2.0  31d42176308937165701f50638db1c31586f183f1aab416268216577aec7306b \
+    tuikit                           0.3.2  4b0701da4a220a188d2c4033a4ee4c1812bfadf8834735ed9abc461409c271ea \
+    ucd-util                         0.1.3  535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86 \
+    unicode-width                    0.1.5  882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526 \
+    unicode-xid                      0.2.0  826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c \
+    utf8-ranges                      1.0.2  796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737 \
+    utf8parse                        0.1.1  8772a4ccbb4e89959023bc5b7cb8623a795caa7092d99f3aa9501b9484d4557d \
+    vec_map                          0.8.1  05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a \
+    void                             1.0.2  6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d \
+    vte                              0.3.3  4f42f536e22f7fcbb407639765c8fd78707a33109301f834a594758bedd6e8cf \
+    winapi                           0.3.6  92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0 \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                      0.1.2  7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    wincolor                         1.0.1  561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba


### PR DESCRIPTION
#### Description

New port for [skim](https://github.com/lotabout/skim)

Addresses: https://trac.macports.org/ticket/60346

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
