### PR TITLE
deno: new port

### DIFF
--- a/devel/deno/Portfile
+++ b/devel/deno/Portfile
@@ -1,0 +1,52 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                deno
+version             1.0.2
+
+homepage            https://deno.land/
+
+description         Deno is a simple, modern and secure runtime for \
+                    JavaScript and TypeScript that uses V8 and is built in \
+                    Rust.
+
+long_description    Deno is a a secure runtime for JavaScript and TypeScript. \
+                    It is secure by default, performs no file, network, or \
+                    environment access, unless explicitly enabled, and \
+                    supports TypeScript out of the box. Deno has built-in \
+                    utilities like a dependency inspector (deno info) and a \
+                    code formatter (deno fmt), with a set of reviewed \
+                    (audited) standard modules that are guaranteed to work \
+                    with Deno.
+
+categories          devel
+license             MIT
+platforms           darwin
+supported_archs     x86_64
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  4b65f1bf105ff0c9ce86e97adb7333337b8c77ed \
+                    sha256  33438ab1a2776d132578f6bb54fc86c2de9e35b865f2c75fc9d1480dd066cae6 \
+                    size    16424909
+
+master_sites        https://github.com/denoland/deno/releases/download/v${version}/
+distname            ${name}-x86_64-apple-darwin
+
+installs_libs       no
+use_configure       no
+use_zip             yes
+
+# No build process as we are currently using the pre-built binary for now.
+#
+# To build from source, we'll need the 3rd-party and typescript repos as
+# submodules, and we'll also need V8 (requiring Python2):
+#
+# - https://deno.land/manual/contributing/building_from_source
+build               {}
+
+destroot {
+    xinstall -m 755 ${workpath}/deno ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

New port for deno (https://deno.land)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
