### PR TITLE
salt: update to version 3000.3

### DIFF
--- a/sysutils/salt/Portfile
+++ b/sysutils/salt/Portfile
@@ -2,27 +2,26 @@
 
 PortSystem        1.0
 
-name               salt
-version            3000.3
-revision           0
-categories         sysutils python
-platforms          darwin
-maintainers        {gmail.com:jeremy.mcmillan @aphor} openmaintainer
-license            Apache-2
-supported_archs    noarch
-description        Salt is a Python-based remote execution, automation, \
-                    configuration, and orchestration engine.
-long_description    SaltStack is fast, scalable and flexible software for data \
-                    center automation, from infrastructure and any cloud, \
-                    to the entire application stack.
-homepage            https://saltstack.com/
+name              salt
+version           3000.3
+categories        sysutils python
+platforms         darwin
+maintainers       {gmail.com:jeremy.mcmillan @aphor} openmaintainer
+license           Apache-2
+supported_archs   noarch
+description       Salt is a Python-based remote execution, automation, \
+                  configuration, and orchestration engine.
+long_description  SaltStack is fast, scalable and flexible software for data \
+                  center automation, from infrastructure and any cloud, \
+                  to the entire application stack.
+homepage          https://saltstack.com/
 
 if {$subport eq $name} {
     PortGroup               github 1.0
     PortGroup               python 1.0
 
     github.setup            saltstack salt ${version} v
-    revision                1
+    revision                0
 
     categories              sysutils python
 
@@ -45,6 +44,7 @@ if {$subport eq $name} {
                             port:py${python.version}-cherrypy \
                             port:py${python.version}-cryptography \
                             port:py${python.version}-dateutil \
+                            port:py${python.version}-distro \
                             port:py${python.version}-gitpython \
                             port:py${python.version}-gnupg \
                             port:py${python.version}-idna \
@@ -73,6 +73,7 @@ if {$subport eq $name} {
                             port:py${python.version}-cherrypy \
                             port:py${python.version}-cryptography \
                             port:py${python.version}-dateutil \
+                            port:py${python.version}-distro \
                             port:py${python.version}-gitpython \
                             port:py${python.version}-gnupg \
                             port:py${python.version}-idna \
@@ -99,6 +100,7 @@ if {$subport eq $name} {
                             port:py${python.version}-cherrypy \
                             port:py${python.version}-cryptography \
                             port:py${python.version}-dateutil \
+                            port:py${python.version}-distro \
                             port:py${python.version}-gitpython \
                             port:py${python.version}-gnupg \
                             port:py${python.version}-idna \
@@ -125,6 +127,7 @@ if {$subport eq $name} {
                             port:py${python.version}-cherrypy \
                             port:py${python.version}-cryptography \
                             port:py${python.version}-dateutil \
+                            port:py${python.version}-distro \
                             port:py${python.version}-gitpython \
                             port:py${python.version}-gnupg \
                             port:py${python.version}-idna \

--- a/sysutils/salt/Portfile
+++ b/sysutils/salt/Portfile
@@ -3,7 +3,8 @@
 PortSystem        1.0
 
 name               salt
-version            2019.2.0
+version            3000.3
+revision           0
 categories         sysutils python
 platforms          darwin
 maintainers        {gmail.com:jeremy.mcmillan @aphor} openmaintainer
@@ -23,56 +24,120 @@ if {$subport eq $name} {
     github.setup            saltstack salt ${version} v
     revision                1
 
-    python.versions         27 35 36
     categories              sysutils python
 
-    checksums       rmd160  47b77490e40fdc2ec4c5d262003afecdb0b8e94a \
-                    sha256  0a65913142577a70924a283a99dc67612630a9601fd5c83d660bad74b84357d4 \
-                    size    14987367
+    checksums rmd160 f1c2a4f0609c3cd64f3b98c3a3bf8efe39703c75 \
+              sha256 c5c16a328b7971fecf1dc8902f2315387894613b198581c090063abc67df8fb7 \
+              size   15255885
 
     notes    "Salt startupitems are installed by subports salt-minion, salt-master, salt-syndic, salt-api."
 
-    if {![variant_isset python35] && ![variant_isset python36]} {
-        default_variants +python27
+    if {![variant_isset python35] && ![variant_isset python36] && ![variant_isset python37]} {
+        default_variants +python38
     }
 
-    variant python27 conflicts python35 python36 description {python-2.7 support} {
-        python.default_version 27
+    variant python35 conflicts python36 python37 python38 description {python-3.5 support} {
+        python.default_version 35
         depends_build       port:py${python.version}-setuptools
 
-        depends_lib-append  port:py${python.version}-yaml \
+        depends_lib-append  port:py${python.version}-asn1 \
+                            port:py${python.version}-cffi \
+                            port:py${python.version}-cherrypy \
+                            port:py${python.version}-cryptography \
+                            port:py${python.version}-dateutil \
+                            port:py${python.version}-gitpython \
+                            port:py${python.version}-gnupg \
+                            port:py${python.version}-idna \
                             port:py${python.version}-jinja2 \
+                            port:py${python.version}-mako \
                             port:py${python.version}-msgpack \
-              port:py${python.version}-tornado \
-              port:py${python.version}-zmq
+                            port:py${python.version}-psutil \
+                            port:py${python.version}-pycryptodome \
+                            port:py${python.version}-pyobjc \
+                            port:py${python.version}-setproctitle \
+                            port:py${python.version}-tornado \
+                            port:py${python.version}-yaml \
+                            port:py${python.version}-zmq
 
         destroot.cmd-append --with-salt-version=${version}
 
         notes    "Salt startupitems are installed by subports salt-minion, salt-master, salt-syndic, salt-api."
     }
 
-    variant python35 conflicts python27 python36 description {python-3.5 support} {
-        python.default_version 35
+    variant python36 conflicts python35 python37 python38 description {python-3.6 support} {
+        python.default_version 36
         depends_build       port:py${python.version}-setuptools
 
-        depends_lib-append  port:py${python.version}-yaml \
+        depends_lib-append  port:py${python.version}-asn1 \
+                            port:py${python.version}-cffi \
+                            port:py${python.version}-cherrypy \
+                            port:py${python.version}-cryptography \
+                            port:py${python.version}-dateutil \
+                            port:py${python.version}-gitpython \
+                            port:py${python.version}-gnupg \
+                            port:py${python.version}-idna \
                             port:py${python.version}-jinja2 \
+                            port:py${python.version}-mako \
                             port:py${python.version}-msgpack \
-              port:py${python.version}-tornado \
-              port:py${python.version}-zmq
+                            port:py${python.version}-psutil \
+                            port:py${python.version}-pycryptodome \
+                            port:py${python.version}-pyobjc \
+                            port:py${python.version}-setproctitle \
+                            port:py${python.version}-tornado \
+                            port:py${python.version}-yaml \
+                            port:py${python.version}-zmq
 
         destroot.cmd-append --with-salt-version=${version}
     }
 
-    variant python36 conflicts python27 python35 description {python-3.6 support} {
-        python.default_version 36
+    variant python37 conflicts python35 python36 python38 description {python-3.7 support} {
+        python.default_version 37
         depends_build       port:py${python.version}-setuptools
 
-        depends_lib-append  port:py${python.version}-yaml \
+        depends_lib-append  port:py${python.version}-asn1 \
+                            port:py${python.version}-cffi \
+                            port:py${python.version}-cherrypy \
+                            port:py${python.version}-cryptography \
+                            port:py${python.version}-dateutil \
+                            port:py${python.version}-gitpython \
+                            port:py${python.version}-gnupg \
+                            port:py${python.version}-idna \
                             port:py${python.version}-jinja2 \
+                            port:py${python.version}-mako \
                             port:py${python.version}-msgpack \
-              port:py${python.version}-tornado \
-              port:py${python.version}-zmq
+                            port:py${python.version}-psutil \
+                            port:py${python.version}-pycryptodome \
+                            port:py${python.version}-pyobjc \
+                            port:py${python.version}-setproctitle \
+                            port:py${python.version}-tornado \
+                            port:py${python.version}-yaml \
+                            port:py${python.version}-zmq
+
+        destroot.cmd-append --with-salt-version=${version}
+    }
+
+    variant python38 conflicts python35 python36 python37 description {python-3.8 support} {
+        python.default_version 38
+        depends_build       port:py${python.version}-setuptools
+
+        depends_lib-append  port:py${python.version}-asn1 \
+                            port:py${python.version}-cffi \
+                            port:py${python.version}-cherrypy \
+                            port:py${python.version}-cryptography \
+                            port:py${python.version}-dateutil \
+                            port:py${python.version}-gitpython \
+                            port:py${python.version}-gnupg \
+                            port:py${python.version}-idna \
+                            port:py${python.version}-jinja2 \
+                            port:py${python.version}-mako \
+                            port:py${python.version}-msgpack \
+                            port:py${python.version}-psutil \
+                            port:py${python.version}-pycryptodome \
+                            port:py${python.version}-pyobjc \
+                            port:py${python.version}-setproctitle \
+                            port:py${python.version}-tornado \
+                            port:py${python.version}-yaml \
+                            port:py${python.version}-zmq
 
         destroot.cmd-append --with-salt-version=${version}
     }
@@ -81,6 +146,16 @@ if {$subport eq $name} {
 
     post-patch {
         reinplace "s|@@PREFIX@@|${prefix}|g" ${worksrcpath}/setup.cfg
+        reinplace "s|msgpack-python==.*|msgpack >= 1.0.0|" ${worksrcpath}/pkg/osx/req.txt
+        reinplace "s|backports.ssl_match_hostname==.*||" ${worksrcpath}/pkg/osx/req.txt
+        reinplace "s|ipaddress==.*||" ${worksrcpath}/pkg/osx/req.txt
+        reinplace "s|timelib==.*||" ${worksrcpath}/pkg/osx/req.txt
+        reinplace "s|linode-python==.*||" ${worksrcpath}/pkg/osx/req.txt
+        reinplace "s|vultr==.*||" ${worksrcpath}/pkg/osx/req.txt
+        reinplace "s|==| >= |" ${worksrcpath}/pkg/osx/req.txt
+        reinplace "s|==| >= |" ${worksrcpath}/pkg/osx/req_ext.txt
+        reinplace "s|pyobjc==.*||" ${worksrcpath}/pkg/osx/req_pyobjc.txt
+        reinplace "s|==| >= |" ${worksrcpath}/pkg/osx/req_pyobjc.txt
     }
 }
 


### PR DESCRIPTION
#### Description

major version bump, long awaited

Note the current port version has a remote execution vulnerability.
https://nvd.nist.gov/vuln/detail/CVE-2020-11651

Closes: https://trac.macports.org/ticket/60527

###### Tested on
macOS 10.14.6 18G4032
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
