### PR TITLE
3mux: new port

### DIFF
--- a/sysutils/3mux/Portfile
+++ b/sysutils/3mux/Portfile
@@ -1,0 +1,63 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/aaronjanse/3mux 0.3.0 v
+categories          sysutils
+maintainers         {@sikmir gmail.com:sikmir} openmaintainer
+license             MIT
+
+description         Terminal multiplexer inspired by i3
+
+long_description    ${description}
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  c0afe1aedb6bbfb04861c01b8e791e6552f40a20 \
+                        sha256  2dc1702ac56524b9db9b6efca7eb7cd9adb4d9ffbd624a6556be20b8178a8246 \
+                        size    10333671
+
+go.vendors          github.com/BurntSushi/toml \
+                        lock    v0.3.1 \
+                        rmd160  fb9650e2d16525153645e5547626f242f3800149 \
+                        sha256  8cc9e5dc68e247554227973d0b4e023b27bbd9ba5a26e4fb40f44743afcb35f1 \
+                        size    42087 \
+                    github.com/BurntSushi/xdg \
+                        lock    e80d3446fea1 \
+                        rmd160  95f5b466e59d445aabbbed3532f9df95839cdcef \
+                        sha256  ddfc963c7ce12e917c2f546f4c54530b6724abc90a34734de93f64696704d1c6 \
+                        size    2790 \
+                    github.com/creack/pty \
+                        lock    v1.1.7 \
+                        rmd160  06ce51de1e7f9a347eee40c40189c6e0c9a13d13 \
+                        sha256  150b50e6eb2fec8c7e904e54be1aacfbb1df09b5a97ef7b77284fea8ac44fc3c \
+                        size    8168 \
+                    github.com/kr/pty \
+                        lock    v1.1.8 \
+                        rmd160  7fc6efad080de4926974713c76d2e74daf254e48 \
+                        sha256  1ea6bd7570dd02351d383c35d2900bca5295a58721afcabbc76b0d9ffbef956c \
+                        size    2120 \
+                    github.com/mattn/go-runewidth \
+                        lock    v0.0.9 \
+                        rmd160  412c0e508e55f4fe437be0f71d7d22eca2b4366f \
+                        sha256  4f0f4a22257ccecfb6beae88052d850380ecc0e806d6bcc92d3656ebcac3b638 \
+                        size    16716 \
+                    golang.org/x/crypto \
+                        lock    056763e48d71 \
+                        rmd160  4c39311fe21dd3b728ebbf38dbcfb7f8849d38ca \
+                        sha256  023286029642de2f3d50ec3b96e1d049c6a52598c6acba7147bfbfeb7628ff2a \
+                        size    1727880 \
+                    golang.org/x/sys \
+                        lock    97732733099d \
+                        rmd160  d83b94fd587bc3799316510e1e5cfda7ff2425e8 \
+                        sha256  62c7cd8777af259c0266055a99d3d67c80a77506104a14a9678547c808010f73 \
+                        size    1350306 \
+                    golang.org/x/text \
+                        lock    v0.3.0 \
+                        rmd160  81061ce2006da3d6f7a8ef8dae237d65305513d3 \
+                        sha256  6243d5bbd9d8550bc44cb58a0d70180f7a3f6767299b490015107b4d27c604ae \
+                        size    6102563
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

> [**3mux**](https://github.com/aaronjanse/3mux) is a terminal multiplexer with out-of-the-box support for search, mouse-controlled scrollback, and i3-like keybindings. Imagine tmux with a smaller learning curve and more sane defaults.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
