### PR TITLE
procmail: avoid using strlcat/strlcpy

### DIFF
--- a/mail/procmail/Portfile
+++ b/mail/procmail/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                procmail
 version             3.22
-revision            7
+revision            8
 categories          mail
 license             {Artistic-1 GPL-2+}
 platforms           darwin
@@ -72,7 +72,8 @@ patchfiles          getline.patch \
                     patch-CVE-2014-3618.diff \
                     patch-CVE-2017-16844.diff \
                     patch-security-fixes.diff \
-                    patch-src-manconf.c.diff
+                    patch-src-manconf.c.diff \
+                    patch-avoid-strlcat-strlcpy.diff
 
 post-patch {
     reinplace "s%^/\\*\\(#define\[ \t\]*DEF\[S\]*PATH\[ \t\]*\".*\\)\".*$%\\1:${prefix}/bin\"%" ${worksrcpath}/config.h

--- a/mail/procmail/files/patch-avoid-strlcat-strlcpy.diff
+++ b/mail/procmail/files/patch-avoid-strlcat-strlcpy.diff
@@ -1,0 +1,10 @@
+--- src/autoconf.orig	2020-06-05 12:39:18.000000000 +0200
++++ src/autoconf	2020-06-05 12:39:39.000000000 +0200
+@@ -1081,6 +1081,7 @@
+ do
+   grepfor $func "#define NO$func"
+ done
++echo "#define NOstrlcat" >>$ACONF
+ 
+ NOstrerror=no
+ grepfor strerror "#define NOstrerror" && NOstrerror=yes


### PR DESCRIPTION
* strlcpy in macOS has undefined behaviour if strings overlap, which causes
  backtick substitution to fail.
* this patch foces to use a substitute function provided in procmail source
  for systems where strlcat/strlcpy are not available.

Fixes: https://trac.macports.org/ticket/46623

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.13.6 17G12034
Xcode 10.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
