### PR TITLE
py-[semver|upt-pypi]: update to latest versions

### DIFF
--- a/python/py-semver/Portfile
+++ b/python/py-semver/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-semver
-version             2.9.1
+version             2.10.1
 revision            0
 
 platforms           darwin
@@ -17,14 +17,14 @@ long_description    ${description}
 
 homepage            https://github.com/k-bx/python-semver
 
-checksums           sha256  723be40c74b6468861e0e3dbb80a41fc3b171a2a45bf956c245304773dc06055 \
-                    rmd160  d376c882ee915ed254152bcc732fe2f91f42fa49 \
-                    size    34508
+checksums           sha256  b08a84f604ef579e474ce448672a05c8d50d1ee0b24cee9fb58a12b260e4d0dc \
+                    rmd160  8e2e82dff987cc8d97e2769e44546d8d009148b0 \
+                    size    21661
 
 python.versions     37 38
 
 if {${name} ne ${subport}} {
-    depends_build-append \
+    depends_lib-append \
                     port:py${python.version}-setuptools
 
     depends_test-append \
@@ -32,8 +32,9 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-pytest-cov
 
     test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.target     -o addopts=''
+    test.cmd        py.test-${python.branch} test_semver.py
+    test.args       -o addopts=''
+    test.target
     test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     post-destroot {

--- a/python/py-upt-pypi/Portfile
+++ b/python/py-upt-pypi/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-upt-pypi
-version             0.5
+version             0.5.1
 revision            0
 
 platforms           darwin
@@ -16,12 +16,10 @@ description         PyPI frontend for upt
 long_description    ${description}
 
 homepage            https://framagit.org/upt/upt-pypi
-master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
-distname            ${python.rootname}-${version}
 
-checksums           sha256  6cfe91ab916ab190d4d6440b829c2c13d42855724f681c39483e98a506cd9c94 \
-                    rmd160  283c92efd5bef46ce74f1b467ea017b40e7341cf \
-                    size    12414
+checksums           sha256  1cb93bf5c91ba2584f53f2b060a21c1c470b3d038c9f859054976815e87499ce \
+                    rmd160  88a40dda5b90c37374e4802420f463bfdbb293a1 \
+                    size    12668
 
 python.versions     37 38
 


### PR DESCRIPTION
#### Description
- py-semver: update to 2.10.1, fix dependency type
- py-upt-pypi: update to 0.5.1 

###### Tested on
macOS 10.14.6 18G4032
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
