### PR TITLE
port catch2: Add new catch2 port for testing pymol

### DIFF
--- a/devel/catch2/Portfile
+++ b/devel/catch2/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.0
+PortGroup           github 1.0
+
+github.setup        catchorg catch2 2.12.1 v
+name                catch2
+
+categories          devel
+platforms           darwin
+maintainers         {gmail.com:howarth.at.macports @jwhowarth} openmaintainer
+license             Boost-1
+
+cmake.out_of_source yes
+
+description         Catch2
+long_description    A modern, C++-native, header-only, test framework for unit-tests, TDD and BDD - using C++11, C++14, C++17 and later.
+homepage            https://github.com/catchorg/catch2
+
+checksums           rmd160  6c13b0a604105d78c8d2a9700df36474c4e5c327 \
+                    sha256  d801f42072131e95486f464ddd107fc34838bd18c1754fc51d7be7846d71a6a6 \
+                    size    641598
+


### PR DESCRIPTION
port catch2: A modern, C++-native, header-only, test framework for unit-tests, TDD and BDD - using C++11, C++14, C++17 and later. Add new catch2 port for testing pymol.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.5 11E608c 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ x] checked your Portfile with `port lint`?
- [ x] tried existing tests with `sudo port test`?
- [x ] tried a full install with `sudo port -vst install`?
- [ x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
