### PR TITLE
graphviz[-devel]: fix livecheck, HTTPS homepage

### DIFF
--- a/graphics/graphviz-devel/Portfile
+++ b/graphics/graphviz-devel/Portfile
@@ -13,7 +13,7 @@ set otherbranch                 [expr {${thisbranch} eq {} ? {-devel} : {}}]
 categories                      graphics
 maintainers                     {ryandesign @ryandesign}
 license                         EPL-1
-homepage                        http://www.graphviz.org/
+homepage                        https://www.graphviz.org/
 master_sites                    ${homepage}pub/graphviz/development/SOURCES/
 platforms                       darwin
 use_parallel_build              yes
@@ -282,8 +282,8 @@ post-destroot {
 }
 
 livecheck.type                  regex
-livecheck.url                   ${homepage}Download_source.php
-livecheck.regex                 ${my_name}-(\[0-9\]+\\.\[0-9\]*\[13579\](\\.\[0-9\]+)*)\\.tar
+livecheck.url                   https://www2.graphviz.org/Packages/development/portable_source/
+livecheck.regex                 ${my_name}-(\[0-9\]+\\.\[0-9\]*\[13579\](\\.\[0-9\]+)*)\\.tar\\.gz
 } else {
     livecheck.type              none
 }

--- a/graphics/graphviz-devel/Portfile
+++ b/graphics/graphviz-devel/Portfile
@@ -283,7 +283,7 @@ post-destroot {
 
 livecheck.type                  regex
 livecheck.url                   https://www2.graphviz.org/Packages/development/portable_source/
-livecheck.regex                 ${my_name}-(\[0-9\]+\\.\[0-9\]*\[13579\](\\.\[0-9\]+)*)\\.tar\\.gz
+livecheck.regex                 ${my_name}-(\[0-9\]+\\.\[0-9\]*\[13579\](\\.\[0-9\]+)*)\\.tar
 } else {
     livecheck.type              none
 }

--- a/graphics/graphviz/Portfile
+++ b/graphics/graphviz/Portfile
@@ -14,7 +14,7 @@ set otherbranch                 [expr {${thisbranch} eq {} ? {-devel} : {}}]
 categories                      graphics
 maintainers                     {ryandesign @ryandesign}
 license                         EPL-1
-homepage                        http://www.graphviz.org/
+homepage                        https://www.graphviz.org/
 master_sites                    ${homepage}pub/graphviz/stable/SOURCES/
 platforms                       darwin
 use_parallel_build              yes
@@ -285,8 +285,8 @@ post-destroot {
 }
 
 livecheck.type                  regex
-livecheck.url                   https://graphviz.gitlab.io/_pages/Download/Download_source.html
-livecheck.regex                 ${my_name}-(\[0-9\]+\\.\[0-9\]*\[02468\](\\.\[0-9\]+)*)\\.tar.gz
+livecheck.url                   https://www2.graphviz.org/Packages/stable/portable_source/
+livecheck.regex                 ${my_name}-(\[0-9\]+\\.\[0-9\]*\[02468\](\\.\[0-9\]+)*)\\.tar\\.gz
 } else {
     livecheck.type              none
 }

--- a/graphics/graphviz/Portfile
+++ b/graphics/graphviz/Portfile
@@ -286,7 +286,7 @@ post-destroot {
 
 livecheck.type                  regex
 livecheck.url                   https://www2.graphviz.org/Packages/stable/portable_source/
-livecheck.regex                 ${my_name}-(\[0-9\]+\\.\[0-9\]*\[02468\](\\.\[0-9\]+)*)\\.tar\\.gz
+livecheck.regex                 ${my_name}-(\[0-9\]+\\.\[0-9\]*\[02468\](\\.\[0-9\]+)*)\\.tar
 } else {
     livecheck.type              none
 }


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
```
% port lint graphviz
--->  Verifying Portfile for graphviz
Warning: missing recommended checksum type: size
--->  0 errors and 1 warnings found.
% port lint graphviz-devel
--->  Verifying Portfile for graphviz-devel
--->  0 errors and 0 warnings found.
```

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
