### PR TITLE
micro: new port

### DIFF
--- a/editors/micro/Portfile
+++ b/editors/micro/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/zyedidia/micro 2.0.4 v
+
+homepage            https://micro-editor.github.io/
+
+description         A modern and intuitive terminal-based text editor
+
+long_description    micro is a terminal-based text editor that aims to be \
+                    easy to use and intuitive, while also taking advantage of \
+                    the capabilities of modern terminals. As its name \
+                    indicates, micro aims to be somewhat of a successor to \
+                    the nano editor by being easy to install and use. Micro \
+                    supports a full-blown plugin system. Plugins are written \
+                    in Lua and there is a plugin manager to automatically \
+                    download and install your plugins for you.
+
+categories          editors
+license             MIT
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+installs_libs       no
+
+build.cmd           make
+build.target        build
+
+
+# Makefile uses info only available in a git checkout.
+fetch.type          git
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
New port for the [micro terminal editor](https://micro-editor.github.io/)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F96
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
