### PR TITLE
perl5: Patch configure script to detect macOS 11

### DIFF
--- a/lang/perl5/Portfile
+++ b/lang/perl5/Portfile
@@ -131,6 +131,11 @@ foreach {perl5.v perl5.subversion perl5.revision perl5.rmd160 perl5.sha256 perl5
             patchfiles-append \
                             ${perl5.major}/enable-syscall-on-sierra.patch
         }
+        if {${perl5.major} < 5.30} {
+            # Fix the configure script to detect newer versions of macOS
+            patchfiles-append \
+                            ${perl5.major}/detect-macOS-11.0.patch
+        }
 
         post-patch {
             reinplace -W ${worksrcpath} "s|__PREFIX__|${prefix}|g" \

--- a/lang/perl5/files/5.16/detect-macOS-11.0.patch
+++ b/lang/perl5/files/5.16/detect-macOS-11.0.patch
@@ -1,0 +1,20 @@
+--- hints/darwin.sh.orig	2020-07-08 10:32:21.000000000 -0700
++++ hints/darwin.sh	2020-07-08 14:15:14.000000000 -0700
+@@ -301,7 +301,7 @@
+    # We now use MACOSX_DEPLOYMENT_TARGET, if set, as an override by
+    # capturing its value and adding it to the flags.
+     case "$MACOSX_DEPLOYMENT_TARGET" in
+-    10.*)
++    [0-9][0-9]*.*)
+       add_macosx_version_min ccflags $MACOSX_DEPLOYMENT_TARGET
+       add_macosx_version_min ldflags $MACOSX_DEPLOYMENT_TARGET
+       ;;
+@@ -327,7 +327,7 @@
+     # "ProductVersion:    10.11"     "10.11"
+         prodvers=`sw_vers|awk '/^ProductVersion:/{print $2}'|awk -F. '{print $1"."$2}'`
+     case "$prodvers" in
+-    10.*)
++    [0-9][0-9]*.*)
+       add_macosx_version_min ccflags $prodvers
+       add_macosx_version_min ldflags $prodvers
+       ;;

--- a/lang/perl5/files/5.18/detect-macOS-11.0.patch
+++ b/lang/perl5/files/5.18/detect-macOS-11.0.patch
@@ -1,0 +1,20 @@
+--- hints/darwin.sh.orig	2020-07-08 10:32:21.000000000 -0700
++++ hints/darwin.sh	2020-07-08 14:15:14.000000000 -0700
+@@ -301,7 +301,7 @@
+    # We now use MACOSX_DEPLOYMENT_TARGET, if set, as an override by
+    # capturing its value and adding it to the flags.
+     case "$MACOSX_DEPLOYMENT_TARGET" in
+-    10.*)
++    [0-9][0-9]*.*)
+       add_macosx_version_min ccflags $MACOSX_DEPLOYMENT_TARGET
+       add_macosx_version_min ldflags $MACOSX_DEPLOYMENT_TARGET
+       ;;
+@@ -327,7 +327,7 @@
+     # "ProductVersion:    10.11"     "10.11"
+         prodvers=`sw_vers|awk '/^ProductVersion:/{print $2}'|awk -F. '{print $1"."$2}'`
+     case "$prodvers" in
+-    10.*)
++    [0-9][0-9]*.*)
+       add_macosx_version_min ccflags $prodvers
+       add_macosx_version_min ldflags $prodvers
+       ;;

--- a/lang/perl5/files/5.20/detect-macOS-11.0.patch
+++ b/lang/perl5/files/5.20/detect-macOS-11.0.patch
@@ -1,0 +1,20 @@
+--- hints/darwin.sh.orig	2020-07-08 10:32:21.000000000 -0700
++++ hints/darwin.sh	2020-07-08 14:15:14.000000000 -0700
+@@ -301,7 +301,7 @@
+    # We now use MACOSX_DEPLOYMENT_TARGET, if set, as an override by
+    # capturing its value and adding it to the flags.
+     case "$MACOSX_DEPLOYMENT_TARGET" in
+-    10.*)
++    [0-9][0-9]*.*)
+       add_macosx_version_min ccflags $MACOSX_DEPLOYMENT_TARGET
+       add_macosx_version_min ldflags $MACOSX_DEPLOYMENT_TARGET
+       ;;
+@@ -327,7 +327,7 @@
+     # "ProductVersion:    10.11"     "10.11"
+         prodvers=`sw_vers|awk '/^ProductVersion:/{print $2}'|awk -F. '{print $1"."$2}'`
+     case "$prodvers" in
+-    10.*)
++    [0-9][0-9]*.*)
+       add_macosx_version_min ccflags $prodvers
+       add_macosx_version_min ldflags $prodvers
+       ;;

