### PR TITLE
py-skrf: submission

### DIFF
--- a/python/py-scikit-rf/Portfile
+++ b/python/py-scikit-rf/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
+
+github.setup        scikit-rf scikit-rf 0.15.3 v
+name                py-scikit-rf
+
+checksums           rmd160  33172e881c9b13d464a3e4bf0a5329c60ac1b188 \
+                    sha256  c0f84010eec1ac07755c9fb8e51295a0116037f2de0a2117f507f7f1848106da \
+                    size    17777889
+
+platforms           darwin
+supported_archs     noarch
+maintainers         nomaintainer
+license             BSD
+
+description         scikit-rf (aka skrf): a Python package for RF engineering
+long_description    scikit-rf (aka skrf) is an Open Source, BSD-licensed \
+                    package for RF/Microwave engineering implemented in the \
+                    Python programming language. It provides a modern, \
+                    object-oriented library which is both flexible and scalable.
+
+python.versions     37 38
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+        port:py${python.version}-setuptools
+    depends_lib-append \
+        port:py${python.version}-numpy \
+        port:py${python.version}-scipy
+    livecheck.type  none
+}


### PR DESCRIPTION
#### Description

Add scikit-rf (aka skrf): a Python package for RF engineering
https://github.com/scikit-rf/scikit-rf

###### Type(s)
- [x] submission

###### Tested on
macOS 10.15.5 19F101
Xcode 11.5 11E608c 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? -> `py38-skrf has no tests turned on`
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
