### PR TITLE
qemu: fix missing binary packages by caused by curl & openssl

### DIFF
--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -39,8 +39,7 @@ depends_build           port:texinfo \
 depends_build-append    port:python38
 license_noconflict      python38
 
-depends_lib             port:curl \
-                        path:lib/pkgconfig/glib-2.0.pc:glib2 \
+depends_lib             path:lib/pkgconfig/glib-2.0.pc:glib2 \
                         port:zlib \
                         path:lib/pkgconfig/pixman-1.pc:libpixman
 
@@ -70,8 +69,8 @@ configure.args-append   --disable-cocoa \
                         --disable-sdl \
                         --disable-gtk \
                         --disable-opengl \
-                        --enable-curl \
                         --enable-bzip2 \
+                        --disable-curl \
                         --disable-attr \
                         --disable-vde \
                         --disable-brlapi \
@@ -183,6 +182,14 @@ variant curses description {Use the curses text-only user interface} {
 variant usb description {Support forwarding of USB devices to the guest} {
     configure.args-replace  --disable-libusb --enable-libusb
     depends_lib-append      path:lib/pkgconfig/libusb-1.0.pc:libusb
+}
+
+variant curl description {Support network block devices using CURL} {
+    # Factored to a separate variant to enable binary packages, as the
+    # CURL port defaults to using OpenSSL for cryptography, which triggers
+    # a licensing conflict.
+    configure.args-replace  --disable-curl --enable-curl
+    depends_lib-append      port:curl
 }
 
 variant vnc description {Support VNC server} {

--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -8,6 +8,7 @@ PortGroup legacysupport 1.0
 
 name                    qemu
 version                 5.0.0
+revision                1
 categories              emulators
 license                 GPL-2+
 platforms               darwin


### PR DESCRIPTION
#### Description

The cURL dependency prevents uploading the binary archives for QEMU:

https://build.macports.org/builders/ports-10.15_x86_64-builder/builds/31774/steps/gather-archives/logs/stdio

The relevant feature — network volumes over HTTP and FTP — appears somewhat esoteric compared to binary packages, doesn't it?

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
