### PR TITLE
teleport: update to 4.2.10

### DIFF
--- a/net/teleport/Portfile
+++ b/net/teleport/Portfile
@@ -1,9 +1,9 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
+PortGroup           golang 1.0
 
-github.setup        gravitational teleport 4.0.6 v
+go.setup            github.com/gravitational/teleport 4.2.10 v
 
 homepage            http://gravitational.com/teleport/
 categories          net
@@ -16,24 +16,16 @@ long_description    Teleport is a modern SSH server and CA for managing clusters
                     and a Web UI.  Built on the Golang SSH library, and compatible with OpenSSH
 license             Apache-2
 
-checksums           rmd160  967b09678a26d297b6d1820dd4e74fa08412a015 \
-                    sha256  c954a24d184290b1aab0e53cc7c86e10513905c7e5e70c861825daa5ead8154d \
-                    size    34935154
+checksums           rmd160  7d3406df247151b632127f75fee5541e90e37cb0 \
+                    sha256  04739461250a7d27fe61341d585557752d769d7a7ca094d663ecc980182cf500 \
+                    size    55846000
 
 depends_lib         port:go port:zip
 platforms           darwin
-use_configure       no
-worksrcdir          src/github.com/${github.author}/${github.project}
 
-build.env-append    GOPATH=${workpath}
+build.cmd           make
 build.target        full
 use_parallel_build  no
-
-post-extract {
-    xinstall -d ${workpath}/src/github.com/${github.author}
-    move ${workpath}/${name}-${github.version} \
-        ${worksrcpath}
-}
 
 destroot {
     foreach i { tctl tsh teleport } {


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
