### PR TITLE
delve: update to 1.4.1

### DIFF
--- a/devel/delve/Portfile
+++ b/devel/delve/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/go-delve/delve 1.4.0 v
+go.setup            github.com/go-delve/delve 1.4.1 v
 
 categories          devel
 license             MIT
@@ -13,9 +13,9 @@ build.target        github.com/go-delve/delve/cmd/dlv
 
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
 
-checksums           rmd160  cb29d31a9c1f10cd324a753bec6e9d962610ded7 \
-                    sha256  7439eb8caeaf9c1320e684e3dc6664dc0496c99bdfc3960594f479a249de37ff \
-                    size    7785378
+checksums           rmd160  442e7ce808bd0975c2cdcde06e67d9b16decde29 \
+                    sha256  49cfd79cb7ea849e166f821dcb82b716b1a95f639715d02de7d11ee7c674b007 \
+                    size    7984258
 
 description         Delve is a debugger for the Go programming language.
 long_description    Delve is a debugger for the Go programming language. \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
