### PR TITLE
prometheus: update to 2.19.2

### DIFF
--- a/net/prometheus/Portfile
+++ b/net/prometheus/Portfile
@@ -1,7 +1,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        prometheus prometheus 2.19.1 v
+github.setup        prometheus prometheus 2.19.2 v
 github.tarball_from archive
 
 description         The Prometheus monitoring system and time series database
@@ -43,9 +43,9 @@ set prom_share_dir  ${prefix}/share/${name}
 set prom_log_dir    ${prefix}/var/log/${name}
 set prom_log_file   ${prom_log_dir}/${name}.log
 
-checksums   rmd160  64b5146a1504ead2b8098c215c93aed90c27367b \
-            sha256  b72b9b6bdbae246dcc29ef354d429425eb3c0a6e1596fc8b29b502578a4ce045 \
-            size    13343138
+checksums   rmd160  cebd2b1dbaf9f31d9f08c627e494536961ac10e5 \
+            sha256  d4e84cae2fed6761bb8a80fcc69b6e0e9f274d19dffc0f38fb5845f11da1bbc3 \
+            size    13338606
 
 add_users           ${prom_user} \
                     group=${prom_user} \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
