### PR TITLE
openjdk8: update GraalVM subports to 20.1.0

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -10,7 +10,7 @@ set build        09
 set major        8
 
 subport openjdk8-graalvm {
-    version      20.0.0
+    version      20.1.0
     revision     0
 
     set major    8
@@ -51,7 +51,7 @@ subport openjdk11 {
 }
 
 subport openjdk11-graalvm {
-    version      20.0.0
+    version      20.1.0
     revision     0
 
     set major    11
@@ -204,9 +204,9 @@ if {${subport} eq "openjdk8"} {
     distname     graalvm-ce-java${major}-darwin-amd64-${version}
     worksrcdir   graalvm-ce-java${major}-${version}
 
-    checksums    rmd160  ea2b19825f77148103f203cbba01c138d7ca681c \
-                 sha256  e3d35fdfe4f62022c42029c052f2b8277b3d896496cf45c2e82d251f5d49701a \
-                 size    379557294
+    checksums    rmd160  4bb85efe5021a9a88758a2815d9f1d35a3e6d542 \
+                 sha256  3b9fd8ce84c9162a188fde88907c66990db22af0ff6ae2c04430113253a9a634 \
+                 size    334191214
 
     description  GraalVM Community Edition based on OpenJDK ${major}
     long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, \
@@ -289,9 +289,9 @@ if {${subport} eq "openjdk8"} {
     distname     graalvm-ce-java${major}-darwin-amd64-${version}
     worksrcdir   graalvm-ce-java${major}-${version}
 
-    checksums    rmd160  0338475f67004e5b3a9cbf6c4fc041b63efd06a0 \
-                 sha256  8ba1205bb08cab04f1efc72423674d5816efbc3b22e482709c508788d87a692a \
-                 size    475292772
+    checksums    rmd160  a076d4fdef59fb3a44b8b38193214d496f7984ea \
+                 sha256  04efcb7bdd2e94715d0f3fddcc754594da032887e6aec94a3701bd4774d1a92e \
+                 size    428722016
 
     description  GraalVM Community Edition based on OpenJDK ${major}
     long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, \


### PR DESCRIPTION
#### Description

Update GraalVM subports to 20.1.0.

###### Tested on

macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?