### PR TITLE
polyml: Fix build with libffi 3.3

### DIFF
--- a/lang/polyml/Portfile
+++ b/lang/polyml/Portfile
@@ -25,7 +25,8 @@ depends_lib         port:gmp port:libffi
 configure.args      --mandir=${prefix}/share/man --build=${build_arch}-apple-darwin${os.major} \
                     --enable-shared --with-system-libffi
 
-patchfiles          patch-no-ppc-reloc-header.diff
+patchfiles          patch-no-ppc-reloc-header.diff \
+                    patch-libffi-fix.diff
 patch.pre_args -p1
 
 post-destroot {

--- a/lang/polyml/files/patch-libffi-fix.diff
+++ b/lang/polyml/files/patch-libffi-fix.diff
@@ -1,0 +1,16 @@
+diff --git a/libpolyml/polyffi.cpp b/libpolyml/polyffi.cpp
+index b95d02b..51492ee 100644
+--- a/libpolyml/polyffi.cpp
++++ b/libpolyml/polyffi.cpp
+@@ -108,9 +108,10 @@ static struct _abiTable { const char *abiName; ffi_abi abiCode; } abiTable[] =
+     {"ms_cdecl", FFI_MS_CDECL},
+ #elif defined(X86_WIN64)
+     {"win64", FFI_WIN64},
++#elif defined(X86_64) || (defined (__x86_64__) && defined (X86_DARWIN))
++    {"unix64", FFI_UNIX64},
+ #elif defined(X86_ANY)
+     {"sysv", FFI_SYSV},
+-    {"unix64", FFI_UNIX64},
+ #endif
+     { "default", FFI_DEFAULT_ABI}
+ };


### PR DESCRIPTION
The build fails with libffi 3.3 due to a reference to the symbol
FFI_SYSV.  This is resolved by adding a patch that applies upstream
commit https://github.com/polyml/polyml/commit/13efa88 which removes
the reference to FFI_SYSV under Darwin x86_64.

#### Description

This patches polyml so that it builds with libffi 3.3.  On Linux x86_64, I have established that Poly/ML 5.7.1 doesn't build with libffi 3.3 and the included patch fixes this.  I therefore assume that the build is failing under Darwin for the same reason.

The revision is not bumped because those already using polyml should not need to update.  I expect that the commit to update libffi to version 3.3 will bump the revision.

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.10.5 14F2511
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->