### PR TITLE
uni: update to 1.1.1

### DIFF
--- a/textproc/uni/Portfile
+++ b/textproc/uni/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/arp242/uni 1.1.0 v
+go.setup            github.com/arp242/uni 1.1.1 v
 
 categories          textproc
 license             MIT
@@ -11,9 +11,9 @@ installs_libs       no
 
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
 
-checksums           rmd160  8000e7a32ad639aa3ca33d0066d26418798631e0 \
-                    sha256  5fd01ff5dc98529150401de3bfbdd553213af6ee4b5d3ca0da32939a37d8f0ff \
-                    size    412258
+checksums           rmd160  61331f93c959c543e3406c39330e04fbe525d70e \
+                    sha256  0090f70b2bdbe7135c79737a851d4bedb1d227c94731edda3f24770f078beb6f \
+                    size    412661
 
 description         uni queries the Unicode database from the commandline.
 long_description    Query the Unicode database from the commandline, with \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F96
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
