### PR TITLE
chruby ruby-install: Add myself to maintainer list

### DIFF
--- a/ruby/chruby/Portfile
+++ b/ruby/chruby/Portfile
@@ -10,7 +10,9 @@ license             MIT
 platforms           darwin
 supported_archs     noarch
 
-maintainers         {catlett.info:chad @chadcatlett} openmaintainer
+maintainers         {catlett.info:chad @chadcatlett} \
+                    {hotmail.com:franklinyu @FranklinYu} \
+                    openmaintainer
 
 description         Ruby version changer
 long_description    chruby changes the current Ruby version. It supports bash \
@@ -24,6 +26,7 @@ use_configure       no
 
 build               {}
 
+# remove this in next release
 destroot.destdir    PREFIX=${destroot}${prefix}
 
 notes "

--- a/ruby/ruby-install/Portfile
+++ b/ruby/ruby-install/Portfile
@@ -10,7 +10,9 @@ license             MIT
 platforms           darwin
 supported_archs     noarch
 
-maintainers         {catlett.info:chad @chadcatlett} openmaintainer
+maintainers         {catlett.info:chad @chadcatlett} \
+                    {hotmail.com:franklinyu @FranklinYu} \
+                    openmaintainer
 
 description         Installs Ruby, JRuby, Rubinius, TruffleRuby or mruby.
 long_description    ${description}
@@ -23,4 +25,4 @@ use_configure       no
 
 build               {}
 
-destroot.destdir    PREFIX=${destroot}${prefix}
+destroot.args       PREFIX=${prefix}


### PR DESCRIPTION
#### Description

Add myself to maintainer list. The update isn’t strictly required so I didn’t bump the revision number.

Refer to postmodern/chruby#308 for details of the fix. Note that latest release of `chruby` predates this fix.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?