### PR TITLE
k9s: update to 0.19.7

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.19.6 v
+go.setup            github.com/derailed/k9s 0.19.7 v
 homepage            https://k9scli.io
 
 categories          sysutils devel
@@ -20,9 +20,9 @@ platforms           darwin
 supported_archs     x86_64
 license             Apache-2
 
-checksums           rmd160  086710f36f5355907dcc840f875aab2feea0f3c9 \
-                    sha256  3eed99f215f909c48a533b754e16845ab51f1b4c66315d887f4e1359e1699a03 \
-                    size    6062168
+checksums           rmd160  e200c48b1907b698de771770966900f26a8d7167 \
+                    sha256  dac047ebf61a0ba9b104ab18d140861e3f0f9bd6ba8f386bfad937fc919aed42 \
+                    size    6064759
 
 # Reproduce the "build" target from the upstream Makefile
 set go_ldflags      "-w -X ${go.package}/cmd.version=${version} \


### PR DESCRIPTION
#### Description

Update to k9s 0.19.7.

###### Tested on

macOS 10.15.4 19E287
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?