### PR TITLE
sqlitebrowser: fix lib not found for qscintilla 2.11.5

### DIFF
--- a/databases/sqlitebrowser/Portfile
+++ b/databases/sqlitebrowser/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        sqlitebrowser sqlitebrowser 3.12.0
-revision            0
+revision            1
 
 categories          databases
 platforms           darwin linux
@@ -55,7 +55,8 @@ platform darwin {
     configure.args-append \
                         CONFIG+=c++11 \
                         INCLUDEPATH+=${qt_includes_dir} \
-                        QMAKE_LIBDIR+=${qt_libs_dir}
+                        QMAKE_LIBDIR+=${qt_libs_dir} \
+                        QMAKE_RPATHDIR+=${qt_libs_dir}
 
     # Uses QSysInfo::buildAbi and QSysInfo::currentCpuArchitecture
     qt5.min_version     5.4


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/60723

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
