### PR TITLE
wireguard-tools: update to 1.0.20200513

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-tools
-version             1.0.20200510
+version             1.0.20200513
 revision            0
-checksums           rmd160  232e9e4647bf56df6070245e9f31c5c4589a53fa \
-                    sha256  cd526c7ea177e59ae4c0ebc4f3cc360b8524881b090d043426bdf7e3c85ac8e7 \
-                    size    94560
+checksums           rmd160  111502a4d2ee8861c341efb0c46df65927b3d7a8 \
+                    sha256  e73409a9fb8c90506db241d1e1a4e7372a60dbfa400e37f4ab2fd70a92ba495f \
+                    size    94500
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
###### Tested on
macOS 10.13.6 17G12034
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?