### PR TITLE
patchelf: New port

### DIFF
--- a/devel/patchelf/Portfile
+++ b/devel/patchelf/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        NixOS patchelf 0.10
+
+categories          devel
+platforms           darwin
+license             GPL-3+
+maintainers         {kollar.me:laszlo @lkollar} openmaintainer
+description         Modify dynamic ELF executables
+long_description    PatchELF is a simple utility for modifying existing ELF executables and libraries
+
+checksums           sha256  717c7b21a8a480611f3b52f595f7529ace60adc2d2bfde89a0558cb6ce9d659e \
+                    rmd160  9aa4451b699f61ded89b2a8c582ec1100598787c \
+                    size    99623
+
+compiler.cxx_standard \
+                    2011
+
+use_autoreconf      yes
+autoreconf.cmd      ./bootstrap.sh
+
+depends_build       port:autoconf \
+                    port:automake
+
+configure.args      --disable-dependency-tracking \
+                    --disable-silent-rules


### PR DESCRIPTION
#### Description

New port for [`patchelf`](https://github.com/NixOS/patchelf).

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4
Xcode 11.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
