### PR TITLE
dtool: new port

### DIFF
--- a/devel/dtool/Portfile
+++ b/devel/dtool/Portfile
@@ -1,0 +1,171 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo 1.0
+
+github.setup        guoxbin dtool 0.9.0 v
+categories          devel
+platforms           darwin
+license             GPL-3
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+description         A command-line tool collection to assist development
+
+long_description    {*}${description}
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  c04583a609a9b37fa5ce7eeb9e54bab17113275b \
+                    sha256  3dc3828f3c3bad94a6a46a31fd7e4662a5827279630d80e0eb88264c9930ff99 \
+                    size    60086
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/${name} ${destroot}${prefix}/bin/
+}
+
+cargo.crates \
+    aho-corasick                     0.7.6  58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d \
+    ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
+    anyhow                          1.0.26  7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c \
+    arrayref                         0.3.5  0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee \
+    arrayvec                         0.5.1  cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8 \
+    arrayvec                        0.4.12  cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9 \
+    atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+    autocfg                          0.1.7  1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2 \
+    autocfg                          1.0.0  f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d \
+    base64                          0.11.0  b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7 \
+    bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
+    blake2b_simd                    0.5.10  d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a \
+    block-buffer                     0.7.3  c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b \
+    block-padding                    0.1.5  fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5 \
+    bs58                             0.3.0  b170cd256a3f9fa6b9edae3e44a7dfdfc77e8124dbc3e2612d75f9c3e2396dae \
+    bstr                             0.2.9  3ede750122d9d1f87919570cb2cccee38c84fbc8c5599b25c289af40625b7030 \
+    build_const                      0.2.1  39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39 \
+    bumpalo                          3.2.0  1f359dc14ff8911330a51ef78022d376f25ed00248912803b58f00cb1c27f742 \
+    byte-tools                       0.3.1  e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7 \
+    byteorder                        1.3.2  a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5 \
+    cc                              1.0.41  8dae9c4b8fedcae85592ba623c4fd08cfdab3e3b72d6df780c6ead964a69bfff \
+    cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
+    chrono                          0.4.10  31850b4a4d6bae316f7a09e691c944c28299298837edc0a03f755618c23cbc01 \
+    clap                            2.33.0  5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9 \
+    clear_on_drop                    0.2.3  97276801e127ffb46b66ce23f35cc96bd454fa311294bced4bbace7baa8b1d17 \
+    cloudabi                         0.0.3  ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
+    constant_time_eq                 0.1.5  245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc \
+    crc                              1.8.1  d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb \
+    crossbeam-utils                  0.6.6  04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6 \
+    csv                              1.1.2  11f8cbd084b9a431d52dfac0b8428a26b68f1061138a7bea18aa56b9cdf55266 \
+    csv-core                         0.1.6  9b5cadb6b25c77aeff80ba701712494213f4a8418fcda2ee11b6560c3ad0bf4c \
+    curve25519-dalek                 1.2.3  8b7dcd30ba50cdf88b55b033456138b7c0ac4afdc436d82e1b79f370f24cc66d \
+    digest                           0.8.1  f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5 \
+    dirs                             1.0.5  3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901 \
+    dtoa                             0.4.4  ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e \
+    ecdsa                            0.3.0  9455b6c4ee3265c116c9ff33df6ae8af776adb9e6674a98319ec7f55b42bca8d \
+    elliptic-curve                   0.2.0  ed8af8090c11491f2eda061d68eb48433176f851dfa6b634f829381c659ea1ff \
+    encode_unicode                   0.3.6  a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f \
+    entities                         1.0.1  b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca \
+    escaper                          0.1.0  39da344028c2227132b2dfa7c186e2104ecc153467583d00ed9c398f9ff693b0 \
+    failure                          0.1.6  f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9 \
+    fake-simd                        0.1.2  e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed \
+    fuchsia-cprng                    0.1.1  a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba \
+    gcc                             0.3.55  8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2 \
+    generic-array                   0.12.3  c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec \
+    getrandom                       0.1.14  7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb \
+    heck                             0.3.1  20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205 \
+    hermit-abi                       0.1.6  eff2656d88f158ce120947499e971d743c05dbcbed62e5bd2f38f1698bbc3772 \
+    hex                              0.4.0  023b39be39e3a2da62a94feb433e91e8bcd37676fbc8bea371daf52b7a769a3e \
+    indexmap                         1.3.1  0b54058f0a6ff80b6803da8faf8997cde53872b38f4023728f6830b06cd3c0dc \
+    itoa                             0.4.4  501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f \
+    js-sys                          0.3.35  7889c7c36282151f6bf465be4700359318aef36baa951462382eae49e9577cf9 \
+    keccak                           0.1.0  67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7 \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    libc                            0.2.66  d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558 \
+    linked-hash-map                  0.5.2  ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83 \
+    log                              0.4.8  14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7 \
+    madato                           0.5.3  c36112680b23ee7a5d2a10e56b59a74e4028963e9080b8abec4e69d0d773dc06 \
+    md5                              0.7.0  490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771 \
+    memchr                           2.3.0  3197e20c7edb283f87c071ddfc7a2cca8f8e0b888c242959846a6fce03c72223 \
+    merlin                           1.3.0  2b0942b357c1b4d0dc43ba724674ec89c3218e6ca2b3e8269e7cb53bcecd2f6e \
+    nodrop                          0.1.14  72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb \
+    nom                              4.2.3  2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6 \
+    num-integer                     0.1.42  3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba \
+    num-traits                      0.2.11  c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096 \
+    opaque-debug                     0.2.3  2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c \
+    parity-codec                     3.5.4  2b9df1283109f542d8852cd6b30e9341acc2137481eb6157d2e62af68b0afec9 \
+    prettytable-rs                   0.8.0  0fd04b170004fa2daccf418a7f8253aaf033c27760b5f225889024cf66d7ac2e \
+    proc-macro2                      1.0.8  3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548 \
+    quote                            1.0.2  053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe \
+    rand                             0.4.6  552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293 \
+    rand                             0.5.6  c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9 \
+    rand                             0.6.5  6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca \
+    rand                            0.3.23  64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c \
+    rand_chacha                      0.1.1  556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef \
+    rand_core                        0.4.2  9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc \
+    rand_core                        0.3.1  7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b \
+    rand_hc                          0.1.0  7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4 \
+    rand_isaac                       0.1.1  ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08 \
+    rand_jitter                      0.1.4  1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b \
+    rand_os                          0.1.3  7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071 \
+    rand_pcg                         0.1.2  abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44 \
+    rand_xorshift                    0.1.1  cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c \
+    rdrand                           0.4.0  678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2 \
+    redox_syscall                   0.1.56  2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84 \
+    redox_users                      0.3.3  1dc1887cbcd764cc066e2c08681a5615433ac3de9752838a9ec114613b118575 \
+    regex                            1.3.3  b5508c1941e4e7cb19965abef075d35a9a8b5cdf0846f30b4050e9b55dc55e87 \
+    regex-automata                   0.1.8  92b73c2a1770c255c240eaa4ee600df1704a38dc3feaa6e949e7fcd4f8dc09f9 \
+    regex-syntax                    0.6.13  e734e891f5b408a29efbf8309e656876276f49ab6a6ac208600b4419bd893d90 \
+    ring-fork-dtool                0.16.13  714737d29d71c49b32d8623f0ebe0286a7a408e83f453db83a778d4bda0ddb66 \
+    ripemd160                        0.8.0  ad5112e0dbbb87577bfbc56c42450235e3012ce336e29c5befd7807bd626da4a \
+    rust-argon2                      0.6.1  416f5109bdd413cec4f04c029297838e7604c993f8d1483b1d438f23bdc3eb35 \
+    rust-crypto                     0.2.36  f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a \
+    rustc-serialize                 0.3.24  dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda \
+    ryu                              1.0.2  bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8 \
+    schnorrkel                       0.8.5  eacd8381b3c37840c9c9f40472af529e49975bdcbc24f83c31059fd6539023d3 \
+    secp256k1                       0.15.5  4d311229f403d64002e9eed9964dfa5a0a0c1ac443344f7546bf48e916c6053a \
+    serde                          1.0.104  414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449 \
+    serde_derive                   1.0.104  128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64 \
+    serde_test                     1.0.104  33f96dff8c3744387b53404ea33e834073b0791dcc1ea9c85b805745f9324704 \
+    serde_yaml                       0.7.5  ef8099d3df28273c99a1728190c7a9f19d444c941044f64adf986bee7ec53051 \
+    sha2                             0.8.1  27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0 \
+    sha3                             0.8.2  dd26bc0e7a2e3a7c959bc494caf58b72ee0c71d67704e9520f736ca7e4853ecf \
+    signatory                       0.17.1  e8266215e389a88750d9d6afb35c839ca6845b9cf1e78513bee006497620686a \
+    signatory-secp256k1             0.17.0  e8c3ccc284465c763da8aa64008f8aaa4d31138687d34cfad210792d523c12cb \
+    signature                  1.0.0-pre.1  a0cfcdc45066661979294e965c21b60355da35eb5d638af8143e5aa83fdfce53 \
+    signature_derive           1.0.0-pre.0  30d0e333aec3605c822b1c7c760f6fa3d28a78d7d762a7b59d21fac4ebbf3680 \
+    sourcefile                       0.1.4  4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3 \
+    spin                             0.5.2  6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d \
+    strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
+    subtle                           2.2.2  7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941 \
+    subtle-encoding                  0.4.1  30492c59ec8bdeee7d6dd2d851711cae5f1361538f10ecfdcd1d377d57c2a783 \
+    syn                             1.0.14  af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5 \
+    synstructure                    0.12.3  67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545 \
+    term                             0.5.2  edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42 \
+    textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
+    thread_local                     1.0.1  d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14 \
+    time                            0.1.42  db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f \
+    typenum                         1.11.2  6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9 \
+    unicode-segmentation             1.6.0  e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0 \
+    unicode-width                    0.1.7  caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479 \
+    unicode-xid                      0.2.0  826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c \
+    untrusted                        0.7.0  60369ef7a31de49bcb3f6ca728d4ba7300d9a1658f94c727d4cab8c8d9f4aece \
+    urlencoding                      1.0.0  3df3561629a8bb4c57e5a2e4c43348d9e29c7c29d9b1c4c1f47166deca8f37ed \
+    vec_map                          0.8.1  05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a \
+    version_check                    0.1.5  914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd \
+    wasi      0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
+    wasm-bindgen                    0.2.58  5205e9afdf42282b192e2310a5b463a6d1c1d774e30dc3c791ac37ab42d2616c \
+    wasm-bindgen-backend            0.2.58  11cdb95816290b525b32587d76419facd99662a07e59d3cdb560488a819d9a45 \
+    wasm-bindgen-macro              0.2.58  574094772ce6921576fb6f2e3f7497b8a76273b6db092be18fc48a082de09dc3 \
+    wasm-bindgen-macro-support      0.2.58  e85031354f25eaebe78bb7db1c3d86140312a911a106b2e29f9cc440ce3e7668 \
+    wasm-bindgen-shared             0.2.58  f5e7e61fc929f4c0dddb748b102ebf9f632e2b8d739f2016542b4de2965a9601 \
+    wasm-bindgen-webidl             0.2.58  ef012a0d93fc0432df126a8eaf547b2dce25a8ce9212e1d3cbeef5c11157975d \
+    web-sys                         0.3.35  aaf97caf6aa8c2b1dac90faf0db529d9d63c93846cca4911856f78a83cebf53b \
+    weedle                          0.10.0  3bb43f70885151e629e2a19ce9e50bd730fd436cfd4b666894c9ce4de9141164 \
+    winapi                           0.3.8  8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6 \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    yaml-rust                        0.4.3  65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d \
+    yogcrypt                         0.0.0  b8709dbece7eccde97e3def21330cf24d5c5f9cdac35d8ba5af7f960e88d8999 \
+    zeroize                          0.9.3  45af6a010d13e4cf5b54c94ba5a2b2eba5596b9e46bf5875612d332a1f2b3f86 \
+    zeroize                          1.1.0  3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8 \
+    zeroize_derive                   1.0.0  de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
