### PR TITLE
cutter-r2: submission

### DIFF
--- a/devel/cutter-r2/Portfile
+++ b/devel/cutter-r2/Portfile
@@ -1,0 +1,82 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           qmake5 1.0
+
+github.setup        radareorg cutter 1.10.3 v
+name                cutter-r2
+revision            0
+
+categories          devel
+platforms           darwin
+license             GPL-3
+maintainers         {@i0ntempest me.com:szf1234} openmaintainer
+
+description         Free and Open Source RE Platform powered by radare2
+long_description    Cutter is a free and open-source reverse engineering framework\
+                    powered by radare2. Its goal is making an advanced, customizable\
+                    and FOSS reverse-engineering platform while keeping the user\
+                    experience at mind. Cutter is created by reverse engineers for\
+                    reverse engineers.
+
+homepage            https://cutter.re/
+
+checksums           rmd160  e2c88f2eb32c0ed6cee9e8cd3bc71ddf69363ed3 \
+                    sha256  4a65e5c2a02e0dd7d7359ede2f0ebb5c9d0e3411d6718f6aad57ba9affe53717 \
+                    size    1866181
+
+depends_lib-append  port:radare2
+qt5.depends_component \
+                    qtsvg
+                    
+compiler.cxx_standard 2011
+configure.args-append \
+                    src/Cutter.pro \
+                    INCLUDEPATH+=${prefix}/include/libr
+
+destroot {
+    copy ${worksrcpath}/Cutter.app ${destroot}${applications_dir}
+}
+
+proc python-depends {python_branch} {
+        global frameworks_dir
+        set python_version [string map {. ""} ${python_branch}]
+        set ::python_framework ${frameworks_dir}/Python.framework
+        global python_framework
+        # same here, and creating an alias of the variable in proc namespace so we can use it here
+
+        depends_lib-append  port:python${python_version} \
+                            port:py${python_version}-pyside2
+
+        configure.args-append \
+                            CONFIG+=CUTTER_ENABLE_PYTHON \
+                            CONFIG+=CUTTER_ENABLE_PYTHON_BINDINGS \
+                            INCLUDEPATH+=${python_framework}/Versions/${python_branch}/include/python${python_branch}/ \
+                            LIBS+="-L${python_framework}/Versions/${python_branch}/lib -lpython${python_branch}" \
+                            QMAKE_RPATHDIR+=${python_framework}/Versions/${python_branch}/lib/python${python_branch}/site-packages/shiboken2/ \
+                            QMAKE_RPATHDIR+=${python_framework}/Versions/${python_branch}/lib/python${python_branch}/site-packages/PySide2/ \
+                            PYTHON_FRAMEWORK_DIR=${python_framework} \
+                            SHIBOKEN_EXECUTABLE=${python_framework}/Versions/${python_branch}/bin/shiboken2 \
+                            SHIBOKEN_INCLUDEDIR=${python_framework}/Versions/${python_branch}/lib/python${python_branch}/site-packages/shiboken2_generator/include/ \
+                            SHIBOKEN_LIBRARY=${python_framework}/Versions/${python_branch}/lib/python${python_branch}/site-packages/shiboken2/libshiboken2.cpython-*-darwin.*.dylib \
+                            PYSIDE_INCLUDEDIR=${python_framework}/Versions/${python_branch}/lib/python${python_branch}/site-packages/PySide2/include/ \
+                            PYSIDE_LIBRARY=${python_framework}/Versions/${python_branch}/lib/python${python_branch}/site-packages/PySide2/libpyside2.cpython-*-darwin.*.dylib \
+                            PYSIDE_TYPESYSTEMS=${python_framework}/Versions/${python_branch}/lib/python${python_branch}/site-packages/PySide2/typesystems
+
+        pre-destroot {
+            move ${worksrcpath}/Cutter.app/Contents/MacOS/Cutter ${worksrcpath}/Cutter.app/Contents/MacOS/Cutter.bin
+            copy ${filespath}/Cutter ${worksrcpath}/Cutter.app/Contents/MacOS/
+            reinplace "s|@PYFRAMEWORK@|${python_framework}|g" ${worksrcpath}/Cutter.app/Contents/MacOS/Cutter
+            reinplace "s|@PYVER@|${python_branch}|g" ${worksrcpath}/Cutter.app/Contents/MacOS/Cutter
+        }
+}
+
+variant python38 description {Enable Python support and bindings using Python 3.8} {
+    set ::python_branch 3.8
+    # :: refers to global namespace, so the variable is created in global ns and is usable in pre-destroot
+    python-depends ${::python_branch}
+}
+
+default_variants \
+                +python38

--- a/devel/cutter-r2/files/Cutter
+++ b/devel/cutter-r2/files/Cutter
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+EXECDIR=$(dirname "$0")
+
+case "$*" in
+    *--pythonhome*)
+        exec "$EXECDIR/Cutter.bin" "$@"
+        ;;
+    *)
+        exec "$EXECDIR/Cutter.bin" --pythonhome "@PYFRAMEWORK@/Versions/@PYVER@/" "$@"
+        ;;
+esac


### PR DESCRIPTION
#### Description
Named "cutter-r2" because the name cutter is already used.
As python libraries installed by macports does not come with .pc file, I have to manually specify the paths to libraries. Is there a better way to do this?

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
