### PR TITLE
k9s: update to 0.19.5

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.19.4 v
+go.setup            github.com/derailed/k9s 0.19.5 v
 homepage            https://k9scli.io
 
 categories          sysutils devel
@@ -20,9 +20,9 @@ platforms           darwin
 supported_archs     x86_64
 license             Apache-2
 
-checksums           rmd160  619c78683b80935092b8bed28e13cc80b87325b9 \
-                    sha256  b076de9d589ea867a304310b4360ca80ea8309bd370a83acf9a25d63512393b6 \
-                    size    6059578
+checksums           rmd160  07129ac9428abd371578f94703c974d4eb9325e7 \
+                    sha256  5116385d02ffd1a1f6e17928bac6014139e8436e939647e9508e374c8fa67ee2 \
+                    size    6061987
 
 # Reproduce the "build" target from the upstream Makefile
 set go_ldflags      "-w -X ${go.package}/cmd.version=${version} \


### PR DESCRIPTION
#### Description

Update to k9s 0.19.5.

###### Tested on

macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?