### PR TITLE
yadm: New port

### DIFF
--- a/sysutils/yadm/Portfile
+++ b/sysutils/yadm/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           makefile 1.0
+
+github.setup        TheLocehiliosan yadm 2.4.0
+
+categories          sysutils
+platforms           darwin
+license             GPL-3+
+maintainers         {kollar.me:laszlo @lkollar} openmaintainer
+description         Yet Another Dotfiles Manager
+long_description    yadm is a tool for managing dotfiles. \
+                    yadm is like having a version of Git, that only \
+                    operates on your dotfiles. If you know how to use \
+                    Git, you already know how to use yadm.
+homepage            https://yadm.io
+
+checksums           sha256  4ea99c4ad763431c4db704b690ee764dcb7cd2814746097fd0787c376cbe8443 \
+                    rmd160  ffd3fedd94edf7676cccc778c1f41029c196366c \
+                    size    96912
+
+installs_libs       no
+supported_archs     noarch
+makefile.has_destdir \
+                    no

--- a/sysutils/yadm/Portfile
+++ b/sysutils/yadm/Portfile
@@ -5,16 +5,19 @@ PortGroup           github 1.0
 PortGroup           makefile 1.0
 
 github.setup        TheLocehiliosan yadm 2.4.0
-
+revision            0
 categories          sysutils
 platforms           darwin
 license             GPL-3+
 maintainers         {kollar.me:laszlo @lkollar} openmaintainer
+
 description         Yet Another Dotfiles Manager
+
 long_description    yadm is a tool for managing dotfiles. \
-                    yadm is like having a version of Git, that only \
+                    yadm is like having a version of Git that only \
                     operates on your dotfiles. If you know how to use \
                     Git, you already know how to use yadm.
+
 homepage            https://yadm.io
 
 checksums           sha256  4ea99c4ad763431c4db704b690ee764dcb7cd2814746097fd0787c376cbe8443 \


### PR DESCRIPTION
#### Description

New port for [`yadm`](https://yadm.io) (Yet Another Dotfiles Manager).
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
