### PR TITLE
gitlab-runner: update to 13.1.1

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 13.1.0 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 13.1.1 v
 
 categories          devel
 platforms           darwin
@@ -23,9 +23,9 @@ homepage            https://docs.gitlab.com/runner/
 master_sites        https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v${version}/
 distname            gitlab-runner-v${version}
 
-checksums           rmd160  f1f5355d3a19466eb9570e28714a714a70f137a6 \
-                    sha256  36b720a1d47f32f8e28bcf951bb322f31aa8aeedf214b8386d33344161e0daf9 \
-                    size    7462771
+checksums           rmd160  10fe73c719d9c5db6b1f7142a40affc2a572c5f9 \
+                    sha256  10eb3fbe848872ef02eea5d7d3c55c3a163d7117c47aee69d28030fb127999c2 \
+                    size    7461116
 
 # Reproduce the "build_simple" target from the upstream Makefile
 set go_ldflags      "-X ${go.package}/common.NAME=${go.package} \


### PR DESCRIPTION
#### Description

Update to GitLab Runner 13.1.1.

###### Tested on

macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?