### PR TITLE
py-gacode:Update to version 0.56

### DIFF
--- a/python/py-gacode/Portfile
+++ b/python/py-gacode/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           compilers 1.0
 
 name                py-gacode
-version             0.52
+version             0.56
 python.rootname     pygacode
 
 
@@ -22,9 +22,10 @@ long_description    ${description}
 license             MIT
 homepage            https://gacode.io
 
-checksums           rmd160  0beb81a47519c007787179b5271cf9567635fb8a \
-                    sha256  1e84c8c845ec033b60f3e1554918edec8d426d11005269da73322da20c669886 \
-                    size    82824
+checksums           rmd160  2ffb74e73190de45a0f477ed980f19af1dc7234a \
+                    sha256  1a9df3f960b0cd2127ba388c9cd6f60cd1decb6d278e6497fc2721ea09701e2c \
+                    size    83512
+
 patchfiles          patch-setup.py.diff
 
 if {${name} ne ${subport}} {


### PR DESCRIPTION
#### Description

Update py-gacode port to version 0.56

###### Type
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G87
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
