### PR TITLE
Tesseract: Update to 4.1.1

### DIFF
--- a/textproc/tesseract/Portfile
+++ b/textproc/tesseract/Portfile
@@ -3,10 +3,9 @@
 PortSystem          1.0
 
 PortGroup           github 1.0
-PortGroup           cxx11 1.1
 
 if {"tesseract" eq ${subport} || "tesseract-training" eq ${subport}} {
-    github.setup    tesseract-ocr tesseract 4.0.0
+    github.setup    tesseract-ocr tesseract 4.1.1
 } else {
     github.setup    tesseract-ocr tessdata  4.0.0
     name            tesseract
@@ -27,9 +26,9 @@ long_description    The Tesseract OCR engine was one of the top  3  engines in \
                     uncompressed TIFF images,  or libtiff can be added to read \
                     compressed images.
 
-checksums           rmd160  237576f9a616aaa013b7c80562d1c0cd8fd4af87 \
-                    sha256  2135162c4b306d9f13d07747058fd0f3406fea06d601503ced3cf99aad9899b9 \
-                    size    1961991
+checksums           rmd160  2dd932d66b7271443ecce27359459f319a1af1a8 \
+                    sha256  5e477a1219c8a7e0dde16d2452edcd978525bea7b9cb9e1a9b3cc78e603c454b \
+                    size    1975412
 
 if {"tesseract" eq ${subport} || "tesseract-training" eq ${subport}} {
     revision                0

--- a/textproc/tesseract/files/patch-fix-mtree-violation-by-cmake-files.diff
+++ b/textproc/tesseract/files/patch-fix-mtree-violation-by-cmake-files.diff
@@ -1,16 +1,15 @@
 diff --git CMakeLists.txt.orig CMakeLists.txt
-index 25ded3c..d7a2160 100644
 --- CMakeLists.txt.orig
 +++ CMakeLists.txt
-@@ -319,11 +319,11 @@ configure_file(tesseract.pc.cmake ${CMAKE_CURRENT_BINARY_DIR}/tesseract.pc @ONLY
+@@ -539,11 +539,11 @@
  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/tesseract.pc DESTINATION lib/pkgconfig)
  install(TARGETS tesseract RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
  install(TARGETS libtesseract EXPORT TesseractTargets RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
 -install(EXPORT TesseractTargets DESTINATION cmake)
 +install(EXPORT TesseractTargets DESTINATION lib/cmake/tesseract)
  install(FILES
-     ${CMAKE_BINARY_DIR}/TesseractConfig.cmake
-     ${CMAKE_BINARY_DIR}/TesseractConfig-version.cmake
+     ${CMAKE_CURRENT_BINARY_DIR}/TesseractConfig.cmake
+     ${CMAKE_CURRENT_BINARY_DIR}/TesseractConfig-version.cmake
 -    DESTINATION cmake)
 +    DESTINATION lib/cmake/tesseract)
  


### PR DESCRIPTION
#### Description
<!-- Note: it is best to make pull requests from a branch rather than from master -->
Updating tesseract from 4.0.0 to 4.1.1 and fixing the patch file. An update was requested in this ticket about 3 weeks ago:
https://trac.macports.org/ticket/59120

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.9.5 13F1911
Xcode 6.2 6C131e 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
