### PR TITLE
nuspell: new port

### DIFF
--- a/textproc/nuspell/Portfile
+++ b/textproc/nuspell/Portfile
@@ -1,0 +1,47 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        nuspell nuspell 3.1.1 v
+
+homepage            https://nuspell.github.io/
+
+description         Fast and safe spellchecking C++ library
+
+long_description    Nuspell is a fast and safe spelling checker software \
+                    program. It is designed for languages with rich \
+                    morphology and complex word compounding. Nuspell is \
+                    written in modern C++ and it supports Hunspell \
+                    dictionaries.
+
+categories          textproc
+platforms           darwin
+license             LGPL-3
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+depends_lib-append  port:boost \
+                    port:icu
+
+checksums           rmd160  4cd33cfabecf3a7be52ac2770b60d8a597bf1188 \
+                    sha256  b7172b35bc66ff957a74ca0b2e23ebad6224565430dadddf4e7cda08b1362457 \
+                    size    379686
+
+set hunspell_path   ${prefix}/share/hunspell
+
+patchfiles          patch-finder-cxx.diff
+
+post-patch {
+    reinplace       "s|@@HUNSPELL_PATH@@|${hunspell_path}|g" \
+                    ${worksrcpath}/src/nuspell/finder.cxx
+}
+
+notes "
+You must install (at least) one of the language dictionaries after installing\
+this port in order for it to work.
+
+One suggestion is the Hunspell US English dictionary:
+\$ sudo port install hunspell-en_US
+"

--- a/textproc/nuspell/files/patch-finder-cxx.diff
+++ b/textproc/nuspell/files/patch-finder-cxx.diff
@@ -1,0 +1,10 @@
+--- src/nuspell/finder.cxx	2020-05-19 03:24:56.000000000 -0400
++++ src/nuspell/finder.cxx	2020-05-19 03:24:53.000000000 -0400
+@@ -92,6 +92,7 @@
+ 		*out++ = home + osx;
+ 	}
+ 	*out++ = osx;
++	*out++ = "@@HUNSPELL_PATH@@";
+ #endif
+ #endif
+ #ifdef _WIN32


### PR DESCRIPTION
New port for https://nuspell.github.io/

Fixes: https://trac.macports.org/ticket/60311

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
