### PR TITLE
mafft: build extensions

### DIFF
--- a/science/mafft/Portfile
+++ b/science/mafft/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                mafft
 version             7.453
-revision            0
+revision            1
 
 categories          science
 platforms           darwin
@@ -16,26 +16,31 @@ long_description    ${description}
 
 homepage            https://mafft.cbrc.jp/alignment/software/
 master_sites        ${homepage}
-distname            mafft-${version}-without-extensions-src
+distname            mafft-${version}-with-extensions-src
 
-checksums           rmd160  82fecc871866986215cbdb93c59b58f8357b407a \
-                    sha256  4c05dfc4d173c9a139fcaa9373fbc2c8d6a59f410a7971f7acc6268be628b1f9 \
-                    size    612421
+checksums           rmd160  24011d6a80c705cf6bab39f2ec0260fb0aa82769 \
+                    sha256  8b2f0d6249c575f80cd51278ab45dd149b8ac9b159adac20fd1ddc7a6722af11 \
+                    size    747816
 
 extract.suffix      .tgz
 
 post-patch {
-    reinplace "s|PREFIX = /usr/local|PREFIX = ${prefix}|g" ${worksrcpath}/core/Makefile
+    reinplace "s|PREFIX = /usr/local|PREFIX = ${prefix}|g" ${worksrcpath}/core/Makefile ${worksrcpath}/extensions/Makefile
     reinplace "s|DESTDIR =|#DESTDIR =|g" ${worksrcpath}/core/Makefile
     reinplace "s|CC =|#CC =|g" ${worksrcpath}/core/Makefile
 }
 
 use_configure       no
 
-build.dir           ${worksrcpath}/core
-build.env           CC=${configure.cc}
+build {
+    system "make -C ${worksrcpath}/core all"
+    system "make -C ${worksrcpath}/extensions all"
+}
 
-destroot.env        DESTDIR=${destroot}${prefix}
+destroot {
+    system "make -C ${worksrcpath}/core install PREFIX=${destroot}${prefix}"
+    system "make -C ${worksrcpath}/extensions install PREFIX=${destroot}${prefix}"
+}
 
 post-destroot {
     set docdir ${prefix}/share/doc/${name}


### PR DESCRIPTION
#### Description

Add support for the RNA structural alignments.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15
Xcode 11.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
