### PR TITLE
gn-devel: bump to most recent commit (committed 20200521)

### DIFF
--- a/devel/gn-devel/Portfile
+++ b/devel/gn-devel/Portfile
@@ -2,9 +2,10 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
+PortGroup           compiler_blacklist_versions 1.0
 
 name                gn-devel
-version             20200109
+version             20200529
 categories          devel
 platforms           darwin
 license             BSD
@@ -14,9 +15,11 @@ long_description    GN is a meta-build system that generates build files for Nin
 homepage            https://gn.googlesource.com/gn
 fetch.type          git
 git.url             ${homepage}
-git.branch          49f5903702378ae9e6c17d588c705af5ad344bf3
+git.branch          b175fa5d6ae1640742aad593185780a08f6ba224
 
-python.default_version 38
+python.default_version      38
+compiler.cxx_standard       2017
+compiler.blacklist-append   {clang < 1001.0.46.4}
 
 depends_build       port:ninja
 


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F96
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
