### PR TITLE
py-isodate: update to version 0.6.0

### DIFF
--- a/python/py-isodate/Portfile
+++ b/python/py-isodate/Portfile
@@ -5,8 +5,8 @@ PortGroup           python 1.0
 
 set base_name       isodate
 name                py-$base_name
-version             0.5.4
-python.versions     27 35 36 37
+version             0.6.0
+python.versions     27 35 36 37 38
 
 license             BSD
 platforms           darwin
@@ -22,22 +22,33 @@ long_description    This module implements ISO 8601 date, time and duration \
 homepage            https://pypi.python.org/pypi/$base_name
 master_sites        pypi:i/$base_name
 
-checksums           rmd160  8b483cedd72d92c3d0182a0d409672e1e21dc893 \
-                    sha256  42105c41d037246dc1987e36d96f3752ffd5c0c24834dd12e4fdbe1e79544e31
+checksums           rmd160  caa3c15705b67d1e8fbcc18536643818affbb306 \
+                    sha256  2e364a3d5759479cdb2d37cce6b9376ea504db2ff90252a2e5b7cc89cc9ff2d8 \
+                    size    28480
 
 distname            $base_name-${version}
 
 if {${name} ne ${subport}} {
-    depends_build-append    port:py${python.version}-setuptools
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-six
+
+# silence warnings for py37 py38
+# https://github.com/gweis/isodate/pull/60
+    patchfiles      patch-avoid-unclosed-file-warning.diff \
+                    patch-fix-py38-deprecationwarning.diff
 
     test.run        yes
-    test.cmd        ${python.bin} run_tests.py
+    test.cmd        ${python.bin} setup.py test
     test.target
 
     post-destroot {
         xinstall -m 644 -W ${worksrcpath} CHANGES.txt MANIFEST.in \
             README.rst TODO.txt ${destroot}${prefix}/share/doc/${subport}
     }
+
     livecheck.type  none
 } else {
     livecheck.type  regex

--- a/python/py-isodate/files/patch-avoid-unclosed-file-warning.diff
+++ b/python/py-isodate/files/patch-avoid-unclosed-file-warning.diff
@@ -1,0 +1,23 @@
+From 40358ac82b948ea8377d5ca32b576def31b39a84 Mon Sep 17 00:00:00 2001
+From: Jose Eduardo <jose.eduardo.gd@gmail.com>
+Date: Fri, 19 Jul 2019 16:21:56 +0100
+Subject: [PATCH] Avoid unclosed file warning
+
+---
+ setup.py | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/setup.py b/setup.py
+index e39446f..9634625 100644
+--- setup.py
++++ setup.py
+@@ -30,7 +30,8 @@
+ 
+ 
+ def read(*rnames):
+-    return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
++    with open(os.path.join(os.path.dirname(__file__), *rnames)) as read_file:
++        return read_file.read()
+ 
+ 
+ setup(name='isodate',

--- a/python/py-isodate/files/patch-fix-py38-deprecationwarning.diff
+++ b/python/py-isodate/files/patch-fix-py38-deprecationwarning.diff
@@ -1,0 +1,39 @@
+From fc0fb3278da5f463ca5b2f0a3acafbbf2869bd7a Mon Sep 17 00:00:00 2001
+From: Jose Eduardo <jose.eduardo.gd@gmail.com>
+Date: Fri, 19 Jul 2019 16:29:43 +0100
+Subject: [PATCH] Fix Python 3.8 DeprecationWarning
+
+Ref: https://docs.python.org/3.8/whatsnew/3.8.html
+
+> Many builtin and extension functions that take integer arguments will
+> now emit a deprecation warning for Decimals, Fractions and any other
+> objects that can be converted to integers only with a loss (e.g. that
+> have the `__int__()` method but do not have the `__index__()` method).
+> In future version they will be errors. (Contributed by Serhiy
+> Storchaka in bpo-36048.)
+---
+ src/isodate/duration.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/isodate/duration.py b/src/isodate/duration.py
+index 6d1848c..d923cee 100644
+--- src/isodate/duration.py
++++ src/isodate/duration.py
+@@ -180,7 +180,7 @@ def __add__(self, other):
+                 newday = maxdays
+             else:
+                 newday = other.day
+-            newdt = other.replace(year=newyear, month=newmonth, day=newday)
++            newdt = other.replace(year=int(newyear), month=int(newmonth), day=newday)
+             # does a timedelta + date/datetime
+             return self.tdelta + newdt
+         except AttributeError:
+@@ -264,7 +264,7 @@ def __rsub__(self, other):
+                 newday = maxdays
+             else:
+                 newday = other.day
+-            newdt = other.replace(year=newyear, month=newmonth, day=newday)
++            newdt = other.replace(year=int(newyear), month=int(newmonth), day=newday)
+             return newdt - self.tdelta
+         except AttributeError:
+             # other probably was not compatible with data/datetime


### PR DESCRIPTION
* add py38 subport
* update dependencies
* patch to fix py37 py38 warnings (https://github.com/gweis/isodate/pull/60)

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
