### PR TITLE
openfortivpn: update to 1.14.1

### DIFF
--- a/net/openfortivpn/Portfile
+++ b/net/openfortivpn/Portfile
@@ -2,7 +2,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        adrienverge openfortivpn 1.10.0 v
+github.setup        adrienverge openfortivpn 1.14.1 v
 revision            1
 
 categories          net
@@ -21,6 +21,6 @@ depends_lib         path:lib/libssl.dylib:openssl
 
 use_autoreconf      yes
 
-checksums           rmd160  aef2a916fa68351599e1259d91e55003fbeba2ad \
-                    sha256  faacc5c0169b2e3c55ef8a34012811a23cbd8b2f86f333054a3934e37ad24f6e \
-                    size    74903
+checksums           rmd160  1a346cdbe9465e7c4d393af64f9cf30ec4f53e2e \
+                    sha256  36650d1a21b81f83772667d4b91958697149d7f1c616f76ccc5143406339c46c \
+                    size    155126

--- a/net/openfortivpn/Portfile
+++ b/net/openfortivpn/Portfile
@@ -1,9 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        adrienverge openfortivpn 1.14.1 v
-revision            1
+revision            0
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
#### Description

Upgrade to latest Openfortivpn

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G5033
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

As requested by the port maintainer: https://github.com/macports/macports-ports/pull/4637