### PR TITLE
fx: new port

### DIFF
--- a/sysutils/fx/Portfile
+++ b/sysutils/fx/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        antonmedv fx 18.0.1
+
+categories          sysutils
+platforms           darwin
+license             MIT
+maintainers         {@sikmir gmail.com:sikmir} openmaintainer
+
+description         Command-line tool and terminal JSON viewer
+long_description    ${description}
+
+checksums           rmd160  86d17a60e47f88a334292566ae584af06c08343e \
+                    sha256  a0e6bf4bac205a5b04b9553d47692a6b80b9fc34e2b679c8472b70686ca78cd5 \
+                    size    11106322
+
+github.tarball_from releases
+distname            ${name}-macos
+
+extract.mkdir       yes
+
+use_configure       no
+use_zip             yes
+
+build {}
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name}-macos ${destroot}${prefix}/bin/${name}
+}


### PR DESCRIPTION
#### Description

[**fx**](https://github.com/antonmedv/fx) - command-line tool and terminal JSON viewer.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
