### PR TITLE
wxMaxima: Fix issue track 60457 - destroot failure

### DIFF
--- a/math/wxMaxima/Portfile
+++ b/math/wxMaxima/Portfile
@@ -17,8 +17,6 @@ categories          math aqua
 description         Graphical user interface for Maxima based on wxWidgets
 long_description    Maxima is a Computer Algebra System (CAS) and wxMaxima is a work book style \
                     graphical front end for it based on wxWidgets
-                    
-
 
 checksums           rmd160  0c10602f6f1d777ff16fe85500f57222eb07fc27 \
                     sha256  055ff34eb98539716a18f7cc11861b5a790fde46aaafabb68f1e690cb649d9df \
@@ -59,7 +57,7 @@ build {
 
 destroot {
     xinstall -m 755 -d ${destroot}${applications_dir}
-    file copy ${worksrcpath}/build/src/wxMaxima.app ${destroot}${applications_dir}
+    file copy ${worksrcpath}/build/src/wxmaxima.app ${destroot}${applications_dir}/wxMaxima.app
 }
 
 notes "
@@ -79,7 +77,9 @@ You might have to restart wxMaxima for this to take effect.
 wxMaxima and Maxima startup files can typically be found in:
   ~/.maxima
 
-ATTENTION: On macOS Catalina up to and including 10.15.3 there are issues with\
-the menus. (They don't work reliably.) Please use macOS 10.15.4 or later or\
-10.14.
+ATTENTION: On macOS Catalina 10.15.X there are issues with the\
+menus (they don't work reliably). There is currently no solution for this.\
+wxMaxima on macOS up to and including 10.14.X works fine.\
+On macOS 10.15.X the only workaround is to click the menu multiple times or to\
+use shortcut keys.
 "


### PR DESCRIPTION
#### Description

This fixes issue (https://trac.macports.org/ticket/60457) for wxMaxima.
In addition I prepared the port for future versions by adding the build dependency on cppcheck (before I forget it - the latets version uses it).
I also updated the issue comment for OSX 10.15 (research of this issue is ongoing).

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.4 19E287
(the supplied script does not work for latest Xcode)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A (GUI app, no automated tests)
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
