### PR TITLE
[volk-]gnss-sdr: Update -devel subports and remove deprecated PortGroup

### DIFF
--- a/science/gnss-sdr/Portfile
+++ b/science/gnss-sdr/Portfile
@@ -5,12 +5,10 @@ PortSystem          1.0
 PortGroup           cmake 1.0
 PortGroup           github 1.0
 PortGroup           active_variants 1.1
-PortGroup           cxx11 1.1
-PortGroup           compiler_blacklist_versions 1.0
 
 name                gnss-sdr
 maintainers         {michaelld @michaelld} {gmail.com:carles.fernandez @carlesfernandez} openmaintainer
-description         An Open Source Global Navigation Satellite Systems (GNSS)(for example: GPS, Galileo, Glonass, Beidou, etc) Software Defined Radio (SDR) Receiver
+description         An Open Source Global Navigation Satellite Systems (GNSS) (for example: GPS, Galileo, Glonass, Beidou, etc) Software Defined Radio (SDR) Receiver
 categories          science
 license             GPL-3
 platforms           darwin
@@ -18,17 +16,7 @@ platforms           darwin
 dist_subdir         gnss-sdr
 
 # Requires C++14
-compiler.blacklist-append {clang < 602} \
-    gcc-4.0 \
-    apple-gcc-4.0 \
-    gcc-4.2 apple-gcc-4.2 llvm-gcc-4.2 macports-llvm-gcc-4.2 \
-    macports-gcc-4.3 \
-    macports-gcc-4.4 \
-    macports-gcc-4.5 \
-    macports-gcc-4.6 \
-    macports-gcc-4.7 \
-    macports-gcc-4.8 \
-    macports-dragonegg-*
+compiler.cxx_standard 2014
 
 if {${subport} eq "gnss-sdr"} {
 
@@ -52,12 +40,12 @@ subport gnss-sdr-devel {
     long_description    ${description}: \
         This port is kept up with the GNSS-SDR GIT next branch, which is typically updated daily to weekly. This version of GNSS-SDR generally contains fixes and new features that will be incorporated in an upcoming release.
     name      gnss-sdr-devel
-    github.setup gnss-sdr gnss-sdr 6da98e3381ca34a9f9eea489fa137026d6df0a6f
-    version   20200313-[string range ${github.version} 0 7]
-    checksums rmd160  f3d25bf1cb24959aa1ea8e6c8a8e8fe6d3e0826f \
-              sha256  bcaebca379be91c89b3a42e40f65ecc052457b59e335d8075d3618127fca3355 \
-              size    3766992
-    revision  4
+    github.setup gnss-sdr gnss-sdr 0c4bdfac48f6674bd0993965a91cfcc3e84e5930
+    version   20200628-[string range ${github.version} 0 7]
+    checksums rmd160 bf58cefb7ab09d324063442e7a4093bb1a67f81a \
+              sha256 b197ceb46e1bbc56006b1e1726f02c226dcbd73acf5315fadfb2b4e6af5a7b86 \
+              size   3940345
+    revision  0
 
     conflicts gnss-sdr
 

--- a/science/volk-gnss-sdr/Portfile
+++ b/science/volk-gnss-sdr/Portfile
@@ -5,8 +5,6 @@ PortSystem          1.0
 PortGroup           cmake 1.0
 PortGroup           github 1.0
 PortGroup           active_variants 1.1
-PortGroup           cxx11 1.1
-PortGroup           compiler_blacklist_versions 1.0
 
 name                volk-gnss-sdr
 maintainers         {michaelld @michaelld} {gmail.com:carles.fernandez @carlesfernandez} openmaintainer
@@ -18,17 +16,7 @@ platforms           darwin
 dist_subdir         gnss-sdr
 
 # Requires C++14
-compiler.blacklist-append {clang < 602} \
-    gcc-4.0 \
-    apple-gcc-4.0 \
-    gcc-4.2 apple-gcc-4.2 llvm-gcc-4.2 macports-llvm-gcc-4.2 \
-    macports-gcc-4.3 \
-    macports-gcc-4.4 \
-    macports-gcc-4.5 \
-    macports-gcc-4.6 \
-    macports-gcc-4.7 \
-    macports-gcc-4.8 \
-    macports-dragonegg-*
+compiler.cxx_standard 2014
 
 if {${subport} eq "volk-gnss-sdr"} {
 
@@ -50,12 +38,12 @@ subport volk-gnss-sdr-devel {
         This port is kept up with the VOLK-GNSS-SDR GIT next branch, which is typically updated daily to weekly. This version of VOLK-GNSS-SDR generally contains fixes and new features that will be incorporated in an upcoming release.
 
     name      volk-gnss-sdr-devel
-    github.setup gnss-sdr gnss-sdr 6da98e3381ca34a9f9eea489fa137026d6df0a6f
-    version   20200313-[string range ${github.version} 0 7]
-    checksums rmd160  f3d25bf1cb24959aa1ea8e6c8a8e8fe6d3e0826f \
-              sha256  bcaebca379be91c89b3a42e40f65ecc052457b59e335d8075d3618127fca3355 \
-              size    3766992
-    revision  2
+    github.setup gnss-sdr gnss-sdr 0c4bdfac48f6674bd0993965a91cfcc3e84e5930
+    version   20200628-[string range ${github.version} 0 7]
+    checksums rmd160 bf58cefb7ab09d324063442e7a4093bb1a67f81a \
+              sha256 b197ceb46e1bbc56006b1e1726f02c226dcbd73acf5315fadfb2b4e6af5a7b86 \
+              size   3940345
+    revision  0
 
     conflicts volk-gnss-sdr
 


### PR DESCRIPTION
#### Description

This PR does a couple of things:

 * It updates `-devel` subports version.
 * It removes deprecated cxx11 PortGroup, replaced by `compiler.cxx_standard 2014`.

There is also a minor edition in the gnss-sdr port description.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5
Xcode 11.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
