### PR TITLE
gmt6: Apply the upstream patch for netcdf-4.7.4 compatibility

### DIFF
--- a/science/gmt5/Portfile
+++ b/science/gmt5/Portfile
@@ -12,7 +12,7 @@ revision            3
 conflicts           gmt6
 subport gmt6 {
     github.setup    GenericMappingTools gmt 6.0.0
-    revision        2
+    revision        3
     epoch           1
     conflicts       gmt5
 }
@@ -48,6 +48,12 @@ if {${subport} eq "gmt5"} {
     checksums           rmd160  a53d2bd50a960dd31893ca377d36a188c5e07f88 \
                         sha256  8b91af18775a90968cdf369b659c289ded5b6cb2719c8c58294499ba2799b650 \
                         size    66892468
+
+    # patch for netcdf 4.7.4 compatibility
+    # Remove with GMT 6.1.0
+    # See https://github.com/GenericMappingTools/gmt/pull/3023
+    patchfiles          patch-netcdf-4.7.4.diff
+    patch.pre_args      -p1
 }
 
 depends_lib         port:curl \

--- a/science/gmt5/files/patch-netcdf-4.7.4.diff
+++ b/science/gmt5/files/patch-netcdf-4.7.4.diff
@@ -1,0 +1,32 @@
+From 53800c1f8206e9988dff88a71915cda7e7bff6e3 Mon Sep 17 00:00:00 2001
+From: Paul Wessel <pwessel@hawaii.edu>
+Date: Sat, 4 Apr 2020 11:27:46 -1000
+Subject: [PATCH] Check if netcdf4 grid before calling nc_inq_var_deflate
+
+netCDF 4.7.4 released April 4, 2002 on macports caused massive crashes when reading netcdf3 grids s the nc_inq_var_deflate now suddenly crashes with an error instead of previous behavior.  Isolating this call by first checking if netcdf4.
+---
+ src/gmt_nc.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/gmt_nc.c b/src/gmt_nc.c
+index 7023561dd5..02f4144b95 100644
+--- a/src/gmt_nc.c
++++ b/src/gmt_nc.c
+@@ -818,7 +818,7 @@ GMT_LOCAL int gmtnc_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *head
+ 			header->z_min = header->z_max = 0.0;
+ 		}
+ 		{	/* Get deflation and chunking info */
+-			int storage_mode, shuffle, deflate, deflate_level;
++			int storage_mode, shuffle = 0, deflate = 0, deflate_level = 0;
+ 			size_t chunksize[5]; /* chunksize of z */
+ 			gmt_M_err_trap (nc_inq_var_chunking (ncid, z_id, &storage_mode, chunksize));
+ 			if (storage_mode == NC_CHUNKED) {
+@@ -828,7 +828,7 @@ GMT_LOCAL int gmtnc_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *head
+ 			else { /* NC_CONTIGUOUS */
+ 				HH->z_chunksize[0] = HH->z_chunksize[1] = 0;
+ 			}
+-			gmt_M_err_trap (nc_inq_var_deflate (ncid, z_id, &shuffle, &deflate, &deflate_level));
++			if (HH->is_netcdf4) gmt_M_err_trap (nc_inq_var_deflate (ncid, z_id, &shuffle, &deflate, &deflate_level));
+ 			HH->z_shuffle = shuffle ? true : false; /* if shuffle filter is turned on */
+ 			HH->z_deflate_level = deflate ? deflate_level : 0; /* if deflate filter is in use */
+ 		}


### PR DESCRIPTION
GMT 6.0.0 crashes due to a breaking change in netcdf 4.7.4.

This PR applies the upstream patch from https://github.com/GenericMappingTools/gmt/pull/3023, to make GMT 6.0.0 work with netcdf 4.7.4.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->

macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
