### PR TITLE
cfm: Use legacysupport portgroup for <=10.9

### DIFF
--- a/sysutils/cfm/Portfile
+++ b/sysutils/cfm/Portfile
@@ -2,7 +2,11 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           legacysupport 1.0
 PortGroup           makefile 1.0
+
+# AT_SYMLINK_NOFOLLOW
+legacysupport.newest_darwin_requires_legacy 13
 
 github.setup        willeccles cfm 0.6.0 v
 revision            1


### PR DESCRIPTION
#### Description

[cfm fails to build on Mac OS X 10.6](https://build.macports.org/builders/ports-10.6_x86_64-builder/builds/26119/steps/install-port/logs/stdio):

```
cfm.c:829:22: warning: implicit declaration of function 'fstatat' is invalid in C99 [-Wimplicit-function-declaration]
            if (0 != fstatat(dfd, dir->d_name, &st, AT_SYMLINK_NOFOLLOW)) {
                     ^
cfm.c:829:53: error: use of undeclared identifier 'AT_SYMLINK_NOFOLLOW'
            if (0 != fstatat(dfd, dir->d_name, &st, AT_SYMLINK_NOFOLLOW)) {
                                                    ^
1 warning and 1 error generated.
```

I believe `AT_SYMLINK_NOFOLLOW` was first defined in OS X 10.10 so this PR adds the legacysupport portgroup for OS X 10.9 and earlier.

A different fix that changes the upstream code might also be possible.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix
