### PR TITLE
virt-manager: Add note regarding X11 server

### DIFF
--- a/gnome/virt-manager/Portfile
+++ b/gnome/virt-manager/Portfile
@@ -27,6 +27,11 @@ long_description \
     \
     The primary use on macOS is for remote administration of Linux boxes.
 
+notes   "\
+    This application requires an X11 server which is not\n\
+    automatically installed by MacPorts. See for example\n\
+    https://www.xquartz.org ."
+
 checksums           rmd160  2e9190ca7d04146650ef9dee832300a4c852a2cc \
                     sha256  34ea069a6565f1f1860a0741e5a5029e8b45c779e81f16d27fb4d767fd4403d4 \
                     size    2617988


### PR DESCRIPTION
This pull request adds a note about virt-manager requiring an X11 server which needs to be installed manually.
