### PR TITLE
update erlang port for Erlang OTP 23.0

### DIFF
--- a/lang/erlang/Portfile
+++ b/lang/erlang/Portfile
@@ -5,7 +5,7 @@ PortGroup           wxWidgets 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 name                erlang
-version             22.1
+version             23.0
 revision            0
 
 categories          lang erlang
@@ -42,18 +42,18 @@ distfiles           otp_src_${version}${extract.suffix}                    \
                     otp_doc_man_${version}${extract.suffix}                \
                     otp_doc_html_${version}${extract.suffix}
 
-checksums           otp_src_22.1.tar.gz \
-                    rmd160 fc2110fcf820e2d47d265d17a7f75af2f3b9a20f \
-                    sha256  cd33a102cbac6dd1c7b1e7a9a0d82d13587771fac4e96e8fff92e403d15e32c8 \
-                    size    86643553 \
-                    otp_doc_man_22.1.tar.gz \
-                    rmd160  f20cba7986642bb65da0a7271909e071e722f677 \
-                    sha256  64f45909ed8332619055d424c32f8cc8987290a1ac4079269572fba6ef9c74d9 \
-                    size    1355169 \
-                    otp_doc_html_22.1.tar.gz \
-                    rmd160  d154d6f570c0bfb6e16e25e003a175deafa130a4 \
-                    sha256  3864ac1aa30084738d783d12c241c0a4943cf22a6d1d0f6c7bb9ba0a45ecb9eb \
-                    33824830
+checksums           otp_src_23.0.tar.gz \
+                    rmd160  2d6949131c3bcfa0e1d9bb9fefa79f40fbd21d1d \
+                    sha256  42dcf3c721f4de59fe74ae7b65950c2174c46dc8d1dd4e27c0594d86f606a635 \
+                    size    88865562 \
+                    otp_doc_man_23.0.tar.gz \
+                    rmd160  f3241039f75a869623bac700dd3d69015930b0cf \
+                    sha256  c0804cb5bead8780de24cf9ba656efefd9307a457e0541cc513109523731bf6f \
+                    size    1383486 \
+                    otp_doc_html_23.0.tar.gz \
+                    rmd160  187c4cc724bf5bce56fe66b3427bc31438c58d38 \
+                    sha256  4da19f0de96d1c516d91c621a5ddf20837303cc25695b944e263e3ea46dd31da \
+                    size 36238699
 
 worksrcdir          otp_src_${version}
 
@@ -82,9 +82,9 @@ post-destroot   {
     system "tar -C ${destroot}${prefix}/lib/erlang -zxvf ${distpath}/otp_doc_html_${version}${extract.suffix}"
     system "tar -C ${destroot}${prefix}/lib/erlang -zxvf ${distpath}/otp_doc_man_${version}${extract.suffix}"
  
-    set erts_dir            erts-10.5
-    set erl_interface_dir   erl_interface-3.13
-    set wx_dir              wx-1.8.9
+    set erts_dir            erts-11.0
+    set erl_interface_dir   erl_interface-4.0
+    set wx_dir              wx-1.9.1
 
     foreach x {dialyzer ear ecc elink epmd erl erlc escript run_erl start to_erl typer} { file delete -force ${destroot}${prefix}/bin/${x} }
     foreach x {dialyzer erl erlc escript run_erl start to_erl typer} { system "ln -s ../lib/erlang/bin/${x} ${destroot}${prefix}/bin/${x}" }


### PR DESCRIPTION
#### Description

This commit update the Erlang port to the latest stable version

###### Type(s)

- [ ] bugfix
- [X ] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.4 19E287
Xcode 11.4.1 11E503a 

###### Verification

- [X] followed our [Commit Message Guidelines (https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?