### PR TITLE
qhull: update to 2020.1

### DIFF
--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -11,6 +11,7 @@ PortGroup           conflicts_build 1.0
 mpi.setup
 
 github.setup        OSGeo gdal 3.1.0 v
+revision            1
 categories          gis
 license             MIT BSD
 platforms           darwin

--- a/gis/libpcl/Portfile
+++ b/gis/libpcl/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 PortGroup           active_variants 1.1
 
 github.setup        PointCloudLibrary pcl 1.9.1 pcl-
-revision            1
+revision            2
 checksums           rmd160  223b36b48c9a77a1092bf0cbe8ed15e843c46386 \
                     sha256  943c618003c0a57046bca7c3b8e9a1e9a51b5f44545ffff9e1e744dd9304cf19 \
                     size    67161112

--- a/gis/saga/Portfile
+++ b/gis/saga/Portfile
@@ -9,7 +9,7 @@ name                saga
 categories          gis
 license             GPL
 version             7.3.0
-revision            1
+revision            2
 #set branch          [join [lrange [split ${version} .] 0 1] .]
 platforms           darwin
 maintainers         {vince @Veence} openmaintainer

--- a/math/octave/Portfile
+++ b/math/octave/Portfile
@@ -9,7 +9,7 @@ PortGroup           linear_algebra 1.0
 name                octave
 version             5.2.0
 set package_version 5.x.x
-revision            1
+revision            2
 categories          math science
 platforms           darwin
 license             GPL-3+

--- a/math/qhull/Portfile
+++ b/math/qhull/Portfile
@@ -31,7 +31,13 @@ checksums           rmd160  67f01d097e922055d45ce8a38c911fb22318b8ee \
                     sha256  0258bbf5de447e3d6b3968c5a7b51c08ca5d98f11f94f86621ed3e7c98365b8d \
                     size    1302031
 
