### PR TITLE
pulumi: update to 2.6.1

### DIFF
--- a/sysutils/pulumi/Portfile
+++ b/sysutils/pulumi/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/pulumi/pulumi 2.6.0 v
+go.setup            github.com/pulumi/pulumi 2.6.1 v
 
 categories          sysutils
 license             Apache-2
@@ -27,9 +27,9 @@ long_description    Pulumi's Infrastructure as Code SDK is the easiest way to \
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  ab5766e308760af3cfa668e2887c4647453634a8 \
-                    sha256  00ce89edf5a8fec0ce6abf77874f9abff4edb150fa03ccdc25e7987f238f112f \
-                    size    2614754
+checksums           rmd160  0ea055ab17b4b65845a03015f7bf09bacb92244f \
+                    sha256  d8fa208329a7de85e3d3bdc9202182e01a97edf9dba24eaf288170ff079be4ba \
+                    size    2624808
 
 build.cmd           make
 build.pre_args      VERSION="${github.tag_prefix}${version}"


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
