### PR TITLE
vgrep: update to 2.3.3

### DIFF
--- a/textproc/vgrep/Portfile
+++ b/textproc/vgrep/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/vrothberg/vgrep 2.3.1 v
+go.setup            github.com/vrothberg/vgrep 2.3.3 v
 
 categories          textproc
 license             GPL-3
@@ -14,9 +14,9 @@ build.target        release
 
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
 
-checksums           rmd160  14d5bdf685ef7381efd6f848b93d5fd5ce330ebe \
-                    sha256  c3fe938f9d1acd604f345a2c914a51bb857c4b6ae2855af446cb2f5000498835 \
-                    size    1150149
+checksums           rmd160  3a393f4e077437a085db0cc52645909113846f51 \
+                    sha256  27c24fed78d6828029bfb4a4df093c622cc492db12a74ca9901c085110c29e3f \
+                    size    1150442
 
 description         an easy to use front-end for (git) grep
 


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
