### PR TITLE
zmq, cppzmq: use cmake to generate .*Config.cmake files

### DIFF
--- a/databases/groonga/Portfile
+++ b/databases/groonga/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                groonga
 version             5.0.5
-revision            3
+revision            4
 categories          databases
 maintainers         clear-code.com:kou openmaintainer
 

--- a/devel/cppzmq/Portfile
+++ b/devel/cppzmq/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           cmake 1.1
 PortGroup           github 1.0
 
 name                cppzmq
@@ -29,20 +30,12 @@ if {${subport} eq ${name}} {
     checksums rmd160 357c74d8ab7cd5be4b761d30ca0b283dbc1b1059 \
               sha256 a26f4f88a814f1652620ded466bf52833c85cd8007558c8950ffee641da13581 \
               size   35093
-    revision  0
+    revision  1
 
     # bump the epoch because I moved the version from 20170720 to 4.2.2
     epoch     1
 
+    depends_build-append port:pkgconfig
+
     depends_lib-append path:lib/libzmq.dylib:zmq
-
-    # this is just a header; skip all steps and manually do destroot
-    supported_archs noarch
-    use_configure no
-    build {}
-
-    destroot {
-        xinstall -m 755 -d ${destroot}${prefix}/include
-        copy ${worksrcpath}/zmq.hpp ${destroot}${prefix}/include
-    }
 }

--- a/devel/czmq/Portfile
+++ b/devel/czmq/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                czmq
 version             4.2.0
-revision            0
+revision            1
 categories          devel sysutils net
 platforms           darwin
 license             LGPL

--- a/devel/ihaskell/Portfile
+++ b/devel/ihaskell/Portfile
@@ -7,7 +7,7 @@ PortGroup           haskell_stack 1.0
 github.setup        gibiansky IHaskell 2318ee2
 name                [string tolower ${github.project}]
 version             2019.12.16
-revision            0
+revision            1
 
 categories          devel haskell
 platforms           darwin

