### PR TITLE
openblas: go native on older systems

### DIFF
--- a/math/OpenBLAS/Portfile
+++ b/math/OpenBLAS/Portfile
@@ -22,7 +22,6 @@ platforms           darwin
 compiler.blacklist-append cc {*gcc-3*} {*gcc-4.[0-7]} {clang < 800.0.38}
 platform darwin i386 {
     compiler.blacklist-append {macports-clang-[3-4].*}
-    compiler.fallback-append macports-clang-9.0 macports-clang-8.0 macports-clang-7.0
 }
 
 #OS 10.7-10.11 supports down to iMac 7,1, with Intel Core 2 Duo architecture

--- a/math/OpenBLAS/Portfile
+++ b/math/OpenBLAS/Portfile
@@ -22,22 +22,9 @@ platforms           darwin
 compiler.blacklist-append cc {*gcc-3*} {*gcc-4.[0-7]} {clang < 800.0.38}
 platform darwin i386 {
     compiler.blacklist-append {macports-clang-[3-4].*}
-    compiler.fallback-append macports-clang-5.0 macports-clang-6.0 macports-clang-7.0
+    compiler.fallback-append macports-clang-9.0 macports-clang-8.0 macports-clang-7.0
 }
 
-#Define target based on version of OS
-#OS 10.5 supports down to Intel Core Solo (Intel) or PowerPC G4
-if {${os.major} == 9} { 
-    if {${os.arch} eq "i386" || [variant_isset universal]} {
-        set blas_arch "YONAH"
-    } else {
-        set blas_arch "PPCG4"
-    }
-}
-#OS 10.6 supports down to Intel Core Solo architecture
-if {${os.major} == 10} { 
-    set blas_arch "YONAH"
-} 
 #OS 10.7-10.11 supports down to iMac 7,1, with Intel Core 2 Duo architecture
 #OS 10.12-13 supports down to iMac 10,1, with Intel Core 2 Duo architecture
 if {${os.major} >= 11 && ${os.major} <= 17} { 


### PR DESCRIPTION
On older systems, the 32bit/64bit differences are
difficult to compensate for in the Portfile. OpenBLAS
now handles this internally quite well. Use that instead.

Buildbot installs of OpenBLAS will be disabled, and users will build
OpenBLAS optimally on their systems -- this is probably for the
best, to maximize the efficiency of older sytems.

tested on 10.4 PPC, 10.5 PPC, 10.4 Intel, 10.6 (including +universal).