### PR TITLE
Update aqbanking

### DIFF
--- a/devel/aqbanking5/Portfile
+++ b/devel/aqbanking5/Portfile
@@ -3,8 +3,14 @@
 PortSystem        1.0
 
 name              aqbanking5
-# This port offers the latest stable version (also as a gtk subport)
-# as well as the latest beta version as aqbanking5-devel
+version             5.8.2
+revision            1
+# this is specific to this port and *version* for downloading it
+set release         107
+
+checksums           rmd160  ce40afdce3d98a6cae7e709582399a28f761e97f \
+                    sha256  93ca523fe175e72042db75f8c3fc6255ab058cf82caf52796e15f030809fb15e \
+                    size    3824997
 
 
 categories        devel net finance
@@ -22,7 +28,7 @@ long_description  aqbanking is a generic online banking interface mainly \
 
 homepage          https://aquamaniac.de/rdm/projects/aqbanking
 
-conflicts         aqbanking5 aqbanking5-devel aqbanking5-gtk aqbanking5-gtk-devel aqbanking5
+conflicts         aqbanking5 aqbanking5-gtk aqbanking5
 
 depends_lib       port:ktoblzcheck \
                   port:libofx \
@@ -40,53 +46,20 @@ if {$subport == $name} {
                         port:qt4-mac
 }
 
-subport aqbanking5-devel {
-    depends_lib-append  port:gwenhywfar4-devel \
-                        port:qt4-mac
-}
-
 subport aqbanking5-gtk {
     depends_lib-append  port:gwenhywfar4-gtk
-}
-
-subport aqbanking5-gtk-devel {
-    depends_lib-append  port:gwenhywfar4-gtk-devel
 }
 
 subport aqbanking5-gtk3 {
     depends_lib-append  port:gwenhywfar4-gtk3
 }
 
-subport aqbanking5-gtk3-devel {
-    depends_lib-append  port:gwenhywfar4-gtk3-devel
-}
-
-
 patchfiles        patch-aqbanking-config.cmake.in.diff
 
-# There isn't currently a newer devel version.
-# if {![string match "*-devel" $subport]} {
-    version             5.8.2
-    revision            1
-    # this is specific to this port and *version* for downloading it
-    set release         107
 
-    checksums           rmd160  ce40afdce3d98a6cae7e709582399a28f761e97f \
-                        sha256  93ca523fe175e72042db75f8c3fc6255ab058cf82caf52796e15f030809fb15e \
-                        size    3824997
-
-    if {$subport eq $name} {
-        depends_lib-append port:gwenhywfar4
-    }
-# } else {
-    # version             5.7.6beta
-    # # this is specific to this port and *version* for downloading it
-    # set release         215
-
-    # checksums           rmd160  3923a8b166a7a67c239fa7ddce3196657a04dd39 \
-    #                     sha256  f9420d8b34c2eee703a7d26dd71a849700fdb2d7372b7649a3488b5a69f55565
-# }
-
+if {$subport eq $name} {
+    depends_lib-append port:gwenhywfar4
+}
 
 
 master_sites      https://aquamaniac.de/rdm/attachments/download/${release}/
@@ -114,23 +87,16 @@ use_parallel_build no
 
 # Allow gtk3 version to replace any gtk2 version if it is installed
 # This will conflicts during gnucash upgrade.
