### PR TITLE
gnucash: don't use -Werror

### DIFF
--- a/gnome/gnucash/Portfile
+++ b/gnome/gnucash/Portfile
@@ -42,6 +42,7 @@ checksums         rmd160  b0bcd9fb472f310e0dabb7945bfc9be4eff63cef \
 
 post-patch {
     reinplace "s|set(HAVE_OSX_KEYCHAIN 1)||" ${worksrcpath}/CMakeLists.txt
+    reinplace "s|-Werror||" ${worksrcpath}/CMakeLists.txt
     
     # Drop in a patched version of glibconfig.h via
     # https://git.gnome.org/browse/gtk-osx/plain/patches/glib-gint64-long-long.patch


### PR DESCRIPTION
it causes the pthread tests to fail on some macOS versions
and it is generally not advised to have -Werror active
in releases of software in general

closes: https://trac.macports.org/ticket/60310

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
