### PR TITLE
dpkg: update to 1.20.5. Add perl 5.30. Remove extract.asroot.

### DIFF
--- a/sysutils/dpkg/Portfile
+++ b/sysutils/dpkg/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 name                dpkg
-version             1.20.0
+version             1.20.5
 revision            0
 
 platforms           darwin
@@ -20,13 +20,14 @@ distname            ${name}_${version}
 worksrcdir          ${name}-${version}
 
 use_xz              yes
-extract.asroot      yes
 
-checksums           rmd160  e0a2ca3232723d4e0927e6ae1a7f92648cc917da \
-                    sha256  b633cc2b0e030efb61e11029d8a3fb1123f719864c9992da2e52b471c96d0900 \
-                    size    4738556
+checksums           rmd160  3d1f1981775fe058cfa8e34851e447965a60bdab \
+                    sha256  f2f23f3197957d89e54b87cf8fc42ab00e1b74f3a32090efe9acd08443f3e0dd \
+                    size    4715684
 
-perl5.branches      5.28
+perl5.branches          5.28 5.30
+perl5.default_branch    5.30
+perl5.create_variants   ${perl5.branches}
 
 depends_build-append \
                     port:pkgconfig \
@@ -41,7 +42,6 @@ depends_lib-append  port:bzip2 \
                     port:gpatch \
                     port:libiconv \
                     port:ncurses \
-                    port:perl${perl5.major} \
                     port:xz \
                     port:zlib
 


### PR DESCRIPTION
#### Description

This PR:

* Updates `dpkg` to `1.20.5`.
* Adds perl 5.30 and sets it as default. Adds `perl5.create_variants`.
* Removes `extract.asroot`. I don't actually know why it was added but it works just fine without it.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6
Xcode Not installed
CLT 11.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files? (not all tho)

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
