### PR TITLE
wren: new port

### DIFF
--- a/lang/wren/Portfile
+++ b/lang/wren/Portfile
@@ -1,0 +1,47 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem        1.0
+PortGroup         github 1.0
+PortGroup         makefile 1.0
+
+github.setup      wren-lang wren 0.3.0
+
+categories        lang
+license           MIT
+platforms         darwin
+supported_archs   x86_64 i386
+
+description       Wren is a small, fast, class-based concurrent scripting \
+                  language.
+
+long_description  {*}${description} Think Smalltalk in a Lua-sized package \
+                  with a dash of Erlang and wrapped up in a familiar, modern \
+                  syntax.  Wren is intended for embedding in applications. It \
+                  has no dependencies, a small standard library, and an \
+                  easy-to-use C API. It compiles cleanly as C99, C++98 or \
+                  anything later.
+
+homepage          https://wren.io
+
+maintainers       {gmail.com:herby.gillot @herbygillot} \
+                  openmaintainer
+
+checksums         rmd160  2b0acc5b21184ff5f8bb485def843418e9a7ca3f \
+                  sha256  489ac252ec805bfa7aab07286e2bc8dc6348bdb55857f7afb9640c5919e118ed \
+                  size    1228925
+
+worksrcdir        ${worksrcdir}/projects/make.mac
+
+build.args-append verbose=1
+build.target      wren_shared
+
+if {${build_arch} eq "x86_64"} {
+    build.args-append config=release_64bit
+} else {
+    build.args-append config=release_32bit
+}
+
+destroot {
+    copy ${worksrcpath}/../../lib/libwren.dylib ${destroot}${prefix}/lib/
+    copy {*}[glob ${worksrcpath}/../../src/include/*] ${destroot}${prefix}/include/
+}


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
