### PR TITLE
google-cloud-sdk: update to 299.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             298.0.0
+version             299.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  9cf822f86662f29d7d1f32d64d185b93d1a783c9 \
-                    sha256  609452e661d98e918d88a38a5fdc2e10a60991efd7cea06a5a20c509d7a7cfb1 \
-                    size    67136455
+    checksums       rmd160  9716739b6b64f9efab2eba918f852977940c7ec0 \
+                    sha256  da6d992cfc80acf540229d9ec7464e39ca7c84707474e382167f55ed0b267efb \
+                    size    78132832
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  ff9c3b876bc2b76740e5e6b22bd68f069dd19b4c \
-                    sha256  6d2e83c7e8bae273647ddc8c88d0eb72a6e24005d2290d90ba2b3505c3b65edc \
-                    size    69100312
+    checksums       rmd160  56b54de0c33f77d332363b823a65643f166e55f8 \
+                    sha256  c1b20c2beac1bcb67752db7fd1345733e31a33b9f0478d23668ba23233cb6618 \
+                    size    79251764
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 299.0.0.

###### Tested on

macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?