### PR TITLE
Cmake 3.18 fixes

### DIFF
--- a/devel/cmake/Portfile
+++ b/devel/cmake/Portfile
@@ -42,7 +42,7 @@ if {${subport} eq ${name}} {
     checksums rmd160 a96e04ae896f7255aa7a807a519624d1cc6482ef \
               sha256 757c9644ec8b0d1a0fbeb5d48743f615efd2861571be40b659e3cca21ffb9105 \
               size   6951421
-    revision  0
+    revision  1
 
     compiler.cxx_standard 2011
 
@@ -56,8 +56,10 @@ if {${subport} eq ${name}} {
 
     # OSX <= 10.11 does not provide "clock_gettime"
     legacysupport.newest_darwin_requires_legacy 15
+
     # see https://trac.macports.org/ticket/59832
-    legacysupport.redirect_bins cmake
+    # see https://trac.macports.org/ticket/60885
+    legacysupport.redirect_bins cmake ccmake cpack ctest
 
     long_description ${base_long_description} \
         The ${subport} release port is updated roughly every few months.

--- a/devel/cmake/Portfile
+++ b/devel/cmake/Portfile
@@ -135,6 +135,12 @@ if {${subport} eq ${name}} {
             configure.cflags-append -fpermissive
             configure.cxxflags-append -fpermissive
         }
+
+        if {${os.major} >= 11 && ${os.major} <= 12} {
+            # some functions in xlocale.h are hidden without this define
+            # https://trac.macports.org/ticket/60885
+            configure.cxxflags-append -D_DARWIN_C_SOURCE
+        }
     }
 
     # jsoncpp 1.0+ requires CMake for building; circular dependencies


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.7
Xcode 4.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

Needs building on 10.4, 10.5, 10.7, 10.8 to triple check, but this should do it.