### PR TITLE
nvchecker: update to latest version

### DIFF
--- a/devel/nvchecker/Portfile
+++ b/devel/nvchecker/Portfile
@@ -4,23 +4,30 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        lilydjwg nvchecker 1.4.4 v
+github.setup        lilydjwg nvchecker 1.6 v
 revision            0
 github.tarball_from archive
+
 platforms           darwin
+supported_archs     noarch
 categories-prepend  devel
 license             MIT
-maintainers         nomaintainer
+maintainers         {reneeotten @reneeotten} openmaintainer
 
 description         New version checker for software
 long_description    nvchecker (short for new version checker) is for checking \
                     if a new version of some software has been released.
 
-checksums           rmd160  4bceed6757b295c0d9927c66a868516295c644a4 \
-                    sha256  3875e0107af343e1836494017dde20e5848c60a2c7438aa7b8a612776fb95242 \
-                    size    30671
+checksums           rmd160  db6851d381d4d21e247bbcc7d807c2e49a0af082 \
+                    sha256  873908bec4ca55c4dc6f243b540855d96f63e6baef7b68d6d772166f8cb30e80 \
+                    size    31977
 
-python.default_version 37
+python.default_version 38
+
+post-patch {
+    # nvchecker uses `grep -P`, which is not available in BSD grep
+    reinplace "s# grep # ${prefix}/bin/ggrep #" ${worksrcpath}/nvchecker/source/vcs.sh
+}
 
 depends_lib-append \
                     port:py${python.version}-setuptools
@@ -30,10 +37,3 @@ depends_run-append \
                     port:py${python.version}-tornado \
                     port:py${python.version}-curl \
                     port:grep
-
-post-extract {
-    # nvchecker uses `grep -P`, which is not available in BSD grep
-    reinplace "s# grep # ${prefix}/bin/ggrep #" ${worksrcpath}/nvchecker/source/vcs.sh
-}
-
-livecheck.type      none


### PR DESCRIPTION
#### Description
This PR adds macOS 10.15 to the build matrix for Travis CI. Additionally, one update to check whether this works..

- nvchecker: update to 1.6, assume maintainership

[edit: there is still no binary for macOS 10.15 available for the CI tests, so remove this again for now]

macOS 10.14.6 18G4032
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->