### PR TITLE
py-pyqtgraph: move to pyqt5 for python >= 3.6

### DIFF
--- a/python/py-pyqtgraph/Portfile
+++ b/python/py-pyqtgraph/Portfile
@@ -14,7 +14,7 @@ supported_archs   noarch
 description       Scientific Graphics and Qt GUI library for Python
 
 long_description  PyQtGraph is a pure-python graphics and GUI library \
-                  built on PyQt4 and numpy. It is intended for use in \
+                  built on PyQt4/PyQt5 and numpy. It is intended for use in \
                   mathematics / scientific / engineering applications. \
                   It is very fast due to its heavy leverage of numpy \
                   for number crunching and Qt’s GraphicsView framework \
@@ -24,7 +24,7 @@ version           0.11.0
 checksums         rmd160  8f1e37d28e0e9675446b9c1c91282b3379090792 \
                   sha256  ca0a6715882579c46c80df18d9b260a09fce0e086521bfb6fc1f4027f938b35c \
                   size    763749
-revision          0
+revision          1
 
 homepage          http://pyqtgraph.org/
 distname          ${python.rootname}-${version}
@@ -51,7 +51,9 @@ if {$subport ne $name} {
         depends_lib-append  port:py${python.version}-opengl
     }
 
-    if {![variant_isset pyside] && ![variant_isset pyqt5]} {
+    if {${python.version} >= 36 && ![variant_isset pyside] && ![variant_isset pyqt4]} {
+        default_variants +pyqt5
+    } elseif {![variant_isset pyside] && ![variant_isset pyqt5]} {
         default_variants +pyqt4
     }
 


### PR DESCRIPTION
#### Description

simple way to move to pyqt5 for python >= 3.6
It works fine for me on python 3.7 and python 3.8 (tested with project's examples)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.6 19G73
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
