### PR TITLE
mythtv.*: switch from perl5.26 to perl5.28

### DIFF
--- a/multimedia/mythtv.27/Portfile
+++ b/multimedia/mythtv.27/Portfile
@@ -10,8 +10,8 @@ set shorthash       3c7582e9
 set majorversion    .27
 set minorversion    .7
 set lastcommit      20180201
-set corerev         3
-set pluginsrev      2
+set corerev         4
+set pluginsrev      3
 github.setup        MythTV mythtv ${shorthash}
 
 name                mythtv${majorversion}
@@ -33,9 +33,9 @@ livecheck.version       ${majorversion}${minorversion}
 livecheck.regex         "archive/v(0.27\[\\.\\d\]?)${extract.suffix}"
 
 
-set perlver         perl5.26
+set perlver         perl5.28
 set perlbin         ${prefix}/bin/${perlver}
-set perlmodver      p5.26
+set perlmodver      p5.28
 set pythonver       python2.7
 set pythonbin       ${prefix}/bin/${pythonver}
 set pymodver        py27

--- a/multimedia/mythtv.28/Portfile
+++ b/multimedia/mythtv.28/Portfile
@@ -12,8 +12,8 @@ set shorthash       8238e839
 set majorversion    .28
 set minorversion    .2
 set lastcommit      20180201
-set corerev         8
-set pluginsrev      2
+set corerev         9
+set pluginsrev      3
 set metarev         0
 github.setup        MythTV mythtv ${shorthash}
 checksums           rmd160  0f468b5e0502afe2672f2e41df5f40cbdb2d43d4 \
@@ -48,7 +48,7 @@ set pythonbranch    2.7
 set pythonver       python${pythonbranch}
 set pythonbin       ${prefix}/bin/${pythonver}
 set pymodver        py27
-perl5.branches      5.26
+perl5.branches      5.28
 # change to 1 to print reinplace warnings
 set maintainer_mode 0
 if {!$maintainer_mode} {


### PR DESCRIPTION
#### Description

See https://trac.macports.org/ticket/58361.

perl 5.32 stable release is tentatively scheduled for 6/20/2020.
https://www.nntp.perl.org/group/perl.perl5.porters/2020/04/msg257375.html

When this occurs, perl5.26 will become deprecated and subject to removal of support from the various p5-* ports.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
