### PR TITLE
py-mmtf-python: added py38 and tests

### DIFF
--- a/python/py-mmtf-python/Portfile
+++ b/python/py-mmtf-python/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             Apache-2
 supported_archs     noarch
 
-python.versions     27 36 37
+python.versions     27 36 37 38
 
 maintainers         {gmail.com:giovanni.bussi @GiovanniBussi} openmaintainer
 
@@ -21,9 +21,6 @@ long_description    ${description} \
                     This repository holds the Python 2 and 3 compatible API, encoding and decoding libraries.
 
 homepage            https://github.com/rcsb/mmtf-python
-master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
-
-distname            ${python.rootname}-${version}
 
 checksums           rmd160  887c43e5a9137b5cdf625377eeea38d9144234c5 \
                     sha256  a5caa7fcd2c1eaa16638b5b1da2d3276cbd3ed3513f0c2322957912003b6a8df \
@@ -33,4 +30,10 @@ if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
     depends_lib-append      port:py${python.version}-msgpack
     livecheck.type          none
+
+    depends_test-append     port:py${python.version}-nose \
+                            port:py${python.version}-numpy
+    test.run                yes
+    test.cmd                nosetests-${python.branch}
+    test.target
 }


### PR DESCRIPTION
#### Description

- Added python 3.8
- Added commands to perform tests

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G5033
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