-variant perf {
+variant perf description {obsolete variant, use 'native' instead} {
+    # remove after June 17, 2021
+    ui_warning "the variant 'perf' is obsolete, please use 'native' instead"
+    default_variants +native
+}
+
+variant native description {Build with best native support for local CPU capabilities} {
     configure.optflags  -O3 -pipe -march=native
 }
 

--- a/math/qhull/Portfile
+++ b/math/qhull/Portfile
@@ -2,19 +2,19 @@
 
 PortSystem 1.0
 PortGroup           cmake 1.1
+PortGroup           github 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
-name                qhull
-set                 vyear   2019
-set                 vext    1
-version             ${vyear}.${vext}
+github.setup        qhull qhull 2020.1
+github.tarball_from archive
 revision            0
+
 categories          math
 platforms           darwin
 maintainers         nomaintainer
 license             Permissive
 
-description Programs and library for computing convex hulls.
+description         Programs and library for computing convex hulls.
 long_description    \
     Qhull computes the convex hull, Delaunay triangulation, Voronoi \
     diagram, halfspace intersection about a point, furthest-site \
@@ -25,21 +25,12 @@ long_description    \
     also computes volumes, surface areas, and approximations to the \
     convex hull.
 
-homepage            http://www.qhull.org
-master_sites        ${homepage}/download
-distname            ${name}-${vyear}-src-7.3.2
-extract.suffix      .tgz
+homepage            https://www.qhull.org
 
-checksums           rmd160  cb7de690c87a050eb073e24458334d4da6e157d9 \
-                    sha256  2b7990558c363076261564f61b74db4d0d73b71869755108a469038c07dc43fb \
-                    size    1236686
+checksums           rmd160  67f01d097e922055d45ce8a38c911fb22318b8ee \
+                    sha256  0258bbf5de447e3d6b3968c5a7b51c08ca5d98f11f94f86621ed3e7c98365b8d \
+                    size    1302031
 
-worksrcdir          ${name}-${version}
-
-patch {
-    # fix for case-insensitive file systems
-    reinplace "s|Qhull/Qhull|cmake/Qhull|g" ${worksrcpath}/CMakeLists.txt
-}
 variant perf {
     configure.optflags  -O3 -pipe -march=native
 }
@@ -47,15 +38,16 @@ variant perf {
 # See https://trac.macports.org/ticket/51486
 compiler.blacklist  *gcc-4.2 {*gcc-4.[0-6]} {clang < 137}
 
-configure.args-append   -DDOC_INSTALL_DIR=share/doc/qhull -DMAN_INSTALL_DIR=share/man/man1
+configure.args-append   -DBIN_INSTALL_DIR=${prefix}/bin \
+                        -DLIB_INSTALL_DIR=${prefix}/lib \
+                        -DINCLUDE_INSTALL_DIR=${prefix}/include \
+                        -DDOC_INSTALL_DIR=${prefix}/share/doc/qhull \
+                        -DMAN_INSTALL_DIR=${prefix}/share/man/man1
 
 post-destroot {
     ln -s ${prefix}/include/libqhull ${destroot}${prefix}/include/qhull
     ln -s ${prefix}/include/libqhull/libqhull.h ${destroot}${prefix}/include/libqhull/qhull.h
     ln -s ${prefix}/lib/libqhullstatic.a ${destroot}${prefix}/lib/libqhull.a
 }
-livecheck.type      regex
-livecheck.url       ${master_sites}
-livecheck.regex     Download: Qhull (\[0-9.\]+) for Unix
 
 test.run  yes

--- a/math/qhull/Portfile
+++ b/math/qhull/Portfile
@@ -35,14 +35,16 @@ variant perf {
     configure.optflags  -O3 -pipe -march=native
 }
 
-# See https://trac.macports.org/ticket/51486
-compiler.blacklist  *gcc-4.2 {*gcc-4.[0-6]} {clang < 137}
+compiler.cxx_standard   2011
 
 configure.args-append   -DBIN_INSTALL_DIR=${prefix}/bin \
                         -DLIB_INSTALL_DIR=${prefix}/lib \
                         -DINCLUDE_INSTALL_DIR=${prefix}/include \
                         -DDOC_INSTALL_DIR=${prefix}/share/doc/qhull \
                         -DMAN_INSTALL_DIR=${prefix}/share/man/man1
+
+configure.cxxflags-append \
+                        -std=c++11
 
 post-destroot {
     ln -s ${prefix}/include/libqhull ${destroot}${prefix}/include/qhull

--- a/python/py-matplotlib/Portfile
+++ b/python/py-matplotlib/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-matplotlib
 version             3.2.1
-revision            0
+revision            1
 
 categories-append   graphics math
 platforms           darwin
@@ -56,7 +56,7 @@ if {${name} ne ${subport}} {
 
     if {${python.version} eq 27} {
         version     2.2.5
-        revision    0
+        revision    1
         distname    ${python.rootname}-${version}
         checksums   rmd160  4532a205e8f40d6f40346b2e461d3dca144b38b9 \
                     sha256  a3037a840cd9dfdc2df9fee8af8f76ca82bfab173c0f9468193ca7a89a2b60ea \
@@ -77,7 +77,7 @@ if {${name} ne ${subport}} {
 
     if {${python.version} eq 35} {
         version     3.0.3
-        revision    1
+        revision    2
         distname    ${python.rootname}-${version}
         checksums   rmd160  98ecd1ca25d555bde5d43fcaef800f7436d7d738 \
                     sha256  e1d33589e32f482d0a7d1957bf473d43341115d40d33f578dad44432e47df7b7 \

--- a/science/FreeSOLID/Portfile
+++ b/science/FreeSOLID/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                FreeSOLID
 version             2.1.2
-revision            1
+revision            2
 
 categories          science
 platforms           darwin

--- a/science/plplot/Portfile
+++ b/science/plplot/Portfile
@@ -10,7 +10,7 @@ if {[variant_isset octave]} {
 
 name            plplot
 version         5.15.0
-revision        2
+revision        3
 platforms       darwin
 maintainers     {takeshi @tenomoto} openmaintainer
 categories      science

--- a/science/plplot510/Portfile
+++ b/science/plplot510/Portfile
@@ -7,7 +7,7 @@ PortGroup       wxWidgets 1.0
 
 name            plplot510
 version         5.10.0
-revision        8
+revision        9
 platforms       darwin
 maintainers     {takeshi @tenomoto} openmaintainer
 categories      science

--- a/science/solid/Portfile
+++ b/science/solid/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 
 name                solid
 version             3.5.7
-revision            1
+revision            2
 categories          science math devel
 platforms           darwin
 license             {GPL-2 QPL-1}


### PR DESCRIPTION
#### Description
This PR updates `qhull` to its latest upstream version and now makes use of the `github` PG. 

I couldn't find a requirement for a ```c++11``` compatible compiler, but I cannot get it to compile without adding `-std=c++11` and `compiler.cxx_standard   2011`. The failures are listed in the commit message and I would appreciate it is someone more knowledgeable than me could take a look my solution is the correct/preferred on.

One other question is whether we should rename the `perf` variant to `native` which is more commonly used for this purpose in other ports.

Finally, I have rev-bumped all ports that depend on `qhull` since this version has "increased the SOVERSION to 8.0 due to ABI breakage in 2019.1"

###### Tested on
macOS 10.14.6 18G5033
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? One test fails with "child aborted" message, don't know why...
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
