### PR TITLE
rust: update to 1.43.1

### DIFF
--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                rust
-version             1.43.0
+version             1.43.1
 revision            0
 categories          lang devel
 platforms           darwin
@@ -47,9 +47,9 @@ distfiles-append    rust-std-${ruststd_version}-${build_arch}-apple-${os.platfor
                     cargo-${cargo_version}-${build_arch}-apple-${os.platform}${extract.suffix}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  994ef055d958f38d23a70575884e2fcb058003f9 \
-                    sha256  75f6ac6c9da9f897f4634d5a07be4084692f7ccc2d2bb89337be86cfc18453a1 \
-                    size    136038757
+                    rmd160  074b72f9fe69342c6071ef254b96c32911710260 \
+                    sha256  cde177b4a8c687da96f20de27630a1eb55c9d146a15e4c900d5c31cd3c3ac41d \
+                    size    136095096
 
 checksums-append \
                     rust-std-${ruststd_version}-x86_64-apple-${os.platform}${extract.suffix} \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
