### PR TITLE
micronaut: update to 1.3.6

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       java 1.0
 
-github.setup    micronaut-projects micronaut-core 1.3.5 v
+github.setup    micronaut-projects micronaut-core 1.3.6 v
 revision        0
 name            micronaut
 categories      java
@@ -43,9 +43,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        ${name}-${version}
 
-checksums       rmd160  58f1176f6ebbe6babc44b02819f6ef80b3a73707 \
-                sha256  456ae4f241772465bfafa4e589fb572a761476186f182ec365fcfb0f486b235e \
-                size    13043095
+checksums       rmd160  384399ef6b781ffe9289de7ff5abfbe35ffc3219 \
+                sha256  271a5af14f87e78ec8c72cfd09d04c50c96826532a5496bd9651a2775815693f \
+                size    13043100
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 1.3.6.

###### Tested on

macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?