### PR TITLE
libsdl: Fix blank window problem on macOS 10.14+

### DIFF
--- a/devel/libsdl/Portfile
+++ b/devel/libsdl/Portfile
@@ -36,6 +36,12 @@ patchfiles \
     no-CGDirectPaletteRef.patch
 
 platform darwin {
+    if {${os.major} >= 18 && ${version} eq {1.2.15}} {
+        incr revision
+        patchfiles-append \
+            blank-window.patch
+    }
+
     configure.ldflags-append -framework Carbon
 
     post-destroot {

--- a/devel/libsdl/files/blank-window.patch
+++ b/devel/libsdl/files/blank-window.patch
@@ -1,0 +1,130 @@
+Fix blank/black/gray window issues on Mojave and later.
+
+https://bugzilla.libsdl.org/show_bug.cgi?id=4788
+https://hg.libsdl.org/SDL/rev/ab7529cb9558
+--- src/video/quartz/SDL_QuartzVideo.m.orig	Sun Mar 22 22:03:38 2020 -0400
++++ src/video/quartz/SDL_QuartzVideo.m	Sun Apr 05 08:54:07 2020 -0700
+@@ -940,6 +940,10 @@
+     /* Set app state, hide cursor if necessary, ... */
+     QZ_DoActivate(this);
+ 
++    [ window_view setNeedsDisplay:YES ];
++  	[ [ qz_window contentView ] setNeedsDisplay:YES ];
++  	[ qz_window displayIfNeeded ];
++    
+     return current;
+ 
+     /* Since the blanking window covers *all* windows (even force quit) correct recovery is crucial */
+@@ -1115,7 +1119,11 @@
+ 
+     /* Save flags to ensure correct teardown */
+     mode_flags = current->flags;
+-
++    
++    [ window_view setNeedsDisplay:YES ];
++   	[ [ qz_window contentView ] setNeedsDisplay:YES ];
++   	[ qz_window displayIfNeeded ];
++    
+     /* Fade in again (asynchronously) if we came from a fullscreen mode and faded to black */
+     if (fade_token != kCGDisplayFadeReservationInvalidToken) {
+         CGDisplayFade (fade_token, 0.5, kCGDisplayBlendSolidColor, kCGDisplayBlendNormal, 0.0, 0.0, 0.0, FALSE);
+@@ -1155,7 +1163,13 @@
+ 
+     if (qz_window != nil) {
+         nsgfx_context = [NSGraphicsContext graphicsContextWithWindow:qz_window];
+-        [NSGraphicsContext setCurrentContext:nsgfx_context];
++        if (nsgfx_context != NULL) {
++        	[NSGraphicsContext setCurrentContext:nsgfx_context];
++      	}
++      	else {
++      		/* Whoops, looks like Mojave doesn't support this anymore */
++      		fprintf(stderr,"Unable to obtain graphics context for NSWindow (Mojave behavior)\n");
++      	}
+     }
+ 
+     /* Setup the new pixel format */
+@@ -1500,10 +1514,17 @@
+     }
+ }
+ 
+-static void QZ_UpdateRects (_THIS, int numRects, SDL_Rect *rects)
+-{
++static SDL_VideoDevice *last_this = NULL;
++
++void QZ_UpdateRectsOnDrawRect(/*TODO: NSRect from drawRect*/) {
++	// HACK
++	SDL_VideoDevice *this = last_this;
++
++	if (this == NULL) return;
++  if (SDL_VideoSurface == NULL) return;
++
+     if (SDL_VideoSurface->flags & SDL_OPENGLBLIT) {
+-        QZ_GL_SwapBuffers (this);
++// TODO
+     }
+     else if ( [ qz_window isMiniaturized ] ) {
+     
+@@ -1512,8 +1533,9 @@
+     
+     else {
+         NSGraphicsContext *ctx = [NSGraphicsContext currentContext];
+-        if (ctx != nsgfx_context) { /* uhoh, you might be rendering from another thread... */
+-            [NSGraphicsContext setCurrentContext:nsgfx_context];
++        /* NTS: nsgfx_context == NULL will occur on Mojave, may be non-NULL on older versions of OS X */
++          if (nsgfx_context != NULL && ctx != nsgfx_context) { /* uhoh, you might be rendering from another thread... */
++                  [NSGraphicsContext setCurrentContext:nsgfx_context];
+             ctx = nsgfx_context;
+         }
+         CGContextRef cgc = (CGContextRef) [ctx graphicsPort];
+@@ -1528,6 +1550,25 @@
+     }
+ }
+ 
++static void QZ_UpdateRects (_THIS, int numRects, SDL_Rect *rects)
++{
++	// HACK
++	last_this = this;
++
++    if (SDL_VideoSurface->flags & SDL_OPENGLBLIT) {
++        QZ_GL_SwapBuffers (this);
++	// TODO?
++    }
++    else if ( [ qz_window isMiniaturized ] ) {
++        /* Do nothing if miniaturized */
++    }
++    else {
++	[ window_view setNeedsDisplay:YES ];
++	[ [ qz_window contentView ] setNeedsDisplay:YES ];
++	[ qz_window displayIfNeeded ];
++    }
++}
++
+ static void QZ_VideoQuit (_THIS)
+ {
+     CGDisplayFadeReservationToken fade_token = kCGDisplayFadeReservationInvalidToken;
+--- src/video/quartz/SDL_QuartzWindow.h.orig	Sun Mar 22 22:03:38 2020 -0400
++++ src/video/quartz/SDL_QuartzWindow.h	Sun Apr 05 08:54:07 2020 -0700
+@@ -47,5 +47,6 @@
+ 
+ /* Subclass of NSView to set cursor rectangle */
+ @interface SDL_QuartzView : NSView
++- (void)drawRect:(NSRect)dirtyRect;
+ - (void)resetCursorRects;
+ @end
+--- src/video/quartz/SDL_QuartzWindow.m.orig	Sun Mar 22 22:03:38 2020 -0400
++++ src/video/quartz/SDL_QuartzWindow.m	Sun Apr 05 08:54:07 2020 -0700
+@@ -220,6 +220,13 @@
+ 
+ @implementation SDL_QuartzView
+ 
++void QZ_UpdateRectsOnDrawRect(/*TODO: NSRect from drawRect*/);
++
++- (void)drawRect:(NSRect)dirtyRect
++{
++	QZ_UpdateRectsOnDrawRect();
++}
++
+ - (void)resetCursorRects
+ {
+     SDL_Cursor *sdlc = SDL_GetCursor();
+


### PR DESCRIPTION
#### Description

This PR fixes the problem that some games that use libsdl, such as raceintospace, display a blank window under macOS 10.14 and later.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G12034
Xcode 9.4.1 9F2000

macOS 10.14.6 18G4032
Xcode 10.3

macOS 10.15.5 19F101
Command line tools

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
