### PR TITLE
cmake: Remove redundant or outdated comments

### DIFF
--- a/devel/cmake/Portfile
+++ b/devel/cmake/Portfile
@@ -44,7 +44,6 @@ if {${subport} eq ${name}} {
               size   7417124
     revision  0
 
-    # require C++11
     compiler.cxx_standard 2011
 
     platform darwin {
@@ -297,7 +296,6 @@ if {${subport} eq ${name}} {
 
     if {[variant_isset docs]} {
 
-        # default Python is 3.6
         if {![variant_isset python35] &&
             ![variant_isset python36] &&
             ![variant_isset python37] &&
@@ -305,7 +303,6 @@ if {${subport} eq ${name}} {
             default_variants +python37
         }
 
-        # make sure -python36 is not specified alone
         if {![variant_isset python35] &&
             ![variant_isset python36] &&
             ![variant_isset python37] &&
@@ -314,7 +311,6 @@ if {${subport} eq ${name}} {
             return -code error "Invalid variant selection"
         }
 
-        # determine Python-related variables
         if {[variant_isset python35]} {
             set PYTHON_VERSION_WITH_DOT "3.5"
         } elseif {[variant_isset python36]} {
@@ -327,7 +323,6 @@ if {${subport} eq ${name}} {
         set PYTHON_VERSION_NO_DOT [join [split ${PYTHON_VERSION_WITH_DOT} "."] ""]
 
         post-patch {
-            # patch Python Version
             reinplace "s|__PYTHON_VERSION_WITH_DOT__|${PYTHON_VERSION_WITH_DOT}|g" ${worksrcpath}/macports.cmake
         }
     }


### PR DESCRIPTION
#### Description

cmake: Remove redundant or outdated comments

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix
