### PR TITLE
nuspell: update to 3.1.2

### DIFF
--- a/textproc/nuspell/Portfile
+++ b/textproc/nuspell/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        nuspell nuspell 3.1.1 v
+github.setup        nuspell nuspell 3.1.2 v
 
 homepage            https://nuspell.github.io/
 
@@ -25,9 +25,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 depends_lib-append  port:boost \
                     port:icu
 
-checksums           rmd160  4cd33cfabecf3a7be52ac2770b60d8a597bf1188 \
-                    sha256  b7172b35bc66ff957a74ca0b2e23ebad6224565430dadddf4e7cda08b1362457 \
-                    size    379686
+checksums           rmd160  413b228acb0a938110c699bc58554b69c36f991a \
+                    sha256  96a2374d9bfd23e3708cd4e8ba35c1d96b9c37472e7940d2791b3dd83c1e0598 \
+                    size    379055
 
 compiler.cxx_standard 2017
 

--- a/textproc/nuspell/files/patch-finder-cxx.diff
+++ b/textproc/nuspell/files/patch-finder-cxx.diff
@@ -1,10 +1,10 @@
---- src/nuspell/finder.cxx	2020-05-19 03:24:56.000000000 -0400
-+++ src/nuspell/finder.cxx	2020-05-19 03:24:53.000000000 -0400
-@@ -92,6 +92,7 @@
- 		*out++ = home + osx;
+--- src/nuspell/finder.cxx	2020-07-01 11:50:30.000000000 -0400
++++ src/nuspell/finder.cxx	2020-07-01 11:51:03.000000000 -0400
+@@ -88,6 +88,7 @@
+ 		paths.push_back(home + osx);
  	}
- 	*out++ = osx;
-+	*out++ = "@@HUNSPELL_PATH@@";
+ 	paths.push_back(osx);
++	paths.push_back("@@HUNSPELL_PATH@@");
  #endif
  #endif
  #ifdef _WIN32


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
