### PR TITLE
berkeleygw, hpl, quantum-espresso, wannier90: Use build.jobs rather than hw.ncpu when running tests

### DIFF
--- a/science/berkeleygw/Portfile
+++ b/science/berkeleygw/Portfile
@@ -85,10 +85,8 @@ pre-test {
         test.args-append    TESTSCRIPT="MPIEXEC=${prefix}/bin/${mpi.exec} make check-parallel"
         test.target         check-jobscript
 
-        # FIXME: what about with threads? set OMP_NUM_THREADS=2 and divide ncpus by 2.
-        if {![catch {sysctl hw.activecpu} ncpus]} {
-            test.env-append BGW_TEST_MPI_NPROCS=$ncpus
-        }
+        # FIXME: what about with threads? set OMP_NUM_THREADS=2 and divide build.jobs by 2.
+        test.env-append BGW_TEST_MPI_NPROCS=${build.jobs}
     } else {
         test.target         check
     }

--- a/science/berkeleygw/Portfile
+++ b/science/berkeleygw/Portfile
@@ -89,7 +89,6 @@ pre-test {
         if {![catch {sysctl hw.activecpu} ncpus]} {
             test.env-append BGW_TEST_MPI_NPROCS=$ncpus
         }
-        ui_msg "Running testsuite in parallel with $ncpus MPI tasks"       
     } else {
         test.target         check
     }

--- a/science/hpl/Portfile
+++ b/science/hpl/Portfile
@@ -59,17 +59,12 @@ pre-build {
 }
 
 pre-test {
-    if {![catch {sysctl hw.ncpu} result]} {
-        set njobs $result
-    } else {
-        set njobs 4
-    }
-
-    test.cmd cd bin/${archname} && ${mpi.exec} -n ${njobs} ./xhpl
+    test.dir        ${worksrcpath}/bin/${archname}
+    test.cmd        ${mpi.exec} -n ${build.jobs} ./xhpl
 }
 
 pre-fetch {
-    notes    "Execute as: cd ${prefix}/share/hpl && ${mpi.exec} -n 4 xhpl"
+    notes    "Execute as: cd ${prefix}/share/hpl && ${mpi.exec} -n ${build.jobs} xhpl"
 }
 
 livecheck.type      regex

--- a/science/quantum-espresso/Portfile
+++ b/science/quantum-espresso/Portfile
@@ -44,16 +44,9 @@ configure.optflags  -O3
 
 pre-test {
     if {[mpi_variant_isset]} {
-        if {![catch {sysctl hw.ncpu} result]} {
-            set njobs $result
-            set n2jobs [expr {$result*2}]
-        } else {
-            set njobs 1
-            set n2jobs 1
-        }
         reinplace -W ${worksrcpath} "s|PARA_PREFIX=\" \"||" environment_variables
-        reinplace -W ${worksrcpath} "s|PARA_PREFIX=\"mpirun -np 4\"|PARA_PREFIX=\"${mpi.exec} -n ${njobs}\"|" environment_variables
-        reinplace -W ${worksrcpath} "s|PARA_IMAGE_PREFIX=\"mpirun -np 4\"|PARA_IMAGE_PREFIX=\"${mpi.exec} -n ${n2jobs}\"|" environment_variables
+        reinplace -W ${worksrcpath} "s|PARA_PREFIX=\"mpirun -np 4\"|PARA_PREFIX=\"${mpi.exec} -n ${build.jobs}\"|" environment_variables
+        reinplace -W ${worksrcpath} "s|PARA_IMAGE_PREFIX=\"mpirun -np 4\"|PARA_IMAGE_PREFIX=\"${mpi.exec} -n [expr ${build.jobs} * 2]\"|" environment_variables
     }
 }
 

--- a/science/wannier90/Portfile
+++ b/science/wannier90/Portfile
@@ -89,9 +89,7 @@ pre-test {
     if {[mpi_variant_isset]} {
         test.target    test-parallel
         # TODO: patch numprocs to appropriate number, not just 4
-        if {![catch {sysctl hw.ncpu} ncpus]} {
-            reinplace "s|mpirun -np tc\.nprocs|${mpi.exec} -np ${ncpus}|" ${worksrcpath}/test-suite/testcode/lib/testcode2/__init__.py
-        }
+        reinplace "s|mpirun -np tc\.nprocs|${mpi.exec} -np ${build.jobs}|" ${worksrcpath}/test-suite/testcode/lib/testcode2/__init__.py
     } else {
         test.target    test-serial
     }


### PR DESCRIPTION
#### Description

This PR proposes using build.jobs when running tests, rather than sysctl hw.ncpu or hw.activecpu. A user may not want to use all the available CPUs, and if so may have configured buildmakejobs thus in macports.conf.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G12034
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
