### PR TITLE
rust: update to 1.45.0

### DIFF
--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                rust
-version             1.44.0
+version             1.45.0
 revision            0
 categories          lang devel
 platforms           darwin
@@ -25,9 +25,9 @@ long_description    Rust is a curly-brace, block-structured expression \
 homepage            https://www.rust-lang.org/
 
 # Get from src/stage0.txt
-set ruststd_version 1.43.1
-set rustc_version   1.43.1
-set cargo_version   0.44.0
+set ruststd_version 1.44.0
+set rustc_version   1.44.0
+set cargo_version   0.45.0
 set llvm_version    9.0
 
 # can use cmake or cmake-devel; default to cmake.
@@ -47,23 +47,23 @@ distfiles-append    rust-std-${ruststd_version}-${build_arch}-apple-${os.platfor
                     cargo-${cargo_version}-${build_arch}-apple-${os.platform}${extract.suffix}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  044d53a0aee5bcab32b9dce679d6b1c0f7a332d4 \
-                    sha256  bf2df62317e533e84167c5bc7d4351a99fdab1f9cd6e6ba09f51996ad8561100 \
-                    size    136756700
+                    rmd160  7a55f13406b8fc510d32cce735c7c3ad97200a06 \
+                    sha256  ba0495f12c7d4e8735f3fa9e036bfafd1ae58c26910393201e95b9d13c80cd7c \
+                    size    141692525
 
 checksums-append \
                     rust-std-${ruststd_version}-x86_64-apple-${os.platform}${extract.suffix} \
-                    rmd160  1ce3cf584ca9467e8a8836282fb959ae898fea54 \
-                    sha256  a08827bf42aa73c8795968c9df28b226668d994332f9ae1e6ec2b9f9935d9ddf \
-                    size    23405362 \
+                    rmd160  3e7f199649fce71dfa8f1c6a80c99ea6efaadad9 \
+                    sha256  af58f742764949765e09bb60bd1c16025a79a1be8152996fd5b3a44e5df90311 \
+                    size    23855414 \
                     rustc-${rustc_version}-x86_64-apple-${os.platform}${extract.suffix} \
-                    rmd160  85cdbc98eefa53d4a1abc2a4a73e97f1fe616f05 \
-                    sha256  c7b92b5c3844b6f8201f1a5e41f91b257e764efb4a6bd960198ae60f03dec4bb \
-                    size    85765376 \
+                    rmd160  cb31619748218c3d5100ad3b6bd896524fd58857 \
+                    sha256  4fd09afcae85f656d4a545ee415e19546e03e34f1ca23be5eaa68c489e3186ab \
+                    size    86233080 \
                     cargo-${cargo_version}-x86_64-apple-${os.platform}${extract.suffix} \
-                    rmd160  088290f96dfb2c271d776f867ad6843426d1a6e8 \
-                    sha256  1071c520204a9e8fe4dd0de66a07a083f06abba16ac88f1df72231328a6395e6 \
-                    size    5608767
+                    rmd160  67ec0a5627d820a6f6be257b825a9abe89d97fdf \
+                    sha256  3a618459c8a22773a299d683e4ea0355e615372ae573300933caf6d00019bdd3 \
+                    size    5690025
 
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
     known_fail yes


### PR DESCRIPTION
May need to be tested, as attempts to build using the version specified in src/stage0.txt fail; it seems that component versions should be matching the Rust version.
 
##### Tested o
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
