### PR TITLE
beekeeper-studio: update to 1.6.9

### DIFF
--- a/aqua/beekeeper-studio/Portfile
+++ b/aqua/beekeeper-studio/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        beekeeper-studio beekeeper-studio 1.6.4 v
+github.setup        beekeeper-studio beekeeper-studio 1.6.9 v
 revision            0
 
 homepage            https://beekeeperstudio.io/
@@ -29,9 +29,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  907ff710b915dfad0d2e292bdfe16e79a685944c \
-                    sha256  dce5b61679e60bb9a5589b16823b18a726935762454511fdf1f657dfa4cf7e75 \
-                    size    44140442
+                    rmd160  27260eb59ef08f2b820b81f49e34f79828f2b487 \
+                    sha256  7fd17a9561ff704a8ccd09570d7493913184e8873d75a447bfd0c8a1e6093585 \
+                    size    44141353
 
 depends_build       port:go \
                     port:yarn


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
