### PR TITLE
apbs: Use build.jobs rather than sysctl hw.ncpu

### DIFF
--- a/science/apbs/Portfile
+++ b/science/apbs/Portfile
@@ -64,7 +64,6 @@ test {
             set njobs 1
         }
         reinplace "s|mpiexec|\"${mpi.exec}\", \"-n\", \"${njobs}\"|" ${worksrcpath}/tests/apbs_tester.py
-        ui_msg "Running testsuite with $njobs jobs in parallel"
     }
     
     system -W ${worksrcpath}/tests "python apbs_tester.py"

--- a/science/apbs/Portfile
+++ b/science/apbs/Portfile
@@ -58,12 +58,7 @@ test {
     ln ${worksrcpath}/tools/manip/psize.py    ${worksrcpath}/tests/
 
     if {[mpi_variant_isset]} {
-        if {![catch {sysctl hw.ncpu} result]} {
-            set njobs $result
-        } else {
-            set njobs 1
-        }
-        reinplace "s|mpiexec|\"${mpi.exec}\", \"-n\", \"${njobs}\"|" ${worksrcpath}/tests/apbs_tester.py
+        reinplace "s|mpiexec|\"${mpi.exec}\", \"-n\", \"${build.jobs}\"|" ${worksrcpath}/tests/apbs_tester.py
     }
     
     system -W ${worksrcpath}/tests "python apbs_tester.py"


### PR DESCRIPTION
#### Description

This PR proposes using build.jobs when running tests, rather than hw.ncpu. A user may not want to use all the available CPUs, and if so may have configured buildmakejobs thus in macports.conf. Or the user may have disabled some cores. (To accommodate that, build.jobs is based on hw.activecpu rather than hw.ncpu.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G12034
Xcode 9.4.1 9F2000


###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
