### PR TITLE
groovy: update to 3.0.4

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            groovy
-version         3.0.3
+version         3.0.4
 revision        0
 
 categories      lang java
@@ -36,14 +36,14 @@ long_description Groovy... \
                 * compiles straight to Java bytecode so you can use it anywhere \
                   you can use Java
 
-homepage        http://groovy-lang.org/
+homepage        https://groovy-lang.org/
 master_sites    https://dl.bintray.com/${name}/maven/
 distname        apache-${name}-binary-${version}
 use_zip         yes
 
-checksums       rmd160  22de3ad6c06b9ff8f124e9a6e7511f829f81dda5 \
-                sha256  291078486c3277efbce39bc7b361f9979995bc095f21f0c647b2dd601638b575 \
-                size    42999230
+checksums       rmd160  a3e2e45557f9dc1127b5378569d1cd068f436888 \
+                sha256  eba1dc30ed0ceeefe56eba6e79cf43c2ae164eea6e407fd7a79f6c434a667146 \
+                size    43238492
 
 worksrcdir      ${name}-${version}
 


### PR DESCRIPTION
#### Description

Update to Groovy 3.0.4.

###### Tested on

macOS 10.15.4 19E287
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?