### PR TITLE
bandwhich: update to 0.15.0

### DIFF
--- a/net/bandwhich/Portfile
+++ b/net/bandwhich/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        imsnif bandwhich 0.14.0
+github.setup        imsnif bandwhich 0.15.0
 categories          net
 platforms           darwin
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
@@ -24,9 +24,9 @@ long_description    bandwhich sniffs a given network interface and records IP \
 github.tarball_from archive
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  d57f757bc0c362efd270aabbeaf287efac9d459a \
-                    sha256  9b9eec854bc9fe5ee8e563d3f65b0acd2cb0ae1b014e51f77cbabf990aaa1398 \
-                    size    2993511
+                    rmd160  42a4b95fc81ca0cbc827c8ddd53e37fa6bc91e6c \
+                    sha256  c4922734bbb3ec17c8a0c9fbff4096ee3e28b4efa7dbca9abbd92e0ad6ff3483 \
+                    size    2997283
 
 destroot {
     xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/${name} ${destroot}${prefix}/bin/
@@ -59,9 +59,9 @@ cargo.crates \
     clap                            2.33.0  5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9 \
     clicolors-control                1.0.1  90082ee5dcdd64dc4e9e0d37fbf3ee325419e39c0092191e0393df65518f741e \
     cloudabi                         0.0.3  ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
-    console                          0.9.1  f5d540c2d34ac9dd0deb5f3b5f54c36c79efa78f6b3ad19106a554d07a7b5d9f \
     console                          0.7.7  8ca57c2c14b8a2bf3105bc9d15574aad80babf6a9c44b1058034cdf8bd169628 \
     console                          0.8.0  b147390a412132d75d10dd3b7b175a69cf5fd95032f7503c7091b8831ba10242 \
+    console                          0.9.1  f5d540c2d34ac9dd0deb5f3b5f54c36c79efa78f6b3ad19106a554d07a7b5d9f \
     crc32fast                        1.2.0  ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1 \
     derive-new                       0.5.8  71f31892cd5c62e414316f2963c5689242c43d8e7bbcaaeca97e5e28c95d91d9 \
     difference                       2.0.0  524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198 \
@@ -93,8 +93,8 @@ cargo.crates \
     hex                              0.4.0  023b39be39e3a2da62a94feb433e91e8bcd37676fbc8bea371daf52b7a769a3e \
     hostname                         0.1.5  21ceb46a83a85e824ef93669c8b390009623863b5c195d1ba747292c0c72f94e \
     idna                             0.2.0  02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9 \
-    insta                           0.12.0  0d499dc062e841590a67230d853bce62d0abeb91304927871670b7c55c461349 \
     insta                           0.11.0  23f83ab4ee86f38b292f0420c27fd412690a4baa9ea0ad4e3fa624bf34379b76 \
+    insta                           0.12.0  0d499dc062e841590a67230d853bce62d0abeb91304927871670b7c55c461349 \
     iovec                            0.1.4  b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e \
     ipconfig                         0.2.1  aa79fa216fbe60834a9c0737d7fcd30425b32d1c58854663e24d4c4b328ed83f \
     ipnetwork                       0.12.8  70783119ac90828aaba91eae39db32c6c1b8838deea3637e5238efa0130801ab \
@@ -107,8 +107,8 @@ cargo.crates \
     libflate                        0.1.27  d9135df43b1f5d0e333385cb6e7897ecd1a43d7d11b91ac003f4d2c2d2401fdd \
     linked-hash-map                  0.5.2  ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83 \
     lock_api                         0.3.1  f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc \
-    log                              0.4.8  14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7 \
     log                              0.3.9  e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b \
+    log                              0.4.8  14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7 \
     lru-cache                        0.1.2  31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c \
     maplit                           1.0.2  3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d \
     matches                          0.1.8  7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
@@ -130,7 +130,7 @@ cargo.crates \
     pest_generator                   2.1.1  7b9fcf299b5712d06ee128a556c94709aaa04512c4dffb8ead07c5c998447fc0 \
     pest_meta                        2.1.2  df43fd99896fd72c485fe47542c7b500e4ac1e8700bf995544d1317a60ded547 \
     pin-project-lite                 0.1.1  f0af6cbca0e6e3ce8692ee19fb8d734b641899e07b68eb73e9bbbd32f1703991 \
-    pin-utils                     0.1.0-alpha.4  5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587 \
+    pin-utils                0.1.0-alpha.4  5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587 \
     pnet                            0.26.0  c62df42dcd72f6f2a658bcf38509f1027df1440ac85f1af4badbe034418302dc \
     pnet_base                       0.26.0  b7cd5f7e15220afa66b0a9a62841ea10089f39dcaa1c29752c0b22dfc03111b5 \
     pnet_datalink                   0.26.0  7318ae1d6e0b7fa1e49933233c9473f2b72d3d18b97e70e2716c6415dde5f915 \
@@ -143,21 +143,21 @@ cargo.crates \
     proc-macro-error                 0.2.6  aeccfe4d5d8ea175d5f0e4a2ad0637e0f4121d63bd99d356fb1f39ab2e7c6097 \
     proc-macro-hack                 0.5.11  ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5 \
     proc-macro-nested                0.1.3  369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e \
-    proc-macro2                      1.0.6  9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27 \
     proc-macro2                     0.4.30  cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759 \
+    proc-macro2                      1.0.6  9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27 \
     procfs                           0.7.4  c81c52c5396135378949a5a71a04339c1e6129f67cd58a62fd4c00d2fa0f177e \
     quick-error                      1.2.2  9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0 \
-    quote                            1.0.2  053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe \
     quote                           0.6.13  6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1 \
+    quote                            1.0.2  053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe \
     rand                             0.6.5  6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca \
     rand                             0.7.2  3ae1b169243eaf61759b8475a998f0a385e42042370f3a7dbaf35246eacc8412 \
     rand_chacha                      0.1.1  556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef \
     rand_chacha                      0.2.1  03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853 \
     rand_core                        0.3.1  7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b \
-    rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
     rand_core                        0.4.2  9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc \
-    rand_hc                          0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
+    rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
     rand_hc                          0.1.0  7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4 \
+    rand_hc                          0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
     rand_isaac                       0.1.1  ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08 \
     rand_jitter                      0.1.4  1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b \
     rand_os                          0.1.3  7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071 \
@@ -186,16 +186,16 @@ cargo.crates \
     signal-hook                     0.1.11  cb543aecec4ba8b867f41284729ddfdb7e8fcd70ec3d7d37fca3007a4b53675f \
     signal-hook-registry             1.1.1  1797d48f38f91643908bb14e35e79928f9f4b3cefb2420a564dde0991b4358dc \
     slab                             0.4.2  c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8 \
-    smallvec                         1.0.0  4ecf3b85f68e8abaa7555aa5abdb1153079387e60b718283d732f03897fcfc86 \
     smallvec                        0.6.13  f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6 \
+    smallvec                         1.0.0  4ecf3b85f68e8abaa7555aa5abdb1153079387e60b718283d732f03897fcfc86 \
     socket2                         0.3.11  e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85 \
     strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
     structopt                       0.2.18  16c2cdbf9cc375f15d1b4141bc48aeef444806655cd0e904207edc8d68d86ed7 \
     structopt                        0.3.4  c167b61c7d4c126927f5346a4327ce20abf8a186b8041bbeb1ce49e5db49587b \
     structopt-derive                0.2.18  53010261a84b37689f9ed7d395165029f9cc7abb9f56bbfe86bee2597ed25107 \
     structopt-derive                 0.3.4  519621841414165d2ad0d4c92be8f41844203f2b67e245f9345a5a12d40c69d7 \
-    syn                              1.0.8  661641ea2aa15845cddeb97dad000d22070bb5c1fb456b96c1cba883ec691e92 \
     syn                            0.15.44  9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5 \
+    syn                              1.0.8  661641ea2aa15845cddeb97dad000d22070bb5c1fb456b96c1cba883ec691e92 \
     synstructure                    0.12.3  67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545 \
     syntex                          0.42.2  0a30b08a6b383a22e5f6edc127d169670d48f905bb00ca79a00ea3e442ebe317 \
     syntex_errors                   0.42.0  04c48f32867b6114449155b2a82114b86d4b09e1bddb21c47ff104ab9172b646 \
@@ -218,18 +218,18 @@ cargo.crates \
     unicode-normalization            0.1.9  09c8070a9942f5e7cfccd93f490fdebd230ee3c3c9f107cb25bad5351ef671cf \
     unicode-segmentation             1.6.0  e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0 \
     unicode-width                    0.1.6  7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20 \
-    unicode-xid                      0.2.0  826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c \
     unicode-xid                      0.0.3  36dff09cafb4ec7c8cf0023eb0b686cb6ce65499116a12201c9e11840ca01beb \
     unicode-xid                      0.1.0  fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc \
+    unicode-xid                      0.2.0  826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c \
     url                              2.1.0  75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61 \
-    uuid                             0.8.1  9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11 \
     uuid                             0.7.4  90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a \
+    uuid                             0.8.1  9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11 \
     vec_map                          0.8.1  05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a \
     walkdir                          2.2.9  9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e \
     wasi                             0.7.0  b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d \
     widestring                       0.4.0  effc0e4ff8085673ea7b9b2e3c73f6bd4d118810c9009ed8f1e16bd96c331db6 \
-    winapi                           0.3.8  8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6 \
     winapi                           0.2.8  167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
+    winapi                           0.3.8  8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6 \
     winapi-build                     0.1.1  2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
     winapi-util                      0.1.2  7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9 \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
