### PR TITLE
mysql8: update to 8.0.21

### DIFF
--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -3,8 +3,8 @@
 PortSystem              1.0
 
 name                    mysql8
-version                 8.0.20
-set boost_version       1.70.0
+version                 8.0.21
+set boost_version       1.72.0
 categories              databases
 platforms               darwin
 license                 GPL-2
@@ -44,13 +44,13 @@ if {$subport eq $name} {
                         ${boost_distname}${extract.suffix}:boost
 
     checksums           ${distname}${extract.suffix} \
-                        rmd160  a078c41c015ab4e1e600b74bb9b5ba1094c0995a \
-                        sha256  4d62eaca43cd9c858baca10d02857382887507a17ffdbfa97daf107d0c62ee5f \
-                        size    268949055 \
+                        rmd160  23446c3351b6467b0d62cf1ba2716529d1f652be \
+                        sha256  ad56535eee03943adeef5f188e1df7a39729a7557d8b2179b1affd994b990034 \
+                        size    281674750 \
                         ${boost_distname}${extract.suffix} \
-                        rmd160  1c39413060dca46a02ea2143788d6ee061b79d03 \
-                        sha256  882b48708d211a5f48e60b0124cf5863c1534cd544ecd0664bb534a4b5d506e9 \
-                        size    116000903
+                        rmd160  84180914f46c95ca1c84881e60ea837c8dab38a9 \
+                        sha256  c66e88d5786f2ca4dbebb14e06b566fb642a1a6947ad8cc9091f9f445134143f \
+                        size    126580835
 
     depends_lib-append  path:lib/libssl.dylib:openssl \
                         port:cyrus-sasl2 \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
