### PR TITLE
nauty: update to version 2.7r1

### DIFF
--- a/math/nauty/Portfile
+++ b/math/nauty/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                nauty
-version             2.6r11
+version             2.7r1
 categories          math science
 license             Apache-2
 platforms           darwin
-maintainers         nomaintainer
+maintainers         {gmail.com:szhorvat @szhorvat} openmaintainer
 
 livecheck.version   [strsed ${version} {g/\.//}]
 livecheck.regex     ${name}(\[0-9r\]+)\\.tar
@@ -28,9 +28,17 @@ long_description    nauty and traces are programs for computing automorphism \
                     multigraphs, and programs for manipulating files of graphs \
                     in a compact format.
 
-checksums           rmd160  7135771524fb4af0ecc13fcc9f1fad7d53efeee4 \
-                    sha256  5ed401917f641af6bf7617a18561b8f1ff5d6563268d815a054786c1ceace617 \
-                    size    1660633
+checksums           rmd160  2e801f1467a75985724a7b3e632922b2e9f97b8f \
+                    sha256  9c2ba0df9702b45dec037f576608a4ad3ba35cbf6f827c27f54873d9c405d5db \
+                    size    3428474
+					
+variant native description {Build optimized for your machine's specific processor} {
+    archive_sites
+}
+
+if {![variant_isset native]} { 
+    configure.args-append --enable-generic
+}
 
 test.run            yes
 test.target         checks
@@ -40,6 +48,7 @@ destroot {
         NRswitchg \
         addedgeg \
         amtog \
+        assembleg \
         biplabg \
         catg \
         complg \
@@ -53,6 +62,7 @@ destroot {
         dreadnaut \
         dretodot \
         dretog \
+        edgetransg \
         genbg \
         genbgL \
         geng \
@@ -74,7 +84,21 @@ destroot {
         showg \
         subdivideg \
         twohamg \
+        underlyingg \
         vcolg \
         watercluster2 \
         ${destroot}${prefix}/bin
+}
+
+post-destroot {
+    set docdir ${prefix}/share/doc/${name}
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} \
+        nug27.pdf \
+        README \
+        README_24 \
+        changes24-27.txt \
+        formats.txt \
+        schreier.txt \
+        ${destroot}${docdir}
 }


### PR DESCRIPTION
## Description

 * update nauty to version 2.7r1
 * ensure that previously missing command-line programs are installed
 * install documentation
 * add native variant
 * add myself as maintainer
 * add openmaintainer

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G4032
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
