### PR TITLE
newreleases: do not override build phase

### DIFF
--- a/devel/newreleases/Portfile
+++ b/devel/newreleases/Portfile
@@ -22,10 +22,9 @@ installs_libs       no
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-build {
-    system -W "${worksrcdir}/${name}" "go build ."
-}
+build.pre_args      -v -o ./nr
+build.args          ./${name}
 
 destroot {
-    xinstall -m 755 ${worksrcdir}/${name}/${name} ${destroot}${prefix}/bin/
+    xinstall -m 755 ${worksrcpath}/nr ${destroot}${prefix}/bin/${name}
 }


### PR DESCRIPTION
Fix to address https://github.com/macports/macports-ports/commit/d17d155f6aa6f3d5247cd68d3119daf3fd39e322#r40162801

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
