### PR TITLE
codesearch: update to 1.2.0

### DIFF
--- a/devel/codesearch/Portfile
+++ b/devel/codesearch/Portfile
@@ -1,9 +1,9 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
+PortGroup           golang 1.0
 
-github.setup        google codesearch 1.1.0 v
+go.setup            github.com/google/codesearch 1.2.0 v
 # Epoch 1: Migration to github
 # Epoch 2: Migration to releases
 epoch               2
@@ -19,29 +19,18 @@ long_description \
 license             BSD
 
 checksums \
-    rmd160  0db92036de842e0e42859fbf6ee64d1b8490d6f5 \
-    sha256  1d46517714d449b4e64f155405b2c9f150e8c68b158197acf90c72654a5751cf \
-    size    34096
+    rmd160  7f5e126205efc9a9225ba10144ef3cb06a8f698e \
+    sha256  e1632998d912b9f577f048fac44d73b41a5b1664bde1c97b48ac8e6918646fa8 \
+    size    34130
 
 platforms           darwin
 
-depends_lib         port:go
-
-worksrcdir          src/github.com/google/codesearch
-
-post-extract {
-    xinstall -d ${workpath}/src/github.com/google
-    move ${workpath}/${name}-${github.version} \
-        ${worksrcpath}
-}
-
-use_configure       no
 set progs           [list cgrep csearch cindex]
 
 build {
     foreach prog ${progs} {
         system -W ${worksrcpath} \
-          "GOPATH=${workpath} ${prefix}/bin/go build cmd/${prog}/${prog}.go"
+          "${build.env} ${build.cmd} cmd/${prog}/${prog}.go"
     }
 }
 


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
