### PR TITLE
sqlitebrowser: update to 3.12.0

### DIFF
--- a/databases/sqlitebrowser/Portfile
+++ b/databases/sqlitebrowser/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        sqlitebrowser sqlitebrowser 3.11.2 v
-revision            1
+github.setup        sqlitebrowser sqlitebrowser 3.12.0
+revision            0
 
 categories          databases
 platforms           darwin linux
@@ -33,20 +33,19 @@ long_description    SQLite Database Browser is a visual tool used to create, des
 
 homepage            http://sqlitebrowser.org
 
-checksums           rmd160  f1e925b87be61b9badba625b3847dd403860cc28 \
-                    sha256  62d1385c16d771758c7dd36612f5b8c0dffbd37bc40a4c23efc3b0243779291e \
-                    size    2530537
+checksums           rmd160  8c0e81ccc7c8df9a0197d9f1651801f5aa9bb155 \
+                    sha256  211e33f7c4ad4b991b23ac02ee7a3e826f88c5297aad5fd8610d55ee8bd6b32f \
+                    size    4017540
 
 # Exclude pre-release candidates
-github.livecheck.regex  {([0-9.]+)}
+github.livecheck.regex \
+                    {([0-9.]+)}
 
 universal_variant   no
 
-depends_lib-append  port:antlr \
-                    port:qscintilla-qt5
+depends_lib-append  port:qscintilla-qt5
 
 patchfiles-append   0001-Changes-for-MacPorts.patch
-patch.pre_args      -p1
 
 compiler.cxx_standard 2011
 
