### PR TITLE
mysql57: try fixing build for older macOS versions

### DIFF
--- a/databases/mysql57/Portfile
+++ b/databases/mysql57/Portfile
@@ -85,6 +85,13 @@ if {$subport eq $name} {
         reinplace "s|@PREFIX@|${prefix}|g" \
             ${cmake.build_dir}/macports/macports-default.cnf \
             ${cmake.build_dir}/macports/my.cnf
+
+        # See https://trac.macports.org/ticket/55238#comment:7
+        # Force using `ifr_name` from `struct ifreq` in net/if.h:
+        # it has always been available on macOS, but is not detected
+        # by CMake on 10.8 and earlier.
+        reinplace {s|#ifdef HAVE_STRUCT_IFREQ_IFR_NAME|#if 1|g} \
+            ${worksrcpath}/rapid/plugin/group_replication/libmysqlgcs/src/bindings/xcom/gcs_xcom_networking.cc
     }
 
     configure.args-delete \


### PR DESCRIPTION
See: https://trac.macports.org/ticket/55238#comment:7
#### Description
Revision not bumped because this should have no effect on macOS versions which are able to build this port.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
**Untested**. If someone with an affected macOS version (10.8 or earlier) can give this a try and report the result here, that would be appreciated; I can then set this PR to close the ticket. Otherwise this can be merged and then wait to see what the buildbot reports.
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
