### PR TITLE
mysql8: use compiler.cxx_standard

### DIFF
--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -23,7 +23,6 @@ set boost_distname      boost_${boost_distver}
 
 if {$subport eq $name} {
     PortGroup           muniversal 1.0
-    PortGroup           cxx11 1.1
     PortGroup           cmake 1.1
     PortGroup           select 1.0
     PortGroup           compiler_blacklist_versions 1.0
@@ -65,8 +64,10 @@ if {$subport eq $name} {
 
     use_parallel_build  yes
 
-    # Requires c++14 (gcc 6.1 or newer, clang-3.4 or newer support c++14)
-    compiler.blacklist-append {*gcc-[3-4].*} *gcc-5 {clang < 900} macports-clang-3.3
+    compiler.cxx_standard 2014
+
+    # TODO: explain why these compilers are blacklisted
+    compiler.blacklist-append *gcc-5 {clang < 900}
 
     # clang 8.0+ are too strict to build this port
     # version:1:1: error: C++ requires a type specifier for all declarations


### PR DESCRIPTION
…instead of deprecated `cxx11 1.1` portgroup
Cleanup `compiler.blacklist`

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5

Not fully tested. I have only verified that the port still fails to compile with macports-clang-9.0 and macports-gcc-5.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
See above
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
