### PR TITLE
raxml: update to 8.2.12

### DIFF
--- a/science/raxml/Portfile
+++ b/science/raxml/Portfile
@@ -6,10 +6,12 @@ PortGroup           mpi 1.0
 PortGroup           xcode_workaround 1.0
 PortGroup           makefile 1.0
 
-github.setup        stamatak standard-RAxML 7.7.6 v
-revision            2
-checksums           sha256  7562b307bc50e38162f104271793a1c8f98f866c2342bea21afe6df6a982fd82 \
-                    rmd160  da76d6623515b7d8f78a69aaf4eec713508789af
+github.setup        stamatak standard-RAxML 8.2.12 v
+github.tarball_from archive
+revision            0
+checksums           sha256  338f81b52b54e16090e193daf36c1d4baa9b902705cfdc7f4497e3e09718533b \
+                    rmd160  eaaa1dc2bc9a55ad070d14f2a4ceab55afa05aac \
+                    size    10138831
 name                raxml
 description         Estimation of phylogenetic trees
 long_description    RAxML is a program for sequential and parallel \
@@ -64,12 +66,22 @@ if {![mpi_variant_isset]} {
 
 #For Intel machines add SSE and AVX as a variant and use it by default with pthreads
 if {${build_arch} eq "i386" || ${build_arch} eq "x86_64"} {
-    variant sse3 conflicts avx description {Use the SSE3 extended instruction set from Intel since 2004} {
+    variant sse3 conflicts avx avx2 description {Use the SSE3 extended instruction set from Intel since 2004} {
         set EXTm ".SSE3"
         set EXTb "-SSE3"
     }
 
-    variant avx conflicts sse3 description {Use the AVX extended instruction set from Intel i7 (sandy bridge) and AMD Bulldozer} {
+    variant avx conflicts avx2 sse3 description {Use the AVX extended instruction set from Intel i7 (sandy bridge) and AMD Bulldozer} {
+        pre-fetch {
+            if {![avx_compiler_isset]} {
+                return -code error "$name: Variant avx2 needs a clang-derived compiler"
+            }
+        }
+        set EXTm ".AVX2"
+        set EXTb "-AVX2"
+    }
+
+    variant avx2 conflicts avx sse3 description {Use the AVX2 extended instruction set from Intel Haswell and AMD Excavator} {
         pre-fetch {
             if {![avx_compiler_isset]} {
                 return -code error "$name: Variant avx needs a clang-derived compiler"
@@ -79,12 +91,12 @@ if {${build_arch} eq "i386" || ${build_arch} eq "x86_64"} {
         set EXTb "-AVX"
     }
 
-    if {![catch {sysctl hw.optional.sse3} result] && ${result} == 1} {
-        if {![catch {sysctl hw.optional.avx1_0} result] && ${result} == 1} {
-            default_variants-append +avx
-        } else {
-            default_variants-append  +sse3
-        }
+    if {![catch {sysctl hw.optional.avx2_0} result] && ${result} == 1} {
+        default_variants-append +avx2
+    } elseif {![catch {sysctl hw.optional.avx1_0} result] && ${result} == 1} {
+        default_variants-append +avx
+    } elseif {![catch {sysctl hw.optional.sse3} result] && ${result} == 1} {
+        default_variants-append  +sse3
     }
 } else {
     post-patch {

--- a/science/raxml/files/patch-Makefiles.diff
+++ b/science/raxml/files/patch-Makefiles.diff
@@ -1,380 +1,275 @@
---- Makefile.AVX.PTHREADS.mac.orig	2013-08-29 06:56:26.000000000 -0700
-+++ Makefile.AVX.PTHREADS.mac	2020-05-17 08:10:17.000000000 -0700
-@@ -3,7 +3,7 @@
- 
- CC = clang 
- 
--CFLAGS = -D_USE_PTHREADS -D__SIM_SSE3 -O2 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops  -D__AVX #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
-+CFLAGS += -D_USE_PTHREADS -D__SIM_SSE3 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops  -D__AVX #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
- 
- 
- LIBRARIES = -lm -pthread 
-@@ -17,7 +17,7 @@
- GLOBAL_DEPS = axml.h globalVariables.h #mem_alloc.h compiler.h  gcc.h  ll_asm.h  ll_list.h
- 
- raxmlHPC : $(objs)
--	$(CC) -o raxmlHPC-PTHREADS-AVX $(objs) $(LIBRARIES) 
-+	$(CC) -o raxmlHPC-PTHREADS-AVX $(objs) $(LIBRARIES) $(LDFLAGS) 
- 
- avxLikelihood.o : avxLikelihood.c $(GLOBAL_DEPS)
- 		$(CC) $(CFLAGS) -mavx -c -o avxLikelihood.o avxLikelihood.c
---- Makefile.AVX.HYBRID.gcc.orig	2013-08-29 06:56:26.000000000 -0700
-+++ Makefile.AVX.HYBRID.gcc	2020-05-17 08:10:18.000000000 -0700
+--- Makefile.AVX.HYBRID.gcc.orig
++++ Makefile.AVX.HYBRID.gcc
 @@ -2,7 +2,7 @@
  
  CC = mpicc 
  
 -CFLAGS = -D_WAYNE_MPI -D_USE_PTHREADS -D__SIM_SSE3 -O2 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops -D__AVX
-+CFLAGS += -D_WAYNE_MPI -D_USE_PTHREADS -D__SIM_SSE3 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops -D__AVX
++CFLAGS += -D_WAYNE_MPI -D_USE_PTHREADS -D__SIM_SSE3 -O2 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops -D__AVX
  
  LIBRARIES = -lm -pthread 
  
-@@ -15,7 +15,7 @@
- GLOBAL_DEPS = axml.h globalVariables.h  #mem_alloc.h compiler.h  gcc.h  ll_asm.h  ll_list.h
- 
- raxmlHPC-HYBRID-AVX : $(objs)
--	$(CC) -o raxmlHPC-HYBRID-AVX $(objs) $(LIBRARIES) 
-+	$(CC) -o raxmlHPC-HYBRID-AVX $(objs) $(LIBRARIES) $(LDFLAGS) 
- 
- avxLikelihood.o : avxLikelihood.c $(GLOBAL_DEPS)
- 		$(CC) $(CFLAGS) -mavx -c -o avxLikelihood.o avxLikelihood.c
---- Makefile.SSE3.HYBRID.gcc.orig	2013-08-29 06:56:26.000000000 -0700
-+++ Makefile.SSE3.HYBRID.gcc	2020-05-17 08:10:18.000000000 -0700
-@@ -2,7 +2,7 @@
- 
- CC = mpicc 
- 
--CFLAGS = -D_WAYNE_MPI -D_USE_PTHREADS -D__SIM_SSE3 -O2 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops  
-+CFLAGS += -D_WAYNE_MPI -D_USE_PTHREADS -D__SIM_SSE3 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops  
- 
- LIBRARIES = -lm -pthread
- 
-@@ -15,7 +15,7 @@
- GLOBAL_DEPS = axml.h globalVariables.h #mem_alloc.h compiler.h  gcc.h  ll_asm.h  ll_list.h
- 
- raxmlHPC-HYBRID-SSE3 : $(objs)
--	$(CC) -o raxmlHPC-HYBRID-SSE3 $(objs) $(LIBRARIES) 
-+	$(CC) -o raxmlHPC-HYBRID-SSE3 $(objs) $(LIBRARIES) $(LDFLAGS) 
- 
- classify.o : classify.c $(GLOBAL_DEPS)
- evaluatePartialSpecialGeneric.o : evaluatePartialSpecialGeneric.c $(GLOBAL_DEPS)
---- Makefile.AVX.MPI.gcc.orig	2013-08-29 06:56:26.000000000 -0700
-+++ Makefile.AVX.MPI.gcc	2020-05-17 08:10:18.000000000 -0700
+--- Makefile.AVX.MPI.gcc.orig
++++ Makefile.AVX.MPI.gcc
 @@ -2,7 +2,7 @@
  
  CC = mpicc 
  
 -CFLAGS = -D_WAYNE_MPI -D__SIM_SSE3 -O2 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops -D__AVX
-+CFLAGS += -D_WAYNE_MPI -D__SIM_SSE3 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops -D__AVX
++CFLAGS += -D_WAYNE_MPI -D__SIM_SSE3 -O2 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops -D__AVX
  
  LIBRARIES = -lm
  
-@@ -15,7 +15,7 @@
- GLOBAL_DEPS = axml.h globalVariables.h #mem_alloc.h
- 
- raxmlHPC-MPI-AVX : $(objs)
--	$(CC) -o raxmlHPC-MPI-AVX $(objs) $(LIBRARIES) 
-+	$(CC) -o raxmlHPC-MPI-AVX $(objs) $(LIBRARIES) $(LDFLAGS) 
- 
- avxLikelihood.o : avxLikelihood.c $(GLOBAL_DEPS)
- 		$(CC) $(CFLAGS) -mavx -c -o avxLikelihood.o avxLikelihood.c
---- Makefile.SSE3.MPI.gcc.orig	2013-08-29 06:56:26.000000000 -0700
-+++ Makefile.SSE3.MPI.gcc	2020-05-17 08:10:18.000000000 -0700
-@@ -2,7 +2,7 @@
- 
- CC = mpicc 
- 
--CFLAGS = -D_WAYNE_MPI -D__SIM_SSE3 -O2 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops  
-+CFLAGS += -D_WAYNE_MPI -D__SIM_SSE3 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops  
- 
- LIBRARIES = -lm
- 
-@@ -15,7 +15,7 @@
- GLOBAL_DEPS = axml.h globalVariables.h #mem_alloc.h
- 
- raxmlHPC-MPI-SSE3 : $(objs)
--	$(CC) -o raxmlHPC-MPI-SSE3 $(objs) $(LIBRARIES) 
-+	$(CC) -o raxmlHPC-MPI-SSE3 $(objs) $(LIBRARIES) $(LDFLAGS) 
- 
- classify.o : classify.c $(GLOBAL_DEPS)
- evaluatePartialSpecialGeneric.o : evaluatePartialSpecialGeneric.c $(GLOBAL_DEPS)
---- Makefile.SSE3.gcc.orig	2013-08-29 06:56:26.000000000 -0700
-+++ Makefile.SSE3.gcc	2020-05-17 08:10:18.000000000 -0700
-@@ -3,7 +3,7 @@
- 
- CC = gcc 
- 
--CFLAGS = -D__SIM_SSE3  -msse3 -D_GNU_SOURCE -O2 -fomit-frame-pointer -funroll-loops  #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
-+CFLAGS += -D__SIM_SSE3  -msse3 -D_GNU_SOURCE -fomit-frame-pointer -funroll-loops  #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
- 
- LIBRARIES = -lm
- 
-@@ -16,7 +16,7 @@
- GLOBAL_DEPS = axml.h globalVariables.h
- 
- raxmlHPC : $(objs)
--	$(CC) -o raxmlHPC-SSE3 $(objs) $(LIBRARIES) 
-+	$(CC) -o raxmlHPC-SSE3 $(objs) $(LIBRARIES) $(LDFLAGS) 
- 
- classify.o : classify.c $(GLOBAL_DEPS)
- evaluatePartialSpecialGeneric.o : evaluatePartialSpecialGeneric.c $(GLOBAL_DEPS)
---- Makefile.HYBRID.gcc.orig	2013-08-29 06:56:26.000000000 -0700
-+++ Makefile.HYBRID.gcc	2020-05-17 08:10:18.000000000 -0700
-@@ -3,7 +3,7 @@
- CC = mpicc 
- 
- 
--CFLAGS = -D_WAYNE_MPI -D_GNU_SOURCE -fomit-frame-pointer -funroll-loops -O2  -D_USE_PTHREADS -msse
-+CFLAGS += -D_WAYNE_MPI -D_GNU_SOURCE -fomit-frame-pointer -funroll-loops  -D_USE_PTHREADS -msse
- 
- 
- LIBRARIES = -lm -pthread 
-@@ -17,7 +17,7 @@
- GLOBAL_DEPS = axml.h globalVariables.h #mem_alloc.h compiler.h  gcc.h  ll_asm.h  ll_list.h
- 
- raxmlHPC-HYBRID : $(objs)
--	$(CC) -o raxmlHPC-HYBRID $(objs) $(LIBRARIES) 
-+	$(CC) -o raxmlHPC-HYBRID $(objs) $(LIBRARIES) $(LDFLAGS) 
- 
- classify.o : classify.c $(GLOBAL_DEPS)
- evaluatePartialSpecialGeneric.o : evaluatePartialSpecialGeneric.c $(GLOBAL_DEPS)
---- Makefile.SSE3.QuartetMPI.gcc.orig	2013-08-29 06:56:26.000000000 -0700
-+++ Makefile.SSE3.QuartetMPI.gcc	2020-05-17 08:10:18.000000000 -0700
-@@ -3,7 +3,7 @@
- 
- CC = mpicc
- 
--CFLAGS = -D__SIM_SSE3  -msse3 -D_GNU_SOURCE -O2 -fomit-frame-pointer -funroll-loops  -D_QUARTET_MPI #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
-+CFLAGS += -D__SIM_SSE3  -msse3 -D_GNU_SOURCE -fomit-frame-pointer -funroll-loops  -D_QUARTET_MPI #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
- 
- LIBRARIES = -lm
- 
-@@ -16,7 +16,7 @@
- GLOBAL_DEPS = axml.h globalVariables.h #mem_alloc.h
- 
- raxmlHPC : $(objs)
--	$(CC) -o raxmlHPC-SSE3-QUARTET-MPI $(objs) $(LIBRARIES) 
-+	$(CC) -o raxmlHPC-SSE3-QUARTET-MPI $(objs) $(LIBRARIES) $(LDFLAGS) 
- 
- classify.o : classify.c $(GLOBAL_DEPS)
- evaluatePartialSpecialGeneric.o : evaluatePartialSpecialGeneric.c $(GLOBAL_DEPS)
---- Makefile.AVX.gcc.orig	2013-08-29 06:56:26.000000000 -0700
-+++ Makefile.AVX.gcc	2020-05-17 08:10:18.000000000 -0700
-@@ -3,7 +3,7 @@
- 
- CC = gcc 
- 
--CFLAGS = -D__SIM_SSE3 -msse3 -D_GNU_SOURCE -O2 -fomit-frame-pointer -funroll-loops -D__AVX #-Wall -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
-+CFLAGS += -D__SIM_SSE3 -msse3 -D_GNU_SOURCE -fomit-frame-pointer -funroll-loops -D__AVX #-Wall -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
- 
- LIBRARIES = -lm
- 
-@@ -16,7 +16,7 @@
- GLOBAL_DEPS = axml.h globalVariables.h
- 
- raxmlHPC : $(objs)
--	$(CC) -o raxmlHPC-AVX $(objs) $(LIBRARIES) 
-+	$(CC) -o raxmlHPC-AVX $(objs) $(LIBRARIES) $(LDFLAGS) 
- 
- avxLikelihood.o : avxLikelihood.c $(GLOBAL_DEPS)
- 		$(CC) $(CFLAGS) -mavx -c -o avxLikelihood.o avxLikelihood.c
---- Makefile.PTHREADS.mac.orig	2013-08-29 06:56:26.000000000 -0700
-+++ Makefile.PTHREADS.mac	2020-05-17 08:10:18.000000000 -0700
-@@ -4,7 +4,7 @@
- CC = gcc 
- 
- 
--CFLAGS = -D_GNU_SOURCE  -fomit-frame-pointer -funroll-loops -O2  -D_USE_PTHREADS -msse #-Wall -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
-+CFLAGS += -D_GNU_SOURCE  -fomit-frame-pointer -funroll-loops  -D_USE_PTHREADS -msse #-Wall -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
- 
- 
- LIBRARIES = -lm -pthread
-@@ -18,7 +18,7 @@
- GLOBAL_DEPS = axml.h globalVariables.h #mem_alloc.h compiler.h  gcc.h  ll_asm.h  ll_list.h
- 
- raxmlHPC-PTHREADS : $(objs)
--	$(CC) -o raxmlHPC-PTHREADS $(objs) $(LIBRARIES) 
-+	$(CC) -o raxmlHPC-PTHREADS $(objs) $(LIBRARIES) $(LDFLAGS) 
- 
- classify.o : classify.c $(GLOBAL_DEPS)
- evaluatePartialSpecialGeneric.o : evaluatePartialSpecialGeneric.c $(GLOBAL_DEPS)
---- Makefile.SSE3.PTHREADS.gcc.orig	2013-08-29 06:56:26.000000000 -0700
-+++ Makefile.SSE3.PTHREADS.gcc	2020-05-17 08:10:19.000000000 -0700
-@@ -3,7 +3,7 @@
- 
- CC = gcc 
- 
--CFLAGS = -D_USE_PTHREADS -D__SIM_SSE3 -O2 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops  #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
-+CFLAGS += -D_USE_PTHREADS -D__SIM_SSE3 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops  #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
- 
- 
- LIBRARIES = -lm -pthread 
-@@ -17,7 +17,7 @@
- GLOBAL_DEPS = axml.h globalVariables.h #mem_alloc.h compiler.h  gcc.h  ll_asm.h  ll_list.h
- 
- raxmlHPC : $(objs)
--	$(CC) -o raxmlHPC-PTHREADS-SSE3 $(objs) $(LIBRARIES) 
-+	$(CC) -o raxmlHPC-PTHREADS-SSE3 $(objs) $(LIBRARIES) $(LDFLAGS) 
- 
- #rev_functions.o : rev_functions.c $(GLOBAL_DEPS)
- classify.o : classify.c $(GLOBAL_DEPS)
---- Makefile.SSE3.PTHREADS.mac.orig	2013-08-29 06:56:26.000000000 -0700
-+++ Makefile.SSE3.PTHREADS.mac	2020-05-17 08:10:19.000000000 -0700
-@@ -3,7 +3,7 @@
- 
- CC = gcc 
- 
--CFLAGS = -D_USE_PTHREADS -D__SIM_SSE3 -O2 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops  #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
-+CFLAGS += -D_USE_PTHREADS -D__SIM_SSE3 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops  #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
- 
- 
- LIBRARIES = -lm -pthread 
-@@ -17,7 +17,7 @@
- GLOBAL_DEPS = axml.h globalVariables.h #mem_alloc.h compiler.h  gcc.h  ll_asm.h  ll_list.h
- 
- raxmlHPC : $(objs)
--	$(CC) -o raxmlHPC-PTHREADS-SSE3 $(objs) $(LIBRARIES) 
-+	$(CC) -o raxmlHPC-PTHREADS-SSE3 $(objs) $(LIBRARIES) $(LDFLAGS) 
- 
- #rev_functions.o : rev_functions.c $(GLOBAL_DEPS)
- classify.o : classify.c $(GLOBAL_DEPS)
---- Makefile.AVX.mac.orig	2013-08-29 06:56:26.000000000 -0700
-+++ Makefile.AVX.mac	2020-05-17 08:10:19.000000000 -0700
-@@ -3,7 +3,7 @@
- 
- CC = clang
- 
--CFLAGS = -D__SIM_SSE3 -msse3 -D_GNU_SOURCE -O2 -fomit-frame-pointer -funroll-loops -D__AVX #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
-+CFLAGS += -D__SIM_SSE3 -msse3 -D_GNU_SOURCE -fomit-frame-pointer -funroll-loops -D__AVX #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
- 
- LIBRARIES = -lm
- 
-@@ -16,7 +16,7 @@
- GLOBAL_DEPS = axml.h globalVariables.h #mem_alloc.h
- 
- raxmlHPC : $(objs)
--	$(CC) -o raxmlHPC-AVX $(objs) $(LIBRARIES) 
-+	$(CC) -o raxmlHPC-AVX $(objs) $(LIBRARIES) $(LDFLAGS) 
- 
- avxLikelihood.o : avxLikelihood.c $(GLOBAL_DEPS)
- 		$(CC) $(CFLAGS) -mavx -c -o avxLikelihood.o avxLikelihood.c
---- Makefile.PTHREADS.gcc.orig	2013-08-29 06:56:26.000000000 -0700
-+++ Makefile.PTHREADS.gcc	2020-05-17 08:10:19.000000000 -0700
-@@ -4,7 +4,7 @@
- CC = gcc 
- 
- 
--CFLAGS = -D_GNU_SOURCE -fomit-frame-pointer -funroll-loops -O2  -D_USE_PTHREADS -msse #-Wall -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
-+CFLAGS += -D_GNU_SOURCE -fomit-frame-pointer -funroll-loops  -D_USE_PTHREADS -msse #-Wall -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
- 
- 
- LIBRARIES = -lm -pthread
-@@ -18,7 +18,7 @@
- GLOBAL_DEPS = axml.h globalVariables.h #mem_alloc.h compiler.h  gcc.h  ll_asm.h  ll_list.h
- 
- raxmlHPC-PTHREADS : $(objs)
--	$(CC) -o raxmlHPC-PTHREADS $(objs) $(LIBRARIES) 
-+	$(CC) -o raxmlHPC-PTHREADS $(objs) $(LIBRARIES) $(LDFLAGS) 
- 
- classify.o : classify.c $(GLOBAL_DEPS)
- evaluatePartialSpecialGeneric.o : evaluatePartialSpecialGeneric.c $(GLOBAL_DEPS)
---- Makefile.gcc.orig	2013-08-29 06:56:26.000000000 -0700
-+++ Makefile.gcc	2020-05-17 08:10:19.000000000 -0700
-@@ -4,7 +4,7 @@
- CC = gcc 
- 
- 
--CFLAGS = -D_GNU_SOURCE -fomit-frame-pointer -funroll-loops -O2 -msse #-Wall -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
-+CFLAGS += -D_GNU_SOURCE -fomit-frame-pointer -funroll-loops -msse #-Wall -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
- 
- LIBRARIES = -lm
- 
-@@ -17,7 +17,7 @@
- GLOBAL_DEPS = axml.h globalVariables.h #mem_alloc.h
- 
- raxmlHPC : $(objs)
--	$(CC) -o raxmlHPC $(objs) $(LIBRARIES) 
-+	$(CC) -o raxmlHPC $(objs) $(LIBRARIES) $(LDFLAGS) 
- 
- classify.o : classify.c $(GLOBAL_DEPS)
- evaluatePartialSpecialGeneric.o : evaluatePartialSpecialGeneric.c $(GLOBAL_DEPS)
---- Makefile.SSE3.mac.orig	2013-08-29 06:56:26.000000000 -0700
-+++ Makefile.SSE3.mac	2020-05-17 08:10:19.000000000 -0700
-@@ -3,7 +3,7 @@
- 
- CC = clang
- 
--CFLAGS = -D__SIM_SSE3  -msse3 -D_GNU_SOURCE -O2 -fomit-frame-pointer -funroll-loops  #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
-+CFLAGS += -D__SIM_SSE3  -msse3 -D_GNU_SOURCE -fomit-frame-pointer -funroll-loops  #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
- 
- LIBRARIES = -lm
- 
-@@ -16,7 +16,7 @@
- GLOBAL_DEPS = axml.h globalVariables.h #mem_alloc.h
- 
- raxmlHPC : $(objs)
--	$(CC) -o raxmlHPC-SSE3 $(objs) $(LIBRARIES) 
-+	$(CC) -o raxmlHPC-SSE3 $(objs) $(LIBRARIES) $(LDFLAGS) 
- 
- classify.o : classify.c $(GLOBAL_DEPS)
- evaluatePartialSpecialGeneric.o : evaluatePartialSpecialGeneric.c $(GLOBAL_DEPS)
---- Makefile.MPI.gcc.orig	2013-08-29 06:56:26.000000000 -0700
-+++ Makefile.MPI.gcc	2020-05-17 08:10:19.000000000 -0700
-@@ -3,7 +3,7 @@
- CC = mpicc 
- 
- 
--CFLAGS = -D_WAYNE_MPI -D_GNU_SOURCE -fomit-frame-pointer -funroll-loops -O2  -msse
-+CFLAGS += -D_WAYNE_MPI -D_GNU_SOURCE -fomit-frame-pointer -funroll-loops  -msse
- 
- 
- LIBRARIES = -lm
-@@ -17,7 +17,7 @@
- GLOBAL_DEPS = axml.h globalVariables.h #mem_alloc.h
- 
- raxmlHPC-MPI : $(objs)
--	$(CC) -o raxmlHPC-MPI $(objs) $(LIBRARIES) 
-+	$(CC) -o raxmlHPC-MPI $(objs) $(LIBRARIES) $(LDFLAGS) 
- 
- classify.o : classify.c $(GLOBAL_DEPS)
- evaluatePartialSpecialGeneric.o : evaluatePartialSpecialGeneric.c $(GLOBAL_DEPS)
---- Makefile.AVX.PTHREADS.gcc.orig	2013-08-29 06:56:26.000000000 -0700
-+++ Makefile.AVX.PTHREADS.gcc	2020-05-17 08:10:19.000000000 -0700
+--- Makefile.AVX.PTHREADS.gcc.orig
++++ Makefile.AVX.PTHREADS.gcc
 @@ -3,7 +3,7 @@
  
  CC = gcc 
  
 -CFLAGS = -D_USE_PTHREADS  -D__SIM_SSE3 -O2 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops  -D__AVX #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
-+CFLAGS += -D_USE_PTHREADS  -D__SIM_SSE3 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops  -D__AVX #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
++CFLAGS += -D_USE_PTHREADS  -D__SIM_SSE3 -O2 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops  -D__AVX #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
  
  
  LIBRARIES = -lm -pthread 
-@@ -17,7 +17,7 @@
- GLOBAL_DEPS = axml.h globalVariables.h  #mem_alloc.h compiler.h  gcc.h  ll_asm.h  ll_list.h
+--- Makefile.AVX.PTHREADS.mac.orig
++++ Makefile.AVX.PTHREADS.mac
+@@ -3,7 +3,7 @@
  
- raxmlHPC : $(objs)
--	$(CC) -o raxmlHPC-PTHREADS-AVX $(objs) $(LIBRARIES) 
-+	$(CC) -o raxmlHPC-PTHREADS-AVX $(objs) $(LIBRARIES) $(LDFLAGS) 
+ CC = clang 
  
- avxLikelihood.o : avxLikelihood.c $(GLOBAL_DEPS)
- 		$(CC) $(CFLAGS) -mavx -c -o avxLikelihood.o avxLikelihood.c
---- Makefile.QuartetMPI.gcc.orig	2013-08-29 06:56:26.000000000 -0700
-+++ Makefile.QuartetMPI.gcc	2020-05-17 08:10:19.000000000 -0700
+-CFLAGS = -D_USE_PTHREADS -D__SIM_SSE3 -O2 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops  -D__AVX #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
++CFLAGS += -D_USE_PTHREADS -D__SIM_SSE3 -O2 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops  -D__AVX #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
+ 
+ 
+ LIBRARIES = -lm -pthread 
+--- Makefile.AVX.gcc.orig
++++ Makefile.AVX.gcc
+@@ -3,7 +3,7 @@
+ 
+ CC = gcc 
+ 
+-CFLAGS = -D__SIM_SSE3 -msse3 -D_GNU_SOURCE -O2 -fomit-frame-pointer -funroll-loops -D__AVX #-Wall -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
++CFLAGS += -D__SIM_SSE3 -msse3 -D_GNU_SOURCE -O2 -fomit-frame-pointer -funroll-loops -D__AVX #-Wall -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
+ 
+ LIBRARIES = -lm 
+ 
+--- Makefile.AVX.mac.orig
++++ Makefile.AVX.mac
+@@ -3,7 +3,7 @@
+ 
+ CC = clang
+ 
+-CFLAGS = -D__SIM_SSE3 -msse3 -D_GNU_SOURCE -O2 -fomit-frame-pointer -funroll-loops -D__AVX #-Weverything -Wno-padded # -Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
++CFLAGS += -D__SIM_SSE3 -msse3 -D_GNU_SOURCE -O2 -fomit-frame-pointer -funroll-loops -D__AVX #-Weverything -Wno-padded # -Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
+ 
+ LIBRARIES = -lm 
+ 
+--- Makefile.AVX2.HYBRID.gcc.orig
++++ Makefile.AVX2.HYBRID.gcc
+@@ -2,7 +2,7 @@
+ 
+ CC = mpicc 
+ 
+-CFLAGS = -D_WAYNE_MPI -D_USE_PTHREADS -D__SIM_SSE3 -O2 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops -D__AVX
++CFLAGS += -D_WAYNE_MPI -D_USE_PTHREADS -D__SIM_SSE3 -O2 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops -D__AVX
+ 
+ LIBRARIES = -lm -pthread 
+ 
+--- Makefile.AVX2.MPI.gcc.orig
++++ Makefile.AVX2.MPI.gcc
+@@ -2,7 +2,7 @@
+ 
+ CC = mpicc 
+ 
+-CFLAGS = -D_WAYNE_MPI -D__SIM_SSE3 -O2 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops -D__AVX
++CFLAGS += -D_WAYNE_MPI -D__SIM_SSE3 -O2 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops -D__AVX
+ 
+ LIBRARIES = -lm
+ 
+--- Makefile.AVX2.PTHREADS.gcc.orig
++++ Makefile.AVX2.PTHREADS.gcc
+@@ -3,7 +3,7 @@
+ 
+ CC = gcc 
+ 
+-CFLAGS = -D_USE_PTHREADS  -D__SIM_SSE3 -O2 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops  -D__AVX #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
++CFLAGS += -D_USE_PTHREADS  -D__SIM_SSE3 -O2 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops  -D__AVX #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
+ 
+ 
+ LIBRARIES = -lm -pthread 
+--- Makefile.AVX2.PTHREADS.mac.orig
++++ Makefile.AVX2.PTHREADS.mac
+@@ -3,7 +3,7 @@
+ 
+ CC = clang 
+ 
+-CFLAGS = -D_USE_PTHREADS -D__SIM_SSE3 -O2 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops  -D__AVX #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
++CFLAGS += -D_USE_PTHREADS -D__SIM_SSE3 -O2 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops  -D__AVX #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
+ 
+ 
+ LIBRARIES = -lm -pthread 
+--- Makefile.AVX2.gcc.orig
++++ Makefile.AVX2.gcc
+@@ -3,7 +3,7 @@
+ 
+ CC = gcc 
+ 
+-CFLAGS = -D__SIM_SSE3 -msse3 -D_GNU_SOURCE -O2 -fomit-frame-pointer -funroll-loops -D__AVX #-Wall -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
++CFLAGS += -D__SIM_SSE3 -msse3 -D_GNU_SOURCE -O2 -fomit-frame-pointer -funroll-loops -D__AVX #-Wall -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
+ 
+ LIBRARIES = -lm
+ 
+--- Makefile.AVX2.mac.orig
++++ Makefile.AVX2.mac
+@@ -3,7 +3,7 @@
+ 
+ CC = clang
+ 
+-CFLAGS = -D__SIM_SSE3 -msse3 -D_GNU_SOURCE -O2 -fomit-frame-pointer -funroll-loops -D__AVX #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
++CFLAGS += -D__SIM_SSE3 -msse3 -D_GNU_SOURCE -O2 -fomit-frame-pointer -funroll-loops -D__AVX #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
+ 
+ LIBRARIES = -lm 
+ 
+--- Makefile.HYBRID.gcc.orig
++++ Makefile.HYBRID.gcc
+@@ -3,7 +3,7 @@
+ CC = mpicc 
+ 
+ 
+-CFLAGS = -D_WAYNE_MPI -D_GNU_SOURCE -fomit-frame-pointer -funroll-loops -O2  -D_USE_PTHREADS -msse
++CFLAGS += -D_WAYNE_MPI -D_GNU_SOURCE -fomit-frame-pointer -funroll-loops -O2  -D_USE_PTHREADS -msse
+ 
+ 
+ LIBRARIES = -lm -pthread
+--- Makefile.MPI.gcc.orig
++++ Makefile.MPI.gcc
+@@ -3,7 +3,7 @@
+ CC = mpicc 
+ 
+ 
+-CFLAGS = -D_WAYNE_MPI -D_GNU_SOURCE -fomit-frame-pointer -funroll-loops -O2  -msse
++CFLAGS += -D_WAYNE_MPI -D_GNU_SOURCE -fomit-frame-pointer -funroll-loops -O2  -msse
+ 
+ 
+ LIBRARIES = -lm
+--- Makefile.PTHREADS.gcc.orig
++++ Makefile.PTHREADS.gcc
+@@ -4,7 +4,7 @@
+ CC = gcc 
+ 
+ 
+-CFLAGS = -D_GNU_SOURCE -fomit-frame-pointer -funroll-loops -O2  -D_USE_PTHREADS -msse #-Wall -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
++CFLAGS += -D_GNU_SOURCE -fomit-frame-pointer -funroll-loops -O2  -D_USE_PTHREADS -msse #-Wall -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
+ 
+ 
+ LIBRARIES = -lm -pthread
+--- Makefile.PTHREADS.mac.orig
++++ Makefile.PTHREADS.mac
+@@ -4,7 +4,7 @@
+ CC = clang
+ 
+ 
+-CFLAGS = -D_GNU_SOURCE  -fomit-frame-pointer -funroll-loops -O2  -D_USE_PTHREADS -msse #-Wall -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
++CFLAGS += -D_GNU_SOURCE  -fomit-frame-pointer -funroll-loops -O2  -D_USE_PTHREADS -msse #-Wall -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
+ 
+ 
+ LIBRARIES = -lm -pthread
+--- Makefile.QuartetMPI.gcc.orig
++++ Makefile.QuartetMPI.gcc
 @@ -4,7 +4,7 @@
  CC = mpicc
  
  
 -CFLAGS = -D_GNU_SOURCE -fomit-frame-pointer -funroll-loops -O2 -msse -D_QUARTET_MPI #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
-+CFLAGS += -D_GNU_SOURCE -fomit-frame-pointer -funroll-loops -msse -D_QUARTET_MPI #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
++CFLAGS += -D_GNU_SOURCE -fomit-frame-pointer -funroll-loops -O2 -msse -D_QUARTET_MPI #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
  
  LIBRARIES = -lm
  
-@@ -17,7 +17,7 @@
- GLOBAL_DEPS = axml.h globalVariables.h #mem_alloc.h
+--- Makefile.SSE3.HYBRID.gcc.orig
++++ Makefile.SSE3.HYBRID.gcc
+@@ -2,7 +2,7 @@
  
- raxmlHPC : $(objs)
--	$(CC) -o raxmlHPC-QUARTET-MPI $(objs) $(LIBRARIES) 
-+	$(CC) -o raxmlHPC-QUARTET-MPI $(objs) $(LIBRARIES) $(LDFLAGS) 
+ CC = mpicc 
  
- classify.o : classify.c $(GLOBAL_DEPS)
- evaluatePartialSpecialGeneric.o : evaluatePartialSpecialGeneric.c $(GLOBAL_DEPS)
+-CFLAGS = -D_WAYNE_MPI -D_USE_PTHREADS -D__SIM_SSE3 -O2 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops  
++CFLAGS += -D_WAYNE_MPI -D_USE_PTHREADS -D__SIM_SSE3 -O2 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops  
+ 
+ LIBRARIES = -lm -pthread 
+ 
+--- Makefile.SSE3.MPI.gcc.orig
++++ Makefile.SSE3.MPI.gcc
+@@ -2,7 +2,7 @@
+ 
+ CC = mpicc 
+ 
+-CFLAGS = -D_WAYNE_MPI -D__SIM_SSE3 -O2 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops  
++CFLAGS += -D_WAYNE_MPI -D__SIM_SSE3 -O2 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops  
+ 
+ LIBRARIES = -lm
+ 
+--- Makefile.SSE3.PTHREADS.gcc.orig
++++ Makefile.SSE3.PTHREADS.gcc
+@@ -3,7 +3,7 @@
+ 
+ CC = gcc 
+ 
+-CFLAGS = -D_USE_PTHREADS -D__SIM_SSE3 -D_GNU_SOURCE -msse3 -O2 -fomit-frame-pointer -funroll-loops  #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
++CFLAGS += -D_USE_PTHREADS -D__SIM_SSE3 -D_GNU_SOURCE -msse3 -O2 -fomit-frame-pointer -funroll-loops  #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
+ 
+ 
+ LIBRARIES = -lm -pthread 
+--- Makefile.SSE3.PTHREADS.mac.orig
++++ Makefile.SSE3.PTHREADS.mac
+@@ -3,7 +3,7 @@
+ 
+ CC = clang
+ 
+-CFLAGS = -D_USE_PTHREADS -D__SIM_SSE3 -O2 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops  #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
++CFLAGS += -D_USE_PTHREADS -D__SIM_SSE3 -O2 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops  #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
+ 
+ 
+ LIBRARIES = -lm -pthread 
+--- Makefile.SSE3.QuartetMPI.gcc.orig
++++ Makefile.SSE3.QuartetMPI.gcc
+@@ -3,7 +3,7 @@
+ 
+ CC = mpicc
+ 
+-CFLAGS = -D__SIM_SSE3  -msse3 -D_GNU_SOURCE -O2 -fomit-frame-pointer -funroll-loops  -D_QUARTET_MPI #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
++CFLAGS += -D__SIM_SSE3  -msse3 -D_GNU_SOURCE -O2 -fomit-frame-pointer -funroll-loops  -D_QUARTET_MPI #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
+ 
+ LIBRARIES = -lm
+ 
+--- Makefile.SSE3.gcc.orig
++++ Makefile.SSE3.gcc
+@@ -3,7 +3,7 @@
+ 
+ CC = gcc 
+ 
+-CFLAGS = -D__SIM_SSE3  -msse3 -D_GNU_SOURCE -O2 -fomit-frame-pointer -funroll-loops  #-pedantic -Wall  -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
++CFLAGS += -D__SIM_SSE3  -msse3 -D_GNU_SOURCE -O2 -fomit-frame-pointer -funroll-loops  #-pedantic -Wall  -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
+ 
+ LIBRARIES = -lm
+ 
+--- Makefile.SSE3.mac.orig
++++ Makefile.SSE3.mac
+@@ -3,7 +3,7 @@
+ 
+ CC = clang
+ 
+-CFLAGS = -D__SIM_SSE3  -msse3 -D_GNU_SOURCE -O2 -fomit-frame-pointer -funroll-loops  #-Weverything -Wno-padded #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
++CFLAGS += -D__SIM_SSE3  -msse3 -D_GNU_SOURCE -O2 -fomit-frame-pointer -funroll-loops  #-Weverything -Wno-padded #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
+ 
+ LIBRARIES = -lm
+ 
+--- Makefile.gcc.orig
++++ Makefile.gcc
+@@ -4,7 +4,7 @@
+ CC = gcc 
+ 
+ 
+-CFLAGS = -D_GNU_SOURCE -fomit-frame-pointer -funroll-loops -O2 -msse #-Wall -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
++CFLAGS += -D_GNU_SOURCE -fomit-frame-pointer -funroll-loops -O2 -msse #-Wall -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
+ 
+ LIBRARIES = -lm
+ 


### PR DESCRIPTION
#### Description

- Add support for the avx2 variants.
- Workaround for the xcode 11 + AVX2 bug.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15
Xcode 11.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
