### PR TITLE
semgrep: new port

### DIFF
--- a/devel/semgrep/Portfile
+++ b/devel/semgrep/Portfile
@@ -1,0 +1,57 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        returntocorp semgrep 0.8.0 v
+
+description         Fast and syntax-aware semantic code pattern search for \
+                    many languages: like grep but for code.
+
+long_description    semgrep is like grep but for code: it is a tool for \
+                    easily detecting and preventing bugs and anti-patterns \
+                    in your codebase. It combines the convenience of grep \
+                    with the correctness of syntactical and semantic search.
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+platforms           darwin
+categories          devel
+license             LGPL-2.1
+
+# Git repository needed as additional dependencies are provided as submodules.
+fetch.type          git
+
+depends_build       port:ocaml \
+                    port:opam  \
+                    port:pkgconfig
+
+installs_libs       no
+use_configure       no
+
+post-fetch {
+    system -W ${worksrcpath} "git submodule update --init --recursive"
+}
+
+build {
+    set opam_env_file ${workpath}/opam.env
+    set opam_install ". ${opam_env_file} && opam install -j ${build.jobs} -y"
+
+    system -W ${workpath} "opam init -n --disable-sandboxing"
+    system "opam env > ${opam_env_file}"
+
+    system "${opam_install} yaml parmap dune-glob"
+    system -W ${worksrcpath} "${opam_install} ./pfff"
+    system -W ${worksrcpath}/semgrep-core ". ${opam_env_file} && ${build.cmd} all"
+}
+
+destroot {
+    set sg_doc_dir ${prefix}/share/doc/${name}
+
+    xinstall -m 755 ${worksrcpath}/semgrep-core/_build/default/bin/Main.exe \
+                    ${destroot}${prefix}/bin/${name}
+
+    file mkdir ${sg_doc_dir}
+    xinstall -m 644 {*}[glob ${worksrcpath}/docs/*] ${sg_doc_dir}
+}


### PR DESCRIPTION
#### Description

New port for [semgrep](https://github.com/returntocorp/semgrep)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
