### PR TITLE
arm-none-eabi-gcc8: submission (new Portfile)

### DIFF
--- a/cross/arm-none-eabi-gcc8/Portfile
+++ b/cross/arm-none-eabi-gcc8/Portfile
@@ -3,6 +3,9 @@
 PortSystem          1.0
 PortGroup           crossgcc 1.0
 
+# gcc 8.x is the latest release that supports Armv2 and Armv3 architectures
+# and their variants. Support for Armv5 and Armv5E has also been removed with
+# gcc 9, yet these architectures have no known implementation
 crossgcc.setup      arm-none-eabi 8.3.0
 name                ${crossgcc.target}-gcc8
 crossgcc.setup_libc newlib 3.1.0

--- a/cross/arm-none-eabi-gcc8/Portfile
+++ b/cross/arm-none-eabi-gcc8/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           crossgcc 1.0
+
+crossgcc.setup      arm-none-eabi 8.3.0
+name                ${crossgcc.target}-gcc8
+crossgcc.setup_libc newlib 3.1.0
+revision            0
+extract.suffix      .gz
+
+conflicts           arm-none-eabi-gcc
+
+maintainers         nomaintainer
+
+# specific to ARM
+configure.args-append \
+                    --enable-interwork \
+                    --disable-newlib-supplied-syscalls \
+                    --with-multilib-list=rmprofile
+
+# GCC's arm target code contains bracket nesting exceeding clangs's default
+# bracket limit.  (https://llvm.org/bugs/show_bug.cgi?id=19650)
+if {[string match "*clang*" ${configure.compiler}]} {
+    configure.cflags-append -fbracket-depth=512
+    configure.cxxflags-append -fbracket-depth=512
+}


### PR DESCRIPTION
Latest 8.x version of arm-non-eabi-gcc.
arm-none-eabi-gcc 9 dropped support for targets such as armv3.

#### Description

New port for gcc 8.x for arm-none-eabi triplet.
Useful toolchain for armv3 targets that are no longer supported with gcc 9.x and higher.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.5 19F101
Xcode 11.5 11E608c 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
