### PR TITLE
hyperfine: update to 1.10.0

### DIFF
--- a/sysutils/hyperfine/Portfile
+++ b/sysutils/hyperfine/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        sharkdp hyperfine 1.9.0 v
+github.setup        sharkdp hyperfine 1.10.0 v
 categories          sysutils
 platforms           darwin
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
@@ -20,9 +20,9 @@ long_description    Features statistical analysis across multiple runs, \
                     CSV/JSON/Markdown/AsciiDoc export and more.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  0220407098ab8854b9dbbc3306cfa11542fbc244 \
-                    sha256  8c969cdf4bdc338460e24b7b7050b1af84455c15a9601580e0b75015be6dc1bf \
-                    size    38421
+                    rmd160  80d6c0b5de63b1109fc0a186f641bbea55905934 \
+                    sha256  bf8dda87bb38bc1ce3752a8b068aa108bcdde91bb6053aac5dfb71aa111b56c4 \
+                    size    43537
 
 destroot {
     xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/${name} ${destroot}${prefix}/bin/
@@ -31,66 +31,75 @@ destroot {
 cargo.crates \
     ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
     approx                           0.3.2  f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3 \
-    atty                            0.2.13  1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90 \
+    atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
     autocfg                          0.1.7  1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2 \
+    autocfg                          1.0.0  f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d \
     bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
-    bstr                             0.2.8  8d6c2c5b58ab920a4f5aeaaca34b4488074e8cc7596af94e6f8c6ff247c60245 \
-    byteorder                        1.3.2  a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5 \
+    bstr                            0.2.13  31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931 \
+    byteorder                        1.3.4  08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de \
     cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
-    clap                            2.33.0  5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9 \
-    clicolors-control                1.0.1  90082ee5dcdd64dc4e9e0d37fbf3ee325419e39c0092191e0393df65518f741e \
+    clap                            2.33.1  bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129 \
     cloudabi                         0.0.3  ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
-    colored                          1.9.0  433e7ac7d511768127ed85b0c4947f47a254131e37864b2dc13f52aa32cd37e5 \
-    console                          0.9.1  f5d540c2d34ac9dd0deb5f3b5f54c36c79efa78f6b3ad19106a554d07a7b5d9f \
-    csv                              1.1.1  37519ccdfd73a75821cac9319d4fce15a81b9fcf75f951df5b9988aa3a0af87d \
-    csv-core                         0.1.6  9b5cadb6b25c77aeff80ba701712494213f4a8418fcda2ee11b6560c3ad0bf4c \
+    colored                          1.9.3  f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59 \
+    console                         0.11.3  8c0994e656bba7b922d8dd1245db90672ffb701e684e45be58f20719d69abc5a \
+    csv                              1.1.3  00affe7f6ab566df61b4be3ce8cf16bc2576bca0963ceb0955e45d514bf9a279 \
+    csv-core                        0.1.10  2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90 \
     encode_unicode                   0.3.6  a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f \
     fuchsia-cprng                    0.1.1  a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba \
-    indicatif                       0.13.0  8572bccfb0665e70b7faf44ee28841b8e0823450cd4ad562a76b5a3c4bf48487 \
-    itoa                             0.4.4  501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f \
-    kernel32-sys                     0.2.2  7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d \
+    getrandom                       0.1.14  7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb \
+    hermit-abi                      0.1.13  91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71 \
+    indicatif                       0.14.0  49a68371cf417889c9d7f98235b7102ea7c54fc59bcbd22f3dea785be9d27e40 \
+    itoa                             0.4.5  b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
-    libc                            0.2.65  1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8 \
-    memchr                           2.2.1  88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e \
-    num                              0.2.0  cf4825417e1e1406b3782a8ce92f4d53f26ec055e3622e1881ca8e9f5f9e08db \
-    num-bigint                       0.2.3  f9c3f34cdd24f334cb265d9bf8bfa8a241920d026916785747a92f0e55541a1a \
-    num-complex                      0.2.3  fcb0cf31fb3ff77e6d2a6ebd6800df7fdcd106f2ad89113c9130bcd07f93dffc \
-    num-integer                     0.1.41  b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09 \
-    num-iter                        0.1.39  76bd5272412d173d6bf9afdf98db8612bbabc9a7a830b7bfc9c188911716132e \
-    num-rational                     0.2.2  f2885278d5fe2adc2f75ced642d52d879bffaceb5a2e0b1d4309ffdfb239b454 \
-    num-traits                      0.2.10  d4c81ffc11c212fa327657cb19dd85eb7419e163b5b076bede2bdb5c974c07e4 \
+    libc                            0.2.70  3baa92041a6fec78c687fa0cc2b3fae8884f743d672cf551bed1d6dac6988d0f \
+    memchr                           2.3.3  3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400 \
+    num                              0.2.1  b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36 \
+    num-bigint                       0.2.6  090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304 \
+    num-complex                      0.2.4  b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95 \
+    num-integer                     0.1.42  3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba \
+    num-iter                        0.1.40  dfb0800a0291891dd9f4fe7bd9c19384f98f7fbe0cd0f39a2c6b88b9868bbc00 \
+    num-rational                     0.2.4  5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef \
+    num-traits                      0.2.11  c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096 \
     number_prefix                    0.3.0  17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a \
-    proc-macro2                      1.0.6  9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27 \
-    quote                            1.0.2  053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe \
+    ppv-lite86                       0.2.8  237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea \
+    proc-macro2                     1.0.17  1502d12e458c49a4c9cbff560d0fe0060c252bc29799ed94ca2ed4bb665a0101 \
+    quote                            1.0.6  54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea \
     rand                             0.6.5  6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca \
+    rand                             0.7.3  6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
     rand_chacha                      0.1.1  556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef \
-    rand_core                        0.4.2  9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc \
+    rand_chacha                      0.2.2  f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402 \
     rand_core                        0.3.1  7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b \
+    rand_core                        0.4.2  9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc \
+    rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
     rand_hc                          0.1.0  7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4 \
+    rand_hc                          0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
     rand_isaac                       0.1.1  ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08 \
     rand_jitter                      0.1.4  1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b \
     rand_os                          0.1.3  7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071 \
     rand_pcg                         0.1.2  abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44 \
     rand_xorshift                    0.1.1  cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c \
     rdrand                           0.4.0  678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2 \
-    regex                            1.3.1  dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd \
-    regex-automata                   0.1.8  92b73c2a1770c255c240eaa4ee600df1704a38dc3feaa6e949e7fcd4f8dc09f9 \
-    regex-syntax                    0.6.12  11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716 \
-    rust_decimal                     1.0.3  f7a28ded8f10361cefb69a8d8e1d195acf59344150534c165c401d6611cf013d \
-    ryu                              1.0.2  bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8 \
-    serde                          1.0.103  1217f97ab8e8904b57dd22eb61cde455fa7446a9c1cf43966066da047c1f3702 \
-    serde_derive                   1.0.103  a8c6faef9a2e64b0064f48570289b4bf8823b7581f1d6157c1b52152306651d0 \
-    serde_json                      1.0.42  1a3351dcbc1f067e2c92ab7c3c1f288ad1a4cffc470b5aaddb4c2e0a3ae80043 \
+    regex                            1.3.7  a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692 \
+    regex-automata                   0.1.9  ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4 \
+    regex-syntax                    0.6.17  7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae \
+    rust_decimal                     1.6.0  26b5f52edf35045e96b07aa29822bf4ce8495295fd5610270f85ab1f26df7ba5 \
+    ryu                              1.0.4  ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1 \
+    serde                          1.0.110  99e7b308464d16b56eba9964e4972a3eee817760ab60d88c3f86e1fecb08204c \
+    serde_derive                   1.0.110  818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984 \
+    serde_json                      1.0.53  993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2 \
     statistical                      1.0.0  49d57902bb128e5e38b5218d3681215ae3e322d99f65d5420e9849730d2ea372 \
     strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
-    syn                              1.0.8  661641ea2aa15845cddeb97dad000d22070bb5c1fb456b96c1cba883ec691e92 \
-    term_size                        0.3.1  9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327 \
-    termios                          0.3.1  72b620c5ea021d75a735c943269bb07d30c9b77d6ac6b236bc8b5c496ef05625 \
+    syn                             1.0.24  f87bc5b2815ebb664de0392fdf1b95b6d10e160f86d9f64ff65e5679841ca06a \
+    term_size                        0.3.2  1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9 \
+    terminal_size                   0.1.12  8038f95fc7a6f351163f4b964af631bd26c9e828f7db085f2a84aca56f70d13b \
+    termios                          0.3.2  6f0fcee7b24a25675de40d5bb4de6e41b0df07bc9856295e7e2b3a3600c400c2 \
     textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
-    unicode-width                    0.1.6  7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20 \
+    unicode-width                    0.1.7  caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479 \
     unicode-xid                      0.2.0  826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c \
+    vec_map                          0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
+    version_check                    0.9.2  b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed \
+    wasi      0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
     winapi                           0.3.8  8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6 \
-    winapi                           0.2.8  167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
-    winapi-build                     0.1.1  2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                      0.1.5  70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
