### PR TITLE
httpie: update to version 2.2.0

### DIFF
--- a/net/httpie/Portfile
+++ b/net/httpie/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        jakubroztocil httpie 2.0.0
+github.setup        jakubroztocil httpie 2.2.0
 
 maintainers         {g5pw @g5pw} openmaintainer
 categories          net
@@ -36,8 +36,8 @@ if {[variant_isset python36]} {
 depends_lib-append  port:py${python.version}-requests \
                     port:py${python.version}-pygments
 
-checksums           rmd160  6b81e8cf12827d91ac73ec2571161d22558a441f \
-                    sha256  1d469d19248b74853fd4d8d35e37e073f56d57b4ad9be6aebe5457970c5eeedf \
-                    size    1752564
+checksums           rmd160  130bf5fc79562e39497e16d96eb7aa6c806494c2 \
+                    sha256  5d0dddeb491176ba5c3c46ef233871cee31b8ff2886584ca0f0d0a369afedc1d \
+                    size    1761920
 
 python.link_binaries_suffix


### PR DESCRIPTION
#### Description

updates httpie to version 2.2.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
