### PR TITLE
gitlab-runner: update to 13.0.1

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 13.0.0 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 13.0.1 v
 
 categories          devel
 platforms           darwin
@@ -23,9 +23,9 @@ homepage            https://docs.gitlab.com/runner/
 master_sites        https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v${version}/
 distname            gitlab-runner-v${version}
 
-checksums           rmd160  c1d2678c39f64a862371790a29ebd90ed119da45 \
-                    sha256  033bac08a009dbc11edcd42c4b244c82b1187963562eb7037bddfd0fff702d37 \
-                    size    7437734
+checksums           rmd160  e21c8816cb171ddd0141a03faac9e7b14c37276f \
+                    sha256  5629f9828e7480e5e81aa2138d2347868ea7cccde405d7454dda1e3c44c2e351 \
+                    size    7437742
 
 # Reproduce the "build_simple" target from the upstream Makefile
 set go_ldflags      "-X ${go.package}/common.NAME=${go.package} \


### PR DESCRIPTION
#### Description

Update to GitLab Runner 13.0.1.

###### Tested on

macOS 10.15.5 19F96
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?