### PR TITLE
help2man: update version of Perl dependency to 5.30.

### DIFF
--- a/textproc/help2man/Portfile
+++ b/textproc/help2man/Portfile
@@ -5,7 +5,7 @@ PortGroup       clang_dependency 1.0
 
 name            help2man
 version         1.47.15
-revision        0
+revision        1
 categories      textproc
 platforms       darwin
 license         GPL-3+
@@ -26,7 +26,7 @@ checksums       rmd160  33ea5d89b13e69dffe04851a1b7750e3a0b98050 \
                 size    202776
 
 # set pbranch to desired perl version
-set pbranch     5.28
+set pbranch     5.30
 
 depends_lib     port:perl${pbranch} port:p${pbranch}-locale-gettext \
                 port:gettext port:libiconv


### PR DESCRIPTION
#### Description

Update version of Perl dependency to 5.30.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G4032
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
