### PR TITLE
Add livecheck regexes

### DIFF
--- a/devel/semgrep/Portfile
+++ b/devel/semgrep/Portfile
@@ -62,3 +62,5 @@ pre-activate {
     # This cleanup hack can be removed after June 2021.
     delete ${sg_doc_dir}
 }
+
+github.livecheck.regex {([0-9.]+)}

--- a/net/alertmanager/Portfile
+++ b/net/alertmanager/Portfile
@@ -145,3 +145,5 @@ Configuration for AlertManager can be found at:
   ${am_config_file}
 
 "
+
+github.livecheck.regex {([0-9.]+)}

--- a/net/grafana/Portfile
+++ b/net/grafana/Portfile
@@ -153,3 +153,5 @@ Here is an example of doing so to set the admin password:
 
 \$ sudo -u grafana grafana-cli --homepath ${grafana_share_dir} --config ${grafana_conf_dir}/grafana.ini admin reset-admin-password onetwothree
 "
+
+github.livecheck.regex {([0-9.]+)}

--- a/net/node_exporter/Portfile
+++ b/net/node_exporter/Portfile
@@ -122,3 +122,5 @@ When enabled, by default, the service will be available at http://localhost:9100
   ${ne_log_file}
 
 "
+
+github.livecheck.regex {([0-9.]+)}

--- a/net/nomad/Portfile
+++ b/net/nomad/Portfile
@@ -49,3 +49,5 @@ post-extract {
 destroot {
     xinstall -m 755 ${workpath}/bin/${name} ${destroot}${prefix}/bin/${name}
 }
+
+github.livecheck.regex {([0-9.]+)}

--- a/net/prometheus/Portfile
+++ b/net/prometheus/Portfile
@@ -152,3 +152,5 @@ Once enabled, the service will:
   - log to: ${prom_log_file}
 
 "
+
+github.livecheck.regex {([0-9.]+)}

--- a/net/websocat/Portfile
+++ b/net/websocat/Portfile
@@ -25,6 +25,8 @@ destroot {
     xinstall -m 644 ${worksrcpath}/doc.md ${destroot}${prefix}/share/doc/${name}/
 }
 
+github.livecheck.regex {([0-9.]+)}
+
 cargo.crates \
 	arc-swap		0.3.11 bc4662175ead9cd84451d5c35070517777949a2ed84551764129cedb88384841 \
 	arrayvec		0.4.11 b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba \

--- a/security/aws-vault/Portfile
+++ b/security/aws-vault/Portfile
@@ -37,3 +37,5 @@ destroot {
     xinstall -m 755 ${worksrcpath}/aws-vault-darwin-amd64 \
                     ${destroot}${prefix}/bin/${name}
 }
+
+github.livecheck.regex {([0-9.]+)}

--- a/security/vault/Portfile
+++ b/security/vault/Portfile
@@ -66,3 +66,5 @@ variant ui description {Enable the Web UI} {
                        port:yarn
 
 }
+
+github.livecheck.regex {([0-9.]+)}

--- a/sysutils/certigo/Portfile
+++ b/sysutils/certigo/Portfile
@@ -28,3 +28,5 @@ checksums           rmd160  dd6ecaef6e7ca89aa072a420ecd05160bb6e832c \
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
 }
+
+github.livecheck.regex {([0-9.]+)}


### PR DESCRIPTION
Adds livecheck for the following ports:
- alertmanager
- aws-vault
- certigo
- grafana
- node_exporter
- nomad
- prometheus
- semgrep
- vault
- websocat

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
