### PR TITLE
py-gacode:Update to version 0.52

### DIFF
--- a/python/py-gacode/Portfile
+++ b/python/py-gacode/Portfile
@@ -5,13 +5,13 @@ PortGroup           python 1.0
 PortGroup           compilers 1.0
 
 name                py-gacode
-version             0.50
+version             0.52
 python.rootname     pygacode
 
 
 compilers.setup     default_fortran
 
-python.versions     37
+python.versions     37 38
 
 categories-append   science
 platforms           darwin
@@ -22,10 +22,9 @@ long_description    ${description}
 license             MIT
 homepage            https://gacode.io
 
-checksums           rmd160  aa48614c5a90755e6763c9e712b20c822aa93920 \
-                    sha256  90603c244172f1d4f1a424603c6500361a623d046f7da9d7c221616af62caced \
-                    size    29258
-
+checksums           rmd160  0beb81a47519c007787179b5271cf9567635fb8a \
+                    sha256  1e84c8c845ec033b60f3e1554918edec8d426d11005269da73322da20c669886 \
+                    size    82824
 patchfiles          patch-setup.py.diff
 
 if {${name} ne ${subport}} {


### PR DESCRIPTION
#### Description

Update py-gacode port to version 0.52

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G87
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

Mention @rfitzp who pointed out that this has not been updated.