@@ -62,14 +61,13 @@ platform darwin {
     qt5.min_version     5.4
 
     pre-configure {
-        reinplace "s|libs/antlr-2.7.7/antlr.pro||g" ${worksrcpath}/sqlitebrowser.pro
         reinplace "s|libs/qscintilla/Qt4Qt5/qscintilla.pro||g" ${worksrcpath}/sqlitebrowser.pro
         reinplace "s|-lqscintilla2|-lqscintilla2_qt5|g" ${worksrcpath}/src/src.pro
-        reinplace "s|\$\$PWD/../libs/antlr-2.7.7||g" ${worksrcpath}/src/src.pro
         reinplace "s|\$\$PWD/../libs/qscintilla/Qt4Qt5||g" ${worksrcpath}/src/src.pro
-        delete ${worksrcpath}/libs/antlr-2.7.7 ${worksrcpath}/libs/qscintilla
+        delete ${worksrcpath}/libs/qscintilla
     }
 
+    use_parallel_build  no
     depends_lib-append  port:sqlite3
     qt5.depends_component \
                         qtmacextras qttools

--- a/databases/sqlitebrowser/files/0001-Changes-for-MacPorts.patch
+++ b/databases/sqlitebrowser/files/0001-Changes-for-MacPorts.patch
@@ -1,18 +1,6 @@
-From 9dce698faa8c4d274389b933717aea475910ca4b Mon Sep 17 00:00:00 2001
-From: Aaron Madlon-Kay <aaron@madlon-kay.com>
-Date: Wed, 13 Nov 2019 16:34:46 +0900
-Subject: [PATCH] Changes for MacPorts
-
----
- CMakeLists.txt             | 18 +++++++++++-------
- cmake/FindQScintilla.cmake |  2 +-
- 2 files changed, 12 insertions(+), 8 deletions(-)
-
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 04e8a828..ee00b942 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -22,6 +22,8 @@ if(NOT CMAKE_BUILD_TYPE)
+--- CMakeLists.txt.orig	2020-06-14 00:08:29.000000000 -0400
++++ CMakeLists.txt	2020-06-22 01:22:28.000000000 -0400
+@@ -24,6 +24,8 @@
      set(CMAKE_BUILD_TYPE "Release")
  endif()
  
@@ -21,80 +9,36 @@ index 04e8a828..ee00b942 100644
  add_definitions(-std=c++11)
  set(CMAKE_CXX_STANDARD 11)
  set(CMAKE_CXX_STANDARD_REQUIRED True)
-@@ -61,10 +63,10 @@ if(WIN32 AND MSVC)
- endif()
+@@ -72,7 +74,7 @@
+ find_package(Qt5 REQUIRED COMPONENTS Concurrent Gui LinguistTools Network PrintSupport Test Widgets Xml)
  
- if(NOT FORCE_INTERNAL_ANTLR)
--    find_package(Antlr2 QUIET)
-+    find_package(Antlr2)
- endif()
  if(NOT FORCE_INTERNAL_QSCINTILLA)
--    find_package(QScintilla QUIET)
-+    find_package(QScintilla)
+-    find_package(QScintilla 2.8.10 QUIET)
++    find_package(QScintilla 2.8.10)
  endif()
- 
- set(QHEXEDIT_DIR libs/qhexedit)
-@@ -304,7 +306,7 @@ endif(WIN32)
+ if(FORCE_INTERNAL_QCUSTOMPLOT)
+     set(QCUSTOMPLOT_FOUND FALSE)
+@@ -351,7 +353,7 @@
  
  #enable version check for MacOS
  if(APPLE)
 -	add_definitions(-DCHECKNEWVERSION)
-+	# add_definitions(-DCHECKNEWVERSION)
++	#add_definitions(-DCHECKNEWVERSION)
  endif(APPLE)
  
  # SQLCipher option
-@@ -343,12 +345,12 @@ include_directories(
- if(ANTLR2_FOUND)
-     include_directories(${ANTLR2_INCLUDE_DIRS})
- else()
--    include_directories(${ANTLR_DIR})
-+    # include_directories(${ANTLR_DIR})
- endif()
+@@ -399,7 +401,7 @@
  if(QSCINTILLA_FOUND)
      include_directories(${QSCINTILLA_INCLUDE_DIR})
  else()
 -    include_directories(${QSCINTILLA_DIR})
-+    # include_directories(${QSCINTILLA_DIR})
++    #include_directories(${QSCINTILLA_DIR})
  endif()
  
  add_executable(${PROJECT_NAME}
-@@ -424,7 +426,7 @@ if(ENABLE_TESTING)
- 	add_subdirectory(src/tests)
- endif()
- 
--if(UNIX AND NOT APPLE)
-+if(UNIX)
- 	install(FILES src/icons/${PROJECT_NAME}.png
- 		DESTINATION share/icons/hicolor/256x256/apps/)
- 
-@@ -433,7 +435,7 @@ if(UNIX AND NOT APPLE)
- 
- 	install(FILES distri/${PROJECT_NAME}.desktop.appdata.xml
- 		DESTINATION share/appdata/)
--endif(UNIX AND NOT APPLE)
-+endif(UNIX)
- 
- if(WIN32 AND MSVC)
- 	install(TARGETS ${PROJECT_NAME}
-@@ -501,3 +503,5 @@ if(WIN32 AND MSVC)
+@@ -566,3 +568,5 @@
  			distri/winlaunch.bat
  		DESTINATION "/")
  endif()
 +
 +feature_summary(WHAT ALL INCLUDE_QUIET_PACKAGES FATAL_ON_MISSING_REQUIRED_PACKAGES)
-diff --git a/cmake/FindQScintilla.cmake b/cmake/FindQScintilla.cmake
-index f469637c..dd46e49b 100644
---- a/cmake/FindQScintilla.cmake
-+++ b/cmake/FindQScintilla.cmake
-@@ -80,7 +80,7 @@ endif ()
- 
- 
- find_library ( QSCINTILLA_LIBRARY
--  NAMES qscintilla qscintilla2 libqscintilla2
-+  NAMES qscintilla qscintilla2 libqscintilla2 qscintilla2_qt5 libqscintilla2_qt5
-   HINTS ${QT_LIBRARY_DIR}
- )
- 
--- 
-2.24.0
-


### PR DESCRIPTION
And disable parallel build until upstream gives a fix
Closes: https://trac.macports.org/ticket/60626

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
