### PR TITLE
ocaml: update to 4.10.0

### DIFF
--- a/lang/ocaml/Portfile
+++ b/lang/ocaml/Portfile
@@ -13,8 +13,8 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                ocaml
 epoch               1
-version             4.08.1
-revision            1
+version             4.10.0
+revision            0
 set major_vers      [join [lrange [split ${version} .] 0 1] .]
 platforms           darwin
 supported_archs     i386 x86_64
@@ -24,9 +24,9 @@ license             LGPL
 homepage            https://ocaml.org
 master_sites        http://caml.inria.fr/pub/distrib/ocaml-${major_vers}/
 
-checksums           rmd160  4787a3cde671253ad634e8aae72dd91a95b6b892 \
-                    sha256  cd4f180453ffd7cc6028bb18954b3d7c3f715af13157df2f7c68bdfa07655ea3 \
-                    size    3382960
+checksums           rmd160  1d3ea27712fbb0724f31b442bdb34229020393cc \
+                    sha256  30734db17b609fdd1609c39a05912325c299023968a2c783e5955dd5163dfeb7 \
+                    size    3416016
 
 description         Compiler and libraries for the OCaml programming language
 long_description    OCaml is an industrial strength programming language \
@@ -73,7 +73,6 @@ configure.env-append \
 
 # Configure.
 configure.pre_args  --prefix=${prefix} --mandir=${prefix}/share/man
-configure.args      --disable-graph-lib
 
 # Building.
 build.target        world.opt


### PR DESCRIPTION
- remove `--disable-graph-lib` configure flag as the graphics lib is no
longer distributed with OCaml since version 4.09

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
