### PR TITLE
ipcalc: add perl 5.30.

### DIFF
--- a/net/ipcalc/Portfile
+++ b/net/ipcalc/Portfile
@@ -5,7 +5,8 @@ PortGroup           perl5 1.0
 
 name                ipcalc
 version             0.41
-revision            4
+revision            5
+
 categories          net
 license             GPL-2+
 platforms           darwin
@@ -23,11 +24,12 @@ homepage            http://jodies.de/ipcalc/
 master_sites        http://jodies.de/ipcalc-archive/
 
 checksums           rmd160  aaa21c1804d7498e2604c907a336c20dc9b4511d \
-                    sha256  dda9c571ce3369e5b6b06e92790434b54bec1f2b03f1c9df054c0988aa4e2e8a
+                    sha256  dda9c571ce3369e5b6b06e92790434b54bec1f2b03f1c9df054c0988aa4e2e8a \
+                    size    21599
 
-perl5.branches      5.28
-
-depends_lib         port:perl${perl5.major}
+perl5.branches          5.28 5.30
+perl5.default_branch    5.30
+perl5.create_variants   ${perl5.branches}
 
 configure {
     reinplace "s|/usr/bin/perl -w|${prefix}/bin/perl${perl5.major} -w|g" ${worksrcpath}/ipcalc


### PR DESCRIPTION
#### Description

This PR:

* Adds perl 5.30 and sets it as default. Adds `perl5.create_variants`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6
Xcode Not installed
CLT 11.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
