### PR TITLE
dblatex: +mactex variant fix installed style detection

### DIFF
--- a/textproc/dblatex/Portfile
+++ b/textproc/dblatex/Portfile
@@ -6,7 +6,7 @@ PortGroup           texlive 1.0
 
 name                dblatex
 version             0.3.11
-revision            0
+revision            1
 categories          textproc tex
 maintainers         {cal @neverpanic} openmaintainer
 license             GPL-2+
@@ -136,7 +136,7 @@ post-destroot {
     file mkdir ${destroot}${dblatex.texmflocal}/tex/latex/dblatex
     fs-traverse f ${destroot}${python.prefix}/share/dblatex/latex {
         if {[file isfile $f]} {
-            if {[catch {exec ${prefix}/bin/kpsewhich -a [file tail $f]} result]} {
+            if {[catch {exec ${dblatex.mactex_bin}/kpsewhich -a [file tail $f]} result]} {
                 set f [string range $f [string length ${destroot}${python.prefix}/share/dblatex/latex/] end]
                 file mkdir [file dirname ${destroot}${dblatex.texmflocal}/tex/latex/dblatex/$f]
                 ln -s ${python.prefix}/share/dblatex/latex/$f ${destroot}${dblatex.texmflocal}/tex/latex/dblatex/$f


### PR DESCRIPTION
dblatex: +mactex variant fix installed style detection

* Correct detection of style allready installed in MacTeX.

Close https://trac.macports.org/ticket/56734

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.12.6 16G2136
Xcode 9.2 9C40b 
MacTex 2020

macOS 10.15.4 19E287
Xcode 11.4.1 11E503a 
MacTex 2020

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
