### PR TITLE
dua-cli: update to 2.9.1

### DIFF
--- a/sysutils/dua-cli/Portfile
+++ b/sysutils/dua-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        Byron dua-cli 2.9.0 v
+github.setup        Byron dua-cli 2.9.1 v
 categories          sysutils
 license             MIT
 platforms           darwin
@@ -24,9 +24,9 @@ long_description    dua (-> Disk Usage Analyzer) is a tool to conveniently \
                     quickly than rm.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  98e75e69fb901a735a3516ba4655870a2f6fe177 \
-                    sha256  3d9e8325742b80704fe845f0f93574d5149de46cae6e3fe089925c80c1d351b8 \
-                    size    60250
+                    rmd160  86d55392de68836f40f978490c2b83d09d5b749d \
+                    sha256  93708fbe1af9f939aff5d116e76535c2abe68f6229e650746a4660a4ae47d654 \
+                    size    60378
 
 destroot {
     xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/dua \
@@ -63,6 +63,7 @@ cargo.crates \
     flume                            0.7.1  855e285c3835897065a6ba6f9463b44553eb9f29c7988d692f3d41283b47388b \
     fuchsia-zircon                   0.3.3  2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
     fuchsia-zircon-sys               0.3.3  3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
+    glob                             0.3.0  9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574 \
     heck                             0.3.1  20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205 \
     hermit-abi                      0.1.15  3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9 \
     indexmap                         1.4.0  c398b2b113b55809ceb9ee3e753fcbac793f1956663f3c36549c1346015c2afe \
@@ -116,6 +117,7 @@ cargo.crates \
     utf8-width                       0.1.3  6f2c54fe5e8d6907c60dc6fba532cc8529245d97ff4e26cb490cb462de114ba4 \
     vec_map                          0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
     version_check                    0.9.2  b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed \
+    wild                             2.0.4  035793abb854745033f01a07647a79831eba29ec0be377205f2a25b0aa830020 \
     winapi                           0.2.8  167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-build                     0.1.1  2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
