### PR TITLE
pybombs: Fix variant conflicts

### DIFF
--- a/science/pybombs/Portfile
+++ b/science/pybombs/Portfile
@@ -67,7 +67,7 @@ foreach this_py_version_no_dot ${pythons_suffixes} {
     set py_version_with_dot [join [split ${this_py_version_no_dot} ""] "."]
     set this_description "Use Python ${py_version_with_dot}"
     variant python${this_py_version_no_dot} \
-        conflicts python${this_conflicts} \
+        conflicts {*}python${this_conflicts} \
         description ${this_description} "
             python.default_version ${this_py_version_no_dot}
             depends_build-append \


### PR DESCRIPTION
Before:

```
$ port lint pybombs
--->  Verifying Portfile for pybombs
Warning: Variant python27 conflicts with non-existing variant python35 python36 python37 python38
Warning: Variant python35 conflicts with non-existing variant python27 python36 python37 python38
Warning: Variant python36 conflicts with non-existing variant python27 python35 python37 python38
Warning: Variant python37 conflicts with non-existing variant python27 python35 python36 python38
Warning: Variant python38 conflicts with non-existing variant python27 python35 python36 python37
--->  0 errors and 5 warnings found.
```

After:

```
$ port lint pybombs
--->  Verifying Portfile for pybombs
--->  0 errors and 0 warnings found.
```