### PR TITLE
mysql56: update to 5.6.48

### DIFF
--- a/databases/mysql56/Portfile
+++ b/databases/mysql56/Portfile
@@ -9,7 +9,7 @@ deprecated.upstream_support no
 
 name                mysql56
 set name_mysql      ${name}
-version             5.6.47
+version             5.6.48
 # Set revision_client and revision_server to 0 on
 # version bump.
 set revision_client 0
@@ -53,10 +53,12 @@ if {$subport eq $name} {
     # VERSION file to VERSION.txt below (c++17 conflict)
     patchfiles-append   patch-mysql56-version-change.diff
 
+    # Add missing `#include <string>`
+    patchfiles-append   patch-storage-innobase-handler-i_s.cc.diff
 
-    checksums           rmd160  c580c4bab8c81db0bc9eac19223fb2b260e35f55 \
-                        sha256  0919096705784c62af831bb607e99345083edd76967c8c65966728742a9127fe \
-                        size    32388152
+    checksums           rmd160  3bc7d47d78b61f5262ce632d81d15c280db671ab \
+                        sha256  82a423acd1f74c1ff5787c38a8b6dc00d36b55662ad50c73bb2261bbc95035c2 \
+                        size    32401200
 
     depends_lib-append  path:lib/libssl.dylib:openssl \
                         port:ncurses \

--- a/databases/mysql56/files/patch-storage-innobase-handler-i_s.cc.diff
+++ b/databases/mysql56/files/patch-storage-innobase-handler-i_s.cc.diff
@@ -1,0 +1,15 @@
+Upstream-Status: Submitted (https://bugs.mysql.com/bug.php?id=99799)
+
+diff --git storage/innobase/handler/i_s.cc.old storage/innobase/handler/i_s.cc
+index be3ab7b..754b836 100644
+--- a/storage/innobase/handler/i_s.cc
++++ b/storage/innobase/handler/i_s.cc
+@@ -65,6 +65,8 @@ Created July 18, 2007 Vasil Dimov
+ #include "btr0btr.h"
+ #include "page0zip.h"
+ 
++#include <string>
++
+ /** structure associates a name string with a file page type and/or buffer
+ page state. */
+ struct buf_page_desc_t{


### PR DESCRIPTION
#### Description
See https://dev.mysql.com/doc/relnotes/mysql/5.6/en/news-5-6-48.html
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Untested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
