### PR TITLE
axel: update to 2.17.8

### DIFF
--- a/net/axel/Portfile
+++ b/net/axel/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        axel-download-accelerator axel 2.17.6 v
-revision            1
+github.setup        axel-download-accelerator axel 2.17.8 v
+revision            0
 categories          net www
 platforms           darwin
-maintainers         nomaintainer
+maintainers         {@i0ntempest me.com:szf1234} openmaintainer
 license             {GPL-2+ OpenSSLException}
 
 description         A light Unix download accelerator
@@ -20,21 +20,19 @@ long_description    Axel does the same thing any other accelerator does: \
 github.tarball_from releases
 use_xz              yes
 
-# https://github.com/axel-download-accelerator/axel/issues/136
-configure.cppflags-append -D_DARWIN_C_SOURCE
-
-# Tiger needs a different workaround for the same issue
-patchfiles          patch-axel-tiger-no-posix-c-source.diff
-
-checksums           rmd160  9167c7d134b71f7b2d56b0ab200ad40c097d869b \
-                    sha256  24ab549021bdfca01ad5e8e95b706869dd30fe9ab1043da4cbb9dff89edc267d \
-                    size    202324
+checksums           rmd160  d6456cb8820cc9b80ac449edf64fe79a9747b291 \
+                    sha256  19c82a095e3ea84f1e24fe6fd6018ee06af73ee03ca8ecf31b34dcc57ef4351e \
+                    size    201224
 
 depends_build-append \
                     port:pkgconfig
 
 depends_lib         port:gettext \
                     path:lib/libssl.dylib:openssl
+
+# Tiger needs a different workaround for this issue:
+# https://github.com/axel-download-accelerator/axel/issues/136
+patchfiles          patch-axel-tiger-no-posix-c-source.diff
 
 post-destroot {
     copy ${worksrcpath}/doc ${destroot}${prefix}/share/doc/${subport}

--- a/net/axel/files/patch-axel-tiger-no-posix-c-source.diff
+++ b/net/axel/files/patch-axel-tiger-no-posix-c-source.diff
@@ -1,35 +1,26 @@
 Tiger does not have the _DARWIN_C_SOURCE override to enable chunks of headers
 when _POSIX_C_SOURCE is defined, so we have to specifically remove the
-_POSIX_C_SOURCE from these headers and files for Tiger builds to succeed.
+_POSIX_C_SOURCE from these files for Tiger builds to succeed.
 
 This patch could not be sent upstream as is... and probably would not be accepted
 if it were sent upstream given the age of Tiger.
 
 kencu@macports.org
-
-
-
-diff --git src/sleep.h src/sleep.h
-index 1958913..1974d8d 100644
---- src/sleep.h
-+++ src/sleep.h
-@@ -1,9 +1,11 @@
- #ifndef AXEL_SLEEP_H
- #define AXEL_SLEEP_H
+--- src/sleep.c.orig	2020-04-06 15:21:04.000000000 -0500
++++ src/sleep.c	2020-05-15 07:56:47.000000000 -0500
+@@ -33,7 +33,9 @@
+ */
  
+ #include "config.h"
 +#if (__APPLE__ && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1050)
- #ifndef _POSIX_C_SOURCE
  #define _POSIX_C_SOURCE 200112L
- #endif
 +#endif
  
- static inline int
- axel_sleep(struct timespec delay)
-diff --git src/tcp.c src/tcp.c
-index 6be557b..f42106b 100644
---- src/tcp.c
-+++ src/tcp.c
-@@ -38,7 +38,9 @@
+ #include <errno.h>
+ #include <time.h>
+--- src/tcp.c.orig	2020-04-06 15:21:04.000000000 -0500
++++ src/tcp.c	2020-05-15 07:55:17.000000000 -0500
+@@ -40,7 +40,9 @@
  
  /* TCP control file */
  
@@ -37,5 +28,5 @@ index 6be557b..f42106b 100644
  #define _POSIX_C_SOURCE 200112L
 +#endif
  
- #include "axel.h"
- 
+ #include "config.h"
+ #include <sys/types.h>


### PR DESCRIPTION
and take maintainership

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
