### PR TITLE
aws-vault: new port

### DIFF
--- a/security/aws-vault/Portfile
+++ b/security/aws-vault/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/99designs/aws-vault 5.4.4 v
+
+description         A vault for securely storing and accessing AWS \
+                    credentials in development environments.
+
+long_description    AWS Vault is a tool to securely store and access AWS \
+                    credentials in a development environment.  AWS Vault \
+                    stores IAM credentials in your operating system's secure \
+                    keystore and then generates temporary credentials from \
+                    those to expose to your shell and applications. It's \
+                    designed to be complementary to the AWS CLI tools, and \
+                    is aware of your profiles and configuration in \
+                    ~/.aws/config.
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+categories          security
+license             MIT
+platforms           darwin
+installs_libs       no
+
+build.cmd           make
+build.pre_args      VERSION=${version}
+build.args          aws-vault-darwin-amd64
+
+checksums           rmd160  d71184316583cb7bbd07c245ecb63b02aba40d5c \
+                    sha256  91ae690dd400e0db317bce1b5af72fe1e2bd0e1195358db42023dcb4b0ffd70f \
+                    size    39658
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/aws-vault-darwin-amd64 \
+                    ${destroot}${prefix}/bin/${name}
+}


### PR DESCRIPTION
#### Description

New port for [aws-vault](https://github.com/99designs/aws-vault)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
