### PR TITLE
node_exporter: update to 1.0.0

### DIFF
--- a/net/node_exporter/Portfile
+++ b/net/node_exporter/Portfile
@@ -1,7 +1,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        prometheus node_exporter 0.18.1 v
+github.setup        prometheus node_exporter 1.0.0 v
 github.tarball_from archive
 
 description         Machine-metric exporter for the Prometheus monitoring \
@@ -17,7 +17,8 @@ platforms           darwin
 categories          net
 license             apache
 
-maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
 
 depends_build       port:promu \
                     port:go
@@ -32,9 +33,9 @@ installs_libs       no
 use_parallel_build  no
 
 checksums \
-  rmd160    e4043a6345c4650cd99d0cabdceea333bf3bc596 \
-  sha256    9ddf187c462f2681ab4516410ada0e6f0f03097db6986686795559ea71a07694 \
-  size      2110072
+  rmd160    4f4c1ce9fba0d047d6b37d36b5ec42525e25bdc6 \
+  sha256    2d82dac251e789b75879ebf1ebe94d1dc15c59ffa28ffe4e15b8d2ff63190607 \
+  size      2779482
 
 set svc_name        prometheus-node-exporter
 set prom_user       prometheus


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
