### PR TITLE
xz-bootstrap: Remove nonessential features

### DIFF
--- a/archivers/xz/Portfile
+++ b/archivers/xz/Portfile
@@ -26,22 +26,41 @@ homepage        https://tukaani.org/xz/
 master_sites    sourceforge:project/lzmautils
 use_bzip2       yes
 
-depends_lib     port:libiconv port:gettext
-
 set my_prefix ${prefix}
 
 if {${subport} eq ${name}} {
     revision    0
+
+    depends_lib-append \
+                port:libiconv \
+                port:gettext
+
+    configure.args-append \
+                --with-libiconv-prefix=${my_prefix} \
+                --with-libintl-prefix=${my_prefix}
+
+    # document that we always need legacy symlinks now that "lzmautils" refers here
+    configure.args-append --enable-lzma-links
 }
 
 # This port is used by clang-3.4 to bootstrap libcxx
 subport ${name}-bootstrap {
-    revision                0
+    revision                1
     set my_prefix ${prefix}/libexec/libcxx-bootstrap
     configure.pre_args      --prefix=${my_prefix}
-    depends_lib-replace     port:libiconv port:libiconv-bootstrap \
-                            port:gettext port:gettext-bootstrap
     configure.ldflags-prepend -L${my_prefix}/lib
+    configure.args          --disable-doc \
+                            --disable-lzma-links \
+                            --disable-lzmadec \
+                            --disable-lzmainfo \
+                            --disable-nls \
+                            --disable-scripts \
+                            --disable-static \
+                            --disable-xzdec \
+                            --without-libiconv-prefix \
+                            --without-libintl-prefix
+    # Don't install manpages
+    destroot.args           dist_man_MANS=
     # Avoid macports-clang dep (doesn't use C++ anyway)
     configure.cxx_stdlib
     compiler.whitelist      clang llvm-gcc-4.2 gcc-4.2 apple-gcc-4.2
@@ -53,11 +72,6 @@ if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"}
 }
 
 patchfiles      c89.patch
-
-configure.args  --with-libiconv-prefix=${my_prefix} --with-libintl-prefix=${my_prefix}
-
-# document that we always need legacy symlinks now that "lzmautils" refers here
-configure.args-append --enable-lzma-links
 
 # the internal "check.h" header conflicts with port check's <check.h>
 configure.cppflags -I${worksrcpath}/src/liblzma/check -I${my_prefix}/include


### PR DESCRIPTION

#### Description

Don't link with gettext.
Don't use libiconv.
Don't create a static library.
Don't create lzmautils compatibility programs and symlinks.
Don't create the xzdec program.
Don't create the scripts.
Don't install documentation.
Don't install manpages.

See: https://trac.macports.org/ticket/58526

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G12034
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
