### PR TITLE
spring-boot-cli: update to 2.3.1.RELEASE

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            spring-boot-cli
-version         2.3.0
+version         2.3.1
 revision        0
 
 categories      java
@@ -30,9 +30,9 @@ master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/
 
 distname        ${name}-${version}.RELEASE-bin
 
-checksums       rmd160  9ec7ebfc9edfbc26a147e00606486f9a8f4357ac \
-                sha256  48fcc9dbe429769a8910e4770cbd63c161fb6237035c6ca06338640e77fb7b4f \
-                size    11568376
+checksums       rmd160  a32c86255fe003ef01bbe4537f233d786a5ebcc7 \
+                sha256  e3ecaac5890c4078ac075239938d049c2eb72032dae32b0bc5c89dfb11f1a7ef \
+                size    11611676
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
#### Description

Update to Spring Boot 2.3.1.RELEASE.

###### Tested on

macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?