### PR TITLE
py-graph-tool: update to 2.33

### DIFF
--- a/python/py-graph-tool/Portfile
+++ b/python/py-graph-tool/Portfile
@@ -6,27 +6,27 @@ PortGroup           active_variants 1.1
 
 set realname        graph-tool
 name                py-${realname}
-version             2.29
+version             2.33
 revision            0
 epoch               20190711
 categories          python science
 platforms           darwin
-license             GPL-3
-maintainers         {skewed.de:tiago @count0}
+license             LGPL-3
+maintainers         nomaintainer
 description         Efficient python graph module
 long_description    graph-tool is an efficient python module for manipulation \
                     and statistical analysis of graphs. The internal data \
                     structures and most algorithms are implemented in C++ with \
                     the Boost Graph Library.
-homepage            http://graph-tool.skewed.de
-master_sites        http://downloads.skewed.de/graph-tool/
+homepage            https://graph-tool.skewed.de
+master_sites        https://downloads.skewed.de/graph-tool/
 use_bzip2           yes
-checksums           rmd160  ad784fc2ffe7dd745d8cadfd90bae2a03eef3116 \
-                    sha256  6c0c4336bed6e2f79c91ace6d6914145ee03d0bd5025473b5918aec2b0657f7a \
-                    size    15068583
+checksums           rmd160  5eecb61bacb6a26d211f9c3c43c2b3641cb9f9bf \
+                    sha256  f07025160a8cb376551508c6d8aa5fd05a146c67c4706ea4635d2766aa5c9fcb \
+                    size    15153528
 distname            ${realname}-${version}
 
-python.versions     27 35 36 37
+python.versions     27 35 36 37 38
 python.default_version 27
 
 if {${os.major} <= 12 && ${os.platform} eq "darwin"} {
@@ -42,21 +42,12 @@ if {${os.major} <= 12 && ${os.platform} eq "darwin"} {
         compiler.cxx_standard   2017
 
         variant openmp description "Enable OpenMP" {
-            # make sure libomp is installed at runtime, even if the compiler gets uninstalled
-            depends_lib-append    lib:${prefix}/lib/libomp/libomp:libomp
+            # TODO: verify OpenMP version required
+            compiler.openmp_version 2.5
             configure.args-append --enable-openmp
         }
 
-        variant clang60 requires openmp conflicts clang70 description "Use clang-6.0 and enable OpenMP" {
-            configure.compiler  macports-clang-6.0
-        }
-        variant clang70 requires openmp conflicts clang60 description "Use clang-7.0 and enable OpenMP" {
-            configure.compiler  macports-clang-7.0
-        }
         default_variants +openmp
-        if {![variant_isset clang60]} {
-            default_variants-append +clang70
-        }
     }
 }
 
@@ -82,37 +73,21 @@ if {${name} ne ${subport}} {
 
     # PYTHON_EXTRA_LDFLAGS is set to work around incorrect detection of
     # link flags by configure
-    if {[vercmp [macports_version] 2.5.99] >= 0} {
     configure.env-append PYTHON=${python.bin} \
                          PYTHON_VERSION=${python.branch} \
                          PYTHON_CPPFLAGS=-I${python.include} \
                          "PYTHON_LDFLAGS=-L${python.libdir}/.. -lpython${python.branch}" \
                          "PYTHON_EXTRA_LDFLAGS=-L${python.libdir}/.. -lpython${python.branch}"
-    } else {
-    configure.env-append PYTHON=${python.bin} \
-                         PYTHON_VERSION=${python.branch} \
-                         PYTHON_CPPFLAGS=-I${python.include} \
-                         PYTHON_LDFLAGS="-L${python.libdir}/.. -lpython${python.branch}" \
-                         PYTHON_EXTRA_LDFLAGS="-L${python.libdir}/.. -lpython${python.branch}"
-    }
     # With python2.7 PYTHON_EXTRA_LIBS is determined to be
     # '-u _PyMac_Error Python.framework/Versions/2.7/Python'. Not clear whether
     # python2.7 or py-graph-tool's configure script is to blame, but we can easily
     # work around this:
     if {${python.version} eq "27"} {
-        if {[vercmp [macports_version] 2.5.99] >= 0} {
         configure.env-append "PYTHON_EXTRA_LIBS=-u _PyMac_Error"
-        } else {
-        configure.env-append PYTHON_EXTRA_LIBS="-u _PyMac_Error"
-        }
     }
     # Something similar is happening with python3.6
     if {${python.version} eq "36"} {
-        if {[vercmp [macports_version] 2.5.99] >= 0} {
         configure.env-append "PYTHON_EXTRA_LIBS=-Wl,-stack_size,1000000 -framework CoreFoundation ${python.lib}"
-        } else {
-        configure.env-append PYTHON_EXTRA_LIBS="-Wl,-stack_size,1000000 -framework CoreFoundation ${python.lib}"
-        }
     }
     configure.cppflags-append -I${prefix}/include -I${python.include}/..
     configure.ldflags-append -L${prefix}/lib


### PR DESCRIPTION
 Project has switched to LGPL-3 license

Remove skewed.de:tiago from maintainers: https://git.io/JJk0q

Use compiler.openmp_version option introduced in MacPorts 2.6.0
See https://trac.macports.org/wiki/CompilerSelection
Remove unneeded `+clang*` variants

Cleanup MacPorts pre-2.6.0 handling in portfile

Add `py38` subport

Use HTTPS URLs
#### Description
See earlier attempt #6915

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5
Xcode command line tools 11.5
Clang 9.0.1
Python 3.8.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
Builds successfully, but takes very long. (Current version 2.29 does not build successfully for me.)
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
