### PR TITLE
python_select, python3_select, pip_select: add Apple's Python 3.7

### DIFF
--- a/python/pip_select/Portfile
+++ b/python/pip_select/Portfile
@@ -5,7 +5,7 @@ PortGroup           select 1.0
 
 name                pip_select
 version             0.1
-revision            1
+revision            2
 categories          python
 license             BSD
 
@@ -30,6 +30,12 @@ destroot {
     foreach bin {pip pip2 pip3} {
         select::install $bin ${filespath}/$bin base
         select::install $bin ${filespath}/none
+    }
+
+    foreach bin {pip pip3} {
+        if {${os.major} >= 19} {
+            select::install $bin ${filespath}/pip3-apple
+        }
     }
 }
 

--- a/python/pip_select/files/pip3-apple
+++ b/python/pip_select/files/pip3-apple
@@ -1,0 +1,1 @@
+/Library/Developer/CommandLineTools/usr/bin/pip3

--- a/sysutils/python3_select/Portfile
+++ b/sysutils/python3_select/Portfile
@@ -5,7 +5,7 @@ PortGroup           select 1.0
 
 name                python3_select
 version             0.0
-revision            1
+revision            2
 categories          sysutils
 platforms           darwin
 supported_archs     noarch
@@ -31,5 +31,19 @@ destroot {}
 
 select.entries      {python3 base} \
                     {python3 none}
+
+platform darwin {
+    set apple_pythons [
+        if {${os.major} == 19} {
+            list python37-apple \
+                 python38-apple
+        } elseif {${os.major} == 20} {
+            list python38-apple
+        }
+    ]
+    foreach python $apple_pythons {
+        select.entries-append [list python3 {*}$python]
+    }
+}
 
 livecheck.type     none

--- a/sysutils/python3_select/files/python37-apple
+++ b/sysutils/python3_select/files/python37-apple
@@ -1,0 +1,10 @@
+/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/bin/python3.7
+/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/bin/python3.7m
+-
+/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/bin/python3.7-config
+/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/bin/python3.7m-config
+-
+/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/bin/pydoc3.7
+/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/bin/2to3-3.7
+/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/bin/pyvenv-3.7
+/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/share/man/man1/python3.7.1

--- a/sysutils/python3_select/files/python38-apple
+++ b/sysutils/python3_select/files/python38-apple
@@ -1,0 +1,10 @@
+/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/bin/python3.8
+-
+-
+/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/bin/python3.8-config
+-
+-
+/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/bin/pydoc3.8
+/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/bin/2to3-3.8
+-
+/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/share/man/man1/python3.8.1

--- a/sysutils/python_select/Portfile
+++ b/sysutils/python_select/Portfile
@@ -5,7 +5,7 @@ PortGroup           select 1.0
 
 name                python_select
 version             0.3
-revision            8
+revision            9
 categories          sysutils
 platforms           darwin
 supported_archs     noarch
@@ -53,8 +53,15 @@ platform darwin {
         } elseif {${os.major} == 14 || ${os.major} == 15 || ${os.major} == 16} {
             list {python26-apple.mtln python26-apple} \
                  {python27-apple.mtln python27-apple}
-        } elseif {${os.major} >= 17} {
+        } elseif {${os.major} == 17 || ${os.major} == 18} {
             list {python27-apple.mtln python27-apple}
+        } elseif {${os.major} == 19} {
+            list {python27-apple.mtln python27-apple} \
+                 python37-apple \
+                 python38-apple
+        } elseif {${os.major} == 20} {
+            list {python27-apple.mtln python27-apple} \
+                 python38-apple
         }
     ]
     foreach python $apple_pythons {

--- a/sysutils/python_select/files/python37-apple
+++ b/sysutils/python_select/files/python37-apple
@@ -1,0 +1,13 @@
+/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/bin/python3.7
+-
+/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/bin/python3.7-config
+-
+/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/bin/pydoc3.7
+-
+/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/bin/2to3-3.7
+/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/share/man/man1/python3.7.1
+-
+/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7
+/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/Headers
+/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/Resources
+/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/Python3

--- a/sysutils/python_select/files/python38-apple
+++ b/sysutils/python_select/files/python38-apple
@@ -1,0 +1,13 @@
+/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/bin/python3.8
+-
+/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/bin/python3.8-config
+-
+/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/bin/pydoc3.8
+-
+/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/bin/2to3-3.8
+/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/share/man/man1/python3.8.1
+-
+/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8
+/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/Headers
+/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/Resources
+/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/Python3


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

I just stumbled on a Python 3.7 distribution, available in /usr and contained within Xcode. We should add that 🙂

(I don't know whether it appeared in Xcode 11.5 or 11.5.1, but it's _definitely_ there.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
