### PR TITLE
igtf-ca-bundle: update to 1.106

### DIFF
--- a/security/igtf-ca-bundle/Portfile
+++ b/security/igtf-ca-bundle/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                igtf-ca-bundle
-version             1.92
+version             1.106
 categories          security net
 platforms           darwin
 supported_archs     noarch
-maintainers         {petr @petrrr} nikhef.nl:dennisvd openmaintainer
+maintainers         {petr @petrrr} openmaintainer
 
 license             {CCBY-3 Permissive} MPL-1.1+
 
@@ -20,16 +20,15 @@ long_description    \
     mentioned in the Authentication Profiles accepted by the IGTF. \
     For a list of those profiles, please refer to the website.
 
-homepage            http://www.igtf.net
+homepage            https://www.igtf.net
 
-master_sites        http://dist.eugridpma.info/distribution/igtf/${version} \
-                    http://www.apgridpma.org/distribution/igtf/${version}
+master_sites        https://dist.eugridpma.info/distribution/igtf/${version}
 
 distname            igtf-policy-installation-bundle-${version}
 
-checksums           rmd160  13572016a14f437969462b7a05d5f82f0069e68e \
-                    sha256  fd1f47e642477e0e38829fa9ff1b34e03944000fcf9539244f5ca4fd53814e74 \
-                    size    185327
+checksums           rmd160  1d6657d2e65b8845071b2759f9cd346b92c4fcf5 \
+                    sha256  b92bef32d9963f0dfe397780bbf9c48307a2102b7770a3dafeb0149ee71cc26a \
+                    size    173857
 
 depends_run         port:fetch-crl
 
@@ -76,5 +75,5 @@ post-deactivate {
 }
 
 livecheck.type      regex
-livecheck.url       http://dist.eugridpma.info/distribution/igtf
+livecheck.url       https://dist.eugridpma.info/distribution/igtf
 livecheck.regex     ">(\\d+\\.\\d{2})/<"


### PR DESCRIPTION
Remove nikhef.nl:dennisvd from maintainers: they have declined to further maintain their ports (see https://github.com/macports/macports-ports/pull/7567#issuecomment-650803009)

Use HTTPS URLs; remove unresponsive site www.apgridpma.org

#### Description

From [CHANGES](http://dist.eugridpma.info/distribution/igtf/1.106/CHANGES) file:
```
Changes from 1.105 to 1.106
---------------------------
(4 May 2020)

* Removed expiring AddTrust External CA Root (US)
* Updated legacy DutchGrid (Nikhef MS) Root CA (NL)
* Removed discontinued NCSA-tfca-2013 CA (US)
* Added TCS G4 ECC trust anchors to experimental area (EU)

Changes from 1.104 to 1.105
---------------------------
(30 March 2020)

* Discontinued CERN-LCG-IOTA-CA following decommissioning by authority (CERN)
* Added new G4 intermediates for the GEANT TCS service and supporting 
  self-signed USERTrust RSA Root (EU)
* Updated AddTrust External CA Root signing policy to support legacy UTN 
  chains for GEANT TCS G4 (EU)


Changes from 1.103 to 1.104
---------------------------
(29 January 2020)

* Reinstated AddTrust External CA Root in parallel to Comodo RSA CA 
  to ease transitionary period (US)

Changes from 1.102 to 1.103
---------------------------
(27 January 2020)

* Updated contact addresses for DigiCert (US)
* Regrafted InCommon IGTF Server CA onto self-signed Comodo RSA CA (US)
* Discontinued superfluous AddTrust External CA Root (US)
* Discontinued AustrianGrid CA (AT)

Changes from 1.101 to 1.102
---------------------------
(14 October 2019)

* Added CESNET-CA-4 ICA accredited classic CA for issuer roll-over (CZ)

Changes from 1.99 to 1.101
--------------------------
(24 June 2019, note: 1.100 was not issued)

* added new trust anchor for PolishGrid (2019) for key roll-over (PL)
* withdrawn discontinued CILogon OSG CA (US)

Changes from 1.98 to 1.99
-------------------------
(27 May 2019)

* withdrawn superseded HKU CA (HK)
* withdrawn discontinued CyGrid CA following migration to TCS (CY)

Changes from 1.97 to 1.98
-------------------------
(29 Apr 2019)

* withdrawn superseded IRAN-GRID authority (IR)

Changes from 1.96 to 1.97
-------------------------
(25 Mar 2019)

* temporarily withdrawn EG-GRID 4a96b1ea for network availability reasons (EG)

Changes from 1.95 to 1.96
-------------------------
(25 Feb 2019)

* withdrawn superseded QuoVadis-Grid-ICA (1st gen) CA (BM)
* added new trust anchor MD-Grid-CA-T for rollover of existing CA (MD)
* discontinued expiring 2009 series MD-Grid-CA (MD)

Changes from 1.94 to 1.95
-------------------------
(26 Nov 2018)

* Updated namespaces and signing_policy files for CILogon Silver CA to
  permit DNs without "/C=US" (US)

Changes from 1.93 to 1.94
-------------------------
(29 Oct 2018)

* extended validity period for the ArmeSFo CA (AM)
* withdrawn expiring DFN-SLCS CA (DE)

Changes from 1.92 to 1.93
-------------------------
(24 Sep 2018)

* Updated contact information for HellasGrid-CA (GR)
* Removed superseded IGCA CA (IN)
```
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
**Untested.**

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
