### PR TITLE
flatbuffers: new port

### DIFF
--- a/devel/flatbuffers/Portfile
+++ b/devel/flatbuffers/Portfile
@@ -1,0 +1,68 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+
+PortGroup               cmake 1.1
+PortGroup               github 1.0
+
+github.setup            google flatbuffers 1.12.0 v
+homepage                http://google.github.io/flatbuffers/
+
+description             Memory Efficient Serialization Library
+
+long_description        FlatBuffers is a cross platform serialization library \
+                        architected for maximum memory efficiency. It allows \
+                        you to directly access serialized data without \
+                        parsing/unpacking it first, while still having great \
+                        forwards/backwards compatibility.
+
+platforms               darwin
+categories              devel
+license                 Apache-2
+
+maintainers             {gmail.com:herby.gillot @herbygillot} \
+                        openmaintainer
+
+checksums               rmd160  589b45cc10db2a99ee9aec8112bdf2cb64a02612 \
+                        sha256  704188c28ed56cc82cf9d41efeb4e9da8d21ccd7a75691d9e582faaaf0b344ad \
+                        size    1145494
+
+set fb_doc_dir          ${prefix}/share/doc/${name}
+set fb_share_dir        ${prefix}/share/${name}
+
+set fb_langs            {
+                            android
+                            dart
+                            go
+                            java
+                            js
+                            lobster
+                            lua
+                            net
+                            php
+                            python
+                            rust
+                            swift
+                        }
+
+post-destroot {
+    file mkdir ${destroot}${fb_doc_dir}
+    file mkdir ${destroot}${fb_share_dir}
+
+    copy {*}[glob ${worksrcpath}/docs/*] ${destroot}${fb_doc_dir}/
+
+    foreach lang ${fb_langs} {
+        copy ${worksrcpath}/${lang} ${destroot}${fb_share_dir}/
+    }
+}
+
+notes "
+Flatbuffers documentation can be found in:
+
+    ${fb_doc_dir}
+
+
+Flatbuffers implementations for various programming languages can be found in:
+
+    ${fb_share_dir}
+"


### PR DESCRIPTION
#### Description

New port for [Google Flatbuffers](http://google.github.io/flatbuffers/)

Addresses: https://trac.macports.org/ticket/59251

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
