### PR TITLE
ipmitool: Update to 1.8.18.20200616

### DIFF
--- a/sysutils/ipmitool/Portfile
+++ b/sysutils/ipmitool/Portfile
@@ -8,11 +8,13 @@ PortGroup       legacysupport 1.1
 # https://trac.macports.org/ticket/59132
 legacysupport.newest_darwin_requires_legacy 10
 
-github.setup    ipmitool ipmitool eed9d59
-
 # Using head of ipmitool until next release for openssl build fixes
-version         1.8.18.20190905
+github.setup    ipmitool ipmitool 84469a9c5486b12db727c129a89ec6b584588f66
+version         1.8.18.20200616
 revision        0
+checksums       rmd160  868587a9abff4e50793c93310aa0f626a9a83974 \
+                sha256  788a50b7f86140926eb24ab31a3805bc868b7650207995f9a911c677e0d70af4 \
+                size    625527
 
 categories      sysutils
 license         BSD
@@ -41,10 +43,7 @@ depends_build   port:autoconf \
 depends_lib     path:lib/libssl.dylib:openssl \
                 port:readline
 
-checksums \
-    rmd160  e2d76e0c1ca496d63e249e0e9204dbc992ed4e41 \
-    sha256  fb0438bac206b4fd9a53f5f66ef4ed8c17bce86c183c338f09d1e844db3f1347 \
-    size    618167
+github.tarball_from archive
 
 configure.args --enable-intf-lanplus --enable-ipmishell
 configure.cppflags-append   -Ds6_addr16=__u6_addr.__u6_addr16


### PR DESCRIPTION
#### Description

ipmitool needs to have its revision increased so that the new libary dependency added by c38f74ba9984edec64a6127dfac2a7bc4399d86b is properly recorded in the user's registry. Since that would force a rebuild, we may as well update to the latest version.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G12034
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
