### PR TITLE
archway: add perl variants, default +perl5_28

### DIFF
--- a/devel/archway/Portfile
+++ b/devel/archway/Portfile
@@ -1,6 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.require_variant   yes
+perl5.conflict_variants yes
+perl5.branches          5.26 5.28 5.30
+perl5.default_branch    5.28
+perl5.create_variants   ${perl5.branches}
 
 name                archway
 version             0.2.1
@@ -22,13 +29,11 @@ checksums           md5 130b7aaec6fc57a5bc0d132158455ce9 \
                     sha1 a8be0c8105b1647c1570dc903727e3e9100c6917 \
                     rmd160 ac30f3df2db502ab5e162957264628e8fd540fa0
 
-set perl_version    5.26
-
 use_configure       no
 build               {}
-destroot.destdir    PERL=${prefix}/bin/perl${perl_version} DESTDIR=${destroot} prefix=${prefix}
+destroot.destdir    PERL=${perl5.bin} DESTDIR=${destroot} prefix=${prefix}
 
-depends_lib         port:arch port:p${perl_version}-gtk2
+depends_lib         port:arch port:p${perl5.major}-gtk2
 
 livecheck.type      regex
 livecheck.regex     {Version <b>([0-9.]+)</b>}


### PR DESCRIPTION
See https://trac.macports.org/ticket/58361

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.5 11E608c 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
