### PR TITLE
hwloc: update to 2.2.0

### DIFF
--- a/devel/hwloc/Portfile
+++ b/devel/hwloc/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           active_variants 1.1
 
 name                hwloc
-set branch          2.1
+set branch          2.2
 version             ${branch}.0
 epoch               1
 categories          devel
 platforms           darwin
-maintainers         nomaintainer
+maintainers         {@i0ntempest me.com:szf1234} openmaintainer
 description         Portable Hardware Locality
 license             BSD
 
@@ -23,9 +23,9 @@ long_description \
 homepage            https://www.open-mpi.org/projects/hwloc/
 master_sites        https://www.open-mpi.org/software/hwloc/v${branch}/downloads/
 
-checksums           rmd160  add29745a69a7ef7f9c35bb067e1858174e07f55 \
-                    sha256  1fb8cc1438de548e16ec3bb9e4b2abb9f7ce5656f71c0906583819fcfa8c2031 \
-                    size    6761831
+checksums           rmd160  98d1ba626ae3ad7462441deb2637a2892095dc99 \
+                    sha256  2defba03ddd91761b858cbbdc2e3a6e27b44e94696dbfa21380191328485a433 \
+                    size    6739742
 
 depends_build       port:pkgconfig
 depends_lib-append  port:libxml2


### PR DESCRIPTION
and claim maintainership

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
