### PR TITLE
leiningen: update to 2.9.3

### DIFF
--- a/devel/leiningen/Portfile
+++ b/devel/leiningen/Portfile
@@ -5,7 +5,7 @@ PortGroup           java 1.0
 # *sigh* can't seem to get the git portgroup to have additional distfiles, so do everything manually
 
 name                leiningen
-version             2.9.1
+version             2.9.3
 categories          devel java
 maintainers         openmaintainer easieste
 platforms           darwin
@@ -14,6 +14,8 @@ license             EPL-1
 
 description         A build tool for Clojure designed to not set your hair on fire.
 long_description    {*}${description}
+
+homepage            https://leiningen.org
 
 # Not entirely sure if this is needed at this point
 depends_run         port:jline
@@ -28,13 +30,13 @@ distfiles           \
 
 checksums           \
     ${version}.tar.gz \
-                    rmd160  4a463058795b5317e434b48e7b72b7eccbd288f5 \
-                    sha256  a4c239b407576f94e2fef5bfa107f0d3f97d0b19c253b08860d9609df4ab8b29 \
-                    size    734694 \
+                    rmd160  a944bd0f10a167089f3b1bf974072d8e729e8eae \
+                    sha256  98cc1e58ebe0d71fede73ae6c7699f1b9b944650d57a220e576bc95a3185b846 \
+                    size    754027 \
     leiningen-${version}-standalone.zip \
-                    rmd160  a2ea357c3a988ad242ba23354f70633e9bb7336b \
-                    sha256  ea7c831a4f5c38b6fc3926c6ad32d1d4b9b91bf830a715ecff5a70a18bda55f8 \
-                    size    14621704
+                    rmd160  e76a97cf17e6e94e89b0b242042bb4fef7916112 \
+                    sha256  23e1df18bc97226d570f47335a8d543e1b759ea303544ea57d5309be3dedcbbb \
+                    size    14670316
 
 java.version    1.8+
 


### PR DESCRIPTION
#### Description

Update [leiningen](https://leiningen.org) to 2.9.3

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.5 19F96
Xcode 11.5 11E608c

###### Verification

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?