### PR TITLE
ngircd: update to 26. Refresh patches.

### DIFF
--- a/irc/ngircd/Portfile
+++ b/irc/ngircd/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 
 name                ngircd
-version             25
+version             26
 revision            0
+
 categories          irc
 platforms           darwin
 license             GPL-2+
@@ -19,9 +20,9 @@ homepage            http://ngircd.barton.de/
 master_sites        http://arthur.barton.de/pub/ngircd/
 use_xz              yes
 
-checksums           rmd160  e28b418b3460b5e7f633b85bf68b41638144944d \
-                    sha256  c4997cae3e3dd6ff6a605ca274268f2b8c9ba0b1a96792c7402e5594222eee4e \
-                    size    349124
+checksums           rmd160  666eb04b8e3889473957b8ab3cb508416adc54af \
+                    sha256  56dcc6483058699fcdd8e54f5010eecee09824b93bad7ed5f18818e550d855c6 \
+                    size    371716
 
 depends_lib         port:libiconv \
                     port:libident \

--- a/irc/ngircd/files/patch-contrib-MacOSX-Makefile.in.diff
+++ b/irc/ngircd/files/patch-contrib-MacOSX-Makefile.in.diff
@@ -1,6 +1,6 @@
 --- contrib/MacOSX/Makefile.in
 +++ contrib/MacOSX/Makefile.in
-@@ -579,7 +579,6 @@ uninstall-am:
+@@ -615,7 +615,6 @@ uninstall-am:
  	    <$< >$@
  
  install-data-local:

--- a/irc/ngircd/files/patch-doc-Makefile.in.diff
+++ b/irc/ngircd/files/patch-doc-Makefile.in.diff
@@ -1,12 +1,12 @@
 --- doc/Makefile.in
 +++ doc/Makefile.in
-@@ -611,10 +611,6 @@ maintainer-clean-local:
+@@ -648,10 +648,6 @@ maintainer-clean-local:
  all: $(generated_docs)
  
  install-data-hook: $(static_docs) $(toplevel_docs) $(generated_docs)
 -	$(MKDIR_P) -m 755 $(DESTDIR)$(sysconfdir)
 -	@if [ ! -f $(DESTDIR)$(sysconfdir)/ngircd.conf ]; then \
--	  make install-config; \
+-	  ${MAKE} install-config; \
 -	 fi
  	$(MKDIR_P) -m 755 $(DESTDIR)$(docdir)
  	for f in $(static_docs) $(toplevel_docs); do \


### PR DESCRIPTION
#### Description

* Update from version `25` to `26`
* Refresh patches

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6
Xcode Not installed
CLT 11.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
