### PR TITLE
gmp: enable assembly on arm64

### DIFF
--- a/devel/gmp/Portfile
+++ b/devel/gmp/Portfile
@@ -142,8 +142,13 @@ if {${os.platform} eq "darwin" && ${os.major} < 10 && [string match *clang* ${co
     configure.args-append           lt_cv_path_NM=${prefix}/bin/nm
 }
 
+patchfiles-append arm64-darwin-support.patch
+use_autoreconf    yes
+
 if {![variant_isset universal]} {
-    if {${build_arch} eq "x86_64"} {
+    if {${build_arch} eq "arm64"} {
+        configure.env-append   ABI=64
+    } elseif {${build_arch} eq "x86_64"} {
         configure.env-append   ABI=64
     } elseif {${build_arch} eq "ppc64"} {
         configure.env-append   ABI=mode64
@@ -205,6 +210,7 @@ if {![variant_isset universal]} {
     } elseif {!${auto_cpu}} {
         # Choose minimum spec so binaries should work for all users.
         switch -- $build_arch {
+            arm64   { set processor aarch64 }
             x86_64  { set processor core2 }
             i386    { set processor pentiumm }
             ppc     { set processor powerpc750 }
@@ -226,6 +232,7 @@ if {![variant_isset universal]} {
         i386    ABI=32
         ppc64   ABI=mode64
         x86_64  ABI=64
+        arm64   ABI=64
     }
 
     # Since CFLAGS and CXXFLAGS must be empty, append -arch ... to CC and CXX.

--- a/devel/gmp/files/arm64-darwin-support.patch
+++ b/devel/gmp/files/arm64-darwin-support.patch
@@ -1,0 +1,182 @@
+
+# HG changeset patch
+# User Torbjorn Granlund <tg@gmplib.org>
+# Date 1593897341 -7200
+# Node ID c5d0fcb069696e02aeff5b64108cd3ba299bf181
+# Parent  9240f425c5853b8f76cf91646301ee39bac434d9
+Initial support for arm64-darwin.
+
+diff -r 9240f425c585 -r c5d0fcb06969 configure.ac
+--- configure.ac.orig	Thu Jun 18 18:39:48 2020 +0200
++++ configure.ac	Sat Jul 04 23:15:41 2020 +0200
+@@ -3699,6 +3699,14 @@
+       case $ABI in
+         32)
+ 	  GMP_INCLUDE_MPN(arm/arm-defs.m4) ;;
++        64)
++	  case $host in
++	    *-*-darwin*)
++	      GMP_INCLUDE_MPN(arm64/darwin.m4) ;;
++	    *)
++	      GMP_INCLUDE_MPN(arm64/arm64-defs.m4) ;;
++          esac
++	  ;;
+       esac
+       ;;
+     hppa*-*-*)
+diff -r 9240f425c585 -r c5d0fcb06969 mpn/arm64/arm64-defs.m4
+--- /dev/null	Thu Jan 01 00:00:00 1970 +0000
++++ mpn/arm64/arm64-defs.m4	Sat Jul 04 23:15:41 2020 +0200
+@@ -0,0 +1,53 @@
++divert(-1)
++
++dnl  m4 macros for ARM64 ELF assembler.
++
++dnl  Copyright 2020 Free Software Foundation, Inc.
++
++dnl  This file is part of the GNU MP Library.
++dnl
++dnl  The GNU MP Library is free software; you can redistribute it and/or modify
++dnl  it under the terms of either:
++dnl
++dnl    * the GNU Lesser General Public License as published by the Free
++dnl      Software Foundation; either version 3 of the License, or (at your
++dnl      option) any later version.
++dnl
++dnl  or
++dnl
++dnl    * the GNU General Public License as published by the Free Software
++dnl      Foundation; either version 2 of the License, or (at your option) any
++dnl      later version.
++dnl
++dnl  or both in parallel, as here.
++dnl
++dnl  The GNU MP Library is distributed in the hope that it will be useful, but
++dnl  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
++dnl  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++dnl  for more details.
++dnl
++dnl  You should have received copies of the GNU General Public License and the
++dnl  GNU Lesser General Public License along with the GNU MP Library.  If not,
++dnl  see https://www.gnu.org/licenses/.
++
++
++dnl  Standard commenting is with @, the default m4 # is for constants and we
++dnl  don't want to disable macro expansions in or after them.
++
++changecom
++
++
++dnl  LEA_HI(reg,gmp_symbol), LEA_LO(reg,gmp_symbol)
++dnl
++dnl  Load the address of gmp_symbol into a register. We split this into two
++dnl  parts to allow separation for manual insn scheduling.
++
++ifdef(`PIC',`dnl
++define(`LEA_HI', `adrp	$1, :got:$2')dnl
++define(`LEA_LO', `ldr	$1, [$1, #:got_lo12:$2]')dnl
++',`dnl
++define(`LEA_HI', `adrp	$1, $2')dnl
++define(`LEA_LO', `add	$1, $1, :lo12:$2')dnl
++')dnl
++
++divert`'dnl
+diff -r 9240f425c585 -r c5d0fcb06969 mpn/arm64/bdiv_q_1.asm
+--- mpn/arm64/bdiv_q_1.asm.orig	Thu Jun 18 18:39:48 2020 +0200
++++ mpn/arm64/bdiv_q_1.asm	Sat Jul 04 23:15:41 2020 +0200
+@@ -61,15 +61,9 @@
+ 	clz	cnt, x6
+ 	lsr	d, d, cnt
+ 
+-ifdef(`PIC',`
+-	adrp	x7, :got:__gmp_binvert_limb_table
++	LEA_HI(	x7, binvert_limb_table)
+ 	ubfx	x6, d, 1, 7
+-	ldr	x7, [x7, #:got_lo12:__gmp_binvert_limb_table]
+-',`
+-	adrp	x7, __gmp_binvert_limb_table
+-	ubfx	x6, d, 1, 7
+-	add	x7, x7, :lo12:__gmp_binvert_limb_table
+-')
++	LEA_LO(	x7, binvert_limb_table)
+ 	ldrb	w6, [x7, x6]
+ 	ubfiz	x7, x6, 1, 8
+ 	umull	x6, w6, w6
+@@ -81,7 +75,7 @@
+ 	mul	x6, x6, x6
+ 	msub	di, x6, d, x7
+ 
+-	b	mpn_pi1_bdiv_q_1
++	b	GSYM_PREFIX`'mpn_pi1_bdiv_q_1
+ EPILOGUE()
+ 
+ PROLOGUE(mpn_pi1_bdiv_q_1)
+diff -r 9240f425c585 -r c5d0fcb06969 mpn/arm64/darwin.m4
+--- /dev/null	Thu Jan 01 00:00:00 1970 +0000
++++ mpn/arm64/darwin.m4	Sat Jul 04 23:15:41 2020 +0200
+@@ -0,0 +1,50 @@
++divert(-1)
++
++dnl  m4 macros for ARM64 Darwin assembler.
++
++dnl  Copyright 2020 Free Software Foundation, Inc.
++
++dnl  This file is part of the GNU MP Library.
++dnl
++dnl  The GNU MP Library is free software; you can redistribute it and/or modify
++dnl  it under the terms of either:
++dnl
++dnl    * the GNU Lesser General Public License as published by the Free
++dnl      Software Foundation; either version 3 of the License, or (at your
++dnl      option) any later version.
++dnl
++dnl  or
++dnl
++dnl    * the GNU General Public License as published by the Free Software
++dnl      Foundation; either version 2 of the License, or (at your option) any
++dnl      later version.
++dnl
++dnl  or both in parallel, as here.
++dnl
++dnl  The GNU MP Library is distributed in the hope that it will be useful, but
++dnl  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
++dnl  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++dnl  for more details.
++dnl
++dnl  You should have received copies of the GNU General Public License and the
++dnl  GNU Lesser General Public License along with the GNU MP Library.  If not,
++dnl  see https://www.gnu.org/licenses/.
++
++
++dnl  Standard commenting is with @, the default m4 # is for constants and we
++dnl  don't want to disable macro expansions in or after them.
++
++changecom
++
++
++dnl  LEA_HI(reg,gmp_symbol), LEA_LO(reg,gmp_symbol)
++dnl
++dnl  Load the address of gmp_symbol into a register. We split this into two
++dnl  parts to allow separation for manual insn scheduling.  TODO: Darwin allows
++dnl  for relaxing these two insns into an adr and a nop, but that requires the
++dnl  .loh pseudo for connecting them.
++
++define(`LEA_HI',`adrp	$1, $2@GOTPAGE')dnl
++define(`LEA_LO',`ldr	$1, [$1, $2@GOTPAGEOFF]')dnl
++
++divert`'dnl
+diff -r 9240f425c585 -r c5d0fcb06969 mpn/arm64/invert_limb.asm
+--- mpn/arm64/invert_limb.asm.orig	Thu Jun 18 18:39:48 2020 +0200
++++ mpn/arm64/invert_limb.asm	Sat Jul 04 23:15:41 2020 +0200
+@@ -41,9 +41,9 @@
+ ASM_START()
+ PROLOGUE(mpn_invert_limb)
+ 	lsr	x2, x0, #54
+-	adrp	x1, approx_tab
++	LEA_HI(	x1, approx_tab)
+ 	and	x2, x2, #0x1fe
+-	add	x1, x1, :lo12:approx_tab
++	LEA_LO(	x1, approx_tab)
+ 	ldrh	w3, [x1,x2]
+ 	lsr	x4, x0, #24
+ 	add	x4, x4, #1


### PR DESCRIPTION
#### Description

Add aarch64 support to gmp, at least to the point where it builds. Patch taken [directly from upstream](https://gmplib.org/repo/gmp/rev/c5d0fcb06969); since a huge number of ports depend on gmp I thought it might be worth carrying it ourselves until gmp cuts a new release.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 11.0 20A5299w
Xcode 12.0 12A8161k 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
