### PR TITLE
jdupes: update to 1.17.1

### DIFF
--- a/sysutils/jdupes/Portfile
+++ b/sysutils/jdupes/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        jbruchon jdupes 1.17.0 v
+github.setup        jbruchon jdupes 1.17.1 v
 revision            0
-checksums           rmd160  5139cf4f3bb295a71c8fd2fc0c17415a48d274f1 \
-                    sha256  345baa8dc12fdd6ab9daa36a410a88ae0d5893cc124d885990e3a9e679a2faf9 \
-                    size    107126
+checksums           rmd160  99b377e2502237b083639bb5232110b954baf16e \
+                    sha256  3399f5dd11f4245527eddb2dddb1f13eb728cc517dc18886e8b8e7a316b3f28b \
+                    size    107894
 
 platforms           darwin
 categories          sysutils
@@ -21,5 +21,10 @@ use_configure       no
 
 build.args          PREFIX=${prefix} \
                     CC="${configure.cc} [get_canonical_archflags cc]"
+
+if {${os.platform} eq "darwin" && ${os.major} > 16} {
+    # dedupe feature requires macOS 10.13 or higher
+    build.args-append   ENABLE_DEDUPE=1
+}
 
 destroot.args       PREFIX=${prefix}


### PR DESCRIPTION
#### Description

* update jdupes to 1.17.1
* adds macOS major version check: dedupe feature (-B) uses APFS clonefile() support and is automatically enabled if building on the required minimum version macOS 10.13 or higher.

###### Tested on
macOS 10.13.6 17G12034
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?