### PR TITLE
py-gnupg: update to version 0.4.6

### DIFF
--- a/python/py-gnupg/Portfile
+++ b/python/py-gnupg/Portfile
@@ -4,7 +4,7 @@ PortSystem           1.0
 PortGroup            python 1.0
 
 name                 py-gnupg
-version              0.4.4
+version              0.4.6
 
 description          A Python wrapper for GnuPG
 long_description     The gnupg module allows Python programs to make use of \
@@ -22,18 +22,19 @@ categories-append    crypto security
 platforms            darwin
 maintainers          {@F30 f30.me:f30} openmaintainer
 
-python.versions      27 35 36
+python.versions      36 37 38
 depends_run          bin:gpg:gnupg2
 
 master_sites         pypi:p/python-gnupg
 distname             python-gnupg-${version}
-checksums            rmd160  ccfbe0ac6cdb1eb4226f1be7f776a220f580314f \
-                     sha256  45daf020b370bda13a1429c859fcdff0b766c0576844211446f9266cae97fb0e \
-                     size    48292
+checksums            rmd160  808403c8ee70a114bd20ee72c83d2e8e5297c1bc \
+                     sha256  3aa0884b3bd414652c2385b9df39e7b87272c2eca1b8fcc3089bc9e58652019a \
+                     size    52527
 
-# Only enable tests for individual subports as otherwise `${python.bin}` is not
+# Only enable tests, build-depends for individual subports as otherwise `${python.*}` are not
 # available
 if {${subport} ne ${name}} {
-    test.run         yes
-    test.cmd         ${python.bin} test_gnupg.py
+    test.run                yes
+    test.cmd                ${python.bin} test_gnupg.py
+    depends_build-append    port:py${python.version}-setuptools
 }


### PR DESCRIPTION
#### Description

update version

deprecated python.versions 27 35 removed

newest python.versions 38 added

###### Tested on
macOS 10.14.6 18G5033
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
