### PR TITLE
net-snmp: extend build fix to cover 11.0

### DIFF
--- a/net/net-snmp/Portfile
+++ b/net/net-snmp/Portfile
@@ -40,6 +40,7 @@ post-extract {
     # https://sourceforge.net/p/net-snmp/bugs/2504/
     copy ${worksrcpath}/include/net-snmp/system/darwin17.h ${worksrcpath}/include/net-snmp/system/darwin18.h
     copy ${worksrcpath}/include/net-snmp/system/darwin17.h ${worksrcpath}/include/net-snmp/system/darwin19.h
+    copy ${worksrcpath}/include/net-snmp/system/darwin17.h ${worksrcpath}/include/net-snmp/system/darwin20.h
 }
 
 patchfiles-append       patch-agent-mibgroup-mibII-icmp.h.diff


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
