### PR TITLE
meson: Don't use -Wl,-no_weak_imports on <= 10.6

### DIFF
--- a/devel/meson/Portfile
+++ b/devel/meson/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           github 1.0
 
 github.setup        mesonbuild meson 0.54.1
-revision            0
+revision            1
 
 github.tarball_from releases
 license             Apache-2
@@ -44,7 +44,11 @@ depends_run-append \
 if {${os.platform} eq "darwin" && ${os.major} <= 9} {
     depends_run-append \
                     port:cctools
+}
 
+if {${os.platform} eq "darwin" && ${os.major} <= 10} {
+    patchfiles-append \
+                    remove-Wl,-no_weak_imports.patch
 }
 
 # https://github.com/mesonbuild/meson/issues/6187

--- a/devel/meson/files/remove-Wl,-no_weak_imports.patch
+++ b/devel/meson/files/remove-Wl,-no_weak_imports.patch
@@ -1,0 +1,23 @@
+Don't use -Wl,-no_weak_imports when checking function existence.
+
+This patch should only be applied on Snow Leopard and earlier because
+the version of ld64 that MacPorts uses by default on Snow Leopard and
+earlier doesn't understand that option.
+
+Temporary workaround for https://github.com/mesonbuild/meson/issues/7204
+--- mesonbuild/compilers/mixins/clang.py.orig	2020-04-26 04:07:10.000000000 -0500
++++ mesonbuild/compilers/mixins/clang.py	2020-05-28 08:15:20.000000000 -0500
+@@ -81,13 +81,6 @@
+                      dependencies: T.Optional[T.List['Dependency']] = None) -> bool:
+         if extra_args is None:
+             extra_args = []
+-        # Starting with XCode 8, we need to pass this to force linker
+-        # visibility to obey OS X/iOS/tvOS minimum version targets with
+-        # -mmacosx-version-min, -miphoneos-version-min, -mtvos-version-min etc.
+-        # https://github.com/Homebrew/homebrew-core/issues/3727
+-        # TODO: this really should be communicated by the linker
+-        if isinstance(self.linker, AppleDynamicLinker) and mesonlib.version_compare(self.version, '>=8.0'):
+-            extra_args.append('-Wl,-no_weak_imports')
+         return super().has_function(funcname, prefix, env, extra_args=extra_args,
+                                     dependencies=dependencies)
+ 


### PR DESCRIPTION
#### Description

meson: Don't use `-Wl,-no_weak_imports` on Mac OS X 10.6 and earlier.

This is a temporary workaround for build failures affecting any port that uses meson's `has_function` check and clang 8 or later on Mac OS X 10.6 and earlier.

Closes: https://trac.macports.org/ticket/60017
Closes: https://trac.macports.org/ticket/60308

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.6.8 10K549
Xcode 3.2.6 DevToolsSupport-1806.0 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
