### PR TITLE
redis: update to 6.0.4

### DIFF
--- a/databases/redis/Portfile
+++ b/databases/redis/Portfile
@@ -6,7 +6,7 @@ PortGroup           xcode_workaround 1.0
 PortGroup           makefile 1.0
 
 name                redis
-version             6.0.3
+version             6.0.4
 categories          databases
 platforms           darwin
 license             BSD
@@ -19,9 +19,9 @@ long_description    {*}${description}
 homepage            https://redis.io/
 master_sites        http://download.redis.io/releases/
 
-checksums           rmd160  ee6b2b44b28fdf9ed35ab28698007bd238d5c046 \
-                    sha256  bca46dce81fe92f7b2de4cf8ae41fbc4b94fbd5674def7f12c87e7f9165cbb3a \
-                    size    2210882
+checksums           rmd160  1f4a8839a6510f1e6d8fa1e2082ac7024372875d \
+                    sha256  3337005a1e0c3aa293c87c313467ea8ac11984921fab08807998ba765c9943de \
+                    size    2217173
 
 patchfiles          patch-redis.conf.diff
 


### PR DESCRIPTION
#### Description
Tested redis-cli / redis-server

###### Type(s)
- [x] enhancement

###### Tested on
macOS 10.14.6 18G5033
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
