### PR TITLE
pymol: minor adjustments after version update

### DIFF
--- a/science/pymol/Portfile
+++ b/science/pymol/Portfile
@@ -34,7 +34,9 @@ variant python36 conflicts python27 python35 python37 python38 description {Use 
 variant python37 conflicts python27 python35 python36 python38 description {Use Python 3.7} {}
 variant python38 conflicts python27 python35 python36 python37 description {Use Python 3.8} {}
 
-if {[variant_isset python35]} {
+if {[variant_isset python27]} {
+    python.default_version 27
+} elseif {[variant_isset python35]} {
     python.default_version 35
 } elseif {[variant_isset python36]} {
     python.default_version 36
@@ -44,8 +46,7 @@ if {[variant_isset python35]} {
     python.default_version 38
 } else {
     if {[variant_isset x11]} {
-        # The APBS Tools plugin requires pdb2pqr
-        # which can't be run under python3 yet
+        # The APBS Tools plugin requires pdb2pqr, which can't be run under python3 yet
         default_variants +python27
         python.default_version 27
     } else {

--- a/science/pymol/Portfile
+++ b/science/pymol/Portfile
@@ -7,15 +7,18 @@ PortGroup           github 1.0
 
 github.setup        schrodinger pymol-open-source 2.4.0 v
 name                pymol
+revision            0
+
 categories          science chemistry
+platforms           darwin
+universal_variant   no
 license             PSF
 maintainers         {gmail.com:howarth.at.macports @jwhowarth} openmaintainer
+
 description         Molecular graphics system
 long_description    PyMOL is a molecular graphics system with an embedded Python interpreter \
                     designed for real-time visualization and rapid generation of high-quality \
                     molecular graphics images and animations.
-
-platforms           darwin
 
 homepage            https://www.pymol.org/
 
@@ -40,7 +43,7 @@ if {[variant_isset python35]} {
 } elseif {[variant_isset python38]} {
     python.default_version 38
 } else {
-    if {[variant_isset x11]} { 
+    if {[variant_isset x11]} {
         # The APBS Tools plugin requires pdb2pqr
         # which can't be run under python3 yet
         default_variants +python27
@@ -52,43 +55,40 @@ if {[variant_isset python35]} {
 }
 python.link_binaries no
 
-depends_lib-append    port:freetype \
-                      port:glew \
-                      port:glm \
-                      port:libpng \
-                      port:libGLU \
-                      port:libxml2 \
-                      port:msgpack \
-                      port:mmtf-cpp \
-                      port:netcdf \
-                      port:py${python.version}-numpy
+depends_lib-append  port:freetype \
+                    port:glew \
+                    port:glm \
+                    port:libpng \
+                    port:libGLU \
+                    port:libxml2 \
+                    port:msgpack \
+                    port:mmtf-cpp \
+                    port:netcdf \
+                    port:py${python.version}-numpy
 
 if {![variant_isset x11]} {
-    depends_lib-append port:py${python.version}-pyqt5
+    depends_lib-append  port:py${python.version}-pyqt5
 }
 
 variant x11 {
-    depends_lib-append    port:freeglut \
-                          port:mesa \
-                          port:py${python.version}-pmw \
-                          port:py${python.version}-tkinter \
-                          port:py${python.version}-tkinter \
-                          port:tcl \
-                          port:tk
+    depends_lib-append  port:freeglut \
+                        port:mesa \
+                        port:py${python.version}-pmw \
+                        port:py${python.version}-tkinter \
+                        port:py${python.version}-tkinter \
+                        port:tcl \
+                        port:tk
 
     require_active_variants tcl "" corefoundation
     require_active_variants tk "" quartz
 }
 
-# py-scipy is not universal
-universal_variant    no
-
-patchfiles           pymol_shell.diff \
-                     pmg_tk_platform.patch \
-                     apbs-psize.patch  \
-                     python_string_split.patch \
-                     pdb2pqr.patch \
-                     setup.py.diff
+patchfiles          pymol_shell.diff \
+                    pmg_tk_platform.patch \
+                    apbs-psize.patch  \
+                    python_string_split.patch \
+                    pdb2pqr.patch \
+                    setup.py.diff
 
 post-patch {
     reinplace  "s|@PREFIX@|${prefix}|g" ${worksrcpath}/setup.py ${worksrcpath}/modules/pmg_tk/startup/apbs_tools.py

--- a/science/pymol/Portfile
+++ b/science/pymol/Portfile
@@ -65,23 +65,23 @@ depends_lib-append  port:freetype \
                     port:msgpack \
                     port:mmtf-cpp \
                     port:netcdf \
-                    port:py${python.version}-numpy
-
-if {![variant_isset x11]} {
-    depends_lib-append  port:py${python.version}-pyqt5
-}
+                    port:py${python.version}-numpy \
+                    port:py${python.version}-pyqt5
 
 variant x11 {
+    depends_lib-delete  port:py${python.version}-pyqt5
+
     depends_lib-append  port:freeglut \
                         port:mesa \
                         port:py${python.version}-pmw \
-                        port:py${python.version}-tkinter \
                         port:py${python.version}-tkinter \
                         port:tcl \
                         port:tk
 
     require_active_variants tcl "" corefoundation
     require_active_variants tk "" quartz
+
+    build.args-append   --glut --no-osx-frameworks
 }
 
 patchfiles          pymol_shell.diff \
@@ -98,11 +98,6 @@ post-patch {
     reinplace  "s|cxx + ' ' + cxxflags|'${configure.cxx} ' + cxxflags|g" ${worksrcpath}/monkeypatch_distutils.py
 }
 
-use_parallel_build yes
-
-if {[variant_isset x11]} {
-    build.cmd ${python.bin} setup.py --no-user-cfg --no-osx-frameworks --glut
-}
 
 post-destroot {
      file copy ${worksrcpath}/setup/pymol_macports ${destroot}${prefix}/bin/pymol


### PR DESCRIPTION
#### Description
A few small changes to the whitespace (so that it complies with the modeline), variant selection logic, move some code in the `x11` variant, and general clean-up.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G4032
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
