### PR TITLE
ttyrec: Fix "Out of pty's" error

### DIFF
--- a/sysutils/ttyrec/Portfile
+++ b/sysutils/ttyrec/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                ttyrec
 version             1.0.8
-revision            1
+revision            2
 categories          sysutils
 maintainers         {cal @neverpanic} openmaintainer
 platforms           darwin
@@ -19,10 +19,15 @@ long_description    \
 homepage            http://0xcc.net/ttyrec/
 master_sites        ${homepage}
 
-checksums           sha256  ef5e9bf276b65bb831f9c2554cd8784bd5b4ee65353808f82b7e2aef851587ec \
-                    rmd160  f7538fa742d1c1e07b8b48f3fa79cfcf13ca8044
+checksums           rmd160  f7538fa742d1c1e07b8b48f3fa79cfcf13ca8044 \
+                    sha256  ef5e9bf276b65bb831f9c2554cd8784bd5b4ee65353808f82b7e2aef851587ec \
+                    size    8528
 
 use_configure       no
+
+patchfiles          patch-ttyrec.c-openpty-in-utilh.diff
+configure.cflags-append \
+                    -DHAVE_openpty
 
 variant universal {}
 

--- a/sysutils/ttyrec/files/patch-ttyrec.c-openpty-in-utilh.diff
+++ b/sysutils/ttyrec/files/patch-ttyrec.c-openpty-in-utilh.diff
@@ -1,0 +1,18 @@
+ttyrec: Use openpty from util.h
+
+macOS ships openpty(3) in util.h, not libutil.h. Fix this by changing the
+include.
+
+Upstream-Status: Inappropriate [configuration]
+
+--- ttyrec.c.orig	2020-06-17 01:25:44.000000000 +0200
++++ ttyrec.c	2020-06-17 01:25:55.000000000 +0200
+@@ -71,7 +71,7 @@
+ #define _(FOO) FOO
+ 
+ #ifdef HAVE_openpty
+-#include <libutil.h>
++#include <util.h>
+ #endif
+ 
+ #if defined(SVR4) && !defined(CDEL)


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/60280

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G5033
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
