### PR TITLE
depot-tools-devel: new port (WIP)

### DIFF
--- a/devel/depot-tools-devel/Portfile
+++ b/devel/depot-tools-devel/Portfile
@@ -1,0 +1,49 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                depot-tools-devel
+
+version             20200530
+categories          devel
+platforms           darwin
+license             Permissive
+
+description         Tools for working with Chromium development.
+long_description    {*}${description}
+
+homepage            https://chromium.googlesource.com/chromium/tools/depot_tools
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+fetch.type          git
+git.url             ${homepage}.git
+git.branch          99044852de36333f88644adfd074189c05eaec12
+
+depends_lib         port:ninja \
+                    port:python38
+
+installs_libs       no
+use_configure       no
+
+set dtpath          ${prefix}/libexec/depot-tools
+
+build               {}
+
+destroot {
+    xinstall -m 755 -d ${destroot}${dtpath}
+    copy {*}[glob ${worksrcpath}/*] ${destroot}${dtpath}/
+
+    # Replace the pre-bundled ninja-mac binary with the ninja from ports.
+    file delete ${destroot}${dtpath}/ninja-mac
+    file link ${destroot}${dtpath}/ninja-mac ${prefix}/bin/ninja
+}
+
+notes "
+    To use depot-tools, edit your shell's rc file (~/.bashrc, ~/.zshrc, ...),
+    and add the following:
+
+    export DEPOT_TOOLS_UPDATE=0
+    export PATH=\"${dtpath}:\$PATH\"
+"


### PR DESCRIPTION
WIP for [depot-tools](https://chromium.googlesource.com/chromium/tools/depot_tools).  This port is meant to install all the `depot-tools` scripts to a path which the user then adds to their `PATH`.

Running into an issue where MacPorts is marking the port as broken, since it is finding a binary that is using a different C++ standard library:
```
--->  No broken files found.
depot-tools-devel is using libstdc++ (this installation is configured to use libc++)
--->  Found 1 broken port, determining rebuild order
DEBUG: Broken: depot-tools-devel
DEBUG: Processing port depot-tools-devel @0:20200530_0
You can always run 'port rev-upgrade' again to fix errors.
The following ports will be rebuilt: depot-tools-devel @20200530
Continue? [Y/n]: n
```

Setting `configure.cxx_stdlib` to `libc++` does not fix this error.

It should be noted that this port does not actually do anything in terms of a `configure` or `build` phase.  Does anyone have any suggestions?

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F96
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
