### PR TITLE
py-tensorflow: Bugfix, add dependencies py-astunparse, py-opt_einsum

### DIFF
--- a/python/py-astunparse/Portfile
+++ b/python/py-astunparse/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-astunparse
+version             1.6.3
+revision            0
+
+license             BSD
+maintainers         nomaintainer
+platforms           darwin
+supported_archs     noarch
+
+description         An AST unparser for Python.
+
+long_description    ${description}. This is a factored out version\
+                    of unparse found in the Python source distribution\;\
+                    under Demo/parser in Python 2 and under Tools/parser\
+                    in Python 3.
+
+homepage            https://github.com/simonpercivall/astunparse
+
+checksums           rmd160  3506f9ca63bfac6efa0a2933ff0257b760972011 \
+                    sha256  5ad93a8456f0d084c3456d059fd9a92cce667963232cbf763eac3bc5b7940872 \
+                    size    18290
+
+python.versions     37 38
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_test-append \
+                    port:py${python.version}-wheel
+
+    test.run        yes
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
+
+    post-destroot {
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} LICENSE README.rst \
+            ${destroot}${docdir}
+    }
+
+    livecheck.type  none
+}

--- a/python/py-opt_einsum/Portfile
+++ b/python/py-opt_einsum/Portfile
@@ -1,0 +1,59 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-opt_einsum
+version             3.2.1
+revision            0
+
+license             MIT
+maintainers         nomaintainer
+platforms           darwin
+supported_archs     noarch
+
+description         A tensor contraction order optimizer.
+
+long_description    Optimized einsum can significantly reduce the\
+                    overall execution time of einsum-like expressions\
+                    (e.g., np.einsum, dask.array.einsum, pytorch.einsum,\
+                    tensorflow.einsum) by optimizing the expression's\
+                    contraction order and dispatching many operations\
+                    to canonical BLAS, cuBLAS, or other specialized\
+                    routines. Optimized einsum is agnostic to the backend\
+                    and can handle NumPy, Dask, PyTorch, Tensorflow, CuPy,\
+                    Sparse, Theano, JAX, and Autograd arrays as well as\
+                    potentially any library which conforms to a standard API.
+
+homepage            https://github.com/dgasmith/opt_einsum
+
+checksums           rmd160  7a3ab41ecc26559b0f01ecfbc93453e7c84ab3ef \
+                    sha256  83b76a98d18ae6a5cc7a0d88955a7f74881f0e567a0f4c949d24c942753eb998 \
+                    size    72186
+
+python.versions     37 38
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-numpy
+
+    depends_test-append \
+                    port:py${python.version}-pytest
+
+    test.run        yes
+    test.cmd        py.test-${python.branch}
+    test.target
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
+
+    post-destroot {
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} LICENSE README.md \
+            ${destroot}${docdir}
+    }
+
+    livecheck.type  none
+}

--- a/python/py-tensorflow/Portfile
+++ b/python/py-tensorflow/Portfile
@@ -94,17 +94,19 @@ if {${name} ne ${subport}} {
         port:py${python.version}-future \
         port:py${python.version}-pip \
         port:py${python.version}-mock \
-        port:bazel-2.0 \
+        port:bazel-3.5 \
         port:cctools
 
     depends_lib-append \
         port:py${python.version}-absl \
         port:py${python.version}-astor \
+        port:py${python.version}-astunparse \
         port:py${python.version}-gast \
         port:py${python.version}-google-pasta \
         port:py${python.version}-grpcio \
         port:py${python.version}-keras \
         port:py${python.version}-numpy \
+        port:py${python.version}-opt_einsum \
         port:py${python.version}-protobuf3 \
         port:py${python.version}-six \
         port:py${python.version}-tensorboard \


### PR DESCRIPTION
py-tensorflow: Bugfix, add dependencies py-astunparse, py-opt_einsum

* Fixes https://trac.macports.org/ticket/60736#ticket
* Add new port py-astunparse version 1.6.3
* Add new port py-opt_einsum versoin 3.2.1

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
