### PR TITLE
swi-prolog-devel: Updated to version 8.3.0

### DIFF
--- a/lang/swi-prolog-devel/Portfile
+++ b/lang/swi-prolog-devel/Portfile
@@ -1,14 +1,16 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem     1.0
 PortGroup      cmake 1.1
 
 name           swi-prolog-devel
 conflicts      swi-prolog swi-prolog-lite
 epoch          20051223
-version        8.1.28
+version        8.3.0
 
 categories     lang
 license        BSD
-maintainers    {uva.nl:J.Wielemaker @JanWielemaker}
+maintainers    {cwi.nl:J.Wielemaker @JanWielemaker} openmaintainer
 platforms      darwin
 description    SWI-Prolog compiler plus extra packages (development version)
 
@@ -23,20 +25,18 @@ long_description	\
 	interface and XPCE (Graphics UI toolkit, integrated editor  \
 	(Emacs-clone) and graphical debugger).
 
-homepage       http://www.swi-prolog.org/
-master_sites   http://www.swi-prolog.org/download/devel/src/
+homepage       https://www.swi-prolog.org/
+master_sites   https://www.swi-prolog.org/download/devel/src/
 
 dist_subdir    swi-prolog
 
 checksums	\
-	rmd160     fd9380c13b56def646b999e00549356aefa0ba0d \
-	sha256     103ae3920f85e1262c606d4cbc7c31b3dbd63f2b7b89b746f9b6b7fbea316e58 \
-	size       10905268
+	rmd160     6d79ef869091fe6f6664bf3f1fd064f2fe8a97b8 \
+	sha256     12d51d38633e733ca42d69bc02b3b844e40592212ac41511797ab6afa1a9b812 \
+	size       10955310
 
 
 depends_build-append \
-	port:gawk      \
-	port:ninja     \
 	port:pkgconfig
 
 depends_lib    \
@@ -54,9 +54,8 @@ depends_lib    \
 	port:xorg-libXinerama \
 	port:xorg-libXt       \
 	port:xpm              \
+	port:libyaml          \
 	port:zlib
-
-use_parallel_build    no
 
 distname  \
 	swipl-${version}
@@ -72,6 +71,9 @@ configure.pre_args  \
 	-DCMAKE_BUILD_TYPE=Release                  \
 	-DCMAKE_INCLUDE_PATH=${prefix}/include      \
 	-DCMAKE_LIBRARY_PATH=/usr/lib:${prefix}/lib
+
+test.run yes
+test.cmd ctest --output-on-failure
 
 universal_variant    no
 


### PR DESCRIPTION
* Updated to version 8.3.0
* Included YAML package
* Enable parallel build
* Include test declaration
* Use https for URLs
* Added mode header for editors

#### Description

Updated version and Portfile according to remarks on the 8.2.0 (stable) PR.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
