### PR TITLE
qemu: Use MacPorts LDFLAGS

### DIFF
--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -104,6 +104,7 @@ configure.env-append   LIBTOOL=${prefix}/bin/glibtool
 set target_list {}
 pre-configure {
     configure.args-append --target-list=${target_list}
+    configure.args-append --extra-ldflags="${configure.ldflags}"
 }
 
 # The qemu build system bugs out when using in-source-tree builds.


### PR DESCRIPTION
#### Description

qemu: Use MacPorts LDFLAGS

Closes: https://trac.macports.org/ticket/60211

Allows legacysupport portgroup to work.

The fact that qemu ignores the LDFLAGS environment variable seems like a bug that should be reported to its developers. It appears to be a recent regression.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G12034
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
