### PR TITLE
redis: update to 6.0.1

### DIFF
--- a/databases/redis/Portfile
+++ b/databases/redis/Portfile
@@ -3,9 +3,10 @@
 PortSystem          1.0
 PortGroup           muniversal 1.0
 PortGroup           xcode_workaround 1.0
+PortGroup           makefile 1.0
 
 name                redis
-version             5.0.8
+version             6.0.1
 categories          databases
 platforms           darwin
 license             BSD
@@ -18,9 +19,9 @@ long_description    {*}${description}
 homepage            https://redis.io/
 master_sites        http://download.redis.io/releases/
 
-checksums           rmd160  91bb5a283b0a040aeb67dcab954a7c1b85490e3b \
-                    sha256  f3c7eac42f433326a8d981b50dba0169fdfaf46abb23fcda2f933a7552ee4ed7 \
-                    size    1985757
+checksums           rmd160  b6b3c04aa80bf8df6ff0476482c3cb929bc102c2 \
+                    sha256  b8756e430479edc162ba9c44dc89ac394316cd482f2dc6b91bcd5fe12593f273 \
+                    size    2204138
 
 patchfiles          patch-redis.conf.diff
 
@@ -42,27 +43,31 @@ if {[string match *clang* ${configure.cxx}]} {
     configure.cxx-append -stdlib=${configure.cxx_stdlib}
 }
 
-if {${configure.sdkroot} ne ""} {
-    configure.cc-append     -isysroot${configure.sdkroot}
-    configure.cxx-append    -isysroot${configure.sdkroot}
-}
+# redis and dep makefiles have their own optflags
+configure.optflags
 
-if {![variant_isset universal]} {
-    build.args-append \
-        CC="${configure.cc} [get_canonical_archflags cc]" \
-        CXX="${configure.cxx} [get_canonical_archflags cxx]"
-} else {
-    foreach arch ${configure.universal_archs} {
-        lappend merger_build_args(${arch}) CC='${configure.cc} -arch ${arch}' \
-                                           CXX='${configure.cxx} -arch ${arch}'
-    }
-}
+# redis doesn't know about CPPFLAGS so pass it this way
+build.args-append   REDIS_CFLAGS=${configure.cppflags}
 
 # disable silent rules
 build.args-append   V=1
 
-# use jemalloc
-build.args-append   MALLOC=jemalloc
+# https://github.com/antirez/redis/issues/7254
+# We have to define environment variables in both
+# build and destroot to work around bugs in the Makefile
+# that would cause the destroot's make install to compile
+# redis twice.
+
+foreach mp_phase {build destroot} {
+    # use jemalloc
+    ${mp_phase}.args-append   MALLOC=jemalloc
+
+    # enable TLS.
+    ${mp_phase}.args-append   BUILD_TLS=yes
+}
+
+# more TLS
+depends_lib         port:openssl
 
 destroot.keepdirs   ${destroot}${prefix}/var/db/redis
 
@@ -75,13 +80,23 @@ if {![variant_isset universal]} {
 }
 
 post-destroot {
-    xinstall -m 0644 ${worksrcpath}/redis.conf \
-        ${destroot}${prefix}/etc/redis.conf.sample
+    foreach conffile {redis.conf sentinel.conf} {
+        xinstall -m 0644 ${worksrcpath}/${conffile} \
+            ${destroot}${prefix}/etc/${conffile}.sample
+    }
+
+    # https://github.com/antirez/redis/pull/3494
+    foreach dup_binary {redis-check-aof redis-check-rdb} {
+        delete ${destroot}${prefix}/bin/${dup_binary}
+        ln -s redis-server ${destroot}${prefix}/bin/${dup_binary}
+    }
 }
 
 post-activate {
-    if {![file exists ${prefix}/etc/redis.conf]} {
-        file copy ${prefix}/etc/redis.conf.sample ${prefix}/etc/redis.conf
+    foreach conffile {redis.conf sentinel.conf} {
+        if {![file exists ${prefix}/etc/${conffile}]} {
+            file copy ${prefix}/etc/${conffile}.sample ${prefix}/etc/${conffile}
+        }
     }
     xinstall -d ${prefix}/var/log
     touch ${prefix}/var/log/redis.log

--- a/databases/redis/files/patch-redis.conf.diff
+++ b/databases/redis/files/patch-redis.conf.diff
@@ -1,29 +1,49 @@
---- redis.conf.orig	2017-07-14 11:28:42.000000000 +0000
-+++ redis.conf	2017-07-14 15:43:39.000000000 +0000
-@@ -155,7 +155,7 @@
+--- redis.conf.orig	2020-05-14 09:42:51.094603573 -0400
++++ redis.conf	2020-05-14 09:50:15.671701491 -0400
+@@ -224,7 +224,7 @@
  #
  # Creating a pid file is best effort: if Redis is not able to create it
  # nothing bad happens, the server will start and run normally.
 -pidfile /var/run/redis_6379.pid
 +pidfile @PREFIX@/var/run/redis_6379.pid
- 
+
  # Specify the server verbosity level.
  # This can be one of:
-@@ -168,7 +168,7 @@
+@@ -237,7 +237,7 @@
  # Specify the log file name. Also the empty string can be used to force
  # Redis to log on the standard output. Note that if you use standard
  # output for logging but daemonize, logs will be sent to /dev/null
 -logfile ""
 +logfile @PREFIX@/var/log/redis.log
- 
+
  # To enable logging to the system logger, just set 'syslog-enabled' to yes,
  # and optionally update the other syslog parameters to suit your needs.
-@@ -260,7 +260,7 @@
+@@ -342,7 +342,7 @@
  # The Append Only File will also be created inside this directory.
  #
  # Note that you must specify a directory here, not a file name.
 -dir ./
 +dir @PREFIX@/var/db/redis
- 
+
  ################################# REPLICATION #################################
- 
+
+--- src/Makefile.orig	2020-05-14 12:03:25.183608552 -0400
++++ src/Makefile	2020-05-14 12:03:51.752513404 -0400
+@@ -103,8 +103,6 @@
+ ifeq ($(uname_S),Darwin)
+ 	# Darwin
+ 	FINAL_LIBS+= -ldl
+-	OPENSSL_CFLAGS=-I/usr/local/opt/openssl/include
+-	OPENSSL_LDFLAGS=-L/usr/local/opt/openssl/lib
+ else
+ ifeq ($(uname_S),AIX)
+         # AIX
+@@ -182,8 +180,7 @@
+ endif
+
+ ifeq ($(BUILD_TLS),yes)
+-    FINAL_CFLAGS+=-DUSE_OPENSSL $(OPENSSL_CFLAGS)
+-    FINAL_LDFLAGS+=$(OPENSSL_LDFLAGS)
++    FINAL_CFLAGS+=-DUSE_OPENSSL
+     FINAL_LIBS += ../deps/hiredis/libhiredis_ssl.a -lssl -lcrypto
+ endif


### PR DESCRIPTION
#### Description
Big update, enable the new TLS support, refactor the Portfile a bit.  I tested basic redis functionality as well as the new TLS connections locally.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G4032
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
