### PR TITLE
espeak-ng: new port, version 1.50

### DIFF
--- a/audio/espeak-ng/Portfile
+++ b/audio/espeak-ng/Portfile
@@ -1,0 +1,47 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        espeak-ng espeak-ng 1.50
+github.tarball_from archive
+revision            0
+categories          audio
+platforms           darwin
+maintainers         nomaintainer
+license             GPL-3+
+
+description         multi-lingual software speech synthesizer
+
+long_description    eSpeak NG is a compact open source software text-to-speech synthesizer for Linux, Windows, \
+                    Mac, Android and other operating systems. It supports more than 100 languages and accents. \
+                    It is based on the eSpeak engine created by Jonathan Duddington.
+
+checksums           rmd160  a39908a309e0ead84d1e8b922adcfa3df153b35d \
+                    sha256  5ce9f24ee662b5822a4acc45bed31425e70d7c50707b96b6c1603a335c7759fa \
+                    size    13665536
+
+conflicts           espeak
+
+patchfiles          patch-espeak-ng-mac.diff
+
+depends_lib         port:pcaudiolib \
+                    port:sonic
+
+use_autoreconf      yes
+autoreconf.cmd      ./autogen.sh
+
+depends_build       port:rb27-ronn-ng \
+                    port:rb27-kramdown \
+                    port:automake \
+                    port:autoconf \
+                    port:libtool \
+                    port:pkgconfig
+
+configure.env       RONN=${prefix}/bin/ronn-2.7 KRAMDOWN=${prefix}/bin/kramdown-2.7
+configure.args      --with-extdict-ru --with-extdict-zh --with-extdict-zhy
+build.target        src/espeak-ng src/speak-ng en
+
+test.run            yes
+test.cmd            ESPEAK_DATA_PATH=`pwd` DYLD_LIBRARY_PATH=src src/espeak-ng "Testing." -w test.wav
+test.target

--- a/audio/espeak-ng/files/patch-espeak-ng-mac.diff
+++ b/audio/espeak-ng/files/patch-espeak-ng-mac.diff
@@ -1,0 +1,40 @@
+--- Makefile.am.orig	2019-11-29 23:50:54.000000000 +0700
++++ Makefile.am	2020-07-01 09:42:15.000000000 +0700
+@@ -79,10 +81,10 @@
+ .md.html: _layouts/webpage.html
+ 	@echo "  MD        $@"
+ 	@cat $< | sed -e 's/\.md)/.html)/g' -e 's/\.ronn/.html/g' | \
+-		kramdown --template _layouts/webpage.html > $@
++		$(KRAMDOWN) --template _layouts/webpage.html > $@
+ 
+ .ronn.html:
+-	ronn --html $<
++	$(RONN) --html $<
+ 
+ ##### vim:
+ 
+@@ -101,10 +103,10 @@
+ ##### documentation:
+ 
+ src/espeak-ng.1: src/espeak-ng.1.ronn
+-	ronn --roff $<
++	$(RONN) --roff $<
+ 
+ src/speak-ng.1: src/speak-ng.1.ronn
+-	ronn --roff $<
++	$(RONN) --roff $<
+ 
+ docs_MARKDOWN != ls docs/*.md docs/*/*.md docs/*/*/*.md
+ docs_HTML = ${docs_MARKDOWN:.md=.html}
+--- configure.ac.orig	2019-11-29 23:50:54.000000000 +0700
++++ configure.ac	2020-07-03 16:12:15.000000000 +0700
+@@ -257,6 +257,8 @@
+ AC_CHECK_PROG(RONN, ronn, ronn, no)
+ 
+ AM_CONDITIONAL(HAVE_RONN, [test ! x"$RONN" = xno])
+ 
++AC_CHECK_PROG(KRAMDOWN, kramdown, kramdown, no)
++
+ dnl ================================================================
+ dnl Extended dictionary checks.
+ dnl ================================================================

