### PR TITLE
1password-cli: update to 1.0.0

### DIFF
--- a/security/1password-cli/Portfile
+++ b/security/1password-cli/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                1password-cli
-version             0.5.6-003
+version             1.0.0
 
 categories          security
 license             Restrictive/Distributable
@@ -20,37 +20,40 @@ homepage            https://support.1password.com/command-line/
 
 set bin_name        op
 set archive         ${bin_name}_darwin_amd64_v
+set pkg_path        ${workpath}/pkg
 
-use_zip             yes
+extract.cmd         pkgutil
+extract.pre_args    --expand
+extract.post_args   ${pkg_path}
 extract.mkdir       yes
+extract.suffix      .pkg
 
 master_sites        https://cache.agilebits.com/dist/1P/op/pkg/v${version}/
 distfiles           ${archive}${version}${extract.suffix}
 
-checksums           rmd160  1864b47b7251f896bfb69efe93870eb1e9e6d09b \
-                    sha256  44071e7e36636726c2ce35b0538bc492fbb8725249e898f0070b4bf985712884 \
-                    size    3640198
+checksums           rmd160  ef762729aedca76254d3f7f405d71f9f40b17eca \
+                    sha256  0f789498ca40163ffacca78d541ffc6204f7669def7722cf3f156ba575c365e9 \
+                    size    4305936
 
 # Pre-built binary
 use_configure       no
 build               {}
 
-set share_dir       ${prefix}/share/${name}
+post-extract {
+    system -W ${pkg_path} "tar -xzf ${pkg_path}/Payload"
+}
 
 destroot {
-    xinstall -m 755 ${worksrcpath}/${bin_name} ${destroot}${prefix}/bin
-    xinstall -d ${destroot}${share_dir}
-    xinstall -m 644 ${worksrcpath}/${bin_name}.sig ${destroot}${share_dir}
+    xinstall -m 755 ${pkg_path}/${bin_name} ${destroot}${prefix}/bin
 }
 
 livecheck.type      regex
 livecheck.url       https://app-updates.agilebits.com/product_history/CLI
 livecheck.regex     ${archive}(\\d+(\\.\\d+)+)${extract.suffix}
 
-# 1Password CLI team requested that this note be displayed
 notes "
-The GPG sigfile has been installed to ${share_dir}/${bin_name}.sig
+1Password CLI has been installed as ${bin_name}
 
-For instructions on verifying the binary, see:
-https://support.1password.com/command-line-getting-started/#set-up-the-command-line-tool
+For instructions on getting started, see:
+https://support.1password.com/command-line-getting-started/#get-started-with-the-command-line-tool
 "


### PR DESCRIPTION
- change extraction to use pkgutil now that macOS is distributed as a .pkg file
- change notes since .sig file is no longer included for macOS

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
