### PR TITLE
salt: Install all launchd plists in main port

### DIFF
--- a/sysutils/salt/Portfile
+++ b/sysutils/salt/Portfile
@@ -1,9 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem        1.0
+PortGroup               github 1.0
+PortGroup               python 1.0
 
-name              salt
-version           3000.3
+github.setup            saltstack salt 3000.3 v
+revision                1
+checksums               rmd160  f1c2a4f0609c3cd64f3b98c3a3bf8efe39703c75 \
+                        sha256  c5c16a328b7971fecf1dc8902f2315387894613b198581c090063abc67df8fb7 \
+                        size    15255885
+
 categories        sysutils python
 platforms         darwin
 maintainers       {gmail.com:jeremy.mcmillan @aphor} openmaintainer
@@ -15,21 +21,6 @@ long_description  SaltStack is fast, scalable and flexible software for data \
                   center automation, from infrastructure and any cloud, \
                   to the entire application stack.
 homepage          https://saltstack.com/
-
-if {$subport eq $name} {
-    PortGroup               github 1.0
-    PortGroup               python 1.0
-
-    github.setup            saltstack salt ${version} v
-    revision                0
-
-    categories              sysutils python
-
-    checksums rmd160 f1c2a4f0609c3cd64f3b98c3a3bf8efe39703c75 \
-              sha256 c5c16a328b7971fecf1dc8902f2315387894613b198581c090063abc67df8fb7 \
-              size   15255885
-
-    notes    "Salt startupitems are installed by subports salt-minion, salt-master, salt-syndic, salt-api."
 
     if {![variant_isset python35] && ![variant_isset python36] && ![variant_isset python37]} {
         default_variants +python38
@@ -60,8 +51,6 @@ if {$subport eq $name} {
                             port:py${python.version}-zmq
 
         destroot.cmd-append --with-salt-version=${version}
-
-        notes    "Salt startupitems are installed by subports salt-minion, salt-master, salt-syndic, salt-api."
     }
 
     variant python36 conflicts python35 python37 python38 description {python-3.6 support} {
@@ -145,6 +134,16 @@ if {$subport eq $name} {
         destroot.cmd-append --with-salt-version=${version}
     }
 
+pre-fetch {
+    # Setting startupitems' executable with args didn't
+    # work in MacPorts 2.6.2 and earlier. See
+    # https://github.com/macports/macports-base/pull/191
+    if {[vercmp [macports_version] 2.6.3] < 0} {
+        ui_error "${name} @${version} requires MacPorts 2.6.3 or later"
+        return -code error "incompatible MacPorts version"
+    }
+}
+
     patchfiles patch-macports_syspaths.diff
 
     post-patch {
@@ -179,21 +178,31 @@ test.args               --log-file=${worksrcpath}/build/minion.log \
                         --local \
                         --id=local
 
-}
+startupitem.create      yes
+startupitem.netchange   yes
+startupitem.logevents   yes
+set daemons             {minion master syndic api}
+foreach daemon ${daemons} {
+    startupitems-append \
+        name            ${name}-${daemon} \
+        logfile         ${prefix}/var/log/${name}/${daemon} \
+        executable      "${prefix}/bin/${name}-${daemon} --config-dir=${prefix}/etc/${name} --pid-file=${prefix}/var/run/${name}-${daemon}.pid"
 
-foreach daemon [list minion master syndic api] {
-    subport salt-${daemon} {
-        startupitem.create       yes
-        startupitem.name         salt-${daemon}
-        startupitem.netchange    yes
-        startupitem.logevents    yes
-        startupitem.logfile      ${prefix}/var/log/salt/${daemon}
-        startupitem.executable   ${prefix}/bin/salt-${daemon} --config-dir=${prefix}/etc/salt --pid-file=${prefix}/var/run/salt-${daemon}.pid
-        depends_run              port:salt
-        description              install startupitem for salt-${daemon}
-        use_configure            no
-        distfiles
-        build {}
-        destroot {}
+    # These subports and deactivate hacks can be removed after July 2021.
+    subport ${name}-${daemon} {
+        revision        1
+        replaced_by     ${name}
+    }
+}
+pre-activate {
+    foreach daemon ${daemons} {
+        # ${name}-${daemon} <= 3000.3_0 installed plists now installed by ${name}.
+        if {![catch {set installed [lindex [registry_active ${name}-${daemon}] 0]}]} {
+            set installed_version [lindex ${installed} 1]
+            set installed_revision [lindex ${installed} 2]
+            if {([vercmp ${installed_version} 3000.3] < 0) || ([vercmp ${installed_version} 3000.3] == 0 && ${installed_revision} == 0)} {
+                registry_deactivate_composite ${name}-${daemon} {} [list ports_nodepcheck 1]
+            }
+        }
     }
 }


### PR DESCRIPTION
#### Description

The salt-minion, salt-master, salt-syndic and salt-api subports only install a single launchd plist each. Presumably this was done because MacPorts used to only be able to create a single launchd plist per port. Two years ago, the `startupitems` functionality was added to MacPorts, allowing each port to install multiple launchd plists. This PR simplifies the port by deprecating the subports and having the main port install all the launchd plists.

Unfortunately while implementing this change I discovered that the `startupitems` functionality had a bug, so **THIS PR SHOULD NOT BE MERGED** until after https://github.com/macports/macports-base/pull/191 is merged and a new version of MacPorts base containing that fix is released. The MacPorts version number check added by this PR may need to be updated, depending on the version of MacPorts in which the fix is released.

This PR leaves the port's whitespace in an inconsistent state, but further functional changes and ultimately unifying whitespace changes are planned.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G12034
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
