### PR TITLE
pcre: Disable JIT for Apple silicon

### DIFF
--- a/devel/pcre/Portfile
+++ b/devel/pcre/Portfile
@@ -55,6 +55,7 @@ configure.args      --disable-silent-rules \
                     --enable-${subport}test-libedit
 subport pcre {
     PortGroup clang_dependency 1.0
+
     configure.args-append --enable-unicode-properties
 }
 
@@ -63,6 +64,10 @@ platform darwin 8 {
     if {[variant_isset universal]} {
         configure.ldflags-append -lncurses
     }
+}
+
+if {${build_arch} eq "arm64"} {
+    configure.args-delete --enable-jit
 }
 
 test.run            yes


### PR DESCRIPTION
#### Description

Disable JIT when building for Apple silicon, due to some additional restrictions when running on that hardware that prevent JIT from functioning correctly without changes. Disable it for now until upstream adds proper support, which is being [discussed here](https://bugs.exim.org/show_bug.cgi?id=2618). Considered adding a short patch that would reenable the old JIT behavior, but given that it depends on extremely undocumented processor-specific register writes I decided against it for now.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 11.0 20A5299w
Xcode 12.0 12A8161k 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
