### PR TITLE
xsv: Update maintainer and add additional checksums and sizes for crates

### DIFF
--- a/textproc/xsv/Portfile
+++ b/textproc/xsv/Portfile
@@ -59,10 +59,182 @@ cargo.crates \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f
 
-checksums-append    ${distname}${extract.suffix} \
+checksums           ${distname}${extract.suffix} \
                     rmd160  7a82208d831582841b2d8bd2faa78c9acab0032c \
                     sha256  fd333294b3a21d3d090238c169e8825b7b9d0e6fc206f5b455c8d8371e312538 \
-                    size    60542
+                    size    60542 \
+                    aho-corasick-0.6.4.crate \
+                    sha256  d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4 \
+                    rmd160  64351ab3da703b5276bba7e1c332ac7e50a5fb63 \
+                    size    25443 \
+                    bitflags-1.0.3.crate \
+                    sha256  d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789 \
+                    rmd160  f64aa6bf708e5e7a943d40cdf59e852a3befee33 \
+                    size    13838 \
+                    byteorder-1.2.2.crate \
+                    sha256  73b5bdfe7ee3ad0b99c9801d58807a9dbc9e09196365b0203853b99889ab3c87 \
+                    rmd160  cd84a9f1aaadc9c826b21e285b16a5381b77598f \
+                    size    18909 \
+                    cfg-if-0.1.3.crate \
+                    sha256  405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18 \
+                    rmd160  95f39d854fe55b262013fd33ede063bb5343c181 \
+                    size    7115 \
+                    chan-0.1.21.crate \
+                    sha256  9af7c487bb99c929ba2715b1a3a7bf45f5062bf5b6eae5d32b292a96c5865172 \
+                    rmd160  7acc846de215bd2fd77c54d8773a14c5ef534e3c \
+                    size    26435 \
+                    csv-1.0.0.crate \
+                    sha256  71903184af9960c555e7f3b32ff17390d20ecaaf17d4f18c4a0993f2df8a49e3 \
+                    rmd160  2e26c5db3543baef70d679b7a69f299a2fd373e6 \
+                    size    888471 \
+                    csv-core-0.1.4.crate \
+                    sha256  4dd8e6d86f7ba48b4276ef1317edc8cc36167546d8972feb4a2b5fec0b374105 \
+                    rmd160  c768ee704b849226b490f41e9d9713e540f33d07 \
+                    size    25406 \
+                    csv-index-0.1.5.crate \
+                    sha256  7b27beef016f9d0d43fd1f6097a469d1ccccd2191888f5dfeb4e7be7dbc8bfc6 \
+                    rmd160  f9ac4ca0ad4bcd65fad79cd821aef528b158cfed \
+                    size    5981 \
+                    docopt-1.0.0.crate \
+                    sha256  e67fb750c36fc6fffbd3575cf8f2b46790fc0b05096ae3c03a36cf71b55e1e2b \
+                    rmd160  21e60993d3a765f2b3a0c43e363112c386845a08 \
+                    size    40894 \
+                    filetime-0.1.15.crate \
+                    sha256  714653f3e34871534de23771ac7b26e999651a0a228f47beb324dfdf1dd4b10f \
+                    rmd160  ca0934509457cfc9a4f1b5026c3c5f7844809ffe \
+                    size    11211 \
+                    fuchsia-zircon-0.3.3.crate \
+                    sha256  2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
+                    rmd160  1c6ff549ecff64347e4b53dc8eb95d1444b78647 \
+                    size    22565 \
+                    fuchsia-zircon-sys-0.3.3.crate \
+                    sha256  3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
+                    rmd160  4b9e5d77223362e647972d7ccc66f69236aa1e89 \
+                    size    7191 \
+                    lazy_static-1.0.0.crate \
+                    sha256  c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d \
+                    rmd160  b3be9fd42b94bb13ff7971303fd61c3069c16327 \
+                    size    12611 \
+                    libc-0.2.40.crate \
+                    sha256  6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b \
+                    rmd160  12e732bd3fc6fd7aff2495981d46137d56fe73de \
+                    size    327272 \
+                    log-0.4.1.crate \
+                    sha256  89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2 \
+                    rmd160  7f3f029ecc7321bf7105603f50094bdc5ff6820f \
+                    size    20731 \
+                    memchr-2.0.1.crate \
+                    sha256  796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d \
+                    rmd160  4894e0ad3a987cf78a6b4be9974e830865db22c5 \
+                    size    9858 \
+                    num-traits-0.2.4.crate \
+                    sha256  775393e285254d2f5004596d69bb8bc1149754570dcc08cf30cabeba67955e28 \
+                    rmd160  86519191b7d8f7689fcef212077dd1f69db92893 \
+                    size    38463 \
+                    num_cpus-1.8.0.crate \
+                    sha256  c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30 \
+                    rmd160  98a3c4f2f1e5e0d7801fe583766f7062c6dd6510 \
+                    size    10539 \
+                    proc-macro2-0.3.8.crate \
+                    sha256  1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7 \
+                    rmd160  ac91272dd78b5d07f44d25153d381ff33555ad92 \
+                    size    24412 \
+                    quickcheck-0.6.2.crate \
+                    sha256  c01babc5ffd48a2a83744b3024814bb46dfd4f2a4705ccb44b1b60e644fdcab7 \
+                    rmd160  e2ad227d3fcc5a089a87cf74ab111c495a6985a7 \
+                    size    24634 \
+                    quote-0.5.2.crate \
+                    sha256  9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8 \
+                    rmd160  ce9f8617754b5b7335887d3a0fea383e7978437a \
+                    size    14982 \
+                    rand-0.3.22.crate \
+                    sha256  15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1 \
+                    rmd160  b205c1039b3f9dc31f58377d27ec3656e7bc4910 \
+                    size    11318 \
+                    rand-0.4.2.crate \
+                    sha256  eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5 \
+                    rmd160  a35c3c8c78007c0bee72082834bb8ed0eccd025e \
+                    size    76170 \
+                    redox_syscall-0.1.37.crate \
+                    sha256  0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd \
+                    rmd160  ab09d6a7a17c7ebbef7fab079e6d0098f590b888 \
+                    size    13980 \
+                    regex-1.0.0.crate \
+                    sha256  75ecf88252dce580404a22444fc7d626c01815debba56a7f4f536772a5ff19d3 \
+                    rmd160  3fa314192670f8063e1d2798f5cba16fafcb95ea \
+                    size    210131 \
+                    regex-syntax-0.6.0.crate \
+                    sha256  8f1ac0f60d675cc6cf13a20ec076568254472551051ad5dd050364d70671bf6b \
+                    rmd160  45abd57e72c02d0d5b2f8c3c7a78ad840b25ea53 \
+                    size    233363 \
+                    serde-1.0.54.crate \
+                    sha256  db9c1726bdebaed7ac8afb7028672e068e12cf1b0b97cddd742a3a7939159699 \
+                    rmd160  8293b5346a7987feecc8e6521178a95e6eecd0d1 \
+                    size    68103 \
+                    serde_derive-1.0.54.crate \
+                    sha256  5121751b76f5a2e6f51b4c0d07976f4f04e33ae7a981467c2845e7cd4b67a114 \
+                    rmd160  0138dc31976e22f220b66f7bd8b6eec8fe208a05 \
+                    size    45143 \
+                    streaming-stats-0.2.0.crate \
+                    sha256  4f233aa550ceeb22c47cff12e167f7bc89c03e265e7fcff64b8359bb6799e0f4 \
+                    rmd160  05646f717a8e776ed9e5c596bf32ea315e1ad5dd \
+                    size    8813 \
+                    strsim-0.7.0.crate \
+                    sha256  bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550 \
+                    rmd160  82c766cebe88a39e3058a21c730b43b3bf6e929d \
+                    size    8435 \
+                    syn-0.13.9.crate \
+                    sha256  505550dded6ff93eb63bd9d0ada380ffccd9f51c046a5e80a3078d53fcef0038 \
+                    rmd160  bd49274e832ad683e5d8548afcbeb9ad5d47c972 \
+                    size    134214 \
+                    tabwriter-1.0.4.crate \
+                    sha256  56ab9ac71e2a71d113e4568ab0a89e2182f0fc214d2e4952c6e5655cb8eac4dd \
+                    rmd160  e4b7a34f8caa81606397248b4125eeeb1f286879 \
+                    size    8218 \
+                    thread_local-0.3.5.crate \
+                    sha256  279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963 \
+                    rmd160  5d166aed0e0aa52f1ec4e0cd440aa2b5a00c878e \
+                    size    11794 \
+                    threadpool-1.7.1.crate \
+                    sha256  e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865 \
+                    rmd160  157de7ec7a56f597cb4f141c61eff8d66627cb75 \
+                    size    15756 \
+                    ucd-util-0.1.1.crate \
+                    sha256  fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d \
+                    rmd160  b36f310b6d4808dc0b20f217727a592eb48b3e05 \
+                    size    24221 \
+                    unicode-width-0.1.4.crate \
+                    sha256  bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f \
+                    rmd160  b4bf85b49ebae6b6f89f6fe6c75785b7cf8e1984 \
+                    size    15283 \
+                    unicode-xid-0.1.0.crate \
+                    sha256  fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc \
+                    rmd160  fc5a8141e55bf6e2660b8c588e1107f179d24bb8 \
+                    size    16000 \
+                    unreachable-1.0.0.crate \
+                    sha256  382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56 \
+                    rmd160  00c79ce6e523b3b09978db8766e3110a637c23ec \
+                    size    6355 \
+                    utf8-ranges-1.0.0.crate \
+                    sha256  662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122 \
+                    rmd160  1b4d6305dd44df57dc34555b7064df1da1d462fd \
+                    size    8599 \
+                    void-1.0.2.crate \
+                    sha256  6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d \
+                    rmd160  5d76f91beb625f5b645c156ca45ee5138e984e80 \
+                    size    2356 \
+                    winapi-0.3.4.crate \
+                    sha256  04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3 \
+                    rmd160  ccf5ba89fc27ec1d28848c74ee3a5f1716f34d65 \
+                    size    905247 \
+                    winapi-i686-pc-windows-gnu-0.4.0.crate \
+                    sha256  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+                    rmd160  a7d1e9e7f940d2e376a1b6dede7f0a50ad191ab8 \
+                    size    2918815 \
+                    winapi-x86_64-pc-windows-gnu-0.4.0.crate \
+                    sha256  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+                    rmd160  300417853d251d91cadb9650992a6aa98248619f \
+                    size    2947998
 
 destroot {
     xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/xsv ${destroot}${prefix}/bin/

--- a/textproc/xsv/Portfile
+++ b/textproc/xsv/Portfile
@@ -11,7 +11,7 @@ long_description    xsv is a command line program for indexing, slicing, \
                     analyzing, splitting and joining CSV files.
 license             MIT
 platforms           darwin
-maintainers         {@lperry perry} \
+maintainers         {@pjl perry} \
                     openmaintainer
 
 cargo.crates \


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?