### PR TITLE
libvirt, virt-manager & qemu hacks

### DIFF
--- a/sysutils/libvirt/Portfile
+++ b/sysutils/libvirt/Portfile
@@ -10,7 +10,7 @@ legacysupport.newest_darwin_requires_legacy 10
 # Remember to update libvirt and py-libvirt at the same time.
 name                libvirt
 version             6.6.0
-revision            0
+revision            1
 checksums           rmd160  72294aa39f53386cfcd8812ddf243bd7aa9ee29c \
                     sha256  94e52ddd2d71b650e1a7eb5ab7e651f9607ecee207891216714020b8ff081ef9 \
                     size    9305836
@@ -87,10 +87,11 @@ configure.args      ac_cv_path_RST2HTML=${prefix}/bin/rst2html-3.8.py \
                     --without-numactl \
                     --without-openvz \
                     --without-openwsman \
-                    --without-phyp \
                     --without-pm-utils \
                     --without-polkit \
-                    --without-qemu \
+                    --with-qemu \
+                    --with-qemu-user=libvirt \
+                    --with-qemu-group=libvirt \
                     --with-readline \
                     --with-remote \
                     --without-sanlock \
@@ -108,12 +109,14 @@ configure.args      ac_cv_path_RST2HTML=${prefix}/bin/rst2html-3.8.py \
                     --without-wireshark-dissector \
                     --with-yajl
 
+add_users           libvirt group=libvirt realname=${description} home=${prefix}/var/lib/libvirt shell=/sbin/nologin
+
 # As of 5.10.0, an out-of-source build is required.
 configure.cmd       ../${worksrcdir}/autogen.sh --no-git
 configure.dir       ${workpath}/build
 build.dir           ${configure.dir}
 post-extract {
-    file mkdir ${configure.dir}
+    xinstall -d -o ${macportsuser} ${configure.dir}
 }
 
 # As of 5.10.0, pregenerated files are no longer included in the tarball,
@@ -129,6 +132,12 @@ configure.args-append \
 # Upstream will not fix this; instead, they will switch to meson.
 configure.universal_args-delete --disable-dependency-tracking
 
