### PR TITLE
qscintilla-qt5: remove rpath from install_name

### DIFF
--- a/aqua/TOra/Portfile
+++ b/aqua/TOra/Portfile
@@ -6,7 +6,7 @@ PortGroup               cmake 1.0
 
 name                    TOra
 version                 2.1.3
-revision                5
+revision                6
 license                 GPL-2
 description             GUI tool for Oracle, PostgreSQL, and MySQL
 long_description        Database developer/DBA frontend for various DB servers.

--- a/databases/sqlitebrowser/Portfile
+++ b/databases/sqlitebrowser/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        sqlitebrowser sqlitebrowser 3.12.0
-revision            1
+revision            2
 
 categories          databases
 platforms           darwin linux

--- a/databases/sqliteman/Portfile
+++ b/databases/sqliteman/Portfile
@@ -7,7 +7,7 @@ PortGroup           cmake 1.0
 
 name                sqliteman
 version             1.2.2
-revision            6
+revision            7
 
 description         GUI tool for Sqlite3
 long_description	The best developer's and/or admin's GUI tool for Sqlite3 in the world. \

--- a/devel/qscintilla/Portfile
+++ b/devel/qscintilla/Portfile
@@ -8,7 +8,7 @@ version             2.11.5
 checksums           rmd160  bf0596f336fe888fd3d08d9ce816231533233bdb \
                     sha256  9361e26fd7fb7b5819a7eb92c5c1880a18de9bd3ed9dd2eb008e57388696716b \
                     size    3007564
-revision            0
+revision            1
 
 categories          devel
 license             GPL-3
@@ -47,6 +47,9 @@ foreach qt_major {4 5} {
 
         # temporary path to fix necessary inclusion of QUrl
         patchfiles-append patch-Qt4Qt5_qsciscintillabase.cpp.diff
+
+        # fixup @rpath in the library's install_name
+        patchfiles-append patch-Qt4Qt5-qscintilla.pro.diff
 
         if {${qt_major} eq 4} {
             # enable C++11
@@ -179,7 +182,7 @@ foreach qt_major {4 5} {
 }
 
 if {${subport} eq ${name}} {
-    revision 1
+    revision 2
 
     distfiles
     patchfiles

--- a/devel/qscintilla/files/patch-Qt4Qt5-qscintilla.pro.diff
+++ b/devel/qscintilla/files/patch-Qt4Qt5-qscintilla.pro.diff
@@ -1,0 +1,13 @@
+--- qscintilla.pro.orig	2020-07-19 10:42:08.000000000 -0400
++++ qscintilla.pro	2020-07-19 10:42:25.000000000 -0400
+@@ -37,10 +37,6 @@
+     TARGET = qscintilla2_qt$${QT_MAJOR_VERSION}
+ }
+ 
+-macx:!CONFIG(staticlib) {
+-    QMAKE_POST_LINK += install_name_tool -id @rpath/$(TARGET1) $(TARGET)
+-}
+-
+ INCLUDEPATH += . ../include ../lexlib ../src
+ 
+ !CONFIG(staticlib) {

--- a/devel/tortoisehg/Portfile
+++ b/devel/tortoisehg/Portfile
@@ -8,6 +8,8 @@ PortGroup           bitbucket 1.0
 bitbucket.setup     tortoisehg thg 5.3rc0
 name                tortoisehg
 version             5.3
+revision            1
+
 categories          devel python
 platforms           darwin
 license             GPL-2+

--- a/gis/qgis/Portfile
+++ b/gis/qgis/Portfile
@@ -8,7 +8,7 @@ PortGroup           github  1.0
 PortGroup           qt4     1.0
 
 github.setup        qgis QGIS 2_18_17 final-
-revision            3
+revision            4
 name                qgis
 version             [string map {_ .} ${github.version}]
 categories          gis
@@ -116,7 +116,7 @@ depends_run-append      port:py27-psycopg2 \
 pre-configure {
                         reinplace -E "s|Versions/Current|Versions/2.7|" \
                         ${worksrcpath}/cmake/FindPythonLibrary.cmake
-}   
+}
 
 # QT5 is no longer supported. Use QGIS 3 instead
 

--- a/gis/qgis3/Portfile
+++ b/gis/qgis3/Portfile
@@ -11,7 +11,7 @@ PortGroup           active_variants 1.1
 github.setup        qgis QGIS 3_14_0 final-
 name                qgis3
 version             [string map {_ .} ${github.version}]
-revision            0
+revision            1
 categories          gis
 maintainers         {vince @Veence} openmaintainer
 description         QGIS 3 is a user-friendly GIS based on Qt 5

--- a/math/octave/Portfile
+++ b/math/octave/Portfile
@@ -9,7 +9,7 @@ PortGroup           linear_algebra 1.0
 name                octave
 version             5.2.0
 set package_version 5.x.x
-revision            3
+revision            4
 categories          math science
 platforms           darwin
 license             GPL-3+

--- a/science/openscad/Portfile
+++ b/science/openscad/Portfile
@@ -10,7 +10,7 @@ if {${subport} eq "openscad"} {
 
     conflicts           openscad-devel
     version             2015.03-3
-    revision            6
+    revision            7
     master_sites        http://files.openscad.org
     distfiles           ${distname}.src${extract.suffix}
     checksums           rmd160  323eda5bd96b2093d4fbb2274763f7a0ae4eb7f4 \
@@ -41,6 +41,7 @@ if {${subport} eq "openscad"} {
     PortGroup           github 1.0
     github.setup        openscad openscad e7c0851d4023817b2a11df2583d6f406f3b58883
     version             2018.04-1
+    revision            1
 
     checksums           rmd160  57ce759879770675cb7853a6735ad66a5956ddd1 \
                         sha256  40447cbb91a853a16dc1872063cd5c90150356ff31c4d8b5e6296a7a4ec26f23


### PR DESCRIPTION
#### Description
Currently the library installed by `qscintilla-qt5` (i.e. `libqscintilla2_qt5.15.0.0.dylib`) uses ```@rpath```:
```
otool -L /opt/local/libexec/qt5/lib/libqscintilla2_qt5.15.0.0.dylib | head -n 2
/opt/local/libexec/qt5/lib/libqscintilla2_qt5.15.0.0.dylib:
	@rpath/libqscintilla2_qt5.15.dylib (compatibility version 15.0.0, current version 15.0.0)
```

this results in issues when [trying to import `py38-qscintilla-qt5`](https://trac.macports.org/ticket/60796) and in [`octave`](https://trac.macports.org/ticket/60845).

This PR changes `@rpath` to `/opt/local/libexec/qt5/lib/`. Re-building `py38-qscintilla-qt5` after this changes resolves that ticket (and presumably the one for `octave` as well). If this is the appropriate fix for a situation like this, then all ports that depend on `qscintilla-qt5` will need a rev-bump.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G5033
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?