### PR TITLE
[submission] Add port py-spiceypy

### DIFF
--- a/python/py-spiceypy/Portfile
+++ b/python/py-spiceypy/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
+
+github.setup        AndrewAnnex SpiceyPy 4.0.0 v
+github.tarball_from archive
+name                py-spiceypy
+
+categories-append   science
+platforms           darwin
+license             MIT
+maintainers         nomaintainer
+
+description         SpiceyPy: The NASA JPL NAIF SPICE toolkit wrapper for Python
+long_description    ${description}
+
+checksums           rmd160  39bb5f19cd14102823a033df8d360928bd3f5ee9 \
+                    sha256  09d27993ab8d9b00ac8409b88915ca637c4db1d6416e7fc0c89839a223344c76 \
+                    size    351429
+
+python.versions     37 38
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-numpy \
+                    port:cspice
+
+    build.env-append \
+                    CSPICE_SHARED_LIB=${prefix}/lib/libcspice.dylib
+    destroot.env-append \
+                    CSPICE_SHARED_LIB=${prefix}/lib/libcspice.dylib
+}


### PR DESCRIPTION
SpiceyPy: The NASA JPL NAIF SPICE toolkit wrapper for Python

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] submission

###### Tested on
macOS 10.15.5 19F101
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? -> `py38-spiceypy has no tests turned on`
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
