### PR TITLE
Add py-pydantic and dependency py-dataclasses

### DIFF
--- a/python/py-pydantic/Portfile
+++ b/python/py-pydantic/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-pydantic
+version             1.5.1
+categories-append   devel
+platforms           darwin
+license             MIT
+
+python.versions     37 38
+
+maintainers         {@jandemter demter.de:jan} openmaintainer
+
+description         Data validation and settings management using Python type hinting
+long_description    Fast and extensible, pydantic plays nicely \
+                    with your linters/IDE/brain. Define how data \
+                    should be in pure, canonical Python 3.6+\; \
+                    validate it with pydantic.
+
+homepage            https://github.com/samuelcolvin/pydantic
+
+checksums           rmd160  7fab2abf0c94c3fc618ab57d5d0cf5042afb5d58 \
+                    sha256  f0018613c7a0d19df3240c2a913849786f21b6539b9f23d85ce4067489dfacfa \
+                    size    114535
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools \
+                            port:py${python.version}-cython
+
+    livecheck.type      none
+}


### PR DESCRIPTION
#### Description

pydantic is a library for "Data validation and settings management using Python type hinting".

For Python 3.6 support, a backport of Python 3.7+ Data Classes is necessary.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
