### PR TITLE
py-numpy: update to 1.19.0

### DIFF
--- a/python/py-numpy/Portfile
+++ b/python/py-numpy/Portfile
@@ -17,10 +17,10 @@ maintainers             {michaelld @michaelld} openmaintainer
 description             The core utilities for the scientific library scipy for Python
 long_description        ${description}
 
-github.setup            numpy numpy 1.18.5 v
-checksums               rmd160 c14f2725afe0f7420d69a6f9ed5744639a2d2b31 \
-                        sha256 4a421fdf82dbb3dce7e62400f69c43722b530db109c3321c6c95452f166560d9 \
-                        size   5167349
+github.setup            numpy numpy 1.19.0 v
+checksums               rmd160  ab8a2b2c7f60776c7dfe463b29e0c155133466a8 \
+                        sha256  2ff34f681c256927d50b238fa2c80d3323b431593b5a54baa519c0cf90576d9b \
+                        size    7022124
 revision                0
 
 if {${name} ne ${subport}} {
@@ -59,6 +59,16 @@ if {${name} ne ${subport}} {
                             patch-fcompiler_g95.diff
 #                            patch-numpy_distutils_fcompiler_gnu.py.diff
     }
+
+    if {${python.version} == 35} {
+        github.setup        numpy numpy 1.18.5 v
+        checksums           rmd160  c14f2725afe0f7420d69a6f9ed5744639a2d2b31 \
+                            sha256  4a421fdf82dbb3dce7e62400f69c43722b530db109c3321c6c95452f166560d9 \
+                            size    5167349
+        revision            0
+        github.livecheck.regex {(1\.18(?:\.\d+)+)}
+    }
+
     compilers.setup         -clang -gcc44 -gcc45 \
                             -gcc46 -gcc47 -gcc48 -g95 clang37
 


### PR DESCRIPTION
#### Description
This PR updates `py-numpy` to its latest version (while pinning to version 1.18.5 for PY35). The new CPU detection code is present in this release and that will hopefully resolve a long-standing issue with building (of dependents) on macOS 10.12.

See: https://trac.macports.org/ticket/59022

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G5033
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->