### PR TITLE
kustomize: update to 3.7.0

### DIFF
--- a/devel/kustomize/Portfile
+++ b/devel/kustomize/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/kubernetes-sigs/kustomize 3.6.1 kustomize/v
+go.setup            github.com/kubernetes-sigs/kustomize 3.7.0 kustomize/v
 revision            0
 
 categories          devel
@@ -23,9 +23,9 @@ long_description    kustomize lets you customize raw, template-free YAML files f
 
 homepage            https://kustomize.io
 
-checksums           rmd160  cc71ad44aff462fb037903dd6e81ca3928333bdb \
-                    sha256  01b8d26b167e11789ea46d01cb48c13f65a8c498fe92fb24675177d98045fdd0 \
-                    size    2479806
+checksums           rmd160  97da32cac02e866f99c5a9461b9fdb1f0735df2d \
+                    sha256  920fe642a2112d17aa0d3a6eb7ad5f855c074f9210814e8bcffcf1f39c1a39fa \
+                    size    25663536
 
 build.dir           ${worksrcpath}/${name}
 


### PR DESCRIPTION
#### Description

Update to kustomize 3.7.0.

###### Tested on

macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?