### PR TITLE
abinit: Use build.jobs rather than sysctl hw.ncpu

### DIFF
--- a/science/abinit/Portfile
+++ b/science/abinit/Portfile
@@ -99,7 +99,7 @@ pre-test {
     } else {
         test.target-append seq
         if {![catch {sysctl hw.ncpu} ncpus]} {
-            test.cmd     tests/runtests.py -j $ncpus
+            test.args-append    -j $ncpus
         }
     }
 }

--- a/science/abinit/Portfile
+++ b/science/abinit/Portfile
@@ -100,7 +100,6 @@ pre-test {
         test.target-append seq
         if {![catch {sysctl hw.ncpu} ncpus]} {
             test.cmd     tests/runtests.py -j $ncpus
-            ui_msg "Running testsuite with $ncpus tasks in parallel"
         }
     }
 }

--- a/science/abinit/Portfile
+++ b/science/abinit/Portfile
@@ -98,9 +98,7 @@ pre-test {
         test.args-append -n 1
     } else {
         test.target-append seq
-        if {![catch {sysctl hw.ncpu} ncpus]} {
-            test.args-append    -j $ncpus
-        }
+        test.args-append -j ${build.jobs}
     }
 }
 


### PR DESCRIPTION
#### Description

This PR proposes using build.jobs when running tests, rather than hw.ncpu. A user may not want to use all the available CPUs, and if so may have configured buildmakejobs thus in macports.conf. Or the user may have disabled some cores. (To accommodate that, build.jobs is based on hw.activecpu rather than hw.ncpu.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G12034
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
