### PR TITLE
kube-ps1: default to kubectl-1.17

### DIFF
--- a/sysutils/kube-ps1/Portfile
+++ b/sysutils/kube-ps1/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        jonmosco kube-ps1 0.7.0 v
-revision            2
+revision            3
 categories          sysutils
 platforms           darwin
 supported_archs     noarch
@@ -19,7 +19,7 @@ checksums           rmd160  0f67b76aa77ca7acbed74700d55e378dc9d3e09f \
                     sha256  089bed64824784c282837f89f8708ec86d661afe4a8cd2b7bdcb16c2d11ac0e8 \
                     size    491884
 
-depends_run         path:${prefix}/bin/kubectl:kubectl-1.16
+depends_run         path:${prefix}/bin/kubectl:kubectl-1.17
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

Install the latest `kubectl` when `kubectl` is not yet present.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.4 19E287
Xcode 11.5 11E608c
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?