### PR TITLE
openmpi: Add gcc10. Closes https://trac.macports.org/ticket/60491.

### DIFF
--- a/science/openmpi/Portfile
+++ b/science/openmpi/Portfile
@@ -92,6 +92,7 @@ if { ${os.major} < 18 } {
 # gcc 9+ only available on macOS10.7 (Darwin11) and newer
 if { ${os.major} > 10 } {
     set clist(gcc9)    {macports-gcc-9}
+    set clist(gcc10)   {macports-gcc-10}
 }
 
 foreach key [array name clist] {

--- a/science/openmpi/files/openmpi-devel-gcc10-fortran
+++ b/science/openmpi/files/openmpi-devel-gcc10-fortran
@@ -1,0 +1,12 @@
+bin/mpicc-openmpi-devel-gcc10
+-
+bin/mpicxx-openmpi-devel-gcc10
+bin/mpiexec-openmpi-devel-gcc10
+bin/mpirun-openmpi-devel-gcc10
+bin/mpif77-openmpi-devel-gcc10
+bin/mpif90-openmpi-devel-gcc10
+-
+-
+lib/openmpi-devel-gcc10/pkgconfig/ompi.pc
+lib/openmpi-devel-gcc10/pkgconfig/orte.pc
+bin/mpifort-openmpi-devel-gcc10

--- a/science/openmpi/files/openmpi-gcc10-fortran
+++ b/science/openmpi/files/openmpi-gcc10-fortran
@@ -1,0 +1,12 @@
+bin/mpicc-openmpi-gcc10
+-
+bin/mpicxx-openmpi-gcc10
+bin/mpiexec-openmpi-gcc10
+bin/mpirun-openmpi-gcc10
+bin/mpif77-openmpi-gcc10
+bin/mpif90-openmpi-gcc10
+-
+-
+lib/openmpi-gcc10/pkgconfig/ompi.pc
+lib/openmpi-gcc10/pkgconfig/orte.pc
+bin/mpifort-openmpi-gcc10


### PR DESCRIPTION
#### Description

openmpi: Add gcc10. Closes https://trac.macports.org/ticket/60491.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.12.6
Xcode 9.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
