### PR TITLE
ffsend: new port

### DIFF
--- a/net/ffsend/Portfile
+++ b/net/ffsend/Portfile
@@ -1,0 +1,315 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo 1.0
+
+github.setup        timvisee ffsend 0.2.64 v
+
+description         Easily and securely share files from the command line. A \
+                    fully featured Firefox Send client.
+
+long_description    Easily and securely share files and directories from the \
+                    command line through a safe, private and encrypted link \
+                    using a single simple command. Files are shared using the \
+                    Send service and may be up to 1GB. Others are able to \
+                    download these files with this tool, or through their \
+                    web browser.
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  8a8e2a19ae9d1857ae3b9db69f726f3038c81118 \
+                    sha256  a22c4e7f95f97b22e03a95c4ec8d0d3a4f8fd42d267757ab1e4714e404b2616a \
+                    size    191021
+
+categories          net
+license             GPL-3+
+platforms           darwin
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/${name} ${destroot}${prefix}/bin/
+}
+
+cargo.crates \
+    addr2line                       0.12.0  456d75cbb82da1ad150c8a9d97285ffcd21c9931dcb11e995903e7d75141b38b \
+    aho-corasick                    0.7.10  8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada \
+    ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
+    arc-swap                         0.4.6  b585a98a234c46fc563103e9278c9391fde1f4e6850334da895d27edb9580f62 \
+    arrayref                         0.3.6  a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544 \
+    arrayvec                         0.5.1  cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8 \
+    atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+    autocfg                          0.1.7  1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2 \
+    autocfg                          1.0.0  f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d \
+    backtrace                       0.3.48  0df2f85c8a2abbe3b7d7e748052fdd9b76a0458fdeb16ad4223f5eca78c7c130 \
+    base-x                           0.2.6  1b20b618342cf9891c292c4f5ac2cde7287cc5c87e87e9c769d617793607dec1 \
+    base64                          0.10.1  0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e \
+    base64                          0.11.0  b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7 \
+    base64                          0.12.1  53d1ccbaf7d9ec9537465a97bf19edc1a4e158ecb49fc16178202238c569cc42 \
+    base64                           0.9.3  489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643 \
+    bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
+    blake2b_simd                    0.5.10  d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a \
+    block                            0.1.6  0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a \
+    block-buffer                     0.7.3  c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b \
+    block-padding                    0.1.5  fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5 \
+    bstr                            0.2.13  31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931 \
+    bumpalo                          3.3.0  5356f1d23ee24a1f785a56d1d1a5f0fd5b0f6a0c0fb2412ce11da71649ab78f6 \
+    byte-tools                       0.3.1  e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7 \
+    byteorder                        1.3.4  08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de \
+    bytes                           0.4.12  206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c \
+    bytes                            0.5.4  130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1 \
+    cc                              1.0.53  404b1fe4f65288577753b17e3b36a04596ee784493ec249bf81c7f2d2acd751c \
+    cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
+    chbs                            0.0.10  9b8579452901e185b65f91bc5571f9543ede86f3238389105a0f44dd4b9a82ab \
+    checked_int_cast                 1.0.0  17cc5e6b5ab06331c33589842070416baa137e8b0eb912b008cfd4a78ada7919 \
+    chrono                          0.4.11  80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2 \
+    clap                            2.33.1  bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129 \
+    clipboard                        0.5.0  25a904646c0340239dcf7c51677b33928bf24fdf424b79a57909c0109075b2e7 \
+    clipboard-win                    2.2.0  e3a093d6fed558e5fe24c3dfc85a68bb68f1c824f440d3ba5aca189e2998786b \
+    cloudabi                         0.0.3  ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
+    colored                          1.9.3  f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59 \
+    constant_time_eq                 0.1.5  245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc \
+    core-foundation                  0.7.0  57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171 \
+    core-foundation-sys              0.7.0  b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac \
+    crossbeam-utils                  0.7.2  c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8 \
+    crossterm                       0.17.4  2a880035bfe4707e344da9acf50cc94d003fe337f50afd94c8722c1bb4e0a933 \
+    crossterm_winapi                 0.6.1  057b7146d02fb50175fd7dbe5158f6097f33d02831f43b4ee8ae4ddf67b68f5c \
+    crypto-mac                       0.7.0  4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5 \
+    csv                              1.1.3  00affe7f6ab566df61b4be3ce8cf16bc2576bca0963ceb0955e45d514bf9a279 \
+    csv-core                        0.1.10  2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90 \
+    ct-logs                          0.6.0  4d3686f5fa27dbc1d76c751300376e167c5a43387f44bb451fd1c24776e49113 \
+    darling                         0.10.2  0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858 \
+    darling_core                    0.10.2  f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b \
+    darling_macro                   0.10.2  d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72 \
+    derive_builder                   0.9.0  a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0 \
+    derive_builder_core              0.9.0  2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef \
+    digest                           0.8.1  f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5 \
+    directories                      2.0.2  551a778172a450d7fc12e629ca3b0428d00f6afa9a43da1b630d54604e97371c \
+    dirs                             1.0.5  3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901 \
+    dirs-sys                         0.3.4  afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b \
+    discard                          1.0.4  212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0 \
+    dtoa                             0.4.5  4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3 \
+    encode_unicode                   0.3.6  a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f \
+    encoding_rs                     0.8.23  e8ac63f94732332f44fe654443c46f6375d1939684c17b0afb6cb56b0456e171 \
+    failure                          0.1.8  d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86 \
+    failure_derive                   0.1.8  aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4 \
+    fake-simd                        0.1.2  e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed \
+    ffsend-api                       0.6.0  7c81d7bf24dc23e394a8692ef208c26c20411c01f398e354ac4d268c34196fc5 \
+    filetime                        0.2.10  affc17579b132fc2461adf7c575cc6e8b134ebca52c51f5411388965227dc695 \
+    fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
+    foreign-types                    0.3.2  f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1 \
+    foreign-types-shared             0.1.1  00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b \
+    fs2                              0.4.3  9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213 \
+    fuchsia-cprng                    0.1.1  a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba \
+    fuchsia-zircon                   0.3.3  2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
+    fuchsia-zircon-sys               0.3.3  3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
+    futures                         0.1.29  1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef \
+    futures-channel                  0.3.5  f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5 \
+    futures-core                     0.3.5  59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399 \
+    futures-io                       0.3.5  de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789 \
+    futures-macro                    0.3.5  d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39 \
+    futures-sink                     0.3.5  3f2032893cb734c7a05d85ce0cc8b8c4075278e93b24b66f9de99d6eb0fa8acc \
+    futures-task                     0.3.5  bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626 \
+    futures-util                     0.3.5  8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6 \
+    generic-array                   0.12.3  c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec \
+    getrandom                       0.1.14  7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb \
+    gimli                           0.21.0  bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c \
+    h2                               0.2.5  79b7246d7e4b979c03fa093da39cfb3617a96bbeee6310af63991668d7e843ff \
+    hermit-abi                      0.1.13  91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71 \
+    hkdf                             0.8.0  3fa08a006102488bd9cd5b8013aabe84955cf5ae22e304c2caf655b633aefae3 \
+    hmac                             0.7.1  5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695 \
+    http                             0.2.1  28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9 \
+    http-body                        0.3.1  13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b \
+    httparse                         1.3.4  cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9 \
+    hyper                          0.10.16  0a0652d9a2609a968c14be1a9ea00bf4b1d64e2e1f53a1b51b6fff3a6e829273 \
+    hyper                           0.13.5  96816e1d921eca64d208a85aab4f7798455a8e34229ee5a88c935bdee1b78b14 \
+    hyper-rustls                    0.20.0  ac965ea399ec3a25ac7d13b8affd4b8f39325cca00858ddf5eb29b79e6b14b08 \
+    hyper-tls                        0.4.1  3adcd308402b9553630734e9c36b77a7e48b3821251ca2493e8cd596763aafaa \
+    ident_case                       1.0.1  b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39 \
+    idna                             0.1.5  38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e \
+    idna                             0.2.0  02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9 \
+    indexmap                         1.3.2  076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292 \
+    iovec                            0.1.4  b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e \
+    itoa                             0.4.5  b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e \
+    js-sys                          0.3.39  fa5a448de267e7358beaf4a5d849518fe9a0c13fce7afd44b06e68550e5562a7 \
+    kernel32-sys                     0.2.2  7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d \
+    language-tags                    0.2.2  a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    libc                            0.2.70  3baa92041a6fec78c687fa0cc2b3fae8884f743d672cf551bed1d6dac6988d0f \
+    lock_api                         0.3.4  c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75 \
+    log                              0.3.9  e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b \
+    log                              0.4.8  14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7 \
+    malloc_buf                       0.0.6  62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb \
+    matches                          0.1.8  7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
+    maybe-uninit                     2.0.0  60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00 \
+    memchr                           2.3.3  3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400 \
+    mime                             0.2.6  ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0 \
+    mime                            0.3.16  2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d \
+    mime_guess                       2.0.3  2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212 \
+    mio                             0.6.22  fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430 \
+    miow                             0.2.1  8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919 \
+    native-tls                       0.2.4  2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d \
+    net2                            0.2.34  2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7 \
+    num-integer                     0.1.42  3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba \
+    num-traits                      0.2.11  c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096 \
+    num_cpus                        1.13.0  05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3 \
+    numtoa                           0.1.0  b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef \
+    objc                             0.2.7  915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1 \
+    objc-foundation                  0.1.1  1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9 \
+    objc_id                          0.1.1  c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b \
+    object                          0.19.0  9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2 \
+    once_cell                        1.4.0  0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d \
+    opaque-debug                     0.2.3  2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c \
+    open                             1.4.0  7c283bf0114efea9e42f1a60edea9859e8c47528eae09d01df4b29c1e489cc48 \
+    openssl                        0.10.29  cee6d85f4cb4c4f59a6a85d5b68a233d280c82e29e822913b9c8b129fbf20bdd \
+    openssl-probe                    0.1.2  77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de \
+    openssl-sys                     0.9.56  f02309a7f127000ed50594f0b50ecc69e7c654e16d41b4e8156d1b3df8e0b52e \
+    parking_lot                     0.10.2  d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e \
+    parking_lot                      0.9.0  f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252 \
+    parking_lot_core                 0.6.2  b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b \
+    parking_lot_core                 0.7.2  d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3 \
+    pathdiff                         0.2.0  877630b3de15c0b64cc52f659345724fbf6bdad9bd9566699fc53688f3c34a34 \
+    pbr                              1.0.2  4403eb718d70c03ee279e51737782902c68cca01e870a33b6a2f9dfb50b9cd83 \
+    percent-encoding                 1.0.1  31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831 \
+    percent-encoding                 2.1.0  d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
+    pin-project                     0.4.16  81d480cb4e89522ccda96d0eed9af94180b7a5f93fb28f66e1fd7d68431663d1 \
+    pin-project-internal            0.4.16  a82996f11efccb19b685b14b5df818de31c1edcee3daa256ab5775dd98e72feb \
+    pin-project-lite                 0.1.5  f7505eeebd78492e0f6108f7171c4948dbb120ee8119d9d77d0afa5469bef67f \
+    pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
+    pkg-config                      0.3.17  05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677 \
+    ppv-lite86                       0.2.8  237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea \
+    prettytable-rs                   0.8.0  0fd04b170004fa2daccf418a7f8253aaf033c27760b5f225889024cf66d7ac2e \
+    proc-macro-hack                 0.5.15  0d659fe7c6d27f25e9d80a1a094c223f5246f6a6596453e09d7229bf42750b63 \
+    proc-macro-nested                0.1.4  8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694 \
+    proc-macro2                     1.0.13  53f5ffe53a6b28e37c9c1ce74893477864d64f74778a93a4beb43c8fa167f639 \
+    qr2term                          0.2.1  840dd4cfb8e5c79316c869eb2b5151ef9b266235e4c8fd014f2c4ae6e1ed7fa8 \
+    qrcode                          0.12.0  16d2f1455f3630c6e5107b4f2b94e74d76dea80736de0981fd27644216cff57f \
+    quote                            1.0.5  42934bc9c8ab0d3b273a16d8551c8f0fcff46be73276ca083ec2414c15c4ba5e \
+    rand                             0.6.5  6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca \
+    rand                             0.7.3  6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
+    rand_chacha                      0.1.1  556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef \
+    rand_chacha                      0.2.2  f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402 \
+    rand_core                        0.3.1  7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b \
+    rand_core                        0.4.2  9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc \
+    rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
+    rand_hc                          0.1.0  7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4 \
+    rand_hc                          0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
+    rand_isaac                       0.1.1  ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08 \
+    rand_jitter                      0.1.4  1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b \
+    rand_os                          0.1.3  7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071 \
+    rand_pcg                         0.1.2  abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44 \
+    rand_xorshift                    0.1.1  cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c \
+    rdrand                           0.4.0  678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2 \
+    redox_syscall                   0.1.56  2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84 \
+    redox_termios                    0.1.1  7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76 \
+    redox_users                      0.3.4  09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431 \
+    regex                            1.3.7  a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692 \
+    regex-automata                   0.1.9  ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4 \
+    regex-syntax                    0.6.17  7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae \
+    remove_dir_all                   0.5.2  4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e \
+    reqwest                         0.10.4  02b81e49ddec5109a9dcfc5f2a317ff53377c915e9ae9d4f2fb50914b85614e2 \
+    ring                           0.16.13  703516ae74571f24b465b4a1431e81e2ad51336cb0ded733a55a1aa3eccac196 \
+    rpassword                        4.0.5  99371657d3c8e4d816fb6221db98fa408242b0b53bac08f8676a41f8554fe99f \
+    rust-argon2                      0.7.0  2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017 \
+    rustc-demangle                  0.1.16  4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783 \
+    rustc_version                    0.2.3  138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a \
+    rustls                          0.17.0  c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1 \
+    rustls-native-certs              0.3.0  a75ffeb84a6bd9d014713119542ce415db3a3e4748f0bfce1e1416cd224a23a5 \
+    ryu                              1.0.4  ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1 \
+    safemem                          0.3.3  ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072 \
+    schannel                        0.1.19  8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75 \
+    scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
+    sct                              0.6.0  e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c \
+    security-framework               0.4.4  64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535 \
+    security-framework-sys           0.4.3  17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405 \
+    semver                           0.9.0  1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403 \
+    semver-parser                    0.7.0  388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
+    serde                          1.0.110  99e7b308464d16b56eba9964e4972a3eee817760ab60d88c3f86e1fecb08204c \
+    serde_derive                   1.0.110  818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984 \
+    serde_json                      1.0.53  993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2 \
+    serde_urlencoded                 0.6.1  9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97 \
+    sha1                             0.6.0  2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d \
+    sha2                             0.8.1  27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0 \
+    signal-hook                     0.1.15  8ff2db2112d6c761e12522c65f7768548bd6e8cd23d2a9dae162520626629bd6 \
+    signal-hook-registry             1.2.0  94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41 \
+    slab                             0.4.2  c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8 \
+    smallvec                        0.6.13  f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6 \
+    smallvec                         1.4.0  c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4 \
+    spin                             0.5.2  6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d \
+    standback                        0.2.8  47e4b8c631c998468961a9ea159f064c5c8499b95b5e4a34b77849d45949d540 \
+    stdweb                          0.4.20  d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5 \
+    stdweb-derive                    0.5.3  c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef \
+    stdweb-internal-macros           0.2.9  58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11 \
+    stdweb-internal-runtime          0.1.5  213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0 \
+    strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
+    strsim                           0.9.3  6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c \
+    subtle                           1.0.0  2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee \
+    syn                             1.0.22  1425de3c33b0941002740a420b1a906a350b88d08b82b2c8a01035a3f9447bac \
+    synstructure                    0.12.3  67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545 \
+    tar                             0.4.26  b3196bfbffbba3e57481b6ea32249fbaf590396a52505a2615adbb79d9d826d3 \
+    tempfile                         3.1.0  7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9 \
+    term                             0.5.2  edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42 \
+    termion                          1.5.5  c22cec9d8978d906be5ac94bceb5a010d885c626c4c8855721a4dbd20e3ac905 \
+    textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
+    thread_local                     1.0.1  d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14 \
+    time                            0.1.43  ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438 \
+    time                            0.2.16  3a51cadc5b1eec673a685ff7c33192ff7b7603d0b75446fb354939ee615acb15 \
+    time-macros                      0.1.0  9ae9b6e9f095bc105e183e3cd493d72579be3181ad4004fceb01adbe9eecab2d \
+    time-macros-impl                 0.1.1  e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa \
+    tokio                           0.2.21  d099fa27b9702bed751524694adbe393e18b36b204da91eb1cbbbbb4a5ee2d58 \
+    tokio-codec                      0.1.2  25b2998660ba0e70d18684de5d06b70b70a3a747469af9dea7618cc59e75976b \
+    tokio-executor                  0.1.10  fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671 \
+    tokio-io                        0.1.13  57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674 \
+    tokio-reactor                   0.1.12  09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351 \
+    tokio-rustls                    0.13.0  4adb8b3e5f86b707f1b54e7c15b6de52617a823608ccda98a15d3a24222f265a \
+    tokio-sync                       0.1.8  edfe50152bc8164fcc456dab7891fa9bf8beaf01c5ee7e1dd43a397c3cf87dee \
+    tokio-tcp                        0.1.4  98df18ed66e3b72e742f185882a9e201892407957e45fbff8da17ae7a7c51f72 \
+    tokio-tls                        0.2.1  354b8cd83825b3c20217a9dc174d6a0c67441a2fae5c41bcb1ea6679f6ae0f7c \
+    tokio-tls                        0.3.1  9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343 \
+    tokio-util                       0.3.1  be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499 \
+    toml                             0.5.6  ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a \
+    tower-service                    0.3.0  e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860 \
+    traitobject                      0.1.0  efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079 \
+    try-lock                         0.2.2  e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382 \
+    typeable                         0.1.2  1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887 \
+    typenum                         1.12.0  373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33 \
+    unicase                          1.4.2  7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33 \
+    unicase                          2.6.0  50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6 \
+    unicode-bidi                     0.3.4  49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5 \
+    unicode-normalization           0.1.12  5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4 \
+    unicode-width                    0.1.7  caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479 \
+    unicode-xid                      0.2.0  826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c \
+    untrusted                        0.7.1  a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a \
+    url                              1.7.2  dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a \
+    url                              2.1.1  829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb \
+    urlshortener                     3.0.0  ed098de5fb4d3eadb600327902b1d32f51e1b9f64e6a7baf588dda55ea989881 \
+    vcpkg                            0.2.8  3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168 \
+    vec_map                          0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
+    version-compare                 0.0.10  d63556a25bae6ea31b52e640d7c41d1ab27faba4ccb600013837a3d0b3994ca1 \
+    version_check                    0.1.5  914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd \
+    version_check                    0.9.1  078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce \
+    want                             0.3.0  1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0 \
+    wasi      0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
+    wasm-bindgen                    0.2.62  e3c7d40d09cdbf0f4895ae58cf57d92e1e57a9dd8ed2e8390514b54a47cc5551 \
+    wasm-bindgen-backend            0.2.62  c3972e137ebf830900db522d6c8fd74d1900dcfc733462e9a12e942b00b4ac94 \
+    wasm-bindgen-futures            0.4.12  8a369c5e1dfb7569e14d62af4da642a3cbc2f9a3652fe586e26ac22222aa4b04 \
+    wasm-bindgen-macro              0.2.62  2cd85aa2c579e8892442954685f0d801f9129de24fa2136b2c6a539c76b65776 \
+    wasm-bindgen-macro-support      0.2.62  8eb197bd3a47553334907ffd2f16507b4f4f01bbec3ac921a7719e0decdfe72a \
+    wasm-bindgen-shared             0.2.62  a91c2916119c17a8e316507afaaa2dd94b47646048014bbdf6bef098c1bb58ad \
+    web-sys                         0.3.39  8bc359e5dd3b46cb9687a051d50a2fdd228e4ba7cf6fcf861a5365c3d671a642 \
+    webpki                          0.21.2  f1f50e1972865d6b1adb54167d1c8ed48606004c2c9d0ea5f1eeb34d95e863ef \
+    webpki-roots                    0.18.0  91cd5736df7f12a964a5067a12c62fa38e1bd8080aff1f80bc29be7c80d19ab4 \
+    websocket                       0.24.0  413b37840b9e27b340ce91b319ede10731de8c72f5bc4cb0206ec1ca4ce581d0 \
+    websocket-base                  0.24.0  5e3810f0d00c4dccb54c30a4eee815e703232819dec7b007db115791c42aa374 \
+    which                            3.1.1  d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724 \
+    winapi                           0.2.8  167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
+    winapi                           0.3.8  8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6 \
+    winapi-build                     0.1.1  2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    winreg                           0.6.2  b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9 \
+    ws2_32-sys                       0.2.1  d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e \
+    x11-clipboard                    0.3.3  89bd49c06c9eb5d98e6ba6536cf64ac9f7ee3a009b2f53996d405b3944f6bcea \
+    xattr                            0.2.2  244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c \
+    xcb                              0.8.2  5e917a3f24142e9ff8be2414e36c649d47d6cc2ba81f16201cdef96e533e02de


### PR DESCRIPTION
New port for [ffsend](https://github.com/timvisee/ffsend)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
