### PR TITLE
nektarpp: new port

### DIFF
--- a/science/nektarpp/Portfile
+++ b/science/nektarpp/Portfile
@@ -1,0 +1,156 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               cmake 1.1
+PortGroup               mpi 1.0
+PortGroup               gitlab 1.0
+
+gitlab.instance         https://gitlab.nektar.info
+gitlab.setup            nektar nektar 5.0.0 v
+
+name                    nektarpp
+
+categories              science
+platforms               darwin
+license                 MIT
+homepage                http://www.nektar.info/
+maintainers             {xyloid.org:dave @mdave} openmaintainer
+description             spectral/hp element framework
+long_description        Nektar++ is a spectral/hp element framework which aims to be easy \
+                        to use and support a wide range of features, including 1D, 2D and \
+                        3D element support, hybrid shaped elements and continuous and \
+                        discontinuous implementations. As well as a modern C++ API, it \
+                        ships with a range of solvers including CFD, advection-diffusion \
+                        equations and cardiac electrophysiology.
+
+# Additional dependencies for Tetgen and Triangle
+master_sites            ${master_sites}:main \
+                        ${homepage}thirdparty/:thirdparty
+
+set main_distfile       ${distfiles}
+distfiles               ${main_distfile}:main \
+                        tetgen-1.5.zip:thirdparty \
+                        triangle-1.6.zip:thirdparty
+
+checksums               nektar-5.0.0.tar.bz2 \
+                        rmd160  f588a4d6429b1ffc85be538885cbb09886ac9cba \
+                        sha256  d98c87af64e6d5cce04f8f60045a63fe63a79274c72a0ba368716fe603a4b625 \
+                        size    48486184 \
+                        tetgen-1.5.zip \
+                        rmd160  d8785f4ca6b26608ec9423f7574a0e736380370a \
+                        sha256  52207793198746de14abcb30a0aeed617d7348ff37544e7d7e65aaaa76d7fa70 \
+                        size    264128 \
+                        triangle-1.6.zip \
+                        rmd160  c92c011c442157cae5abcf246935d61bdfeede26 \
+                        sha256  7d74d7efbe35dc5a497bd179bdc87b4670740e466f67043d41e0b0546ce76cb5 \
+                        size    130331
+
+# Only the full Nektar++ source should be extracted - CMake will extract any
+# third-party dependencies.
+extract.only            ${main_distfile}
+
+patchfiles              no-homebrew.patch \
+                        avoid-python-install.patch \
+                        thirdparty-sources.patch
+
+compiler.cxx_standard   2011
+cmake.build_type        Release
+
+mpi.setup
+
+depends_lib-append      port:arpack \
+                        port:boost \
+                        port:fftw-3 \
+                        port:opencascade \
+                        port:scotch \
+                        port:tinyxml \
+                        port:zlib
+
+# Don't build demos and tests by default.
+configure.args-append   -DNEKTAR_BUILD_DEMOS=OFF \
+                        -DNEKTAR_BUILD_TESTS=OFF \
+                        -DNEKTAR_BUILD_UNIT_TESTS=OFF \
+                        -DNEKTAR_SOLVER_DIFFUSION=OFF \
+                        -DNEKTAR_SOLVER_DUMMY=OFF \
+                        -DNEKTAR_SOLVER_ELASTICITY=OFF \
+                        -DNEKTAR_SOLVER_MMF=OFF \
+                        -DNEKTAR_USE_ARPACK=ON \
+                        -DNEKTAR_USE_FFTW=ON \
+                        -DNEKTAR_USE_MESHGEN=ON \
+                        -DNEKTAR_USE_SCOTCH=ON
+
+variant petsc description {
+    Enable PETSc support for linear algebra solvers.
+} {
+    depends_lib-append port:petsc
+
+    configure.args-append \
+                        -DNEKTAR_USE_PETSC=ON
+}
+
+if {[mpi_variant_isset]} {
+    distfiles-append    gsmpi-1.2.1_1.tar.bz2:thirdparty
+    checksums-append    gsmpi-1.2.1_1.tar.bz2 \
+                        rmd160 3a1ad71c552ea9d62bebabd4ed528531f9c0eec6 \
+                        sha256 c9bc966c92f45e81f4e9d1887dd7c59808e7a4ef9ec41e1e5f1e6c5c01745211 \
+                        size 39737
+
+    depends_lib-append port:hdf5
+
+    require_active_variants hdf5 [mpi_variant_name]
+    require_active_variants scotch [mpi_variant_name]
+
+    configure.args-append \
+                        -DNEKTAR_USE_HDF5=ON \
+                        -DNEKTAR_USE_MPI=ON
+}
+
+variant oce description {
+    use Community Edition version of OpenCASCADE
+} {
+    depends_lib-replace port:opencascade port:oce
+}
+
+post-extract {
+    # Copy additional third-party sources into correct position.
+    file mkdir ${worksrcpath}/ThirdParty
+    foreach distfile ${distfiles} {
+        set distfile [lindex [split ${distfile} :] 0]
+        if {${distfile} ne ${main_distfile}} {
+            copy ${distpath}/${distfile} ${worksrcpath}/ThirdParty/
+        }
+    }
+}
+
+set pythons_suffixes    {37 38}
+
+set pythons_ports       {}
+foreach s ${pythons_suffixes} {
+    lappend pythons_ports python${s}
+}
+
+foreach s ${pythons_suffixes} {
+    set p python${s}
+    set v [string index ${s} 0].[string index ${s} 1]
+    set pe ${prefix}/bin/python${v}
+    set i [lsearch -exact ${pythons_ports} ${p}]
+    set c [lreplace ${pythons_ports} ${i} ${i}]
+    variant ${p} description "Build the Python ${v} bindings" conflicts {*}${c} "
+        depends_lib-append      port:${p} \
+                                port:py${s}-numpy \
+                                port:boost-numpy
+
+        configure.args-append   -DNEKTAR_BUILD_PYTHON=ON \
+                                -DNEKTAR_PYTHON3_STATUS=ON \
+                                -DNEKTAR_USE_PYTHON3=ON \
+                                -DPYTHON_EXECUTABLE=${pe}
+
+        # Install Python libraries using setup.py.
+        post-destroot {
+            system -W ${build.dir} \"${pe} setup.py install --root=${destroot}\"
+        }
+
+        require_active_variants boost       ${p}
+        require_active_variants boost-numpy ${p}
+    "
+}

