### PR TITLE
xdelta: Add file's size to checksums and set maintainer to nomaintainer

### DIFF
--- a/archivers/xdelta/Portfile
+++ b/archivers/xdelta/Portfile
@@ -17,7 +17,8 @@ github.tarball_from releases
 distname            xdelta3-${version}
 
 checksums           rmd160  2e6dd8cfab9434f1354f98eb316a0d50970e049c \
-                    sha256  114543336ab6cee3764e3c03202701ef79d7e5e8e4863fe64811e4d9e61884dc
+                    sha256  114543336ab6cee3764e3c03202701ef79d7e5e8e4863fe64811e4d9e61884dc \
+                    size    727607
 
 depends_lib         port:xz
 

--- a/archivers/xdelta/Portfile
+++ b/archivers/xdelta/Portfile
@@ -4,7 +4,7 @@ PortGroup           github 1.0
 github.setup        jmacd xdelta-devel 3.1.0 v
 name                xdelta
 categories          archivers
-maintainers         {perry @lperry} openmaintainer
+maintainers         nomaintainer
 platforms           darwin
 
 description         open-source binary diff, differential compression tools, \


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?