### PR TITLE
petsc-devel: remove obsolete port

### DIFF
--- a/math/petsc/Portfile
+++ b/math/petsc/Portfile
@@ -129,16 +129,6 @@ if {[variant_isset universal]} {
     }
 }
 
-# Remove after 2020-05-21
-subport petsc-devel {
-    PortGroup           obsolete 1.0
-
-    name                petsc-devel
-    replaced_by         petsc
-    version             3.7.99
-    revision            9
-}
-
 notes               "Add the following line to your .bash_profile if you plan to use\
                     the PETSC makefile rules in ${prefix}/lib/petsc/conf: \n\
                     \texport PETSC_DIR=${prefix}/lib/${name}"


### PR DESCRIPTION
Replaced by `petsc` in 2f6a601853

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
