### PR TITLE
perl5: Disable parallel build

### DIFF
--- a/lang/perl5/Portfile
+++ b/lang/perl5/Portfile
@@ -13,6 +13,8 @@ maintainers         {mojca @mojca} openmaintainer
 homepage            https://www.perl.org/
 master_sites        http://www.cpan.org/src/5.0/
 
+use_parallel_build no
+
 # current Perl versions
 #
 # meaning of the fields:


### PR DESCRIPTION
#### Description

Building perl5 in parallel causes inscrutable errors like `Can't locate Errno.pm in @INC (you may need to install the Errno module)` to show up, even on a fresh MacPorts install/trace mode enabled. In my testing, this has been around for a while and occurs regardless of machine or OS.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 11.0 20A5299w
Xcode 12.0 12A8161k 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
