### PR TITLE
mpich: Add gcc10.

### DIFF
--- a/science/mpich/Portfile
+++ b/science/mpich/Portfile
@@ -95,6 +95,7 @@ if { ${os.major} < 16 } {
 # gcc 9+ only available on macOS10.7 (Darwin11) and newer
 if { ${os.major} > 10 } {
     set clist(gcc9)    {macports-gcc-9}
+    set clist(gcc10)    {macports-gcc-10}
 }
 # clang 6+ only available on macOS10.9 (Darwin13) and newer
 if { ${os.major} > 12 } {
@@ -396,11 +397,12 @@ notes "
         [variant_isset gcc5] ||
         [variant_isset gcc6] ||
         [variant_isset gcc7] ||
-        [variant_isset gcc8] } {
+        [variant_isset gcc8] ||
+        [variant_isset gcc9] } {
         set DEFAULT_MSG "
-NOTE: Default fortran changed to +gcc9; consider switching variants to enable
+NOTE: Default fortran changed to +gcc10; consider switching variants to enable
 pre-built packages for ${subport} by running:
-\"sudo port clean ${subport} && sudo port upgrade ${subport} +gcc9 -[gcc_variant_name]\"
+\"sudo port clean ${subport} && sudo port upgrade ${subport} +gcc10 -[gcc_variant_name]\"
 "
         notes-append    ${DEFAULT_MSG}
 

--- a/science/mpich/files/mpich-devel-gcc10-fortran
+++ b/science/mpich/files/mpich-devel-gcc10-fortran
@@ -1,0 +1,11 @@
+bin/mpicc-mpich-devel-gcc10
+bin/mpichversion-mpich-devel-gcc10
+bin/mpicxx-mpich-devel-gcc10
+bin/mpiexec-mpich-devel-gcc10
+bin/mpirun-mpich-devel-gcc10
+bin/mpif77-mpich-devel-gcc10
+bin/mpif90-mpich-devel-gcc10
+bin/parkill-mpich-devel-gcc10
+lib/mpich-devel-gcc10/pkgconfig/mpich.pc
+lib/mpich-devel-gcc10/pkgconfig/openpa.pc
+bin/mpifort-mpich-devel-gcc10

--- a/science/mpich/files/mpich-gcc10-fortran
+++ b/science/mpich/files/mpich-gcc10-fortran
@@ -1,0 +1,11 @@
+bin/mpicc-mpich-gcc10
+bin/mpichversion-mpich-gcc10
+bin/mpicxx-mpich-gcc10
+bin/mpiexec-mpich-gcc10
+bin/mpirun-mpich-gcc10
+bin/mpif77-mpich-gcc10
+bin/mpif90-mpich-gcc10
+bin/parkill-mpich-gcc10
+lib/mpich-gcc10/pkgconfig/mpich.pc
+lib/mpich-gcc10/pkgconfig/openpa.pc
+bin/mpifort-mpich-gcc10


### PR DESCRIPTION
#### Description

mpich: Add gcc10.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.12.6
Xcode 9.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
