### PR TITLE
plumed and py-plumed: update to 2.6.1

### DIFF
--- a/python/py-plumed/Portfile
+++ b/python/py-plumed/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        plumed plumed2 2.6.0 v
+github.setup        plumed plumed2 2.6.1 v
 name                py-plumed
 categories          python
 
@@ -18,9 +18,9 @@ long_description    ${description} They allow the plumed library to be directly 
 
 homepage            http://www.plumed.org
 
-checksums           rmd160  4aacc2e0bc31f94f7432d2be1a75c9fd10c0907d \
-                    sha256  117d15bf8b74268243b615576a19676beb21e3fb2542a131d7ab9768b9502f87 \
-                    size    74671170
+checksums           rmd160  be0480e4ea8405d02151305799e1994e62f39239 \
+                    sha256  8d196b01d9b06c784d0c7a57e2817faa01c8449b505bf6dbe232ed882c249110 \
+                    size    75229530
 
 python.versions     36 37 38
 

--- a/science/plumed/Portfile
+++ b/science/plumed/Portfile
@@ -2,14 +2,11 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
-# Notice that this rules out gcc variants.
-# See https://github.com/macports/macports-ports/pull/1252
-PortGroup           cxx11 1.1
 PortGroup           mpi 1.0
 PortGroup           linear_algebra 1.0
 PortGroup           debug 1.0
 
-github.setup        plumed plumed2 2.6.0 v
+github.setup        plumed plumed2 2.6.1 v
 name                plumed
 
 categories          science
@@ -28,9 +25,9 @@ platforms           darwin
 
 homepage            http://www.plumed.org/
 
-checksums           rmd160  4aacc2e0bc31f94f7432d2be1a75c9fd10c0907d \
-                    sha256  117d15bf8b74268243b615576a19676beb21e3fb2542a131d7ab9768b9502f87 \
-                    size    74671170
+checksums           rmd160  be0480e4ea8405d02151305799e1994e62f39239 \
+                    sha256  8d196b01d9b06c784d0c7a57e2817faa01c8449b505bf6dbe232ed882c249110 \
+                    size    75229530
 
 # Enable optional features.
 # --enable-asmjit:        Compile internal asmjit. Notice that internal asmjit is protected in
@@ -64,6 +61,8 @@ configure.args-append BASH_COMPLETION_DIR=${prefix}/share/bash-completion/comple
 configure.cppflags-append "-D__PLUMED_DEFAULT_KERNEL=${prefix}/lib/libplumedKernel.dylib"
 
 compilers.choose    cc cxx
+compiler.cxx_standard  2011
+
 mpi.setup
 
 # To enable mpi, replace a configure flag
@@ -116,14 +115,14 @@ pre-configure {
 # plumed-devel subport
 # This subport installs the developer version
 subport plumed-devel {
-    github.setup        plumed plumed2 a33c1fc6934e73f26979059b96f03493c7285f00
-    version             2.7-20200127
+    github.setup        plumed plumed2 6e28005abefb168b871ed5ae01a730cb4ed1741e
+    version             2.7-20200708
     description         ${description} (development version)
     long_description    ${long_description} (development version)
     conflicts plumed
-    checksums           rmd160  b8b0dd634343fa1166dbdee6c06c578ff0aaaa25 \
-                        sha256  0a468f094ee7275e8dea255f19e8b67b4a14b1c9b9446f3601591bf3e37de947 \
-                        size    75067013
+    checksums           rmd160  5e3d5a8a642b7fd3ab3d2cd3ae893ef8877a2620 \
+                        sha256  186f39652e89307ab27f52d96f4596843b9c9317b9996b083c9e8600c8a07602 \
+                        size    99936155
 }
 
 # Allow running tests from MacPorts


### PR DESCRIPTION
#### Description

This is just an update. However, I am not 100% about this change, that I implemented after receiving a warning from `port install`:

```
removed: PortGroup           cxx11 1.1	
added: compiler.cxx_standard  2011
```

It looks that now a lot of `gcc` variants are suddenly available.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G5033
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
