### PR TITLE
sshuttle: update to 1.0.1

### DIFF
--- a/net/sshuttle/Portfile
+++ b/net/sshuttle/Portfile
@@ -4,23 +4,23 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        sshuttle sshuttle 0.78.5 v
+github.setup        sshuttle sshuttle 1.0.1 v
 fetch.type          git
-revision            1
+revision            0
 
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
 categories          net
 description         Transparent proxy server that works as a poor man's VPN.
 long_description    Transparent proxy server that works as a poor man's VPN. \
                     Forwards over ssh. Doesn't require admin. Works with \
-                    Linux and MacOS. Supports DNS tunneling. 
+                    Linux and MacOS. Supports DNS tunneling.
 
 platforms           darwin
 license             LGPL-2
 homepage            https://sshuttle.readthedocs.io/en/stable/
 
-python.default_version      37
-python.versions     27 35 36 37
+python.default_version          38
+python.versions     27 35 36 37 38
 
 depends_build-append port:py${python.version}-setuptools \
                      port:py${python.version}-setuptools_scm


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
