### PR TITLE
py-avro: Update to version 1.10.0, improvements, and bugfixes

### DIFF
--- a/python/py-avro/Portfile
+++ b/python/py-avro/Portfile
@@ -1,12 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        apache avro 1.9.1 release-
+name                py-avro
+version             1.10.0
 revision            0
-name                py-${github.project}
 categories-append   devel
 
 platforms           darwin
@@ -18,17 +17,25 @@ long_description    ${description}
 
 homepage            https://avro.apache.org/
 
-checksums           rmd160  61c45d1cfa9914306401cb88d880ac63602d43cc \
-                    sha256  f456539183df0d6912daedfbf0f94d7cf69b4fba7200490e8a06d1e8f23af43d \
-                    size    1845163
+checksums           rmd160  f7465dfc3a5bbdd27265617d3039591313eefc82 \
+                    sha256  bbf9f89fd20b4cf3156f10ec9fbce83579ece3e0403546c305957f9dac0d2f03 \
+                    size    67793
 
 python.versions     37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \
-                        port:py${python.version}-setuptools
+                    port:py${python.version}-setuptools \
+                    port:py${python.version}-codestyle \
+                    port:py${python.version}-isort
 
-    worksrcdir          ${distname}/lang/py3
+    depends_test-append \
+                    port:py${python.version}-pytest
+
+    test.run        yes
+    test.cmd        py.test-${python.branch}
+    test.target
+    test.env-append PYTHONPATH=${worksrcpath}/build/lib
 
     livecheck.type      none
 }


### PR DESCRIPTION
py-avros: Update to version 1.10.0, improvements, and bugfixes

* Update to version 1.10.0
* Move to pypi source to avoud tar extraction issue on some systems
* Add tests

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
