### PR TITLE
KeePassXC: update to version 2.6.0

### DIFF
--- a/security/KeePassXC/Portfile
+++ b/security/KeePassXC/Portfile
@@ -20,7 +20,7 @@ platforms               darwin
 license                 GPL-2+
 license_noconflict      openssl
 
-github.setup            keepassxreboot keepassxc 2.5.4
+github.setup            keepassxreboot keepassxc 2.6.0
 github.tarball_from     releases
 distname                keepassxc-${version}-src
 use_xz                  yes
@@ -28,12 +28,12 @@ distfiles-append        ${distname}${extract.suffix}.sig
 
 # See keepassxc-${version}-src.tar.xz.DIGEST on upstream GitHub releases page for SHA256 sums
 checksums               ${distname}${extract.suffix} \
-                        rmd160  635c4eff7769c3edf80af1e3070d535157487ee6 \
-                        sha256  a55e0801c318b02b1ac4e16e9b7a87ccfa7b039ea60d2c62610bd1bbbdd6cd4a \
-                        size    6839396 \
+                        rmd160  edeb9d4f61a7af05da46577242bf9307e2003c34 \
+                        sha256  d0d23d97a73ac1cbf59bfca2f5d1506ae36dfcd4fbfb4225efe19931f035fd3a \
+                        size    5628800 \
                         ${distname}${extract.suffix}.sig \
-                        rmd160  44153573ac36bc47b97e58b845bfee2a91db0c6a \
-                        sha256  fc527280cfa05c2ed75529c280432ab8d301f69911f2d74c56fe8061f2b0d2f1 \
+                        rmd160  28f39119f9da098268cfd3c8e0970609daa29adb \
+                        sha256  49fba6442d484389803c66ae2fb8da7cc80b8eb17bc29a4f47599f865efa3c91 \
                         size    488
 
 gpg_verify.use_gpg_verification \
@@ -95,7 +95,8 @@ configure.pre_args-append \
     -DWITH_XC_NETWORKING=ON \
     -DWITH_XC_SSHAGENT=ON \
     -DWITH_XC_YUBIKEY=ON \
-    -DWITH_XC_UPDATECHECK=OFF
+    -DWITH_XC_UPDATECHECK=OFF \
+    -DWITH_XC_DOCS=OFF
 
 # In the future the Touch ID feature may require Darwin 17 (10.13)
 # https://github.com/keepassxreboot/keepassxc/issues/2484
@@ -112,9 +113,9 @@ if {${os.major} < 16} {
 
 post-destroot {
     xinstall -d ${destroot}${prefix}/share/doc/${name}
-    xinstall -W ${worksrcpath} COPYING LICENSE.BOOST-1.0 LICENSE.BSD \
-             LICENSE.CC0 LICENSE.GPL-2 LICENSE.GPL-3 LICENSE.LGPL-2.1 \
-             LICENSE.LGPL-3 LICENSE.NOKIA-LGPL-EXCEPTION \
+    xinstall -W ${worksrcpath} COPYING LICENSE.BSD LICENSE.CC0 \
+             LICENSE.GPL-2 LICENSE.GPL-3 LICENSE.LGPL-2.1 LICENSE.LGPL-3 \
+             LICENSE.MIT LICENSE.NOKIA-LGPL-EXCEPTION LICENSE.OFL \
              ${destroot}${prefix}/share/doc/${name}
 
     ln -s ${applications_dir}/KeePassXC.app/Contents/MacOS/keepassxc-cli \
@@ -123,3 +124,4 @@ post-destroot {
 
 test.run        yes
 test.target     test ARGS="-V"
+test.env        TMPDIR=/tmp

--- a/security/KeePassXC/files/patch-old-mac.diff
+++ b/security/KeePassXC/files/patch-old-mac.diff
@@ -1,5 +1,5 @@
---- src/gui/macutils/AppKitImpl.mm	2020-04-09 18:24:20.000000000 +0200
-+++ src/gui/macutils/AppKitImpl.mm.new	2020-04-23 13:24:04.000000000 +0200
+--- src/gui/osutils/macutils/AppKitImpl.mm	2020-04-09 18:24:20.000000000 +0200
++++ src/gui/osutils/macutils/AppKitImpl.mm.new	2020-04-23 13:24:04.000000000 +0200
 @@ -134,6 +134,7 @@
  //
  - (bool) enableScreenRecording


### PR DESCRIPTION
#### Description

* update to version 2.6.0
* add missing and remove nonexistent licenses
* fix old mac patch

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G5033
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->