### PR TITLE
go-migrate: new port

### DIFF
--- a/devel/go-migrate/Portfile
+++ b/devel/go-migrate/Portfile
@@ -1,0 +1,45 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/golang-migrate/migrate 4.11.0 v
+name                go-migrate
+
+categories          devel databases
+license             MIT
+platforms           darwin
+installs_libs       no
+
+description         CLI for Go library performing database migrations.
+
+long_description    {*}${description} Migrate reads migrations from sources \
+                    and applies them in the correct order to the database. \
+                    Sources include the filesystem, go-bindata, GitHub \
+                    repositories, Gitlab repositories, AWS S3 & Google Cloud \
+                    Storage.
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  e18987257659ebd27ba4dd4517951451d037bd35 \
+                    sha256  28c65abb86ae6a9d7b56fb77bf69f33956f395490435cbb7d7bc5d4f5e7e7ac6 \
+                    size    143355
+
+build.cmd           make
+build.pre_args      VERSION=${version}
+build.args          build-cli
+
+post-extract {
+    # Comment out builds for non-Darwin platforms
+    reinplace -E "s/(\s*)(.*GOOS=\[^d\]\[^a\]\[^r\]\[^w\])/\\1#\\2/g" Makefile
+    # Comment out build steps that create tarballs
+    reinplace -E "s/(\s*)(.*cli\\/build.*tar czf)/\\1#\\2/g" Makefile
+    # Comment out any build steps involved with generating the SHA sums text file.
+    reinplace -E "s/(\s*)(.*sha256sum)/\\1#\\2/g" Makefile
+}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/cli/build/migrate.darwin-amd64 \
+                    ${destroot}${prefix}/bin/migrate
+}


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
