### PR TITLE
elixir: update to version 1.10.3

### DIFF
--- a/lang/elixir/Portfile
+++ b/lang/elixir/Portfile
@@ -3,7 +3,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        elixir-lang elixir 1.9.0 v
+github.setup        elixir-lang elixir 1.10.3 v
+github.tarball_from archive
 epoch               1
 categories          lang
 platforms           darwin
@@ -23,9 +24,9 @@ homepage            http://elixir-lang.org/
 
 depends_lib         port:erlang
 
-checksums           rmd160 7f1aa6439ca25bc7058e63c9868c185de0b3c405 \
-                    sha256 d4b36ccdf4f0cf452fec6ceb6b97ddd54793e7e424668bc9dbeeaf8d50ec9f90 \
-                    size   2247425
+checksums           rmd160 5f8e121a9288f0114b2c431a13f6e07f45b22ffe \
+                    sha256 f3035fc5fdade35c3592a5fa7c8ee1aadb736f565c46b74b68ed7828b3ee1897 \
+                    size   2329031
 
 # bin/mix
 conflicts           arb


### PR DESCRIPTION
1. update elixir to version 1.10.3
2. use "github.tarball_from archive" to replace tarball config, as stated in [PR #2587](https://github.com/macports/macports-ports/pull/2587)

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.13.4
Xcode 9.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
