### PR TITLE
kustomize: update to 3.8.1

### DIFF
--- a/devel/kustomize/Portfile
+++ b/devel/kustomize/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/kubernetes-sigs/kustomize 3.8.0 kustomize/v
+go.setup            github.com/kubernetes-sigs/kustomize 3.8.1 kustomize/v
 revision            0
 
 categories          devel
@@ -23,9 +23,9 @@ long_description    kustomize lets you customize raw, template-free YAML files f
 
 homepage            https://kustomize.io
 
-checksums           rmd160  c5a0f47be7d373d1565ee84dbfb6d971f114f105 \
-                    sha256  7f5ae33acc867a277f74b6a13bc0daa69d552131f218572e9f3b5a29247a3771 \
-                    size    25660994
+checksums           rmd160  785513f119809bd5957f3a4a59ff7f6f14dd1b3b \
+                    sha256  576483bbb493f42cccddc382c10f380ec32e479c259cd4c5c29e38655eb3ca81 \
+                    size    25768272
 
 build.dir           ${worksrcpath}/${name}
 


### PR DESCRIPTION
#### Description

Update to kustomize 3.8.1.

###### Tested on

macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?