+variant hvf description {Experimental native hypervisor support} {
+    # this patch is a rebase the hvf-domain branch from
+    # https://github.com/roolebo/libvirt -- and it appears to work!
+    patchfiles-append   hvf.diff
+}
+
 variant fuse description {FUSE support} {
     depends_lib-append      port:osxfuse
     configure.args-replace  --without-fuse --with-fuse
@@ -137,10 +146,6 @@ variant fuse description {FUSE support} {
 variant libssh2 description {Enable the libssh2 transport} {
     depends_lib-append      port:libssh2
     configure.args-replace  --without-ssh2 --with-ssh2
-}
-
-variant phyp requires libssh2 description {Phyp driver support} {
-    configure.args-replace  --without-phyp --with-phyp
 }
 
 variant sasl description {Use Cyrus SASL for authentication} {

--- a/sysutils/libvirt/Portfile
+++ b/sysutils/libvirt/Portfile
@@ -132,6 +132,10 @@ configure.args-append \
 # Upstream will not fix this; instead, they will switch to meson.
 configure.universal_args-delete --disable-dependency-tracking
 
+# adjust default remote socket path so that users to avoid something like
+# virsh -c qemu+ssh://user@host/system?socket=/var/run/libvirt/libvirt-sock
+patchfiles-append   remote-sockname.diff
+
 variant hvf description {Experimental native hypervisor support} {
     # this patch is a rebase the hvf-domain branch from
     # https://github.com/roolebo/libvirt -- and it appears to work!
@@ -152,14 +156,6 @@ variant sasl description {Use Cyrus SASL for authentication} {
     depends_lib-append      port:cyrus-sasl2
     configure.args-replace  --without-sasl --with-sasl
 }
-
-notes "
-    The default socket path for the libvirt client is ${prefix}/var/run/libvirt/libvirt-sock,\
-    which might cause problems when you want to attach to a remote libvirtd instance.\
-    In this case, remember to also specify the socket path for the remote side, which is\
-    usually /var/run/libvirt/libvirt-sock. For example to connect to a remote host with virsh:
-      $ virsh -c qemu+ssh://user@host/system?socket=/var/run/libvirt/libvirt-sock
-"
 
 livecheck.type      regex
 livecheck.url       [lindex ${master_sites} 0]

--- a/sysutils/libvirt/files/hvf.diff
+++ b/sysutils/libvirt/files/hvf.diff
@@ -1,0 +1,350 @@
+diff --git src/conf/domain_conf.c src/conf/domain_conf.c
+--- src/conf/domain_conf.c
++++ src/conf/domain_conf.c
+@@ -130,6 +130,7 @@ VIR_ENUM_IMPL(virDomainVirt,
+               "parallels",
+               "bhyve",
+               "vz",
++              "hvf",
+ );
+ 
+ VIR_ENUM_IMPL(virDomainOS,
+@@ -210,6 +211,10 @@ VIR_ENUM_IMPL(virDomainKVM,
+               "hint-dedicated",
+ );
+ 
++VIR_ENUM_IMPL(virDomainHVF,
++              VIR_DOMAIN_HVF_LAST,
++);
++
+ VIR_ENUM_IMPL(virDomainXen,
+               VIR_DOMAIN_XEN_LAST,
+               "e820_host",
+diff --git src/conf/domain_conf.h src/conf/domain_conf.h
+--- src/conf/domain_conf.h
++++ src/conf/domain_conf.h
+@@ -137,6 +137,7 @@ typedef enum {
+     VIR_DOMAIN_VIRT_PARALLELS,
+     VIR_DOMAIN_VIRT_BHYVE,
+     VIR_DOMAIN_VIRT_VZ,
++    VIR_DOMAIN_VIRT_HVF,
+ 
+     VIR_DOMAIN_VIRT_LAST
+ } virDomainVirtType;
+@@ -1856,6 +1857,10 @@ typedef enum {
+ } virDomainKVM;
+ 
+ typedef enum {
++    VIR_DOMAIN_HVF_LAST
++} virDomainHVF;
++
++typedef enum {
+     VIR_DOMAIN_MSRS_UNKNOWN = 0,
+ 
+     VIR_DOMAIN_MSRS_LAST
+@@ -3591,6 +3596,7 @@ VIR_ENUM_DECL(virDomainGraphicsSpiceMous
+ VIR_ENUM_DECL(virDomainGraphicsVNCSharePolicy);
+ VIR_ENUM_DECL(virDomainHyperv);
+ VIR_ENUM_DECL(virDomainKVM);
++VIR_ENUM_DECL(virDomainHVF);
+ VIR_ENUM_DECL(virDomainXen);
+ VIR_ENUM_DECL(virDomainXenPassthroughMode);
+ VIR_ENUM_DECL(virDomainMsrsUnknown);
+diff --git src/qemu/qemu_capabilities.c src/qemu/qemu_capabilities.c
+--- src/qemu/qemu_capabilities.c
++++ src/qemu/qemu_capabilities.c
+@@ -54,6 +54,10 @@
+ #include <unistd.h>
+ #include <stdarg.h>
+ #include <sys/utsname.h>
++#ifdef __APPLE__
++# include <sys/types.h>
++# include <sys/sysctl.h>
++#endif
+ 
+ #define VIR_FROM_THIS VIR_FROM_QEMU
+ 
+@@ -582,6 +586,9 @@ VIR_ENUM_IMPL(virQEMUCaps,
+               "tcg",
+               "virtio-blk-pci.scsi.default.disabled",
+               "pvscsi",
++
++              /* 370 */
++              "hvf",
+     );
+ 
+ 
+@@ -684,6 +691,7 @@ struct _virQEMUCaps {
+ 
+     /* Capabilities which may differ depending on the accelerator. */
+     virQEMUCapsAccel kvm;
++    virQEMUCapsAccel hvf;
+     virQEMUCapsAccel tcg;
+ };
+ 
+@@ -787,6 +795,8 @@ virQEMUCapsGetAccel(virQEMUCapsPtr qemuC
+ {
+     if (type == VIR_DOMAIN_VIRT_KVM)
+         return &qemuCaps->kvm;
++    else if (type == VIR_DOMAIN_VIRT_HVF)
++        return &qemuCaps->hvf;
+ 
+     return &qemuCaps->tcg;
+ }
+@@ -916,6 +926,8 @@ virQEMUCapsGetMachineTypesCaps(virQEMUCa
+      * take the set of machine types we probed first. */
+     if (virQEMUCapsGet(qemuCaps, QEMU_CAPS_KVM))
+         accel = &qemuCaps->kvm;
++    else if (virQEMUCapsGet(qemuCaps, QEMU_CAPS_HVF))
++        accel = &qemuCaps->hvf;
+     else
+         accel = &qemuCaps->tcg;
+ 
+@@ -1047,6 +1059,17 @@ virQEMUCapsInitGuestFromBinary(virCapsPt
+         }
+     }
+ 
++    if (virQEMUCapsGet(qemuCaps, QEMU_CAPS_HVF)) {
++        if (virCapabilitiesAddGuestDomain(guest,
++                                          VIR_DOMAIN_VIRT_HVF,
++                                          NULL,
++                                          NULL,
++                                          0,
++                                          NULL) == NULL) {
++            goto cleanup;
++        }
++    }
++
+     if ((ARCH_IS_X86(guestarch) || guestarch == VIR_ARCH_AARCH64))
+         virCapabilitiesAddGuestFeatureWithToggle(guest, VIR_CAPS_GUEST_FEATURE_TYPE_ACPI,
+                                                  true, true);
+@@ -1917,6 +1940,7 @@ virQEMUCapsPtr virQEMUCapsNewCopy(virQEM
+     ret->arch = qemuCaps->arch;
+ 
+     if (virQEMUCapsAccelCopy(&ret->kvm, &qemuCaps->kvm) < 0 ||
++        virQEMUCapsAccelCopy(&ret->hvf, &qemuCaps->hvf) < 0 ||
+         virQEMUCapsAccelCopy(&ret->tcg, &qemuCaps->tcg) < 0)
+         goto error;
+ 
+@@ -1973,6 +1997,7 @@ void virQEMUCapsDispose(void *obj)
+     virSEVCapabilitiesFree(qemuCaps->sevCapabilities);
+ 
+     virQEMUCapsAccelClear(&qemuCaps->kvm);
++    virQEMUCapsAccelClear(&qemuCaps->hvf);
+     virQEMUCapsAccelClear(&qemuCaps->tcg);
+ }
+ 
+@@ -2357,6 +2382,10 @@ virQEMUCapsIsVirtTypeSupported(virQEMUCa
+         virQEMUCapsGet(qemuCaps, QEMU_CAPS_KVM))
+         return true;
+ 
++    if (virtType == VIR_DOMAIN_VIRT_HVF &&
++        virQEMUCapsGet(qemuCaps, QEMU_CAPS_HVF))
++        return true;
++
+     return false;
+ }
+ 
+@@ -2389,7 +2418,7 @@ virQEMUCapsIsCPUModeSupported(virQEMUCap
+ 
+     switch (mode) {
+     case VIR_CPU_MODE_HOST_PASSTHROUGH:
+-        return type == VIR_DOMAIN_VIRT_KVM &&
++        return (type == VIR_DOMAIN_VIRT_KVM || type == VIR_DOMAIN_VIRT_HVF) &&
+                virQEMUCapsGuestIsNative(hostarch, qemuCaps->arch);
+ 
+     case VIR_CPU_MODE_HOST_MODEL:
+@@ -3014,7 +3043,7 @@ virQEMUCapsProbeQMPHostCPU(virQEMUCapsPt
+                            qemuMonitorPtr mon,
+                            virDomainVirtType virtType)
+ {
+-    const char *model = virtType == VIR_DOMAIN_VIRT_KVM ? "host" : "max";
++    const char *model = virtType == VIR_DOMAIN_VIRT_KVM || virtType == VIR_DOMAIN_VIRT_HVF ? "host" : "max";
+     qemuMonitorCPUModelInfoPtr modelInfo = NULL;
+     qemuMonitorCPUModelInfoPtr nonMigratable = NULL;
+     virHashTablePtr hash = NULL;
+@@ -3240,6 +3269,33 @@ virQEMUCapsProbeQMPKVMState(virQEMUCapsP
+     return 0;
+ }
+ 
++#ifdef __APPLE__
++static int
++virQEMUCapsProbeHVF(virQEMUCapsPtr qemuCaps)
++{
++    int hv_support;
++    size_t len = sizeof(hv_support);
++    if (sysctlbyname("kern.hv_support", &hv_support, &len, NULL, 0))
++        hv_support = 0;
++
++    if (qemuCaps->version >= 2012000 &&
++        ARCH_IS_X86(qemuCaps->arch) &&
++        hv_support) {
++        virQEMUCapsSet(qemuCaps, QEMU_CAPS_HVF);
++    }
++
++    return 0;
++}
++#else
++static int
++virQEMUCapsProbeHVF(virQEMUCapsPtr qemuCaps)
++{
++  (void) qemuCaps;
++
++  return 0;
++}
++#endif
++
+ struct virQEMUCapsCommandLineProps {
+     const char *option;
+     const char *param;
+@@ -3718,7 +3774,7 @@ virQEMUCapsInitHostCPUModel(virQEMUCapsP
+                   virArchToString(qemuCaps->arch),
+                   virDomainVirtTypeToString(type));
+         goto error;
+-    } else if (type == VIR_DOMAIN_VIRT_KVM &&
++    } else if ((type == VIR_DOMAIN_VIRT_KVM || type == VIR_DOMAIN_VIRT_HVF) &&
+                virCPUGetHostIsSupported(qemuCaps->arch)) {
+         if (!(fullCPU = virQEMUCapsProbeHostCPU(qemuCaps->arch, NULL)))
+             goto error;
+@@ -4074,7 +4130,7 @@ virQEMUCapsLoadAccel(virQEMUCapsPtr qemu
+                      virDomainVirtType type)
+ {
+     virQEMUCapsAccelPtr caps = virQEMUCapsGetAccel(qemuCaps, type);
+-    const char *typeStr = type == VIR_DOMAIN_VIRT_KVM ? "kvm" : "tcg";
++    const char *typeStr = type == VIR_DOMAIN_VIRT_KVM ? "kvm" : type == VIR_DOMAIN_VIRT_HVF ? "hvf" : "tcg";
+ 
+     if (virQEMUCapsLoadHostCPUModelInfo(caps, ctxt, typeStr) < 0)
+         return -1;
+@@ -4318,6 +4374,7 @@ virQEMUCapsLoadCache(virArch hostArch,
+     VIR_FREE(str);
+ 
+     if (virQEMUCapsLoadAccel(qemuCaps, ctxt, VIR_DOMAIN_VIRT_KVM) < 0 ||
++        virQEMUCapsLoadAccel(qemuCaps, ctxt, VIR_DOMAIN_VIRT_HVF) < 0 ||
+         virQEMUCapsLoadAccel(qemuCaps, ctxt, VIR_DOMAIN_VIRT_QEMU) < 0)
+         goto cleanup;
+ 
+@@ -4390,7 +4447,10 @@ virQEMUCapsLoadCache(virArch hostArch,
+     if (virQEMUCapsParseSEVInfo(qemuCaps, ctxt) < 0)
+         goto cleanup;
+ 
+-    virQEMUCapsInitHostCPUModel(qemuCaps, hostArch, VIR_DOMAIN_VIRT_KVM);
++    if (virQEMUCapsGet(qemuCaps, QEMU_CAPS_KVM))
++        virQEMUCapsInitHostCPUModel(qemuCaps, hostArch, VIR_DOMAIN_VIRT_KVM);
++    if (virQEMUCapsGet(qemuCaps, QEMU_CAPS_HVF))
++        virQEMUCapsInitHostCPUModel(qemuCaps, hostArch, VIR_DOMAIN_VIRT_HVF);
+     virQEMUCapsInitHostCPUModel(qemuCaps, hostArch, VIR_DOMAIN_VIRT_QEMU);
+ 
+     if (virXPathBoolean("boolean(./kvmSupportsNesting)", ctxt) > 0)
+@@ -4534,7 +4594,7 @@ virQEMUCapsFormatAccel(virQEMUCapsPtr qe
+                        virDomainVirtType type)
+ {
+     virQEMUCapsAccelPtr caps = virQEMUCapsGetAccel(qemuCaps, type);
+-    const char *typeStr = type == VIR_DOMAIN_VIRT_KVM ? "kvm" : "tcg";
++    const char *typeStr = type == VIR_DOMAIN_VIRT_KVM ? "kvm" : type == VIR_DOMAIN_VIRT_HVF ?  "hvf" : "tcg";
+ 
+     virQEMUCapsFormatHostCPUModelInfo(caps, buf, typeStr);
+     virQEMUCapsFormatCPUModels(caps, buf, typeStr);
+@@ -4608,6 +4668,7 @@ virQEMUCapsFormatCache(virQEMUCapsPtr qe
+     virBufferAsprintf(&buf, "<arch>%s</arch>\n",
+                       virArchToString(qemuCaps->arch));
+ 
++    virQEMUCapsFormatAccel(qemuCaps, &buf, VIR_DOMAIN_VIRT_HVF);
+     virQEMUCapsFormatAccel(qemuCaps, &buf, VIR_DOMAIN_VIRT_KVM);
+     virQEMUCapsFormatAccel(qemuCaps, &buf, VIR_DOMAIN_VIRT_QEMU);
+ 
+@@ -5111,6 +5172,8 @@ virQEMUCapsGetVirtType(virQEMUCapsPtr qe
+     virDomainVirtType type;
+     if (virQEMUCapsGet(qemuCaps, QEMU_CAPS_KVM))
+         type = VIR_DOMAIN_VIRT_KVM;
++    else if (virQEMUCapsGet(qemuCaps, QEMU_CAPS_HVF))
++        type = VIR_DOMAIN_VIRT_HVF;
+     else if (virQEMUCapsGet(qemuCaps, QEMU_CAPS_TCG))
+         type = VIR_DOMAIN_VIRT_QEMU;
+     else
+@@ -5163,6 +5226,9 @@ virQEMUCapsInitQMPMonitor(virQEMUCapsPtr
+     if (virQEMUCapsProbeQMPKVMState(qemuCaps, mon) < 0)
+         return -1;
+ 
++    if (virQEMUCapsProbeHVF(qemuCaps) < 0)
++        return -1;
++
+     type = virQEMUCapsGetVirtType(qemuCaps);
+     accel = virQEMUCapsGetAccel(qemuCaps, type);
+ 
+@@ -5290,6 +5356,7 @@ virQEMUCapsInitQMP(virQEMUCapsPtr qemuCa
+      * off.
+      */
+     if (virQEMUCapsGet(qemuCaps, QEMU_CAPS_KVM) &&
++        virQEMUCapsGet(qemuCaps, QEMU_CAPS_HVF) &&
+         virQEMUCapsGet(qemuCaps, QEMU_CAPS_TCG) &&
+         virQEMUCapsInitQMPSingle(qemuCaps, libDir, runUid, runGid, true) < 0)
+         return -1;
+@@ -5339,7 +5406,10 @@ virQEMUCapsNewForBinaryInternal(virArch 
+     qemuCaps->libvirtCtime = virGetSelfLastChanged();
+     qemuCaps->libvirtVersion = LIBVIR_VERSION_NUMBER;
+ 
+-    virQEMUCapsInitHostCPUModel(qemuCaps, hostArch, VIR_DOMAIN_VIRT_KVM);
++    if (virQEMUCapsGet(qemuCaps, QEMU_CAPS_KVM))
++        virQEMUCapsInitHostCPUModel(qemuCaps, hostArch, VIR_DOMAIN_VIRT_KVM);
++    if (virQEMUCapsGet(qemuCaps, QEMU_CAPS_HVF))
++        virQEMUCapsInitHostCPUModel(qemuCaps, hostArch, VIR_DOMAIN_VIRT_HVF);
+     virQEMUCapsInitHostCPUModel(qemuCaps, hostArch, VIR_DOMAIN_VIRT_QEMU);
+ 
+     if (virQEMUCapsGet(qemuCaps, QEMU_CAPS_KVM)) {
+@@ -5671,13 +5741,20 @@ virQEMUCapsCacheLookupDefault(virFileCac
+     if (virttype == VIR_DOMAIN_VIRT_NONE)
+         virttype = capsType;
+ 
+-    if (virttype == VIR_DOMAIN_VIRT_KVM && capsType == VIR_DOMAIN_VIRT_QEMU) {
++    if (virttype == VIR_DOMAIN_VIRT_KVM && capsType != VIR_DOMAIN_VIRT_KVM) {
+         virReportError(VIR_ERR_INVALID_ARG,
+                        _("KVM is not supported by '%s' on this host"),
+                        binary);
+         goto cleanup;
+     }
+ 
++    if (virttype == VIR_DOMAIN_VIRT_HVF && capsType != VIR_DOMAIN_VIRT_HVF) {
++        virReportError(VIR_ERR_INVALID_ARG,
++                       _("Hypervisor.framework is not supported by '%s' on this host"),
++                       binary);
++        goto cleanup;
++    }
++
+     if (machine) {
+         /* Turn @machine into canonical name */
+         machine = virQEMUCapsGetCanonicalMachine(qemuCaps, virttype, machine);
+@@ -6277,6 +6354,7 @@ virQEMUCapsStripMachineAliasesForVirtTyp
+ void
+ virQEMUCapsStripMachineAliases(virQEMUCapsPtr qemuCaps)
+ {
++    virQEMUCapsStripMachineAliasesForVirtType(qemuCaps, VIR_DOMAIN_VIRT_HVF);
+     virQEMUCapsStripMachineAliasesForVirtType(qemuCaps, VIR_DOMAIN_VIRT_KVM);
+     virQEMUCapsStripMachineAliasesForVirtType(qemuCaps, VIR_DOMAIN_VIRT_QEMU);
+ }
+diff --git src/qemu/qemu_capabilities.h src/qemu/qemu_capabilities.h
+--- src/qemu/qemu_capabilities.h
++++ src/qemu/qemu_capabilities.h
+@@ -564,6 +564,9 @@ typedef enum { /* virQEMUCapsFlags group
+     QEMU_CAPS_VIRTIO_BLK_SCSI_DEFAULT_DISABLED, /* virtio-blk-pci.scsi disabled by default */
+     QEMU_CAPS_SCSI_PVSCSI, /* -device pvscsi */
+ 
++    /* 370 */
++    QEMU_CAPS_HVF, /* Whether Hypervisor.framework is available */
++
+     QEMU_CAPS_LAST /* this must always be the last item */
+ } virQEMUCapsFlags;
+ 
+diff --git src/qemu/qemu_command.c src/qemu/qemu_command.c
+--- src/qemu/qemu_command.c
++++ src/qemu/qemu_command.c
+@@ -6677,6 +6677,10 @@ qemuBuildMachineCommandLine(virCommandPt
+         virBufferAddLit(&buf, ",accel=kvm");
+         break;
+ 
++    case VIR_DOMAIN_VIRT_HVF:
++        virBufferAddLit(&buf, ",accel=hvf");
++        break;
++
+     case VIR_DOMAIN_VIRT_KQEMU:
+     case VIR_DOMAIN_VIRT_XEN:
+     case VIR_DOMAIN_VIRT_LXC:

--- a/sysutils/libvirt/files/remote-sockname.diff
+++ b/sysutils/libvirt/files/remote-sockname.diff
@@ -1,0 +1,12 @@
+diff --git src/remote/remote_driver.c src/remote/remote_driver.c
+--- src/remote/remote_driver.c
++++ src/remote/remote_driver.c
+@@ -788,7 +788,7 @@ remoteGetUNIXSocketHelper(remoteDriverTr
+          * any machine with /run will have a /var/run symlink.
+          * The portable option is to thus use $LOCALSTATEDIR/run
+          */
+-        sockname = g_strdup_printf("%s/run/libvirt/%s-%s", LOCALSTATEDIR,
++        sockname = g_strdup_printf("/var/run/libvirt/%s-%s",
+                                    sock_prefix,
+                                    flags & VIR_DRV_OPEN_REMOTE_RO ? "sock-ro" : "sock");
+     }


### PR DESCRIPTION
#### Description

This is mostly provided for comment, and to see whether the ports build on the infrastructure. Combined, the changes allow me to run a VM in QEMU under `libvirt` — using the native hypervisor — and control it using `virt-manager`.

There are a few obvious mistakes in the changes; this isn't ready yet.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
