### PR TITLE
python27-bootstrap: Stop using gettext-bootstrap

### DIFF
--- a/lang/python27/Portfile
+++ b/lang/python27/Portfile
@@ -64,6 +64,7 @@ openssl.branch      1.1
 
 # This port is used by clang-3.4 to bootstrap libcxx
 subport ${name}-bootstrap {
+    revision                6
     set stdprefix ${prefix}
     prefix ${prefix}/libexec/libcxx-bootstrap
     set frameworks_dir      ${prefix}/Library/Frameworks
@@ -75,9 +76,9 @@ subport ${name}-bootstrap {
     compiler.whitelist      clang llvm-gcc-4.2 gcc-4.2 apple-gcc-4.2
     patchfiles-delete       patch-libedit.diff
     depends_build-replace   port:pkgconfig port:pkgconfig-bootstrap
-    depends_lib-replace     port:gettext port:gettext-bootstrap \
-                            port:ncurses port:ncurses-bootstrap
+    depends_lib-replace     port:ncurses port:ncurses-bootstrap
     depends_lib-delete      port:db48 \
+                            port:gettext \
                             port:libedit \
                             port:sqlite3
     # no need to be 'port select'able
@@ -91,13 +92,17 @@ subport ${name}-bootstrap {
         # libstdc++ can't be used on Mojave and later
         known_fail          yes
     }
+    configure.args      ac_cv_header_libintl_h=no \
+                        ac_cv_lib_intl_textdomain=no \
+                        ac_cv_search_bind_textdomain_codeset=no
 }
 # Also needed by later clangs.
 if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {
     clang_dependency.extra_versions 3.7
 }
 
-configure.args      --enable-framework=${frameworks_dir} \
+configure.args-append \
+                    --enable-framework=${frameworks_dir} \
                     --enable-ipv6 \
                     --with-system-expat \
                     --with-system-ffi


### PR DESCRIPTION

#### Description

In an effort to remove the gettext-bootstrap port, this PR changes the python27-bootstrap port to no longer use gettext-bootstrap.

See: https://trac.macports.org/ticket/58526

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G12034
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
