### PR TITLE
boost169: fix compiler selection

### DIFF
--- a/devel/boost169/Portfile
+++ b/devel/boost169/Portfile
@@ -1,9 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
-PortGroup       compiler_blacklist_versions 1.0
 PortGroup       mpi 1.0
-PortGroup       cxx11 1.1
 PortGroup       active_variants 1.1
 
 name            boost169
@@ -93,11 +91,6 @@ proc write_jam s {
     close ${config}
 }
 
-# clang++ produces broken boost libraries (https://trac.macports.org/ticket/31525)
-# If Apple's clang is used on 32-bit systems, it seems to silently ignore the '-march=i386' flag.
-# (https://trac.macports.org/ticket/38157)
-compiler.blacklist {clang < 421} *llvm-gcc-4.2 *gcc-4.0 gcc-3.3
-
 compilers.choose   cc cxx
 mpi.setup          -gcc
 
@@ -107,6 +100,7 @@ mpi.setup          -gcc
 # require ports depending on Boost to also require C++11 compliance,
 # and requiring it does make such building easier for those ports.
 configure.cxxflags-append -std=gnu++11
+compiler.cxx_standard   2011
 
 # It turns out that ccache and distcc can produce boost libraries that, although they
 # compile without warning, have all sorts of runtime errors especially with pointer corruption.


### PR DESCRIPTION
As done for `boost` in f1cdc3adaa

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
**Untested.**

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
