### PR TITLE
gitqlite: new port

### DIFF
--- a/devel/gitqlite/Portfile
+++ b/devel/gitqlite/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/augmentable-dev/gitqlite 0.0.1 v
+
+categories          devel
+license             MIT
+installs_libs       no
+
+description         Query git repositories with SQL.
+
+long_description    ${name} is a tool for running SQL queries on git \
+                    repositories. It implements SQLite virtual tables and \
+                    uses go-git. It's meant for ad-hoc querying of git \
+                    repositories on disk through a common interface (SQL), \
+                    as an alternative to patching together various shell \
+                    commands.
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  2390ab5eee08e2a7ee4fb62f2efd8a28c31d631f \
+                    sha256  84a856c4bd82f0ad0b0208f5dd01983935a6c45d37137cb2ab8f0012ffd24932 \
+                    size    18928
+
+build.cmd           make
+build.target        build
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
New port for [gitqlite](https://github.com/augmentable-dev/gitqlite), a tool that allows one to query a Git repo via SQL.

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
