### PR TITLE
mtools: Update to version 4.0.24

### DIFF
--- a/sysutils/mtools/Portfile
+++ b/sysutils/mtools/Portfile
@@ -3,17 +3,19 @@
 PortSystem          1.0
 
 name                mtools
-version             3.9.11
+version             4.0.24
 categories          sysutils
 maintainers         goudal.net:francois
 description         MS-DOS disk access utilities
 long_description    Utilities to access MS-DOS disks from Unix without \
                     mounting them
-homepage            http://mtools.linux.lu/
+homepage            https://www.gnu.org/software/mtools
 platforms           darwin
-master_sites        ${homepage}
-checksums           md5 3c0ae05b0d98a5d3bd06d3d72fcaf80d \
-                    sha1 964b8af11ac6441e832f2bc4737f35cc3ed0226e \
-                    rmd160 f8498768a432f28689a58840baa11d80a2ba8532
+master_sites        gnu:mtools
+checksums           rmd160  98c592c5e00c515d9a79e72ea5005970fd95ed63 \
+                    sha256  3483bdf233e77d0cf060de31df8e9f624c4bf26bd8a38ef22e06ca799d60c74e \
+                    size    520902
+depends_lib         port:libiconv
 configure.args      --mandir=${prefix}/share/man \
                     --infodir=${prefix}/share/info
+configure.ldflags-append    -Wl,-liconv


### PR DESCRIPTION
Update to current version of mtools, and add iconv library to link flags, which is necessary to build the package successfully.

#### Description

This change set upgrades the version of mtools to the current version.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.5
Xcode 11.5

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
