### PR TITLE
py-[colorama|pint|neovim]: update to latest version

### DIFF
--- a/python/py-colorama/Portfile
+++ b/python/py-colorama/Portfile
@@ -1,10 +1,12 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=Portfile:et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-colorama
-version             0.4.1
+version             0.4.3
+revision            0
+
 categories-append   devel
 license             BSD
 platforms           darwin
@@ -12,24 +14,19 @@ supported_archs     noarch
 
 maintainers         {g5pw @g5pw} openmaintainer
 
-description         Cross-platform colored terminal text.
+description         Cross-platform colored terminal text
 long_description    ${description} Makes ANSI escape character sequences, for \
                     producing colored terminal text and cursor positioning, work \
                     under MS Windows.
 
-homepage            https://code.google.com/p/colorama/
-master_sites        pypi:c/colorama/
+homepage            https://github.com/tartley/colorama
+
+checksums           rmd160  f89f18525f19877eb048d287407f3da7a8adc249 \
+                    sha256  e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1 \
+                    size    27328
+
 python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
-    distname            colorama-${version}
-
-    checksums           rmd160  394b56b9a61bbe3be247f61386b5c78c408f8a65 \
-                        sha256  05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d \
-                        size    24104
-    livecheck.type      none
-} else {
-    livecheck.type      regex
-    livecheck.url       https://pypi.python.org/pypi/colorama/json
-    livecheck.regex     {colorama-(\d+(?:\.\d+)*)\.[tz]}
+    livecheck.type  none
 }

--- a/python/py-neovim/Portfile
+++ b/python/py-neovim/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        neovim pynvim 0.4.0
+github.setup        neovim pynvim 0.4.1
 revision            0
 name                py-neovim
 maintainers         {g5pw @g5pw} openmaintainer
@@ -17,7 +17,11 @@ license             Apache-2
 
 supported_archs     noarch
 
-python.versions     27 35 36 37
+checksums           rmd160  9d3084c884f581426e3f001a6984767cb2f339d4 \
+                    sha256  a1076d50fa6ee23ad5f58af6f72def220792349ad34cde77e0d4343c55a8fe41 \
+                    size    52340
+
+python.versions     27 35 36 37 38
 
 if { ${name} ne ${subport} } {
     depends_build-append \
@@ -31,16 +35,12 @@ if { ${name} ne ${subport} } {
         depends_lib-append  port:py${python.version}-trollius
     }
 
-    depends_test-append \
-                        port:py${python.version}-pytest
-
-    checksums           rmd160  5d195a6610f26315412d818dfcd3af1eb26f4fe5 \
-                        sha256  a9a73418db9e6c082cb62429e23eae311419318881a0b1deb09f365c9f4f2397 \
-                        size    53455
+    depends_test-append port:py${python.version}-pytest
 
     test.run            yes
     test.cmd            py.test-${python.branch}
     test.target
+    test.env            PYTHONPATH=${worksrcpath}/build/lib
 
     livecheck.type      none
 }

--- a/python/py-pint/Portfile
+++ b/python/py-pint/Portfile
@@ -2,18 +2,18 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
-PortGroup           github 1.0
-
-github.setup        hgrecco pint 0.9
-revision            0
 
 name                py-pint
-categories-append   science
+python.rootname     Pint
+version             0.12
+revision            0
 
+categories-append   science
 platforms           darwin
 supported_archs     noarch
 license             BSD
 maintainers         {g5pw @g5pw} openmaintainer
+
 description         Pint: a Python units library
 long_description    Pint is Python module/package to define, operate and \
                     manipulate physical quantities: the product of a numerical \
@@ -23,28 +23,52 @@ long_description    Pint is Python module/package to define, operate and \
 
 homepage            https://pint.readthedocs.org/
 
-checksums           rmd160  e181cfa8aa84a47f930830e940f64d48831759b3 \
-                    sha256  4d7a3c78e68991ad1a254a2f792c0c2fdb27aeb0debb7fcecc529a9df3320ae4 \
-                    size    166980
+checksums           rmd160  a12e946d2ff7c539d87877e71a20e467b4a650b5 \
+                    sha256  dc899061f9dc478e0aac3b0d872ca33d120efd32c382984818adab3522b6c793 \
+                    size    254180
 
-python.versions     27 35 36 37
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
+    if {${python.version} in "27 35"} {
+        version     0.9
+        revision    0
+        checksums   rmd160  84046fb4f727d8ce49d324dd159431c7e76ae575 \
+                    sha256  32d8a9a9d63f4f81194c0014b3b742679dce81a26d45127d9810a68a561fe4e2 \
+                    size    178344
+
+        if {${python.version} eq 27} {
+            depends_lib-append \
+                        port:py${python.version}-funcsigs
+        }
+    } else {
+        depends_build-append \
+                    port:py${python.version}-setuptools_scm
+
+        depends_test-append \
+                    port:py${python.version}-pytest
+
+        test.cmd    py.test-${python.branch}
+        test.target
+    }
+
     depends_lib-append \
                     port:py${python.version}-setuptools
 
-    if {${python.version} eq 27} {
-        depends_lib-append \
-                    port:py${python.version}-funcsigs
-    }
-
     test.run        yes
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
         xinstall -d ${destroot}${docdir}
         xinstall -m 0644 -W ${worksrcpath} AUTHORS CHANGES LICENSE \
-           README ${destroot}${docdir}
+           ${destroot}${docdir}
+
+        if {${python.version} in "27 35"} {
+            xinstall -m 0644 -W ${worksrcpath} README ${destroot}${docdir}
+        } else {
+            xinstall -m 0644 -W ${worksrcpath} README.rst ${destroot}${docdir}
+        }
     }
 
     livecheck.type none


### PR DESCRIPTION
#### Description
This PR updates three Python ports by the same maintainer to their latest version.

###### Tested on
macOS 10.14.6 18G4032
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? Yes, if present.
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
