### PR TITLE
libomp: Update to 10.0.0

### DIFF
--- a/lang/libomp/Portfile
+++ b/lang/libomp/Portfile
@@ -29,19 +29,19 @@ subport                 libomp-devel {}
 
 if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} ne "libstdc++"} {
     if { ${subport} eq "libomp-devel" } {
-        version                 10.0.0-rc3
+        version                 10.0.1-rc1
         checksums \
-            rmd160  24b50ccf7264748452154a4c9a5c728a8844f350 \
-            sha256  4b56ff1cff324cc69c783a3dd56305078c8cb92fc59fee494e736714b2eaad2b \
-            size    958880
+            rmd160  0481fc3468617bf4b4c90db9fbe91fc0db48f0f0 \
+            sha256  7e652770b02afb803fbcce47ca11116d383cccc932eddc0260d128e655f2df66 \
+            size    958200
 
         livecheck.regex         {"llvmorg-([0-9.rc-]+)".*}
     } else {
-        version                 9.0.1
+        version                 10.0.0
         checksums \
-            rmd160  e5562fce183a9838d412d4e60c5afb41607b0c37 \
-            sha256  5c94060f846f965698574d9ce22975c0e9f04c9b14088c3af5f03870af75cace \
-            size    938360
+            rmd160  818001eb0d6f92592af75a87ccd8e05ccc7f8b4d \
+            sha256  3b9ff29a45d0509a1e9667a0feb43538ef402ea8cfc7df3758a01f20df08adfa \
+            size    959016
 
         livecheck.regex         {"llvmorg-([0-9.]+)".*}
     }


### PR DESCRIPTION
Maintainer update... but as this port is pulled in by clang-*, it would be good if a few people took a look / tried it out.