### PR TITLE
zettlr: new port

### DIFF
--- a/aqua/zettlr/Portfile
+++ b/aqua/zettlr/Portfile
@@ -1,0 +1,71 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        Zettlr Zettlr 1.6.0 v
+name                zettlr
+revision            0
+
+homepage            https://www.zettlr.com/
+
+description         A Markdown Editor for the 21st century.
+
+long_description    Zettlr is a Markdown Editor for the 21st century. \
+                    Zettlr supercharges your writing experience and makes no \
+                    compromises.  It supports standard Markdown and does not \
+                    need any special handling.  Just pull in your existing \
+                    notes, Zettelkasten, and paper projects and start working \
+                    on them immediately.  Zettlr uses a WYSIWYM (What You See \
+                    Is What You Mean) approach and renders certain elements \
+                    such as links directly for your convenience.  Zettlr is \
+                    the first Markdown editor directly aimed at writing \
+                    professionally. Whether you are a college student, a \
+                    researcher, a journalist or an author -- Zettlr has the \
+                    right tools for you.
+
+categories          aqua editors
+license             GPL-3
+platforms           darwin
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  d9a8ee7f46caa6d90e45e3f9f792d05bbb4cec43 \
+                    sha256  2a3322e490d3b13e36b6b4db599816161ca9b32e81407bbb0cc36a8b657ab093 \
+                    size    31024746
+
+set ab_bin_commit   b85740334fec875f5dd8dcd22eb1f729599109db
+
+depends_build       port:go \
+                    port:yarn
+
+use_configure       no
+
+patchfiles          patch-make.sh.diff \
+                    patch-package.json.diff
+
+build {
+    set gopath ${workpath}/go
+
+    # Fetch and build JS dependencies
+    system -W ${worksrcpath} "yarn"
+
+    # Build app-builder-bin locally using Go from ports and insert it into node_modules
+    system "GOPATH=${gopath} GO111MODULE=on go get -v github.com/develar/app-builder@${ab_bin_commit}"
+    file delete ${worksrcpath}/node_modules/app-builder-bin/mac/app-builder
+    file link ${worksrcpath}/node_modules/app-builder-bin/mac/app-builder ${gopath}/bin/app-builder
+
+    # Build project source
+    system -W ${worksrcpath} "scripts/make.sh"
+
+    # Build electron app
+    system -W ${worksrcpath} "CSC_IDENTITY_AUTO_DISCOVERY=false yarn release:mac"
+}
+
+destroot {
+    copy ${worksrcpath}/release/mac/Zettlr.app ${destroot}${applications_dir}
+}
+
+github.livecheck.regex {([0-9.]+)}

--- a/aqua/zettlr/files/patch-make.sh.diff
+++ b/aqua/zettlr/files/patch-make.sh.diff
@@ -1,0 +1,60 @@
+--- scripts/make.sh	2020-06-07 15:45:06.000000000 -0400
++++ scripts/make.sh	2020-06-07 15:41:59.000000000 -0400
+@@ -38,7 +38,7 @@
+ echo "Package version is: $pkgver"
+ echo ""
+ 
+-read -p "Press enter to continue (Ctrl+C to abort)"
++# read -p "Press enter to continue (Ctrl+C to abort)"
+ 
+ echo ""
+ 
+@@ -58,34 +58,34 @@
+ yarn lang:refresh
+ 
+ # Build NSIS EXE installer
+-yarn release:win
++# yarn release:win
+ 
+ # Build DMG installer
+-yarn release:mac
++# yarn release:mac
+ 
+ # Build .deb + .rpm
+-yarn release:linux
++# yarn release:linux
+ 
+ # Build an AppImage
+-yarn release:app-image
++# yarn release:app-image
+ 
+ # Switch working directory to the release folder.
+-cd ./release
++# cd ./release
+ 
+ # Generate the checksums
+-echo "Generating SHA 256 checksums for all installers ..."
+-shasum -a 256 "Zettlr-$pkgver.exe" > "SHA256SUMS.txt"
+-shasum -a 256 "Zettlr-$pkgver.dmg" >> "SHA256SUMS.txt"
+-shasum -a 256 "Zettlr-$pkgver-amd64.deb" >> "SHA256SUMS.txt"
+-shasum -a 256 "Zettlr-$pkgver-x86_64.rpm" >> "SHA256SUMS.txt"
+-shasum -a 256 "Zettlr-$pkgver-i386.AppImage" >> "SHA256SUMS.txt"
+-shasum -a 256 "Zettlr-$pkgver-x86_64.AppImage" >> "SHA256SUMS.txt"
++# echo "Generating SHA 256 checksums for all installers ..."
++# shasum -a 256 "Zettlr-$pkgver.exe" > "SHA256SUMS.txt"
++# shasum -a 256 "Zettlr-$pkgver.dmg" >> "SHA256SUMS.txt"
++# shasum -a 256 "Zettlr-$pkgver-amd64.deb" >> "SHA256SUMS.txt"
++# shasum -a 256 "Zettlr-$pkgver-x86_64.rpm" >> "SHA256SUMS.txt"
++# shasum -a 256 "Zettlr-$pkgver-i386.AppImage" >> "SHA256SUMS.txt"
++# shasum -a 256 "Zettlr-$pkgver-x86_64.AppImage" >> "SHA256SUMS.txt"
+ 
+ echo ""
+ 
+ # Test the checksums
+-echo "Testing the checksums ..."
+-shasum -a 256 -c SHA256SUMS.txt
++# echo "Testing the checksums ..."
++# shasum -a 256 -c SHA256SUMS.txt
+ 
+ echo ""
+ echo "Done."

--- a/aqua/zettlr/files/patch-package.json.diff
+++ b/aqua/zettlr/files/patch-package.json.diff
@@ -1,0 +1,11 @@
+--- package.json	2020-06-07 15:44:02.000000000 -0400
++++ package.json	2020-06-07 15:43:58.000000000 -0400
+@@ -18,7 +18,7 @@
+         "start": "electron .",
+         "build:quick": "node scripts/build-app.js --dir",
+         "release:this": "node scripts/build-app.js",
+-        "release:mac": "node scripts/build-app.js --mac",
++        "release:mac": "node scripts/build-app.js --mac --dir",
+         "release:win": "node scripts/build-app.js --win",
+         "release:linux": "node scripts/build-app.js --linux",
+         "release:app-image": "node scripts/build-app.js --app-image",


### PR DESCRIPTION
#### Description

New port for [Zettlr](https://www.zettlr.com/)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
