### PR TITLE
beekeeper-studio: update to 1.6.4

### DIFF
--- a/aqua/beekeeper-studio/Portfile
+++ b/aqua/beekeeper-studio/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        beekeeper-studio beekeeper-studio 1.5.3 v
+github.setup        beekeeper-studio beekeeper-studio 1.6.4 v
 revision            0
 
 homepage            https://beekeeperstudio.io/
@@ -29,9 +29,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  8db602fbc3368addfbd82bd5d2d70025f8dcb6a9 \
-                    sha256  1a6953be93c956d8cd8dbc24626eafe943d12bc618ccc73eae2d6dd215be87a0 \
-                    size    44123933
+                    rmd160  907ff710b915dfad0d2e292bdfe16e79a685944c \
+                    sha256  dce5b61679e60bb9a5589b16823b18a726935762454511fdf1f657dfa4cf7e75 \
+                    size    44140442
 
 depends_build       port:go \
                     port:yarn
@@ -42,7 +42,7 @@ build {
     set gopath ${workpath}/go
 
     # Set up all JS dependencies
-    system -W ${worksrcpath} "yarn"
+    system -W ${worksrcpath} "yarn --frozen-lockfile"
 
     # Workaround for: https://trac.macports.org/ticket/60555
     # Build app-builder-bin locally and insert it into node_modules
@@ -53,7 +53,7 @@ build {
 
     # Build electron app
     system -W ${worksrcpath} \
-        "CSC_IDENTITY_AUTO_DISCOVERY=false yarn run electron:build --mac dir"
+        "CSC_IDENTITY_AUTO_DISCOVERY=false yarn run electron:build --mac dir --publish never"
 }
 
 destroot {


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
