### PR TITLE
vit: add perl variants, default +perl5_28

### DIFF
--- a/office/vit/Portfile
+++ b/office/vit/Portfile
@@ -3,10 +3,15 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
+perl5.require_variant   yes
+perl5.conflict_variants yes
+perl5.branches          5.26 5.28 5.30
+perl5.default_branch    5.28
+perl5.create_variants   ${perl5.branches}
+
 name                vit
 version             1.2
-revision            5
-perl5.branches      5.26
+revision            6
 maintainers         {g5pw @g5pw} openmaintainer
 categories          office
 description         Vit is a full-screen terminal interface for Taskwarrior
@@ -17,12 +22,13 @@ platforms           darwin
 license             GPL-3+
 supported_archs     noarch
 
-homepage            http://tasktools.org/projects/vit.html
+homepage            https://taskwarrior.org/news/news.20140406.html
 
-master_sites        http://taskwarrior.org/download/
+master_sites        https://taskwarrior.org/download/
 
 checksums           rmd160  492f50e2f8b3cefb766dd78750a00e69083550ef \
-                    sha256  a78dee573130c8d6bc92cf60fafac0abc78dd2109acfba587cb0ae202ea5bbd0
+                    sha256  a78dee573130c8d6bc92cf60fafac0abc78dd2109acfba587cb0ae202ea5bbd0 \
+                    size    48729
 
 depends_lib         port:p${perl5.major}-curses \
                     port:task
@@ -49,5 +55,6 @@ destroot {
     xinstall ${worksrcpath}/vitrc.5 ${destroot}${prefix}/share/man/man5
 }
 
-livecheck.url       http://tasktools.org/
+livecheck.type      regex
+livecheck.url       ${homepage}
 livecheck.regex     ${name}-(\[0-9\]+\.\[0-9\]+)${extract.suffix}


### PR DESCRIPTION
See https://trac.macports.org/ticket/58361

This is a minimal update to add multiple perl variants and switch the default variant
to +perl5_28 for the purposes of the ticket cited above.

@g5pw It appears that some time around the release of this version, development of this project moved away from taskwarrior.org to https://github.com/scottkosty/vit where two newer versions of vit can be found:  a version 1.3 of this perl implementation and a 2.0.0 version which is a complete rewrite in python.

I propose to merge this update now and leave it to you to do a more complete update to one of the more recent versions. Let me know what you think.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.5 11E608c 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
