### PR TITLE
py-numpydoc: update to 1.0.0

### DIFF
--- a/python/py-numpydoc/Portfile
+++ b/python/py-numpydoc/Portfile
@@ -4,8 +4,11 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-numpydoc
-version             0.9.2
+version             1.0.0
+revision            0
+
 platforms           darwin
+supported_archs     noarch
 license             BSD
 maintainers         {mojca @mojca} openmaintainer
 
@@ -15,27 +18,30 @@ long_description    Numpydoc inserts a hook into Sphinx’s autodoc \
                     to a form palatable to Sphinx.
 
 homepage            https://github.com/numpy/numpydoc
-master_sites        pypi:n/${python.rootname}/
-distname            ${python.rootname}-${version}
 
-checksums           rmd160  de791bad34fe958841e1df7101931c1149d3453f \
-                    sha256  9140669e6b915f42c6ce7fef704483ba9b0aaa9ac8e425ea89c76fe40478f642 \
-                    size    27555
+checksums           rmd160  35e2ee29b71a2493ac95abaf39c913355ae184a2 \
+                    sha256  e481c0799dfda208b6a2c2cb28757fa6b6cbc4d6e43722173697996cf556df7f \
+                    size    42206
 
 python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
+    if {${python.version} == 27} {
+        version     0.9.2
+        checksums   rmd160  de791bad34fe958841e1df7101931c1149d3453f \
+                    sha256  9140669e6b915f42c6ce7fef704483ba9b0aaa9ac8e425ea89c76fe40478f642 \
+                    size    27555
+    }
+
     depends_build-append \
                         port:py${python.version}-setuptools \
                         port:py${python.version}-sphinx \
                         port:py${python.version}-jinja2
 
-    depends_test-append  \
-                        port:py${python.version}-nose \
-                        port:py${python.version}-pytest
+    depends_test-append port:py${python.version}-pytest
 
     test.run            yes
-    test.cmd            nosetests-${python.branch}
+    test.cmd            py.test-${python.branch}
     test.target
     test.env            PYTHONPATH=${worksrcpath}/build/lib
 


### PR DESCRIPTION
#### Description
This PR updates `py-numpydoc` to its latest version; with additionally the following changes:
- pin to version 0.9.2 for PY27
- add noarch
- update test-phase

###### Tested on
macOS 10.14.6 18G5033
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?