### PR TITLE
gh: update to 0.10.1

### DIFF
--- a/devel/gh/Portfile
+++ b/devel/gh/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        cli cli 0.10.0 v
+github.setup        cli cli 0.10.1 v
 name                gh
 categories          devel
 platforms           darwin
@@ -23,9 +23,9 @@ homepage            https://cli.github.com/
 github.tarball_from releases
 distname            gh_${version}_macOS_amd64
 
-checksums           rmd160  af0d07d79b0b6d2ed5d76993fb9d2955a25a99f8 \
-                    sha256  3d30518775f1d519a8fbd14296f52ed374328ad85b5aa9ec5b8341ba610448d5 \
-                    size    6204700
+checksums           rmd160  c5fa3d4294e69a48417b85d8ecc4925712d456ca \
+                    sha256  36340a0af921d9ab4eca22af66055eb4a649903368590cede179886ffbd15531 \
+                    size    6215877
 
 use_configure       no
 installs_libs       no


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
