### PR TITLE
openjdk8: update AdoptOpenJDK versions to 8u262, 11.0.8, 14.0.2

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -3,10 +3,10 @@
 PortSystem       1.0
 
 name             openjdk8
-version          8u252
-revision         1
+version          8u262
+revision         0
 
-set build        09
+set build        10
 set major        8
 
 subport openjdk8-graalvm {
@@ -17,21 +17,21 @@ subport openjdk8-graalvm {
 }
 
 subport openjdk8-openj9 {
-    version      8u252
-    revision     2
+    version      8u262
+    revision     0
 
-    set build    09
+    set build    10
     set major    8
-    set openj9_version 0.20.0
+    set openj9_version 0.21.0
 }
 
 subport openjdk8-openj9-large-heap {
-    version      8u252
-    revision     2
+    version      8u262
+    revision     0
 
-    set build    09
+    set build    10
     set major    8
-    set openj9_version 0.20.0
+    set openj9_version 0.21.0
 }
 
 subport openjdk10 {
@@ -58,21 +58,21 @@ subport openjdk11-graalvm {
 }
 
 subport openjdk11-openj9 {
-    version      11.0.7
-    revision     2
+    version      11.0.8
+    revision     0
 
     set build    10
     set major    11
-    set openj9_version 0.20.0
+    set openj9_version 0.21.0
 }
 
 subport openjdk11-openj9-large-heap {
-    version      11.0.7
-    revision     2
+    version      11.0.8
+    revision     0
 
     set build    10
     set major    11
-    set openj9_version 0.20.0
+    set openj9_version 0.21.0
 }
 
 subport openjdk12 {
@@ -128,29 +128,29 @@ subport openjdk13-openj9-large-heap {
 }
 
 subport openjdk14 {
-    version      14.0.1
+    version      14.0.2
     revision     0
 
-    set build    7
+    set build    12
     set major    14
 }
 
 subport openjdk14-openj9 {
-    version      14.0.1
-    revision     2
+    version      14.0.2
+    revision     0
 
-    set build    7
+    set build    12
     set major    14
-    set openj9_version 0.20.0
+    set openj9_version 0.21.0
 }
 
 subport openjdk14-openj9-large-heap {
-    version      14.0.1
-    revision     2
+    version      14.0.2
+    revision     0
 
-    set build    7
+    set build    12
     set major    14
-    set openj9_version 0.20.0
+    set openj9_version 0.21.0
 }
 
 categories       java devel
@@ -186,14 +186,11 @@ if {${os.platform} eq "darwin" && ${os.major} < 14} {
 }
 
 if {${subport} eq "openjdk8"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}.1/
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}/
 
-    # Stealth update
-    dist_subdir  ${name}/${version}_1
-    
-    checksums    rmd160  7e63fa413519502a03d1fa80774c96afa43443e4 \
-                 sha256  2caed3ec07d108bda613f9b4614b22a8bdd196ccf2a432a126161cd4077f07a5 \
-                 size    100518315
+    checksums    rmd160  b6d468109e432ba536b5523a5709fc37ab37d34c \
+                 sha256  787c37e286d76d42adc8938399a1411da8035d2c283298acb625f3e7b21baf06 \
+                 size    101389824
 
     distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}b${build}
     worksrcdir   jdk${version}-b${build}
@@ -215,14 +212,11 @@ if {${subport} eq "openjdk8"} {
 
     homepage     https://www.graalvm.org
 } elseif {${subport} eq "openjdk8-openj9"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}.2_openj9-${openj9_version}/
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
 
-    # Stealth update
-    dist_subdir  ${name}/${version}_2
-
-    checksums    rmd160  b0f23be9c2f7df5ee0438b726bcb53a207d31762 \
-                 sha256  f522061a23290bce3423e49025a95b6e78d6f30e2741817e83c8fdba4c0c4ae7 \
-                 size    113265117
+    checksums    rmd160  0491fa0163996174ac94db6a65eec4f9e153c60e \
+                 sha256  a200abbeb5e01a642bf6405f4706e78a1e0a31bf5f4d5359e93ffdd983a2a104 \
+                 size    113716716
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}b${build}_openj9-${openj9_version}
     worksrcdir   jdk${version}-b${build}
@@ -235,14 +229,11 @@ if {${subport} eq "openjdk8"} {
                  VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
                  suitable for running all workloads.
 } elseif {${subport} eq "openjdk8-openj9-large-heap"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}.2_openj9-${openj9_version}/
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
 
