### PR TITLE
port mmtf-cpp: Add new mmtf-cpp port for pymol

### DIFF
--- a/science/mmtf-cpp/Portfile
+++ b/science/mmtf-cpp/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.0
+PortGroup           github 1.0
+
+github.setup        rcsb mmtf-cpp 1.0.0 v
+name                mmtf-cpp
+
+categories          science
+platforms           darwin
+maintainers         {gmail.com:howarth.at.macports @jwhowarth} openmaintainer
+license             MIT
+
+description         MMTF in C++
+long_description    The macromolecular transmission format (MMTF) is a binary encoding of biological structures.
+homepage            https://github.com/rcsb/mmtf-cpp
+
+checksums           rmd160  ddee6c5f449254bd58f1a919bfe7e8818e77a026 \
+                    sha256  276e19f1019b080969d40b85094ff604dc2f1762707be0fa4c59bf67b8cff2e5 \
+                    size    59370
+


### PR DESCRIPTION
port mmtf-cpp: The proposed mmtf-cpp port allows pymol to build its default fast MMTF loading and export support.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.5 11E608c 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ x] checked your Portfile with `port lint`?
- [ x] tried existing tests with `sudo port test`?
- [x ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
