### PR TITLE
keystone: new port

### DIFF
--- a/devel/keystone/Portfile
+++ b/devel/keystone/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        keystone-engine keystone 0.9.2
+
+categories          devel
+license             GPL-2
+platforms           darwin linux
+
+homepage            https://www.keystone-engine.org/
+
+description         Keystone is a multi-arch, multi-platform assembler framework \
+                    for Arm, Arm64 (AArch64/Armv8), MIPS, Sparc, PowerPC, x86 \
+                    (16/32/64-bit), SystemZ, Hexagon and more.
+
+long_description    {*}${description} It is clean/simple/lightweight with an \
+                    architecture-neutral API, and implemented in C/C++ with \
+                    bindings for Java, MASM, C#, PowerShell, Perl, Python, \
+                    NodeJS, Ruby, Go, Rust, Haskell, VB6 & OCaml available. It \
+                    is based on LLVM, and has native support for Windows & \
+                    *nix (with macOS, Linux, *BSD & Solaris confirmed).
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  bef285e41a23a26aa2763adea26bbb5ea36d55c3 \
+                    sha256  2725d30768931c8f54cbadd51cba41da8b0fa722a029449e3f34acc35d922973 \
+                    size    4433601
+
+cmake.build_type    RELEASE


### PR DESCRIPTION
New port for [Keystone](https://www.keystone-engine.org/)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
