### PR TITLE
newreleases: new port

### DIFF
--- a/devel/newreleases/Portfile
+++ b/devel/newreleases/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/newreleasesio/cli-go 0.1.4 v
+name                newreleases
+
+description         A command line client for managing NewReleases \
+                    (newreleases.io) projects.
+
+long_description    {*}${description}
+
+checksums           rmd160  acba7f18026fe7e6310bcc8d759be5d2bdc61e8f \
+                    sha256  93ec1d36b298311502bf16d5241dce290f40c436c46b864fe23306fcfd49d2da \
+                    size    39553
+
+categories          devel
+license             BSD
+installs_libs       no
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+build {
+    system -W "${worksrcdir}/${name}" "go build ."
+}
+
+destroot {
+    xinstall -m 755 ${worksrcdir}/${name}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
New port for the [newreleases CLI](github.com/newreleasesio/cli-go), CLI for [https://newreleases.io/](https://newreleases.io/)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
