### PR TITLE
wtfutil: update to 0.31.0

### DIFF
--- a/sysutils/wtfutil/Portfile
+++ b/sysutils/wtfutil/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/wtfutil/wtf 0.30.0 v
+go.setup            github.com/wtfutil/wtf 0.31.0 v
 
 homepage            https://wtfutil.com
 
@@ -18,9 +18,9 @@ description         A personal terminal-based dashboard utility, designed for \
                     data.
 long_description    ${description}
 
-checksums           rmd160  4a63bfc0fa035f9a1e5a151596288e481f29560b \
-                    sha256  04cdbb17545dc1558ef1f69759d6fd2f5a5ef20a3b1aa8a082d245818379e941 \
-                    size    2237899
+checksums           rmd160  0402d145d95275e1b276152c052cfdc6235aa1fb \
+                    sha256  4fdbc1f7eb444f39a73e11c08e30f7de55bffc09cc86151c11fb4af00d1e7ffa \
+                    size    2244422
 
 set build_date      [exec date +%FT%T%z]
 


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
