### PR TITLE
sshuttle: update to 1.0.2

### DIFF
--- a/net/sshuttle/Portfile
+++ b/net/sshuttle/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        sshuttle sshuttle 1.0.1 v
+github.setup        sshuttle sshuttle 1.0.2 v
 fetch.type          git
 revision            0
 
@@ -19,10 +19,7 @@ platforms           darwin
 license             LGPL-2
 homepage            https://sshuttle.readthedocs.io/en/stable/
 
-python.default_version          38
-python.versions     27 35 36 37 38
+python.default_version 38
 
-depends_build-append port:py${python.version}-setuptools \
-                     port:py${python.version}-setuptools_scm
-
-depends_run-append  port:py${python.version}-setuptools
+depends_build-append port:py${python.version}-setuptools_scm
+depends_lib-append   port:py${python.version}-setuptools


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
