### PR TITLE
science/ompl: update to version 1.5.0

### DIFF
--- a/science/ompl/Portfile
+++ b/science/ompl/Portfile
@@ -3,10 +3,11 @@
 PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           active_variants 1.1
+PortGroup           github 1.0
 
-name                ompl
-version             1.4.2
+version             1.5.0
 revision            1
+
 categories          science
 maintainers         {mmoll @mamoll}
 description         The Open Motion Planning Library (OMPL)
@@ -15,13 +16,15 @@ long_description    The Open Motion Planning Library (OMPL) consists of a set \
 homepage            http://ompl.kavrakilab.org
 platforms           darwin
 license             BSD
-master_sites        https://bitbucket.org/ompl/ompl/downloads
-distname            ${name}-${version}-Source
-checksums           rmd160  86636ba53ff3c291487c9ad605bb9a87d1381f8c \
-                    sha256  03d5a661061928ced63bb945055579061665634ef217559b1f47fef842e1fa85 \
-                    size    22777652
+
+github.setup        ompl ompl ${version}
+github.tarball_from archive
+checksums           rmd160  322bc13424910a059b1817714b57975b6071b3bf \
+                    sha256  a7df8611b7823ef44c731f02897571adfc23551e85c6618d926e7720004267a5 \
+                    size    23081668
+
 depends_build-append port:pkgconfig
-depends_lib-append  port:boost port:ode port:flann port:triangle port:eigen3
+depends_lib-append   port:boost port:ode port:flann port:triangle port:eigen3
 
 compiler.cxx_standard   2011
 configure.args-append   -DOMPL_BUILD_DEMOS=OFF \
@@ -60,10 +63,12 @@ http://ompl.kavrakilab.org/license.html#ricelicense"
         -DCMAKE_DISABLE_FIND_PACKAGE_PQP=ON \
         -DOMPLAPP_RESOURCE_DIR=${prefix}/share/ompl/resources \
         -DASSIMP_LIBRARIES=assimp -DASSIMP_INCLUDE_DIRS=${prefix}/include
-    distname            omplapp-${version}-Source
-    checksums           rmd160  eb1969b0489d1acfd91d8bb5dccbbeeb6d2adf1e \
-                        sha256  70782c458af368de6419075bf3cbdce703e4819f3ba9c67517c6cf74f27c2d0a \
-                        size    51016629
+    github.setup        ompl omplapp ${version}
+    github.tarball_from releases
+    distname            ${github.project}-${github.version}-Source
+    checksums           rmd160  5c439dc0a59a459a67b5dd125d765ee268e20db8 \
+                        sha256  f310b48a7be024b032b6f316fa24a5f32d45698294e8af964fc942caef2c5eb5 \
+                        size    38266250
 
     notes "
     If you intend to use ompl_webapp, you need to first launch the redis server:


### PR DESCRIPTION
* update to version 1.5.0
* ompl is now hosted on GitHub