### PR TITLE
fetch-crl: update to 3.0.21

### DIFF
--- a/security/fetch-crl/Portfile
+++ b/security/fetch-crl/Portfile
@@ -3,13 +3,13 @@
 PortSystem          1.0
 
 name                fetch-crl
-version             3.0.19
+version             3.0.21
 categories          security net
 platforms           darwin
 supported_archs     noarch
 license             Apache-2
 
-maintainers         nikhef.nl:dennisvd {petr @petrrr} openmaintainer
+maintainers         {petr @petrrr} openmaintainer
 
 description         Download tool for Certificate Revocation Lists
 
@@ -23,9 +23,9 @@ homepage            https://wiki.nikhef.nl/grid/FetchCRL3
 
 master_sites        https://dist.eugridpma.info/distribution/util/fetch-crl3/
 
-checksums           md5     f292bf2cb2fdc721a84379425c605cd7 \
-                    rmd160  87a69e6ded450138548675c85b6dd30bef17254d \
-                    sha256  64d8f573601568554415c9ad853864285313538a90de92b3dcf2d16b92b2bcde
+checksums           size    46656 \
+                    rmd160  8ed2e0ed632dfd96e936855141617f82d3cf5f14 \
+                    sha256  19a96b95a1c22da9d812014660744c6a31aac597b53ac17128068a77c269cde8
 
 use_configure       no
 
@@ -63,7 +63,7 @@ subport ${name} {
 
 # The subport provides a launchd item
 subport ${name}-launchd {
-    revision            1
+    revision            0
     # update descriptions
     description         Creates a launchd entry for fetch-crl utility
     long_description    ${description}. ${long_description}


### PR DESCRIPTION
#### Description

From [CHANGES file](https://dist.eugridpma.info/distribution/util/fetch-crl/CHANGES):
```
Changes in 3.0.20-1
----------------------
* network connection failure messages are pre-filtered and only primary
  status lines shown in logs for download and head requests (bugzilla #29)

Changes in 3.0.19-1
----------------------
* Do not add spurious newline to DER-format files (fixes report 201670320-01)
* run a script after the completion of every fetch-crl run (uses postexec
  directive in config file)
```
From [wiki](https://wiki.nikhef.nl/grid/FetchCRL3) for 3.0.21:
```
* Add option to override the UserAgent string sent in the LWP web requests (both HEAD and GET)
```

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
**Untested.**

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
