### PR TITLE
py-pytest: add dependency on py-hypothesis

### DIFF
--- a/python/py-pytest/Portfile
+++ b/python/py-pytest/Portfile
@@ -6,7 +6,7 @@ PortGroup           select 1.0
 
 name                py-pytest
 version             5.4.3
-revision            0
+revision            1
 
 categories-append   devel
 platforms           darwin
@@ -58,6 +58,8 @@ if {${name} ne ${subport}} {
         depends_lib-append  port:py${python.version}-atomicwrites \
                             port:py${python.version}-six \
                             port:py${python.version}-funcsigs
+    } else {
+        depends_lib-append  port:py${python.version}-hypothesis
     }
 
     if {${python.version} < 36} {


### PR DESCRIPTION
Subject says it all. Sometime recently py-pytest added in the need for py-hypothesis ... for example NumPy requires PyTest for "numpy.test()", and PyTest will not work without py-hypothesis.