### PR TITLE
botan1: set cpu configure option only when defined

### DIFF
--- a/security/botan1/Portfile
+++ b/security/botan1/Portfile
@@ -81,7 +81,9 @@ array set merger_configure_args {
 }
 
 if {![variant_isset universal]} {
-    configure.args-append $merger_configure_args(${build_arch})
+    if {[info exists merger_configure_args(${build_arch})]} {
+        configure.args-append $merger_configure_args(${build_arch})
+    }
 }
 
 # configure.py rejects this argument


### PR DESCRIPTION
#### Description

The Portfile currently tries to set the `--cpu` arg from using a predefined array which has `build_arch` as the key. However, on linux the behaviour of `build_arch` is inconsistent and causes failure (no such element exists) when trying to parse the `Portfile`.

The documentation says that if cpu is not set it can try to set it automatically. 
https://botan.randombit.net/handbook/building.html#cpu-cpu

So, if in case it is not set using the array, we can let the build handle it itself. This should not affect any OSX devices.

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?