### PR TITLE
hashcat: update to 6.0.0

### DIFF
--- a/security/hashcat/Portfile
+++ b/security/hashcat/Portfile
@@ -1,19 +1,16 @@
 # -*- coding: utf-8; mode: _tcl; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- vim:fenc=utf-8:ft=tcl:et:sw=2:ts=2:sts=2
 
 PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               makefile 1.0
 
-name                    hashcat
-version                 5.1.0
-master_sites            https://hashcat.net/files/
-
-checksums               rmd160  af192e07415d8b24cfa305e5a3e9b9dcca6ab8b1 \
-                        sha256  283beaa68e1eab41de080a58bb92349c8e47a2bb1b93d10f36ea30f418f1e338 \
-                        size    4266878
+github.setup            hashcat hashcat 6.0.0 v
 
 categories              security
 license                 MIT
 platforms               darwin
 maintainers             @gaming-hacker openmaintainer
+
 description             World's fastest and most advanced password recovery utility.
 
 long_description        hashcat is the world's fastest and most advanced \
@@ -25,9 +22,9 @@ long_description        hashcat is the world's fastest and most advanced \
 
 homepage                https://hashcat.net/hashcat/
 
-use_configure           no
+build.target            {}
 
-build.env-append        PREFIX=${prefix}
-build.target
+checksums               rmd160  c53d308a1b89e1d48ef26d2f9bf1146e9368d5bf \
+                        sha256  92540830c0078254a4b90bdcd6a329add2da85dd85002725d91bd6948a2486ee \
+                        size    5365734
 
-destroot.env-append     PREFIX=${prefix}


### PR DESCRIPTION
- use release from Github

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
