### PR TITLE
ispc: Update to 1.13.0 and switch to bespoke build of LLVM/clang for build dependency

### DIFF
--- a/lang/ispc/Portfile
+++ b/lang/ispc/Portfile
@@ -1,74 +1,162 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem          1.0
-PortGroup           github 1.0
-PortGroup           cmake  1.1
-PortGroup           active_variants 1.1
+PortSystem                                             1.0
+PortGroup                github                        1.0
+PortGroup                compiler_blacklist_versions   1.0
+PortGroup                legacysupport                 1.0
+PortGroup                cmake                         1.1
 
-github.setup        ispc ispc 1.12.0 v
-categories          lang parallel               
-platforms           darwin
-supported_archs     x86_64
-license             BSD
-maintainers         {takeshi @tenomoto} openmaintainer
-description         Intel SPMD program compiler
-long_description \
-    ${name} is a compiler for a variant of the C programming language, \
-    with extensions for single program, multiple data programming. 
-homepage            http://${name}.github.com
-checksums           rmd160  9b933175ad243d8acf4511781409841531f8f8f6 \
-                    sha256  d9633001825f82ce6fa3f525bdd948db81e56461829e828fac110b41e40225dc \
-                    size    19300769
+# link legacysupport statically for compilers
+legacysupport.use_static                       yes
+# limit legacysupport to OSX 10.9 for now
+legacysupport.newest_darwin_requires_legacy    13
 
-set llvm_version    8.0
+name                     ispc
+categories               lang parallel               
+platforms                darwin
+supported_archs          x86_64
+maintainers              {takeshi @tenomoto} openmaintainer
 
