### PR TITLE
iperf3: remove --disable-profiling flag to fix build

### DIFF
--- a/net/iperf3/Portfile
+++ b/net/iperf3/Portfile
@@ -17,9 +17,6 @@ long_description    ${name} is a tool for active measurements of the maximum \
 
 depends_lib-append  path:lib/libssl.dylib:openssl
 
-configure.args-append \
-    --disable-profiling
-
 test.run            yes
 test.target         check
 


### PR DESCRIPTION
#### Description
Profiling is now disabled by default: 
https://github.com/esnet/iperf/commit/4a3efb37da2d60b150b0b29b0f4af4faf559079b

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
