### PR TITLE
google-cloud-sdk: update to 301.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             300.0.0
+version             301.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  fe993874dedac06db291ad3ef24f91814ff10531 \
-                    sha256  e0143e0c187d3444fb21a36b51742463db23514620850f67a534b3c67945cbf6 \
-                    size    77526855
+    checksums       rmd160  51f1fa80e9ff3347a67a44db0a5f0028fd1d6cda \
+                    sha256  ac68d797d5dbe7514896bdedaaa883dc1218ff55de2d321ef29ed605f9fef373 \
+                    size    77637489
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  072e26548b7a4dc60df225d6fc84dfb2e0b6209d \
-                    sha256  f4b5ccf3e53d336b4eee60a6d26534db1561e5535e6ef5f021a81ea8124c5991 \
-                    size    78547817
+    checksums       rmd160  3764021e8b614982b6f87852d27d2b318785946e \
+                    sha256  d99f4724dd7e0641c291c933bed15a18c71969176a241235d387a32426a837ad \
+                    size    78658451
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 301.0.0.

###### Tested on

macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?