### PR TITLE
libconfig-hr: update to 1.7.2

### DIFF
--- a/devel/libconfig-hr/Portfile
+++ b/devel/libconfig-hr/Portfile
@@ -4,17 +4,18 @@ PortSystem      1.0
 
 name            libconfig-hr
 conflicts       libconfig
-version         1.4.9
+version         1.7.2
 categories      devel
 license         LGPL-2.1+
 maintainers     nomaintainer
 platforms       darwin
-homepage        http://www.hyperrealm.com/libconfig/
-master_sites    ${homepage}
+homepage        https://hyperrealm.github.io/libconfig/
+master_sites    ${homepage}/dist
 distname        libconfig-${version}
 
-checksums       rmd160 ec0f28737fa603379f3b91c2de1857d7b1ae676f \
-                sha256 09c8979252e60193e2969e9b0e1cd597f7820087867989b2f0939ad164473041
+checksums       rmd160 582d4e94779eec04016a2d424cf26d218321502e \
+                sha256 7c3c7a9c73ff3302084386e96f903eb62ce06953bb1666235fac74363a16fad9 \
+                size   721362
 
 description \
     A new libconfig implementation with both C and C++ bindings.
@@ -30,5 +31,4 @@ configure.cppflags
 configure.ldflags
 
 livecheck.type  regex
-livecheck.url   ${master_sites}
 livecheck.regex ">libconfig-(\\d+(?:\\.\\d+)*)${extract.suffix}<"

--- a/multimedia/shairport-sync/Portfile
+++ b/multimedia/shairport-sync/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        mikebrady shairport-sync 2.8.6
-revision            1
+revision            2
 
 categories          multimedia
 platforms           darwin

--- a/net/sslh/Portfile
+++ b/net/sslh/Portfile
@@ -9,6 +9,7 @@ legacysupport.newest_darwin_requires_legacy 10
 name                sslh
 epoch               1
 version             1.20
+revision            1
 categories          net security www
 platforms           darwin
 maintainers         {amake @amake} openmaintainer


### PR DESCRIPTION
#### Description

Update libconfig-hr to 1.7.2

###### Tested on
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
