### PR TITLE
mumps: Use build.jobs rather than hw.ncpu when running tests

### DIFF
--- a/math/mumps/Portfile
+++ b/math/mumps/Portfile
@@ -88,9 +88,9 @@ post-extract {
 }
 
 destroot {
-  xinstall -m 644 {*}[glob ${worksrcpath}/include/*.h] ${destroot}${prefix}/include
-  xinstall -m 644 {*}[glob ${worksrcpath}/lib/*.a] ${destroot}${prefix}/lib
-  xinstall -m 644 {*}[glob ${worksrcpath}/lib/*.dylib] ${destroot}${prefix}/lib
+    xinstall -m 644 {*}[glob ${worksrcpath}/include/*.h] ${destroot}${prefix}/include
+    xinstall -m 644 {*}[glob ${worksrcpath}/lib/*.a] ${destroot}${prefix}/lib
+    xinstall -m 644 {*}[glob ${worksrcpath}/lib/*.dylib] ${destroot}${prefix}/lib
 }
 
 livecheck.url               http://mumps.enseeiht.fr/index.php?page=dwnld

--- a/math/mumps/Portfile
+++ b/math/mumps/Portfile
@@ -101,12 +101,7 @@ test.target                 all
 test.args-append            LPORD=../lib/libpord.a
 
 post-test {
-    if {![catch {sysctl hw.ncpu} result]} {
-        set njobs $result
-    } else {
-        set njobs 1
-    }
-    set runcmd "${mpi.exec} -np ${njobs}"
+    set runcmd "${mpi.exec} -np ${build.jobs}"
 
     system -W ${worksrcpath}/examples "${runcmd} ./ssimpletest < input_simpletest_real"
     system -W ${worksrcpath}/examples "${runcmd} ./dsimpletest < input_simpletest_real"


### PR DESCRIPTION
#### Description

This PR proposes using build.jobs when running tests, rather than hw.ncpu. A user may not want to use all the available CPUs, and if so may have configured buildmakejobs thus in macports.conf. Or the user may have disabled some cores. (To accommodate that, build.jobs is based on hw.activecpu rather than hw.ncpu.)

I also fixed a minor whitespace issue in a separate commit.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G12034
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
