### PR TITLE
krew: new port

### DIFF
--- a/sysutils/krew/Portfile
+++ b/sysutils/krew/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/kubernetes-sigs/krew 0.3.4 v
+
+description         Find and install kubectl plugins
+
+long_description    Krew is the package manager for kubectl plugins. Krew \
+                    helps you discover plugins, install and manage them on \
+                    your machine. It is similar to tools like apt, dnf or \
+                    brew. Today, over 70 kubectl plugins are available on Krew.
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  e8b370e3e66fa39453a8cf1be4e77fc95b58b2dd \
+                    sha256  9a10120ddf7611547da373240c2cb64a40cc8e6226ec09d662581e9765a62be7 \
+                    size    568686
+
+categories          sysutils
+license             Apache-2
+installs_libs       no
+
+build.target        sigs.k8s.io/krew/cmd/krew
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/krew ${destroot}${prefix}/bin/
+
+    set krew_doc_dir ${prefix}/share/doc/${name}
+    xinstall -d ${destroot}${krew_doc_dir}
+    copy {*}[glob ${worksrcpath}/docs/*] ${destroot}${krew_doc_dir}/
+}


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
