### PR TITLE
dulwich, urllib3 & hg-git: upgrade and fix dependencies

### DIFF
--- a/devel/hg-evolve/Portfile
+++ b/devel/hg-evolve/Portfile
@@ -1,0 +1,47 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               python 1.0
+PortGroup               gitlab 1.0
+
+gitlab.instance         https://foss.heptapod.net
+gitlab.setup            mercurial evolve 10.0.2
+name                    hg-evolve
+revision                0
+
+categories              devel
+license                 GPL-2
+platforms               darwin
+supported_archs         noarch
+maintainers             {lbschenkel @lbschenkel} openmaintainer
+
+homepage                https://www.mercurial-scm.org/doc/evolution/
+description             Additional history rewriting commands for Mercurial.
+long_description        Additional history rewriting commands for Mercurial \
+                        for faster and safer mutable history. The extension \
+                        offers a safe and simple way to refine changesets \
+                        locally and propagate those changes to other \
+                        repositories. The complex issues that can arise from \
+                        exchanging draft changesets are automatically \
+                        detected and handled, and it possible's for multiple \
+                        developers to safely rewrite the same parts of history \
+                        in a distributed way.
+
+checksums               rmd160  a3441a1feea1ca3eb840bc64e37063afd5cd449e \
+                        sha256  ad84282d1c5f0af53aedbfb90921edab088b076290120d37c17da1c0aa30e672 \
+                        size    729305
+
+python.default_version  38
+
+depends_lib-append      port:mercurial
+
+notes               "
+To enable the evolve extension, add the following to your ~/.hgrc:
+
+\[extensions\]
+evolve =
+"
+
+post-patch {
+    file delete ${worksrcpath}/hgext3rd/__init__.py
+}

--- a/devel/hg-git/Portfile
+++ b/devel/hg-git/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               python 1.0
+PortGroup               gitlab 1.0
+
+gitlab.instance         https://foss.heptapod.net
+gitlab.setup            mercurial hg-git 0.9.0
+revision                0
+
+categories              devel
+license                 GPL-2
+platforms               darwin
+supported_archs         noarch
+maintainers             {danchr @danchr} openmaintainer
+
+homepage                https://www.mercurial-scm.org/wiki/HgGit
+description             Push to and pull from a Git server repository from Mercurial.
+long_description        This is the Hg-Git plugin for Mercurial, adding the ability \
+                        to push to and pull from a Git server repository from Mercurial.\
+                        This means you can collaborate on Git based projects from Mercurial, \
+                        or use a Git server as a collaboration point for a team with \
+                        developers using both Git and Mercurial.
+
+checksums               rmd160  c492877cdcdffeae972f3791f391f22516db9997 \
+                        sha256  eedd8773de76b21b47fd21a7e5c04c05c7ab0ecfc62a54bc947eb225b2c44424 \
+                        size    129138
+
+python.default_version  38
+
+depends_lib-append      port:mercurial port:py${python.version}-dulwich
+
+# workaround for https://foss.heptapod.net/mercurial/hg-git/-/issues/326
+depends_lib-append      port:py${python.version}-brotli
+
+notes               "
+To enable hggit, add the following to your ~/.hgrc:
+
+\[extensions\]
+hggit =
+"
+
+test {
+    system -W ${worksrcpath} "${python.bin} ./tests/run-tests.py -v -j ${build.jobs}"
+}
+
+# reject alphas and betas, for now
+gitlab.livecheck.regex (\[0-9.]+)

--- a/devel/mercurial/Portfile
+++ b/devel/mercurial/Portfile
@@ -2,17 +2,16 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
-PortGroup           bitbucket 1.0
 
 name                mercurial
 # don't forget to update dependents for mercurial:
 # port echo rdepends:mercurial and \( name:hg or name:mercurial \) | grep -v 'py[[:digit:]]'
-version             5.5
+version             5.5.1
 revision            0
 categories          devel python
 platforms           darwin
 license             GPL-2+
-maintainers         nomaintainer
+maintainers         {danchr @danchr} openmaintainer
 
 description         A fast, lightweight, distributed SCM system written in \
                     Python.
@@ -32,18 +31,18 @@ long_description    Mercurial is a fast, lightweight Source Control Management \
 
 homepage            https://www.mercurial-scm.org
 master_sites        ${homepage}/release/
-checksums           rmd160  40beaddc36912a6d57a2238346082b02f4f75f8f \
-                    sha256  c1ed28e1534304a7a4981ed59905286d1c56acd5b75755eedd184171a4a782b4 \
-                    size    7757631
-
-depends_build       port:py38-docutils
-
-depends_run         path:share/curl/curl-ca-bundle.crt:curl-ca-bundle \
-                    port:py38-gnureadline
-
-patchfiles          patch-setup.py.diff
+checksums           rmd160  aaf7781ef0c235134fcfde60c7463247d445ca32 \
+                    sha256  4f95ad8d575941835d67210e9f8700cc594a441e4fd0bd029c084923b4f40874 \
+                    size    7759341
 
 python.default_version 38
