### PR TITLE
chromedriver: update to 84.0.4147.30

### DIFF
--- a/www/chromedriver/Portfile
+++ b/www/chromedriver/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                chromedriver
-version             83.0.4103.39
+version             84.0.4147.30
 categories          www
 platforms           darwin
 maintainers         nomaintainer
@@ -42,9 +42,9 @@ destroot {
 set latest_major_version \
                     [lindex [split ${version} .] 0]
 
-checksums           rmd160  b894f547fe802306b59ebacff8e113f0f35c0e41 \
-                    sha256  d902d4b3e77e466102ebfe25e13a25798b473655461fa3e928268faf6fc7fef6 \
-                    size    7204839
+checksums           rmd160  beb65c30aa0fca8ab028e0b61081c5aeec8e1850 \
+                    sha256  1bed996247f5f93eed28110927a10b45f01a7deeda4ab1b1acfd6bb66784acc5 \
+                    size    7332572
 
 if {${subport} eq ${name}} {
     conflicts       ${name}-${latest_major_version}
@@ -57,6 +57,19 @@ subport ${name}-${latest_major_version} {
             ${prefix}/bin/${name}-${latest_major_version} \
             ${destroot}${prefix}/bin/chromedriver
     }
+}
+
+subport ${name}-83 {
+    version         83.0.4103.39
+
+
+    checksums       rmd160  b894f547fe802306b59ebacff8e113f0f35c0e41 \
+                    sha256  d902d4b3e77e466102ebfe25e13a25798b473655461fa3e928268faf6fc7fef6 \
+                    size    7204839
+
+    master_sites    https://chromedriver.storage.googleapis.com/${version}/
+    dist_subdir     ${name}/${version}
+    livecheck.type  none
 }
 
 subport ${name}-81 {
@@ -98,7 +111,7 @@ subport ${name}-79 {
 subport ${name}-78 {
     version         78.0.3904.70
 
-    # This subport can be removed on September 8, 2020. 
+    # This subport can be removed on September 8, 2020.
     PortGroup       obsolete 1.0
 
     distfiles


### PR DESCRIPTION
#### Description

Update chromedriver to 84.0.4147.30

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F96
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
