### PR TITLE
ledger: Update to 3.2.1

### DIFF
--- a/finance/ledger/Portfile
+++ b/finance/ledger/Portfile
@@ -5,10 +5,12 @@ PortGroup           active_variants 1.1
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        ledger ledger 3.1.3 v
+github.setup        ledger ledger 3.2.1 v
 revision            1
 homepage            https://ledger-cli.org/
 categories          finance
+
+master_sites        https://github.com/ledger/ledger
 
 description         A command-line, double-entry accounting tool.
 long_description    Ledger is a powerful, double-entry accounting system that \
@@ -18,18 +20,19 @@ maintainers         nomaintainer
 
 platforms           darwin
 
-checksums           rmd160  ff4502d36d80b4b5e4e3b824e3148a4d771273cd \
-                    sha256  47b474c3c29029191c7f05b7d228becaa8e2ba8221d6968fa0b5fd9241ff10fe \
-                    size    800631
+checksums           rmd160  bd3f7d6c0f09f8438d025d16c0323a2d57d7426c \
+                    sha256  3c13c844e69d9c331929066d6c8f2af5231fbd68025e181eebfbf46ffef21753 \
+                    size    791116
 
-depends_lib-append  port:boost \
-                    port:python27 \
+depends_lib         port:boost \
+                    port:boost-jam \
+                    port:python38 \
                     port:libedit \
                     port:gmp \
                     port:mpfr \
                     port:gettext
 
-require_active_variants boost python27
+require_active_variants boost python38 \
 
 compiler.cxx_standard   2011
 
@@ -42,9 +45,10 @@ configure.args-append \
                     -DGMP_PATH=${prefix}/include \
                     -DMPFR_LIB=${prefix}/lib/libmpfr.dylib \
                     -DMPFR_PATH=${prefix}/include \
-                    -DPYTHON_EXECUTABLE=${prefix}/bin/python2.7 \
-                    -DUSE_PYTHON27_COMPONENT=ON \
+                    -DPYTHON_EXECUTABLE=${prefix}/bin/python3.7 \
+                    -DUSE_PYTHON38_COMPONENT=ON \
                     -DUSE_DOXYGEN=OFF \
                     -DUSE_PYTHON=ON
 
+configure.python ${prefix}/bin/python3.8
 test.run            yes

--- a/finance/ledger/Portfile
+++ b/finance/ledger/Portfile
@@ -13,7 +13,7 @@ revision            1
 homepage            https://ledger-cli.org/
 categories          finance
 
-master_sites        https://github.com/ledger/ledger/archive/v${major}.${minor}.${revision}.zip
+master_sites        https://github.com/ledger/ledger/archive/v${major}.${minor}.${revision}.tar.gz
 
 description         A command-line, double-entry accounting tool.
 long_description    Ledger is a powerful, double-entry accounting system that \

--- a/finance/ledger/Portfile
+++ b/finance/ledger/Portfile
@@ -21,9 +21,9 @@ maintainers         nomaintainer
 
 platforms           darwin
 
-checksums           rmd160  bd3f7d6c0f09f8438d025d16c0323a2d57d7426c \
-                    sha256  3c13c844e69d9c331929066d6c8f2af5231fbd68025e181eebfbf46ffef21753 \
-                    size    791116
+checksums           rmd160  6286315fcad52f51c59f9b41261713aa141e9fae \
+                    sha256  92bf09bc385b171987f456fe3ee9fa998ed5e40b97b3acdd562b663aa364384a \
+                    size    790959
 
 depends_lib         port:boost \
                     port:boost-jam \

--- a/finance/ledger/Portfile
+++ b/finance/ledger/Portfile
@@ -6,11 +6,14 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 
 github.setup        ledger ledger 3.2.1 v
+set major           3
+set minor           2
+set revision        1
 revision            1
 homepage            https://ledger-cli.org/
 categories          finance
 
-master_sites        https://github.com/ledger/ledger
+master_sites        https://github.com/ledger/ledger/archive/v${major}.${minor}.${revision}.zip
 
 description         A command-line, double-entry accounting tool.
 long_description    Ledger is a powerful, double-entry accounting system that \

--- a/finance/ledger/Portfile
+++ b/finance/ledger/Portfile
@@ -6,14 +6,12 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 
 github.setup        ledger ledger 3.2.1 v
-set major           3
-set minor           2
-set revision        1
-revision            1
+
+revision            0
 homepage            https://ledger-cli.org/
 categories          finance
 
-master_sites        https://github.com/ledger/ledger/archive/v${major}.${minor}.${revision}.tar.gz
+github.tarball_from archive
 
 description         A command-line, double-entry accounting tool.
 long_description    Ledger is a powerful, double-entry accounting system that \
@@ -35,7 +33,7 @@ depends_lib         port:boost \
                     port:mpfr \
                     port:gettext
 
-require_active_variants boost python38 \
+require_active_variants boost python38
 
 compiler.cxx_standard   2011
 
@@ -48,10 +46,9 @@ configure.args-append \
                     -DGMP_PATH=${prefix}/include \
                     -DMPFR_LIB=${prefix}/lib/libmpfr.dylib \
                     -DMPFR_PATH=${prefix}/include \
-                    -DPYTHON_EXECUTABLE=${prefix}/bin/python3.7 \
+                    -DPYTHON_EXECUTABLE=${prefix}/bin/python3.8 \
                     -DUSE_PYTHON38_COMPONENT=ON \
                     -DUSE_DOXYGEN=OFF \
                     -DUSE_PYTHON=ON
 
-configure.python ${prefix}/bin/python3.8
 test.run            yes

--- a/finance/ledger/Portfile
+++ b/finance/ledger/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  6286315fcad52f51c59f9b41261713aa141e9fae \
                     sha256  92bf09bc385b171987f456fe3ee9fa998ed5e40b97b3acdd562b663aa364384a \
                     size    790959
 
-depends_lib         port:boost \
+depends_lib-append  port:boost \
                     port:boost-jam \
                     port:python38 \
                     port:libedit \


### PR DESCRIPTION
OK, looks like I got ledger 3.2.1 building.

#### Description
Just made a temporary fork for this. That said, this is complete due to possible macports bug.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?

- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?


SO, I got this to work with whatever the state of my macports install was on my computer. However, it failed to install with `sudo port -vst install ledger @3.2.1_1`?

Here is the log: https://hastepaste.com/raw/9yraDBd

I spoke with JMR over IRC; they believe this is a macports bug.

What to do to advance this?



