### PR TITLE
nghttp2: separate library into a subport not depending on OpenSSL

### DIFF
--- a/www/nghttp2/Portfile
+++ b/www/nghttp2/Portfile
@@ -40,6 +40,8 @@ compiler.cxx_standard   2011
 configure.args      --disable-silent-rules \
                     --disable-threads \
                     --enable-lib-only \
+                    --disable-python-bindings \
+                    --without-cython \
                     ac_cv_prog_AWK=/usr/bin/awk
 
 if {${subport} eq ${name}} {
@@ -81,48 +83,50 @@ subport nghttp2-tools {
     }
 }
 
-if {${subport} eq ${name}} {
-    if {[variant_isset python27]} { set PythonVersion   2.7 }
-    if {[variant_isset python36]} { set PythonVersion   3.6 }
-    if {[variant_isset python37]} { set PythonVersion   3.7 }
-    if {[variant_isset python38]} { set PythonVersion   3.8 }
+set pyversions {27 36 37 38}
 
-    if {[variant_isset python27] || [variant_isset python36] || [variant_isset python37] || [variant_isset python38]} {
-        set PythonBranch    [join [lrange [split ${PythonVersion} .] 0 1] ""]
+foreach pyversion ${pyversions} {
+    subport py${pyversion}-${name} {
+        PortGroup           python 1.0
+
+        python.version      ${pyversion}
+
+        description         Python ${python.branch} bindings for nghttp2.
+        long_description    ${description}
+        homepage            https://nghttp2.org/documentation/python-apiref.html
+
+        use_configure       yes
+
+        depends_build-append \
+                    port:py${python.version}-cython
 
         depends_lib-append \
-                        port:py${PythonBranch}-cython \
-                        port:py${PythonBranch}-setuptools \
-                        port:python${PythonBranch}
+                    port:nghttp2 \
+                    port:py${python.version}-setuptools \
+                    port:python${python.version}
+
+        configure.args-replace \
+                        --disable-python-bindings --enable-python-bindings
+        configure.args-replace \
+                        --without-cython --with-cython
 
         configure.env-append \
-                        CYTHON=${prefix}/bin/cython-${PythonVersion} \
-                        PYTHON=${prefix}/bin/python${PythonVersion}
+                      CYTHON=${prefix}/bin/cython-${python.branch} \
+                      PYTHON=${prefix}/bin/python${python.branch}
 
-        destroot.env    PYTHONPATH=${destroot}${prefix}/lib/python${PythonVersion}/site-packages/
+        destroot.env   PYTHONPATH=${destroot}${prefix}/lib/python${python.branch}/site-packages/
 
-        pre-destroot {
-            xinstall -d ${destroot}${prefix}/lib/python${PythonVersion}/site-packages/
+        build.dir      ${worksrcpath}/python
+        destroot.dir   ${worksrcpath}/python
+
+        build.env-append LDFLAGS=-L${prefix}/lib
+
+        pre-build {
+            system -W ${worksrcpath}/python "cython-${python.branch} nghttp2.pyx"
         }
-    } else {
-        configure.args-append \
-                        --disable-python-bindings \
-                        --without-cython
-    }
 
-    variant python27 conflicts python36 python37 python38 description {Build using Python 2.7} {
-        configure.env-append   "PYTHON_EXTRA_LDFLAGS=-u _PyMac_Error ${frameworks_dir}/Python.framework/Versions/${PythonVersion}/Python"
-    }
-
-    variant python36 conflicts python27 python37 python38 description {Build using Python 3.6} {}
-
-    variant python37 conflicts python27 python36 python38 description {Build using Python 3.7} {}
-
-    variant python38 conflicts python27 python36 python37 description {Build using Python 3.8} {}
-
-    post-destroot {
-        # remove files contained in the libnghttp2 subport
-        delete ${destroot}${prefix}/lib
-        delete ${destroot}${prefix}/include
+        if {${python.version} eq 27} {
+            configure.env-append   "PYTHON_EXTRA_LDFLAGS=-u _PyMac_Error ${frameworks_dir}/Python.framework/Versions/${python.version}/Python"
+        }
     }
 }

--- a/www/nghttp2/Portfile
+++ b/www/nghttp2/Portfile
@@ -6,16 +6,14 @@ PortGroup           github 1.0
 PortGroup           legacysupport 1.0
 
 github.setup        tatsuhiro-t nghttp2 1.41.0 v
-revision            0
+revision            1
 categories          www
 platforms           darwin
 maintainers         {mps @Schamschula} openmaintainer
 license             MIT
 
-description         nghttp2 is an implementation of HTTP/2 in C.
-
-long_description    ${description} Included are a HTTP/2 client, server and proxy. The \
-                    package also provides a load test and benchmarking tool for HTTP/2.
+description         An implementation of HTTP/2 in C.
+long_description    ${description}
 
 github.tarball_from releases
 use_xz              yes
@@ -29,14 +27,6 @@ compiler.blacklist-append {clang < 602}
 
 depends_build       port:pkgconfig
 
-depends_lib         port:c-ares \
-                    port:jansson \
-                    port:libev \
-                    port:libevent \
-                    port:libxml2 \
-                    path:lib/libssl.dylib:openssl \
-                    port:zlib
-
 # See: https://trac.macports.org/ticket/57960
 patchfiles-append   patch-configure-nopython.diff \
                     patch-src-shrpx_client_handler.cc.diff \
@@ -49,52 +39,90 @@ compiler.cxx_standard   2011
 
 configure.args      --disable-silent-rules \
                     --disable-threads \
-                    --enable-app \
+                    --enable-lib-only \
                     ac_cv_prog_AWK=/usr/bin/awk
 
-configure.env       JANSSON_CFLAGS=-I${prefix}/include \
-                    LIBEVENT_OPENSSL_CFLAGS=-I${prefix}/include/event2 \
-                    OPENSSL_CFLAGS=-I${prefix}/include/openssl
+if {${subport} eq ${name}} {
+    build.dir       ${worksrcpath}/lib
+    destroot.dir    ${worksrcpath}/lib
+}
 
-configure.env-append \
-                    "JANSSON_LIBS=-L${prefix}/lib -ljansson" \
-                    "LIBEVENT_OPENSSL_LIBS=-L${prefix}/lib -levent -levent_openssl" \
-                    "OPENSSL_LIBS=-L${prefix}/lib -lcrypto -lssl"
+subport nghttp2-tools {
+    description         Tools for nghttp2, an implementation of HTTP/2 in C.
+    long_description    HTTP/2 client, server and proxy tools, as well as a \
+                        load test and benchmarking tool for HTTP/2.
 
-if {[variant_isset python27]} { set PythonVersion   2.7 }
-if {[variant_isset python36]} { set PythonVersion   3.6 }
-if {[variant_isset python37]} { set PythonVersion   3.7 }
-if {[variant_isset python38]} { set PythonVersion   3.8 }
+    configure.args-replace \
+                        --enable-lib-only --enable-app
 
-if {[variant_isset python27] || [variant_isset python36] || [variant_isset python37] || [variant_isset python38]} {
-    set PythonBranch    [join [lrange [split ${PythonVersion} .] 0 1] ""]
+    depends_lib         port:c-ares \
+                        port:jansson \
+                        port:libev \
+                        port:libevent \
+                        port:libxml2 \
+                        path:lib/libssl.dylib:openssl \
+                        port:zlib
 
-    depends_lib-append \
-                    port:py${PythonBranch}-cython \
-                    port:py${PythonBranch}-setuptools \
-                    port:python${PythonBranch}
+    depends_run         port:nghttp2
+
+    configure.env       JANSSON_CFLAGS=-I${prefix}/include \
+                        LIBEVENT_OPENSSL_CFLAGS=-I${prefix}/include/event2 \
+                        OPENSSL_CFLAGS=-I${prefix}/include/openssl
 
     configure.env-append \
-                    CYTHON=${prefix}/bin/cython-${PythonVersion} \
-                    PYTHON=${prefix}/bin/python${PythonVersion}
+                        "JANSSON_LIBS=-L${prefix}/lib -ljansson" \
+                        "LIBEVENT_OPENSSL_LIBS=-L${prefix}/lib -levent -levent_openssl" \
+                        "OPENSSL_LIBS=-L${prefix}/lib -lcrypto -lssl"
 
-    destroot.env    PYTHONPATH=${destroot}${prefix}/lib/python${PythonVersion}/site-packages/
-
-    pre-destroot {
-        xinstall -d ${destroot}${prefix}/lib/python${PythonVersion}/site-packages/
+    post-destroot {
+        # remove files contained in the main port
+        delete ${destroot}${prefix}/lib
+        delete ${destroot}${prefix}/include
     }
-} else {
-    configure.args-append \
-                    --disable-python-bindings \
-                    --without-cython
 }
 
-variant python27 conflicts python36 python37 python38 description {Build using Python 2.7} {
-    configure.env-append   "PYTHON_EXTRA_LDFLAGS=-u _PyMac_Error ${frameworks_dir}/Python.framework/Versions/${PythonVersion}/Python"
+if {${subport} eq ${name}} {
+    if {[variant_isset python27]} { set PythonVersion   2.7 }
+    if {[variant_isset python36]} { set PythonVersion   3.6 }
+    if {[variant_isset python37]} { set PythonVersion   3.7 }
+    if {[variant_isset python38]} { set PythonVersion   3.8 }
+
+    if {[variant_isset python27] || [variant_isset python36] || [variant_isset python37] || [variant_isset python38]} {
+        set PythonBranch    [join [lrange [split ${PythonVersion} .] 0 1] ""]
+
+        depends_lib-append \
+                        port:py${PythonBranch}-cython \
+                        port:py${PythonBranch}-setuptools \
+                        port:python${PythonBranch}
+
+        configure.env-append \
+                        CYTHON=${prefix}/bin/cython-${PythonVersion} \
+                        PYTHON=${prefix}/bin/python${PythonVersion}
+
+        destroot.env    PYTHONPATH=${destroot}${prefix}/lib/python${PythonVersion}/site-packages/
+
+        pre-destroot {
+            xinstall -d ${destroot}${prefix}/lib/python${PythonVersion}/site-packages/
+        }
+    } else {
+        configure.args-append \
+                        --disable-python-bindings \
+                        --without-cython
+    }
+
+    variant python27 conflicts python36 python37 python38 description {Build using Python 2.7} {
+        configure.env-append   "PYTHON_EXTRA_LDFLAGS=-u _PyMac_Error ${frameworks_dir}/Python.framework/Versions/${PythonVersion}/Python"
+    }
+
+    variant python36 conflicts python27 python37 python38 description {Build using Python 3.6} {}
+
+    variant python37 conflicts python27 python36 python38 description {Build using Python 3.7} {}
+
+    variant python38 conflicts python27 python36 python37 description {Build using Python 3.8} {}
+
+    post-destroot {
+        # remove files contained in the libnghttp2 subport
+        delete ${destroot}${prefix}/lib
+        delete ${destroot}${prefix}/include
+    }
 }
-
-variant python36 conflicts python27 python37 python38 description {Build using Python 3.6} {}
-
-variant python37 conflicts python27 python36 python38 description {Build using Python 3.7} {}
-
-variant python38 conflicts python27 python36 python37 description {Build using Python 3.8} {}


### PR DESCRIPTION
#### Description

The tools have various dependencies, including OpenSSL, which could cause licence conflicts. The main issue with this PR is that it breaks `port upgrade` since `nghttp2` has a runtime dependency on `libnghttp2`, but the latter conflicts with _older_ versions of the former. I'm not sure how to fix that; do you have any pointers?

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
