### PR TITLE
gnuradio: move 'graphviz' to a build dependency & rev-bump

### DIFF
--- a/science/gnuradio/Portfile
+++ b/science/gnuradio/Portfile
@@ -26,7 +26,7 @@ if {${subport} eq ${name}} {
     checksums       rmd160  4c4a4eb71cf4ed7f3782167a17e979059103d99a \
                     sha256  97763da635063d472eae7cbb7680f36c69359ea5b88348d26f8fa7f8b5e7289a \
                     size    3377964
-    revision        0
+    revision        1
 
     long_description    ${description}: \
         This port is kept up with the GNU Radio release, \
@@ -76,7 +76,7 @@ subport gnuradio37 {
     checksums       rmd160  0165a52a4770a02b4843544e4ba6bc59d84fa7d1 \
                     sha256  3d895e29417efd4ef8ab4053bed2ea9117b4476c0ae729f065088242f0f61f9f \
                     size    4460817
-    revision        0
+    revision        1
 
     long_description    ${description}: \
         This port is kept up with the GNU Radio 3.7 release, \
@@ -126,7 +126,7 @@ subport gnuradio-next {
     checksums       rmd160  0a9e1294036e786116c96d68f9116e3f2798d325 \
                     sha256  bb2dab14e159a4b58ccf317ece3b4132959739f4b5b217d8e0add3c5ce581f5f \
                     size    3950832
-    revision        0
+    revision        1
 
     long_description    ${description}: \
         This port is kept up with the GNU Radio GIT 'master' \
@@ -307,13 +307,16 @@ app.create no
 variant docs description "Install GNU Radio documentation" {
 
     depends_lib-append \
-        port:doxygen \
-        path:bin/dot:graphviz \
         port:xmlto
 
     depends_build-append \
+        port:doxygen \
+        path:bin/dot:graphviz \
         port:py${active_python_version_no_dot}-sphinx \
         port:texlive-latex
+
+    # see https://github.com/macports/macports-ports/pull/7805#issuecomment-663546723
+    license_noconflict graphviz
 
     configure.args-delete \
         -DENABLE_DOXYGEN=OFF \
@@ -547,6 +550,15 @@ variant sdl description "Install GNU Radio with support for SDL-based video" {
 }
 
 variant ctrlport description {Install GNU Radio with support for control port (CTRLPORT) enhancements (EXPERIMENTAL)} {
+
+    # A ctrlport utility uses graphviz for display purposes. This
+    # dependency is not checked for during configuration nor used
+    # during building or testing. It is just a runtime dependency.
+    depends_run-append \
+        path:bin/dot:graphviz
+
+    # see https://github.com/macports/macports-ports/pull/7805#issuecomment-663546723
+    license_noconflict graphviz
 
     # enable configuration arguments for ctrlport
     configure.args-replace \


### PR DESCRIPTION
Small tweak as discussed here: https://github.com/macports/macports-ports/pull/6880#issuecomment-662045139 ... hopefully this clears up the licensing issue with GraphViz ...