### PR TITLE
google-cloud-sdk: update to 294.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             293.0.0
+version             294.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  d4ee9272e1c63bf335944756360618daa1032f69 \
-                    sha256  20715c1bd1feb0eb03285251b141952643e5dceccf5222268a7d239b6f55696e \
-                    size    68301086
+    checksums       rmd160  740f370af838c99aebdc16b65daa56f6efea7a14 \
+                    sha256  9cc6900664463783e39cece9ccb34dd897bc348a6374a2c828a8682cf8af22ff \
+                    size    68551882
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  40ec47631dee1439fb168ce87e8e78bdab1b2a8b \
-                    sha256  d6a13d7cc0791c104ac2a1a1da1f676bcd7c6fc11d0f2079f60d866f1ded94b6 \
-                    size    70269623
+    checksums       rmd160  23670803e1b68f44a4c510920abf70e8e3e8a549 \
+                    sha256  0bb172000bcf861f1be054c1ae30856b8f3a90b754cb642aff2c44f2678a0db5 \
+                    size    70513789
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 294.0.0.

###### Tested on

macOS 10.15.5 19F96
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?