--- a/devel/zmq/Portfile
+++ b/devel/zmq/Portfile
@@ -22,14 +22,19 @@ long_description    \
     protocols and more.
 
 if {${name} eq ${subport}} {
+    PortGroup cmake 1.1
+
     github.setup zeromq libzmq 4.3.2 v
     checksums rmd160 6bfdb9378428accf70719bfac23e4f5debe35f42 \
               sha256 8b1778a6d51944c0394d80e3c708bdc3ce58de44119bab4096b0d7e78348a8cf \
               size   836825
-    revision  0
+    revision  1
 
     conflicts    zmq-devel zmq22 zmq3
-    configure.args-append --disable-libunwind --disable-cxx11 --disable-c11
+    configure.args-append \
+                     -DWITH_PERF_TOOL=OFF \
+                     -DZMQ_BUILD_TESTS=OFF \
+                     -DENABLE_CPACK=OFF
 
     patch.pre_args -p1
     patchfiles-append patch-cxx11.release.diff
@@ -51,6 +56,13 @@ subport zmq3 {
                  sha256 3ba8fbdee4845e26f25f3d1d43492bc182077338f4e857fa50a06e1b21bade7f
 
     conflicts    zmq zmq-devel zmq22
+
+    use_autoconf  yes
+    autoconf.cmd  ./autogen.sh
+
+    depends_build-append port:automake port:autoconf
+
+    configure.args-append --disable-silent-rules
 }
 
 # Legacy subport (as a dependency for p5-zeromq)
@@ -61,18 +73,30 @@ subport zmq22 {
                  sha256 e021b62c6be211b5a1ac4b9e038068e0a8caaf81c22ee050183b25e991825e05
 
     conflicts    zmq zmq-devel zmq3
+
+    use_autoconf  yes
+    autoconf.cmd  ./autogen.sh
+
+    depends_build-append port:automake port:autoconf
+
+    configure.args-append --disable-silent-rules
 }
 
 subport zmq-devel {
+    PortGroup cmake 1.1
+
     github.setup zeromq libzmq c1d195641d81c702e342772cd48aa3ad3481a352
     version   20200520-[string range ${github.version} 0 7]
     checksums rmd160 7927dfe091ab759e1bf9ee00d0f2f39f1f5a839e \
               sha256 1ec15f01638605198b0062c4b13a3f0d5181e791926b166e0bd442eaf646d2b1 \
               size   908640
-    revision  0
+    revision  1
 
     conflicts    zmq zmq22 zmq3
-    configure.args-append --disable-libunwind --disable-cxx11 --disable-c11
+    configure.args-append \
+                     -DWITH_PERF_TOOL=OFF \
+                     -DZMQ_BUILD_TESTS=OFF \
+                     -DENABLE_CPACK=OFF
 
     patch.pre_args -p1
     patchfiles-append patch-cxx11.devel.diff
@@ -87,14 +111,6 @@ homepage            http://www.zeromq.org/
 # common directory for storing downloaded tarballs
 
 dist_subdir         zmq
-
-# use autoconf / automake
-
-use_autoconf        yes
-autoconf.cmd        ./autogen.sh
-depends_build-append port:automake port:autoconf
-
-configure.args-append --disable-silent-rules
 
 # macports libtool allows linking against libc++,
 # the libtool in the distribution does not

--- a/devel/zmqpp/Portfile
+++ b/devel/zmqpp/Portfile
@@ -5,6 +5,7 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 
 github.setup        zeromq zmqpp 4.2.0
+revision            1
 categories          devel net
 platforms           darwin
 license             MPL-2.0

--- a/finance/bitcoin/Portfile
+++ b/finance/bitcoin/Portfile
@@ -5,7 +5,7 @@ PortSystem              1.0
 name                    bitcoin
 categories              finance crypto
 version                 0.20.0
-revision                0
+revision                1
 platforms               darwin
 license                 MIT
 maintainers             {easieste @easye} yopmail.com:sami.laine openmaintainer

--- a/finance/litecoin/Portfile
+++ b/finance/litecoin/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 PortGroup           qt5 1.0
 
 github.setup        litecoin-project litecoin 0.16.3 v
-revision            4
+revision            5
 checksums           rmd160  aa2470a9e4f32c62953c5aae460471e0e3f1f801 \
                     sha256  0dccc577d704bd48226d11b749cca3bd7cadd23694ccbb15a87a0806704a69c3 \
                     size    6045235

--- a/math/octave-zeromq/Portfile
+++ b/math/octave-zeromq/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           octave 1.0
 
 octave.setup        zeromq 1.5.1
-revision            0
+revision            1
 platforms           darwin
 license             GPL-2+
 maintainers         {mps @Schamschula} openmaintainer

--- a/perl/p5-zmq-ffi/Portfile
+++ b/perl/p5-zmq-ffi/Portfile
@@ -5,6 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28 5.30
 perl5.setup         ZMQ-FFI 1.17 ../../authors/id/C/CA/CALID
+revision            1
 license             {Artistic-1 GPL}
 maintainers         {devans @dbevans} openmaintainer
 description         ZMQ::FFI - version agnostic Perl bindings for zeromq using ffi

--- a/python/py-pytorch/Portfile
+++ b/python/py-pytorch/Portfile
@@ -8,7 +8,7 @@ PortGroup           python 1.0
 
 name                py-pytorch
 version             1.5.0
-revision            0
+revision            1
 github.setup        pytorch pytorch ${version} v
 fetch.type          git
 

--- a/python/py-zmq/Portfile
+++ b/python/py-zmq/Portfile
@@ -10,7 +10,7 @@ version             19.0.1
 checksums           rmd160 c15a1acbeae4e19ac0e33f90f949975218f2ce30 \
                     sha256 13a5638ab24d628a6ade8f794195e1a1acd573496c3b85af2f1183603b7bf5e0 \
                     size   1152365
-revision            0
+revision            1
 
 python.versions     27 35 36 37 38
 

--- a/science/gnuradio/Portfile
+++ b/science/gnuradio/Portfile
@@ -26,7 +26,7 @@ if {${subport} eq ${name}} {
     checksums rmd160 6a7f38601633658632cf13a8dc157bbb1e9fcad7 \
               sha256 f0c1fb0bbec673a798efdbdad27d4a1b914ef1fd77528642f1e2134920156335 \
               size   4434061
-    revision  6
+    revision  7
 
     long_description    ${description}: \
         This port is kept up with the GNU Radio release, currently ${version}, which is typically updated every few months.
@@ -54,7 +54,7 @@ subport gnuradio-devel {
 
     github.setup        gnuradio gnuradio 896d1c9da31963ecf5b0d90942c2af51ca998a69
     version             20180824
-    revision            9
+    revision            10
     checksums    rmd160 8ad7fccef7e21ea96356253432f5f13ad61660ed \
                  sha256 51080fad6f776f8aec1a6c557320c6c64b4c3c3fde3615ca4d43802de65f324f \
                  size   4425148
@@ -82,7 +82,7 @@ subport gnuradio-next {
     checksums rmd160 3f27981c0fbc2abf197fb59f7054b774676d47f5 \
               sha256 101cd40bd9765ba2a2264f44600b8a7088740a136e7c5457b783c8e87626da3b \
               size   3369676
-    revision  4
+    revision  5
 
     # set the version override string
 

--- a/science/gr-ofdm/Portfile
+++ b/science/gr-ofdm/Portfile
@@ -8,7 +8,7 @@ PortGroup           cxx11 1.1
 
 github.setup        rwth-ti gr-ofdm a40720c708b75ad4c12ff09e49931879e9f90e78
 version             20180306
-revision            13
+revision            14
 checksums           rmd160 ee1f3054e00e57986fa7536d9691018c69e9e68a \
                     sha256 b053745b3590f1842a35c9914b344db295c2a479ce65711cc3112dc848427e7b \
                     size   3257234

--- a/www/mongrel2/Portfile
+++ b/www/mongrel2/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        zedshaw mongrel2 1.9.1 v
+revision            1
 license             BSD
 categories          www
 platforms           darwin


### PR DESCRIPTION
Switching from autotools to cmake causes an issue with the library
current and compatability version numbers of libzmq. Hence, all
dependents of zmq need a version bump.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
macOS 10.14.6 18G5033
Xcode 10.3 10G8 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
