### PR TITLE
tektoncd-cli: new port

### DIFF
--- a/devel/tektoncd-cli/Portfile
+++ b/devel/tektoncd-cli/Portfile
@@ -1,0 +1,49 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/tektoncd/cli 0.10.0 v
+name                tektoncd-cli
+
+categories          devel
+license             Apache-2
+platforms           darwin
+supported_archs     x86_64 i386
+
+description         A CLI for interacting with Tekton
+
+long_description    The Tekton Pipelines cli project provides a CLI for \
+                    interacting with Tekton. Tekton is a powerful yet \
+                    flexible framework for building CI/CD systems on \
+                    Kubernetes. It lets you build, test, and deploy across \
+                    multiple cloud providers or on-premises systems by \
+                    abstracting away the underlying implementation details.
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  74c692dcace7b499612798a80b8e88e95b5a0c97 \
+                    sha256  150344c4997db792594a8683da27fa66ef0ca70c7a69494496af90e98067a0b2 \
+                    size    6964051
+
+if {${build_arch} eq "x86_64"} {
+    set tektoncd_target amd64
+} else {
+    set tektoncd_target 386
+}
+
+patchfiles          patch-Makefile.diff
+
+build.cmd           make
+build.pre_args      RELEASE_VERSION=${version}
+build.args          ${tektoncd_target}
+installs_libs       no
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/bin/tkn-darwin-${tektoncd_target} \
+                    ${destroot}${prefix}/bin/tkn
+
+    copy {*}[glob ${worksrcpath}/docs/man/man1/*] \
+                  ${destroot}${prefix}/share/man/man1/
+}

--- a/devel/tektoncd-cli/files/patch-makefile.diff
+++ b/devel/tektoncd-cli/files/patch-makefile.diff
@@ -1,0 +1,21 @@
+--- Makefile	2020-07-11 09:06:35.000000000 -0400
++++ Makefile	2020-07-11 09:07:23.000000000 -0400
+@@ -33,14 +33,14 @@
+ 
+ .PHONY: amd64
+ amd64:
+-	GOOS=linux GOARCH=amd64 go build -mod=vendor $(LDFLAGS) -o bin/tkn-linux-amd64 ./cmd/tkn
+-	GOOS=windows GOARCH=amd64 go build -mod=vendor $(LDFLAGS) -o bin/tkn-windows-amd64 ./cmd/tkn
++	# GOOS=linux GOARCH=amd64 go build -mod=vendor $(LDFLAGS) -o bin/tkn-linux-amd64 ./cmd/tkn
++	# GOOS=windows GOARCH=amd64 go build -mod=vendor $(LDFLAGS) -o bin/tkn-windows-amd64 ./cmd/tkn
+ 	GOOS=darwin GOARCH=amd64 go build -mod=vendor $(LDFLAGS) -o bin/tkn-darwin-amd64 ./cmd/tkn
+ 
+ .PHONY: 386
+ 386:
+-	GOOS=linux GOARCH=386 go build -mod=vendor $(LDFLAGS) -o bin/tkn-linux-386 ./cmd/tkn
+-	GOOS=windows GOARCH=386 go build -mod=vendor $(LDFLAGS) -o bin/tkn-windows-386 ./cmd/tkn
++	# GOOS=linux GOARCH=386 go build -mod=vendor $(LDFLAGS) -o bin/tkn-linux-386 ./cmd/tkn
++	# GOOS=windows GOARCH=386 go build -mod=vendor $(LDFLAGS) -o bin/tkn-windows-386 ./cmd/tkn
+ 	GOOS=darwin GOARCH=386 go build -mod=vendor $(LDFLAGS) -o bin/tkn-darwin-386 ./cmd/tkn
+ 
+ .PHONY: arm


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