+
+depends_build       port:py${python.version}-docutils
+
+depends_run         path:share/curl/curl-ca-bundle.crt:curl-ca-bundle \
+                    port:py${python.version}-gnureadline
+
+patchfiles          patch-setup.py.diff
 
 build.cmd           make
 build.target        all PYTHON=${python.bin}

--- a/python/py-dulwich/Portfile
+++ b/python/py-dulwich/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        dulwich dulwich 0.20.2 dulwich-
+github.setup        dulwich dulwich 0.20.5 dulwich-
+revision            0
 name                py-dulwich
 categories-append   devel
 maintainers         {lbschenkel @lbschenkel} openmaintainer
@@ -18,9 +19,9 @@ long_description    Simple Pure-Python implementation of the Git file \
 
 homepage            https://www.dulwich.io
 
-checksums           rmd160  3557712ed0c45d73c104a5dd5dc215bfb3e940cb \
-                    sha256  2b2512ad80e03a1d9ffaafc38d884992b40ac7cfa6ddd814db098733365712dc \
-                    size    370540
+checksums           rmd160  c0619e80fb49e6524898ccc6606c42bc63758e20 \
+                    sha256  b12d6f804a7c1ae60029105809dcbb71c2ddf8631b59356e7ca5e181a11ac292 \
+                    size    374505
 
 python.versions     27 38
 
