### PR TITLE
gh: update to 0.10.0

### DIFF
--- a/devel/gh/Portfile
+++ b/devel/gh/Portfile
@@ -3,13 +3,15 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        cli cli 0.9.0 v
+github.setup        cli cli 0.10.0 v
 name                gh
 categories          devel
 platforms           darwin
 supported_archs     x86_64
 license             MIT
-maintainers         {l2dy @l2dy} openmaintainer
+maintainers         {l2dy @l2dy} \
+                    {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
 
 description         The GitHub CLI
 long_description    gh is GitHub on the command line, and it's now available in beta.
@@ -21,9 +23,9 @@ homepage            https://cli.github.com/
 github.tarball_from releases
 distname            gh_${version}_macOS_amd64
 
-checksums           rmd160  41bd96c98e530f9eda9959a8853edff7ce4e4054 \
-                    sha256  aa2216395b74437209bca15565ec31eb14b37e2205989f08920f71575df435c5 \
-                    size    6154114
+checksums           rmd160  af0d07d79b0b6d2ed5d76993fb9d2955a25a99f8 \
+                    sha256  3d30518775f1d519a8fbd14296f52ed374328ad85b5aa9ec5b8341ba610448d5 \
+                    size    6204700
 
 use_configure       no
 installs_libs       no


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
