### PR TITLE
skaffold: update to 1.10.0

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 1.9.1 v
+github.setup        GoogleContainerTools skaffold 1.10.0 v
 revision            0
 
 categories          devel
@@ -23,9 +23,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  a050dc600e299ba21f3fc379ab3a0dd3be83b61d \
-                    sha256  2fa0d499e253fa5bf3ec2f812ee1e94319227b7065be0aa37afd278ffadb0273 \
-                    size    27061491
+checksums           rmd160  7230a7982300e0db4fc33804a2885881b4890eb5 \
+                    sha256  dde91487fff14812a45825b663375c180730e5c7d7646950a9de75dd721bc093 \
+                    size    27095346
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 1.10.0.

###### Tested on

macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?