### PR TITLE
wren-cli: new port

### DIFF
--- a/lang/wren-cli/Portfile
+++ b/lang/wren-cli/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem        1.0
+PortGroup         github 1.0
+PortGroup         makefile 1.0
+
+github.setup      wren-lang wren-cli 0.3.0
+
+categories        lang
+license           MIT
+platforms         darwin
+supported_archs   x86_64 i386
+
+description       A command line tool for the Wren programming language
+
+long_description  The CLI project is a small and simple REPL and CLI tool for \
+                  running Wren scripts. It is backed by libuv to implement IO \
+                  functionality, and is a work in progress.
+
+homepage          https://wren.io/cli/
+
+maintainers       {gmail.com:herby.gillot @herbygillot} \
+                  openmaintainer
+
+checksums         rmd160  f92affe56d28b0697ec3e618e3b1fbfd515b2ccc \
+                  sha256  6ded2552c919f41b6e6c37801e1b2f29691de534c0d5328641d4daa6184cd850 \
+                  size    509880
+
+worksrcdir        ${worksrcdir}/projects/make.mac
+
+build.args-append verbose=1
+
+if {${build_arch} eq "x86_64"} {
+    build.args-append config=release_64bit
+} else {
+    build.args-append config=release_32bit
+}
+
+destroot {
+    copy ${worksrcpath}/../../bin/wren_cli ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
nr cf###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
