### PR TITLE
cgal4: Update to 4.14.3 and fix livecheck

### DIFF
--- a/gis/cgal4/Portfile
+++ b/gis/cgal4/Portfile
@@ -17,8 +17,12 @@ long_description    \
 
 platforms           darwin
 
-github.setup        CGAL cgal 4.14 releases%2FCGAL-
+github.setup        CGAL cgal 4.14.3 releases/CGAL-
 revision            0
+checksums           rmd160  c297a51c63a8161000d91128628d8c20ffdbf487 \
+                    sha256  5bafe7abe8435beca17a1082062d363368ec1e3f0d6581bb0da8b010fb389fe4 \
+                    size    15618196
+
 conflicts           cgal5
 github.tarball_from releases
 name                cgal4
@@ -26,20 +30,15 @@ license             LGPL-3+ GPL-3+
 categories          gis science
 maintainers         {vince @Veence}
 use_xz              yes
+distname            CGAL-${version}
 
 homepage            http://www.cgal.org/
 
-checksums           rmd160  12b008b415133061f6b4933093c889890e4f4c72 \
-                    sha256  59464b1eaee892f2223ba570a7642892c999e29524ab102a6efd7c29c94a29f7 \
-                    size    15602228
-
-worksrcdir          CGAL-${version}
 depends_lib-append  port:boost \
                     port:mpfr \
                     port:zlib \
                     port:gmp \
                     path:include/eigen3/Eigen/Eigen:eigen3
-
 
 configure.args-append   -DCGAL_INSTALL_CMAKE_DIR="share/CGAL/cmake" \
                         -DWITH_CGAL_Qt5:BOOL=OFF \
@@ -65,6 +64,4 @@ variant qt5 description {Build with Qt5 bindings} {
     configure.args-delete   -DWITH_CGAL_Qt5:BOOL=OFF
 }
 
-livecheck.type      regex
-livecheck.url       ${homepage}
-livecheck.regex     CGAL (4.\[0-9.\]+)
+github.livecheck.regex  {(4\.[0-9.]+)}


### PR DESCRIPTION
#### Description

cgal4: Update to 4.14.3 and fix livecheck

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G12034
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
