### PR TITLE
cgal5: Fix livecheck

### DIFF
--- a/gis/cgal5/Portfile
+++ b/gis/cgal5/Portfile
@@ -18,7 +18,7 @@ long_description        \
 
 platforms               darwin
 
-github.setup            CGAL cgal 5.0.2 releases%2FCGAL-
+github.setup            CGAL cgal 5.0.2 releases/CGAL-
 revision                0
 conflicts               cgal4
 github.tarball_from     releases
@@ -27,6 +27,8 @@ license                 LGPL-3+ GPL-3+
 categories              gis science
 maintainers             {vince @Veence}
 use_xz                  yes
+# switch to this (and remove worksrcdir) with the next version update
+#distname                CGAL-${version}
 
 homepage                http://www.cgal.org/
 
@@ -54,6 +56,4 @@ variant headers_only description "Install only the headers" {
     configure.args-append   -DCGAL_HEADER_ONLY=ON
 }
 
-livecheck.type          regex
-livecheck.url           ${homepage}
-livecheck.regex         stable.*CGAL (5.\[0-9.\]+)
+github.livecheck.regex  {([0-9.]+)}


### PR DESCRIPTION
#### Description

cgal5: Fix livecheck

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G12034
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
