### PR TITLE
apply post-patch command to use non bundled binary

### DIFF
--- a/net/syncthing-macos/Portfile
+++ b/net/syncthing-macos/Portfile
@@ -4,6 +4,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 
 github.setup            syncthing syncthing-macos 1.6.1-1 v
+revision                1
 
 checksums               rmd160  26f6e9d6b946dd92e598bf9695e8454e8508a93c \
                         sha256  030e09533e98da4dcd93711979d73dcb15cff5613e86bad9a62884dcd4da18f3 \
@@ -22,6 +23,10 @@ depends_lib-append      port:syncthing
 
 patchfiles              no-bundled-syncthing.patch \
                         disable-autoupdatechecks.patch
+
+post-patch {
+    reinplace "s|__PREFIX__|${prefix}|" ${worksrcpath}/syncthing/STApplication.m
+}
 
 use_configure           no
 use_xcode               yes


### PR DESCRIPTION
partly reverts de3da7c to use the non bundled syncthing binary

#### Description
This PR reimplements the replacement of `no-bundled-syncthing.patch`'s `__PREFIX__` with the macports `${prefix}` environmental variable. This ensures that syncthing-macos uses the syncthing binary provided by macports.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