-    # Stealth update
-    dist_subdir  ${name}/${version}_2
-
-    checksums    rmd160  3e9394986bc60248d4bb267261cda0c52b87d41b \
-                 sha256  79ab9e7f745201a353b2f95856ada555b4b844bcf64e825e3c7b73cd4f1641b4 \
-                 size    113908307
+    checksums    rmd160  e4319b6783f0a98e4ac75d7092a1e21501c83e3f \
+                 sha256  d13f8622cba393989517da258af1cba08e5bcc23302c337841348ee573c9304a \
+                 size    114370050
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}b${build}_openj9-${openj9_version}
     worksrcdir   jdk${version}-b${build}
@@ -300,14 +291,11 @@ if {${subport} eq "openjdk8"} {
 
     homepage     https://www.graalvm.org
 } elseif {${subport} eq "openjdk11-openj9"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.2_openj9-${openj9_version}/
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
 
-    # Stealth update
-    dist_subdir  ${name}/${version}_2
-
-    checksums    rmd160  9f852323878d78c838acce77f77ce04811ad1f3e \
-                 sha256  a0de749c37802cc233ac58ffde68191a4dc985c71b626e7c0ff53944f743427f \
-                 size    194540776
+    checksums    rmd160  a21fefdde2a624285e10650188198b447cc59506 \
+                 sha256  71df9865d068a2dd1a963636b7e30f4e9188bac73b3935822b76b354f9e30216 \
+                 size    195447520
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
     worksrcdir   jdk-${version}+${build}
@@ -320,14 +308,11 @@ if {${subport} eq "openjdk8"} {
                  VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
                  suitable for running all workloads.
 } elseif {${subport} eq "openjdk11-openj9-large-heap"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.2_openj9-${openj9_version}/
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
 
-    # Stealth update
-    dist_subdir  ${name}/${version}_2
-
-    checksums    rmd160  b4b3aa8c4f639f8f874df2ec6f4e4d642967956a \
-                 sha256  96518b3a9b303bed5ab7bd697a4fbd0ea8525df7e581543830ca7e1e0d7ed90b \
-                 size    193760354
+    checksums    rmd160  db07b68e990116eae21fcef91c7c1be1b78aa90a \
+                 sha256  c698263cc776f6179a81576a6aefb07fc724c4447cffa40a9055b010aed4231f \
+                 size    194670767
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
     worksrcdir   jdk-${version}+${build}
@@ -435,21 +420,18 @@ if {${subport} eq "openjdk8"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}/
     distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}_${build}
 
-    checksums    rmd160  bc4afe3ada4aceaab7d4e00d83a325a9f5ebbdb9 \
-                 sha256  b11cb192312530bcd84607631203d0c1727e672af12813078e6b525e3cce862d \
-                 size    195769653
+    checksums    rmd160  2b6beb756626e8ab72eb85d25701be522e5beb3f \
+                 sha256  09b7e6ab5d5eb4b73813f4caa793a0b616d33794a17988fa6a6b7c972e8f3dd3 \
+                 size    195705010
 
     worksrcdir   jdk-${version}+${build}
 } elseif {${subport} eq "openjdk14-openj9"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.2_openj9-${openj9_version}/
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
 
-    # Stealth update
-    dist_subdir  ${name}/${version}_2
-
-    checksums    rmd160  0600f3cba4e925c94b3a5b7b1f944c7d34190f4b \
-                 sha256  4203f1939704de50d4fae4b98fdd0c63f154aab804eb1ebd5cd6bbcbf0811a1d \
-                 size    200744726
+    checksums    rmd160  0ea69114a43e0c4e3e4cb80abf7bcd9bf86c05ca \
+                 sha256  95e6abcc12dde676ccd5ba65ab86f06ddaa22749dde00e31f4c6d3ea95277359 \
+                 size    200090793
 
     worksrcdir   jdk-${version}+${build}
 
@@ -461,15 +443,12 @@ if {${subport} eq "openjdk8"} {
                  VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
                  suitable for running all workloads.
 } elseif {${subport} eq "openjdk14-openj9-large-heap"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.2_openj9-${openj9_version}/
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
 
-    # Stealth update
-    dist_subdir  ${name}/${version}_2
-
-    checksums    rmd160  21789f13b72e62370ec7d926c5998cc8d1c6fc1f \
-                 sha256  eb5f8708e586afc80054c8c16946dc27c86113185cccced4b8f0a2c4992b999c \
-                 size    200741041
+    checksums    rmd160  f77124d360ab493a5f69b3b58e5dd9e8d77c718a \
+                 sha256  178270b6cc2213bad148c32e3bced0fb18aafee1f83be735d729e0261b4958da \
+                 size    200881593
 
     worksrcdir   jdk-${version}+${build}
 


### PR DESCRIPTION
#### Description

Update all AdoptOpenJDK-based subports to 8u262, 11.0.8, 14.0.2.

###### Tested on

macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?