### PR TITLE
Update to port1.0 group (stub port now displays notes)

### DIFF
--- a/_resources/port1.0/group/perl5-1.0.tcl
+++ b/_resources/port1.0/group/perl5-1.0.tcl
@@ -177,6 +177,11 @@ proc perl5.setup {module vers {cpandir ""}} {
                 xinstall -d -m 0755 ${destroot}${prefix}/share/doc/${name}
                 system "echo $name is a stub port > ${destroot}${prefix}/share/doc/${name}/README"
             }
+            notes "
+            This is a stub port and does not install any binary files!
+            You will instead need to install one its subports!
+            You can safely uninstall this port.
+            "
         }
     } else {
         depends_lib-append port:perl${perl5.default_branch}

--- a/_resources/port1.0/group/perl5-1.0.tcl
+++ b/_resources/port1.0/group/perl5-1.0.tcl
@@ -177,11 +177,10 @@ proc perl5.setup {module vers {cpandir ""}} {
                 xinstall -d -m 0755 ${destroot}${prefix}/share/doc/${name}
                 system "echo $name is a stub port > ${destroot}${prefix}/share/doc/${name}/README"
             }
-            notes "
-            This is a stub port and does not install any binary files!
-            You will instead need to install one its subports!
-            You can safely uninstall this port.
-            "
+            uplevel {
+                description-append (stub port)
+                long_description-append (NOTE: This is a stub port.)
+            }
         }
     } else {
         depends_lib-append port:perl${perl5.default_branch}

--- a/_resources/port1.0/group/php-1.1.tcl
+++ b/_resources/port1.0/group/php-1.1.tcl
@@ -72,11 +72,10 @@ proc php._set_branches {option action args} {
                     xinstall -d -m 0755 ${destroot}${prefix}/share/doc/${subport}
                     system "echo \"${subport} is a stub port\" > ${destroot}${prefix}/share/doc/${subport}/README"
                 }
-                notes "
-                This is a stub port and does not install any binary files!
-                You will instead need to install one its subports!
-                You can safely uninstall this port.
-                "
+                uplevel {
+                    description-append (stub port)
+                    long_description-append (NOTE: This is a stub port.)
+                }
             }
         } else {
             # Single-branch extension port; add the code to the port directly.

--- a/_resources/port1.0/group/php-1.1.tcl
+++ b/_resources/port1.0/group/php-1.1.tcl
@@ -70,8 +70,13 @@ proc php._set_branches {option action args} {
                 test {}
                 destroot {
                     xinstall -d -m 0755 ${destroot}${prefix}/share/doc/${subport}
-                    system "echo \"${subport} is a stub port\" > ${destroot}${prefix}/share/doc/${subport}/README"
+                    system "echo $name is a stub port > ${destroot}${prefix}/share/doc/${name}/README"
                 }
+                notes "
+                This is a stub port and does not install any binary files!
+                You will instead need to install one its subports!
+                You can safely uninstall this port.
+                "
             }
         } else {
             # Single-branch extension port; add the code to the port directly.

--- a/_resources/port1.0/group/php-1.1.tcl
+++ b/_resources/port1.0/group/php-1.1.tcl
@@ -70,7 +70,7 @@ proc php._set_branches {option action args} {
                 test {}
                 destroot {
                     xinstall -d -m 0755 ${destroot}${prefix}/share/doc/${subport}
-                    system "echo $name is a stub port > ${destroot}${prefix}/share/doc/${name}/README"
+                    system "echo \"${subport} is a stub port\" > ${destroot}${prefix}/share/doc/${subport}/README"
                 }
                 notes "
                 This is a stub port and does not install any binary files!

--- a/_resources/port1.0/group/python-1.0.tcl
+++ b/_resources/port1.0/group/python-1.0.tcl
@@ -123,11 +123,10 @@ proc python_set_versions {option action args} {
             destroot {
                 system "echo $name is a stub port > ${destroot}${prefix}/share/doc/${name}/README"
             }
-            notes "
-            This is a stub port and does not install any binary files!
-            You will instead need to install one its subports!
-            You can safely uninstall this port.
-            "
+            uplevel {
+                description-append (stub port)
+                long_description-append (NOTE: This is a stub port.)
+            }
         } else {
             set addcode 1
         }

--- a/_resources/port1.0/group/python-1.0.tcl
+++ b/_resources/port1.0/group/python-1.0.tcl
@@ -123,6 +123,11 @@ proc python_set_versions {option action args} {
             destroot {
                 system "echo $name is a stub port > ${destroot}${prefix}/share/doc/${name}/README"
             }
+            notes "
+            This is a stub port and does not install any binary files!
+            You will instead need to install one its subports!
+            You can safely uninstall this port.
+            "
         } else {
             set addcode 1
         }

--- a/_resources/port1.0/group/ruby-1.0.tcl
+++ b/_resources/port1.0/group/ruby-1.0.tcl
@@ -180,6 +180,11 @@ proc ruby.setup {module vers {type "install.rb"} {docs {}} {source "custom"} {im
                     xinstall -d -m 0755 ${destroot}${prefix}/share/doc/${name}
                     system "echo $name is a stub port > ${destroot}${prefix}/share/doc/${name}/README"
                 }
+                notes "
+                This is a stub port and does not install any binary files!
+                You will instead need to install one its subports!
+                You can safely uninstall this port.
+                "
                 return
             }
         }


### PR DESCRIPTION
#### Description

Update port groups:
perl5-1.0
php-1.1
python-1.0
ruby-1.0

Installing a stub port now displays a system note informing the user that it is a stub port and the need to install a subport instead.

See: https://trac.macports.org/ticket/60759#comment:8

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