@@ -28,7 +29,7 @@ if {${name} ne ${subport}} {
     # 0.20 dropped support for Python 2.7
     if {${python.version} == 27} {
         github.setup            dulwich dulwich 0.19.16 dulwich-
-        github.livecheck.regex  {(0\.1[0-9.]+)}
+        livecheck.type          none
 
         checksums               rmd160  1029473c8fd18718ef7f4a3dea082a053ee92ca4 \
                                 sha256  6d225b7d5f5a293beb1d0855f41feef74230605ffde7929a5719eed4019cb6d1 \

--- a/python/py-dulwich/Portfile
+++ b/python/py-dulwich/Portfile
@@ -7,6 +7,7 @@ PortGroup           github 1.0
 github.setup        dulwich dulwich 0.20.5 dulwich-
 revision            0
 name                py-dulwich
+revision            1
 categories-append   devel
 maintainers         {lbschenkel @lbschenkel} openmaintainer
 platforms           darwin
@@ -41,7 +42,9 @@ if {${name} ne ${subport}} {
     patchfiles      patch-archflags.diff \
                     patch-strnlen-lion.diff
 
-    depends_lib-append port:py${python.version}-setuptools
+    depends_lib-append \
+                    port:py${python.version}-setuptools \
+                    port:py${python.version}-urllib3
 
     build.target-append build_ext
     build.args-append   --inplace

--- a/python/py-hgevolve/Portfile
+++ b/python/py-hgevolve/Portfile
@@ -1,42 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
+# obsoleted 20200825
 PortSystem              1.0
-PortGroup               python 1.0
-PortGroup               bitbucket 1.0
+PortGroup               obsolete 1.0
 
-bitbucket.setup         marmoute mutable-history 9.2.2
 name                    py-hgevolve
+version                 10.0.1
+revision                0
 
-categories-append       devel
-platforms               darwin
-license                 GPL-2+
-maintainers             {lbschenkel @lbschenkel} openmaintainer
-supported_archs         noarch
+replaced_by             hg-evolve
 
-description             Mutable history for mercurial
-long_description        This extension provides several commands to mutate history \
-                        and deal with issues it may raise.
-
-checksums               rmd160  2c1facccbeb44909f259affd8740d9bb0a5af906 \
-                        sha256  de05f20c805115bba90a06311408cd2a1a18d48a217ab5bb73846b0b47dbed5a \
-                        size    796971
-
-python.versions         27
-
-if {${name} ne ${subport}} {
-    depends_lib         port:mercurial
-
-    post-destroot {
-        file delete ${destroot}${python.pkgd}/hgext3rd/__init__.py
-        file delete ${destroot}${python.pkgd}/hgext3rd/__init__.pyc
-        file delete -force -- ${destroot}${python.pkgd}/hgext3rd/topic
-    }
-
-    notes               "
-To enable hgevolve, add the following to your ~/.hgrc:
-
-\[extensions\]
-rebase =
-evolve =
-"
-}
+subport py27-hgevolve {}

--- a/python/py-hggit/Portfile
+++ b/python/py-hggit/Portfile
@@ -1,44 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
+# obsoleted 20200820
 PortSystem              1.0
-PortGroup               python 1.0
-PortGroup               bitbucket 1.0
+PortGroup               obsolete 1.0
 
-epoch                   20130201
-
-bitbucket.setup         durin42 hg-git aa15905ca87fd1e13c60684ff40ccde026cd7dd0
 name                    py-hggit
-version                 0.8.12-git-20190807
+version                 0.9.0
 revision                0
 
-categories-append       devel
-license                 GPL-2
-platforms               darwin
-supported_archs         noarch
-maintainers             {easieste @easye} openmaintainer
+replaced_by             hg-git
 
-homepage                http://hg-git.github.com/
-description             Push to and pull from a Git server repository from Mercurial.
-long_description        This is the Hg-Git plugin for Mercurial, adding the ability \
-                        to push to and pull from a Git server repository from Mercurial.\
-                        This means you can collaborate on Git based projects from Mercurial, \
-                        or use a Git server as a collaboration point for a team with \
-                        developers using both Git and Mercurial.
-
-checksums               rmd160  d78cb278f0902a8d3e7d1718eacc99e9124be479 \
-                        sha256  17b8c8b23834f456ab577d7a3ef436e9b295a5586132b5594713f64820eb26e1 \
-                        size    136809
-
-python.versions         27
-
-if {${name} ne ${subport}} {
-    depends_lib-append  port:mercurial \
-                        bin:dulwich-2.7:py${python.version}-dulwich
-
-    notes               "
-To enable hggit, add the following to your ~/.hgrc:
-
-\[extensions\]
-hggit =
-"
-}
+subport py27-hggit {}

--- a/python/py-mercurial_extension_utils/Portfile
+++ b/python/py-mercurial_extension_utils/Portfile
@@ -2,9 +2,11 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
-PortGroup           bitbucket 1.0
+PortGroup           gitlab 1.0
 
-bitbucket.setup     Mekk mercurial-extension_utils 1.5.0
+gitlab.instance     https://foss.heptapod.net
+gitlab.setup        mercurial mercurial-extension_utils 1.5.1
+
 name                py-mercurial_extension_utils
 
 categories-append   devel
@@ -16,9 +18,9 @@ maintainers         nomaintainer
 description         Utility methods for Mercurial extensions
 long_description    ${description}
 
-checksums           rmd160  8a9fba94512dda03f85325d4799ffe594f16191e \
-                    sha256  61b9d674f09d087a9fdc87db552e58bc147a144eb298718efe9415b76dbe1a24 \
-                    size    24608
+checksums           rmd160  e1ff7af4305f77856a9df35ced0d898028ce83ae \
+                    sha256  e864519f7070cc2d03f937d0c0f6e3240c981b7b3d162f7b746b2fe420601e74 \
+                    size    22071
 
 python.versions     27 37 38
 

--- a/python/py-mercurial_keyring/Portfile
+++ b/python/py-mercurial_keyring/Portfile
@@ -2,10 +2,12 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
-PortGroup           bitbucket 1.0
+PortGroup           gitlab 1.0
 
-bitbucket.setup     Mekk mercurial_keyring 1.3.0
-name                py-mercurial_keyring
+gitlab.instance     https://foss.heptapod.net
+gitlab.setup        mercurial mercurial_keyring 1.3.1
+
+name                py-${name}
 
 categories-append   devel
 platforms           darwin
@@ -20,9 +22,9 @@ long_description \
     KWallet, OSXKeyChain, specific solutions for Win32 and command line). This \
     extension uses and wraps services of the keyring library.
 
-checksums           rmd160  6fc19a89cffd56d61885fbff7efbe166edb9adb5 \
-                    sha256  df09a00a377aece5d436f2449e85bea205c89219b15a2374173d1ae676e45abe \
-                    size    20948
+checksums           rmd160  281bcd19171ab0e3832087161046d6d023c1a04d \
+                    sha256  2d17b3eeef284b026e927232e97dd82db6b0630896bf2ca432023379580d5310 \
+                    size    19273
 
 python.versions     27 37 38
 
@@ -38,8 +40,8 @@ if {${name} ne ${subport}} {
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
         xinstall -d ${destroot}${docdir}
-        xinstall -m 0644 -W ${worksrcpath} README.txt HISTORY.txt \
-            LICENSE.txt README-devel.txt ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} README.rst HISTORY.rst \
+            LICENSE.txt README-devel.rst ${destroot}${docdir}
     }
 
     livecheck.type      none

--- a/python/py-urllib3/Portfile
+++ b/python/py-urllib3/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-urllib3
 version             1.25.10
-revision            0
+revision            1
 categories-append   devel net
 platforms           darwin
 license             MIT
@@ -26,6 +26,9 @@ checksums           rmd160  4cdf1de72e5872e1c317efa072f8ebcf30578265 \
 if {${name} ne ${subport}} {
     depends_build-append \
                         port:py${python.version}-setuptools
+    depends_lib-append \
+                        port:py${python.version}-certifi \
+                        port:py${python.version}-ipaddress
 
     livecheck.type      none
 }


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

I wanted to use hg-git to fetch a port that had migrated to Git, but neglected to fix their build system. Unfortunately, that didn't work due to missing dependencies.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
