### PR TITLE
k9s: update to 0.21.2

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.21.1 v
+go.setup            github.com/derailed/k9s 0.21.2 v
 homepage            https://k9scli.io
 
 categories          sysutils devel
@@ -20,9 +20,9 @@ platforms           darwin
 supported_archs     x86_64
 license             Apache-2
 
-checksums           rmd160  9909cbaf673f298ac549e3bcca302c76a468dc74 \
-                    sha256  92086dd18a92c3aa4dcc6aba8714642f0730c70e9578221376e825fcd4ff2ea7 \
-                    size    6080458
+checksums           rmd160  b4308a029152bf679c5dc30312d0db03fec6eee9 \
+                    sha256  1fd1c3ea3ca744d59c890677f74ad15f8f7e1c89a1080c1f3f3b4c577acbc959 \
+                    size    6080582
 
 # Reproduce the "build" target from the upstream Makefile
 set go_ldflags      "-w -X ${go.package}/cmd.version=${version} \


### PR DESCRIPTION
#### Description

Update to k9s 0.21.2.

###### Tested on

macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?