### PR TITLE
josm: update to 16538

### DIFF
--- a/gis/JOSM/Portfile
+++ b/gis/JOSM/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                JOSM
-version             16239
+version             16538
 categories          gis editors java
 platforms           darwin
 license             GPL-2+
@@ -19,9 +19,9 @@ homepage            https://josm.openstreetmap.de
 master_sites        ${homepage}/download/macosx/
 distname            josm-macosx-${version}
 
-checksums           rmd160  d80e13f48a71f8b484b08282a54946e7101badd4 \
-                    sha256  0c008bce6fa4f0e8dfc616282dcc3c0b824afd45914adf3584e1bac6770e9cda \
-                    size    14296718
+checksums           rmd160  c5e4c916bd4fd8c8bf547bcf80c45f829131b2cc \
+                    sha256  4289a926d19c6355eb07bddd41911525a954076b6f282779dfac5aec78d61af8 \
+                    size    14391785
 
 extract.mkdir       yes
 


### PR DESCRIPTION
#### Description
[Changelog (2020-06-02: Stable release 16538)](https://josm.openstreetmap.de/wiki/Changelog#stable-release-20.05)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
