### PR TITLE
wireguard-tools: update to 1.0.20200510

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-tools
-version             1.0.20200319
+version             1.0.20200510
 revision            0
-checksums           rmd160  0b1bd49e1a2820084a4b000d90c9b72d657936de \
-                    sha256  757ed31d4d48d5fd7853bfd9bfa6a3a1b53c24a94fe617439948784a2c0ed987 \
-                    size    92324
+checksums           rmd160  232e9e4647bf56df6070245e9f31c5c4589a53fa \
+                    sha256  cd526c7ea177e59ae4c0ebc4f3cc360b8524881b090d043426bdf7e3c85ac8e7 \
+                    size    94560
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
###### Tested on
macOS 10.13.6 17G12034
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?