### PR TITLE
py-[coverage|qdarktstyle|xarray|requests-mock]: update to latest version

### DIFF
--- a/python/py-coverage/Portfile
+++ b/python/py-coverage/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-coverage
-version             5.0.4
+version             5.1
 revision            0
 
 categories-append   devel
@@ -21,9 +21,9 @@ long_description    Coverage measures code coverage, typically during test \
 
 homepage            https://github.com/nedbat/coveragepy
 
-checksums           rmd160  c41bdab0c235262e2db76bbb38439caf74423093 \
-                    sha256  1b60a95fc995649464e0cd48cecc8288bac5f4198f21d04b8229dc4097d76823 \
-                    size    680353
+checksums           rmd160  57177411db2e8163f51cdfa7c8b1d8941a606cb7 \
+                    sha256  f90bfc4ad18450c80b024036eaf91e4a246ae287701aaa88eaebebf150868052 \
+                    size    687427
 
 python.versions     27 35 36 37 38
 

--- a/python/py-qdarkstyle/Portfile
+++ b/python/py-qdarkstyle/Portfile
@@ -5,8 +5,8 @@ PortGroup           python 1.0
 
 name                py-qdarkstyle
 python.rootname     QDarkStyle
-version             2.8
-revision            1
+version             2.8.1
+revision            0
 
 categories-append   devel
 platforms           darwin
@@ -20,9 +20,9 @@ long_description    This package provides a dark style sheet for \
 
 homepage            https://github.com/ColinDuquesnoy/QDarkStyleSheet
 
-checksums           sha256  6a967c4b664446f8bed9df12d1032cf68cb54f186bfc9cbfdbbc756bf9a5d475 \
-                    rmd160  95b7cbcdbec958e2ee685aff8348e5601a2a1c35 \
-                    size    405579
+checksums           sha256  d53b0120bddd9e3efba9801731e22ef86ed798bb5fc6a802f5f7bb32dedf0321 \
+                    rmd160  de0d2cd8ecbcdf057eb1db65ad25a04d22c6780f \
+                    size    222439
 
 python.versions     27 35 36 37 38
 

--- a/python/py-requests-mock/Portfile
+++ b/python/py-requests-mock/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-requests-mock
-version             1.7.0
+version             1.8.0
 revision            0
 
 platforms           darwin
@@ -18,9 +18,9 @@ long_description    ${python.rootname} provides a building block to stub out the
 
 homepage            https://requests-mock.readthedocs.io/
 
-checksums           sha256  88d3402dd8b3c69a9e4f9d3a73ad11b15920c6efd36bc27bf1f701cf4a8e4646 \
-                    rmd160  9ed441c9af42bdaec79febfd27edb32d93e59f57 \
-                    size    51705
+checksums           sha256  e68f46844e4cee9d447150343c9ae875f99fa8037c6dcf5f15bf1fe9ab43d226 \
+                    rmd160  60952e442286478f73da16567cd0108b29c45cb1 \
+                    size    59794
 
 python.versions     27 36 37 38
 

--- a/python/py-xarray/Portfile
+++ b/python/py-xarray/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-xarray
-version             0.15.0
+version             0.15.1
 revision            0
 
 categories-append   science math
@@ -21,9 +21,9 @@ long_description    \
 
 homepage            https://github.com/pydata/xarray
 
-checksums           rmd160  183dda75d79215d8a8fda0cf32f33fa67f09d937 \
-                    sha256  c72d160c970725201f769e80fb91cbad68d6ebf21d68fcc371385a6c950459c3 \
-                    size    1911362
+checksums           rmd160  215db3e091b5d6712390116a4006cda7fbab226b \
+                    sha256  64e3138d87b641e22fe7a003c94abc685896b247b63e434505c1e6b38c91a8fb \
+                    size    1934184
 
 python.versions     27 35 36 37 38
 
@@ -51,13 +51,18 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-setuptools_scm
     }
 
-    depends_build-append    port:py${python.version}-setuptools
-
-    depends_lib-append      port:py${python.version}-numpy \
-                            port:py${python.version}-pandas
+    depends_lib-append \
+                    port:py${python.version}-numpy \
+                    port:py${python.version}-pandas \
+                    port:py${python.version}-setuptools
 
     depends_test-append \
                     port:py${python.version}-pytest
+
+    test.run        yes
+    test.cmd        py.test-${python.branch}
+    test.target
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     livecheck.type  none
 }


### PR DESCRIPTION
#### Description
This PR updates four outdated Python ports maintained by @petrrr 

- py-coverage: update to 5.1
- py-qdarkstyle: update to 2.8.1
- py-xarray: update to 0.15.1, enable tests
- py-requests-mock: update to 1.8.0 


###### Tested on
macOS 10.14.6 18G4032
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
