### PR TITLE
port pdb2pqr: fix pdb2pqr shell script to run and add size field to checksums

### DIFF
--- a/science/pdb2pqr/Portfile
+++ b/science/pdb2pqr/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                pdb2pqr
 version             2.1.1
+revision            1
 categories          science
 maintainers         {gmail.com:howarth.at.macports @jwhowarth}
 description         automate Poisson-Boltzmann electrostatics calculations
@@ -19,7 +20,8 @@ distfiles           ${name}-src-${version}.tar.gz
 checksums           md5     266dd7614de4adb0981d50471d38083a \
                     sha1    ec3b2548fd32b3a3e207aed8c8a71767fe8d6068 \
                     rmd160  b08fc9118cc3b96f57af510829e58af14bbefe16 \
-                    sha256  c2b14b0c95ffd76c910af108541a34beaea5f5c2e44246a61640644b2990c3cb
+                    sha256  c2b14b0c95ffd76c910af108541a34beaea5f5c2e44246a61640644b2990c3cb \
+                    size    14711417
 
 python.default_version  27
 
@@ -56,7 +58,7 @@ pre-destroot {
 destroot {
       move ${worksrcpath} ${destroot}${prefix}/share/${name}
       system "echo '#!/bin/zsh -f' >| ${destroot}${prefix}/bin/pdb2pqr"
-      system "echo '${prefix}/share/${name}/pdb2pqr.py \"\$@\"' >> ${destroot}${prefix}/bin/pdb2pqr"
+      system "echo '${prefix}/bin/python${python.branch} ${prefix}/share/${name}/pdb2pqr.py \"\$@\"' >> ${destroot}${prefix}/bin/pdb2pqr"
       file attributes ${destroot}${prefix}/bin/pdb2pqr -permissions a+x
       file attributes ${destroot}${prefix}/share/${name}/propka30/propka.py -permissions a+x
       system "echo '#!/bin/zsh -f' >| ${destroot}${prefix}/bin/propka"


### PR DESCRIPTION
pdb2pqr: fix pdb2pqr shell script to run
 - add size field to checksums

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F96
Xcode 11.5 11E608c 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
