### PR TITLE
swi-prolog-lite: discontinued port

### DIFF
--- a/lang/swi-prolog-lite/Portfile
+++ b/lang/swi-prolog-lite/Portfile
@@ -1,105 +1,31 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem	1.0
+PortSystem      1.0
+PortGroup       obsolete 1.0
 
-name		swi-prolog-lite
-conflicts	swi-prolog swi-prolog-devel
-version		5.8.3
-revision		2
+name            swi-prolog-lite
+replaced_by     swi-prolog
+version         5.8.3
+revision        3
 
-categories	lang
-license		LGPL-2.1
-maintainers	{uva.nl:J.Wielemaker @JanWielemaker} {logtalk.org:pmoura @pmoura}
-platforms	darwin
-description	SWI-Prolog compiler (without extra packages)
+categories      lang
+platforms       darwin
+license         LGPL-2.1
+maintainers     {vu.nl:J.Wielemaker @JanWielemaker} {logtalk.org:pmoura @pmoura}
 
-long_description	\
-	ISO/Edinburgh-style Prolog compiler including modules,		\
-	autoload, libraries, Garbage-collector, stack-expandor,		\
-	C/C++-interface, Multiple threads, GNU-readline interface,	\
-	coroutining, constraint programming, global variables,		\
-	very fast compiler. Including packages clib (Unix process	\
-	control, sockets, MIME), cpp (C++ interface), sgml (reading	\
-	XML/SGML), sgml/RDF (reading RDF into triples), ODBC		\
-	interface and XPCE (Graphics UI toolkit, integrated editor	\
-	(Emacs-clone) and graphical debugger).
+description     SWI-Prolog compiler (without extra packages)
+long_description \
+    ISO/Edinburgh-style Prolog compiler including modules, \
+    autoload, libraries, Garbage-collector, stack-expandor, \
+    C/C++-interface, Multiple threads, GNU-readline interface, \
+    coroutining, constraint programming, global variables, \
+    very fast compiler. Including packages clib (Unix process \
+    control, sockets, MIME), cpp (C++ interface), sgml (reading \
+    XML/SGML), sgml/RDF (reading RDF into triples), ODBC \
+    interface and XPCE (Graphics UI toolkit, integrated editor \
+    (Emacs-clone) and graphical debugger).
 
-homepage	http://www.swi-prolog.org/
-master_sites	http://www.swi-prolog.org/download/stable/src
+homepage        https://www.swi-prolog.org/
 
-dist_subdir	swi-prolog
-
-checksums       \
-	md5     faeb7ade8da9832f113e6748ba6cab03 \
-	sha1    f0bb08d00162165b23fe3372d0b1fd3967cfc311 \
-	rmd160  907ee5445b977167d5db508254675648f5d8633c
-
-depends_build   \
-	port:gawk	\
-	port:junit
-
-depends_lib		\
-	port:readline
-
-use_parallel_build	no
-
-distname	pl-${version}
-worksrcdir 	pl-${version}/src
-
-configure.env	\
-	LIBRARY_PATH=/usr/lib:${prefix}/lib 	\
-	CPATH=/usr/include:${prefix}/include
-
-configure.ldflags
-
-configure.args	\
-	--prefix=${prefix}				\
-	--mandir=${prefix}/share/man	\
-	--disable-gmp \
-	--enable-shared
-
-build.env	\
-	LIBRARY_PATH=/usr/lib:${prefix}/lib	\
-	CPATH=/usr/include:${prefix}/include	\
-	CC=${configure.cc}
-
-post-build {
-	file mkdir ${workpath}/macosx
-	file copy -force -- ${workpath}/pl-${version}/man/macosx/License.html ${workpath}/macosx/
-	file copy -force -- ${workpath}/pl-${version}/man/macosx/macosx.html ${workpath}/macosx/
-	file copy -force -- ${workpath}/pl-${version}/man/macosx/Welcome.html ${workpath}/macosx/
-}
-
-post-pkg {
-	set resources ${workpath}/${name}-${version}.pkg/Contents/Resources/
-	file copy -force -- ${workpath}/macosx/License.html ${resources}
-	file copy -force -- ${workpath}/macosx/macosx.html ${resources}
-	file copy -force -- ${workpath}/macosx/Welcome.html ${resources}
-	file rename ${resources}/macosx.html ${resources}/ReadMe.html
-	file delete -force -- ${resources}/Welcome.rtf
-}
-
-post-mpkg {
-	set resources ${workpath}/${name}-${version}.mpkg/Contents/Resources/
-	file copy -force -- ${workpath}/macosx/License.html ${resources}
-	file copy -force -- ${workpath}/macosx/macosx.html ${resources}
-	file copy -force -- ${workpath}/macosx/Welcome.html ${resources}
-	file rename ${resources}/macosx.html ${resources}/ReadMe.html
-	file delete -force -- ${resources}/Welcome.rtf
-}
-
-if {![variant_isset st]} {
-	default_variants +mt
-}
-
-variant st conflicts mt description {Single-threaded} {
-	configure.args-append --disable-mt
-}
-
-variant mt conflicts st description {Multi-threaded} {
-	configure.args-append --enable-mt
-}
-
-livecheck.type      regexm
-livecheck.url       ${homepage}download/stable
-livecheck.regex     "/download/stable/src/pl-(\\d+\\.\\d+\\.\\d+).tar.gz"
+livecheck.type  none
+# remomve after June 14, 2021

--- a/lang/swi-prolog/Portfile
+++ b/lang/swi-prolog/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 
 name                swi-prolog
-conflicts           swi-prolog-devel swi-prolog-lite
+conflicts           swi-prolog-devel
 epoch               20051223
 version             8.2.0
 revision            0


### PR DESCRIPTION
#### Description

Dropping port as it is not maintained for a very long time.

Followup for https://github.com/macports/macports-ports/pull/7251#issuecomment-636370658

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
