### PR TITLE
zettlr: update to 1.7.1

### DIFF
--- a/aqua/zettlr/Portfile
+++ b/aqua/zettlr/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        Zettlr Zettlr 1.7.0 v
+github.setup        Zettlr Zettlr 1.7.1 v
 name                zettlr
 revision            0
 
@@ -32,9 +32,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  52f17677702b834a1fc4fd71fc46d0fb10156126 \
-                    sha256  34fb05612994d5778075cde8b046b08fea7adb14174b4d2e702a3fa49742bca0 \
-                    size    28025781
+                    rmd160  48c385ecb3bd12504a7e3f5f70f502b3e0daa912 \
+                    sha256  587e035ad9d8b7f93ae9a22e490c91ad03a8f192df30f6945a25e43fdfc454aa \
+                    size    28211660
 
 set ab_bin_commit   b85740334fec875f5dd8dcd22eb1f729599109db
 


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
