### PR TITLE
py-mayavi:  add py38-mayavi subport

### DIFF
--- a/python/py-apptools/Portfile
+++ b/python/py-apptools/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  4afafbe5a5115b92567ef9675d36be5e249048f5 \
                     sha256  c46fc598f02a1a70bfb37538853c1acf8c4b344cad41766b812219d83a99481d \
                     size    305783
 
-python.versions     35 36 37
+python.versions     35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-envisage/Portfile
+++ b/python/py-envisage/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  2c95a0299c38b13a7a1491528edbbcef39d64159 \
                     sha256  98770c290633e3dcb09f1cc2ae4b776541380e18cdb052a42d2ecfd43bc5a2e0 \
                     size    497046
 
-python.versions     35 36 37
+python.versions     35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build   port:py${python.version}-setuptools

--- a/python/py-mayavi/Portfile
+++ b/python/py-mayavi/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  a78fee221fa1243096101cf088dc26dd14567d5f \
                     sha256  5dff720e2d3342697d2f6b22621a9a7cf4a34134aceb9bf22446eea2257e4789 \
                     size    9066423
 
-python.versions     35 36 37
+python.versions     35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools \

--- a/python/py-pyface/Portfile
+++ b/python/py-pyface/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  69b252a285f3d8342d3717bee09bf1b13ae22a6c \
                     sha256  f3bc73a1a58b094a866108ad5f74a1211675c19f5cdfe5faeb61203bdb77d65f \
                     size    5313673
 
-python.versions         35 36 37
+python.versions         35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-traits/Portfile
+++ b/python/py-traits/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  52b3ef50370d4c6ddf1da661e6250f9996550642 \
                     sha256  82097d159370ce6b864376675cab97e16ef0cb75dbf767d137f92acb92d2fa8f \
                     size    435847
 
-python.versions     35 36 37
+python.versions     35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-traitsui/Portfile
+++ b/python/py-traitsui/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  a616786cd6594ad7037b71bc8bb8c188e3f5d366 \
                     sha256  b7a843192c8e4584c91b9119e5297d4a86da6fba7335aa767c62e9e288c21a1f \
                     size    5120702
 
-python.versions     35 36 37
+python.versions     35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
* add py38-mayavi subport
* add py38 subports for the enthought deps: apptools, envisage, pyface, traits, and traitsui

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G5033
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
