### PR TITLE
chezmoi: update to 1.0.3

### DIFF
--- a/sysutils/chezmoi/Portfile
+++ b/sysutils/chezmoi/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/twpayne/chezmoi 1.8.2 v
+go.setup            github.com/twpayne/chezmoi 1.8.3 v
 
 categories          sysutils
 license             MIT
@@ -11,9 +11,9 @@ installs_libs       no
 
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
 
-checksums           rmd160  9c52961a40d8d0bb72ee076d063c84a779caf100 \
-                    sha256  90650a182f1440577cf8b06df87051eef4518e0c80d95052e8148e01332f069d \
-                    size    2231853
+checksums           rmd160  b6c256becdf65b6bf512b6b5b8096f2e3eb59ef7 \
+                    sha256  ec29be2fcabf63c60ca02eb5365e092fb13576a64a0d935b3dd22315db2aa170 \
+                    size    2235170
 
 homepage            https://chezmoi.io/
 


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
