### PR TITLE
gdal: Use configure.pkg_config_path

### DIFF
--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -347,7 +347,9 @@ foreach s ${postgresql_suffixes} {
         depends_lib-append      port:${p}
         configure.args-delete   --without-pg
         configure.args-append   --with-pg=yes
-        configure.env-append    PKG_CONFIG_PATH=${prefix}/lib/postgresql${s}/pkgconfig:${prefix}/lib/pkgconfig
+        configure.pkg_config_path-append \
+                                ${prefix}/lib/postgresql${s}/pkgconfig \
+                                ${prefix}/lib/pkgconfig
     "
 }
 


### PR DESCRIPTION
Use configure.pkg_config_path intead of manually setting the PKG_CONFIG_PATH environment variable.
