### PR TITLE
dua-cli: new port

### DIFF
--- a/sysutils/dua-cli/Portfile
+++ b/sysutils/dua-cli/Portfile
@@ -1,0 +1,106 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo 1.0
+
+github.setup        Byron dua-cli 2.6.0 v
+categories          sysutils
+license             MIT
+platforms           darwin
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+homepage            https://lib.rs/crates/dua-cli
+
+description         A tool to conveniently learn about the disk usage of \
+                    directories, fast!
+
+long_description    dua (-> Disk Usage Analyzer) is a tool to conveniently \
+                    learn about the usage of disk space of a given directory. \
+                    It's parallel by default and will max out your SSD, \
+                    providing relevant information as fast as possible. \
+                    Optionally delete superfluous data, and do so more \
+                    quickly than rm.
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  2430d8b562967544642b81a218368fd6aa285a4a \
+                    sha256  4889c7254132488ff3d25615e76f89fcf057e76686aba3272b24a01e74bbc943 \
+                    size    57675
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/dua \
+                    ${destroot}${prefix}/bin/
+}
+
+cargo.crates \
+    ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
+    atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+    autocfg                          1.0.0  f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d \
+    backtrace                       0.3.46  b1e692897359247cc6bb902933361652380af0f1b7651ae5c5013407f30e109e \
+    backtrace-sys                   0.1.37  18fbebbe1c9d1f383a9cc7e8ccdb471b91c8d024ee9c2ca5b5346121fe8b4399 \
+    bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
+    byte-unit                        3.0.3  6894a79550807490d9f19a138a6da0f8830e70c83e83402dd23f16fd6c479056 \
+    cassowary                        0.3.0  df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53 \
+    cc                              1.0.52  c3d87b23d6a92cd03af510a5ade527033f6aa6fa92161e2d5863a907d4c5e31d \
+    cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
+    clap                            2.33.0  5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9 \
+    crossbeam                        0.7.3  69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e \
+    crossbeam-channel                0.4.2  cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061 \
+    crossbeam-deque                  0.7.3  9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285 \
+    crossbeam-epoch                  0.8.2  058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace \
+    crossbeam-queue                  0.2.1  c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db \
+    crossbeam-utils                  0.7.2  c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8 \
+    ctor                            0.1.14  cf6b25ee9ac1995c54d7adb2eff8cfffb7260bc774fb63c601ec65467f43cd9d \
+    difference                       2.0.0  524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198 \
+    either                           1.5.3  bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3 \
+    failure                          0.1.8  d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86 \
+    failure-tools                    4.0.5  03d1b6907412387e932f12ad6e93adab19fed0ca10a03de8b744d275977d72ca \
+    failure_derive                   0.1.8  aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4 \
+    filesize                         0.2.0  12d741e2415d4e2e5bd1c1d00409d1a8865a57892c2d689b504365655d237d43 \
+    fixedbitset                      0.2.0  37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d \
+    flume                            0.7.1  855e285c3835897065a6ba6f9463b44553eb9f29c7988d692f3d41283b47388b \
+    heck                             0.3.1  20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205 \
+    hermit-abi                      0.1.12  61565ff7aaace3525556587bd2dc31d4a07071957be715e63ce7b1eccf51a8f4 \
+    indexmap                         1.3.2  076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292 \
+    itertools                        0.9.0  284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b \
+    jwalk                            0.5.1  88746778a47f54f83bc0d3d8ba40ce83808024405356b4d521c2bf93c1273cd4 \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    libc                            0.2.69  99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005 \
+    log                              0.4.8  14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7 \
+    maybe-uninit                     2.0.0  60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00 \
+    memoffset                        0.5.4  b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8 \
+    num_cpus                        1.13.0  05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3 \
+    numtoa                           0.1.0  b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef \
+    open                             1.4.0  7c283bf0114efea9e42f1a60edea9859e8c47528eae09d01df4b29c1e489cc48 \
+    output_vt100                     0.1.2  53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9 \
+    petgraph                         0.5.0  29c127eea4a29ec6c85d153c59dc1213f33ec74cead30fe4730aecc88cc1fd92 \
+    pretty_assertions                0.6.1  3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427 \
+    proc-macro-error                 1.0.2  98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678 \
+    proc-macro-error-attr            1.0.2  4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53 \
+    proc-macro2                     1.0.12  8872cf6f48eee44265156c111456a700ab3483686b3f96df4cf5481c89157319 \
+    quote                            1.0.4  4c1f4b0efa5fc5e8ceb705136bfee52cfdb6a4e3509f770b478cd6ed434232a7 \
+    rayon                            1.3.0  db6ce3297f9c85e16621bb8cca38a06779ffc31bb8184e1be4bed2be4678a098 \
+    rayon-core                       1.7.0  08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9 \
+    redox_syscall                   0.1.56  2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84 \
+    redox_termios                    0.1.1  7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76 \
+    rustc-demangle                  0.1.16  4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783 \
+    scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
+    spin                             0.5.2  6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d \
+    strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
+    structopt                       0.3.14  863246aaf5ddd0d6928dfeb1a9ca65f505599e4e1b399935ef7e75107516b4ef \
+    structopt-derive                 0.4.7  d239ca4b13aee7a2142e6795cbd69e457665ff8037aed33b3effdc430d2f927a \
+    syn                             1.0.18  410a7488c0a728c7ceb4ad59b9567eb4053d02e8cc7f5c0e0eeeb39518369213 \
+    syn-mid                          0.5.0  7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a \
+    synstructure                    0.12.3  67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545 \
+    termion                          1.5.5  c22cec9d8978d906be5ac94bceb5a010d885c626c4c8855721a4dbd20e3ac905 \
+    textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
+    tui                              0.9.1  b7de74b91c6cb83119a2140e7c215d95d9e54db27b58a500a2cbdeec4987b0a2 \
+    unicode-segmentation             1.6.0  e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0 \
+    unicode-width                    0.1.7  caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479 \
+    unicode-xid                      0.2.0  826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c \
+    vec_map                          0.8.1  05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a \
+    version_check                    0.9.1  078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce \
+    winapi                           0.3.8  8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6 \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
