### PR TITLE
diskonaut: new port

### DIFF
--- a/sysutils/diskonaut/Portfile
+++ b/sysutils/diskonaut/Portfile
@@ -1,0 +1,117 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo 1.0
+
+github.setup        imsnif diskonaut 0.6.0
+categories          sysutils
+license             MIT
+platforms           darwin
+
+description         Terminal disk-space navigator
+
+long_description    Given a path on your hard-drive (which could also be the \
+                    root path, eg. /). diskonaut scans it and indexes its \
+                    metadata to memory so that you could explore its contents \
+                    (even while still scanning!). Once completed, you can \
+                    navigate through subfolders, getting a visual treemap \
+                    representation of what's taking up your disk space. You \
+                    can even delete files or folders and diskonaut will track \
+                    how much space you've freed up in this session.
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  4b3ac61e60e3fb9f38a95cdb9fb0fa41f8222fa6 \
+                    sha256  d1f87bbdb82197814ff7e89576ee329c7dad67ceedd9897d1cb2db2b2bdfa928 \
+                    size    2773983
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/${name} ${destroot}${prefix}/bin/
+}
+
+cargo.crates \
+    addr2line                       0.12.1  a49806b9dadc843c61e7c97e72490ad7f7220ae249012fbda9ad0609457c0543 \
+    adler32                          1.1.0  567b077b825e468cc974f0020d4082ee6e03132512f207ef1a02fd5d00d1f32d \
+    ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
+    arc-swap                         0.4.7  4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034 \
+    atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+    autocfg                          1.0.0  f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d \
+    backtrace                       0.3.49  05100821de9e028f12ae3d189176b41ee198341eb8f369956407fea2f5cc666c \
+    bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
+    cassowary                        0.3.0  df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53 \
+    cc                              1.0.55  b1be3409f94d7bdceeb5f5fac551039d9b3f00e25da7a74fc4d33400a0d96368 \
+    cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
+    clap                            2.33.1  bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129 \
+    clicolors-control                1.0.1  90082ee5dcdd64dc4e9e0d37fbf3ee325419e39c0092191e0393df65518f741e \
+    console                         0.10.3  2586208b33573b7f76ccfbe5adb076394c88deaf81b84d7213969805b0a952a7 \
+    crossbeam                        0.7.3  69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e \
+    crossbeam-channel                0.4.2  cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061 \
+    crossbeam-deque                  0.7.3  9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285 \
+    crossbeam-epoch                  0.8.2  058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace \
+    crossbeam-queue                  0.2.3  774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570 \
+    crossbeam-utils                  0.7.2  c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8 \
+    difference                       2.0.0  524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198 \
+    dtoa                             0.4.6  134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b \
+    either                           1.5.3  bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3 \
+    encode_unicode                   0.3.6  a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f \
+    failure                          0.1.8  d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86 \
+    failure_derive                   0.1.8  aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4 \
+    filesize                         0.2.0  12d741e2415d4e2e5bd1c1d00409d1a8865a57892c2d689b504365655d237d43 \
+    gimli                           0.21.0  bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c \
+    heck                             0.3.1  20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205 \
+    hermit-abi                      0.1.14  b9586eedd4ce6b3c498bc3b4dd92fc9f11166aa908a914071953768066c67909 \
+    insta                           0.16.0  8386e795fb3927131ea4cede203c529a333652eb6dc4ff29616b832b27e9b096 \
+    itertools                        0.9.0  284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b \
+    itoa                             0.4.6  dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6 \
+    jwalk                            0.5.1  88746778a47f54f83bc0d3d8ba40ce83808024405356b4d521c2bf93c1273cd4 \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    libc                            0.2.71  9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49 \
+    linked-hash-map                  0.5.3  8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a \
+    maybe-uninit                     2.0.0  60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00 \
+    memoffset                        0.5.4  b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8 \
+    miniz_oxide                      0.3.7  791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435 \
+    nix                             0.17.0  50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363 \
+    num_cpus                        1.13.0  05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3 \
+    numtoa                           0.1.0  b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef \
+    object                          0.20.0  1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5 \
+    proc-macro-error                 1.0.2  98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678 \
+    proc-macro-error-attr            1.0.2  4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53 \
+    proc-macro2                     1.0.18  beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa \
+    quote                            1.0.7  aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37 \
+    rayon                            1.3.1  62f02856753d04e03e26929f820d0a0a337ebe71f849801eea335d464b349080 \
+    rayon-core                       1.7.1  e92e15d89083484e11353891f1af602cc661426deb9564c298b270c726973280 \
+    redox_syscall                   0.1.56  2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84 \
+    redox_termios                    0.1.1  7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76 \
+    rustc-demangle                  0.1.16  4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783 \
+    ryu                              1.0.5  71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e \
+    scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
+    serde                          1.0.112  736aac72d1eafe8e5962d1d1c3d99b0df526015ba40915cb3c49d042e92ec243 \
+    serde_derive                   1.0.112  bf0343ce212ac0d3d6afd9391ac8e9c9efe06b533c8d33f660f6390cc4093f57 \
+    serde_json                      1.0.55  ec2c5d7e739bc07a3e73381a39d61fdb5f671c60c1df26a130690665803d8226 \
+    serde_yaml                      0.8.13  ae3e2dd40a7cdc18ca80db804b7f461a39bb721160a85c9a1fa30134bf3c02a5 \
+    signal-hook                     0.1.16  604508c1418b99dfe1925ca9224829bb2a8a9a04dda655cc01fcad46f4ab05ed \
+    signal-hook-registry             1.2.0  94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41 \
+    strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
+    structopt                       0.3.15  de2f5e239ee807089b62adce73e48c625e0ed80df02c7ab3f068f5db5281065c \
+    structopt-derive                 0.4.8  510413f9de616762a4fbeab62509bf15c729603b72d7cd71280fbca431b1c118 \
+    syn                             1.0.31  b5304cfdf27365b7585c25d4af91b35016ed21ef88f17ced89c7093b43dba8b6 \
+    syn-mid                          0.5.0  7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a \
+    synstructure                    0.12.4  b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701 \
+    terminal_size                   0.1.12  8038f95fc7a6f351163f4b964af631bd26c9e828f7db085f2a84aca56f70d13b \
+    termion                          1.5.5  c22cec9d8978d906be5ac94bceb5a010d885c626c4c8855721a4dbd20e3ac905 \
+    termios                          0.3.2  6f0fcee7b24a25675de40d5bb4de6e41b0df07bc9856295e7e2b3a3600c400c2 \
+    textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
+    tui                              0.9.5  9533d39bef0ae8f510e8a99d78702e68d1bbf0b98a78ec9740509d287010ae1e \
+    unicode-segmentation             1.6.0  e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0 \
+    unicode-width                    0.1.7  caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479 \
+    unicode-xid                      0.2.0  826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c \
+    vec_map                          0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
+    version_check                    0.9.2  b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed \
+    void                             1.0.2  6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d \
+    winapi                           0.3.8  8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6 \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    yaml-rust                        0.4.4  39f0c922f1a334134dc2f7a8b67dc5d25f0735263feec974345ff706bcf20b0d

--- a/sysutils/diskonaut/Portfile
+++ b/sysutils/diskonaut/Portfile
@@ -12,7 +12,7 @@ platforms           darwin
 description         Terminal disk-space navigator
 
 long_description    Given a path on your hard-drive (which could also be the \
-                    root path, eg. /). diskonaut scans it and indexes its \
+                    root path, i.e. /). diskonaut scans it and indexes its \
                     metadata to memory so that you could explore its contents \
                     (even while still scanning!). Once completed, you can \
                     navigate through subfolders, getting a visual treemap \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
