### PR TITLE
emacs: fix build on 10.15.4 and later

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -79,13 +79,13 @@ platform darwin {
 
 if {$subport eq $name || $subport eq "emacs-app"} {
     version         26.3
-    revision        6
+    revision        7
 
     checksums       rmd160  263c0152f538d3371c60accb710f3825b01ae097 \
                     sha256  09c747e048137c99ed35747b012910b704e0974dde4db6696fde7054ce387591 \
                     size    65207899
 
-    patchfiles      patch-configure.diff
+    patchfiles      patch-configure.diff patch-fix-unexec.diff
 
     pre-configure {
         system -W ${worksrcpath} "sh ./autogen.sh"

--- a/editors/emacs/files/patch-fix-unexec.diff
+++ b/editors/emacs/files/patch-fix-unexec.diff
@@ -1,0 +1,85 @@
+From 888ffd960c06d56a409a7ff15b1d930d25c56089 Mon Sep 17 00:00:00 2001
+From: YAMAMOTO Mitsuharu <mituharu@math.s.chiba-u.ac.jp>
+Date: Sun, 16 Feb 2020 09:50:26 +0900
+Subject: Fix unexec failure on macOS 10.15.4
+
+* src/unexmacosx.c (unexec_regions_merge): Align region start addresses to
+page boundaries and then merge regions.
+---
+ src/unexmacosx.c | 47 ++++++++++++++++++++++++-----------------------
+ 1 file changed, 24 insertions(+), 23 deletions(-)
+
+(limited to 'src/unexmacosx.c')
+
+diff --git src/unexmacosx.c b/src/unexmacosx.c
+index 8d132417e8..59cbe3c18b 100644
+--- src/unexmacosx.c
++++ src/unexmacosx.c
+@@ -503,22 +503,34 @@ unexec_regions_sort_compare (const void *a, const void *b)
+ static void
+ unexec_regions_merge (void)
+ {
+-  int i, n;
+-  unexec_region_info r;
+-  vm_size_t padsize;
+-
+   qsort (unexec_regions, num_unexec_regions, sizeof (unexec_regions[0]),
+ 	 &unexec_regions_sort_compare);
+-  n = 0;
+-  r = unexec_regions[0];
+-  padsize = r.range.address & (pagesize - 1);
+-  if (padsize)
++
++  /* Align each region start address to a page boundary.  */
++  for (unexec_region_info *cur = unexec_regions;
++       cur < unexec_regions + num_unexec_regions; cur++)
+     {
+-      r.range.address -= padsize;
+-      r.range.size += padsize;
+-      r.filesize += padsize;
++      vm_size_t padsize = cur->range.address & (pagesize - 1);
++      if (padsize)
++	{
++	  cur->range.address -= padsize;
++	  cur->range.size += padsize;
++	  cur->filesize += padsize;
++
++	  unexec_region_info *prev = cur == unexec_regions ? NULL : cur - 1;
++	  if (prev
++	      && prev->range.address + prev->range.size > cur->range.address)
++	    {
++	      prev->range.size = cur->range.address - prev->range.address;
++	      if (prev->filesize > prev->range.size)
++		prev->filesize = prev->range.size;
++	    }
++	}
+     }
+-  for (i = 1; i < num_unexec_regions; i++)
++
++  int n = 0;
++  unexec_region_info r = unexec_regions[0];
++  for (int i = 1; i < num_unexec_regions; i++)
+     {
+       if (r.range.address + r.range.size == unexec_regions[i].range.address
+ 	  && r.range.size - r.filesize < 2 * pagesize)
+@@ -530,17 +542,6 @@ unexec_regions_merge (void)
+ 	{
+ 	  unexec_regions[n++] = r;
+ 	  r = unexec_regions[i];
+-	  padsize = r.range.address & (pagesize - 1);
+-	  if (padsize)
+-	    {
+-	      if ((unexec_regions[n-1].range.address
+-		   + unexec_regions[n-1].range.size) == r.range.address)
+-		unexec_regions[n-1].range.size -= padsize;
+-
+-	      r.range.address -= padsize;
+-	      r.range.size += padsize;
+-	      r.filesize += padsize;
+-	    }
+ 	}
+     }
+   unexec_regions[n++] = r;
+-- 
+cgit v1.2.1
+


### PR DESCRIPTION
This is a straight application of the following change from the Emacs
repository:

http://git.savannah.gnu.org/cgit/emacs.git/commit/?id=888ffd960c06
https://github.com/emacs-mirror/emacs/commit/888ffd960c06d56a409a7ff15b1d930d25c56089

Fixes: https://trac.macports.org/ticket/60447
Fixes: https://trac.macports.org/ticket/60562

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Prior to this change, a self-built Emacs on 10.15.4 crashes at launch with the message `KILLED`. This indicates that the resulting binary is corrupt — and considering how dreadful the Emacs build methodology is, that's hardly surprising. Someting probably went wrong in the `unexec()` call… and they have a fix for just that in their repository!

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.5 11E608c 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
