### PR TITLE
curl: default to darwinssl to avoid OpenSSL licence tainting dependencies

### DIFF
--- a/net/centerim/Portfile
+++ b/net/centerim/Portfile
@@ -25,8 +25,6 @@ depends_build       port:pkgconfig
 depends_lib         port:libiconv port:gettext port:ncurses path:lib/libssl.dylib:openssl \
                     port:jpeg port:gpgme port:curl
 
-require_active_variants curl {ssl}
-
 patchfiles          patch-configure.diff patch-libjabber_jconn.c.diff
 
 configure.args      --with-libiconv-prefix=${prefix} \

--- a/net/curl/Portfile
+++ b/net/curl/Portfile
@@ -48,7 +48,6 @@ if {${name} eq ${subport}} {
     configure.args              --disable-silent-rules \
                                 --enable-ipv6 \
                                 --without-brotli \
-                                --without-ca-bundle \
                                 --without-cyassl \
                                 --without-gnutls \
                                 --without-gssapi \
@@ -141,23 +140,25 @@ if {${name} eq ${subport}} {
         configure.args-replace  --disable-ares --enable-ares
     }
 
-    platform darwin {
-        configure.args-replace  --without-darwinssl --with-darwinssl
+    # only allow Secure Transport on systems actively maintained by Apple
+    if {${os.platform} eq "darwin" || ${os.version} >= 17} {
+        variant darwinssl conflicts openssl gnutls wolfssl description {Allow secure connections using Apple OS native TLS} {
+            configure.args-replace  --without-darwinssl --with-darwinssl
+            configure.args-append   --without-ca-bundle
+        }
     }
 
-    variant gnutls conflicts openssl wolfssl description {Use GNU TLS for secure connections} {
+    variant gnutls conflicts openssl wolfssl darwinssl description {Allow secure connections using GNU TLS} {
         depends_lib-append      port:gnutls \
                                 path:share/curl/curl-ca-bundle.crt:curl-ca-bundle
         configure.args-replace  --without-gnutls --with-gnutls
-        configure.args-delete   --without-ca-bundle --with-darwinssl
         configure.args-append   --with-ca-bundle=${prefix}/share/curl/curl-ca-bundle.crt
     }
 
-    variant wolfssl conflicts openssl gnutls description {Use wolfSSL, formerly CyaSSL, for secure connections} {
+    variant wolfssl conflicts openssl gnutls darwinssl description {Allow secure connections using wolfSSL, formerly CyaSSL} {
         depends_lib-append      port:wolfssl \
                                 path:share/curl/curl-ca-bundle.crt:curl-ca-bundle
         configure.args-replace  --without-cyassl --with-cyassl
-        configure.args-delete   --without-ca-bundle --with-darwinssl
         configure.args-append   --with-ca-bundle=${prefix}/share/curl/curl-ca-bundle.crt
     }
 
@@ -191,17 +192,17 @@ if {${name} eq ${subport}} {
         configure.args-replace  --without-libssh2 --with-libssh2
     }
 
-    variant openssl conflicts gnutls wolfssl description {Use OpenSSL for secure connections} {
+    variant openssl conflicts gnutls wolfssl darwinssl description {Allow secure connections using OpenSSL} {
         depends_lib-append      path:lib/libssl.dylib:openssl \
                                 path:share/curl/curl-ca-bundle.crt:curl-ca-bundle
         configure.args-replace  --without-ssl --with-ssl=${prefix}
-        configure.args-delete   --without-ca-bundle --with-darwinssl
         configure.args-append   --with-ca-bundle=${prefix}/share/curl/curl-ca-bundle.crt
     }
 
-    # the system cURL switched Secure Transport in Mavericks
-    if {${os.platform} ne "darwin" || ${os.version} < 13} {
-        if {![variant_isset gnutls] && ![variant_isset wolfssl]} {
+    if {![variant_isset gnutls] && ![variant_isset darwinssl] && ![variant_isset wolfssl] && ![variant_isset openssl]} {
+        if ([variant_exists darwinssl]) {
+            default_variants +darwinssl
+        } else {
             default_variants +openssl
         }
     }

--- a/net/curl/Portfile
+++ b/net/curl/Portfile
@@ -33,7 +33,7 @@ checksums                       ${curl_distfile} \
 if {${name} eq ${subport}} {
     PortGroup                   muniversal 1.0
 
-    revision                    0
+    revision                    1
 
     depends_build               port:pkgconfig
 
@@ -48,6 +48,7 @@ if {${name} eq ${subport}} {
     configure.args              --disable-silent-rules \
                                 --enable-ipv6 \
                                 --without-brotli \
+                                --without-ca-bundle \
                                 --without-cyassl \
                                 --without-gnutls \
                                 --without-gssapi \
@@ -140,22 +141,23 @@ if {${name} eq ${subport}} {
         configure.args-replace  --disable-ares --enable-ares
     }
 
-    variant darwinssl conflicts ssl gnutls wolfssl description {Allow secure connections using Apple OS native TLS} {
+    platform darwin {
         configure.args-replace  --without-darwinssl --with-darwinssl
-        configure.args-append   --without-ca-bundle
     }
 
-    variant gnutls conflicts ssl wolfssl darwinssl description {Allow secure connections using GNU TLS} {
+    variant gnutls conflicts openssl wolfssl description {Use GNU TLS for secure connections} {
         depends_lib-append      port:gnutls \
                                 path:share/curl/curl-ca-bundle.crt:curl-ca-bundle
         configure.args-replace  --without-gnutls --with-gnutls
+        configure.args-delete   --without-ca-bundle --with-darwinssl
         configure.args-append   --with-ca-bundle=${prefix}/share/curl/curl-ca-bundle.crt
     }
 
-    variant wolfssl conflicts ssl gnutls darwinssl description {Allow secure connections using wolfSSL, formerly CyaSSL} {
+    variant wolfssl conflicts openssl gnutls description {Use wolfSSL, formerly CyaSSL, for secure connections} {
         depends_lib-append      port:wolfssl \
                                 path:share/curl/curl-ca-bundle.crt:curl-ca-bundle
         configure.args-replace  --without-cyassl --with-cyassl
+        configure.args-delete   --without-ca-bundle --with-darwinssl
         configure.args-append   --with-ca-bundle=${prefix}/share/curl/curl-ca-bundle.crt
     }
 
@@ -166,6 +168,9 @@ if {${name} eq ${subport}} {
     }
 
     variant http2 description {Support HTTP/2 with nghttp2} {
+        # enabling this by default would be nice, but the
+        # OpenSSL dependency is likely to trigger a licensing conflict
+        # in the many GPL ports that depend on cURL
         depends_lib-append      port:nghttp2
         configure.args-replace  --without-nghttp2 --with-nghttp2
     }
@@ -186,15 +191,19 @@ if {${name} eq ${subport}} {
         configure.args-replace  --without-libssh2 --with-libssh2
     }
 
-    variant ssl conflicts gnutls wolfssl darwinssl description {Allow secure connections using OpenSSL} {
+    variant openssl conflicts gnutls wolfssl description {Use OpenSSL for secure connections} {
         depends_lib-append      path:lib/libssl.dylib:openssl \
                                 path:share/curl/curl-ca-bundle.crt:curl-ca-bundle
         configure.args-replace  --without-ssl --with-ssl=${prefix}
+        configure.args-delete   --without-ca-bundle --with-darwinssl
         configure.args-append   --with-ca-bundle=${prefix}/share/curl/curl-ca-bundle.crt
     }
 
-    if {![variant_isset gnutls] && ![variant_isset darwinssl] && ![variant_isset wolfssl]} {
-        default_variants +ssl
+    # the system cURL switched Secure Transport in Mavericks
+    if {${os.platform} ne "darwin" || ${os.version} < 13} {
+        if {![variant_isset gnutls] && ![variant_isset wolfssl]} {
+            default_variants +openssl
+        }
     }
 
     livecheck.type              regex

--- a/python/py-isce2/Portfile
+++ b/python/py-isce2/Portfile
@@ -100,8 +100,6 @@ Other important notes
                             port:py${python.version}-nose \
                             port:py${python.version}-scipy
 
-    require_active_variants port:curl ssl
-
     post-patch {
         ###Replace cython3 with full path
         set cypath ${prefix}/bin/cython-${python.branch}

--- a/security/shibboleth/Portfile
+++ b/security/shibboleth/Portfile
@@ -35,8 +35,6 @@ checksums           rmd160  6cd57e048c15daa8e4ca3261eb73387afb436920 \
                     sha256  40dfedbb0f8e604ed4b6d606143de7980b4f8c13fc4682375ace94f8ac194654 \
                     size    809498
 
-require_active_variants curl ssl
-
 configure.args      --enable-apache24
 
 variant odbc description {enable odbc support} {


### PR DESCRIPTION
The licence taint prevents the builders from uploading binary archives of any GPL package that depends on cURL. This affects at least the Git and QEMU ports, and probably others too. See for example:

https://build.macports.org/builders/ports-10.15_x86_64-builder/builds/31774/steps/gather-archives/logs/stdio

This is a rather invasive change, and it might not be desirable, but I figured I'd post it here as an alternative to #7484.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
