### PR TITLE
MenuMeters: update to 2.0.7

### DIFF
--- a/aqua/MenuMeters/Portfile
+++ b/aqua/MenuMeters/Portfile
@@ -6,13 +6,10 @@ PortGroup           github 1.0
 PortGroup           xcode 1.0
 PortGroup           xcodeversion 1.0
 
-github.setup        yujitach MenuMeters 1.9.8
+github.setup        yujitach MenuMeters 2.0.7
 categories          aqua sysutils
 maintainers         {stevenmyint.com:git @myint} openmaintainer
 license             GPL-2
-
-# bundled MenuCracker is only compiled for these archs
-supported_archs     i386 ppc x86_64
 
 description         Set of CPU, memory, disk, and network monitoring tools
 long_description    The MenuMeters monitors are true SystemUIServer plugins     \
@@ -20,24 +17,19 @@ long_description    The MenuMeters monitors are true SystemUIServer plugins     
                     using command-drag and remember their positions in the menubar  \
                     across logins and restarts.
 
-checksums           rmd160  a93d08d6e4a0bf180171550c97eaf27b970f3786 \
-                    sha256  3c6b3a22f095da6dccbe0f54211d1b6abd26491421a316b8128335000339be5e \
-                    size    234533
+checksums           rmd160  d41810a5d34656f96d2343ccb73c7a1f043fb68e \
+                    sha256  585023277222064fe2889b9dc34fb4e671592f6b9e7c933b50eb94fe4999dce9 \
+                    size    1218059
 
 patchfiles          patch-MenuMeters.xcodeproj-project.pbxproj.diff
 
 xcode.configuration Release
-xcode.scheme        PrefPane
+xcode.scheme        MenuMeters
 destroot.pre_args   -derivedDataPath ./DerivedData
 build.pre_args      -derivedDataPath ./DerivedData
 
-destroot.violate_mtree \
-                    yes
-
 destroot    {
-    xinstall -m 755 -d ${destroot}/Library/PreferencePanes
-    file copy ${worksrcpath}/build/UninstalledProducts/macosx/${name}.prefPane \
-        ${destroot}/Library/PreferencePanes
+    file copy ${worksrcpath}/build/Release/MenuMeters.app ${destroot}${applications_dir}
 }
 
 minimum_xcodeversions {14 8.0}
@@ -48,3 +40,9 @@ pre-fetch {
         return -code error "incompatible macOS version"
     }
 }
+
+notes "
+Support for the System Preferences panel has been removed from\
+MenuMeters. It is now a standalone application installed to\
+${applications_dir}. You may want to 'killall MenuMetersApp' after\
+installation and before opening the new version."

--- a/aqua/MenuMeters/files/patch-MenuMeters.xcodeproj-project.pbxproj.diff
+++ b/aqua/MenuMeters/files/patch-MenuMeters.xcodeproj-project.pbxproj.diff
@@ -1,10 +1,59 @@
---- MenuMeters.xcodeproj/project.pbxproj.orig
+diff --git MenuMeters-Info.plist MenuMeters-Info.plist
+index 08b976d..7f83df0 100644
+--- MenuMeters-Info.plist
++++ MenuMeters-Info.plist
+@@ -33,7 +33,9 @@
+ 	<key>NSPrincipalClass</key>
+ 	<string>NSApplication</string>
+ 	<key>SUEnableAutomaticChecks</key>
+-	<true/>
++	<false/>
++	<key>SUAllowsAutomaticUpdates</key>
++	<false/>
+ 	<key>SUPublicDSAKeyFile</key>
+ 	<string>dsa_pub.pem</string>
+ 	<key>SUScheduledCheckInterval</key>
+diff --git MenuMeters.xcodeproj/project.pbxproj MenuMeters.xcodeproj/project.pbxproj
+index 69436b7..c42d053 100644
+--- MenuMeters.xcodeproj/project.pbxproj
 +++ MenuMeters.xcodeproj/project.pbxproj
-@@ -1380,6 +1380,7 @@
- 				PRODUCT_NAME = MenuMeters;
- 				SDKROOT = macosx;
- 				WRAPPER_EXTENSION = prefPane;
-+				SKIP_INSTALL = YES;
- 			};
- 			name = Release;
- 		};
+@@ -722,7 +722,6 @@
+ 						CreatedOnToolsVersion = 7.0;
+ 					};
+ 					33883CEE23655C9900B8AC14 = {
+-						DevelopmentTeam = 95AQ7YKR5A;
+ 						ProvisioningStyle = Automatic;
+ 					};
+ 				};
+@@ -1150,13 +1149,13 @@
+ 				CLANG_WARN_UNREACHABLE_CODE = YES;
+ 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+ 				CODE_SIGN_ENTITLEMENTS = MenuMeters.entitlements;
+-				CODE_SIGN_IDENTITY = "Apple Development";
++				CODE_SIGN_IDENTITY = "-";
+ 				CODE_SIGN_STYLE = Automatic;
+ 				COMBINE_HIDPI_IMAGES = YES;
+ 				COPY_PHASE_STRIP = NO;
+ 				CURRENT_PROJECT_VERSION = MM_VERSION;
+ 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+-				DEVELOPMENT_TEAM = 95AQ7YKR5A;
++				DEVELOPMENT_TEAM = "";
+ 				DSTROOT = "/tmp/$(PROJECT_NAME)App.dst";
+ 				ENABLE_HARDENED_RUNTIME = YES;
+ 				ENABLE_NS_ASSERTIONS = NO;
+@@ -1216,13 +1215,13 @@
+ 				CLANG_WARN_UNREACHABLE_CODE = YES;
+ 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+ 				CODE_SIGN_ENTITLEMENTS = MenuMeters.entitlements;
+-				CODE_SIGN_IDENTITY = "Apple Development";
++				CODE_SIGN_IDENTITY = "-";
+ 				CODE_SIGN_STYLE = Automatic;
+ 				COMBINE_HIDPI_IMAGES = YES;
+ 				COPY_PHASE_STRIP = NO;
+ 				CURRENT_PROJECT_VERSION = MM_VERSION;
+ 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+-				DEVELOPMENT_TEAM = 95AQ7YKR5A;
++				DEVELOPMENT_TEAM = "";
+ 				DSTROOT = "/tmp/$(PROJECT_NAME)App.dst";
+ 				ENABLE_HARDENED_RUNTIME = YES;
+ 				ENABLE_STRICT_OBJC_MSGSEND = YES;


### PR DESCRIPTION
#### Description
Unfortunately, upstream has removed support for the preference pane in [this commit](https://github.com/yujitach/MenuMeters/commit/40e669b2394e0893db2559ed80b8517878590e18) which will go into the next release of MenuMeters. I decided to put in the effort here to switch the Portfile over to the new way but would appreciate any feedback. I did test the upgrade path and it seems like just removing the preference pane as part of deactivating the old version is enough to clean up the System Preferences app.

Note that the preference pane version of MenuMeters requires `killall MenuMetersApp` but going forward you'll have to `killall MenuMeters`. Because everyone's upgrading from a MenuMetersApp version it's not relevant yet, but the note will have to be changed the next time an upgrade goes out.

###### Type(s)
- [x] enhancement

###### Tested on
macOS 10.14.6 18G5033
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
