### PR TITLE
diskonaut: update to 0.9.0

### DIFF
--- a/sysutils/diskonaut/Portfile
+++ b/sysutils/diskonaut/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        imsnif diskonaut 0.8.0
+github.setup        imsnif diskonaut 0.9.0
 categories          sysutils
 license             MIT
 platforms           darwin
@@ -24,9 +24,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  4f4402a49379ee043421baa6a34db0fc0bdcc58b \
-                    sha256  ad9533373ff71d78be2e4d702d91bd5ef127b7d2ae6125ae7561b6b27b6290b2 \
-                    size    2777302
+                    rmd160  01a812dc13aff56846c2e99959b434b29ad9032a \
+                    sha256  4bd8055738bb2f47dd076b5e05514ebdc01c94c66da797b34fb7e90f6b55632b \
+                    size    2777810
 
 destroot {
     xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
