### PR TITLE
prometheus: update to 2.19.1

### DIFF
--- a/net/prometheus/Portfile
+++ b/net/prometheus/Portfile
@@ -1,7 +1,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        prometheus prometheus 2.19.0 v
+github.setup        prometheus prometheus 2.19.1 v
 github.tarball_from archive
 
 description         The Prometheus monitoring system and time series database
@@ -43,9 +43,9 @@ set prom_share_dir  ${prefix}/share/${name}
 set prom_log_dir    ${prefix}/var/log/${name}
 set prom_log_file   ${prom_log_dir}/${name}.log
 
-checksums   rmd160  90564766771e82374a201ea91d5fcf9ba02f7f73 \
-            sha256  72fc19722deb0d9f11df1dce58e2ee31fd8f3d1a584848166c2a2bc2aaf8ce74 \
-            size    13343177
+checksums   rmd160  64b5146a1504ead2b8098c215c93aed90c27367b \
+            sha256  b72b9b6bdbae246dcc29ef354d429425eb3c0a6e1596fc8b29b502578a4ce045 \
+            size    13343138
 
 add_users           ${prom_user} \
                     group=${prom_user} \
@@ -145,9 +145,10 @@ To enable the Prometheus service, use `port load`, as follows:
 
 \$ sudo port load ${name}
 
-Once enabled, the service will log to:
- ${prom_log_file}
+Once enabled, the service will:
 
-After enabling the Prometheus service with `port load`, the service will
-be listening by default on http://localhost:9090
+  - listen by default on http://localhost:9090
+
+  - log to: ${prom_log_file}
+
 "


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