--- a/audio/pcaudiolib/Portfile
+++ b/audio/pcaudiolib/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        espeak-ng pcaudiolib 1.1
+github.tarball_from archive
+revision            0
+categories          audio
+platforms           darwin
+maintainers         nomaintainer
+license             GPL-3+
+
+description         Portable C Audio Library
+
+long_description    The Portable C Audio Library (pcaudiolib) provides a C API to different audio devices.
+
+checksums           rmd160  ff0fd3c813d83458c937db771ec5e7ded79f9b59 \
+                    sha256  699a5a347b1e12dc5b122e192e19f4db01621826bf41b9ebefb1cbc63ae2180b \
+                    size    34049
+
+use_autoreconf      yes
+autoreconf.cmd      ./autogen.sh
+
+depends_build       port:automake \
+                    port:autoconf \
+                    port:libtool \
+                    port:pkgconfig
+
+test.run            yes
+test.target         check

--- a/audio/sonic/Portfile
+++ b/audio/sonic/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           makefile 1.0
+
+github.setup        espeak-ng sonic 0.2.0 release-
+github.tarball_from archive
+revision            0
+categories          audio
+platforms           darwin
+maintainers         nomaintainer
+license             Apache-2
+
+description         Simple library to speed up or slow down speech
+
+long_description    Sonic is a simple algorithm for speeding up or slowing down speech.  However, \
+                    it's optimized for speed ups of over 2X, unlike previous algorithms for changing \
+                    speech rate.  The Sonic library is a very simple ANSI C library that is designed \
+                    to easily be integrated into streaming voice applications, like TTS back ends.
+
+checksums           rmd160  4fb75a94018d16f052828cbd6b292a93e2ca0f41 \
+                    sha256  c7827ce576838467590ffa1f935fbe1049e896dfed6c515cf569ad3779c24085 \
+                    size    5340269
+
+patchfiles          patch-sonic-mac.diff
+
+compiler.cxx_standard 1998
+configure.cxxflags-append -std=c++98
+
+makefile.override   PREFIX
+
+build.args-append   USE_SPECTROGRAM=0
+destroot.args       {*}${build.args}
+
+test.run            yes
+test.target         check

