### PR TITLE
kustomize: update to 3.6.1

### DIFF
--- a/devel/kustomize/Portfile
+++ b/devel/kustomize/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/kubernetes-sigs/kustomize 3.6.0 kustomize/v
+go.setup            github.com/kubernetes-sigs/kustomize 3.6.1 kustomize/v
 revision            0
 
 categories          devel
@@ -23,9 +23,9 @@ long_description    kustomize lets you customize raw, template-free YAML files f
 
 homepage            https://kustomize.io
 
-checksums           rmd160  32c8a71fe1c27410a3c8cbd933dfd4098507c730 \
-                    sha256  ee35742d901c860eb063a713835cee9f6d047a5e6a0a49c66980107be9fd9169 \
-                    size    2475638
+checksums           rmd160  cc71ad44aff462fb037903dd6e81ca3928333bdb \
+                    sha256  01b8d26b167e11789ea46d01cb48c13f65a8c498fe92fb24675177d98045fdd0 \
+                    size    2479806
 
 build.dir           ${worksrcpath}/${name}
 


### PR DESCRIPTION
#### Description

Update to Kustomize 3.6.1.

###### Tested on

macOS 10.15.5 19F96
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?