### PR TITLE
dua-cli: update to 2.8.2

### DIFF
--- a/sysutils/dua-cli/Portfile
+++ b/sysutils/dua-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        Byron dua-cli 2.6.1 v
+github.setup        Byron dua-cli 2.8.2 v
 categories          sysutils
 license             MIT
 platforms           darwin
@@ -24,9 +24,9 @@ long_description    dua (-> Disk Usage Analyzer) is a tool to conveniently \
                     quickly than rm.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  f1d9c3fdc5c3e2f996759d50fd76e3071ca88cd6 \
-                    sha256  4dbcbb755d706d7ee8f53f8e99a8c8f0987e8b8598b71aa2d286daa44cfd3389 \
-                    size    57977
+                    rmd160  219062cec7db033fcba84fe17e91e01bd2b62207 \
+                    sha256  b887f39a53f45cfc38e84c8eea883481beea88aa7557920ad059c86d8e078471 \
+                    size    57923
 
 destroot {
     xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/dua \
@@ -34,13 +34,12 @@ destroot {
 }
 
 cargo.crates \
-    addr2line                       0.12.1  a49806b9dadc843c61e7c97e72490ad7f7220ae249012fbda9ad0609457c0543 \
     ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
+    anyhow                          1.0.31  85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f \
     atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
     autocfg                          1.0.0  f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d \
-    backtrace                       0.3.48  0df2f85c8a2abbe3b7d7e748052fdd9b76a0458fdeb16ad4223f5eca78c7c130 \
     bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
-    byte-unit                        3.1.3  55390dbbf21ce70683f3e926dace00a21da373e35e44a60cafd232e3e9bf2041 \
+    byte-unit                        4.0.4  a83e250117a919810172ac4d81016eb6da74f235399ac97df3dd8846275d03b6 \
     cassowary                        0.3.0  df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53 \
     cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
     clap                            2.33.1  bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129 \
@@ -48,60 +47,53 @@ cargo.crates \
     crossbeam-channel                0.4.2  cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061 \
     crossbeam-deque                  0.7.3  9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285 \
     crossbeam-epoch                  0.8.2  058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace \
-    crossbeam-queue                  0.2.2  ab6bffe714b6bb07e42f201352c34f51fefd355ace793f9e638ebd52d23f98d2 \
+    crossbeam-queue                  0.2.3  774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570 \
     crossbeam-utils                  0.7.2  c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8 \
-    ctor                            0.1.14  cf6b25ee9ac1995c54d7adb2eff8cfffb7260bc774fb63c601ec65467f43cd9d \
+    ctor                            0.1.15  39858aa5bac06462d4dd4b9164848eb81ffc4aa5c479746393598fd193afa227 \
     difference                       2.0.0  524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198 \
     either                           1.5.3  bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3 \
-    failure                          0.1.8  d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86 \
-    failure-tools                    4.0.5  03d1b6907412387e932f12ad6e93adab19fed0ca10a03de8b744d275977d72ca \
-    failure_derive                   0.1.8  aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4 \
     filesize                         0.2.0  12d741e2415d4e2e5bd1c1d00409d1a8865a57892c2d689b504365655d237d43 \
     fixedbitset                      0.2.0  37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d \
     flume                            0.7.1  855e285c3835897065a6ba6f9463b44553eb9f29c7988d692f3d41283b47388b \
-    gimli                           0.21.0  bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c \
     heck                             0.3.1  20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205 \
-    hermit-abi                      0.1.13  91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71 \
-    indexmap                         1.3.2  076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292 \
+    hermit-abi                      0.1.14  b9586eedd4ce6b3c498bc3b4dd92fc9f11166aa908a914071953768066c67909 \
+    indexmap                         1.4.0  c398b2b113b55809ceb9ee3e753fcbac793f1956663f3c36549c1346015c2afe \
     itertools                        0.9.0  284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b \
     jwalk                            0.5.1  88746778a47f54f83bc0d3d8ba40ce83808024405356b4d521c2bf93c1273cd4 \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
     libc                            0.2.71  9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49 \
     log                              0.4.8  14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7 \
     maybe-uninit                     2.0.0  60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00 \
-    memoffset                        0.5.4  b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8 \
+    memoffset                        0.5.5  c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f \
     num_cpus                        1.13.0  05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3 \
     numtoa                           0.1.0  b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef \
-    object                          0.19.0  9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2 \
     open                             1.4.0  7c283bf0114efea9e42f1a60edea9859e8c47528eae09d01df4b29c1e489cc48 \
     output_vt100                     0.1.2  53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9 \
     petgraph                         0.5.1  467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7 \
     pretty_assertions                0.6.1  3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427 \
-    proc-macro-error                 1.0.2  98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678 \
-    proc-macro-error-attr            1.0.2  4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53 \
-    proc-macro2                     1.0.17  1502d12e458c49a4c9cbff560d0fe0060c252bc29799ed94ca2ed4bb665a0101 \
-    quote                            1.0.6  54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea \
-    rayon                            1.3.0  db6ce3297f9c85e16621bb8cca38a06779ffc31bb8184e1be4bed2be4678a098 \
-    rayon-core                       1.7.0  08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9 \
+    proc-macro-error                 1.0.3  fc175e9777c3116627248584e8f8b3e2987405cabe1c0adf7d1dd28f09dc7880 \
+    proc-macro-error-attr            1.0.3  3cc9795ca17eb581285ec44936da7fc2335a3f34f2ddd13118b6f4d515435c50 \
+    proc-macro2                     1.0.18  beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa \
+    quote                            1.0.7  aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37 \
+    rayon                            1.3.1  62f02856753d04e03e26929f820d0a0a337ebe71f849801eea335d464b349080 \
+    rayon-core                       1.7.1  e92e15d89083484e11353891f1af602cc661426deb9564c298b270c726973280 \
     redox_syscall                   0.1.56  2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84 \
     redox_termios                    0.1.1  7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76 \
-    rustc-demangle                  0.1.16  4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783 \
     scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
     spin                             0.5.2  6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d \
     strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
-    structopt                       0.3.14  863246aaf5ddd0d6928dfeb1a9ca65f505599e4e1b399935ef7e75107516b4ef \
-    structopt-derive                 0.4.7  d239ca4b13aee7a2142e6795cbd69e457665ff8037aed33b3effdc430d2f927a \
-    syn                             1.0.29  bb37da98a55b1d08529362d9cbb863be17556873df2585904ab9d2bc951291d0 \
+    structopt                       0.3.15  de2f5e239ee807089b62adce73e48c625e0ed80df02c7ab3f068f5db5281065c \
+    structopt-derive                 0.4.8  510413f9de616762a4fbeab62509bf15c729603b72d7cd71280fbca431b1c118 \
+    syn                             1.0.33  e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd \
     syn-mid                          0.5.0  7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a \
-    synstructure                    0.12.3  67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545 \
     termion                          1.5.5  c22cec9d8978d906be5ac94bceb5a010d885c626c4c8855721a4dbd20e3ac905 \
     textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
     tui                              0.9.5  9533d39bef0ae8f510e8a99d78702e68d1bbf0b98a78ec9740509d287010ae1e \
     unicode-segmentation             1.6.0  e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0 \
-    unicode-width                    0.1.7  caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479 \
-    unicode-xid                      0.2.0  826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c \
+    unicode-width                    0.1.8  9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3 \
+    unicode-xid                      0.2.1  f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564 \
     vec_map                          0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
     version_check                    0.9.2  b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed \
-    winapi                           0.3.8  8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6 \
+    winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
