### PR TITLE
py{36,37}-htmldocs: update to latest

### DIFF
--- a/lang/py-htmldocs/Portfile
+++ b/lang/py-htmldocs/Portfile
@@ -14,8 +14,8 @@ license             {PSF}
 if {$subport != $name} {
     if {${python.version} == 27} { version 2.7.18 }
     if {${python.version} == 35} { version 3.5.9 }
-    if {${python.version} == 36} { version 3.6.10 }
-    if {${python.version} == 37} { version 3.7.7 }
+    if {${python.version} == 36} { version 3.6.11 }
+    if {${python.version} == 37} { version 3.7.8 }
     if {${python.version} == 38} { version 3.8.3 }
 }
 
@@ -61,16 +61,16 @@ if {${name} != ${subport}} {
 
     if {${python.version} == 36} {
       checksums \
-        rmd160  be1dca75f33f83b074172c064df57f7e39e9c483 \
-        sha256  2269cb0693f8838793206353b1e5684d8ba4d77ec7cce07ff7f749170f96e768 \
-        size    5994263
+        rmd160  6af5ea87e9e365a7f8947e855122fac78c3a912d \
+        sha256  465b36b188cb5a3e704f1713a1ac91defb0c98cfb6b4658219be0d88e818dc41 \
+        size    6012332
     }
 
     if {${python.version} == 37} {
       checksums \
-        rmd160  9f06d4f6c48da0eadf6fd4c75b421db72944d0bf \
-        sha256  f9f2a375eaf847ea927edafd0d64aaef76e32db7cfdcafc7d5a198feff48613f \
-        size    6259882
+        rmd160  470ae22ad0d13fa201e220947e41357c34f0869e \
+        sha256  36792f03171181623e9a826d53922d9e4b635308f002762c025b2cfc16b289b7 \
+        size    6283763
     }
 
     if {${python.version} == 38} {

--- a/lang/python35/Portfile
+++ b/lang/python35/Portfile
@@ -6,7 +6,7 @@ PortGroup select 1.0
 name                python35
 
 epoch               20170810
-# Remember to keep py35-tkinter and py35-gdbm's versions sync'd with this
+# Remember to keep py35-tkinter, py35-htmldocs, and py35-gdbm's versions sync'd with this
 version             3.5.9
 
 set major           [lindex [split $version .] 0]

--- a/lang/python36/Portfile
+++ b/lang/python36/Portfile
@@ -6,7 +6,7 @@ PortGroup select 1.0
 name                python36
 
 epoch               20170717
-# Remember to keep py36-tkinter and py36-gdbm's versions sync'd with this
+# Remember to keep py36-tkinter, py36-htmldocs, and py36-gdbm's versions sync'd with this
 version             3.6.11
 
 set major           [lindex [split $version .] 0]

--- a/lang/python37/Portfile
+++ b/lang/python37/Portfile
@@ -5,7 +5,7 @@ PortGroup select 1.0
 
 name                python37
 
-# Remember to keep py37-tkinter and py37-gdbm's versions sync'd with this
+# Remember to keep py37-tkinter, py37-htmldocs, and py37-gdbm's versions sync'd with this
 version             3.7.8
 
 set major           [lindex [split $version .] 0]

--- a/lang/python39-devel/Portfile
+++ b/lang/python39-devel/Portfile
@@ -5,7 +5,7 @@ PortGroup select 1.0
 
 name                python39-devel
 
-# Remember to keep py39-tkinter and py39-gdbm's versions sync'd with this
+# Remember to keep py39-tkinter, py39-htmldocs (once 3.9.0 is released), and py39-gdbm's versions sync'd with this
 version             3.9.0b4
 
 set branch          [join [lrange [split ${version} .] 0 1] .]


### PR DESCRIPTION
Add update reminders to `python{35,36,37,39-devel}` ports

#### Description
(`py38-htmldocs` updated in #7748)

###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
**Untested**

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
