### PR TITLE
evince: update to version 3.36.5

### DIFF
--- a/gnome/evince/Portfile
+++ b/gnome/evince/Portfile
@@ -7,7 +7,7 @@ PortGroup           cxx11 1.1
 PortGroup           gobject_introspection 1.0
 
 name                evince
-version             3.35.92
+version             3.36.4
 license             GPL-2+
 set branch          [join [lrange [split ${version} .] 0 1] .]
 description         Evince is a document viewer for multiple document formats like pdf, and many others.
@@ -20,9 +20,9 @@ master_sites        gnome:sources/${name}/${branch}/
 
 use_xz              yes
 
-checksums           rmd160  f5952d0bb25ee161fc630b26da3805d7da3775bb \
-                    sha256  34dac203c1e77109d696a984d624f8c09d940d8a7f27034b7b60e7ed71340a97 \
-                    size    2578436
+checksums           rmd160  fc81da7a491d17669d73ad96eb8dcfb52536d9f0 \
+                    sha256  36f4b9ff7f28c74216853ea867ad978927616a637930e5d87d807c7d6ddae442 \
+                    size    2917900
 
 depends_build       port:pkgconfig \
                     port:intltool \

--- a/gnome/evince/Portfile
+++ b/gnome/evince/Portfile
@@ -7,7 +7,7 @@ PortGroup           cxx11 1.1
 PortGroup           gobject_introspection 1.0
 
 name                evince
-version             3.28.4
+version             3.35.92
 license             GPL-2+
 set branch          [join [lrange [split ${version} .] 0 1] .]
 description         Evince is a document viewer for multiple document formats like pdf, and many others.
@@ -20,9 +20,9 @@ master_sites        gnome:sources/${name}/${branch}/
 
 use_xz              yes
 
-checksums           rmd160  0989258ec2d226258bc53c71e46fb14e7c1b1e0d \
-                    sha256  df64b1c6a6c220ca5592f2cf564f7e6b8b77e6d7009468065bc9470f92437c81 \
-                    size    2174604
+checksums           rmd160  f5952d0bb25ee161fc630b26da3805d7da3775bb \
+                    sha256  34dac203c1e77109d696a984d624f8c09d940d8a7f27034b7b60e7ed71340a97 \
+                    size    2578436
 
 depends_build       port:pkgconfig \
                     port:intltool \


### PR DESCRIPTION
Fix: https://trac.macports.org/ticket/60407; previous version 3.28.4 did
not build for me. Seems to work just by updating to later upstream
version. I did not test 3.36 or 3.37 evince branches.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.4 19E287
Xcode 11.4.1 11E503a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [n/a] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
