### PR TITLE
ultralist: update to 0.9.6

### DIFF
--- a/office/ultralist/Portfile
+++ b/office/ultralist/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/ultralist/ultralist 0.9.5
+go.setup            github.com/ultralist/ultralist 0.9.6
 
 homepage            https://ultralist.io/
 
@@ -22,9 +22,9 @@ installs_libs       no
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  6e205526e1e218d5d812ff7344e3bc81f1792086 \
-                    sha256  44c4b3e5735006bc36e87307b92ed05dd88ebf83528128082972cf1e997c6cc6 \
-                    size    2060583
+checksums           rmd160  4e97b2f17365ab5cbdab47f0b48ebff5f2b4f971 \
+                    sha256  c7fa433dae99488aa42369a82fb0344dffa94109108630548fca52b9e11fb5e1 \
+                    size    2060395
 
 build.args-append   -o ${workpath}/${name}
 


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
