### PR TITLE
py-[xdis|uncompyle6|trepan3k|pyficache]: update to latest versions

### DIFF
--- a/python/py-columnize/Portfile
+++ b/python/py-columnize/Portfile
@@ -4,35 +4,43 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        rocky pycolumnize 0.3.9 release-
+github.setup        rocky pycolumnize 0.3.10
 name                py-columnize
+
 platforms           darwin
 supported_archs     noarch
-license             GPL-3+
-maintainers         nomaintainer
+license             MIT
+maintainers         {reneeotten @reneeotten} openmaintainer
 
 description         Format a simple list into aligned columns
 long_description    A Python module to format a simple (i.e. not \
                     nested) list into aligned columns. A string with \
                     embedded newline characters is returned.
 
-checksums           rmd160  7dff9bc5ffab9411c4420bcf28eaa696289171c7 \
-                    sha256  3a7917418dab04d45a3ceecad5e6a19224648eb354b11be2ffa1000a84ad34aa \
-                    size    14217
+checksums           rmd160  27b2b1f2c5e7bd574829f9f148876313334636f2 \
+                    sha256  a332cece8dea33d1474d465ac02fee358febf765bfca1acda4a17771bbf42f73 \
+                    size    19692
 
 python.versions     27 35 36 37 38
 
 if {${subport} ne ${name}} {
-    depends_build-append    port:py${python.version}-nose \
-                            port:py${python.version}-setuptools
+    depends_build-append \
+                    port:py${python.version}-nose \
+                    port:py${python.version}-setuptools
 
-    if {${python.version} eq 27} {
-        depends_lib-append  port:py${python.version}-backports-shutil_get_terminal_size
+    if {${python.version} == 27} {
+        depends_lib-append \
+                    port:py${python.version}-backports-shutil_get_terminal_size
     }
 
-    depends_test-append     port:py${python.version}-mock
-    test.run                yes
-    test.env                PYTHONPATH=${worksrcpath}/build/lib
+    depends_test-append \
+                    port:py${python.version}-mock \
+                    port:py${python.version}-pytest
 
-    livecheck.type          none
+    test.run        yes
+    test.cmd        py.test-${python.branch}
+    test.target
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
+
+    livecheck.type  none
 }

--- a/python/py-pyficache/Portfile
+++ b/python/py-pyficache/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        rocky python-filecache 1.0.0 release-
+github.setup        rocky python-filecache 2.0.1
 revision            0
 name                py-pyficache
 
@@ -19,9 +19,9 @@ long_description    The pyficache module allows one to get any line from \
                     to the file. Although the file may be any file, the \
                     common use is when the file is a Python script.
 
-checksums           rmd160  b1f950c3ee5a043ed26795f331fb10f7a2455eaa \
-                    sha256  8db3241a6648fd3ac478daa19786d722e8f6eaa3f5158af28c3ff86cfef34b1e \
-                    size    43907
+checksums           rmd160  616150a136db19165cfa8bc878ed6ddc9759a0f1 \
+                    sha256  2edd3dfa41c98d8b956ff84e5e43b89a389583f0a414d71358b237e853c97f34 \
+                    size    46134
 
 python.versions     27 35 36 37 38
 
@@ -30,8 +30,8 @@ if {${subport} ne ${name}} {
                     port:py${python.version}-setuptools
 
     depends_lib-append \
-                    port:py${python.version}-coverage \
-                    port:py${python.version}-pygments
+                    port:py${python.version}-pygments \
+                    port:py${python.version}-xdis
 
     depends_lib-append \
                     port:py${python.version}-nose
@@ -43,7 +43,7 @@ if {${subport} ne ${name}} {
         set docdir ${prefix}/share/doc/${subport}
         xinstall -d ${destroot}${docdir}
         xinstall -m 0644 -W ${worksrcpath} COPYING ChangeLog \
-           NEWS README.rst ${destroot}${docdir}
+           NEWS.md README.rst ${destroot}${docdir}
     }
 
     livecheck.type  none

--- a/python/py-trepan3k/Portfile
+++ b/python/py-trepan3k/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 PortGroup           github 1.0
 
-github.setup        rocky python3-trepan 0.8.11
+github.setup        rocky python3-trepan 1.0.1
 name                py-trepan3k
 revision            0
 
@@ -20,9 +20,9 @@ long_description    This is a gdb-like debugger for Python. It is a rewrite of p
                     from the ground up. A command-line interface (CLI) is provided \
                     as well as an remote access interface over TCP/IP.
 
-checksums           rmd160  572b56aa5b5be07eb8131db0be7d11af630e9db1 \
-                    sha256  9e450970d413441273d257784f87af0f465f0d9d60ae3c9e7530811b9fb91cbc \
-                    size    271940
+checksums           rmd160  c43fdf363dd0bec245a70841bb9faa454bba4c9b \
+                    sha256  c7605c1db20087cf1d9009e14d1a73d22898eaa950b6922e73c4477f1a55680b \
+                    size    274022
 
 python.versions     37 38
 

--- a/python/py-trepan3k/Portfile
+++ b/python/py-trepan3k/Portfile
@@ -41,7 +41,8 @@ if {${subport} ne ${name}} {
                     port:trepan3k_select
 
     depends_test-append \
-                    port:py${python.version}-nose
+                    port:py${python.version}-nose \
+                    port:py${python.version}-pyficache
 
     test.run        yes
     test.env        PYTHONPATH=${worksrcpath}/build/lib

--- a/python/py-uncompyle6/Portfile
+++ b/python/py-uncompyle6/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-uncompyle6
-version             3.6.7
+version             3.7.0
 revision            0
 
 categories-append   devel
@@ -18,9 +18,9 @@ long_description    ${description}
 
 homepage            https://github.com/rocky/python-uncompyle6/
 
-checksums           rmd160  c76455245c009dba62cd9052b3b8a660816abe0a \
-                    sha256  6f5ae93cfb0ccf22b6b10b608c982bc0fa9bed2481ead57242c02ac64a573db7 \
-                    size    2375402
+checksums           rmd160  c81742041d33ded739b57cb232e78dfd20450759 \
+                    sha256  cb0d5dd28ed6b82da17bcb29b84f5823dc8398d9dafb0e4ee8e6f958db220134 \
+                    size    2377098
 
 python.versions     27 35 36 37 38
 

--- a/python/py-xdis/Portfile
+++ b/python/py-xdis/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-xdis
-version             4.5.1
+version             4.6.0
 platforms           darwin
 supported_archs     noarch
 license             GPL-2
@@ -23,9 +23,9 @@ long_description \
 
 homepage            https://github.com/rocky/python-xdis
 
-checksums           rmd160  0d2900fe6543f7f760586d0c2dd35b2c64afe4d6 \
-                    sha256  2cbdbff1325a78b2f825bc065ccd1d3c827cd5188963ec87a2f89576eb5867bd \
-                    size    224393
+checksums           rmd160  165c22d498a5b4167b4d478fb89b1f7f122a8462 \
+                    sha256  d4cad319d3ea644ea7b9f8c8b45440263e7bf8e02a5a8c3f546a6ff27d1b3de1 \
+                    size    224124
 
 python.versions     27 35 36 37 38
 


### PR DESCRIPTION
#### Description

- py-trepan3k: update to 1.0.1
- py-uncompyle6: update to 3.7.0
- py-xdis: update to 4.6.0
- py-pyficache: update to 2.0.1
- py-columnize: update to 0.3.10, fix license, assume maintainership

@kurthindenburg: the update for `py-xdis` is a requirement for the others

###### Tested on
macOS 10.14.6 18G4032
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
