### PR TITLE
google-cloud-sdk: update to 296.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             295.0.0
+version             296.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  9c632e4620c3cf1163e412a79270cbc06e3458ea \
-                    sha256  e308dd1942fa2b398db78db500da4cda989e9da344dbc82bfe4ef4cf43470b5f \
-                    size    68592166
+    checksums       rmd160  19afddb89965ab2ee94f3a6edfd4d153e7ce1813 \
+                    sha256  271b194506d2d196fe12b42ecdc74501de744f8d1e1a76a5d99f2bc7eaec6380 \
+                    size    68638545
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  6a88841f402b13fd1f63259ab7a818d767c2803f \
-                    sha256  06b9a978d776e39d1b0ef64e0d38177379a2f1233b24cbfdb37cb7974463ccc3 \
-                    size    70556108
+    checksums       rmd160  76d79a986a244c7b6f9324a94fa608e4bd9f7df4 \
+                    sha256  4d270182bc135c00ecc22d3e923c82e301b8967032445d745c6429c68300effa \
+                    size    70597018
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 296.0.0.

###### Tested on

macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?