### PR TITLE
ultralist: update to 1.1

### DIFF
--- a/office/ultralist/Portfile
+++ b/office/ultralist/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/ultralist/ultralist 1.0
+go.setup            github.com/ultralist/ultralist 1.1 v
 
 homepage            https://ultralist.io/
 
@@ -22,9 +22,9 @@ installs_libs       no
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  0001f4085b7daee4a8e012afe44ed37352d6f7c0 \
-                    sha256  122e6b7e1b7053e79c5bcc317682e84ed12ff708a7c27d3ff29b4e1983faabed \
-                    size    2137753
+checksums           rmd160  7f4c6b8f35f3e268a86d0885b10cb96fb81f709e \
+                    sha256  7c984df65af5ed48a228606a52855a018341f990cea2509b93b8992b262644c8 \
+                    size    2138183
 
 build.args-append   -o ${workpath}/${name}
 


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
