### PR TITLE
yaegi: update to 0.8.11

### DIFF
--- a/devel/yaegi/Portfile
+++ b/devel/yaegi/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/containous/yaegi 0.8.10 v
+go.setup            github.com/containous/yaegi 0.8.11 v
 
 description         Yaegi is Another Elegant Go Interpreter
 
@@ -24,9 +24,9 @@ categories          devel
 license             Apache-2
 installs_libs       no
 
-checksums           rmd160  1f6f1d7a4528345161408f6b8e000af46b84976b \
-                    sha256  3bb20b88f41e2ac21e2598017545219de479155b240da581a113f366a71524be \
-                    size    1922240
+checksums           rmd160  f358935460fe7d45485438cc5bd4ee364a20e1e7 \
+                    sha256  94b249204442b580aafc301a6679d5d3a48c4dd9b6ca81cd820ba715557fb107 \
+                    size    1925204
 
 build.target        github.com/containous/yaegi/cmd/yaegi
 


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