--- a/science/nektarpp/files/avoid-python-install.patch
+++ b/science/nektarpp/files/avoid-python-install.patch
@@ -1,0 +1,21 @@
+Avoid setting Python libraries as install targets to avoid DESTDIR
+installation issues.
+--- cmake/NektarCommon.cmake.orig	2020-07-10 10:19:58.000000000 +0100
++++ cmake/NektarCommon.cmake	2020-07-10 10:20:47.000000000 +0100
+@@ -268,6 +268,8 @@
+     # Python requires a .so extension, even on OS X.
+     SET_TARGET_PROPERTIES(_${name} PROPERTIES PREFIX "")
+     SET_TARGET_PROPERTIES(_${name} PROPERTIES SUFFIX ".so")
++    SET_TARGET_PROPERTIES(_${name} PROPERTIES
++        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/NekPy/${name})
+ 
+     ADD_DEPENDENCIES(_${name} boost-numpy)
+ 
+@@ -287,7 +289,6 @@
+     SET(TMPOUT "${TMPOUT}from ._${name} import *")
+ 
+     FILE(WRITE ${CMAKE_BINARY_DIR}/NekPy/${name}/__init__.py ${TMPOUT})
+-    INSTALL(TARGETS _${name} DESTINATION ${CMAKE_BINARY_DIR}/NekPy/${name})
+ ENDMACRO()
+ 
+ MACRO(ADD_NEKPY_EXECUTABLE name source)