--- a/audio/sonic/files/patch-sonic-mac.diff
+++ b/audio/sonic/files/patch-sonic-mac.diff
@@ -1,0 +1,100 @@
+--- Makefile.orig	2020-06-30 13:32:50.000000000 +0700
++++ Makefile	2020-07-02 09:20:44.000000000 +0700
+@@ -5,22 +5,30 @@
+ # safe.  We call malloc, and older Linux versions only linked in the thread-safe
+ # malloc if -pthread is specified.
+ 
+-SONAME=soname
++PREFIX=/usr/local
++BINDIR=$(PREFIX)/bin
++LIBDIR=$(PREFIX)/lib
++INCDIR=$(PREFIX)/include
++
++SONAME=-soname,
++SHARED_OPT=-shared
++LIB_NAME=libsonic.so
++LIB_TAG=.0.3.0
++
+ UNAME := $(shell uname)
+ ifeq ($(UNAME), Darwin)
+-  SONAME=install_name
++  SONAME=-install_name,$(LIBDIR)/
++  SHARED_OPT=-dynamiclib
++  LIB_NAME=libsonic.dylib
++  LIB_TAG=
+ endif
+-#CFLAGS=-Wall -g -ansi -fPIC -pthread
++
+ CFLAGS=-Wall -O3 -ansi -fPIC -pthread
+-LIB_TAG=0.2.0
+-CC=gcc
+-PREFIX=/usr
+-LIBDIR=$(PREFIX)/lib
+ 
+-all: sonic libsonic.so.$(LIB_TAG) libsonic.a
++all: sonic $(LIB_NAME)$(LIB_TAG) libsonic.a
+ 
+-sonic: wave.o main.o libsonic.so.$(LIB_TAG)
+-	$(CC) $(CFLAGS) -o sonic wave.o main.o libsonic.so.$(LIB_TAG)
++sonic: wave.o main.o $(LIB_NAME)$(LIB_TAG)
++	$(CC) $(CFLAGS) -o sonic wave.o main.o $(LIB_NAME)$(LIB_TAG)
+ 
+ sonic.o: sonic.c sonic.h
+ 	$(CC) $(CFLAGS) -c sonic.c
+@@ -31,30 +39,38 @@
+ main.o: main.c sonic.h wave.h
+ 	$(CC) $(CFLAGS) -c main.c
+ 
+-libsonic.so.$(LIB_TAG): sonic.o
+-	$(CC) $(CFLAGS) -shared -Wl,-$(SONAME),libsonic.so.0 sonic.o -o libsonic.so.$(LIB_TAG)
+-	ln -sf libsonic.so.$(LIB_TAG) libsonic.so
+-	ln -sf libsonic.so.$(LIB_TAG) libsonic.so.0
++$(LIB_NAME)$(LIB_TAG): sonic.o
++	$(CC) $(CFLAGS) $(SHARED_OPT) -Wl,$(SONAME)$(LIB_NAME) sonic.o -o $(LIB_NAME)$(LIB_TAG)
++ifneq ($(UNAME), Darwin)
++	ln -sf $(LIB_NAME)$(LIB_TAG) $(LIB_NAME)
++	ln -sf $(LIB_NAME)$(LIB_TAG) $(LIB_NAME).0
++endif
+ 
+ libsonic.a: sonic.o
+ 	$(AR) cqs libsonic.a sonic.o
+ 
+-install: sonic libsonic.so.$(LIB_TAG) sonic.h
+-	install -d $(DESTDIR)$(PREFIX)/bin $(DESTDIR)$(PREFIX)/include $(DESTDIR)$(PREFIX)/lib
+-	install sonic $(DESTDIR)$(PREFIX)/bin
+-	install sonic.h $(DESTDIR)$(PREFIX)/include
+-	install libsonic.so.$(LIB_TAG) $(DESTDIR)$(PREFIX)/lib
++install: sonic $(LIB_NAME)$(LIB_TAG) sonic.h
++	install -d $(DESTDIR)$(BINDIR) $(DESTDIR)$(INCDIR) $(DESTDIR)$(LIBDIR)
++	install sonic $(DESTDIR)$(BINDIR)
++	install sonic.h $(DESTDIR)$(INCDIR)
+ 	install libsonic.a $(DESTDIR)$(LIBDIR)
+-	ln -sf libsonic.so.$(LIB_TAG) $(DESTDIR)$(PREFIX)/lib/libsonic.so
+-	ln -sf libsonic.so.$(LIB_TAG) $(DESTDIR)$(PREFIX)/lib/libsonic.so.0
++	install $(LIB_NAME)$(LIB_TAG) $(DESTDIR)$(LIBDIR)
++ifneq ($(UNAME), Darwin)
++	ln -sf $(LIB_NAME)$(LIB_TAG) $(DESTDIR)$(LIBDIR)/$(LIB_NAME)
++	ln -sf $(LIB_NAME)$(LIB_TAG) $(DESTDIR)$(LIBDIR)/$(LIB_NAME).0
++endif
+ 
+-uninstall: 
+-	rm -f $(DESTDIR)$(PREFIX)/bin/sonic 
+-	rm -f $(DESTDIR)$(PREFIX)/include/sonic.h
+-	rm -f $(DESTDIR)$(PREFIX)/lib/libsonic.so.$(LIB_TAG)
+-	rm -f $(DESTDIR)$(PREFIX)/lib/libsonic.so
+-	rm -f $(DESTDIR)$(PREFIX)/lib/libsonic.so.0
++
++uninstall:
++	rm -f $(DESTDIR)$(BINDIR)/sonic
++	rm -f $(DESTDIR)$(INCDIR)/sonic.h
+ 	rm -f $(DESTDIR)$(LIBDIR)/libsonic.a
++	rm -f $(DESTDIR)$(LIBDIR)/$(LIB_NAME)$(LIB_TAG)
++	rm -f $(DESTDIR)$(LIBDIR)/$(LIB_NAME).0
++	rm -f $(DESTDIR)$(LIBDIR)/$(LIB_NAME)
+ 
+ clean:
+-	rm -f *.o sonic libsonic.so* libsonic.a
++	rm -f *.o sonic $(LIB_NAME)* libsonic.a test.wav
++
++check:
++	./sonic -s 2.0 ./samples/talking.wav ./test.wav


### PR DESCRIPTION
espeak-ng: new port, version 1.50

Plus dependent ports:
pcaudiolib: new port, version 1.1
sonic: new port, version 0.2.0

#### Description

The eSpeak NG is a compact open source software text-to-speech synthesizer for Linux, Windows, Android and other operating systems. It supports more than 100 languages and accents. It is based on the eSpeak engine created by Jonathan Duddington.

This replaces the espeak port per:
https://trac.macports.org/ticket/60732

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
