### PR TITLE
whitebox-tools: update to version 1.3.0

### DIFF
--- a/gis/whitebox-tools/Portfile
+++ b/gis/whitebox-tools/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        jblindsay whitebox-tools 1.2.0 v
+github.setup        jblindsay whitebox-tools 1.3.0 v
 categories          gis
 platforms           darwin
 maintainers         {@mholling gmail.com:mdholling} openmaintainer
@@ -15,86 +15,85 @@ homepage            https://jblindsay.github.io/ghrg/WhiteboxTools/index.html
 license             MIT
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  49e95f5c7fc91e2aaa0b813bcb9a069f93818360 \
-                    sha256  27c5aadb8105ffab3c83bc3eda1ec76469c71cab6f36002fbf8df8af4c6ab170 \
-                    size    7920772
+                    rmd160  67cc18a34fd4bd4edd81705da9e7f581488a8c13 \
+                    sha256  14ae2fb344d4dddac9ba44d359283dc3c63462a7ab62a9fd5ab781b9f3f8ad0e \
+                    size    7975126
 
 # When updating Portfile version, see instructions in cargo_fetch
 # PortGroup file for updating crate versions and checksums:
 
 cargo.crates \
-                    adler32 1.0.3 7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c \
-                    alga 0.9.1 d708cb68c7106ed1844de68f50f0157a7788c2909a6926fad5a87546ef6a4ff8 \
+                    adler32 1.0.4 5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2 \
+                    alga 0.9.3 4f823d037a7ec6ea2197046bafd4ae150e6bc36f9ca347404f46a46823fa84f2 \
                     approx 0.3.2 f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3 \
-                    autocfg 0.1.4 0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf \
-                    bitflags 1.1.0 3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd \
-                    build_const 0.2.1 39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39 \
-                    byteorder 1.3.1 a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb \
+                    autocfg 0.1.7 1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2 \
+                    autocfg 1.0.0 f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d \
+                    bitflags 1.2.1 cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
+                    byteorder 1.3.4 08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de \
                     bzip2 0.3.3 42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b \
-                    bzip2-sys 0.1.7 6584aa36f5ad4c9247f5323b0a42f37802b37a836f0ad87084d7a33961abe25f \
-                    c2-chacha 0.2.2 7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101 \
-                    cc 1.0.31 c9ce8bb087aacff865633f0bd5aeaed910fe2fe55b55f4739527f2e023a2e53d \
-                    cfg-if 0.1.7 11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4 \
-                    chrono 0.4.6 45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878 \
+                    bzip2-sys 0.1.8+1.0.8 05305b41c5034ff0e93937ac64133d109b5a2660114ec45e9760bc6816d83038 \
+                    cc 1.0.52 c3d87b23d6a92cd03af510a5ade527033f6aa6fa92161e2d5863a907d4c5e31d \
+                    cfg-if 0.1.10 4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
+                    chrono 0.4.11 80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2 \
                     cloudabi 0.0.3 ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
-                    crc 1.8.1 d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb \
                     crc32fast 1.2.0 ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1 \
-                    flate2 1.0.7 f87e68aa82b2de08a6e037f1385455759df6e445a8df5e005b4297191dbf18aa \
+                    flate2 1.0.14 2cfff41391129e0a856d6d822600b8d71179d46879e310417eb9c762eb178b42 \
                     fuchsia-cprng 0.1.1 a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba \
                     generic-array 0.12.3 c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec \
-                    getrandom 0.1.6 e65cce4e5084b14874c4e7097f38cab54f47ee554f9194673456ea379dcc4c55 \
-                    itoa 0.4.3 1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b \
+                    getrandom 0.1.14 7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb \
+                    hermit-abi 0.1.12 61565ff7aaace3525556587bd2dc31d4a07071957be715e63ce7b1eccf51a8f4 \
+                    itoa 0.4.5 b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e \
                     kdtree 0.6.0 80ee359328fc9087e9e3fc0a4567c4dd27ec69a127d6a70e8d9dd22845b8b1a2 \
-                    lazy_static 1.3.0 bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14 \
-                    libc 0.2.58 6281b86796ba5e4366000be6e9e18bf35580adf9e63fbe2294aadb587613a319 \
-                    libflate 0.1.21 7346a83e8a2c3958d44d24225d905385dc31fc16e89dffb356c457b278914d20 \
-                    libm 0.1.4 7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a \
+                    late-static 0.3.0 fa0fc01ae4c505cff39f8bf927b37a4799ef3309bb865f8cffad2fa3250439c2 \
+                    libc 0.2.69 99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005 \
+                    libm 0.2.1 c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a \
                     lzw 0.10.0 7d947cbb889ed21c2a84be6ffbaebf5b4e0f4340638cba0444907e38b56be084 \
-                    matrixmultiply 0.2.2 dcfed72d871629daa12b25af198f110e8095d7650f5f4c61c5bac28364604f9b \
-                    miniz_oxide 0.2.1 c468f2369f07d651a5d0bb2c9079f8488a66d5466efe42d0c5c6466edcb7f71e \
-                    miniz_oxide_c_api 0.2.1 b7fe927a42e3807ef71defb191dc87d4e24479b221e67015fe38ae2b7b447bab \
+                    matrixmultiply 0.2.3 d4f7ec66360130972f34830bfad9ef05c6610a43938a467bcc9ab9369ab3478f \
+                    miniz_oxide 0.3.6 aa679ff6578b1cddee93d7e82e263b94a575e0bfced07284eb0c037c1d2416a5 \
                     msdos_time 0.1.6 aad9dfe950c057b1bfe9c1f2aa51583a8468ef2a5baba2ebbe06d775efeb7729 \
-                    nalgebra 0.18.0 8e12856109b5cb8e2934b5e45e4624839416e1c6c1f7d286711a7a66b79db29d \
-                    num-complex 0.2.3 fcb0cf31fb3ff77e6d2a6ebd6800df7fdcd106f2ad89113c9130bcd07f93dffc \
-                    num-integer 0.1.39 e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea \
-                    num-traits 0.2.8 6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32 \
-                    num_cpus 1.10.0 1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba \
+                    nalgebra 0.18.1 aaa9fddbc34c8c35dd2108515587b8ce0cab396f17977b8c738568e4edb521a2 \
+                    num-complex 0.2.4 b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95 \
+                    num-integer 0.1.42 3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba \
+                    num-rational 0.2.4 5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef \
+                    num-traits 0.2.11 c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096 \
+                    num_cpus 1.13.0 05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3 \
+                    pdqselect 0.1.0 4ec91767ecc0a0bbe558ce8c9da33c068066c57ecc8bb8477ef8c1ad3ef77c27 \
                     podio 0.1.6 780fb4b6698bbf9cf2444ea5d22411cef2953f0824b98f33cf454ec5615645bd \
-                    ppv-lite86 0.2.5 e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b \
-                    proc-macro2 0.4.27 4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915 \
-                    quote 0.6.11 cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1 \
+                    ppv-lite86 0.2.6 74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b \
+                    proc-macro2 1.0.12 8872cf6f48eee44265156c111456a700ab3483686b3f96df4cf5481c89157319 \
+                    quote 1.0.4 4c1f4b0efa5fc5e8ceb705136bfee52cfdb6a4e3509f770b478cd6ed434232a7 \
                     rand 0.3.23 64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c \
                     rand 0.4.6 552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293 \
                     rand 0.6.5 6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca \
-                    rand 0.7.0 d47eab0e83d9693d40f825f86948aa16eff6750ead4bdffc4ab95b8b3a7f052c \
+                    rand 0.7.3 6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
                     rand_chacha 0.1.1 556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef \
-                    rand_chacha 0.2.0 e193067942ef6f485a349a113329140d0ab9e2168ce92274499bb0e9a4190d9d \
+                    rand_chacha 0.2.2 f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402 \
                     rand_core 0.3.1 7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b \
-                    rand_core 0.4.0 d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0 \
-                    rand_core 0.5.0 615e683324e75af5d43d8f7a39ffe3ee4a9dc42c5c701167a71dc59c3a493aca \
-                    rand_distr 0.2.1 c37e54d811c5a51195156444e298a98ba57df6dca1e511f34d4791993883b921 \
+                    rand_core 0.4.2 9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc \
+                    rand_core 0.5.1 90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
+                    rand_distr 0.2.2 96977acbdd3a6576fb1d27391900035bf3863d4a16422973a409b488cf29ffb2 \
                     rand_hc 0.1.0 7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4 \
                     rand_hc 0.2.0 ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
                     rand_isaac 0.1.1 ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08 \
                     rand_jitter 0.1.4 1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b \
                     rand_os 0.1.3 7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071 \
                     rand_pcg 0.1.2 abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44 \
-                    rand_pcg 0.2.0 3e196346cbbc5c70c77e7b4926147ee8e383a38ee4d15d58a08098b169e492b6 \
+                    rand_pcg 0.2.1 16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429 \
                     rand_xorshift 0.1.1 cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c \
-                    rawpointer 0.1.0 ebac11a9d2e11f2af219b8b8d833b76b1ea0e054aa0e8d8e9e4cbde353bdf019 \
+                    rawpointer 0.2.1 60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3 \
                     rdrand 0.4.0 678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2 \
-                    redox_syscall 0.1.51 423e376fffca3dfa06c9e9790a9ccd282fafb3cc6e6397d01dbf64f9bacc6b85 \
-                    ryu 1.0.0 c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997 \
-                    serde 1.0.94 076a696fdea89c19d3baed462576b8f6d663064414b5c793642da8dfeb99475b \
-                    serde_derive 1.0.94 ef45eb79d6463b22f5f9e16d283798b7c0175ba6050bc25c1a946c122727fe7b \
-                    serde_json 1.0.40 051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704 \
-                    spin 0.5.0 44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55 \
+                    rstar 0.7.1 0650eaaa56cbd1726fd671150fce8ac6ed9d9a25d1624430d7ee9d196052f6b6 \
+                    ryu 1.0.4 ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1 \
+                    serde 1.0.110 99e7b308464d16b56eba9964e4972a3eee817760ab60d88c3f86e1fecb08204c \
+                    serde_derive 1.0.110 818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984 \
+                    serde_json 1.0.53 993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2 \
                     statrs 0.9.0 7d8c8660e3867d1a0578cbf7fd9532f1368b7460bd00b080e2d4669618a9bec7 \
-                    syn 0.15.29 1825685f977249735d510a242a6727b46efe914bb67e38d30c071b1b72b1d5c2 \
-                    time 0.1.42 db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f \
-                    typenum 1.10.0 612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169 \
-                    unicode-xid 0.1.0 fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc \
-                    winapi 0.3.6 92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0 \
+                    syn 1.0.19 e8e5aa70697bb26ee62214ae3288465ecec0000f05182f039b477001f08f5ae7 \
+                    time 0.1.43 ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438 \
+                    typenum 1.12.0 373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33 \
+                    unicode-xid 0.2.0 826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c \
+                    wasi 0.9.0+wasi-snapshot-preview1 cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
+                    winapi 0.3.8 8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6 \
                     winapi-i686-pc-windows-gnu 0.4.0 ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
                     winapi-x86_64-pc-windows-gnu 0.4.0 712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
                     zip 0.3.3 77ce0ceee93c995954a31f77903925a6a8bb094709445238e344f2107910e29e


### PR DESCRIPTION
#### Description
Updates Whitebox Tools to version 1.3.0

###### Type(s)
- [x] enhancement

###### Tested on
macOS 10.14.6 18G103
Xcode command-line tools

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