-if {$subport == "aqbanking5-gtk3" || $subport == "aqbanking5-gtk3-devel"} {
-    conflicts-delete aqbanking5-gtk aqbanking5-gtk-devel
+if {$subport == "aqbanking5-gtk3" } {
+    conflicts-delete aqbanking5-gtk
     pre-activate {
         if { ![catch {set vers [lindex [registry_active aqbanking5-gtk] 0]}] } {
             registry_deactivate_composite aqbanking5-gtk "" [list ports_nodepcheck 1]
-        }
-        if { ![catch {set vers [lindex [registry_active aqbanking5-gtk-devel] 0]}] } {
-            registry_deactivate_composite aqbanking5-gtk-devel "" [list ports_nodepcheck 1]
         }
     }
 }
 
 livecheck.type    regex
 livecheck.url     https://aquamaniac.de/rdm/projects/aqbanking/files
-if {[string match "*-devel" $subport]} {
-    livecheck.regex   aqbanking-(\[0-9.\]*(beta)?)\\.tar
-} else {
-    livecheck.regex   aqbanking-(\[0-9.\]*)\\.tar
-}
+livecheck.regex   aqbanking-(\[0-9.\]*)\\.tar
 

--- a/devel/aqbanking6/Portfile
+++ b/devel/aqbanking6/Portfile
@@ -1,0 +1,91 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        aqbanking aqbanking 6.2.1
+name                aqbanking6
+
+checksums           rmd160  8b0a7968648f4fac419b88bcc14a91448d7d4efa \
+                    sha256  bf7f110c9b4a3edeb8c90c8ce97c9e09c413cb044904cb2c5ec8e7db62996a2c \
+                    size    3209003
+
+categories          devel net finance
+maintainers         {dports @drkp} openmaintainer
+platforms           darwin
+license             {GPL-2 GPL-3 OpenSSLException}
+
+description         a generic online banking interface
+long_description    aqbanking is a generic online banking interface mainly \
+                    supporting Home Banking Computer Interface, a standard \
+                    used for German checking accounts, but also suitable \
+                    for OFX as used in several other countries. \
+                    Note that the YellowNet backend (for Suisse Postfinance) \
+                    is not available for OS X (upstream only has a Linux binary).
+
+homepage            https://www.aquamaniac.de/rdm/projects/aqbanking
+
+conflicts           aqbanking6 aqbanking6-gtk2 aqbanking6-gtk3 \
+                    aqbanking5 aqbanking5-gtk aqbanking5-gtk3
+
+depends_lib         port:ktoblzcheck \
+                    port:libofx \
+                    port:gmp \
+                    port:gnutls
+
+depends_build       port:pkgconfig
+
+universal_variant no
+
+patchfiles patch-src-plugins-backends-Makefile.am.diff
+
+conflicts-delete  $subport
+
+pre-configure {
+        system -W ${worksrcpath} "\
+        aclocal -Im4 -I${prefix}/share/aclocal && \
+        autoconf && \
+        autoheader && \
+        glibtoolize && \
+        automake --add-missing \
+        "
+}
+
+# generate prerequisites for compilation, ignore errors
+pre-build {
+        system -W ${worksrcpath} "make typedefs || true"
+        system -W ${worksrcpath} "make typefiles || true"
+        system -W ${worksrcpath} "make types || true "
+}
+
+if {$subport == $name} {
+    PortGroup qt4 1.0
+    depends_lib-append  port:gwenhywfar5 \
+                        port:qt4-mac
+}
+
+subport aqbanking6-gtk2 {
+    depends_lib-append  port:gwenhywfar5-gtk2
+}
+
+subport aqbanking6-gtk3 {
+    depends_lib-append  port:gwenhywfar5-gtk3
+}
+
+configure.cppflags-append "-L${prefix}/lib"
+configure.cflags-append   "-L${prefix}/lib"
+configure.ldflags-append  "-Wl,-dylib_file,/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL.dylib:/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL.dylib"
+configure.env             PKG_CONFIG=${prefix}/bin/pkg-config QTDIR=${prefix}
+configure.args-append \
+                          --enable-static \
+                          --disable-dependency-tracking \
+                          --with-backends="aqhbci aqofxconnect aqnone aqpaypal"
+
+# Makefiles not suitable for parallel build
+use_parallel_build no
+
+# variants
+variant debug description "Enable debug." {
+    configure.args-append --enable-debug
+}
+

--- a/devel/aqbanking6/files/patch-src-plugins-backends-Makefile.am.diff
+++ b/devel/aqbanking6/files/patch-src-plugins-backends-Makefile.am.diff
@@ -1,0 +1,11 @@
+--- src/libs/plugins/backends/Makefile.am.orig
++++ src/libs/plugins/backends/Makefile.am
+@@ -1,6 +1,8 @@
+ SUBDIRS = $(aqbanking_plugins_backends_dirs) aqnone
+ DIST_SUBDIRS = aqfints aqhbci aqofxconnect aqnone aqebics aqpaypal
+ 
++aqfints aqhbci aqofxconnect aqnone aqebics aqpaypal: aqhbci
++
+ noinst_LTLIBRARIES=libabbackends.la
+ libabbackends_la_SOURCES=dummy.c
+ libabbackends_la_LIBADD=@aqbanking_plugins_backends_libs@ aqnone/libaqnone.la

--- a/devel/gwenhywfar4/Portfile
+++ b/devel/gwenhywfar4/Portfile
@@ -1,11 +1,16 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 # kate: backspace-indents true; indent-pasted-text true; indent-width 4; keep-extra-spaces true; remove-trailing-spaces modified; replace-tabs true; replace-tabs-save true; syntax Tcl/Tk; tab-indents true; tab-width 4;
 
-PortSystem        1.0
+PortSystem          1.0
 
-name              gwenhywfar4
-# This port offers the latest stable version (also as a gtk subport)
-# as well as the latest beta version as gwenhywfar4-devel!
+name                gwenhywfar4
+version             4.20.2
+# this is specific to this port and *version* for downloading it
+set release         108
+
+checksums           rmd160  e8530ab018e28ca48d3947466e75f471ca793c50 \
+                    sha256  0f4fd92351c8a11f053aa482fc5c459499db3dc78dd8bb469e878890ef3d3270 \
+                    size    2350327
 
 categories        devel net finance
 maintainers       {dports @drkp} openmaintainer
@@ -17,7 +22,7 @@ long_description  {*}${description}
 
 homepage          https://www.aquamaniac.de/rdm/projects/gwenhywfar
 
-conflicts         gwenhywfar4 gwenhywfar4-devel gwenhywfar4-gtk gwenhywfar4-gtk-devel gwenhywfar4-gtk3 gwenhywfar4-gtk3-devel
+conflicts         gwenhywfar4 gwenhywfar4-gtk gwenhywfar4-gtk3
 
 depends_lib       path:lib/libssl.dylib:openssl \
                   port:libgcrypt \
@@ -32,30 +37,14 @@ configure.args    --enable-static
 
 conflicts-delete  $subport
 
-
-# Usually the port has a different version than the *-devel subports
-# (but right now it doesn't)
-#if {$subport eq $name || $subport eq "gwenhywfar4-gtk"} {
-    version                 4.20.2
-    # this is specific to this port and *version* for downloading it
-    set release             108
-
-    checksums           rmd160  e8530ab018e28ca48d3947466e75f471ca793c50 \
-                        sha256  0f4fd92351c8a11f053aa482fc5c459499db3dc78dd8bb469e878890ef3d3270 \
-                        size    2350327
-#}
-
 subport gwenhywfar4-gtk {}
 subport gwenhywfar4-gtk3 {}
-subport gwenhywfar4-devel {}
-subport gwenhywfar4-gtk-devel {}
-subport gwenhywfar4-gtk3-devel {}
 
 patchfiles      patch-gwenhywfar-config.cmake.in.diff \
                 patch-gwengui-qt4-config.cmake.in.diff \
                 patch-gwengui-cpp-config.cmake.in.diff
 
-if {$subport eq $name || $subport eq "gwenhywfar4-devel"} {
+if {$subport eq $name} {
     # the correct way to depend on Qt4:
     PortGroup               qt4 1.0
     configure.args-append   --with-qt4-libs=${qt_libs_dir} \
@@ -68,27 +57,23 @@ if {$subport eq $name || $subport eq "gwenhywfar4-devel"} {
 master_sites      https://www.aquamaniac.de/rdm/attachments/download/${release}/
 distname          gwenhywfar-${version}
 
-if {$subport == "gwenhywfar4-gtk" || $subport == "gwenhywfar4-gtk-devel"} {
+if {$subport == "gwenhywfar4-gtk"} {
     depends_lib-append      port:gtk2
     configure.args-append   --with-guis="gtk2 cpp" --disable-qt4
 }
 
-if {$subport == "gwenhywfar4-gtk3" || $subport == "gwenhywfar4-gtk3-devel"} {
+if {$subport == "gwenhywfar4-gtk3"} {
     depends_lib-append      port:gtk3
     configure.args-append   --with-guis="gtk3 cpp" --disable-qt4
 }
 
-
 # Allow gtk3 version to replace any gtk2 version if it is installed
 # This will conflicts during gnucash upgrade.
-if {$subport == "gwenhywfar4-gtk3" || $subport == "gwenhywfar4-gtk3-devel"} {
-    conflicts-delete gwenhywfar4-gtk gwenhywfar4-gtk-devel
+if {$subport == "gwenhywfar4-gtk3"} {
+    conflicts-delete gwenhywfar4-gtk
     pre-activate {
         if { ![catch {set vers [lindex [registry_active gwenhywfar4-gtk] 0]}] } {
             registry_deactivate_composite gwenhywfar4-gtk "" [list ports_nodepcheck 1]
-        }
-        if { ![catch {set vers [lindex [registry_active gwenhywfar4-gtk-devel] 0]}] } {
-            registry_deactivate_composite gwenhywfar4-gtk-devel "" [list ports_nodepcheck 1]
         }
     }
 }
@@ -105,8 +90,4 @@ configure.args-append   --disable-dependency-tracking --disable-silent-rules
 
 livecheck.type    regex
 livecheck.url     https://www.aquamaniac.de/rdm/projects/gwenhywfar/files
-if {[string match "*-devel" $subport]} {
-    livecheck.regex   gwenhywfar-(\[0-9.\]*(beta)?)\\.tar
-} else {
-    livecheck.regex   gwenhywfar-(\[0-9.\]*)\\.tar
-}
+livecheck.regex   gwenhywfar-(\[0-9.\]*)\\.tar

--- a/devel/gwenhywfar5/Portfile
+++ b/devel/gwenhywfar5/Portfile
@@ -49,7 +49,8 @@ subport gwenhywfar5-gtk3 {
         name ${subport}
 }
 
-patchfiles          configure.ac.patch
+patchfiles          configure.ac.patch \
+                    fix-CMAKE-libnames.patch
 
 pre-configure {
     system -W ${worksrcpath} "\

--- a/devel/gwenhywfar5/Portfile
+++ b/devel/gwenhywfar5/Portfile
@@ -40,13 +40,11 @@ conflicts-delete  $subport
 subport gwenhywfar5-gtk2 {
         depends_lib-append      port:gtk2
         configure.args-append   --with-guis="gtk2 cpp" --disable-qt4 --disable-qt5
-        name ${subport}
 }
 
 subport gwenhywfar5-gtk3 {
         depends_lib-append      port:gtk3
         configure.args-append   --with-guis="gtk3 cpp" --disable-qt4 --disable-qt5
-        name ${subport}
 }
 
 patchfiles          configure.ac.patch \

--- a/devel/gwenhywfar5/Portfile
+++ b/devel/gwenhywfar5/Portfile
@@ -1,0 +1,79 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        aqbanking gwenhywfar 5.3.0
+name                gwenhywfar5
+
+checksums           rmd160  3596fc65052af8767f2e07f541d6eb8d09a5f4f9 \
+                    sha256  b2ec45a5021593f82b6f8d2eb768b2a62da400c23bcd56c383b2ad56c41b0532 \
+                    size    1640992
+
+categories          devel net finance
+maintainers         {dports @drkp} openmaintainer
+platforms           darwin
+license             {LGPL-2.1 OpenSSLException}
+
+description         Utility library required by aqbanking and related software.
+long_description    ${description}
+
+homepage            https://www.aquamaniac.de/rdm/projects/gwenhywfar
+
+conflicts           gwenhywfar4 gwenhywfar4-gtk gwenhywfar4-gtk3
+
+depends_lib         path:lib/libssl.dylib:openssl \
+                    port:libgcrypt \
+                    port:gettext \
+                    port:libxml2 \
+                    port:gnutls
+
+depends_build       port:libtool \
+                    port:automake \
+                    port:autoconf \
+                    port:pkgconfig
+
+configure.args      --enable-static
+
+conflicts-delete  $subport
+
+subport gwenhywfar5-gtk2 {
+        depends_lib-append      port:gtk2
+        configure.args-append   --with-guis="gtk2 cpp" --disable-qt4 --disable-qt5
+        name ${subport}
+}
+
+subport gwenhywfar5-gtk3 {
+        depends_lib-append      port:gtk3
+        configure.args-append   --with-guis="gtk3 cpp" --disable-qt4 --disable-qt5
+        name ${subport}
+}
+
+patchfiles          configure.ac.patch
+
+pre-configure {
+    system -W ${worksrcpath} "\
+        aclocal -Im4 -I${prefix}/share/aclocal && \
+        autoconf && \
+        autoheader && \
+        glibtoolize && \
+        automake --add-missing \
+        "
+}
+
+if {$subport eq $name} {
+    PortGroup       qt4 1.0
+    configure.args-append \
+	--with-qt4-libs=${qt_libs_dir} \
+        --with-qt4-includes=${qt_includes_dir} \
+        --with-qt4-moc=${qt_moc_cmd} \
+        --with-qt4-uic=${qt_uic_cmd} \
+        --with-guis="qt4 cpp cocoa"
+}
+
+# variants
+variant debug description "Enable debug." {
+    configure.args-append --enable-debug
+}
+
+configure.args-append --disable-dependency-tracking --disable-silent-rules

--- a/devel/gwenhywfar5/files/configure.ac.patch
+++ b/devel/gwenhywfar5/files/configure.ac.patch
@@ -1,0 +1,10 @@
+--- configure.ac.orig	2019-12-29 19:29:52.000000000 +0100
++++ configure.ac	2019-12-29 19:28:41.000000000 +0100
+@@ -20,6 +20,7 @@
+ AC_INIT
+ AC_CANONICAL_BUILD
+ AC_CANONICAL_HOST
++AC_CONFIG_MACRO_DIRS([m4])
+ AC_CONFIG_SRCDIR([src/gwenhywfarapi.h])
+ AC_CONFIG_HEADERS([config.h])
+ 

--- a/devel/gwenhywfar5/files/fix-CMAKE-libnames.patch
+++ b/devel/gwenhywfar5/files/fix-CMAKE-libnames.patch
@@ -1,0 +1,33 @@
+--- gui/cpp/gwengui-cpp-config.cmake.in
++++ gui/cpp/gwengui-cpp-config.cmake.in
+@@ -27,6 +27,8 @@ set_and_check(includedir "@includedir@")
+ set_and_check(GWENGUI_CPP_INCLUDE_DIRS "@gwenhywfar_headerdir@")
+ if(WIN32)
+     set_and_check(GWENGUI_CPP_LIBRARIES "@libdir@/libgwengui-cpp.dll.a")
++elseif(APPLE)
++    set_and_check(GWENHYWFAR_LIBRARIES "@libdir@/libgwengui-cpp.@GWENHYWFAR_SO_EFFECTIVE@.dylib")
+ else()
+     set_and_check(GWENGUI_CPP_LIBRARIES "@libdir@/libgwengui-cpp.so")
+ endif()
+--- gui/qt4/gwengui-qt4-config.cmake.in
++++ gui/qt4/gwengui-qt4-config.cmake.in
+@@ -46,6 +46,8 @@ set_and_check(includedir "@includedir@")
+ set_and_check(${CMAKE_FIND_PACKAGE_NAME}_INCLUDE_DIRS "@gwenhywfar_headerdir@")
+ if(WIN32)
+   set_and_check(${CMAKE_FIND_PACKAGE_NAME}_LIBRARIES "@libdir@/libgwengui-qt4.dll.a")
++elseif(APPLE)
++  set_and_check(GWENHYWFAR_LIBRARIES "@libdir@/libgwengui-qt4.@GWENHYWFAR_SO_EFFECTIVE@.dylib")
+ else()
+   set_and_check(${CMAKE_FIND_PACKAGE_NAME}_LIBRARIES "@libdir@/libgwengui-qt4.so")
+ endif()
+--- gwenhywfar-config.cmake.in
++++ gwenhywfar-config.cmake.in
+@@ -25,6 +25,8 @@ set_and_check(includedir "@includedir@")
+ set_and_check(GWENHYWFAR_INCLUDE_DIRS "@gwenhywfar_headerdir@")
+ if(WIN32)
+     set_and_check(GWENHYWFAR_LIBRARIES "@libdir@/libgwenhywfar.dll.a")
++elseif(APPLE)
++    set_and_check(GWENHYWFAR_LIBRARIES "@libdir@/libgwenhywfar.@GWENHYWFAR_SO_EFFECTIVE@.dylib")
+ else()
+     set_and_check(GWENHYWFAR_LIBRARIES "@libdir@/libgwenhywfar.so.@GWENHYWFAR_SO_EFFECTIVE@")
+ endif()


### PR DESCRIPTION
#### Description

This set of patches:
* removes the -devel variants from legacy aqbanking and gwenhywfar (aq5 and gwen4 are discontinued)
* adds the most recent versions of aqbanking and gwenhywfar as separate ports (some ports may rely on the old versions)

See #7489 for the plan.
CC @NicosPavlov , @drkp 

###### Type(s)
- [x] enhancement
- [x] submission

###### Tested on
macOS 10.15.5 19F101
Xcode 11.5 11E608c 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

