### PR TITLE
port pymol: update to 2.4.0 and introduce x11 variant revised

### DIFF
--- a/science/pymol/Portfile
+++ b/science/pymol/Portfile
@@ -6,7 +6,7 @@ PortGroup           active_variants 1.1
 PortGroup           compilers 1.0
 PortGroup           github 1.0
 
-github.setup        schrodinger pymol-open-source 2.3.0 v
+github.setup        schrodinger pymol-open-source 2.4.0 v
 name                pymol
 categories          science chemistry
 license             PSF
@@ -20,17 +20,17 @@ platforms           darwin
 
 homepage            https://www.pymol.org/
 
-checksums           rmd160  2ff2f0035e3ff089a77c5e705d031fe2ac2848b4 \
-                    sha256  802a30e638a3bdc6254ece60bef3e9739a619335ce55c36b3a4c51adf5d646d5 \
-                    size    10448291
+checksums           rmd160  e7a962473732172b370e6c7a880384e7a1ffa62e \
+                    sha256  b0af15082c44c92c285cab341506da50407619f5dee09d98fdf2802e356219fd \
+                    size    10552074
 
-compilers.choose    cc cxx
-compilers.setup
+compiler.cxx_standard 2011
 
-variant python27 conflicts python35 python36 python37 description {Use Python 2.7} {}
-variant python35 conflicts python27 python36 python37 description {Use Python 3.5} {}
-variant python36 conflicts python27 python35 python37 description {Use Python 3.6} {}
-variant python37 conflicts python27 python35 python36 description {Use Python 3.7} {}
+variant python27 conflicts python35 python36 python37 python38 description {Use Python 2.7} {}
+variant python35 conflicts python27 python36 python37 python38 description {Use Python 3.5} {}
+variant python36 conflicts python27 python35 python37 python38 description {Use Python 3.6} {}
+variant python37 conflicts python27 python35 python36 python38 description {Use Python 3.7} {}
+variant python38 conflicts python27 python35 python36 python37 description {Use Python 3.8} {}
 
 if {[variant_isset python35]} {
     python.default_version 35
@@ -38,27 +38,46 @@ if {[variant_isset python35]} {
     python.default_version 36
 } elseif {[variant_isset python37]} {
     python.default_version 37
+} elseif {[variant_isset python38]} {
+    python.default_version 38
 } else {
-    default_variants +python27
-    python.default_version 27
+    if {[variant_isset x11]} { 
+        # The APBS Tools plugin requires pdb2pqr
+        # which can't be run under python3 yet
+        default_variants +python27
+        python.default_version 27
+    } else {
+        default_variants +python38
+        python.default_version 38
+    }
 }
 python.link_binaries no
 
-depends_lib-append  port:freeglut \
-                    port:freetype \
+depends_lib-append  port:freetype \
                     port:glew \
                     port:glm \
                     port:libpng \
                     port:libGLU \
                     port:libxml2 \
-                    port:mesa \
-                    port:py${python.version}-numpy \
-                    port:py${python.version}-pmw \
-                    port:py${python.version}-pyqt5 \
-                    port:py${python.version}-tkinter \
-                    port:tcl \
-                    port:tk
-depends_run         port:xdpyinfo
+                    port:netcdf \
+                    port:py${python.version}-numpy
+
+if {![variant_isset x11]} {
+    depends_lib-append port:py${python.version}-pyqt5
+}
+
+variant x11 {
+    depends_lib-append port:freeglut \
+                       port:mesa \
+                       port:py${python.version}-pmw \
+                       port:py${python.version}-tkinter \
+                       port:py${python.version}-tkinter \
+                       port:tcl \
+                       port:tk
+
+    require_active_variants tcl "" corefoundation
+    require_active_variants tk "" quartz
+}
 
 # py-scipy is not universal
 universal_variant   no
@@ -66,11 +85,9 @@ universal_variant   no
 patchfiles          pymol_shell.diff \
                     pmg_tk_platform.patch \
                     apbs-psize.patch  \
+                    python_string_split.patch \
                     pdb2pqr.patch \
                     setup.py.diff
-
-require_active_variants tcl "" corefoundation
-require_active_variants tk "" quartz
 
 post-patch {
     reinplace  "s|@PREFIX@|${prefix}|g" ${worksrcpath}/setup.py ${worksrcpath}/modules/pmg_tk/startup/apbs_tools.py
@@ -81,22 +98,23 @@ post-patch {
 
 use_parallel_build yes
 
-build {}
-
-destroot.cmd ${python.bin} setup.py --no-user-cfg --osx-frameworks --glut --use-msgpackc=no
-
-pre-destroot {
-    destroot.env CC=${configure.cc} CXX=${configure.cxx} PREFIX_PATH=${prefix}
+if {[variant_isset x11]} {
+    build.cmd ${python.bin} setup.py --no-user-cfg --no-osx-frameworks --glut --use-msgpackc=no
+} else {
+    build.cmd ${python.bin} setup.py --no-user-cfg --use-msgpackc=no
 }
 
 post-destroot {
      file copy ${worksrcpath}/setup/pymol_macports ${destroot}${prefix}/bin/pymol
      file attributes ${destroot}${prefix}/bin/pymol -permissions a+x
+     if {![variant_isset x11]} {
+          file delete ${destroot}${python.pkgd}/pmg_tk/startup/apbs_tools.py
+     } else {
+          reinplace "s|options.gui \= \'pmg_qt\'|options.gui \= \'pmg_tk\'|g" ${destroot}${python.pkgd}/pymol/invocation.py
+     }
 }
 
 test.run            yes
 test.dir            ${worksrcpath}/test
 test.cmd            ${python.bin}
 test.target         run
-
-notes "Pymol can be started with the classic Tk GUI by appending the '-N pmg_tk' runtime option."

--- a/science/pymol/python_string_split.patch
+++ b/science/pymol/python_string_split.patch
@@ -1,0 +1,580 @@
+From aa0645e90fb6aab6180cca726e3f2a2453cde829 Mon Sep 17 00:00:00 2001
+From: Thomas Holder <thomas.holder@schrodinger.com>
+Date: Fri, 22 May 2020 08:45:20 +0200
+Subject: [PATCH] Fix #101 `string.split()` usage in apbs_tools.py
+
+Patch by @jwhowarth
+---
+ modules/pmg_tk/startup/apbs_tools.py | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git modules/pmg_tk/startup/apbs_tools.py modules/pmg_tk/startup/apbs_tools.py
+index 75f06f22..473379bc 100644
+--- modules/pmg_tk/startup/apbs_tools.py
++++ modules/pmg_tk/startup/apbs_tools.py
+@@ -145,7 +145,6 @@
+ 
+ import tempfile
+ import os,math,re
+-import string
+ import sys
+ 
+ if sys.version_info[0] < 3:
+@@ -269,7 +268,7 @@ def verify(name,f):
+     searchDirs.append(os.path.join("/sw", "share", "apbs-mpi-lammpi", "tools", "manip"))
+     searchDirs.append(os.path.join("/usr", "local", "share", "tools", "manip"))
+ 
+-    searchDirs.extend(string.split(os.environ["PATH"], ":"))
++    searchDirs.extend(os.environ["PATH"].split(":"))
+     searchDirs.append(os.path.join("/usr", "local", "bin"))
+     searchDirs.append(os.path.join("/opt", "local", "bin"))
+     searchDirs.append(os.path.join("/sw", "bin"))
+From e1122b078e43fb7e503a32ed5c6176e8d36ec4ea Mon Sep 17 00:00:00 2001
+From: Thomas Holder <thomas.holder@schrodinger.com>
+Date: Fri, 22 May 2020 08:52:37 +0200
+Subject: [PATCH] Fix remaining `string` module uses
+
+---
+ examples/devel/importing.py    |   3 +-
+ examples/devel/syncmol.py      |   2 +-
+ modules/chempy/cc1.py          |   8 +--
+ modules/chempy/mmd.py          |  15 +++--
+ modules/chempy/mol.py          |  11 ++--
+ modules/chempy/pdb.py          |  15 +++--
+ modules/chempy/sdf.py          |   7 +--
+ modules/chempy/tinker/amber.py | 101 ++++++++++++++++-----------------
+ modules/chempy/tinker/state.py |   9 ++-
+ 9 files changed, 81 insertions(+), 90 deletions(-)
+
+diff --git examples/devel/importing.py examples/devel/importing.py
+index f704356f..2daadf58 100644
+--- examples/devel/importing.py
++++ examples/devel/importing.py
+@@ -12,13 +12,12 @@
+ # sleep a second after importing.
+ 
+ 
+-import string
+ import __main__
+ 
+ # note that passing in a "-z" option would keep the window hidden
+ # until you called pymol.cmd.window("show").
+ 
+-__main__.pymol_argv= string.split("pymol -qxiF  -X 300 -Y 100 -H 400 -W 400")
++__main__.pymol_argv= "pymol -qxiF  -X 300 -Y 100 -H 400 -W 400".split()
+ import pymol
+ 
+ # give PyMOL enough time to initialize (we need to find a safe and
+diff --git examples/devel/syncmol.py examples/devel/syncmol.py
+index ef55cd24..bbce8926 100644
+--- examples/devel/syncmol.py
++++ examples/devel/syncmol.py
+@@ -195,7 +195,7 @@ def handle(self):
+             _stdin_reader_thread.setDaemon(1)
+             _stdin_reader_thread.start()
+         elif tok == 'send':
+-            addr = string.split(sys.argv.pop(),':')
++            addr = sys.argv.pop().split(':')
+             if len(addr)==1:
+                 host = 'localhost'
+                 port = int(addr[0])
+diff --git modules/chempy/cc1.py modules/chempy/cc1.py
+index 199fff4a..2328c988 100644
+--- modules/chempy/cc1.py
++++ modules/chempy/cc1.py
+@@ -15,8 +15,6 @@
+ from chempy.models import Indexed
+ from chempy import Storage,Atom,Bond
+ 
+-import string
+-
+ class CC1(Storage): # ChemDraw3D 5.0 std., cartesian coordinates
+ 
+     def fromList(self,molList):
+@@ -33,12 +31,12 @@ def fromList(self,molList):
+         for a in range(nAtom):
+             at = Atom()
+             at.index = cnt
+-            id_dict[string.strip(molList[irec][3:8])] = at.index
++            id_dict[molList[irec][3:8].strip()] = at.index
+             at.coord = [float(molList[irec][8:20]),
+                 float(molList[irec][20:32]),float(molList[irec][32:44])]
+-            at.symbol = string.strip(molList[irec][0:3])
++            at.symbol = molList[irec][0:3].strip()
+             at.numeric_type = int(molList[irec][44:49])
+-            lst = string.split(string.strip(molList[irec][49:]))
++            lst = molList[irec][49:].split()
+             at.bonds = lst
+             irec = irec + 1
+             cnt = cnt + 1
+diff --git modules/chempy/mmd.py modules/chempy/mmd.py
+index ef8e16fe..a93262c3 100644
+--- modules/chempy/mmd.py
++++ modules/chempy/mmd.py
+@@ -17,7 +17,6 @@
+ from chempy.models import Indexed,Connected
+ from chempy import Storage,Atom,Bond
+ 
+-import string
+ import copy
+ 
+ class MMD(Storage):
+@@ -29,7 +28,7 @@ def fromList(self,MMODList):
+ 
+ # get header information
+         nAtom = int(MMODList[0][1:6])
+-        model.molecule.title = string.strip(MMODList[0][8:])
++        model.molecule.title = MMODList[0][8:].strip()
+         irec = 1
+ 
+ # loop through atoms
+@@ -42,7 +41,7 @@ def fromList(self,MMODList):
+             at.numeric_type = int(MMODList[irec][1:4])
+ 
+ # extract connectivity information
+-            tokens = string.splitfields(MMODList[irec][5:52])
++            tokens = MMODList[irec][5:52].split()
+             at.neighbor = []
+             at.bondorder = []
+ 
+@@ -61,20 +60,20 @@ def fromList(self,MMODList):
+ # extract other information
+             at.coord = [float(MMODList[irec][53:64]),
+                 float(MMODList[irec][65:76]), float(MMODList[irec][77:88])]
+-            at.resi = string.strip(MMODList[irec][89:94])
++            at.resi = MMODList[irec][89:94].strip()
+             at.resi_number = int(at.resi)
+-            resn_code = string.strip(MMODList[irec][94:95])
++            resn_code = MMODList[irec][94:95].strip()
+             if len(resn_code): at.resn_code = resn_code
+-            color_code = string.strip(MMODList[irec][96:100])
++            color_code = MMODList[irec][96:100].strip()
+             if color_code!='':
+                 at.color_code = int(color_code)
+             else:
+                 at.color_code = 0
+-            chain = string.strip(MMODList[irec][95:96])
++            chain = MMODList[irec][95:96].strip()
+             if len(chain): at.chain = chain
+             at.partial_charge = float(MMODList[irec][100:109])
+             at.resn = MMODList[irec][119:123]
+-            name = string.strip(MMODList[irec][124:128])
++            name = MMODList[irec][124:128].strip()
+             if len(name): at.name = name
+             model.atom.append(at)
+             irec = irec + 1
+diff --git modules/chempy/mol.py modules/chempy/mol.py
+index 175a248f..748a0aed 100644
+--- modules/chempy/mol.py
++++ modules/chempy/mol.py
+@@ -20,7 +20,6 @@
+ except ImportError:
+     CmdException = Exception
+ 
+-import string
+ 
+ class MOL(Storage):
+ 
+@@ -29,9 +28,9 @@ def fromList(self,molList):
+         model = Indexed()
+ 
+         # read header information
+-        model.molecule.title = string.strip(molList[0])
+-        model.molecule.dim_code = string.strip(molList[1][20:22])
+-        model.molecule.comments = string.strip(molList[2])
++        model.molecule.title = molList[0].strip()
++        model.molecule.dim_code = molList[1][20:22].strip()
++        model.molecule.comments = molList[2].strip()
+         try:
+             model.molecule.chiral = int(molList[3][12:15])
+         except:
+@@ -48,7 +47,7 @@ def fromList(self,molList):
+             at.index = cnt
+             at.coord = [float(molList[irec][0:10]),
+                 float(molList[irec][10:20]),float(molList[irec][20:30])]
+-            at.symbol = string.strip(molList[irec][31:33])
++            at.symbol = molList[irec][31:33].strip()
+             try:
+                 at.stereo = int(molList[irec][39:42])
+             except:
+@@ -75,7 +74,7 @@ def fromList(self,molList):
+             # obtain formal charges from M  CHG record
+         while molList[irec][0:6]!='M  END':
+             if molList[irec][0:6]=='M  CHG':
+-                cl = string.split(string.strip(molList[irec][6:]))
++                cl = molList[irec][6:].split()
+                 cll = int(cl[0])*2
+                 a=1
+                 while a<=cll:
+diff --git modules/chempy/pdb.py modules/chempy/pdb.py
+index 505731e2..0d061be3 100644
+--- modules/chempy/pdb.py
++++ modules/chempy/pdb.py
+@@ -14,7 +14,6 @@
+ 
+ from chempy import Storage,Atom
+ from chempy.models import Indexed
+-import string
+ 
+ class PDB(Storage):
+ 
+@@ -31,11 +30,11 @@ def fromList(self,list):   # currently no handling of conect records
+                 at = Atom()
+                 if rec[0]=='A': at.hetatm=0  # default is 1
+                 at.index = cnt
+-                at.name = string.strip(rec[12:16])
+-                at.alt = string.strip(rec[16:17])
+-                at.resn = string.strip(rec[17:20])
+-                at.chain = string.strip(rec[21:22])
+-                at.resi = string.strip(rec[22:27]) # note: insertion is part of resi
++                at.name = rec[12:16].strip()
++                at.alt = rec[16:17].strip()
++                at.resn = rec[17:20].strip()
++                at.chain = rec[21:22].strip()
++                at.resi = rec[22:27].strip() # note: insertion is part of resi
+                 at.resi_number = int(rec[22:26])
+                 at.coord = [float(rec[30:38]),
+                                 float(rec[38:46]),
+@@ -48,8 +47,8 @@ def fromList(self,list):   # currently no handling of conect records
+                     at.b = float(rec[60:66])
+                 except ValueError:
+                     at.b = 0.0
+-                at.segi = string.strip(rec[72:76])
+-                at.symbol = string.strip(rec[76:78])
++                at.segi = rec[72:76].strip()
++                at.symbol = rec[76:78].strip()
+                 if not len(at.symbol):
+                     at.symbol = at.name[0:1]
+                     if at.symbol in '012345678':
+diff --git modules/chempy/sdf.py modules/chempy/sdf.py
+index a36cd8d3..78e462f8 100644
+--- modules/chempy/sdf.py
++++ modules/chempy/sdf.py
+@@ -14,7 +14,6 @@
+ 
+ from __future__ import print_function
+ 
+-import string
+ import re
+ import copy
+ 
+@@ -66,7 +65,7 @@ def __init__(self,sdflist):
+                 sd = self.data[kee]
+                 l = l + 1
+                 while l<ll:
+-                    if len(string.strip(sdflist[l]))!=0:
++                    if sdflist[l].strip():
+                         sd.append(sdflist[l])
+                         l = l + 1
+                     else:
+@@ -98,7 +97,7 @@ def get_single(self,kee): # automatic stripping
+         if kee in self.data:
+             sdk = self.data[kee]
+             if len(sdk):
+-                return string.strip(sdk[0])
++                return sdk[0].strip()
+             else:
+                 return None
+         else:
+@@ -142,7 +141,7 @@ def __init__(*args):
+             return None
+         if mode=='pf': # pseudofile
+             self.file = fname
+-        elif (mode[0:1]=='r') and (string.find(fname,':')>1):
++        elif mode[0:1] == 'r' and '://' in fname:
+             # does this look like a URL? (but not a DOS path)
+             try:
+                 from urllib import urlopen
+diff --git modules/chempy/tinker/amber.py modules/chempy/tinker/amber.py
+index 7ded34b2..1f4deec0 100644
+--- modules/chempy/tinker/amber.py
++++ modules/chempy/tinker/amber.py
+@@ -16,7 +16,6 @@
+ 
+ from chempy import feedback
+ 
+-import string
+ import copy
+ 
+ default_extra = { # atomic number, and normal valency (for tinker)
+@@ -126,33 +125,33 @@ def __init__(self,fname):
+         self.type = []
+         self.mw = {}
+         while 1:
+-            l = string.strip(f.readline())
++            l = f.readline().strip()
+             if not len(l): break
+-            a2 = string.strip(l[0:2])
++            a2 = l[0:2].strip()
+             self.type.append(a2)
+-            self.mw[a2] = [float(l[3:13]),string.strip(l[34:])]
++            self.mw[a2] = [float(l[3:13]),l[34:].strip()]
+         # skip 1
+         l = f.readline()
+         # read bonds
+         self.bond = {}
+         while 1:
+-            l = string.strip(f.readline())
++            l = f.readline().strip()
+             if not len(l): break
+             a5 = l[0:5]
+             self.bond[a5] = [float(l[5:12]),float(l[12:22]),
+-                                  string.strip(l[22:])]
++                                  l[22:].strip()]
+         # read angles
+         self.angle = {}
+         while 1:
+-            l = string.strip(f.readline())
++            l = f.readline().strip()
+             if not len(l): break
+             a5 = l[0:8]
+             self.angle[a5] = [float(l[8:16]),float(l[16:28]),
+-                                  string.strip(l[28:])]
++                                  l[28:].strip()]
+         # read torsion
+         self.torsion = {}
+         while 1:
+-            l = string.strip(f.readline())
++            l = f.readline().strip()
+             if not len(l): break
+             a5 = l[0:11]
+             if a5 in self.torsion:
+@@ -161,49 +160,49 @@ def __init__(self,fname):
+                      float(l[15:27]),
+                      float(l[27:36]),
+                      abs(int(float(l[40:52]))),
+-                     string.strip(l[52:])])
++                     l[52:].strip()])
+             else:
+                 self.torsion[a5] = [int(l[11:15]),
+                                           float(l[15:27]),
+                                           float(l[27:36]),
+                                           abs(int(float(l[40:52]))),
+-                                          string.strip(l[52:])]
++                                          l[52:].strip()]
+         # read impropers
+         self.improper = {}
+         while 1:
+-            l = string.strip(f.readline())
++            l = f.readline().strip()
+             if not len(l): break
+             a5 = l[0:11]
+             self.improper[a5] = [float(l[15:27]),
+                                         float(l[27:40]),
+                                         abs(int(float(l[40:51]))),
+-                                        string.strip(l[51:])]
++                                        l[51:].strip()]
+         # skip
+         while 1:
+-            l = string.strip(f.readline())
++            l = f.readline().strip()
+             if not len(l): break
+         # read vdw equivalents
+         self.vdw_eq = {}
+         while 1:
+-            l = string.strip(f.readline())
++            l = f.readline().strip()
+             if not len(l): break
+-            a4 = string.strip(l[0:4])
++            a4 = l[0:4].strip()
+             l = l[4:]
+             while len(l):
+-                self.vdw_eq[string.strip(l[0:4])] = a4
++                self.vdw_eq[l[0:4].strip()] = a4
+                 l = l[4:]
+         # skip
+-        l = string.strip(f.readline())
++        l = f.readline().strip()
+         # read vdw parameters
+         self.vdw = {}
+         while 1:
+-            l = string.strip(f.readline())
++            l = f.readline().strip()
+             if not len(l): break
+             l = '  ' + l
+-            a4 = string.strip(l[0:4])
++            a4 = l[0:4].strip()
+             self.vdw[a4] =  [float(l[4:20]),
+                                   float(l[20:37]),
+-                                  string.strip(l[37:])]
++                                  l[37:].strip()]
+ 
+         # read extra tinker information if present
+         self.extra = {}
+@@ -211,7 +210,7 @@ def __init__(self,fname):
+             l = f.readline()
+             if not l: break
+             if l[0:6] == 'TINKER':
+-                self.extra[string.strip(l[6:12])]  = [
++                self.extra[l[6:12].strip()]  = [
+                     int(l[12:18]),
+                     int(l[18:24])]
+         if not self.extra:
+@@ -757,7 +756,7 @@ def write_tinker_prm(self,fname,proofread=None,smooth=None):
+         # bonds
+         bond = {}
+         for a in list(self.bond.keys()):
+-            kee = (map[string.strip(a[0:2])],map[string.strip(a[3:5])])
++            kee = (map[a[0:2].strip()],map[a[3:5].strip()])
+             bond[kee] = a
+         kees = list(bond.keys())
+         kees.sort()
+@@ -768,9 +767,9 @@ def write_tinker_prm(self,fname,proofread=None,smooth=None):
+         # angles
+         angle = {}
+         for a in list(self.angle.keys()):
+-            kee = (map[string.strip(a[0:2])],
+-                     map[string.strip(a[3:5])],
+-                     map[string.strip(a[6:8])],
++            kee = (map[a[0:2].strip()],
++                     map[a[3:5].strip()],
++                     map[a[6:8].strip()],
+                      )
+             angle[kee] = a
+         kees = list(angle.keys())
+@@ -783,10 +782,10 @@ def write_tinker_prm(self,fname,proofread=None,smooth=None):
+         if not smooth:
+             improper = {}
+             for a in self.improper.keys():
+-                kee = (map[string.strip(a[0:2])],
+-                         map[string.strip(a[3:5])],
+-                         map[string.strip(a[6:8])],
+-                         map[string.strip(a[9:11])],
++                kee = (map[a[0:2].strip()],
++                         map[a[3:5].strip()],
++                         map[a[6:8].strip()],
++                         map[a[9:11].strip()],
+                          )
+                 improper[kee] = a
+             kees = list(improper.keys())
+@@ -799,10 +798,10 @@ def write_tinker_prm(self,fname,proofread=None,smooth=None):
+         else:
+             improper = {}
+             for a in self.improper.keys():
+-                kee = (map[string.strip(a[0:2])],
+-                         map[string.strip(a[3:5])],
+-                         map[string.strip(a[6:8])],
+-                         map[string.strip(a[9:11])],
++                kee = (map[a[0:2].strip()],
++                         map[a[3:5].strip()],
++                         map[a[6:8].strip()],
++                         map[a[9:11].strip()],
+                          )
+                 improper[kee] = a
+             kees = list(improper.keys())
+@@ -814,10 +813,10 @@ def write_tinker_prm(self,fname,proofread=None,smooth=None):
+         # torsions
+         torsion = {}
+         for a in self.torsion.keys():
+-            kee = (map[string.strip(a[0:2])],
+-                     map[string.strip(a[3:5])],
+-                     map[string.strip(a[6:8])],
+-                     map[string.strip(a[9:11])],
++            kee = (map[a[0:2].strip()],
++                     map[a[3:5].strip()],
++                     map[a[6:8].strip()],
++                     map[a[9:11].strip()],
+                      )
+             torsion[kee] = a
+         kees = list(torsion.keys())
+@@ -834,7 +833,7 @@ def write_tinker_prm(self,fname,proofread=None,smooth=None):
+                     lst[0]/div,lst[1],lst[2])
+                 lst = lst[5:]
+             while len(st)>79:
+-                st = string.replace(st,'  ',' ')
++                st = st.replace('  ',' ')
+             f.write(st+"\n")
+         # null charge records
+         for c in range(len(self.present)):
+@@ -876,7 +875,7 @@ def get_list(self):
+         bnd_list = []
+         bond = {}
+         for a in list(self.bond.keys()):
+-            kee = (map[string.strip(a[0:2])],map[string.strip(a[3:5])])
++            kee = (map[a[0:2].strip()],map[a[3:5].strip()])
+             bond[kee] = a
+         kees = list(bond.keys())
+         kees.sort()
+@@ -888,9 +887,9 @@ def get_list(self):
+         ang_list = []
+         angle = {}
+         for a in self.angle.keys():
+-            kee = (map[string.strip(a[0:2])],
+-                     map[string.strip(a[3:5])],
+-                     map[string.strip(a[6:8])],
++            kee = (map[a[0:2].strip()],
++                     map[a[3:5].strip()],
++                     map[a[6:8].strip()],
+                      )
+             angle[kee] = a
+         kees = list(angle.keys())
+@@ -903,10 +902,10 @@ def get_list(self):
+         imp_list = []
+         improper = {}
+         for a in self.improper.keys():
+-            kee = (map[string.strip(a[0:2])],
+-                     map[string.strip(a[3:5])],
+-                     map[string.strip(a[6:8])],
+-                     map[string.strip(a[9:11])],
++            kee = (map[a[0:2].strip()],
++                     map[a[3:5].strip()],
++                     map[a[6:8].strip()],
++                     map[a[9:11].strip()],
+                      )
+             improper[kee] = a
+         kees = list(improper.keys())
+@@ -920,10 +919,10 @@ def get_list(self):
+         tor_list = []
+         torsion = {}
+         for a in self.torsion.keys():
+-            kee = (map[string.strip(a[0:2])],
+-                     map[string.strip(a[3:5])],
+-                     map[string.strip(a[6:8])],
+-                     map[string.strip(a[9:11])],
++            kee = (map[a[0:2].strip()],
++                     map[a[3:5].strip()],
++                     map[a[6:8].strip()],
++                     map[a[9:11].strip()],
+                      )
+             torsion[kee] = a
+         kees = list(torsion.keys())
+diff --git modules/chempy/tinker/state.py modules/chempy/tinker/state.py
+index 93e3f286..2df7187e 100644
+--- modules/chempy/tinker/state.py
++++ modules/chempy/tinker/state.py
+@@ -17,7 +17,6 @@
+ from chempy import tinker,io,feedback
+ from chempy.tinker import keyword
+ import copy
+-import string
+ 
+ class State:
+ 
+@@ -81,15 +80,15 @@ def analyze(self,kw=None,summary=1):
+                 if not flag:
+                     if lin[0:25]==' Total Potential Energy :':
+                         self.summary.append([
+-                            string.strip(lin[0:23]),
++                            lin[0:23].strip(),
+                             float(lin[25:49])])
+                         flag = 1
+                 else:
+-                    tok = string.split(string.strip(lin))
++                    tok = lin.split()
+                     if len(tok):
+                         if(tok[0]!='Energy'):
+                             self.summary.append([
+-                                string.strip(lin[0:23]),
++                                lin[0:23].strip(),
+                                 float(lin[25:49]),
+                                 int(lin[49:64])])
+             f.close()
+@@ -150,7 +149,7 @@ def minimize(self,gradient=0.1,max_iter=100,
+                                 float(lin[41:51]),
+                                 float(lin[51:60]),
+                                 int(lin[60:67]),
+-                                string.strip(lin[67:])])
++                                lin[67:].strip()])
+                     except ValueError:
+                         pass
+             f.close()


### PR DESCRIPTION
port pymol: This commit updates the pymol package to the 2.4.0 release, adds upstream patches for the deprecated string.split python call and introduces an x11 variant. The APBS Tools plugin requires pmg_tk (X11) in order to run. The pdb2pqr functionality of APBS Tools also requires python2.7. So the x11 variant defaults to python27 while the  -x11 variant defaults to python38. The x11 variant switches the default options.gui to pmg_tk to prevent pymol from favoring the pmg_qt gui.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.5 11E608c 

###### Verification <!-- (delete not applicable items) -->
Have you

- [ x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ x] checked your Portfile with `port lint`?
- [x ] tried existing tests with `sudo port test`?
- [x ] tried a full install with `sudo port -vst install`?
- [ x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
