### PR TITLE
multiple libimobiledevice ports: update to latest versions

### DIFF
--- a/devel/ideviceinstaller/Portfile
+++ b/devel/ideviceinstaller/Portfile
@@ -47,6 +47,11 @@ subport ideviceinstaller-devel {
                     sha256  1ad1adf8d797717685cb66bf50e830d76dcfc59ff4575fb75e5652a28d5ac45b \
                     size    20318
 
+    depends_lib-delete path:lib/libimobiledevice.dylib:libimobiledevice \
+                       port:libplist
+    depends_lib-append path:lib/libimobiledevice.dylib:libimobiledevice-devel\
+                       port:libplist-devel
+
     conflicts       ideviceinstaller
 
     livecheck.url   ${github.homepage}/commits/${github.livecheck.branch}.atom

--- a/devel/libimobiledevice/Portfile
+++ b/devel/libimobiledevice/Portfile
@@ -48,13 +48,13 @@ configure.args      --disable-silent-rules \
                     --without-cython
 
 subport libimobiledevice-devel {
-    github.setup    libimobiledevice libimobiledevice af91dc6376946daffd5c9ece916d9f33af828890
-    version         20191113
+    github.setup    libimobiledevice libimobiledevice 42e40aacc333ee759425e7d64124d31c312c6f40
+    version         20200507
     revision        0
 
-    checksums       rmd160  82583e8e635c8908cf1be39bc3cc5f1793a793ad \
-                    sha256  b4299f250e391a1c493f78944eac1165170c76dedd95677ed181592989ed765b \
-                    size    244977
+    checksums       rmd160  8d7b1db6131eb3afc791be6664eed7723438ca99 \
+                    sha256  e691c08d7d9e70a1198b513b1c173c15855a40ab3ba8b09f2254e878db0141d3 \
+                    size    250578
 
     depends_lib-delete port:libusbmuxd
     depends_lib-append port:libusbmuxd-devel

--- a/devel/libusbmuxd/Portfile
+++ b/devel/libusbmuxd/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        libimobiledevice libusbmuxd 2.0.0
+github.setup        libimobiledevice libusbmuxd 2.0.1
 
 categories          devel
 platforms           darwin
@@ -16,9 +16,9 @@ long_description    A client library to multiplex connections from and to iOS de
 
 license             LGPL-2.1
 
-checksums           rmd160  87eaeb1df29ccfbc17bce4ce8f13bd0eac1ce1bc \
-                    sha256  b7fe9a550fe7e3671f0a81d103b40fc220fa533cbadffbdaee9b6dbca02069b9 \
-                    size    42118
+checksums           rmd160  1af2257b4e818d5f386cc7f01a3c992df9052096 \
+                    sha256  285337ba29733870197629a51e57c141a1d976117f7c8c1d031fbd3cafd3aa86 \
+                    size    42178
 
 depends_build-append \
                     port:autoconf \
@@ -33,14 +33,17 @@ configure.cmd       ./autogen.sh
 configure.args      --disable-silent-rules
 
 subport libusbmuxd-devel {
-    github.setup    libimobiledevice libusbmuxd 8f3afaf4cac7fcf64723be466fdb29009b34bb73
-    version         20191108
+    github.setup    libimobiledevice libusbmuxd 5364a1b45e79c605d5e5f02b2b57b5a7fe75636c
+    version         20200518
     # Epoch 1: Downgrade due to https://github.com/libimobiledevice/libusbmuxd/issues/71
     epoch           1
 
-    checksums       rmd160  a6ef8d5601ec284c6a6a0019e8bf571302bd61c6 \
-                    sha256  efcc8b0be68a1197a6f743b213cd9c045b94a7049c1f4ed55ad6a9ab67fb9724 \
-                    size    42119
+    checksums       rmd160  0ab1d175e1ee66886582974e2a4686f593000cd4 \
+                    sha256  f0fb4b5c35b70cd2f12b22f42d0f0783100a2f516d39d7fc7f5b2b975f7ed8bd \
+                    size    44083
+    
+    depends_lib-delete port:libplist
+    depends_lib-append port:libplist-devel
 
     conflicts       libusbmuxd
 

--- a/devel/usbmuxd/Portfile
+++ b/devel/usbmuxd/Portfile
@@ -29,3 +29,24 @@ configure.cmd       ./autogen.sh
 configure.args      --disable-silent-rules \
                     --without-preflight \
                     --without-systemd
+
+subport usbmuxd-devel {
+    github.setup    libimobiledevice usbmuxd 45dd28e6a1ce8bcd42cc7d547c223b05ffebff9b
+    version         20200507
+    revision        0
+
+    checksums       rmd160  d1e8b40c7ca6e97dedd0d4b1f26ba33f7d2e799a \
+                    sha256  b4fe9d00b1ac51a6627dedc96eae503ab12eb6695e3256f7ecb6195ce5744338 \
+                    size    59771
+
+    conflicts       usbmuxd
+
+    depends_lib-delete port:libplist
+    depends_lib-append port:libplist-devel
+
+    livecheck.url   ${github.homepage}/commits/${github.livecheck.branch}.atom
+}
+
+if {${subport} eq ${name}} {
+    conflicts       usbmuxd-devel
+}

--- a/textproc/libplist/Portfile
+++ b/textproc/libplist/Portfile
@@ -30,3 +30,21 @@ configure.cmd       ./autogen.sh
 
 configure.args      --disable-silent-rules \
                     --without-cython
+
+subport libplist-devel {
+    github.setup    libimobiledevice libplist bbde6a4ac4c1cd0abad294b7533d01ab5b230880
+    version         20200514
+    revision        0
+
+    checksums       rmd160  34be1e0175f697f20ee70bb9015174d05efbec58 \
+                    sha256  ef1a155999776075f10c1bdca43a415aa22aa080e5ca40704a0c5555b45d31b2 \
+                    size    179795
+
+    conflicts       libplist
+
+    livecheck.url   ${github.homepage}/commits/${github.livecheck.branch}.atom
+}
+
+if {${subport} eq ${name}} {
+    conflicts       libplist-devel
+}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
