### PR TITLE
ghostscript: use macports versions of dependencies

### DIFF
--- a/print/ghostscript/Portfile
+++ b/print/ghostscript/Portfile
@@ -5,7 +5,7 @@ PortGroup           muniversal 1.0
 
 name                ghostscript
 version             9.50
-revision            0
+revision            1
 categories          print
 license             AGPL-3 BSD
 maintainers         nomaintainer
@@ -60,6 +60,7 @@ depends_lib         port:expat \
                     port:libidn \
                     port:libpaper \
                     port:libpng \
+                    port:openjpeg \
                     port:tiff \
                     port:zlib \
                     port:lcms2
@@ -75,7 +76,7 @@ extract.only        ${distname}.tar.gz \
 post-extract {
     system -W ${workpath} "unzip '${distpath}/${mappingresources_commit}.zip'"
 
-    foreach d {freetype jbig2dec jpeg lcms2mt libpng tiff zlib} {
+    foreach d {expat freetype jbig2dec jpeg lcms2mt libpng openjpeg tiff zlib} {
         move ${worksrcpath}/${d} ${worksrcpath}/${d}_local
     }
 

--- a/print/ghostscript/Portfile
+++ b/print/ghostscript/Portfile
@@ -51,8 +51,7 @@ checksums           ${distname}.tar.gz \
                     sha256  03bb11a4db4b01f8509e93db469a24f904934fece3b5b9b8be932267ed7173f4 \
                     size    1600471
 
-depends_lib         port:expat \
-                    port:fontconfig \
+depends_lib         port:fontconfig \
                     port:freetype \
                     port:jbig2dec \
                     port:jpeg \
@@ -206,6 +205,7 @@ variant cups description {Enable CUPS driver} {
 
 variant ghostpdl description {Install GhostPDL} {
     license-append          noncommercial
+    depends_lib-append      port:expat
     configure.args-replace  --without-pcl --with-pcl=gpcl6
     configure.args-replace  --without-xps --with-xps=gxps
     configure.args-replace  --without-gpdl --with-gpdl=gpdl


### PR DESCRIPTION
#### Description

Use versions of upstream libraries provided by MacPorts instead of local versions from the GhostPDL source distribution.

* Disable local expat
* Add openjpeg dependency and disable local openjpeg

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.13.6 17G13035
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] <strike>referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?</strike> <!-- Please don't open a new Trac ticket if you are submitting a pull request. --> (not applicable)
- [x] checked your Portfile with `port lint`?
- [x] <strike>tried existing tests with `sudo port test`?</strike> (not applicable)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
