### PR TITLE
bootstrap.sh: Don't download PortIndex.json

### DIFF
--- a/_ci/bootstrap.sh
+++ b/_ci/bootstrap.sh
@@ -27,7 +27,7 @@ echo "archive_site_local https://packages.macports.org/:tbz2 https://packages-pr
 #echo "preferred_hosts packages.macports.org" | sudo tee -a /opt/local/etc/macports/macports.conf >/dev/null
 
 # Update PortIndex
-rsync --no-motd -zvl "rsync://rsync-origin.macports.org/macports/release/ports/PortIndex_darwin_${OS_MAJOR}_i386/PortIndex*" .
+rsync --no-motd -zvl "rsync://rsync-origin.macports.org/macports/release/ports/PortIndex_darwin_${OS_MAJOR}_i386/PortIndex" .
 git remote add macports https://github.com/macports/macports-ports.git
 git fetch macports master
 ## Run portindex on recent commits if PR is newer


### PR DESCRIPTION
#### Description

Fixes bootstrap.sh so that it doesn't needlessly download PortIndex.json.

Closes: https://trac.macports.org/ticket/60605

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix