### PR TITLE
rust: update to 1.44.0

### DIFF
--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                rust
-version             1.43.1
+version             1.44.0
 revision            0
 categories          lang devel
 platforms           darwin
@@ -25,9 +25,9 @@ long_description    Rust is a curly-brace, block-structured expression \
 homepage            https://www.rust-lang.org/
 
 # Get from src/stage0.txt
-set ruststd_version 1.42.0
-set rustc_version   1.42.0
-set cargo_version   0.43.0
+set ruststd_version 1.43.1
+set rustc_version   1.43.1
+set cargo_version   0.44.0
 set llvm_version    9.0
 
 # can use cmake or cmake-devel; default to cmake.
@@ -47,23 +47,23 @@ distfiles-append    rust-std-${ruststd_version}-${build_arch}-apple-${os.platfor
                     cargo-${cargo_version}-${build_arch}-apple-${os.platform}${extract.suffix}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  074b72f9fe69342c6071ef254b96c32911710260 \
-                    sha256  cde177b4a8c687da96f20de27630a1eb55c9d146a15e4c900d5c31cd3c3ac41d \
-                    size    136095096
+                    rmd160  044d53a0aee5bcab32b9dce679d6b1c0f7a332d4 \
+                    sha256  bf2df62317e533e84167c5bc7d4351a99fdab1f9cd6e6ba09f51996ad8561100 \
+                    size    136756700
 
 checksums-append \
                     rust-std-${ruststd_version}-x86_64-apple-${os.platform}${extract.suffix} \
-                    rmd160  b6a5f43438bedda5415722acd87cd93871c43116 \
-                    sha256  1d61e9ed5d29e1bb4c18e13d551c6d856c73fb8b410053245dc6e0d3b3a0e92c \
-                    size    22972985 \
+                    rmd160  1ce3cf584ca9467e8a8836282fb959ae898fea54 \
+                    sha256  a08827bf42aa73c8795968c9df28b226668d994332f9ae1e6ec2b9f9935d9ddf \
+                    size    23405362 \
                     rustc-${rustc_version}-x86_64-apple-${os.platform}${extract.suffix} \
-                    rmd160  9cdf25b0b539943b752563c67a4467cf710baf8e \
-                    sha256  778dea93d7e46261e2c06cadec35b68f9857604f279ce6fbd1b37c1a89634625 \
-                    size    83826769 \
+                    rmd160  85cdbc98eefa53d4a1abc2a4a73e97f1fe616f05 \
+                    sha256  c7b92b5c3844b6f8201f1a5e41f91b257e764efb4a6bd960198ae60f03dec4bb \
+                    size    85765376 \
                     cargo-${cargo_version}-x86_64-apple-${os.platform}${extract.suffix} \
-                    rmd160  be99fef6ddeb53590b0f3976ff2d60d6c01b0923 \
-                    sha256  92d4c9fb4747dce158cdfb773651aea8eac894277f3a2de5aa2c3b9d92439d8e \
-                    size    5375241
+                    rmd160  088290f96dfb2c271d776f867ad6843426d1a6e8 \
+                    sha256  1071c520204a9e8fe4dd0de66a07a083f06abba16ac88f1df72231328a6395e6 \
+                    size    5608767
 
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
     known_fail yes


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
