### PR TITLE
alertmanager: update to 0.21.0

### DIFF
--- a/net/alertmanager/Portfile
+++ b/net/alertmanager/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        prometheus alertmanager 0.20.0 v
+github.setup        prometheus alertmanager 0.21.0 v
 github.tarball_from archive
 
 description         The Alertmanager handles alerts sent by client \
@@ -36,9 +36,9 @@ use_parallel_build  no
 
 distfiles           alertmanager-${version}${extract.suffix}:main
 
-checksums   rmd160  8c108540f1460557f9f44e2579c19c7febbd96bc \
-            sha256  4789ef95b09ba86a66a2923c3535d1bfe30a566390770784c52052c7c83ee1bc \
-            size    5837531
+checksums   rmd160  198803ec96526154d70cacc77fd4587407f911eb \
+            sha256  1e7749588de13ff3dcf90bd7813ada69b92f5469c15d5dface19d1a279480e50 \
+            size    5704209
 
 set svc_name        prometheus-alertmanager
 set prom_user       prometheus
@@ -134,9 +134,11 @@ To enable the Prometheus AlertManager service, use `port load`, as follows:
 
 \$ sudo port load ${name}
 
-When enabled, the service will log to:
+When enabled, the service will:
 
-  ${am_log_file}
+  - listen by default on http://localhost:9093
+
+  - log to: ${am_log_file}
 
 Configuration for AlertManager can be found at:
 


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
