### PR TITLE
ultralist: new port

### DIFF
--- a/office/ultralist/Portfile
+++ b/office/ultralist/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/ultralist/ultralist 0.9.5
+
+homepage            https://ultralist.io/
+
+description         Simple task management for tech folks.
+
+long_description    Ultralist is a task management system for technical \
+                    people. It is a command-line component that is very fast \
+                    and stays out of the way.  Ultralist is based off of the \
+                    Getting Things Done system. It has a concept of due \
+                    dates, projects, and contexts.
+
+categories          office
+license             MIT
+installs_libs       no
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  6e205526e1e218d5d812ff7344e3bc81f1792086 \
+                    sha256  44c4b3e5735006bc36e87307b92ed05dd88ebf83528128082972cf1e997c6cc6 \
+                    size    2060583
+
+build.args-append   -o ${workpath}/${name}
+
+destroot {
+    xinstall -m 755 ${workpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
