### PR TITLE
gh: update to 0.9.0

### DIFF
--- a/devel/gh/Portfile
+++ b/devel/gh/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        cli cli 0.8.0 v
+github.setup        cli cli 0.9.0 v
 name                gh
 categories          devel
 platforms           darwin
@@ -21,9 +21,9 @@ homepage            https://cli.github.com/
 github.tarball_from releases
 distname            gh_${version}_macOS_amd64
 
-checksums           rmd160  30f01f034c67959c89ad69267b6a7698dadb4848 \
-                    sha256  da388314df66f2c1763f5d6d94a1360ae3e71ce5e4077ce9f8919a385a457bc0 \
-                    size    6120457
+checksums           rmd160  41bd96c98e530f9eda9959a8853edff7ce4e4054 \
+                    sha256  aa2216395b74437209bca15565ec31eb14b37e2205989f08920f71575df435c5 \
+                    size    6154114
 
 use_configure       no
 installs_libs       no
@@ -35,5 +35,5 @@ destroot {
 
     set docdir ${prefix}/share/doc/${name}
     xinstall -d ${destroot}${docdir}
-    xinstall -m 0644 -W ${worksrcpath} LICENSE README.md CHANGELOG.md ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} LICENSE ${destroot}${docdir}
 }


### PR DESCRIPTION
- remove README and use notes to refer the user to the official docs
- remove CHANGELOG.md as it is no longer present as of the 0.9.0 branch

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
