### PR TITLE
comix: Fix outdated PIL version check

### DIFF
--- a/graphics/comix/Portfile
+++ b/graphics/comix/Portfile
@@ -2,7 +2,7 @@ PortSystem          1.0
 
 name                comix
 version             4.0.4
-revision            4
+revision            5
 categories          graphics
 maintainers         nomaintainer
 platforms           darwin
@@ -35,7 +35,8 @@ depends_lib         port:py${python.version}-pygtk \
                     port:python${python.version} \
                     port:unrar
 
-patchfiles          patch-pillow-compat.diff
+patchfiles          patch-pillow-compat.diff \
+                    patch-pillow-version-compat.diff
 
 use_configure       no
 

--- a/graphics/comix/files/patch-pillow-version-compat.diff
+++ b/graphics/comix/files/patch-pillow-version-compat.diff
@@ -1,0 +1,34 @@
+--- install.py.old	2020-06-22 14:49:31.000000000 +0200
++++ install.py	2020-06-22 14:49:46.000000000 +0200
+@@ -241,13 +241,13 @@
+         required_found = False
+     try:
+         from PIL import Image
+-        assert Image.VERSION >= '1.1.5'
++        assert Image.__version__ >= '1.1.5'
+         print '    Python Imaging Library ....... OK'
+     except ImportError:
+         print '    !!! Python Imaging Library ... Not found'
+         required_found = False
+     except AssertionError:
+-        print '    !!! Python Imaging Library ... version', Image.VERSION,
++        print '    !!! Python Imaging Library ... version', Image.__version__,
+         print 'found'
+         print '    !!! Python Imaging Library 1.1.5 or higher is required'
+         required_found = False
+--- src/comix.py.old	2020-06-22 14:48:45.000000000 +0200
++++ src/comix.py	2020-06-22 14:49:02.000000000 +0200
+@@ -50,11 +50,11 @@
+ 
+ try:
+     from PIL import Image
+-    assert Image.VERSION >= '1.1.5'
++    assert Image.__version__ >= '1.1.5'
+ except AssertionError:
+     print "You don't have the required version of the Python Imaging",
+     print 'Library (PIL) installed.'
+-    print 'Installed PIL version is: %s' % Image.VERSION
++    print 'Installed PIL version is: %s' % Image.__version__
+     print 'Required PIL version is: 1.1.5 or higher'
+     sys.exit(1)
+ except ImportError:


### PR DESCRIPTION
#### Description
Fix comix build by updating PIL version check.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G5033
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
