### PR TITLE
osx2x: fix build with current openssl

### DIFF
--- a/aqua/osx2x/Portfile
+++ b/aqua/osx2x/Portfile
@@ -6,7 +6,7 @@ PortGroup       xcode 1.0
 name            osx2x
 version         2.4.0
 set my_version  2.4
-revision        7
+revision        8
 set git_hash    3cc708236898ab789bb99a5fba7420ff76ede9f7
 license         BSD
 platforms       darwin
@@ -35,6 +35,7 @@ checksums \
     rmd160  cc2a63b9dbfd9485c039fc989bbab96e6cf919ac
 
 patchfiles      patch-osx2x.xcodeproj.diff \
+                patch-XXRemoteX11Daemon.m.diff \
                 patch-XXRemoteVNC.m.diff \
                 patch-offbyone.diff \
                 XXView.m.diff

--- a/aqua/osx2x/files/patch-XXRemoteX11Daemon.m.diff
+++ b/aqua/osx2x/files/patch-XXRemoteX11Daemon.m.diff
@@ -1,0 +1,10 @@
+--- XXRemoteX11Daemon.m.orig	2020-05-20 11:12:39.000000000 +0200
++++ XXRemoteX11Daemon.m	2020-05-20 11:12:48.000000000 +0200
+@@ -86,7 +86,7 @@
+
+         // Init the SSL connection
+         SSLeay_add_ssl_algorithms();
+-        meth = SSLv2_client_method();
++        meth = TLS_client_method();
+         SSL_load_error_strings();
+         ctx = SSL_CTX_new (meth);


### PR DESCRIPTION
#### Description

Patch to use TLS_client_method() instead of SSLv2_client_method() to fix the build.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G4032
Xcode 11.3.1 11C504

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
