### PR TITLE
fossil: update to 2.10.1

### DIFF
--- a/devel/fossil/Portfile
+++ b/devel/fossil/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                fossil
-version             2.10
+version             2.10.1
 revision            0
 epoch               20110901182519
 categories          devel
@@ -26,9 +26,9 @@ distname            ${name}-src-${version}
 
 worksrcdir          ${name}-${version}
 
-checksums           rmd160  e4ac6020a0369b3aff8942e06f45fe0de6cd3f50 \
-                    sha256  d8a3776d2ce77385ed5ff20a2776d13bb534fb2508e87351e14e94f91cd12b10 \
-                    size    5634327
+checksums           rmd160  f2bbd2210282ee3aa7f6288ab143c058a4645227 \
+                    sha256  6f415746214d76028788fb623ccdb5cb0ed187d3204e29625db816852632b86d \
+                    size    5674712
 
 test.run            yes
 
@@ -42,11 +42,8 @@ configure.args-append       --with-tcl=${prefix}/lib \
                             --with-th1-hooks \
                             --with-exec-rel-paths \
                             --json
-if {[vercmp [macports_version] 2.5.99] >= 0} {
+
 configure.env-append "CC_FOR_BUILD=${configure.cc} [get_canonical_archflags]"
-} else {
-configure.env-append CC_FOR_BUILD="${configure.cc} [get_canonical_archflags]"
-}
 
 configure.ldflags-append    -liconv
 


### PR DESCRIPTION
Remove `configure.env-append` usage for MacPorts < 2.6.0

#### Description
From announcement today (2020-06-08):
```
A vulnerability has been found in the "fossil git export" command.
…
Upgrading is recommended, especially if you use "fossil git export".
```
2.11.1 is also available.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5
Xcode command line tools 11.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
