### PR TITLE
certigo: new port

### DIFF
--- a/sysutils/certigo/Portfile
+++ b/sysutils/certigo/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/square/certigo 1.12.1 v
+
+description         A utility to examine and validate certificates in a \
+                    variety of formats.
+
+long_description    Certigo is a utility to examine and validate certificates \
+                    to help with debugging SSL/TLS issues. It supports all \
+                    common file formats such as X.509 (DER/PEM), JCEKS, PKCS7 \
+                    and PKCS12 files, supports STARTTLS protocols, can \
+                    validate, lint and has scripting support.
+
+categories          sysutils
+license             Apache-2
+installs_libs       no
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  dd6ecaef6e7ca89aa072a420ecd05160bb6e832c \
+                    sha256  dc8430ba91d4d716800c15515be3afea5686d11bd1cee8cf8122cae0198b197f \
+                    size    379580
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
