### PR TITLE
mpv: add bluray variant and aacs encryption support 

### DIFF
--- a/multimedia/mpv/Portfile
+++ b/multimedia/mpv/Portfile
@@ -7,7 +7,7 @@ PortGroup               legacysupport 1.0
 
 # Please revbump mpv whenever ffmpeg{,-devel} is updated!
 github.setup            mpv-player mpv 0.32.0 v
-revision                0
+revision                1
 categories              multimedia
 license                 GPL-2+
 maintainers             {ionic @Ionic}
@@ -47,12 +47,11 @@ depends_lib             path:lib/libavcodec.dylib:ffmpeg \
                         port:libiconv \
                         port:zlib \
                         port:libass \
-                        port:libbluray \
                         port:lcms2
 
 universal_variant       no
 
-default_variants        +network +osd +opengl +dvd +audiocd +libarchive
+default_variants        +network +osd +opengl +bluray +dvd +audiocd +libarchive
 
 if {${os.platform} eq "darwin" && ${os.major} > 10} {
     # current macOS bundle errors on < 10.7 due to unhandled -psn_* argument
@@ -115,6 +114,7 @@ configure.args-append   --disable-caca \
                         --disable-jpeg \
                         --disable-libarchive \
                         --disable-libass-osd \
+                        --disable-libbluray \
                         --disable-libsmbclient \
                         --disable-lua \
                         --disable-openal \
@@ -424,6 +424,19 @@ variant network description {Enable networking support via youtube-dl (supports 
     depends_run-append      port:youtube-dl
 }
 
+variant bluray description {Enable Bluray and AACS encryption support} {
+    depends_lib-append     port:libbluray
+    depends_run-append     port:libaacs
+    configure.args-delete  --disable-libbluray
+    notes-append {
+                    
+                    To play Bluray discs with AACS encryption, decryption key database file "keydb.cfg" needs to be placed at:
+                    * ~/Library/Preferences/aacs/ (on macOS, or)
+                    * ~/.config/aacs/ (on other darwin).
+                    You can easily find this file on the internet.
+    }
+}
+
 variant dvd description {Enable DVD and DeCSS support} {
     depends_lib-append      port:libdvdread \
                             port:libdvdnav
@@ -523,8 +536,7 @@ variant smb description {Enable Samba support} {
 }
 
 variant debug description {Compile with debugging symbols} {
-    configure.args-replace  --disable-debug-build \
-                            --enable-debug-build
+    configure.args-delete   --disable-debug-build
 }
 
 variant printable_doc description {Generate printable documents (PDF help)} {


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
