### PR TITLE
py-scipy: update to 1.5.0

### DIFF
--- a/python/py-scipy/Portfile
+++ b/python/py-scipy/Portfile
@@ -7,10 +7,10 @@ PortGroup               github 1.0
 PortGroup               compilers 1.0
 PortGroup               compiler_blacklist_versions 1.0
 
-github.setup            scipy scipy 1.4.1 v
-checksums               rmd160 e232695a51ed02b362187ea164ce269cb431e2ab \
-                        sha256 4cc4e820d0770225bfb83e2a0ae340bb230fafb5402ea8efa87c6576a3f342cf \
-                        size   18892400
+github.setup            scipy scipy 1.5.0 v
+checksums               rmd160  bae805468c0781ea8fff87f25b7c3384dcd0875e \
+                        sha256  b31b616b4571f19a4c1a925b1b19f4eb325d098265692d88ea386537aa3742ab \
+                        size    19831004
 revision                0
 
 name                    py-scipy
@@ -40,10 +40,10 @@ if {${name} ne ${subport}} {
     if {${python.version} == 27} {
 
         github.setup scipy scipy 1.2.3 v
-        checksums rmd160 868076b4d88257a6b536f4c3a4e1e8230b587290 \
-                  sha256 beb6123e91a0bdfba4557b6560be4899dac174a38c30876e5cfc60382ecb4ff7 \
-                  size   18564471
-        revision  0
+        checksums   rmd160 868076b4d88257a6b536f4c3a4e1e8230b587290 \
+                    sha256 beb6123e91a0bdfba4557b6560be4899dac174a38c30876e5cfc60382ecb4ff7 \
+                    size   18564471
+        revision    0
         github.livecheck.regex {(1\.2\.[0-9.-]+)}
 
     } else {
@@ -62,6 +62,15 @@ if {${name} ne ${subport}} {
         compiler.blacklist-append {clang < 800}
 
         compilers.allow_arguments_mismatch yes
+    }
+
+    if {${python.version} == 35} {
+        github.setup scipy scipy 1.4.1 v
+        checksums   rmd160  e232695a51ed02b362187ea164ce269cb431e2ab \
+                    sha256  4cc4e820d0770225bfb83e2a0ae340bb230fafb5402ea8efa87c6576a3f342cf \
+                    size    18892400
+        revision    0
+        github.livecheck.regex {(1\.4\.[0-9.-]+)}
     }
 
     depends_lib-append      port:py${python.version}-numpy \


### PR DESCRIPTION
#### Description
- update to latest version, pin to 1.4.1 for PY35

###### Tested on
macOS 10.14.6 18G5033
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
