### PR TITLE
virt-manager: add app bundle for the quartz variant

### DIFF
--- a/_resources/port1.0/group/app-1.0.tcl
+++ b/_resources/port1.0/group/app-1.0.tcl
@@ -279,13 +279,13 @@ platform macosx {
                             return -code error "app.icon ${app.icon} could not be converted to png: $::errorInfo"
                         }
                     }
-                    if {[catch {system -W ${worksrcpath} "${prefix}/bin/makeicns $makeicnsargs -out ${destroot}${applications_dir}/${app.name}.app/Contents/Resources/${app.name}.icns 2>@1"}]} {
+                    if {[catch {system -W ${worksrcpath} "${prefix}/bin/makeicns $makeicnsargs -out \"${destroot}${applications_dir}/${app.name}.app/Contents/Resources/${app.name}.icns\" 2>@1"}]} {
                         return -code error "app.icns could not be created: $::errorInfo"
                     }
 
                 # If app.icon is another type of image file, convert it.
                 } else {
-                    if {[catch {system -W ${worksrcpath} "${prefix}/bin/makeicns -in ${icon} -out ${destroot}${applications_dir}/${app.name}.app/Contents/Resources/${app.name}.icns 2>@1"}]} {
+                    if {[catch {system -W ${worksrcpath} "${prefix}/bin/makeicns -in ${icon} -out \"${destroot}${applications_dir}/${app.name}.app/Contents/Resources/${app.name}.icns\" 2>@1"}]} {
                         return -code error "app.icon ${app.icon} could not be converted to ${app.name}.icns: $::errorInfo"
                     }
                 }

--- a/gnome/virt-manager/Portfile
+++ b/gnome/virt-manager/Portfile
@@ -4,9 +4,10 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 PortGroup           active_variants 1.1
+PortGroup           app 1.0
 
 github.setup        virt-manager virt-manager 2.2.1 v
-revision            1
+revision            2
 categories          gnome emulators
 supported_archs     noarch
 maintainers         {danchr @danchr} openmaintainer
@@ -15,19 +16,16 @@ license             GPL-2+
 homepage            https://virt-manager.org
 master_sites        http://releases.pagure.org/virt-manager/
 
-description         Desktop tool for managing virtual machines via libvirt
+description         Virtual Machine Manager
 
 long_description \
-    The virt-manager application is a GNOME desktop user interface for \
-    managing virtual machines through libvirt. It primarily targets \
-    Linux KVM VMs, but also manages Xen and LXC (linux containers). It \
-    presents a summary view of running domains, their live performance \
-    & resource utilization statistics. Wizards enable the creation of \
-    new domains, and configuration & adjustment of a domain’s resource \
-    allocation & virtual hardware. An embedded VNC and SPICE client \
-    viewer presents a full graphical console to the guest domain. \
-    \
-    The primary use on macOS is for remote administration of Linux boxes.
+    virt-manager is a graphical tool for managing virtual machines via \
+    libvirt. Most usage is with QEMU/KVM virtual machines, but Xen and \
+    libvirt LXC containers are well supported. Common operations for \
+    any libvirt driver should work. \
+    \n\nExpect limited functionality as macOS is not the usual \
+    platform for this application\; its primary use on macOS is for \
+    remote administration of Linux boxes.
 
 checksums           rmd160  9c06e912feb3f44f0ba4b50d94b22118106d380e \
                     sha256  cfd88d66e834513e067b4d3501217e21352fadb673103bacb9e646da9f029a1b \
@@ -44,6 +42,7 @@ post-patch {
 
 depends_build \
     port:intltool \
+    port:gtk2 \
     port:python${python.version} \
     bin:podman:perl5 \
     path:lib/pkgconfig/glib-2.0.pc:glib2
@@ -55,20 +54,38 @@ depends_run \
     port:libvirt-glib \
     port:vte \
     port:gtk-vnc \
-    port:gtk2 \
+    port:gtk3 \
+    port:gtksourceview4 \
     port:spice-gtk \
     port:libosinfo
+
+app.name                Virtual Machine Manager
+app.executable          ${workpath}/virt-manager.sh
+app.icon                data/icons/256x256/apps/virt-manager.png
+app.use_launch_script   yes
 
 use_configure       yes
 configure.cmd       ${build.cmd} configure
 configure.args      --prefix ${python.prefix}
 
+set depspecs [list cairo glib2 gtk3 librsvg pango py${python.version}-cairo spice-gtk gtksourceview4]
+
 variant quartz conflicts x11 {
-    require_active_variants gtk2 quartz
+    foreach dep ${depspecs} {
+        require_active_variants $dep quartz x11
+    }
+}
+
+post-patch {
+    copy ${filespath}/virt-manager.sh ${workpath}
+    reinplace s+@PREFIX@+${prefix}+ ${workpath}/virt-manager.sh
 }
 
 variant x11 conflicts quartz {
-    require_active_variants gtk2 x11
+    foreach dep $depspecs {
+        ui_msg $dep
+        require_active_variants $dep x11 quartz
+    }
 
     depends_run-append      path:bin/Xquartz:xorg-server
 }

--- a/gnome/virt-manager/files/virt-manager.sh
+++ b/gnome/virt-manager/files/virt-manager.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec @PREFIX@/bin/virt-manager --no-fork "$@"


### PR DESCRIPTION
#### Description

An idea for the `virt-manager` port; create a minimal app bundle for the `quartz` variant. Is this something MacPorts should do?

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
