### PR TITLE
tokei: update to 11.2.1

### DIFF
--- a/devel/tokei/Portfile
+++ b/devel/tokei/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        XAMPPRocky tokei 11.2.0 v
+github.setup        XAMPPRocky tokei 11.2.1 v
 categories          devel
 platforms           darwin
 maintainers         {gmail.com:herby.gillot @herbygillot} \
@@ -19,9 +19,9 @@ long_description    Tokei is a program that displays statistics about your \
                     by language.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  5488a76848ec83910a22a1d02fe333fe69dc0fbb \
-                    sha256  0e0ef475dca1bfd387731a8de25011724afd1f2a1bb49c1c6a68d5d04e6459fd \
-                    size    75494
+                    rmd160  a02c4b9ae4cea685b80388bd41f96b7b7033b378 \
+                    sha256  145f0d22546a500ed98378b19688e8c7b9dc6f0d1f90ca93a9f9c77c713e523c \
+                    size    75667
 
 destroot {
     xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/${name} ${destroot}${prefix}/bin/
@@ -44,7 +44,7 @@ cargo.crates \
     byte-tools                       0.3.1  e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7 \
     bytecount                        0.6.0  b0017894339f586ccb943b01b9555de56770c11cda818e7e3d8bd93f4ed7f46e \
     byteorder                        1.3.4  08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de \
-    cc                              1.0.53  404b1fe4f65288577753b17e3b36a04596ee784493ec249bf81c7f2d2acd751c \
+    cc                              1.0.54  7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311 \
     cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
     clap                            2.33.1  bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129 \
     cloudabi                         0.0.3  ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
@@ -56,7 +56,7 @@ cargo.crates \
     crossbeam-epoch                  0.8.2  058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace \
     crossbeam-queue                  0.2.1  c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db \
     crossbeam-utils                  0.7.2  c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8 \
-    dashmap                         3.11.1  0f87a04c37da1d3d27db1fb7f372802b72fb8c3ff3e9c0914530995127f4a6a1 \
+    dashmap                         3.11.2  d8b384aed866a28e92a6943f4f5d869f0a623776b550751cb87e711148803c18 \
     digest                           0.8.1  f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5 \
     dirs                             2.0.2  13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3 \
     dirs-sys                         0.3.4  afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b \
@@ -83,7 +83,7 @@ cargo.crates \
     itoa                             0.4.5  b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e \
     jobserver                       0.1.21  5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2 \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
-    libc                            0.2.70  3baa92041a6fec78c687fa0cc2b3fae8884f743d672cf551bed1d6dac6988d0f \
+    libc                            0.2.71  9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49 \
     libgit2-sys               0.12.6+1.0.0  bf81b43f9b45ab07897a780c9b7b26b1504497e469c7a78162fc29e3b8b1c1b3 \
     libz-sys                        1.0.25  2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe \
     linked-hash-map                  0.5.3  8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a \
@@ -106,8 +106,8 @@ cargo.crates \
     pest_meta                        2.1.3  54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d \
     pkg-config                      0.3.17  05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677 \
     ppv-lite86                       0.2.8  237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea \
-    proc-macro-hack                 0.5.15  0d659fe7c6d27f25e9d80a1a094c223f5246f6a6596453e09d7229bf42750b63 \
-    proc-macro2                     1.0.13  53f5ffe53a6b28e37c9c1ce74893477864d64f74778a93a4beb43c8fa167f639 \
+    proc-macro-hack                 0.5.16  7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4 \
+    proc-macro2                     1.0.17  1502d12e458c49a4c9cbff560d0fe0060c252bc29799ed94ca2ed4bb665a0101 \
     quick-error                      1.2.3  a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0 \
     quote                            1.0.6  54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea \
     rand                             0.7.3  6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
@@ -133,7 +133,7 @@ cargo.crates \
     sha-1                            0.8.2  f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df \
     smallvec                         1.4.0  c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4 \
     strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
-    syn                             1.0.22  1425de3c33b0941002740a420b1a906a350b88d08b82b2c8a01035a3f9447bac \
+    syn                             1.0.27  ef781e621ee763a2a40721a8861ec519cb76966aee03bb5d00adb6a31dc1c1de \
     tempfile                         3.1.0  7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9 \
     term_size                        0.3.2  1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9 \
     termcolor                        1.1.0  bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F96
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
