### PR TITLE
turbogit: update to 1.1.1

### DIFF
--- a/devel/turbogit/Portfile
+++ b/devel/turbogit/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        b4nst turbogit 1.1.0 v
+github.setup        b4nst turbogit 1.1.1 v
 categories          devel
 platforms           darwin
 supported_archs     x86_64
@@ -16,9 +16,9 @@ long_description    Cli tool built to help you deal with your day-to-day git wor
 github.tarball_from releases
 worksrcdir          .
 
-checksums           rmd160  165dadd377603bfdd52d7efab784d25003956e09 \
-                    sha256  7771e3013e6c44dbcb955687b9355f727479966fe253bd0c42f700f4213ef5dc \
-                    size    1135241
+checksums           rmd160  3f074b41b44ecad49f0e267bbb1b1d9ba2139cef \
+                    sha256  061a2caa6bf4ec658c9b584167a6ecf75eeb1f51b07a23377953b4d7ee27de8a \
+                    size    1138091
 
 use_configure       no
 installs_libs       no


### PR DESCRIPTION
#### Description
- build(deps): bump github.com/stretchr/testify from 1.5.1 to 1.6.1
- fix: b4nst/turbogit#21

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
