### PR TITLE
up: new port

### DIFF
--- a/sysutils/up/Portfile
+++ b/sysutils/up/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/akavel/up 0.3.2 v
+
+description         Ultimate Plumber is a tool for writing Linux pipes with \
+                    instant live preview
+
+long_description    The main goal of the Ultimate Plumber is to help \
+                    interactively and incrementally explore textual data in \
+                    Linux, by making it easier to quickly build complex \
+                    pipelines, thanks to a fast feedback loop. This is \
+                    achieved by boosting any typical Linux text-processing \
+                    utils such as grep, sort, cut, paste, awk, wc, perl, \
+                    etc., etc., by providing a quick, interactive, scrollable \
+                    preview of their results.
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  b2da5077d2c5de8c8bccf48a45462e9153fa3865 \
+                    sha256  9f1a61aaeef293694745bf11237bcf8f2866169e038f585f1a477e957bf7a1e2 \
+                    size    157031
+
+categories          sysutils
+license             Apache-2
+installs_libs       no
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
New port for [up](https://github.com/akavel/up)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
