### PR TITLE
cloudmonkey: new port

### DIFF
--- a/sysutils/cloudmonkey/Portfile
+++ b/sysutils/cloudmonkey/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/apache/cloudstack-cloudmonkey 6.0.0
+name                cloudmonkey
+
+categories          sysutils
+license             Apache-2
+
+description         CloudMonkey is a command line interface for Apache \
+                    Cloudstack.
+
+long_description    {*}${description} CloudMonkey can be used both as an \
+                    interactive shell, and as a command line tool which \
+                    simplifies Apache CloudStack configuration and management.
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+# The build process wants to see a git checkout.
+fetch.type          git
+
+build.cmd           make
+build.target        all
+
+installs_libs       no
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/bin/cmk ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
New port for [Apache CloudMonkey](https://github.com/apache/cloudstack-cloudmonkey), Go CLI for Apache Cloudstack

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