--- a/science/nektarpp/files/no-homebrew.patch
+++ b/science/nektarpp/files/no-homebrew.patch
@@ -1,0 +1,44 @@
+Don't automatically use Homebrew paths.
+MacPorts already sets the correct paths to use.
+--- CMakeLists.txt.orig	2019-11-19 10:55:14.000000000 -0600
++++ CMakeLists.txt	2020-07-07 12:40:45.000000000 -0500
+@@ -69,39 +69,6 @@
+     SET(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/dist CACHE PATH "" FORCE)
+ ENDIF()
+ 
+-# Find default search paths for OS X; adapted from Stack Overflow question
+-# 1487752.
+-IF (APPLE)
+-    EXECUTE_PROCESS(COMMAND which port
+-        RESULT_VARIABLE DETECT_MACPORTS
+-        OUTPUT_VARIABLE MACPORTS_PREFIX
+-        ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+-    EXECUTE_PROCESS(COMMAND brew --prefix
+-        RESULT_VARIABLE DETECT_HOMEBREW
+-        OUTPUT_VARIABLE HOMEBREW_PREFIX
+-        ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+-
+-    IF (${DETECT_MACPORTS} EQUAL 0)
+-        GET_FILENAME_COMPONENT(MACPORTS_PREFIX ${MACPORTS_PREFIX} DIRECTORY)
+-        GET_FILENAME_COMPONENT(MACPORTS_PREFIX ${MACPORTS_PREFIX} DIRECTORY)
+-        SET(CMAKE_LIBRARY_PATH ${MACPORTS_PREFIX}/lib ${CMAKE_LIBRARY_PATH})
+-        SET(CMAKE_INCLUDE_PATH ${MACPORTS_PREFIX}/include ${CMAKE_INCLUDE_PATH})
+-        MESSAGE(STATUS "Detected MacPorts installation: ${MACPORTS_PREFIX}")
+-    ELSE()
+-        UNSET(MACPORTS_PREFIX)
+-    ENDIF()
+-
+-    IF (${DETECT_HOMEBREW} EQUAL 0)
+-        SET(CMAKE_LIBRARY_PATH ${HOMEBREW_PREFIX}/lib ${CMAKE_LIBRARY_PATH})
+-        SET(CMAKE_INCLUDE_PATH ${HOMEBREW_PREFIX}/include ${CMAKE_INCLUDE_PATH})
+-        MESSAGE(STATUS "Detected Homebrew installation: ${HOMEBREW_PREFIX}")
+-    ELSE()
+-        UNSET(HOMEBREW_PREFIX)
+-    ENDIF()
+-
+-    UNSET(DETECT_HOMEBREW)
+-    UNSET(DETECT_MACPORTS)
+-ENDIF()
+ 
+ # Attempt to retrieve git branch and SHA1 hash of current changeset.
+ INCLUDE(GetGitRevisionDescription)

--- a/science/nektarpp/files/thirdparty-sources.patch
+++ b/science/nektarpp/files/thirdparty-sources.patch
@@ -1,0 +1,23 @@
+Patch filenames of third-party sources to include version numbers.
+--- cmake/ThirdPartyTriangle.cmake.orig	2020-07-10 11:22:33.000000000 +0100
++++ cmake/ThirdPartyTriangle.cmake	2020-07-10 11:22:52.000000000 +0100
+@@ -25,7 +25,7 @@
+         EXTERNALPROJECT_ADD(
+             triangle-1.6
+             PREFIX ${TPSRC}
+-            URL ${TPURL}/triangle.zip
++            URL ${TPURL}/triangle-1.6.zip
+             URL_MD5 357cb7107f51f3f89940c47435d4fa49
+             STAMP_DIR ${TPBUILD}/stamp
+             DOWNLOAD_DIR ${TPSRC}
+--- cmake/ThirdPartyTetGen.cmake.orig	2020-07-10 11:23:15.000000000 +0100
++++ cmake/ThirdPartyTetGen.cmake	2019-11-19 16:55:14.000000000 +0000
+@@ -25,7 +25,7 @@
+         EXTERNALPROJECT_ADD(
+             tetgen-1.5
+             PREFIX ${TPSRC}
+-            URL ${TPURL}/tetgen.zip
++            URL ${TPURL}/tetgen-1.5.zip
+             URL_MD5 6d62e63f9b1e7a8ce53d5bc87e6a0a09
+             STAMP_DIR ${TPBUILD}/stamp
+             DOWNLOAD_DIR ${TPSRC}


### PR DESCRIPTION
#### Description

Adds a new port for the [Nektar++ spectral element framework](https://www.nektar.info/).

###### Tested on

macOS 10.15.5 19F96
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?