### PR TITLE
gitlab-runner: update to 13.2.0

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 13.1.1 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 13.2.0 v
 
 categories          devel
 platforms           darwin
@@ -23,9 +23,9 @@ homepage            https://docs.gitlab.com/runner/
 master_sites        https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v${version}/
 distname            gitlab-runner-v${version}
 
-checksums           rmd160  10fe73c719d9c5db6b1f7142a40affc2a572c5f9 \
-                    sha256  10eb3fbe848872ef02eea5d7d3c55c3a163d7117c47aee69d28030fb127999c2 \
-                    size    7461116
+checksums           rmd160  9dfa9b234b74b8227db5671e9f808621b0976f15 \
+                    sha256  da822db4761c8e18a424c6e58d2b9c8fc47bfcd03e72bff51b3e7ce239aee72f \
+                    size    7430115
 
 # Reproduce the "build_simple" target from the upstream Makefile
 set go_ldflags      "-X ${go.package}/common.NAME=${go.package} \


### PR DESCRIPTION
#### Description

Update to GitLab Runner 13.2.0.

###### Tested on

macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?