### PR TITLE
yaegi: new port

### DIFF
--- a/devel/yaegi/Portfile
+++ b/devel/yaegi/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/containous/yaegi 0.8.6 v
+
+description         Yaegi is Another Elegant Go Interpreter
+
+long_description    Yaegi is Another Elegant Go Interpreter. It powers \
+                    executable Go scripts and plugins, in embedded \
+                    interpreters or interactive shells, on top of the Go \
+                    runtime. It has complete support for the Go \
+                    specification, is written in Pure Go, and works \
+                    everywhere Go works. All Go & runtime resources \
+                    accessible from script (with control), and for security, \
+                    "unsafe" and "syscall" packages are neither used nor \
+                    exported by default.
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+categories          devel
+license             Apache-2
+installs_libs       no
+
+checksums           rmd160  8f7ed4141613f08c52ac689c2cf37935167f29b6 \
+                    sha256  ad367f707e696f3571013161fa323c2b7b329e4790dbacb370263af9c92edcc7 \
+                    size    1834537
+
+build.target        github.com/containous/yaegi/cmd/yaegi
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
