### PR TITLE
Cmakebootstrap

### DIFF
--- a/devel/cmake-bootstrap/Portfile
+++ b/devel/cmake-bootstrap/Portfile
@@ -1,0 +1,97 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           muniversal 1.0
+
+name                cmake-bootstrap
+categories          devel
+license             BSD
+installs_libs       no
+maintainers         {kencu @kencu} openmaintainer
+homepage            http://www.cmake.org/
+platforms           darwin
+dist_subdir         cmake
+
+set branch          3.9
+version             ${branch}.4
+distname            cmake-${version}
+
+checksums           rmd160  bb9c30f2726413f0d7d7b92e0294b61438151d62 \
+                    sha256  b5d86f12ae0072db520fdbdad67405f799eb728b610ed66043c20a92b4906ca1 \
+                    size    7705052
+
+master_sites        https://cmake.org/files/v${branch}/
+description         Cross-platform make pegged at version ${version}. No dependencies.
+long_description    ${description} This was the last version of cmake to not require c++11.
+
+# save original prefix
+set orig_prefix    ${prefix}
+prefix             ${prefix}/libexec/${name}
+
+patchfiles-append \
+    patch-Modules-FindQt4.cmake.release.diff \
+    patch-Modules-FindFreetype.cmake.release.diff \
+    patch-Modules-noArchCheck.release.diff \
+    patch-CMakeFindFrameworks.cmake.release.diff \
+    patch-Source_CMakeVersionCompute.cmake.release.diff \
+    patch-Source-kwsys-kwsysPlatformTestsCXX.cxx.diff
+
+post-patch {
+    # installed cmake will search first in the main macports prefix for frameworks
+    reinplace "s|__ORIG_PREFIX__|${orig_prefix}|g" ${worksrcpath}/Modules/CMakeFindFrameworks.cmake
+}
+
+configure.cxx_stdlib
+
+platform darwin {
+    configure.env-append   CMAKE_OSX_DEPLOYMENT_TARGET=${macosx_deployment_target}
+
+	if {${configure.sdkroot} eq ""} {
+		configure.env-append SDKROOT=/
+	}
+
+	if {${os.arch} eq "i386" && ${os.major} <= 9} {
+		# The old system headers do some bit shifting on Intel about which newer compilers throw errors:
+		# SecKeychain.h:102:46: error: shift expression '(1853123693 << 8)' overflows [-fpermissive]
+		configure.cflags-append -fpermissive
+		configure.cxxflags-append -fpermissive
+	}
+}
+
+# Clear CPATH and LIBRARY_PATH as we want to be completely independent of other ports
+compiler.cpath
+compiler.library_path
+
+configure.args-append --docdir=share/doc/cmake \
+                      --parallel=${build.jobs} \
+                      --no-system-libs \
+                      --no-server
+
+configure.universal_args
+configure.post_args
+
+# CMake's configure script doesn't recognize `--host`.
+array set merger_host {i386 {} x86_64 {} ppc {} ppc64 {}}
+
+# Leopard's Rosetta has some difficulties configuring the ppc slice
+platform darwin 9 {
+    global universal_archs_supported
+    if {${build_arch} eq "i386" || ${build_arch} eq "x86_64"} {
+        supported_archs i386 x86_64
+    } elseif {${build_arch} eq "ppc" || ${build_arch} eq "ppc64"} {
+        supported_archs ppc ppc64
+    }
+    set universal_archs_supported ${supported_archs}
+}
+
+build.post_args VERBOSE=ON
+
+notes "
+To use this bootstrap version of cmake instead of the usual cmake port, add the\
+following lines to the Portfile:
+
+depends_build-replace  path:bin/cmake:cmake port:cmake-bootstrap
+configure.cmd          \$\{prefix\}/libexec/cmake-bootstrap/bin/cmake
+"
+
+livecheck.type  none

