### PR TITLE
kubergrunt: new port

### DIFF
--- a/sysutils/kubergrunt/Portfile
+++ b/sysutils/kubergrunt/Portfile
@@ -1,0 +1,46 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/gruntwork-io/kubergrunt 0.5.13 v
+
+categories          sysutils
+license             Apache-2
+installs_libs       no
+
+description         Kubergrunt is a standalone go binary with a collection of \
+                    commands to fill in the gaps between Terraform, Helm, and \
+                    Kubectl.
+
+long_description    kubergrunt is a standalone go binary with a collection of \
+                    commands that attempts to fill in the gaps between \
+                    Terraform, Helm, and Kubectl for managing a Kubernetes \
+                    Cluster. Some of the features of kubergrunt include: \
+                    Configuring kubectl to authenticate with a given EKS \
+                    cluster, managing Helm and associated TLS certificates \
+                    on any Kubernetes cluster, setting up Helm client with \
+                    TLS certificates on any Kubernetes cluster. generating \
+                    TLS certificate key pairs and storing them as Kubernetes \
+                    Secrets on any Kubernetes cluster.
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  6dbed7716bacd6ffff225f1f0717ab6fedfd67f1 \
+                    sha256  867998917c086365a935b5f58dda54ebe2e3b3224563bce19d5d522cbae94fc1 \
+                    size    119914
+
+depends_build-append \
+                    port:dep
+
+build.pre_args      -v -o ${worksrcpath}/${name}
+build.args          ./cmd
+
+pre-build {
+    system -W "${worksrcpath}" "${build.env} dep ensure -v -vendor-only"
+}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
New port for [kubergrunt](https://github.com/gruntwork-io/kubergrunt/)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
