### PR TITLE
chezmoi: update to 1.8.2

### DIFF
--- a/sysutils/chezmoi/Portfile
+++ b/sysutils/chezmoi/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/twpayne/chezmoi 1.8.1 v
+go.setup            github.com/twpayne/chezmoi 1.8.2 v
 
 categories          sysutils
 license             MIT
@@ -11,9 +11,9 @@ installs_libs       no
 
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
 
-checksums           rmd160  9f05c1261867e38d3a5ca7222fc455013c3b70f1 \
-                    sha256  759deceb78c4b8a073d39f6f64bb575623b0fed60e39752cb2fb8aa5dafd36a5 \
-                    size    2217165
+checksums           rmd160  9c52961a40d8d0bb72ee076d063c84a779caf100 \
+                    sha256  90650a182f1440577cf8b06df87051eef4518e0c80d95052e8148e01332f069d \
+                    size    2231853
 
 homepage            https://chezmoi.io/
 


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
