### PR TITLE
py-dulwich: update to 0.19.16; add python38 variant

### DIFF
--- a/python/py-dulwich/Portfile
+++ b/python/py-dulwich/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        dulwich dulwich 0.19.15 dulwich-
+github.setup        dulwich dulwich 0.20.2 dulwich-
 name                py-dulwich
 categories-append   devel
 maintainers         {lbschenkel @lbschenkel} openmaintainer
@@ -18,26 +18,30 @@ long_description    Simple Pure-Python implementation of the Git file \
 
 homepage            https://www.dulwich.io
 
-checksums           rmd160  c81b9d7f4b6a65b4699b4f2e046fe471aa4dc29f \
-                    sha256  08b7e0ad62c06c82810ac91925512d2a6ae9875625fc67e8d50150b089bd0a94 \
-                    size    363564
+checksums           rmd160  3557712ed0c45d73c104a5dd5dc215bfb3e940cb \
+                    sha256  2b2512ad80e03a1d9ffaafc38d884992b40ac7cfa6ddd814db098733365712dc \
+                    size    370540
 
-python.versions     27
+python.versions     27 38
 
 if {${name} ne ${subport}} {
-    conflicts           py${python.version}-dulwich-devel
-    if {[string match "*-devel" $subport]} {
-        conflicts           py${python.version}-dulwich
+    # 0.20 dropped support for Python 2.7
+    if {${python.version} == 27} {
+        github.setup            dulwich dulwich 0.19.16 dulwich-
+        github.livecheck.regex  {(0.1[0-9.]+)}
+
+        checksums               rmd160  1029473c8fd18718ef7f4a3dea082a053ee92ca4 \
+                                sha256  6d225b7d5f5a293beb1d0855f41feef74230605ffde7929a5719eed4019cb6d1 \
+                                size    369717
     } else {
-        livecheck.type  none
+        livecheck.type          none
     }
 
     patchfiles      patch-archflags.diff \
                     patch-strnlen-lion.diff
 
+    depends_lib-append port:py${python.version}-setuptools
+
     build.target-append build_ext
     build.args-append   --inplace
-} else {
-    livecheck.type  regex
-    livecheck.regex dulwich-(\[0-9.\]+)${extract.suffix}
 }


### PR DESCRIPTION
#### Description

This adds the most recent version of Dulwich as Python 3.8 variant, and bumps the current Python 2.7 variant.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
