### PR TITLE
intltool: update version of Perl dependency to 5.30.

### DIFF
--- a/textproc/intltool/Portfile
+++ b/textproc/intltool/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                intltool
 epoch               1
 version             0.51.0
-revision            5
+revision            6
 maintainers         {devans @dbevans} openmaintainer
 categories          textproc gnome
 license             GPL-2+
@@ -32,7 +32,7 @@ checksums           rmd160  f10a7a86bdc504db22c2e1eb4e09705c6a41fbaa \
 
 # intltool only uses perl internally and publishes no public modules
 # so there is no need for multiple perl variants
-set pbranch         5.28
+set pbranch         5.30
 
 depends_build       port:gnome-common
 


### PR DESCRIPTION
#### Description

Update version of Perl dependency to 5.30.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G4032
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
