### PR TITLE
git-delta: update to 0.3.0

### DIFF
--- a/textproc/git-delta/Portfile
+++ b/textproc/git-delta/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        dandavison delta 0.2.0
+github.setup        dandavison delta 0.3.0
 name                git-delta
 categories          textproc
 platforms           darwin
@@ -18,9 +18,9 @@ long_description    Delta provides language syntax-highlighting, within-line \
                     output for git on the command line.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  009f4aac46689dfb7745a841b25b5e212c4dd5e5 \
-                    sha256  9a2994b9dcb9d518862c64b807838b6d4d92971eb0e3063dca0666a8eb08fc81 \
-                    size    853075
+                    rmd160  3e00f1ad3a71b896c6c18390d9cb6c7bf1dbf95e \
+                    sha256  9f11f8939e42b17be0b1520386194a07276ef1d9b7ec88469755d0c6b0c82d4d \
+                    size    869091
 
 destroot {
     xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/delta \
@@ -67,7 +67,7 @@ cargo.crates \
     constant_time_eq                 0.1.4  995a44c877f9212528ccc74b21a232f66ad69001e40ede5bcee2ac9ef2657120 \
     crc32fast                        1.2.0  ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1 \
     crossbeam-utils                  0.6.6  04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6 \
-    dirs                             3.0.0  2fddc3610d8f9552384e06ebc87f714e1d0b2b64a99194d2faf36d7ae5f48549 \
+    dirs                             3.0.1  142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff \
     dirs-sys                         0.3.5  8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a \
     either                           1.5.3  bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3 \
     encode_unicode                   0.3.5  90b2c9496c001e8cb61827acdefad780795c42264c137744cae6f7d9e3450abd \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