-depends_build-append  \
-                    port:bison \
-                    port:flex \
-                    port:python27
-# add llvm-${llvm_version} explicitly to force require_active_variants
-depends_lib-append \
-                    port:llvm-${llvm_version} \
-                    port:clang-${llvm_version}
-require_active_variants \
-                    llvm-${llvm_version} debug
+if { ${subport} eq ${name} } {
 
-cmake.out_of_source yes
+    github.setup         ispc ispc 1.13.0 v
 
-patchfiles          patch-CMakeLists.txt.diff
-patchfiles-append   unknown-architecture-i386.patch
-post-patch {
-    if {${os.major} >= 14} {
-        reinplace "s|-emit-llvm|-isysroot ${developer_dir}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk -emit-llvm|" \
-            ${worksrcpath}/cmake/GenerateBuiltins.cmake
+    checksums            rmd160  33475aba8516f361b1016d37d32d11a78a65205f \
+                         sha256  aca595508b51dd1ff065c406a3fd7c93822320c510077dd4d97a2b98a23f097a \
+                         size    19206050
+
+    license              BSD
+ 
+    description          Intel SPMD program compiler
+    long_description     ${name} is a compiler for a variant of the C programming language, \
+                         with extensions for single program, multiple data programming. 
+
+    set py_ver           3.8
+    set py_ver_nodot     [string map {. {}} ${py_ver}]
+
+    depends_build-append port:bison \
+                         port:flex \
+                         port:ispc-clang \
+                         port:python${py_ver_nodot}
+
+    patchfiles           patch-CMakeLists.txt.diff \
+                         unknown-architecture-i386.patch
+
+    post-patch {
+        if {${os.major} >= 14} {
+            set sdkroot ${developer_dir}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+            reinplace "s|-emit-llvm|-isysroot ${sdkroot} -emit-llvm|" \
+                ${worksrcpath}/cmake/GenerateBuiltins.cmake
+        }
+        # Fix python shebang to use explicit path to MP python 3.x
+        foreach f [ exec find ${worksrcpath}/ -name "*.py" ] {
+            reinplace -q "s|/usr/bin/env python3|${prefix}/bin/python${py_ver}|" ${f}
+        }
     }
+
+    # Need to use a recent MacPorts build.
+    compiler.cxx_standard  2014
+    compiler.blacklist     *gcc* clang {macports-clang-[5-8].0} macports-clang-3.*
+
+    use_xcode              yes
+    cmake.out_of_source    yes
+
+    cmake.build_type       Release
+    configure.args-append  -DBISON_EXECUTABLE=${prefix}/bin/bison \
+                           -DFLEX_EXECUTABLE=${prefix}/bin/flex \
+                           -DLLVM_DIR=${prefix}/libexec/ispc-clang/lib/cmake/llvm \
+                           -DISPC_INCLUDE_TESTS=OFF
+
+    test.run               yes
+    test.dir               ${worksrcpath}
+    test.cmd               ./run_tests.py
+    test.args              --verbose --non-interactive --compiler=[file tail ${configure.cc}]
+    test.target            ""
+    depends_test-append    port:python${py_ver_nodot}
+    
+    post-destroot {
+        xinstall -d -m 755 ${destroot}${prefix}/share/${name}
+        move ${destroot}${prefix}/examples ${destroot}${prefix}/share/${name}
+    }
+
+    # remove after 11 Aug 2020
+    variant doc description {deprecated variant} { }
+
 }
 
-configure.compiler  macports-clang-${llvm_version}
-configure.cflags-append \
-                    -DLLVM_ENABLE_DUMP
-configure.cxxflags-append \
-                    -DLLVM_ENABLE_DUMP
-configure.args-append \
-                    -DBISON_EXECUTABLE=${prefix}/bin/bison \
-                    -DFLEX_EXECUTABLE=${prefix}/bin/flex \
-                    -DPYTHON_EXECUTABLE=${prefix}/bin/python2.7 \
-                    -DLLVM_DIR=${prefix}/libexec/llvm-${llvm_version}/lib/cmake/llvm \
-                    -DISPC_INCLUDE_TESTS=OFF
+subport ispc-clang {
 
-test.run            yes
-test.cmd            {python run_tests.py}
-test.target         ""
+    github.setup           llvm llvm-project 10.0.0 llvmorg-
 
-post-destroot {
-    xinstall -d -m 755 ${destroot}${prefix}/share/${name}
-    move ${destroot}${prefix}/examples ${destroot}${prefix}/share/${name}
+    checksums              rmd160  6733d734a728ba8d022f0cc283c6cb42a2f8ec9b \
+                           sha256  de4c766f5b3fffbe160af0f75e52804646beab0a4bdbf4fae916e3f055b8e463 \
+                           size    120817709
+
+    license                NCSA
+
+    description            Clang build specifically for ispc compiler. 
+    long_description       ${description} NOT TO BE USED IN GENERAL. This build is specifically tuned \
+                           to satisfy the requirements of ispc which uses it as a build dependency only. \
+                           Has assertions and dump enabled by default, which is not the case in the \
+                           primary MacPorts LLVM/Clang builds.
+    
+    # Build configuration is largely taken from lang/llvm ports,
+    # then simplified and adapted for usage here
+
+    patchfiles             patch-compilerrtdarwinutils-find-macosxsdkversion.diff
+    
+    set py_ver             2.7
+    set py_ver_nodot       [string map {. {}} ${py_ver}]
+    
+    depends_lib-append     port:libedit \
+                           port:ncurses port:z3 \
+                           path:lib/libxar.dylib:xar \
+                           port:zlib \
+                           port:libxml2 \
+                           port:libomp \
+                           bin:perl:perl5 \
+                           port:ld64
+    depends_build-append   port:pkgconfig \
+                           port:cctools \
+                           port:python${py_ver_nodot}
+
+    compiler.cxx_standard  2014
+    compiler.blacklist     *gcc* {clang < 801} macports-clang-3.* {macports-clang-[4-8].0}
+
+    cmake.install_prefix   ${prefix}/libexec/${subport}
+    cmake.build_type       Release
+    
+    configure.post_args    ../${worksrcdir}/llvm
+    default configure.dir  {${workpath}/build}
+    default build.dir      {${workpath}/build}
+
+    configure.args-delete  -DCMAKE_INSTALL_NAME_DIR=${cmake.install_prefix}/lib \
+                           -DCMAKE_INSTALL_RPATH=${cmake.install_prefix}/lib
+
+    configure.args-replace -DCMAKE_SYSTEM_PREFIX_PATH="${prefix}\;/usr" \
+                           -DCMAKE_SYSTEM_PREFIX_PATH="${cmake.install_prefix}\;${prefix}\;/usr"
+
+    configure.args-append  -DLLVM_ENABLE_PROJECTS="clang\;libcxx\;compiler-rt" \
+                           -DLLVM_LINK_LLVM_DYLIB=ON \
+                           -DLLVM_ENABLE_ASSERTIONS=ON \
+                           -DLLVM_ENABLE_DUMP=ON \
+                           -DLLVM_ENABLE_RTTI=ON \
+                           -DLLVM_INCLUDE_TESTS=OFF \
+                           -DLLVM_INCLUDE_EXAMPLES=OFF \
+                           -DLLVM_ENABLE_FFI=OFF \
+                           -DLLVM_BINDINGS_LIST=none \
+                           -DCMAKE_LINKER=${prefix}/bin/ld \
+                           -DCLANG_INCLUDE_TESTS=OFF \
+                           -DCLANG_ENABLE_STATIC_ANALYZER=OFF \
+                           -DCLANG_ENABLE_ARCMT=OFF \
+                           -DDARWIN_PREFER_PUBLIC_SDK=ON \
+                           -DLLVM_BUILD_RUNTIME=ON \
+                           -DLIBCXX_ENABLE_SHARED=OFF \
+                           -DLIBCXX_INSTALL_LIBRARY=OFF \
+                           -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
+                           -DPYTHON_EXECUTABLE=${prefix}/bin/python${py_ver}
+
+    livecheck.url          https://github.com/llvm/llvm-project/releases
+    livecheck.regex        "LLVM (\\d+(?:\\.\\d+)*) Release"
+
 }
-
-# remove after 11 Aug 2020
-variant doc description {deprecated variant} {
-}
-
-livecheck.type      regex
-livecheck.url       ${homepage}/downloads.html
-livecheck.regex     {v([0-9]+\.[0-9]+\.[0-9])}

--- a/lang/ispc/files/patch-compilerrtdarwinutils-find-macosxsdkversion.diff
+++ b/lang/ispc/files/patch-compilerrtdarwinutils-find-macosxsdkversion.diff
@@ -1,0 +1,30 @@
+--- compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake.orig	2020-04-20 17:14:08.000000000 -0700
++++ compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake	2020-04-20 17:31:44.000000000 -0700
+@@ -66,15 +66,6 @@
+       ERROR_FILE /dev/null
+     )
+   endif()
+-  if(NOT result_process EQUAL 0)
+-    message(FATAL_ERROR
+-      "Failed to determine SDK version for \"${sdk_name}\" SDK")
+-  endif()
+-  # Check reported version looks sane.
+-  if (NOT "${var_internal}" MATCHES "^[0-9]+\\.[0-9]+(\\.[0-9]+)?$")
+-    message(FATAL_ERROR
+-      "Reported SDK version \"${var_internal}\" does not look like a version")
+-  endif()
+   set(${var} ${var_internal} PARENT_SCOPE)
+ endfunction()
+ 
+@@ -125,6 +116,11 @@
+     # binaries.
+     if ("${os}" STREQUAL "osx")
+       find_darwin_sdk_version(macosx_sdk_version "macosx")
++      # if there is no sdk that responds to "macosx" use the CMAKE passed in deployment target
++      if(NOT macosx_sdk_version)
++        message(WARNING "Could not determine MacOSX SDK Version, trying CMAKE_OSX_DEPLOYMENT_TARGET")
++        set(macosx_sdk_version CMAKE_OSX_DEPLOYMENT_TARGET)
++      endif()
+       if ("${macosx_sdk_version}" VERSION_GREATER 10.15 OR "${macosx_sdk_version}" VERSION_EQUAL 10.15)
+         message(STATUS "Disabling i386 slice for ${valid_archs}")
+         list(REMOVE_ITEM archs "i386")

--- a/lang/ispc/files/unknown-architecture-i386.patch
+++ b/lang/ispc/files/unknown-architecture-i386.patch
@@ -1,22 +1,26 @@
---- examples/cmake/AddISPCExample.cmake.orig	2019-08-16 06:18:07.000000000 +0900
-+++ examples/cmake/AddISPCExample.cmake	2019-10-13 12:22:13.000000000 +0900
-@@ -44,7 +44,7 @@
+diff --git a/benchmarks/cmake/AddBenchmark.cmake b/benchmarks/cmake/AddBenchmark.cmake
+index 6183bf44..966e8dc8 100644
+--- benchmarks/cmake/AddBenchmark.cmake.orig
++++ benchmarks/cmake/AddBenchmark.cmake
+@@ -41,7 +41,7 @@ endif()
+ 
+ # Identify host arch
+ if(UNIX)
+-    execute_process(COMMAND bash "-c" "uname -m | sed -e s/x86_64/x86/ -e s/i686/x86/ -e s/arm.*/arm/ -e s/sa110/arm/" OUTPUT_VARIABLE ARCH)
++    execute_process(COMMAND bash "-c" "uname -m | sed -e s/x86_64/x86/ -e s/i686/x86/ -e s/i686/x86/ -e s/arm.*/arm/ -e s/sa110/arm/" OUTPUT_VARIABLE ARCH)
+     string(STRIP ${ARCH} ARCH)
+     execute_process(COMMAND getconf LONG_BIT OUTPUT_VARIABLE ARCH_BIT)
+     string(STRIP ${ARCH_BIT} ARCH_BIT)
+diff --git a/examples/cmake/AddISPCExample.cmake b/examples/cmake/AddISPCExample.cmake
+index 0887ab0f..4b1cc43f 100644
+--- examples/cmake/AddISPCExample.cmake.orig
++++ examples/cmake/AddISPCExample.cmake
+@@ -44,7 +44,7 @@ function(add_ispc_example)
      set(ISPC_OBJ_NAME "${CMAKE_CURRENT_BINARY_DIR}/${ISPC_SRC_NAME}_ispc${CMAKE_CXX_OUTPUT_EXTENSION}")
      set(ISPC_FLAGS ${example_ISPC_FLAGS})
      if (UNIX)
--        execute_process( COMMAND bash "-c" "uname -m | sed -e s/x86_64/x86/ -e s/i686/x86/ -e s/arm.*/arm/ -e s/sa110/arm/" OUTPUT_VARIABLE ARCH)
-+        execute_process( COMMAND bash "-c" "uname -m | sed -e s/x86_64/x86/ -e s/i686/x86/ -e s/i386/x86/ -e s/arm.*/arm/ -e s/sa110/arm/" OUTPUT_VARIABLE ARCH)
+-        execute_process( COMMAND bash "-c" "uname -m | sed -e s/x86_64/x86/ -e s/amd64/x86/ -e s/i686/x86/ -e s/arm64/aarch64/ -e s/arm.*/arm/ -e s/sa110/arm/" OUTPUT_VARIABLE ARCH)
++        execute_process( COMMAND bash "-c" "uname -m | sed -e s/x86_64/x86/ -e s/amd64/x86/ -e s/i686/x86/ -e s/i386/x86/ -e s/arm64/aarch64/ -e s/arm.*/arm/ -e s/sa110/arm/" OUTPUT_VARIABLE ARCH)
          string(STRIP ${ARCH} ARCH)
          execute_process( COMMAND getconf LONG_BIT OUTPUT_VARIABLE ARCH_BIT)
          string(STRIP ${ARCH_BIT} ARCH_BIT)
---- examples/portable/common_cpu.mk.orig	2019-08-16 06:18:07.000000000 +0900
-+++ examples/portable/common_cpu.mk	2019-10-13 12:24:16.000000000 +0900
-@@ -17,7 +17,7 @@
- ISPC_FLAGS+=-O2
- ISPC_HEADER=objs/$(ISPC_SRC:.ispc=_ispc.h)
- 
--ARCH:=$(shell uname -m | sed -e s/x86_64/x86/ -e s/i686/x86/ -e s/arm.*/arm/ -e s/sa110/arm/)
-+ARCH:=$(shell uname -m | sed -e s/x86_64/x86/ -e s/i686/x86/ -e s/i386/x86/ -e s/arm.*/arm/ -e s/sa110/arm/)
- 
- ifeq ($(ARCH),x86)
-   ISPC_OBJS=$(addprefix objs/, $(ISPC_SRC:.ispc=)_ispc.o)


### PR DESCRIPTION
#### Description

- Updates ispc to 1.13.0
- Switches to use a sub-port build of LLVM/clang (10.0.0) for the build time dependency. Removes the need to force a dependency on a non-default LLVM variant.
- Fixes builds on some older systems.
- Fixes the port tests. All run cleanly on all tested platforms (10.15, 10.13, 10.11 and 10.9)

Previous dependency on a non-default variant of LLVM (+debug) was problematic for a number of reasons.
 - Forces a (time consuming) build on users.
 - Prevents testing of PRs for ports that require ispc to build (e.g. https://github.com/macports/macports-ports/pull/7145)
 - Prevents builds in buildbots and distribution of binary tarballs.
New scheme adds a sub-port `ispc-clang` that builds a 'private' build with the correct settings as required by `ispc`. As it is a build dep. only, users will not need to install this when installing via the binary tarballs.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS (10.15, 10.13, 10.11 and 10.9)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
