### PR TITLE
py-json5: update to 0.9.5, fix license, enable tests

### DIFF
--- a/python/py-json5/Portfile
+++ b/python/py-json5/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        dpranke pyjson5 0.8.5 v
-revision            1
+github.setup        dpranke pyjson5 0.9.5 v
+revision            0
 name                py-json5
 
 python.versions     27 36 37 38
 categories-append   devel
-license             apache
+license             Apache-2
 platforms           darwin
 supported_archs     noarch
 maintainers         {aronnax @lpsinger} openmaintainer
@@ -19,18 +19,17 @@ long_description \
   ${description}. JSON5 extends the JSON data interchange format to make it \
   slightly more usable as a configuration language.
 
-checksums           rmd160  e6c157c8021ae81038491722f996e99646cff854 \
-                    sha256  ba6cfd27e79f306ae6d9954e50086a2893c2f63cc02272e00c2067399e5da56f \
-                    size    106706
+checksums           rmd160  942ef9c2163f9ace5982077a68f480f1265ae660 \
+                    sha256  2eaefd6a0ad37aa965960963704b41e9534532e91bb5f124db779ac82fcad720 \
+                    size    109264
 
 if {${subport} ne ${name}} {
     livecheck.type  none
 
     depends_lib-append    port:py${python.version}-setuptools
 
-    post-destroot {
-        # make sure the "tests" directory is inside the pybtex directory so that it
-        # doesn't get installed into ${python.pkgd}
-        file rename ${destroot}/${python.pkgd}/tests ${destroot}/${python.pkgd}/${python.rootname}/tests
-    }
+    depends_test-append \
+                    port:py${python.version}-hypothesis
+    test.run        yes
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
 }


### PR DESCRIPTION
#### Description
- update to latest version
- license is Apache-2
- enabled tests

###### Tested on
macOS 10.14.6 18G5033
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
