### PR TITLE
dua-cli: update to 2.9.0

### DIFF
--- a/sysutils/dua-cli/Portfile
+++ b/sysutils/dua-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        Byron dua-cli 2.8.2 v
+github.setup        Byron dua-cli 2.9.0 v
 categories          sysutils
 license             MIT
 platforms           darwin
@@ -24,9 +24,9 @@ long_description    dua (-> Disk Usage Analyzer) is a tool to conveniently \
                     quickly than rm.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  219062cec7db033fcba84fe17e91e01bd2b62207 \
-                    sha256  b887f39a53f45cfc38e84c8eea883481beea88aa7557920ad059c86d8e078471 \
-                    size    57923
+                    rmd160  98e75e69fb901a735a3516ba4655870a2f6fe177 \
+                    sha256  3d9e8325742b80704fe845f0f93574d5149de46cae6e3fe089925c80c1d351b8 \
+                    size    60250
 
 destroot {
     xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/dua \
@@ -36,39 +36,55 @@ destroot {
 cargo.crates \
     ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
     anyhow                          1.0.31  85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f \
+    arc-swap                         0.4.7  4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034 \
     atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
     autocfg                          1.0.0  f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d \
     bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
-    byte-unit                        4.0.4  a83e250117a919810172ac4d81016eb6da74f235399ac97df3dd8846275d03b6 \
+    byte-unit                        4.0.8  1ba58563da2fefa88ddca9db6347a1818fc224be2faf916cd4c5e210d2653f4c \
     cassowary                        0.3.0  df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53 \
     cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
     clap                            2.33.1  bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129 \
+    cloudabi                         0.0.3  ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
+    colored                          1.9.3  f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59 \
     crossbeam                        0.7.3  69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e \
     crossbeam-channel                0.4.2  cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061 \
     crossbeam-deque                  0.7.3  9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285 \
     crossbeam-epoch                  0.8.2  058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace \
     crossbeam-queue                  0.2.3  774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570 \
     crossbeam-utils                  0.7.2  c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8 \
+    crossterm                       0.17.5  9851d20b9809e561297ec3ca85d7cba3a57507fe8d01d07ba7b52469e1c89a11 \
+    crossterm_winapi                 0.6.1  057b7146d02fb50175fd7dbe5158f6097f33d02831f43b4ee8ae4ddf67b68f5c \
+    crosstermion                     0.1.4  74ba604c40d092aa60a7a17f6cf148f2ede84f4372e2b691d49fdd89820e7846 \
     ctor                            0.1.15  39858aa5bac06462d4dd4b9164848eb81ffc4aa5c479746393598fd193afa227 \
     difference                       2.0.0  524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198 \
     either                           1.5.3  bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3 \
     filesize                         0.2.0  12d741e2415d4e2e5bd1c1d00409d1a8865a57892c2d689b504365655d237d43 \
     fixedbitset                      0.2.0  37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d \
     flume                            0.7.1  855e285c3835897065a6ba6f9463b44553eb9f29c7988d692f3d41283b47388b \
+    fuchsia-zircon                   0.3.3  2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
+    fuchsia-zircon-sys               0.3.3  3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
     heck                             0.3.1  20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205 \
-    hermit-abi                      0.1.14  b9586eedd4ce6b3c498bc3b4dd92fc9f11166aa908a914071953768066c67909 \
+    hermit-abi                      0.1.15  3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9 \
     indexmap                         1.4.0  c398b2b113b55809ceb9ee3e753fcbac793f1956663f3c36549c1346015c2afe \
+    iovec                            0.1.4  b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e \
     itertools                        0.9.0  284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b \
     jwalk                            0.5.1  88746778a47f54f83bc0d3d8ba40ce83808024405356b4d521c2bf93c1273cd4 \
+    kernel32-sys                     0.2.2  7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
     libc                            0.2.71  9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49 \
+    lock_api                         0.3.4  c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75 \
     log                              0.4.8  14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7 \
     maybe-uninit                     2.0.0  60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00 \
     memoffset                        0.5.5  c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f \
+    mio                             0.6.22  fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430 \
+    miow                             0.2.1  8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919 \
+    net2                            0.2.34  2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7 \
     num_cpus                        1.13.0  05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3 \
     numtoa                           0.1.0  b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef \
     open                             1.4.0  7c283bf0114efea9e42f1a60edea9859e8c47528eae09d01df4b29c1e489cc48 \
     output_vt100                     0.1.2  53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9 \
+    parking_lot                     0.10.2  d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e \
+    parking_lot_core                 0.7.2  d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3 \
     petgraph                         0.5.1  467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7 \
     pretty_assertions                0.6.1  3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427 \
     proc-macro-error                 1.0.3  fc175e9777c3116627248584e8f8b3e2987405cabe1c0adf7d1dd28f09dc7880 \
@@ -80,6 +96,10 @@ cargo.crates \
     redox_syscall                   0.1.56  2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84 \
     redox_termios                    0.1.1  7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76 \
     scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
+    signal-hook                     0.1.16  604508c1418b99dfe1925ca9224829bb2a8a9a04dda655cc01fcad46f4ab05ed \
+    signal-hook-registry             1.2.0  94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41 \
+    slab                             0.4.2  c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8 \
+    smallvec                         1.4.0  c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4 \
     spin                             0.5.2  6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d \
     strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
     structopt                       0.3.15  de2f5e239ee807089b62adce73e48c625e0ed80df02c7ab3f068f5db5281065c \
@@ -89,11 +109,16 @@ cargo.crates \
     termion                          1.5.5  c22cec9d8978d906be5ac94bceb5a010d885c626c4c8855721a4dbd20e3ac905 \
     textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
     tui                              0.9.5  9533d39bef0ae8f510e8a99d78702e68d1bbf0b98a78ec9740509d287010ae1e \
+    tui-react                        0.4.0  c585aaa750085a1eeb4b78cdfdd0306e86e8fb76acc2349a787e70b5ce8413d4 \
     unicode-segmentation             1.6.0  e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0 \
     unicode-width                    0.1.8  9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3 \
     unicode-xid                      0.2.1  f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564 \
+    utf8-width                       0.1.3  6f2c54fe5e8d6907c60dc6fba532cc8529245d97ff4e26cb490cb462de114ba4 \
     vec_map                          0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
     version_check                    0.9.2  b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed \
+    winapi                           0.2.8  167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
+    winapi-build                     0.1.1  2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
-    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    ws2_32-sys                       0.2.1  d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
