### PR TITLE
deno: update to 1.1.2

### DIFF
--- a/devel/deno/Portfile
+++ b/devel/deno/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        denoland deno 1.0.2 v
+github.setup        denoland deno 1.1.2 v
 revision            0
 
 homepage            https://deno.land/
@@ -29,12 +29,13 @@ supported_archs     x86_64
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  4b65f1bf105ff0c9ce86e97adb7333337b8c77ed \
-                    sha256  33438ab1a2776d132578f6bb54fc86c2de9e35b865f2c75fc9d1480dd066cae6 \
-                    size    16424909
+checksums           rmd160  1fa2c6cfb2c8bb5dcf29b127ce329d93c3b43067 \
+                    sha256  4db0c41024b0b84c098198df44e083f1235311487b66118848638cffd41c6a42 \
+                    size    17332420
 
 github.tarball_from releases
 distname            ${name}-x86_64-apple-darwin
+dist_subdir         ${name}/${version}
 extract.mkdir       yes
 
 installs_libs       no


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
