### PR TITLE
duckdb: new port

### DIFF
--- a/databases/duckdb/Portfile
+++ b/databases/duckdb/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim: fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+
+github.setup        cwida duckdb 0.1.7 v
+
+homepage            https://www.duckdb.org/
+
+description         DuckDB is an embeddable SQL OLAP Database Management System
+
+long_description    DuckDB is an embedded database designed to execute \
+                    analytical SQL queries fast while embedded in another \
+                    process. It is designed to be easy to install and easy to \
+                    use. DuckDB has no external dependencies. DuckDB has \
+                    bindings for C/C++, Python and R. DuckDB is developed by \
+                    the Database Architectures group of the CWI.
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+categories          databases
+platforms           darwin
+license             MIT
+
+checksums           rmd160  f1bc0b469ca1804d6ec4dabcb7c48defc97858c4 \
+                    sha256  a0ac9f3c640b36878a7f5952968429abae709b9107e8f0b367005e96f5a89f57 \
+                    size    17295443
+
+depends_build-append \
+                    port:pkgconfig \
+                    port:zstd
+
+post-destroot {
+    # For some reason, the CLI doesn't get installed by CMake.
+    # So we come in and do so manually.
+    copy ${cmake.build_dir}/duckdb_cli ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description
New port for [DuckDB](https://www.duckdb.org/)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
