### PR TITLE
node_exporter: update to 1.0.1

### DIFF
--- a/net/node_exporter/Portfile
+++ b/net/node_exporter/Portfile
@@ -1,7 +1,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        prometheus node_exporter 1.0.0 v
+github.setup        prometheus node_exporter 1.0.1 v
 github.tarball_from archive
 
 description         Machine-metric exporter for the Prometheus monitoring \
@@ -33,9 +33,9 @@ installs_libs       no
 use_parallel_build  no
 
 checksums \
-  rmd160    4f4c1ce9fba0d047d6b37d36b5ec42525e25bdc6 \
-  sha256    2d82dac251e789b75879ebf1ebe94d1dc15c59ffa28ffe4e15b8d2ff63190607 \
-  size      2779482
+  rmd160    c1bf34bc93f44db6fefc47a0fac86cd03de5b049 \
+  sha256    a841bf3e236376840be9e1d8e6c4a38196be6f3957b0982d1c7970a5e416b0ad \
+  size      2792033
 
 set svc_name        prometheus-node-exporter
 set prom_user       prometheus
@@ -115,6 +115,10 @@ To enable the Prometheus Node Exporter service, use `port load`, as follows:
 
 \$ sudo port load ${name}
 
-When enabled, the service will log to:
-${ne_log_file}
+When enabled, by default, the service will be available at http://localhost:9100
+
+...and by default will also log to:
+
+  ${ne_log_file}
+
 "


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
