### PR TITLE
py-pycryptodome: update to version 3.9.7

### DIFF
--- a/python/py-pycryptodome/Portfile
+++ b/python/py-pycryptodome/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pycryptodome
-version             3.4.5
+version             3.9.7
 license             BSD
 platforms           darwin
 supported_archs     noarch
@@ -14,15 +14,14 @@ long_description    PyCryptodome is a self-contained Python package of \
                     low-level cryptographic primitives. \
                     PyCryptodome is a fork of PyCrypto.
 
-python.versions     27 35 36
+python.versions     27 35 36 37 38
 
 homepage            https://pypi.python.org/pypi/${python.rootname}/
-master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  ebdb0edb86f048889f467ddabb9efe95b74254e6 \
-                    sha256  be84544eadc2bb71d4ace39e4984ed2990111f053f24267a07afb4b4e1e5428f \
-                    size    6494255
+checksums           rmd160 a04415452518532e99d44dae2df38f7492431a52 \
+                    sha256 f1add21b6d179179b3c177c33d18a2186a09cc0d3af41ff5ed3f377360b869f2 \
+                    size   15451558
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

version bump
added support for Python version 37, 38 variants

###### Tested on
macOS 10.14.6 18G4032
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
