### PR TITLE
ripgrep: update to 12.1.1

### DIFF
--- a/textproc/ripgrep/Portfile
+++ b/textproc/ripgrep/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        BurntSushi ripgrep 12.0.1
+github.setup        BurntSushi ripgrep 12.1.1
 categories          textproc
 platforms           darwin
 maintainers         {raimue @raimue} \
@@ -20,48 +20,48 @@ cargo.crates \
     aho-corasick                  0.7.10   8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada  \
     atty                          0.2.14   d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8  \
     autocfg                       1.0.0    f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d  \
-    base64                        0.11.0   b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7  \
+    base64                        0.12.1   53d1ccbaf7d9ec9537465a97bf19edc1a4e158ecb49fc16178202238c569cc42  \
     bitflags                      1.2.1    cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693  \
-    bstr                          0.2.12   2889e6d50f394968c8bf4240dc3f2a7eb4680844d27308f798229ac9d4725f41  \
+    bstr                          0.2.13   31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931  \
     bytecount                     0.6.0    b0017894339f586ccb943b01b9555de56770c11cda818e7e3d8bd93f4ed7f46e  \
     byteorder                     1.3.4    08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de  \
-    cc                            1.0.50   95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd  \
+    cc                            1.0.54   7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311  \
     cfg-if                        0.1.10   4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822  \
-    clap                          2.33.0   5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9  \
+    clap                          2.33.1   bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129  \
     crossbeam-channel             0.4.2    cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061  \
     crossbeam-utils               0.7.2    c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8  \
-    encoding_rs                   0.8.22   cd8d03faa7fe0c1431609dfad7bbe827af30f82e1e2ae6f7ee4fca6bd764bc28  \
+    encoding_rs                   0.8.23   e8ac63f94732332f44fe654443c46f6375d1939684c17b0afb6cb56b0456e171  \
     encoding_rs_io                0.1.7    1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83  \
-    fnv                           1.0.6    2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3  \
+    fnv                           1.0.7    3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1  \
     fs_extra                      1.1.0    5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674  \
     glob                          0.3.0    9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574  \
-    hermit-abi                    0.1.9    0ebe6e23502442c4c9cd80fcb8bdf867dc5f4a9e9f1d882499fa49c5ed83e559  \
+    hermit-abi                    0.1.13   91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71  \
     itoa                          0.4.5    b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e  \
     jemalloc-sys                  0.3.2    0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45  \
     jemallocator                  0.3.2    43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69  \
     lazy_static                   1.4.0    e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646  \
-    libc                          0.2.68   dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0  \
+    libc                          0.2.71   9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49  \
     log                           0.4.8    14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7  \
     maybe-uninit                  2.0.0    60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00  \
     memchr                        2.3.3    3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400  \
     memmap                        0.7.0    6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b  \
-    num_cpus                      1.12.0   46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6  \
+    num_cpus                      1.13.0   05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3  \
     packed_simd                   0.3.3    a85ea9fc0d4ac0deb6fe7911d38786b32fc11119afd9e9d38b84ff691ce64220  \
     pcre2                         0.2.3    85b30f2f69903b439dd9dc9e824119b82a55bf113b29af8d70948a03c1b11ab1  \
     pcre2-sys                     0.2.2    876c72d05059d23a84bd9fcdc3b1d31c50ea7fe00fe1522b4e68cd3608db8d5b  \
     pkg-config                    0.3.17   05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677  \
-    proc-macro2                   1.0.9    6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435  \
-    quote                         1.0.3    2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f  \
-    regex                         1.3.6    7f6946991529684867e47d86474e3a6d0c0ab9b82d5821e314b1ede31fa3a4b3  \
+    proc-macro2                   1.0.17   1502d12e458c49a4c9cbff560d0fe0060c252bc29799ed94ca2ed4bb665a0101  \
+    quote                         1.0.6    54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea  \
+    regex                         1.3.9    9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6  \
     regex-automata                0.1.9    ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4  \
-    regex-syntax                  0.6.17   7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae  \
-    ryu                           1.0.3    535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76  \
+    regex-syntax                  0.6.18   26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8  \
+    ryu                           1.0.4    ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1  \
     same-file                     1.0.6    93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502  \
-    serde                         1.0.105  e707fbbf255b8fc8c3b99abb91e7257a622caeb20a9818cbadbeeede4e0932ff  \
-    serde_derive                  1.0.105  ac5d00fc561ba2724df6758a17de23df5914f20e41cb00f94d5b7ae42fffaff8  \
-    serde_json                    1.0.50   78a7a12c167809363ec3bd7329fc0a3369056996de43c4b37ef3cd54a6ce4867  \
+    serde                         1.0.110  99e7b308464d16b56eba9964e4972a3eee817760ab60d88c3f86e1fecb08204c  \
+    serde_derive                  1.0.110  818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984  \
+    serde_json                    1.0.53   993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2  \
     strsim                        0.8.0    8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a  \
-    syn                           1.0.17   0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03  \
+    syn                           1.0.27   ef781e621ee763a2a40721a8861ec519cb76966aee03bb5d00adb6a31dc1c1de  \
     termcolor                     1.1.0    bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f  \
     textwrap                      0.11.0   d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060  \
     thread_local                  1.0.1    d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14  \
@@ -70,13 +70,13 @@ cargo.crates \
     walkdir                       2.3.1    777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d  \
     winapi                        0.3.8    8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6  \
     winapi-i686-pc-windows-gnu    0.4.0    ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6  \
-    winapi-util                   0.1.3    4ccfbf554c6ad11084fb7517daca16cfdcaccbdadba4fc336f032a8b12c2ad80  \
+    winapi-util                   0.1.5    70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178  \
     winapi-x86_64-pc-windows-gnu  0.4.0    712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f
 
 checksums-append    ${distname}${extract.suffix} \
-                    rmd160  fef612f8f637008d288990018689b3a05f1e3061 \
-                    sha256  8462e8f42885bd4c1452d6225536ee89bc5eccdac3ebc23bd3a65cd78a66fc0a \
-                    size    475166 \
+                    rmd160  a1acb9fd8f3c59533538e846976f1f59f95aa0c2 \
+                    sha256  d3a4b97f5dfa0da3351eef751e6541abd6f07793e7e54fff30ef06461bcfb05a \
+                    size    480716
 
 depends_build-append \
                     port:asciidoc \


### PR DESCRIPTION
#### Description
Tested with a grep over the portfile repository.

###### Type(s)
- [x] enhancement

###### Tested on
macOS 10.14.6 18G5033
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
