### PR TITLE
alacritty: minor changes and cleanups

### DIFF
--- a/aqua/alacritty/Portfile
+++ b/aqua/alacritty/Portfile
@@ -57,7 +57,7 @@ cargo.crates \
     block                            0.1.6  0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a \
     byteorder                        1.3.4  08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de \
     bzip2                            0.3.3  42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b \
-    bzip2-sys                     0.1.8+1.0.8  05305b41c5034ff0e93937ac64133d109b5a2660114ec45e9760bc6816d83038 \
+    bzip2-sys                  0.1.8+1.0.8  05305b41c5034ff0e93937ac64133d109b5a2660114ec45e9760bc6816d83038 \
     c2-chacha                        0.2.3  214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb \
     calloop                          0.4.4  7aa2097be53a00de9e8fc349fea6d76221f398f5c4fa550d420669906962d160 \
     cc                              1.0.50  95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd \
@@ -262,7 +262,7 @@ cargo.crates \
     vte                              0.7.1  8299f6cd1505d50a633aa31b4088aeffe511099d8c7bc38e5d3669379a08a2b8 \
     vte_generate_state_changes       0.1.1  d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff \
     walkdir                          2.3.1  777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d \
-    wasi                          0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
+    wasi      0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
     wayland-client                  0.23.6  af1080ebe0efabcf12aef2132152f616038f2d7dcbbccf7b2d8c5270fe14bcda \
     wayland-commons                 0.23.6  bb66b0d1a27c39bbce712b6372131c6e25149f03ffb0cd017cf8f7de8d66dbdb \
     wayland-protocols               0.23.6  6cc286643656742777d55dc8e70d144fa4699e426ca8e9d4ef454f4bf15ffcf9 \

--- a/aqua/alacritty/Portfile
+++ b/aqua/alacritty/Portfile
@@ -24,21 +24,17 @@ checksums           ${distname}${extract.suffix} \
                     size    1486955
 
 set al_app_name     Alacritty.app
-set al_app_dir      "${applications_dir}/${al_app_name}"
-set al_app_template "extra/osx/${al_app_name}"
-set al_app_bindir   "${al_app_dir}/Contents/MacOS"
-set al_target_dir   "target/${build_arch}-apple-${platforms}/release"
+set al_app_dir      ${applications_dir}/${al_app_name}
+set al_app_template extra/osx/${al_app_name}
+set al_app_bindir   ${al_app_dir}/Contents/MacOS
+set al_target_dir   target/${build_arch}-apple-${platforms}/release
 
 destroot {
+    copy ${worksrcpath}/${al_app_template}/ ${destroot}${applications_dir}
 
-    file mkdir "${destroot}${applications_dir}"
+    file mkdir ${destroot}${al_app_bindir}
 
-    copy "${worksrcpath}/${al_app_template}/" "${destroot}${applications_dir}"
-
-    file mkdir "${destroot}/${al_app_bindir}"
-
-    move "${worksrcpath}/${al_target_dir}/${name}" \
-        "${destroot}${al_app_bindir}"
+    move ${worksrcpath}/${al_target_dir}/${name} ${destroot}${al_app_bindir}
 }
 
 cargo.crates \

--- a/aqua/alacritty/Portfile
+++ b/aqua/alacritty/Portfile
@@ -37,6 +37,8 @@ destroot {
     move ${worksrcpath}/${al_target_dir}/${name} ${destroot}${al_app_bindir}
 }
 
+github.livecheck.regex {([0-9.]+)}
+
 cargo.crates \
     adler32                          1.0.4  5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2 \
     aho-corasick                     0.7.9  d5e63fd144e18ba274ae7095c0197a870a7b9468abc801dd62f190d80817d2ec \


### PR DESCRIPTION
#### Description

A few minor changes and cleanups to the alacritty portfile that don't affect the way that it installs:

* **Remove unnecessary quotation marks.** In Tcl you don't need quotation marks unless there is *literal* whitespace between them. (This is unlike in shell scripting, where you need quotation marks if the values of the variables might contain whitespace.)
* **Remove unnecessary creation of applications_dir.** MacPorts makes this and other standard directories for you.
* **Remove unnecessary slash before al_app_bindir.** Its value already begins with a slash.
* **Adjust whitespace of crates so that the checksums are aligned.**
* **Fix livecheck to avoid release candidates.**

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G12034
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
