### PR TITLE
py-scipy: update to 1.5.1, move gfortran10 fix

### DIFF
--- a/python/py-scipy/Portfile
+++ b/python/py-scipy/Portfile
@@ -7,10 +7,10 @@ PortGroup               github 1.0
 PortGroup               compilers 1.0
 PortGroup               compiler_blacklist_versions 1.0
 
-github.setup            scipy scipy 1.5.0 v
-checksums               rmd160  bae805468c0781ea8fff87f25b7c3384dcd0875e \
-                        sha256  b31b616b4571f19a4c1a925b1b19f4eb325d098265692d88ea386537aa3742ab \
-                        size    19831004
+github.setup            scipy scipy 1.5.1 v
+checksums               rmd160  112cc52964a9c7890328ea53045bfac024309f7f \
+                        sha256  f46dcb2f84822eb7c31fedfd607d9ed5893b1071a060557131ac1d434cd18eb4 \
+                        size    19834361
 revision                0
 
 name                    py-scipy

--- a/python/py-scipy/Portfile
+++ b/python/py-scipy/Portfile
@@ -46,6 +46,8 @@ if {${name} ne ${subport}} {
         revision    0
         github.livecheck.regex {(1\.2\.[0-9.-]+)}
 
+        # See https://trac.macports.org/ticket/60520#comment:6
+        compilers.allow_arguments_mismatch yes
     } else {
 
         # requires PyBind11 as of 1.4.0
@@ -60,8 +62,6 @@ if {${name} ne ${subport}} {
         # Work around thread local compiler selection bug. Remove after
         # https://github.com/macports/macports-base/pull/161 is released.
         compiler.blacklist-append {clang < 800}
-
-        compilers.allow_arguments_mismatch yes
     }
 
     if {${python.version} == 35} {
@@ -71,6 +71,9 @@ if {${name} ne ${subport}} {
                     size    18892400
         revision    0
         github.livecheck.regex {(1\.4\.[0-9.-]+)}
+
+        # See https://trac.macports.org/ticket/60520
+        compilers.allow_arguments_mismatch yes
     }
 
     depends_lib-append      port:py${python.version}-numpy \


### PR DESCRIPTION
#### Description
https://docs.scipy.org/doc/scipy-1.5.1/reference/release.1.5.1.html
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5
Xcode command line tools 11.5
MacPorts GCC 9
Python 3.8.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
