### PR TITLE
libetonyek: blacklist incompatible compilers

### DIFF
--- a/textproc/libetonyek/Portfile
+++ b/textproc/libetonyek/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
+PortGroup       compiler_blacklist_versions 1.0
 
 name            libetonyek
 version         0.1.2
@@ -29,6 +30,9 @@ depends_lib     port:zlib \
                 port:librevenge \
                 port:libxml2 \
                 port:glm
+
+# error "GLM requires Clang 3.4 / Apple Clang 6.0 or higher"
+compiler.blacklist-append {clang < 600} macports-clang-3.3
 
 # disable some of the chattiest warnings (gives significant speed-up, about 14% for me)
 configure.cflags-append   -Wno-c99-extensions -Wno-variadic-macros -Wno-c++11-long-long


### PR DESCRIPTION
fixes build on older systems
closes: https://trac.macports.org/ticket/48183

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.7.5
Xcode 4.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
