### PR TITLE
py-astroplan: update to astroplan 0.6

### DIFF
--- a/python/py-astroplan/Portfile
+++ b/python/py-astroplan/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        astropy astroplan 0.5 v
+github.setup        astropy astroplan 0.6 v
 name                py-${name}
 maintainers         {aronnax @lpsinger} openmaintainer
 categories-append   science
@@ -21,11 +21,11 @@ supported_archs     noarch
 license             BSD
 
 homepage            https://astroplan.readthedocs.io/
-checksums           rmd160  e85a2fc65d3ea468a48f82fedc2321d3ce23bd5f \
-                    sha256  07cb7e8ee74e0bf59e0ba80506f2b7536367f37afd4990605649cb522c84ee01 \
-                    size    142179
+checksums           rmd160  43f080a68a0810c6a92444ae8922f72b9b66c281 \
+                    sha256  c15a7174ea1f391d1884cbdeb7f293efb776341fdbf53d3265143b75f26d66f4 \
+                    size    144982
 
-python.versions     27 35 36 37
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
 


### PR DESCRIPTION
#### Description

Astroplan 0.6 is needed for compatibility with the current version of the py-astropy port (see https://github.com/astropy/astroplan/issues/439).
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
