### PR TITLE
mpv: Fix build on 10.14 with Xcode 11

### DIFF
--- a/multimedia/mpv/Portfile
+++ b/multimedia/mpv/Portfile
@@ -223,8 +223,8 @@ platform darwin {
         }
     }
 
-    # Fix for building on 10.15
-    if {[vercmp ${xcodeversion} 11] >= 0 || ${os.major} >= 19} {
+    # Fix for building on >= 10.14
+    if {[vercmp ${xcodeversion} 11] >= 0 || ${os.major} >= 18} {
         use_xcode yes
     }
 


### PR DESCRIPTION
#### Description
With trace mode enabled, configure fails, but does not fail when `use_xcode yes` is set, so enable that.

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G4032
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?