### PR TITLE
beekeeper-studio: new port

### DIFF
--- a/aqua/beekeeper-studio/Portfile
+++ b/aqua/beekeeper-studio/Portfile
@@ -1,0 +1,49 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        beekeeper-studio beekeeper-studio 1.4.0 v
+
+homepage            https://beekeeperstudio.io/
+
+description         Cross platform SQL editor and database management app for \
+                    Windows, Linux, and Mac.
+
+long_description    Beekeeper Studio is a free and open source SQL editor and \
+                    database manager. Beekeeper Studio is cross-platform, and \
+                    available for Linux, Mac, and Windows. It features \
+                    autocomplete SQL query editor with syntax highlighting, \
+                    tabbed interface, so you can multitask, the ability to \
+                    sort and filter table data to find just what you need, \
+                    sensible keyboard-shortcuts, the ability to save queries \
+                    for later, query run-history so you can find that one \
+                    query you got working 3 days ago, and a default dark theme.
+
+categories          aqua databases
+license             MIT
+platforms           darwin
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  52ac34178ba23938e184030ed530f980efff89b9 \
+                    sha256  093a41aa23e2d4b2259265a0a9fbe3feef8cfd1e4054417f39bedc0f768d5c1b \
+                    size    42107147
+
+depends_build       port:yarn
+
+use_configure       no
+
+build {
+    system -W ${worksrcpath} "yarn"
+    system -W ${worksrcpath} "CSC_IDENTITY_AUTO_DISCOVERY=false yarn run electron:build --mac dir"
+}
+
+destroot {
+    copy ${worksrcpath}/dist_electron/mac/Beekeeper\ Studio.app \
+         ${destroot}${applications_dir}
+}
+
+github.livecheck.regex {([0-9.]+)}


### PR DESCRIPTION
#### Description

New port for [Beekeeper Studio](https://www.beekeeperstudio.io/)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
