### PR TITLE
zeal: new port

### DIFF
--- a/devel/zeal/Portfile
+++ b/devel/zeal/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+PortGroup           qt5 1.0
+
+github.setup        zealdocs zeal 0.6.1 v
+categories          devel
+platforms           darwin
+license             GPL-3+
+maintainers         {@sikmir gmail.com:sikmir} openmaintainer
+
+description         Offline documentation browser
+long_description    Zeal is a simple offline documentation \
+                    browser inspired by Dash.
+homepage            https://zealdocs.org/
+
+checksums           rmd160  4149ec839f0bfd3a73bb452fbc08152145d73f9d \
+                    sha256  084fb42bcc3756c431cefb8ceb65b815625b178a224bb24c7e605f05340ff10d \
+                    size    1064016
+
+depends_lib-append  port:libarchive \
+                    port:sqlite3
+
+qt5.depends_component qtwebkit
+
+destroot {
+    copy ${destroot.dir}/bin/Zeal.app ${destroot}${applications_dir}
+}


### PR DESCRIPTION
#### Description
[Zeal](https://zealdocs.org/) is an offline documentation browser for software developers inspired by [Dash](https://kapeli.com/dash).

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
