### PR TITLE
bossa: new port

### DIFF
--- a/cross/bossa/Portfile
+++ b/cross/bossa/Portfile
@@ -1,0 +1,53 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           makefile 1.0
+PortGroup           github 1.0
+PortGroup           wxWidgets 1.0
+
+github.setup        shumatech BOSSA 1.9.1
+
+name                bossa
+categories          cross devel
+license             BSD
+maintainers         {mit.edu:quentin @quentinmit} \
+                    openmaintainer
+description         Basic Open Source SAM-BA Application
+long_description    BOSSA is a flash programming utility for Atmel's SAM \
+                    family of flash-based ARM microcontrollers.
+
+homepage            http://www.shumatech.com/web/products/bossa
+platforms           darwin
+
+checksums           sha1    ec911282fe3872769a73195c9e0d6e57b2a6e5b2 \
+                    rmd160  729652752baa57dde02ce30608b208ddc753d8c0 \
+                    sha256  811b9c6833cb43072fa3f3e76131fb46cbc36d8f7181b8a25085f0f4ba5ae77d \
+                    size    544207
+
+default_variants    +wxwidgets
+depends_lib-append  port:readline
+
+# Remove default CXXFLAGS so MacPorts can set them.
+patchfiles          patch-Makefile
+
+# The Makefile is racy
+use_parallel_build  no
+
+# "strip" builds the command-line binaries.
+build.target        strip-bossac strip-bossash
+build.args          VERSION=${version} Q=
+
+destroot {
+    xinstall -m 755 -W ${worksrcpath}/bin bossac bossash ${destroot}${prefix}/bin
+}
+
+variant wxwidgets description {Build graphical wxWidgets app} {
+    wxWidgets.use       wxWidgets-3.0
+    build.target-append strip app
+    depends_lib-append  port:${wxWidgets.port}
+    build.env-append    "PATH=${wxWidgets.wxdir}:${env(PATH)}"
+    post-destroot {
+        xinstall -m 755 -W ${worksrcpath}/bin bossa ${destroot}${prefix}/bin
+        file copy ${worksrcpath}/bin/BOSSA.app ${destroot}${applications_dir}/BOSSA.app
+    }
+}

--- a/cross/bossa/files/patch-Makefile
+++ b/cross/bossa/files/patch-Makefile
@@ -1,0 +1,13 @@
+--- Makefile.orig	2020-07-20 20:23:20.000000000 -0400
++++ Makefile	2020-07-20 20:23:56.000000000 -0400
+@@ -99,8 +99,8 @@
+ #
+ ifeq ($(OS),Darwin)
+ COMMON_SRCS+=PosixSerialPort.cpp OSXPortFactory.cpp
+-COMMON_CXXFLAGS=-arch x86_64 -mmacosx-version-min=10.9
+-COMMON_LDFLAGS=-arch x86_64 -mmacosx-version-min=10.9
++COMMON_CXXFLAGS=
++COMMON_LDFLAGS=
+ APP=BOSSA.app
+ DMG=bossa-$(VERSION).dmg
+ VOLUME=BOSSA


### PR DESCRIPTION
#### Description

New portfile for BOSSA, the set of command line tools (notably `bossac`) for programming SAM-based Ardunio devices like the Arduino MKR.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G103
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
