### PR TITLE
xcode_workaround PG: add problematic OS option

### DIFF
--- a/_resources/port1.0/group/xcode_workaround-1.0.tcl
+++ b/_resources/port1.0/group/xcode_workaround-1.0.tcl
@@ -16,6 +16,8 @@
 #      avoid_xcode_compiler     (blacklist broken compiler)
 #
 #   xcode_workaround.fixed_xcode_version: minimum developer version in which bug is fixed
+#
+#   xcode_workaround.os_versions: major Darwin versions to attempt to apply workarounds
 
 PortGroup cltversion 1.0
 
@@ -24,9 +26,11 @@ namespace eval xcode_workaround {
 
 options xcode_workaround.type
 options xcode_workaround.fixed_xcode_version
+options xcode_workaround.os_versions
 
 default xcode_workaround.type                {append_to_compiler_flags}
 default xcode_workaround.fixed_xcode_version {11.3}
+default xcode_workaround.os_versions         {19}
 
 proc xcode_workaround::xcode_workaround.appy_fix {} {
 
@@ -37,6 +41,7 @@ proc xcode_workaround::xcode_workaround.appy_fix {} {
         developerversion \
         xcode_workaround.type \
         xcode_workaround.fixed_xcode_version \
+        xcode_workaround.os_versions \
         configure.cc \
         configure.cxx \
         configure.cflags \
@@ -47,7 +52,15 @@ proc xcode_workaround::xcode_workaround.appy_fix {} {
         use_xcode
 
     # Xcode 11 fixes (applicable to macOS 10.14 and macOS 10.15)
-    set attempt_fix [ expr ( ${os.major} == 19 || ( ${os.major} == 18 && [vercmp $xcodeversion 11] >= 0 ) ) ]
+    set attempt_fix no
+    if { [lsearch -exact ${xcode_workaround.os_versions} ${os.major}] != -1 } {
+        if { ${os.major} == 19 } {
+            set attempt_fix yes
+        }
+        if { ${os.major} == 18 && [vercmp $xcodeversion 11] >= 0 } {
+            set attempt_fix yes
+        }
+    }
 
     if { ${attempt_fix} } {
 

--- a/python/py-tensorflow/Portfile
+++ b/python/py-tensorflow/Portfile
@@ -60,6 +60,7 @@ set use_mp_clang [ expr ( [ string match macports-clang-* ${configure.compiler} 
 
 # https://trac.macports.org/ticket/59192
 xcode_workaround.type                  avoid_xcode_compiler
+xcode_workaround.os_versions           18 19
 xcode_workaround.fixed_xcode_version   11.4
 
 #patch.pre_args      -p1


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6
Xcode 11.2 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
