### PR TITLE
google-cloud-sdk: update to 298.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             297.0.1
+version             298.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  a6a91e6f4ab9d09906ed60f0156f4a7708305264 \
-                    sha256  9711658910d5a7502941fdc86c9eeb326426c45e7b20460f46b9798f7b68a4d0 \
-                    size    67159603
+    checksums       rmd160  9cf822f86662f29d7d1f32d64d185b93d1a783c9 \
+                    sha256  609452e661d98e918d88a38a5fdc2e10a60991efd7cea06a5a20c509d7a7cfb1 \
+                    size    67136455
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  937ad072e5596f7bd44087084351aef90b6e65d2 \
-                    sha256  69dc2faabc2461551286c15d2fcc5dca82a1fe118cde890ad65134de36d4ba46 \
-                    size    69125889
+    checksums       rmd160  ff9c3b876bc2b76740e5e6b22bd68f069dd19b4c \
+                    sha256  6d2e83c7e8bae273647ddc8c88d0eb72a6e24005d2290d90ba2b3505c3b65edc \
+                    size    69100312
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 298.0.0.

###### Tested on

macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?