### PR TITLE
openjdk8: update subport openjdk11 to 11.0.8

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -43,7 +43,7 @@ subport openjdk10 {
 }
 
 subport openjdk11 {
-    version      11.0.7
+    version      11.0.8
     revision     0
 
     set build    10
@@ -278,9 +278,9 @@ if {${subport} eq "openjdk8"} {
 } elseif {${subport} eq "openjdk11"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}/
 
-    checksums    rmd160  7d924b45bcac2e03d1cb0b02b9fb64a42010eda5 \
-                 sha256  0ab1e15e8bd1916423960e91b932d2b17f4c15b02dbdf9fa30e9423280d9e5cc \
-                 size    184353243
+    checksums    rmd160  678de7cdaaf6fd8f66bae841fcc0a91977562198 \
+                 sha256  4a8dadd58cdc32c7e59978971d56aec610be7ee0ddf0dc1d137bb8b78456499f \
+                 size    185054456
 
     distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}_${build}
     worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to AdoptOpenJDK HotSpot 11.0.8.

###### Tested on

macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?