### PR TITLE
libfilezilla: fix build issues

### DIFF
--- a/devel/libfilezilla/Portfile
+++ b/devel/libfilezilla/Portfile
@@ -30,6 +30,9 @@ checksums           rmd160  c8dba10cb670364777b29f797f9852f00708ffa6 \
 
 patchfiles          patch-lib-process.cpp.diff
 
+configure.env-append \
+                    DX_PERL=/usr/bin/perl
+
 depends_build       port:pkgconfig \
                     port:cppunit \
                     bin:perl:perl5

--- a/devel/libfilezilla/Portfile
+++ b/devel/libfilezilla/Portfile
@@ -28,6 +28,8 @@ checksums           rmd160  c8dba10cb670364777b29f797f9852f00708ffa6 \
                     sha256  c5f660c4b339ed6a9e89ec0bafd5d39ba53cb3a3b52051bc571bb74e03ef8f7a \
                     size    557320
 
+# fix case-incorrect header, for details see https://trac.filezilla-project.org/ticket/12192 and 
+# https://github.com/macports/macports-ports/commit/dc2f8a1f8a5c9fb898b725c1169335df9b0fea2c#commitcomment-39432066
 patchfiles          patch-lib-process.cpp.diff
 
 configure.env-append \

--- a/devel/libfilezilla/Portfile
+++ b/devel/libfilezilla/Portfile
@@ -28,6 +28,8 @@ checksums           rmd160  c8dba10cb670364777b29f797f9852f00708ffa6 \
                     sha256  c5f660c4b339ed6a9e89ec0bafd5d39ba53cb3a3b52051bc571bb74e03ef8f7a \
                     size    557320
 
+patchfiles          patch-lib-process.cpp.diff
+
 depends_build       port:pkgconfig \
                     port:cppunit \
                     bin:perl:perl5

--- a/devel/libfilezilla/files/patch-lib-process.cpp.diff
+++ b/devel/libfilezilla/files/patch-lib-process.cpp.diff
@@ -1,0 +1,11 @@
+--- lib/process.cpp.orig	2020-05-26 12:59:24.000000000 +0200
++++ lib/process.cpp	2020-05-26 12:59:55.000000000 +0200
+@@ -263,7 +263,7 @@
+ #include "libfilezilla/local_filesys.hpp"
+ 
+ #include <CoreFoundation/CFArray.h>
+-#include <CoreFoundation/CFUrl.h>
++#include <CoreFoundation/CFURL.h>
+ #include <CoreFoundation/CFBundle.h>
+ 
+ #include <ApplicationServices/ApplicationServices.h>


### PR DESCRIPTION
###### Tested on

macOS 10.15.4 19E287
Xcode 11.5 11E608c

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?