### PR TITLE
openttd: use application bundle

### DIFF
--- a/games/openttd/Portfile
+++ b/games/openttd/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                openttd
 
-categories          games
+categories          games aqua
 platforms           macosx
 
 maintainers         {cal @neverpanic} openmaintainer
@@ -13,7 +13,7 @@ maintainers         {cal @neverpanic} openmaintainer
 if {${name} eq ${subport}} {
 
     version             1.10.1
-    revision            0
+    revision            1
 
     checksums           rmd160  d5549e42fc8c79af68f22c4bb5660724e4d6d588 \
                         sha256  0d22a3c50f7a321f4f211594f4987ac16c381e8e3e40f116848e63e91e7fbb9b \
@@ -53,8 +53,10 @@ if {${name} eq ${subport}} {
     # icu-lx has a preprocessor define of INITIAL_CAPACITY in layout/RunArrays.h
     # icu has a variable INITIAL_CAPACITY in unicode/uniset.h
     # ensure that unicode/uniset.h is included after layout/RunArrays.h
-    patchfiles-append   patch-name_conflict.diff
-    
+    patchfiles-append   patch-name_conflict.diff \
+                        patch-lto.diff \
+                        patch-sysroot.diff
+
     # claims only 2011 needed, but actually is using more recent features.
     compiler.cxx_standard   2017
 
@@ -62,10 +64,9 @@ if {${name} eq ${subport}} {
                         CFLAGS_BUILD=${configure.cflags} \
                         CXXFLAGS_BUILD=${configure.cxxflags} \
                         LDFLAGS_BUILD=${configure.ldflags}
-    configure.args      --prefix-dir=${prefix} \
-                        --binary-dir=bin \
-                        --icon-theme-dir=share/icons/hicolor \
+    configure.args      --prefix-dir=${applications_dir} \
                         --install-dir=${destroot} \
+                        --with-osx-sysroot=${configure.sdkroot} \
                         --with-cocoa \
                         --with-zlib \
                         --with-liblzma \
@@ -74,19 +75,26 @@ if {${name} eq ${subport}} {
                         --with-freetype \
                         --with-fontconfig \
                         --with-icu \
-                        --without-application-bundle \
+                        --enable-lto \
                         --enable-strip
 
     build.args-append   VERBOSE=1
     destroot.args-append VERBOSE=1
+    destroot.target     bundle
 
     livecheck.type      regex
     livecheck.url       ${homepage}
     livecheck.regex     {Download stable \((\d+(\.\d+)+)\)}
+
+    post-destroot {
+        xinstall -m 644 ${worksrcpath}/bundle/man/openttd.6.gz ${destroot}/${prefix}/share/man/man6/
+        copy ${worksrcpath}/bundle/OpenTTD.app ${destroot}${applications_dir}
+    }
 }
 
 subport openttd-opengfx {
     version             0.6.0
+    revision            1
     checksums           rmd160  6ef0cbd399b3a4e117a70e723c072ed694b7517f \
                         sha256  d419c0f5f22131de15f66ebefde464df3b34eb10e0645fe218c59cbc26c20774 \
                         size    3551230
@@ -114,7 +122,7 @@ subport openttd-opengfx {
     use_configure       no
     build               {}
     destroot {
-        set target ${destroot}${prefix}/share/games/openttd/baseset/opengfx
+        set target ${destroot}${applications_dir}/OpenTTD.app/Contents/Resources/baseset/opengfx
         xinstall -d -m 755 ${target}
         fs-traverse file ${worksrcpath} {
             if {[file isfile ${file}]} {
@@ -124,12 +132,12 @@ subport openttd-opengfx {
     }
 
     livecheck.url       http://www.openttd.org/en/download-opengfx
-    livecheck.regex     {Latest release in opengfx is (\d+(\.\d+)+),}
+    livecheck.regex     {Latest stable release in opengfx is (\d+(\.\d+)+),}
 }
 
 subport openttd-opensfx {
     version             0.2.3
-    revision            1
+    revision            2
     checksums           rmd160  426b641b5a29556598d8a3033b4c4dc5b98630ce \
                         sha256  6831b651b3dc8b494026f7277989a1d757961b67c17b75d3c2e097451f75af02 \
                         size    11359588
@@ -153,7 +161,7 @@ subport openttd-opensfx {
     use_configure       no
     build               {}
     destroot {
-        set target ${destroot}${prefix}/share/games/openttd/baseset/opensfx
+        set target ${destroot}${applications_dir}/OpenTTD.app/Contents/Resources/baseset/opensfx
         xinstall -d -m 755 ${target}
         fs-traverse file ${worksrcpath} {
             if {[file isfile ${file}]} {
@@ -163,12 +171,12 @@ subport openttd-opensfx {
     }
 
     livecheck.url       http://www.openttd.org/en/download-opensfx
-    livecheck.regex     {Latest release in opensfx is (\d+(\.\d+)+),}
+    livecheck.regex     {Latest stable release in opensfx is (\d+(\.\d+)+),}
 }
 
 subport openttd-openmsx {
     version             0.3.1
-    revision            1
+    revision            2
     checksums           rmd160  8eff246e89e44f63ca480e9acef94a1da5fa81d2 \
                         sha256  92e293ae89f13ad679f43185e83fb81fb8cad47fe63f4af3d3d9f955130460f5 \
                         size    136981
@@ -191,7 +199,7 @@ subport openttd-openmsx {
     use_configure       no
     build               {}
     destroot {
-        set target ${destroot}${prefix}/share/games/openttd/baseset/openmsx
+        set target ${destroot}${applications_dir}/OpenTTD.app/Contents/Resources/baseset/openmsx
         xinstall -d -m 755 ${target}
         fs-traverse file ${worksrcpath} {
             if {[file isfile ${file}]} {
@@ -201,5 +209,5 @@ subport openttd-openmsx {
     }
 
     livecheck.url       http://www.openttd.org/en/download-openmsx
-    livecheck.regex     {Latest release in openmsx is (\d+(\.\d+)+),}
+    livecheck.regex     {Latest stable release in openmsx is (\d+(\.\d+)+),}
 }

--- a/games/openttd/files/patch-lto.diff
+++ b/games/openttd/files/patch-lto.diff
@@ -1,0 +1,36 @@
+From d7e7c639157385a47280553c474dfee9f32fb9af Mon Sep 17 00:00:00 2001
+From: Dan Villiom Podlaski Christiansen <danchr@gmail.com>
+Date: Wed, 3 Jun 2020 18:26:27 +0200
+Subject: [PATCH] Add: support Clang LTO in configure
+
+---
+ config.lib | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git config.lib config.lib
+index 287c596233..e9c389726f 100644
+--- config.lib
++++ config.lib
+@@ -667,7 +667,8 @@ check_params() {
+ 
+ 	if [ "$enable_lto" != "0" ]; then
+ 		# GCC 4.5 outputs '%{flto}', GCC 4.6 outputs '%{flto*}'
+-		has_lto=`($cxx_build -dumpspecs 2>&1 | grep '\%{flto') || ($cxx_build -help ipo 2>&1 | grep '\-ipo')`
++		# Clang outputs -flto=thin
++		has_lto=`($cxx_build -dumpspecs 2>&1 | grep '\%{flto') || ($cxx_build -help ipo 2>&1 | grep '\-ipo') || ($cxx_build --help 2>&1 | grep 'lto.*thin')`
+ 		if [ -n "$has_lto" ]; then
+ 			log 1 "using link time optimization... yes"
+ 		else
+@@ -1336,6 +1337,12 @@ make_compiler_cflags() {
+ 		# rdynamic is used to get useful stack traces from crash reports.
+ 		ldflags="$ldflags -rdynamic"
+ 
++		if [ "$enable_lto" != "0" ]; then
++			flags="$flags -flto=thin"
++			features="$features lto"
++			features_host="$features_host lto"
++		fi
++
+ 	# Assume gcc, since it just uses argv[0] in its --version output
+ 	else
+ 		# Enable some things only for certain GCC versions

--- a/games/openttd/files/patch-sysroot.diff
+++ b/games/openttd/files/patch-sysroot.diff
@@ -1,0 +1,24 @@
+From a6ef620b751c736794e4ad95dac091a6d34c72ad Mon Sep 17 00:00:00 2001
+From: Dan Villiom Podlaski Christiansen <danchr@gmail.com>
+Date: Wed, 3 Jun 2020 18:50:13 +0200
+Subject: [PATCH] Fix: unbreak setting sysroot/SDK on recent versions of macOS
+
+The 10.15 SDK cannot target 10.4 due to missing libstdc++ headers.
+---
+ config.lib | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git config.lib config.lib
+index e9c389726f..64f6724f5c 100644
+--- config.lib
++++ config.lib
+@@ -2111,8 +2111,7 @@ check_osx_sdk() {
+ 			return 1
+ 		fi
+ 
+-		# Set minimum version to 10.4 as that's when kCGBitmapByteOrder32Host was introduced
+-		sysroot="-isysroot $osx_sdk_path -Wl,-syslibroot,$osx_sdk_path -mmacosx-version-min=10.4"
++		sysroot="-isysroot $osx_sdk_path -Wl,-syslibroot,$osx_sdk_path"
+ 	fi
+ 
+ cat > tmp.osx.mm << EOF


### PR DESCRIPTION
This adjusts the OpenTTD port to build an application bundle. While at
it I set the SDK, enabled LTO and fixed the livecheck.

#### Description

This adjusts the OpenTTD port to build an application bundle. While at
it I set the SDK, enabled LTO and fixed the livecheck.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
