### PR TITLE
github-1.0: Wrong value of livecheck.url in subport

### DIFF
--- a/_resources/port1.0/group/github-1.0.tcl
+++ b/_resources/port1.0/group/github-1.0.tcl
@@ -111,12 +111,12 @@ proc github.setup {gh_author gh_project gh_version {gh_tag_prefix ""} {gh_tag_su
         [join ${github.tag_suffix}] eq "" && \
         [regexp "^\[0-9a-f\]{7,}\$" ${github.version}] && \
         ![regexp "^\[0-9\]{8}\$" ${github.version}]} {
-        livecheck.type      regexm
+        livecheck.type          regexm
         default livecheck.url   {${github.homepage}/commits/${github.livecheck.branch}.atom}
-        livecheck.regex     <id>tag:github.com,2008:Grit::Commit/(\[0-9a-f\]{[string length ${github.version}]})\[0-9a-f\]*</id>
+        default livecheck.regex {<id>tag:github.com,2008:Grit::Commit/(\[0-9a-f\]{[string length ${github.version}]})\[0-9a-f\]*</id>}
     } else {
-        livecheck.type      regex
-        livecheck.url       ${github.homepage}/tags
+        livecheck.type          regex
+        default livecheck.url   {${github.homepage}/tags}
         default livecheck.regex {[list archive/[join ${github.tag_prefix}][join ${github.livecheck.regex}][join ${github.tag_suffix}]\\.tar\\.gz]}
     }
     livecheck.version       ${github.version}


### PR DESCRIPTION
#### Description

github portgroup livecheck values interfere with one another when `github.setup`
is called twice

It was missing a couple of defaults.

  - Closes: https://trac.macports.org/ticket/60553

###### Type(s)

- [x] bugfix

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503 

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