--- a/devel/cmake-bootstrap/files/patch-CMakeFindFrameworks.cmake.release.diff
+++ b/devel/cmake-bootstrap/files/patch-CMakeFindFrameworks.cmake.release.diff
@@ -1,0 +1,10 @@
+--- Modules/CMakeFindFrameworks.cmake.orig
++++ Modules/CMakeFindFrameworks.cmake
+@@ -18,6 +18,7 @@
+     if(APPLE)
+       foreach(dir
+           ~/Library/Frameworks/${fwk}.framework
++          __ORIG_PREFIX__/Library/Frameworks/${fwk}.framework
+           /usr/local/Frameworks/${fwk}.framework
+           /Library/Frameworks/${fwk}.framework
+           /System/Library/Frameworks/${fwk}.framework

--- a/devel/cmake-bootstrap/files/patch-Modules-FindFreetype.cmake.release.diff
+++ b/devel/cmake-bootstrap/files/patch-Modules-FindFreetype.cmake.release.diff
@@ -1,0 +1,13 @@
+--- Modules/FindFreetype.cmake.orig
++++ Modules/FindFreetype.cmake
+@@ -46,10 +46,6 @@
+   HINTS
+     ENV FREETYPE_DIR
+   PATHS
+-    /usr/X11R6
+-    /usr/local/X11R6
+-    /usr/local/X11
+-    /usr/freeware
+     ENV GTKMM_BASEPATH
+     [HKEY_CURRENT_USER\\SOFTWARE\\gtkmm\\2.4;Path]
+     [HKEY_LOCAL_MACHINE\\SOFTWARE\\gtkmm\\2.4;Path]

--- a/devel/cmake-bootstrap/files/patch-Modules-FindQt4.cmake.release.diff
+++ b/devel/cmake-bootstrap/files/patch-Modules-FindQt4.cmake.release.diff
@@ -1,0 +1,13 @@
+--- Modules/FindQt4.cmake.orig
++++ Modules/FindQt4.cmake
+@@ -733,9 +733,7 @@
+       find_path(QT_IMPORTS_DIR NAMES Qt
+         HINTS ${qt_cross_paths} ${qt_imports_dir}
+         DOC "The location of the Qt imports"
+-        NO_CMAKE_FIND_ROOT_PATH
+-        NO_CMAKE_PATH NO_CMAKE_ENVIRONMENT_PATH NO_SYSTEM_ENVIRONMENT_PATH
+-        NO_CMAKE_SYSTEM_PATH)
++        NO_DEFAULT_PATH)
+       mark_as_advanced(QT_IMPORTS_DIR)
+     endif()
+   endif ()

