### PR TITLE
libcoverart: new port, version 1.0.0

### DIFF
--- a/devel/libcoverart/Portfile
+++ b/devel/libcoverart/Portfile
@@ -1,0 +1,42 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        metabrainz libcoverart 1.0.0 release-
+github.tarball_from releases
+categories          devel
+platforms           darwin
+maintainers         nomaintainer
+license             LGPL-2.1+
+
+description         C/C++ library for accessing the MusicBrainz Cover Art Archive
+
+long_description    ${name} is a {*}${description}.
+
+homepage            https://musicbrainz.org/doc/libcoverart
+
+checksums           rmd160  2c3d15b3399b16b842cde85fa02401caf72e4cdb \
+                    sha256  5d9d4a4c46f35754e016affab83957961a364d7a4c7d64447f73bff22a300f44 \
+                    size    57933
+
+# this software is unusual, and the cmake scripts are such that
+# out_of_source builds don't presently work
+cmake.out_of_source no
+
+patchfiles          \
+                    patch-cmakelists-1.diff \
+                    patch-cmakelists-2.diff \
+                    patch-cmakelists-3.diff
+patch.args          -p1
+
+depends_lib-append  \
+                    port:neon \
+                    port:jansson \
+                    port:libxml2
+
+depends_build-append \
+                    port:pkgconfig
+
+github.livecheck.regex {([0-9.]+)}

--- a/devel/libcoverart/files/patch-cmakelists-1.diff
+++ b/devel/libcoverart/files/patch-cmakelists-1.diff
@@ -1,0 +1,10 @@
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -3,6 +3,7 @@ INCLUDE_DIRECTORIES(
+ 	${CMAKE_CURRENT_SOURCE_DIR}/..
+ 	${CMAKE_CURRENT_SOURCE_DIR}/../include
+ 	${CMAKE_CURRENT_BINARY_DIR}/../include
++	${CMAKE_CURRENT_BINARY_DIR}/..
+ 	${NEON_INCLUDE_DIR}
+ 	${JANSSON_INCLUDE_DIR}
+ 	${LIBXML2_INCLUDE_DIR}

--- a/devel/libcoverart/files/patch-cmakelists-2.diff
+++ b/devel/libcoverart/files/patch-cmakelists-2.diff
@@ -1,0 +1,13 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -29,8 +29,8 @@ SET(LIB_INSTALL_DIR ${EXEC_INSTALL_PREFIX}/lib${LIB_SUFFIX} CACHE PATH  "Install
+ SET(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/include CACHE PATH "Installation prefix for C header files" FORCE)
+ 
+ CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/libcoverart.pc.cmake ${CMAKE_CURRENT_BINARY_DIR}/libcoverart.pc)
+-CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.cmake ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile)
+-CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_SOURCE_DIR}/config.h)
++CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.cmake ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
++CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h)
+ 
+ FILE(GLOB headers ${CMAKE_CURRENT_SOURCE_DIR}/include/coverart/*.h)
+ INSTALL(FILES ${headers} include/coverart/caa_c.h DESTINATION ${INCLUDE_INSTALL_DIR}/coverart)

--- a/devel/libcoverart/files/patch-cmakelists-3.diff
+++ b/devel/libcoverart/files/patch-cmakelists-3.diff
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -33,7 +33,7 @@ CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.cmake ${CMAKE_CURRENT_BINARY
+ CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h)
+ 
+ FILE(GLOB headers ${CMAKE_CURRENT_SOURCE_DIR}/include/coverart/*.h)
+-INSTALL(FILES ${headers} include/coverart/caa_c.h DESTINATION ${INCLUDE_INSTALL_DIR}/coverart)
++INSTALL(FILES ${headers} ${CMAKE_CURRENT_BINARY_DIR}/include/coverart/caa_c.h DESTINATION ${INCLUDE_INSTALL_DIR}/coverart)
+ INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/libcoverart.pc DESTINATION ${LIB_INSTALL_DIR}/pkgconfig)
+ 
+ ADD_SUBDIRECTORY(src)


### PR DESCRIPTION
#### Description

libcoverart is a C/C++ library for accessing the MusicBrainz Cover Art Archive

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
