### PR TITLE
beekeeper-studio: update to 1.5.2

### DIFF
--- a/aqua/beekeeper-studio/Portfile
+++ b/aqua/beekeeper-studio/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        beekeeper-studio beekeeper-studio 1.5.1 v
+github.setup        beekeeper-studio beekeeper-studio 1.5.2 v
 revision            0
 
 homepage            https://beekeeperstudio.io/
@@ -29,9 +29,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  21f168d3bdfbac68569ec30f493827a556f1ed7d \
-                    sha256  1bb51dce33a887509254f2f3bd60047fbd15ad80e3716bcd90d4846bf02371bb \
-                    size    43914935
+                    rmd160  e283ac6289cf54225718008bf5459741dae57a29 \
+                    sha256  3f9f902c079ea85ba0907dc5a03a235a015bf31ff0c16300514e8a1e5acc8d5b \
+                    size    44123907
 
 depends_build       port:go \
                     port:yarn


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
