### PR TITLE
ccache: update to 3.7.10

### DIFF
--- a/devel/ccache/Portfile
+++ b/devel/ccache/Portfile
@@ -3,13 +3,13 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        ccache ccache 3.7.9 v
+github.setup        ccache ccache 3.7.10 v
 revision            0
 # Use tarball, since the releases archive discourages running ./autogen.sh
 github.tarball_from tarball
-checksums           rmd160  dc94fdc3888b7354058283bb5737dc2acd8c4bc2 \
-                    sha256  1520eb802dcbbd24e5589696d82e376a0fa2f65a41cff3dfae89f4af2391bc4e \
-                    size    387820
+checksums           rmd160  b435dca4352246ba62e305ac8bc67a478ae6cae5 \
+                    sha256  263abaf5716b3be082d68634366491caf0ba100adabe572ac821f0ceb5089b58 \
+                    size    388938
 
 categories          devel
 platforms           darwin freebsd


### PR DESCRIPTION
#### Description
See https://ccache.dev/releasenotes.html#_ccache_3_7_10
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5
Xcode command line tools 11.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
Tests are not enabled for this port.
- [x] tried a full install with `sudo port -vst install`?
Build succeeds only without trace mode, see below.
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
