### PR TITLE
google-cloud-sdk: update to 293.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             292.0.0
+version             293.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  82b30652837e60d65146e9a9221e41ee23f2f307 \
-                    sha256  56be448fc794ab716784c1e1cdf9f55e19b4e7cbf9fe1e0d9322041cb46faac5 \
-                    size    50249926
+    checksums       rmd160  d4ee9272e1c63bf335944756360618daa1032f69 \
+                    sha256  20715c1bd1feb0eb03285251b141952643e5dceccf5222268a7d239b6f55696e \
+                    size    68301086
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  07d25dc75c02cda78867862d9dfa0bba9ccb5b50 \
-                    sha256  a594a5c850f3c27a4a209fc7683fc5cbda72b7351c8a92a41c909ba45dc1c345 \
-                    size    51341420
+    checksums       rmd160  40ec47631dee1439fb168ce87e8e78bdab1b2a8b \
+                    sha256  d6a13d7cc0791c104ac2a1a1da1f676bcd7c6fc11d0f2079f60d866f1ded94b6 \
+                    size    70269623
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 293.0.0.

###### Tested on

macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?