### PR TITLE
keystore-explorer: new port

### DIFF
--- a/security/keystore-explorer/Portfile
+++ b/security/keystore-explorer/Portfile
@@ -1,0 +1,50 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               java 1.0
+PortGroup               github 1.0
+
+github.setup            lhaeger keystore-explorer 5.4.3 macports-
+
+categories              security
+platforms               darwin
+supported_archs         x86_64
+license                 GPL-3
+maintainers             {@lhaeger gmx.net:lothar.haeger} openmaintainer
+
+description             KeyStore Explorer is a free GUI replacement for the Java command-line utilities keytool and jarsigner
+long_description        ${description} with the following features: \
+                        \n* Create, load, save and convert between various KeyStore types: JKS, JCEKS, PKCS#12, BKS (V1 and V2) and UBER \
+                        \n* Change KeyStore and KeyStore entry passwords \
+                        \n* Delete or rename KeyStore entries \
+                        \n* Cut/copy/paste KeyStore entries \
+                        \n* Append certificates to key pair certificate chains \
+                        \n* Generate RSA, ECC and DSA key pairs with self-signed X.509 certificates \
+                        \n* Apply X.509 certificate extensions to generated key pairs and Certificate Signing Requests (CSRs) \
+                        \n* View X.509 Certificate, CRL and CRL entry X.509 V3 extensions \
+                        \n* Import and export keys and certificates in many formats: PKCS#12, PKCS#8, PKCS#7, DER/PEM X.509 certificate files, Microsoft PVK, SPC, PKI Path, OpenSSL \
+                        \n* Generate, view and sign CSRs in PKCS #10 and SPKAC formats \
+                        \n* Sign JAR files \
+                        \n* Configure a CA Certs KeyStore for use with KeyStore operations
+
+homepage                http://keystore-explorer.org/
+
+checksums               rmd160  70787aa34b795670c9314c7023af01a1e148c241 \
+                        sha256  3e8aef812c16c01149ecdd286b8cbf5798ac735463bb44e3d7d8a623032769be \
+                        size    8230235
+
+java.version            1.8+
+java.fallback           openjdk8
+
+use_configure           no
+
+depends_build-append    port:gradle
+
+build.env-append        GRADLE_USER_HOME=${worksrcpath}/kse
+build.cmd               ${prefix}/bin/gradle
+build.args              --no-daemon --console=plain --stacktrace -p ${worksrcpath}/kse
+build.target            clean appbundler
+
+destroot {
+    copy "${worksrcpath}/kse/build/appBundle/KeyStore Explorer.app" ${destroot}${applications_dir}
+}


### PR DESCRIPTION
###### Tested on

macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?