### PR TITLE
radare2: update to 4.5.0

### DIFF
--- a/devel/radare2/Portfile
+++ b/devel/radare2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           conflicts_build 1.0
 PortGroup           github 1.0
 
-github.setup        radareorg radare2 4.4.0
+github.setup        radareorg radare2 4.5.0
 revision            0
 categories          devel
 platforms           darwin
@@ -21,9 +21,9 @@ depends_lib         port:capstone \
                     port:libzip
 conflicts_build     ${name}
 
-checksums           rmd160  b3ac5cdbc2bfe45401dbdcdbd20307d293e29b57 \
-                    sha256  1cce090d65429464c7275537a8aaffbe55031822639f71353d2671f338eed51e \
-                    size    8133621
+checksums           rmd160  361a04b407210823675fe406440c07dfb66804bf \
+                    sha256  a7d35f62fb449c4b911a90d14049c2f4b763ebc645900e4c27ac6919595784ad \
+                    size    8264274
 
 configure.args-append \
                     --with-syscapstone \


### PR DESCRIPTION
#### Description

Updates [radare2](https://github.com/radareorg/radare2) to `4.5.0`, but seeing the following errors on destroot:

```
...
for LIB in tree-sitter/libtree-sitter.a radare2-shell-parser/libshell-parser.a ar/libr_ar.a bochs/lib/libbochs.a capstone/libcapstone.a gdb/lib/libgdbr.a grub/libgrubfs.a java/libr_java.a lz4/liblz4.a qnx/lib/libqnxr.a yxml/libyxml.a windbg/libr_windbg.a zip/librz.a ; do \
		if [ -f "${LIB}" ]; then ld -r -all_load -o .libr/$(basename ${LIB}.a).o ${LIB} ; fi ; \
	done
ld: warning: platform not specified
ld: warning: -arch not specified
ld: warning: ignoring file tree-sitter/libtree-sitter.a, building for macOS-unknown but attempting to link with file built for macOS-x86_64
0  0x1084c40d8  __assert_rtn + 127
1  0x1084ce0b5  ld::passes::objc::fixClassAliases(ld::Atom const*) (.cold.1) + 0
2  0x10849f930  void ld::passes::objc::doPass<x86_64, true>(Options const&, ld::Internal&) + 0
3  0x1083a6e2e  main + 868
A linker snapshot was created at:
	/tmp/libtree-sitter.a.a.o-2020-06-22-084259.ld-snapshot
ld: Assertion failed: (0 && "unknown objc arch"), function doPass, file /Library/Caches/com.apple.xbs/Sources/ld64/ld64-530/src/ld/passes/objc.cpp, line 1747.
ld: warning: platform not specified
ld: warning: -arch not specified
ld: warning: ignoring file radare2-shell-parser/libshell-parser.a, building for macOS-unknown but attempting to link with file built for macOS-x86_64
0  0x10da830d8  __assert_rtn + 127
1  0x10da8d0b5  ld::passes::objc::fixClassAliases(ld::Atom const*) (.cold.1) + 0
2  0x10da5e930  void ld::passes::objc::doPass<x86_64, true>(Options const&, ld::Internal&) + 0
3  0x10d965e2e  main + 868
4  0x7fff6da18cc9  start + 1
A linker snapshot was created at:
	/tmp/libshell-parser.a.a.o-2020-06-22-084259.ld-snapshot
ld: Assertion failed: (0 && "unknown objc arch"), function doPass, file /Library/Caches/com.apple.xbs/Sources/ld64/ld64-530/src/ld/passes/objc.cpp, line 1747.
ld: warning: platform not specified
ld: warning: -arch not specified
ld: warning: ignoring file ar/libr_ar.a, building for macOS-unknown but attempting to link with file built for macOS-x86_64
0  0x1051e10d8  __assert_rtn + 127
1  0x1051eb0b5  ld::passes::objc::fixClassAliases(ld::Atom const*) (.cold.1) + 0
2  0x1051bc930  void ld::passes::objc::doPass<x86_64, true>(Options const&, ld::Internal&) + 0
3  0x1050c3e2e  main + 868
4  0x7fff6da18cc9  start + 1
A linker snapshot was created at:
	/tmp/libr_ar.a.a.o-2020-06-22-084259.ld-snapshot
ld: Assertion failed: (0 && "unknown objc arch"), function doPass, file /Library/Caches/com.apple.xbs/Sources/ld64/ld64-530/src/ld/passes/objc.cpp, line 1747.
ld: warning: platform not specified
ld: warning: -arch not specified
ld: warning: ignoring file bochs/lib/libbochs.a, building for macOS-unknown but attempting to link with file built for macOS-x86_64
0  0x10f08c0d8  __assert_rtn + 127
1  0x10f0960b5  ld::passes::objc::fixClassAliases(ld::Atom const*) (.cold.1) + 0
2  0x10f067930  void ld::passes::objc::doPass<x86_64, true>(Options const&, ld::Internal&) + 0
3  0x10ef6ee2e  main + 868
A linker snapshot was created at:
	/tmp/libbochs.a.a.o-2020-06-22-084259.ld-snapshot
ld: Assertion failed: (0 && "unknown objc arch"), function doPass, file /Library/Caches/com.apple.xbs/Sources/ld64/ld64-530/src/ld/passes/objc.cpp, line 1747.
ld: warning: platform not specified
ld: warning: -arch not specified
ld: warning: ignoring file gdb/lib/libgdbr.a, building for macOS-unknown but attempting to link with file built for macOS-x86_64
0  0x10bc020d8  __assert_rtn + 127
1  0x10bc0c0b5  ld::passes::objc::fixClassAliases(ld::Atom const*) (.cold.1) + 0
2  0x10bbdd930  void ld::passes::objc::doPass<x86_64, true>(Options const&, ld::Internal&) + 0
3  0x10bae4e2e  main + 868
A linker snapshot was created at:
	/tmp/libgdbr.a.a.o-2020-06-22-084259.ld-snapshot
ld: Assertion failed: (0 && "unknown objc arch"), function doPass, file /Library/Caches/com.apple.xbs/Sources/ld64/ld64-530/src/ld/passes/objc.cpp, line 1747.
ld: warning: platform not specified
ld: warning: -arch not specified
ld: warning: ignoring file grub/libgrubfs.a, building for macOS-unknown but attempting to link with file built for macOS-x86_64
0  0x101d1e0d8  __assert_rtn + 127
1  0x101d280b5  ld::passes::objc::fixClassAliases(ld::Atom const*) (.cold.1) + 0
2  0x101cf9930  void ld::passes::objc::doPass<x86_64, true>(Options const&, ld::Internal&) + 0
3  0x101c00e2e  main + 868
A linker snapshot was created at:
	/tmp/libgrubfs.a.a.o-2020-06-22-084259.ld-snapshot
ld: Assertion failed: (0 && "unknown objc arch"), function doPass, file /Library/Caches/com.apple.xbs/Sources/ld64/ld64-530/src/ld/passes/objc.cpp, line 1747.
ld: warning: platform not specified
ld: warning: -arch not specified
ld: warning: ignoring file java/libr_java.a, building for macOS-unknown but attempting to link with file built for macOS-x86_64
0  0x1009ad0d8  __assert_rtn + 127
1  0x1009b70b5  ld::passes::objc::fixClassAliases(ld::Atom const*) (.cold.1) + 0
2  0x100988930  void ld::passes::objc::doPass<x86_64, true>(Options const&, ld::Internal&) + 0
3  0x10088fe2e  main + 868
A linker snapshot was created at:
	/tmp/libr_java.a.a.o-2020-06-22-084259.ld-snapshot
ld: Assertion failed: (0 && "unknown objc arch"), function doPass, file /Library/Caches/com.apple.xbs/Sources/ld64/ld64-530/src/ld/passes/objc.cpp, line 1747.
ld: warning: platform not specified
ld: warning: -arch not specified
ld: warning: ignoring file qnx/lib/libqnxr.a, building for macOS-unknown but attempting to link with file built for macOS-x86_64
0  0x105b2b0d8  __assert_rtn + 127
1  0x105b350b5  ld::passes::objc::fixClassAliases(ld::Atom const*) (.cold.1) + 0
2  0x105b06930  void ld::passes::objc::doPass<x86_64, true>(Options const&, ld::Internal&) + 0
3  0x105a0de2e  main + 868
A linker snapshot was created at:
	/tmp/libqnxr.a.a.o-2020-06-22-084259.ld-snapshot
ld: Assertion failed: (0 && "unknown objc arch"), function doPass, file /Library/Caches/com.apple.xbs/Sources/ld64/ld64-530/src/ld/passes/objc.cpp, line 1747.
ld: warning: platform not specified
ld: warning: -arch not specified
ld: warning: ignoring file yxml/libyxml.a, building for macOS-unknown but attempting to link with file built for macOS-x86_64
0  0x10199e0d8  __assert_rtn + 127
1  0x1019a80b5  ld::passes::objc::fixClassAliases(ld::Atom const*) (.cold.1) + 0
2  0x101979930  void ld::passes::objc::doPass<x86_64, true>(Options const&, ld::Internal&) + 0
3  0x101880e2e  main + 868
4  0x7fff6da18cc9  start + 1
A linker snapshot was created at:
	/tmp/libyxml.a.a.o-2020-06-22-084259.ld-snapshot
ld: Assertion failed: (0 && "unknown objc arch"), function doPass, file /Library/Caches/com.apple.xbs/Sources/ld64/ld64-530/src/ld/passes/objc.cpp, line 1747.
ld: warning: platform not specified
ld: warning: -arch not specified
ld: warning: ignoring file windbg/libr_windbg.a, building for macOS-unknown but attempting to link with file built for macOS-x86_64
0  0x10f7600d8  __assert_rtn + 127
1  0x10f76a0b5  ld::passes::objc::fixClassAliases(ld::Atom const*) (.cold.1) + 0
2  0x10f73b930  void ld::passes::objc::doPass<x86_64, true>(Options const&, ld::Internal&) + 0
3  0x10f642e2e  main + 868
4  0x7fff6da18cc9  start + 1
A linker snapshot was created at:
	/tmp/libr_windbg.a.a.o-2020-06-22-084259.ld-snapshot
ld: Assertion failed: (0 && "unknown objc arch"), function doPass, file /Library/Caches/com.apple.xbs/Sources/ld64/ld64-530/src/ld/passes/objc.cpp, line 1747.
ar crs libr_shlr.a .libr/*.o
ar: .libr/*.o: No such file or directory
make[1]: *** [libr_shlr.a] Error 1
make[1]: Leaving directory `/opt/macports-test/var/macports/build/_Users_herby_Source_macports-ports_devel_radare2/radare2/work/radareorg-radare2-9d7eda5/shlr'
make: *** [install] Error 2
make: Leaving directory `/opt/macports-test/var/macports/build/_Users_herby_Source_macports-ports_devel_radare2/radare2/work/radareorg-radare2-9d7eda5'
Command failed:  cd "/opt/macports-test/var/macports/build/_Users_herby_Source_macports-ports_devel_radare2/radare2/work/radare2-4.5.0" && /usr/bin/make -w install DESTDIR=/opt/macports-test/var/macports/build/_Users_herby_Source_macports-ports_devel_radare2/radare2/work/destroot
Exit code: 2
Error: Failed to destroot radare2: command execution failed
DEBUG: Error code: CHILDSTATUS 21760 2
DEBUG: Backtrace: command execution failed
    while executing
"system {*}$notty {*}$nice $fullcmdstring"
    invoked from within
"command_exec destroot"
    (procedure "portdestroot::destroot_main" line 2)
    invoked from within
"$procedure $targetname"
Error: See /opt/macports-test/var/macports/logs/_Users_herby_Source_macports-ports_devel_radare2/radare2/main.log for details.
Error: Follow https://guide.macports.org/#project.tickets to report a bug.
Error: Processing of port radare2 failed
```

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
