### PR TITLE
mod_python26: remove obsolete port

### DIFF
--- a/www/mod_python/Portfile
+++ b/www/mod_python/Portfile
@@ -58,9 +58,3 @@ subport mod_python27 {
     configure.args-append \
                         --with-python=${prefix}/bin/python2.7
 }
-
-subport mod_python26 {
-    # remove after 2020-05-06
-    replaced_by         mod_python27
-    revision            1
-}


### PR DESCRIPTION
Replaced by `mod_python27` in d84ecab9c4

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?