### PR TITLE
py-numpy: update to 1.18.4

### DIFF
--- a/python/py-numpy/Portfile
+++ b/python/py-numpy/Portfile
@@ -17,11 +17,11 @@ maintainers             {michaelld @michaelld} openmaintainer
 description             The core utilities for the scientific library scipy for Python
 long_description        ${description}
 
-github.setup            numpy numpy 1.18.2 v
-checksums               rmd160  ba58a89eb7c1112541e8037dd66774d9b5747ca8 \
-                        sha256  5f684cf7b31f725c121f94dc1c6cd5a8af910ead9e71cddf4af4f16d7ce4d78b \
-                        size    5161709
-revision                1
+github.setup            numpy numpy 1.18.4 v
+checksums               rmd160  5bd0d7999ecdc7c0a3ef42ea147399da0aca0de2 \
+                        sha256  ed8952de7749bda7df802ac480b97871aaaededdc495b26b71a1902420a609be \
+                        size    5167092
+revision                0
 
 if {${name} ne ${subport}} {
     # the python PortGroup puts compiler names in build.env and destroot.env


### PR DESCRIPTION
#### Description
- update `py-numpy` to its latest version
###### Tested on
macOS 10.14.6 18G4032
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
