### PR TITLE
mtm: new port

### DIFF
--- a/sysutils/mtm/Portfile
+++ b/sysutils/mtm/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+
+PortSystem        1.0
+PortGroup         github 1.0
+PortGroup         makefile 1.0
+
+github.setup      deadpixi mtm 1.2.0
+
+description       Perhaps the smallest useful terminal multiplexer in the \
+                  world.
+
+long_description  mtm is the Micro Terminal Multiplexer, a terminal \
+                  multiplexer. It has four major features/principles: \
+                  Simplicity, Compatibility, Small Size and Stability
+
+maintainers       {gmail.com:herby.gillot @herbygillot} \
+                  openmaintainer
+
+checksums         rmd160  6485480560dad9cd136370fee1e3c046e5264015 \
+                  sha256  1a9e2c8ecc6a2b17e322f98c69a69ff4e55383864d149030763affefbeaa3187 \
+                  size    382514
+
+categories        sysutils
+license           GPL-3+
+platforms         darwin linux
+
+depends_lib       port:ncurses
+
+installs_libs     no
+
+pre-build {
+    if {${os.platform} == "darwin"} {
+        reinplace "s|strip -s|strip|g" Makefile
+    }
+}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/mtm   ${destroot}${prefix}/bin/
+    xinstall -m 644 ${worksrcpath}/mtm.1 ${destroot}${prefix}/share/man/man1/
+}


### PR DESCRIPTION
New port for [mtm](https://github.com/deadpixi/mtm), a terminal multiplexer

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