--- a/lang/perl5/files/5.22/detect-macOS-11.0.patch
+++ b/lang/perl5/files/5.22/detect-macOS-11.0.patch
@@ -1,0 +1,20 @@
+--- hints/darwin.sh.orig	2020-07-08 10:32:21.000000000 -0700
++++ hints/darwin.sh	2020-07-08 14:15:14.000000000 -0700
+@@ -301,7 +301,7 @@
+    # We now use MACOSX_DEPLOYMENT_TARGET, if set, as an override by
+    # capturing its value and adding it to the flags.
+     case "$MACOSX_DEPLOYMENT_TARGET" in
+-    10.*)
++    [0-9][0-9]*.*)
+       add_macosx_version_min ccflags $MACOSX_DEPLOYMENT_TARGET
+       add_macosx_version_min ldflags $MACOSX_DEPLOYMENT_TARGET
+       ;;
+@@ -327,7 +327,7 @@
+     # "ProductVersion:    10.11"     "10.11"
+         prodvers=`sw_vers|awk '/^ProductVersion:/{print $2}'|awk -F. '{print $1"."$2}'`
+     case "$prodvers" in
+-    10.*)
++    [0-9][0-9]*.*)
+       add_macosx_version_min ccflags $prodvers
+       add_macosx_version_min ldflags $prodvers
+       ;;

--- a/lang/perl5/files/5.24/detect-macOS-11.0.patch
+++ b/lang/perl5/files/5.24/detect-macOS-11.0.patch
@@ -1,0 +1,20 @@
+--- hints/darwin.sh.orig	2020-07-08 10:32:21.000000000 -0700
++++ hints/darwin.sh	2020-07-08 14:15:14.000000000 -0700
+@@ -301,7 +301,7 @@
+    # We now use MACOSX_DEPLOYMENT_TARGET, if set, as an override by
+    # capturing its value and adding it to the flags.
+     case "$MACOSX_DEPLOYMENT_TARGET" in
+-    10.*)
++    [0-9][0-9]*.*)
+       add_macosx_version_min ccflags $MACOSX_DEPLOYMENT_TARGET
+       add_macosx_version_min ldflags $MACOSX_DEPLOYMENT_TARGET
+       ;;
+@@ -327,7 +327,7 @@
+     # "ProductVersion:    10.11"     "10.11"
+         prodvers=`sw_vers|awk '/^ProductVersion:/{print $2}'|awk -F. '{print $1"."$2}'`
+     case "$prodvers" in
+-    10.*)
++    [0-9][0-9]*.*)
+       add_macosx_version_min ccflags $prodvers
+       add_macosx_version_min ldflags $prodvers
+       ;;

--- a/lang/perl5/files/5.26/detect-macOS-11.0.patch
+++ b/lang/perl5/files/5.26/detect-macOS-11.0.patch
@@ -1,0 +1,20 @@
+--- hints/darwin.sh.orig	2020-07-08 10:32:21.000000000 -0700
++++ hints/darwin.sh	2020-07-08 14:15:14.000000000 -0700
+@@ -301,7 +301,7 @@
+    # We now use MACOSX_DEPLOYMENT_TARGET, if set, as an override by
+    # capturing its value and adding it to the flags.
+     case "$MACOSX_DEPLOYMENT_TARGET" in
+-    10.*)
++    [0-9][0-9]*.*)
+       add_macosx_version_min ccflags $MACOSX_DEPLOYMENT_TARGET
+       add_macosx_version_min ldflags $MACOSX_DEPLOYMENT_TARGET
+       ;;
+@@ -327,7 +327,7 @@
+     # "ProductVersion:    10.11"     "10.11"
+         prodvers=`sw_vers|awk '/^ProductVersion:/{print $2}'|awk -F. '{print $1"."$2}'`
+     case "$prodvers" in
+-    10.*)
++    [0-9][0-9]*.*)
+       add_macosx_version_min ccflags $prodvers
+       add_macosx_version_min ldflags $prodvers
+       ;;

--- a/lang/perl5/files/5.28/detect-macOS-11.0.patch
+++ b/lang/perl5/files/5.28/detect-macOS-11.0.patch
@@ -1,0 +1,20 @@
+--- hints/darwin.sh.orig	2020-07-08 10:32:21.000000000 -0700
++++ hints/darwin.sh	2020-07-08 14:15:14.000000000 -0700
+@@ -301,7 +301,7 @@
+    # We now use MACOSX_DEPLOYMENT_TARGET, if set, as an override by
+    # capturing its value and adding it to the flags.
+     case "$MACOSX_DEPLOYMENT_TARGET" in
+-    10.*)
++    [0-9][0-9]*.*)
+       add_macosx_version_min ccflags $MACOSX_DEPLOYMENT_TARGET
+       add_macosx_version_min ldflags $MACOSX_DEPLOYMENT_TARGET
+       ;;
+@@ -327,7 +327,7 @@
+     # "ProductVersion:    10.11"     "10.11"
+         prodvers=`sw_vers|awk '/^ProductVersion:/{print $2}'|awk -F. '{print $1"."$2}'`
+     case "$prodvers" in
+-    10.*)
++    [0-9][0-9]*.*)
+       add_macosx_version_min ccflags $prodvers
+       add_macosx_version_min ldflags $prodvers
+       ;;


### PR DESCRIPTION
#### Description

I checked that my branch is up-to-date this time :P Add a patch to support building on macOS 11, which was not detected properly by darwin.sh. There is a pull request with similar changes upstream, https://github.com/Perl/perl5/pull/17946, but it hasn't been merged yet and even when merged only seems like it will be backported to 5.30. I've written my own patch that will apply to 5.28 and below. A lot of ports depend on perl5 working, but some use 5.30 and above, and I wasn't sure if I should short-circuit the check to let those build right now. See also #7688, though I'm sure many of you have ;)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 11.0 20A5299w
Xcode 12.0 12A8161k 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`? (Fails two tests, likely due to OS changes.)
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
