### PR TITLE
skaffold: update to 1.11.0

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 1.10.1 v
+github.setup        GoogleContainerTools skaffold 1.11.0 v
 revision            0
 
 categories          devel
@@ -23,9 +23,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  fc4223c7b4d46e07a685eda4a46ff5d35f54d0f3 \
-                    sha256  576c68e2656b58090c597fa2b2179acd80ecc88b5e1ddc41b0d90026a0c62e7b \
-                    size    27097983
+checksums           rmd160  3c3a58a84852c8df7d53e1ba6ad79a82d533c5f9 \
+                    sha256  1803f372cee128981e4e5a559d572738a64e2dda171f194697d6888ebfc67e3d \
+                    size    27112720
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 1.11.0.

###### Tested on

macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?