--- a/devel/cmake-bootstrap/files/patch-Modules-noArchCheck.release.diff
+++ b/devel/cmake-bootstrap/files/patch-Modules-noArchCheck.release.diff
@@ -1,0 +1,56 @@
+--- Modules/BasicConfigVersion-AnyNewerVersion.cmake.in.orig
++++ Modules/BasicConfigVersion-AnyNewerVersion.cmake.in
+@@ -17,15 +17,3 @@
+     set(PACKAGE_VERSION_EXACT TRUE)
+   endif()
+ endif()
+-
+-# if the installed or the using project don't have CMAKE_SIZEOF_VOID_P set, ignore it:
+-if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "" OR "@CMAKE_SIZEOF_VOID_P@" STREQUAL "")
+-   return()
+-endif()
+-
+-# check that the installed version has the same 32/64bit-ness as the one which is currently searching:
+-if(NOT CMAKE_SIZEOF_VOID_P STREQUAL "@CMAKE_SIZEOF_VOID_P@")
+-   math(EXPR installedBits "@CMAKE_SIZEOF_VOID_P@ * 8")
+-   set(PACKAGE_VERSION "${PACKAGE_VERSION} (${installedBits}bit)")
+-   set(PACKAGE_VERSION_UNSUITABLE TRUE)
+-endif()
+--- Modules/BasicConfigVersion-ExactVersion.cmake.in.orig
++++ Modules/BasicConfigVersion-ExactVersion.cmake.in
+@@ -32,16 +32,3 @@
+ if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)
+   set(PACKAGE_VERSION_EXACT TRUE)
+ endif()
+-
+-
+-# if the installed or the using project don't have CMAKE_SIZEOF_VOID_P set, ignore it:
+-if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "" OR "@CMAKE_SIZEOF_VOID_P@" STREQUAL "")
+-   return()
+-endif()
+-
+-# check that the installed version has the same 32/64bit-ness as the one which is currently searching:
+-if(NOT CMAKE_SIZEOF_VOID_P STREQUAL "@CMAKE_SIZEOF_VOID_P@")
+-  math(EXPR installedBits "@CMAKE_SIZEOF_VOID_P@ * 8")
+-  set(PACKAGE_VERSION "${PACKAGE_VERSION} (${installedBits}bit)")
+-  set(PACKAGE_VERSION_UNSUITABLE TRUE)
+-endif()
+--- Modules/BasicConfigVersion-SameMajorVersion.cmake.in.orig
++++ Modules/BasicConfigVersion-SameMajorVersion.cmake.in
+@@ -31,16 +31,3 @@
+       set(PACKAGE_VERSION_EXACT TRUE)
+   endif()
+ endif()
+-
+-
+-# if the installed or the using project don't have CMAKE_SIZEOF_VOID_P set, ignore it:
+-if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "" OR "@CMAKE_SIZEOF_VOID_P@" STREQUAL "")
+-   return()
+-endif()
+-
+-# check that the installed version has the same 32/64bit-ness as the one which is currently searching:
+-if(NOT CMAKE_SIZEOF_VOID_P STREQUAL "@CMAKE_SIZEOF_VOID_P@")
+-  math(EXPR installedBits "@CMAKE_SIZEOF_VOID_P@ * 8")
+-  set(PACKAGE_VERSION "${PACKAGE_VERSION} (${installedBits}bit)")
+-  set(PACKAGE_VERSION_UNSUITABLE TRUE)
+-endif()

--- a/devel/cmake-bootstrap/files/patch-Source-kwsys-kwsysPlatformTestsCXX.cxx.diff
+++ b/devel/cmake-bootstrap/files/patch-Source-kwsys-kwsysPlatformTestsCXX.cxx.diff
@@ -1,0 +1,15 @@
+--- Source/kwsys/kwsysPlatformTestsCXX.cxx.orig
++++ Source/kwsys/kwsysPlatformTestsCXX.cxx
+@@ -265,6 +265,12 @@
+ #ifdef TEST_KWSYS_CXX_HAS_UTIMENSAT
+ #include <fcntl.h>
+ #include <sys/stat.h>
++#if defined(__APPLE__)
++#include <AvailabilityMacros.h>
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 101300
++#error "utimensat not available on macOS < 10.13"
++#endif
++#endif
+ int main()
+ {
+   struct timespec times[2] = { { 0, UTIME_OMIT }, { 0, UTIME_NOW } };

--- a/devel/cmake-bootstrap/files/patch-Source_CMakeVersionCompute.cmake.release.diff
+++ b/devel/cmake-bootstrap/files/patch-Source_CMakeVersionCompute.cmake.release.diff
@@ -1,0 +1,12 @@
+--- Source/CMakeVersionCompute.cmake.orig
++++ Source/CMakeVersionCompute.cmake
+@@ -10,6 +10,9 @@
+   set(CMake_VERSION_IS_DIRTY 0) # may be set to 1 by CMakeVersionSource
+   set(CMake_VERSION_IS_RELEASE 0)
+   include(${CMake_SOURCE_DIR}/Source/CMakeVersionSource.cmake)
++  if(NOT CMake_VERSION_IS_DIRTY)
++    set(CMake_VERSION_IS_DIRTY 0)
++  endif()
+ endif()
+ 
+ # Compute the full version string.


### PR DESCRIPTION
This is a very compatible, reasonably capable cmake version that has no dependencies.

It builds on 10.4 PPC and up, with the default toolchains (Tiger needs apple-gcc42 installed, as usual for Tiger).

It is new enough to build up to at least llvm/clang-10.