### PR TITLE
teleport: update to 4.2.11

### DIFF
--- a/net/teleport/Portfile
+++ b/net/teleport/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gravitational/teleport 4.2.10 v
+go.setup            github.com/gravitational/teleport 4.2.11 v
 
 homepage            http://gravitational.com/teleport/
 categories          net
@@ -16,9 +16,9 @@ long_description    Teleport is a modern SSH server and CA for managing clusters
                     and a Web UI.  Built on the Golang SSH library, and compatible with OpenSSH
 license             Apache-2
 
-checksums           rmd160  7d3406df247151b632127f75fee5541e90e37cb0 \
-                    sha256  04739461250a7d27fe61341d585557752d769d7a7ca094d663ecc980182cf500 \
-                    size    55846000
+checksums           rmd160  df8e44b2d6250bc7b53d916d215a5eed9add4eeb \
+                    sha256  1fd2f21ce1608c72ebbf8ac3812f74428d9f93f616bed4d767f3d35e612c6013 \
+                    size    55847499
 
 depends_lib         port:go port:zip
 platforms           darwin


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
