### PR TITLE
fontconfig: use system uuid.h

### DIFF
--- a/graphics/fontconfig/Portfile
+++ b/graphics/fontconfig/Portfile
@@ -5,6 +5,7 @@ PortGroup                   muniversal 1.0
 
 name                        fontconfig
 version                     2.13.1
+revision                    1
 checksums                   rmd160  a971903874fb0395a7ab2d5705378af1ffce2b2c \
                             sha256  f655dd2a986d7aa97e052261b36aa67b0a64989496361eca8d604e6414006741 \
                             size    1723639
@@ -29,8 +30,10 @@ depends_build               port:pkgconfig
 depends_lib                 port:expat \
                             port:freetype \
                             port:gettext \
-                            port:libiconv \
-                            port:ossp-uuid
+                            port:libiconv
+if {${os.platform} eq "darwin" && ${os.major} < 8} {
+    depends_lib-append      port:ossp-uuid
+}
 
 if {${os.platform} eq "darwin" && ${os.major} < 9} {
     set add_fonts           /usr/X11R6/lib/X11/fonts


### PR DESCRIPTION
#### Description
Fontconfig added support for using Apple's `uuid.h` in [this commit](https://gitlab.freedesktop.org/fontconfig/fontconfig/-/commit/bb50f62b58b5057f80f3775f91fa94b225fc6672). According to [this repo](https://github.com/phracker/MacOSX-SDKs) Apple has been shipping that header since 10.4.

To test this out, I tried all of this:
- `port disable ossp-uuid`
- recompile fontconfig
- `DYLD_PRINT_LIBRARIES=1 /opt/local/bin/fc-cache -sv` to validate that it was no longer linking against ossp-uuid and the thing still worked.

I think moving off of ossp-uuid is justified here because it's not maintained in MacPorts or upstream and the world of software outside of MacPorts seems to be moving over to e2fs-style UUID support.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G4032
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
