### PR TITLE
py-uncertainties: update to 3.1.4

### DIFF
--- a/python/py-uncertainties/Portfile
+++ b/python/py-uncertainties/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 PortGroup               github 1.0
 
-github.setup            lebigot uncertainties 3.1.2
+github.setup            lebigot uncertainties 3.1.4
 revision                0
 
 name                    py-uncertainties
@@ -17,9 +17,9 @@ long_description        The uncertainties package transparently handles\
 platforms               darwin
 supported_archs         noarch
 
-checksums               rmd160  ac8ad135b95eca4b49b1af9b9fd097a2b2763e78 \
-                        sha256  db59232740d90c811e20c0a8828a264ce9d52b1462466b558aed8a1ccb1ff613 \
-                        size    148503
+checksums               rmd160  9e3841cb210964d715a4dc42e2609089632e1142 \
+                        sha256  58b308c255c7004a1b7a0ce84c8eaf0ffdc9609d414f715fa373e2ab4fa32f37 \
+                        size    148972
 
 python.versions         27 35 36 37 38
 
@@ -27,10 +27,12 @@ if {${name} ne ${subport}} {
     depends_build-append  \
                         port:py${python.version}-setuptools
 
+    depends_lib-append  port:py${python.version}-future
+
     depends_test-append port:py${python.version}-nose \
                         port:py${python.version}-numpy
+
     test.run            yes
-    test.cmd            ${python.bin} setup.py
     test.target         nosetests
     test.env            PYTHONPATH=${worksrcpath}/build/lib
 


### PR DESCRIPTION
#### Description
- update to version 3.1.4

###### Tested on
macOS 10.14.6 18G5033
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
