### PR TITLE
nanovg: update to version that is compatible with NanoGUI

### DIFF
--- a/graphics/nanovg/Portfile
+++ b/graphics/nanovg/Portfile
@@ -11,9 +11,10 @@ maintainers         @jasonliu-- openmaintainer
 
 if {$subport eq "nanovg"} {
 
-github.setup        memononen $subport 2bead03bea43b2418060aaa154f972829995e663
-version             20200320
+github.setup        wjakob $subport bf2320d1175122374a9b806d91e9e666c9336375
+version             20190524
 revision            0
+epoch               1
 
 license             zlib
 description         antialiased 2-D vector drawing library on top of \
@@ -24,17 +25,18 @@ long_description    NanoVG is a small antialiased vector graphics \
                     intended to be a practical toolset for building \
                     scalable user interfaces and visualizations.
 
-checksums           rmd160  b2b619156f4321b67df34e3ca8aab41e972c8328 \
-                    sha256  6467b3274d148ed550b2f148dfad0c342fa948665b15b5f3e662ae17a04443c4 \
-                    size    2032399
+checksums           rmd160  d86f86dee2d1d00e8b012c765f4ab2057c0e8871 \
+                    sha256  b170cf73e56b76827c3d3d745d3a75904be845ad0333334c892ab4b96fcf35bc \
+                    size    2023722
 
 }
 
 subport metalnanovg {
 
-github.setup        ollix MetalNanoVG 615df90de566f25e25522abaadf9ea063a433a36
-version             20200228
+github.setup        wjakob nanovg_metal 075b04f16c579728c693b46a2ce408f2325968cf
+version             20190710
 revision            0
+epoch               1
 
 license             MIT
 description         Metal port of NanoVG
@@ -42,9 +44,9 @@ long_description    MetalNanoVG is the native Metal port of NanoVG \
                     that tries to get the most out of Apple's Graphics \
                     API.
 
-checksums           rmd160  e61e19a5ccb0519974080affbb88b9095f195ed3 \
-                    sha256  efc132489a075d329cc8e2e9433a016690b17efb5bfbbec5ab0ba8f2b89d5e60 \
-                    size    81691
+checksums           rmd160  38c518b04026e3ef11a2efe6768509196be8e167 \
+                    sha256  99dbf03e16faeaa60506438a46dba8126219cc78c1b00f4a0ad570554c73b769 \
+                    size    159280
 
 depends_lib-append  port:nanovg
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Update port to use fork that is compatible with NanoGUI.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.11.6 15G22010
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->