### PR TITLE
emacs-devel: update to 20200524

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -94,18 +94,19 @@ if {$subport eq $name || $subport eq "emacs-app"} {
 
 if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
     epoch           1
-    version         20200417
+    version         20200524
 
     fetch.type      git
-    git.url         http://git.savannah.gnu.org/r/emacs.git
-    git.branch      c36c5a3dedbb2e0349be1b6c3b7567ea7b594f1c
+    git.url         https://github.com/emacs-mirror/emacs.git
+    git.branch      e7a3ed8a6dddb6e16c83d27a04dfa6ec8160e580
 
     pre-configure {
         system -W ${worksrcpath} "sh ./autogen.sh"
     }
 
     configure.args-append  --with-json
-    depends_lib-append     port:jansson
+    depends_lib-append     port:jansson \
+                           port:gmp
 
     livecheck.type none
 } else {


### PR DESCRIPTION
* add dependency on port:gmp

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14
Xcode 11.3.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
