### PR TITLE
kubectx: update to 0.9.1

### DIFF
--- a/sysutils/kubectx/Portfile
+++ b/sysutils/kubectx/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        ahmetb kubectx 0.9.0 v
+github.setup        ahmetb kubectx 0.9.1 v
 revision            0
 categories          sysutils
 platforms           darwin
@@ -15,9 +15,9 @@ description         Power tools for kubectl
 long_description    kubectx helps you switch between clusters back and forth. \
                     kubens helps you switch between Kubernetes namespaces smoothly.
 
-checksums           rmd160  300f2d22eead8726cc250dde7f45e1a57082e57c \
-                    sha256  ff9dca999946a76b2d1809670f0d2e1347498ca21b31ed948fbd95ce2943f582 \
-                    size    510599
+checksums           rmd160  dc6a1b33555b13c07970f53a08ad3ca7bf85552e \
+                    sha256  6c1f140b5e02988b13aa87be6e788af98ba93c947aaa48c9a015209c49a00dc9 \
+                    size    512930
 
 depends_run         path:${prefix}/bin/kubectl:kubectl-1.17
 


### PR DESCRIPTION
#### Description

Update to kubectx 0.9.1.

###### Tested on

macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?