### PR TITLE
dijo: new port

### DIFF
--- a/office/dijo/Portfile
+++ b/office/dijo/Portfile
@@ -1,0 +1,142 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo 1.0
+
+github.setup        NerdyPepper dijo 0.2.2 v
+
+categories          office
+platforms           darwin
+license             MIT
+
+description         scriptable, curses-based, digital habit tracker
+
+long_description    dijo is a habit tracker. It is curses-based, it runs in \
+                    your terminal. dijo is scriptable, hook it up with \
+                    external programs to track events without moving a \
+                    finger. dijo is modal, much like a certain text editor.
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  6cd730e41d40b83dba42637ad801227d7c5b23d7 \
+                    sha256  fb5b6ccc5cbe525016492f3d85085e060dac4e02c1893c4d8cafc50e0c0016b3 \
+                    size    21332
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/${name} ${destroot}${prefix}/bin/
+}
+
+cargo.crates \
+    ahash                            0.3.8  e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217 \
+    ahash                            0.4.3  b5b1d27b53c9b0be4ee14c0777359f77f39e7d6d127b07a9f60fdd43850f8ec3 \
+    ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
+    arc-swap                         0.4.7  4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034 \
+    array-macro                      1.0.5  06e97b4e522f9e55523001238ac59d13a8603af57f69980de5d8de4bbbe8ada6 \
+    arrayref                         0.3.6  a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544 \
+    arrayvec                         0.5.1  cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8 \
+    atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+    autocfg                          1.0.0  f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d \
+    base64                          0.11.0  b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7 \
+    bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
+    blake2b_simd                    0.5.10  d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a \
+    cc                              1.0.58  f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518 \
+    cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
+    chrono                          0.4.13  c74d84029116787153e02106bf53e66828452a4b325cc8652b788b5967c0a0b6 \
+    clap                            2.33.1  bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129 \
+    const-random                     0.1.8  2f1af9ac737b2dd2d577701e59fd09ba34822f6f2ebdb30a7647405d9e55e16a \
+    const-random-macro               0.1.8  25e4c606eb459dd29f7c57b2e0879f2b6f14ee130918c2b78ccb58a9624e6c7a \
+    constant_time_eq                 0.1.5  245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc \
+    crossbeam-channel                0.4.3  09ee0cc8804d5393478d743b035099520087a5186f3b93fa58cec08fa62407b6 \
+    crossbeam-utils                  0.7.2  c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8 \
+    ctor                            0.1.15  39858aa5bac06462d4dd4b9164848eb81ffc4aa5c479746393598fd193afa227 \
+    cursive                         0.15.0  7a9f12332ab2bca26979ef00cfef9a1c2e287db03b787a83d892ad9961f81374 \
+    cursive_core                     0.1.1  85fc5b6a8ba2f1bc743892068bde466438f78d6247197e2dc094bfd53fdea4b7 \
+    darling                         0.10.2  0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858 \
+    darling_core                    0.10.2  f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b \
+    darling_macro                   0.10.2  d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72 \
+    directories                      3.0.1  f8fed639d60b58d0f53498ab13d26f621fd77569cc6edb031f4cc36a2ad9da0f \
+    dirs-sys                         0.3.5  8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a \
+    enum-map                         0.6.2  70a375f899a53b9848ad9fb459b5bf90e4851ae5d9fea89134b062dc1828b26e \
+    enum-map-derive                  0.4.3  e57001dfb2532f5a103ff869656887fae9a8defa7d236f3e39d2ee86ed629ad7 \
+    enumset                          1.0.0  3691ce759534316ad900d57dd8e688e2c4263f9750c0f7c1e9b9a4516d4ca241 \
+    enumset_derive                   0.5.0  74bef436ac71820c5cf768d7af9ba33121246b09a00e09a55d94ef8095a875ac \
+    erased-serde                    0.3.12  6ca8b296792113e1500fd935ae487be6e00ce318952a6880555554824d6ebf38 \
+    filetime                        0.2.10  affc17579b132fc2461adf7c575cc6e8b134ebca52c51f5411388965227dc695 \
+    fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
+    fsevent                          0.4.0  5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6 \
+    fsevent-sys                      2.0.1  f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0 \
+    fuchsia-zircon                   0.3.3  2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
+    fuchsia-zircon-sys               0.3.3  3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
+    getrandom                       0.1.14  7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb \
+    ghost                            0.1.2  1a5bcf1bbeab73aa4cf2fde60a846858dc036163c7c33bec309f8d17de785479 \
+    hermit-abi                      0.1.15  3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9 \
+    ident_case                       1.0.1  b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39 \
+    inotify                          0.7.1  4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f \
+    inotify-sys                      0.1.3  e74a1aa87c59aeff6ef2cc2fa62d41bc43f54952f55652656b18a02fd5e356c0 \
+    inventory                        0.1.7  621b50c176968fd3b0bd71f821a28a0ea98db2b5aea966b2fbb8bd1b7d310328 \
+    inventory-impl                   0.1.7  f99a4111304bade76468d05beab3487c226e4fe4c4de1c4e8f006e815762db73 \
+    iovec                            0.1.4  b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e \
+    itoa                             0.4.6  dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6 \
+    kernel32-sys                     0.2.2  7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    lazycell                         1.2.1  b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f \
+    libc                            0.2.73  bd7d4bd64732af4bf3a67f367c27df8520ad7e230c5817b8ff485864d80242b9 \
+    log                             0.4.11  4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b \
+    maplit                           1.0.2  3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d \
+    mio                             0.6.22  fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430 \
+    mio-extras                       2.0.6  52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19 \
+    miow                             0.2.1  8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919 \
+    ncurses                         5.99.0  15699bee2f37e9f8828c7b35b2bc70d13846db453f2d507713b758fabe536b82 \
+    net2                            0.2.34  2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7 \
+    notify                          4.0.15  80ae4a7688d1fab81c5bf19c64fc8db920be8d519ce6336ed4e7efe024724dbd \
+    num                              0.3.0  ab3e176191bc4faad357e3122c4747aa098ac880e88b168f106386128736cf4a \
+    num-complex                      0.3.0  b05ad05bd8977050b171b3f6b48175fea6e0565b7981059b486075e1026a9fb5 \
+    num-integer                     0.1.43  8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b \
+    num-iter                        0.1.41  7a6e6b7c748f995c4c29c5f5ae0248536e04a5739927c74ec0fa564805094b9f \
+    num-rational                     0.3.0  a5b4d7360f362cfb50dde8143501e6940b22f644be75a4cc90b2d81968908138 \
+    num-traits                      0.2.12  ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611 \
+    owning_ref                       0.4.1  6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce \
+    pancurses                       0.16.1  d3058bc37c433096b2ac7afef1c5cdfae49ede0a4ffec3dfc1df1df0959d0ff0 \
+    pdcurses-sys                     0.7.1  084dd22796ff60f1225d4eb6329f33afaf4c85419d51d440ab6b8c6f4529166b \
+    pkg-config                      0.3.18  d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33 \
+    proc-macro-hack                 0.5.16  7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4 \
+    proc-macro2                     1.0.19  04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12 \
+    quote                            1.0.7  aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37 \
+    redox_syscall                   0.1.57  41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce \
+    redox_users                      0.3.4  09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431 \
+    rust-argon2                      0.7.0  2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017 \
+    ryu                              1.0.5  71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e \
+    same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
+    serde                          1.0.114  5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3 \
+    serde_derive                   1.0.114  2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e \
+    serde_json                      1.0.56  3433e879a558dde8b5e8feb2a04899cf34fdde1fafb894687e52105fc1162ac3 \
+    signal-hook                     0.1.16  604508c1418b99dfe1925ca9224829bb2a8a9a04dda655cc01fcad46f4ab05ed \
+    signal-hook-registry             1.2.0  94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41 \
+    slab                             0.4.2  c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8 \
+    stable_deref_trait               1.2.0  a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3 \
+    strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
+    strsim                           0.9.3  6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c \
+    syn                             1.0.35  fb7f4c519df8c117855e19dd8cc851e89eb746fe7a73f0157e0d95fdec5369b0 \
+    term_size                        0.3.2  1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9 \
+    textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
+    time                            0.1.43  ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438 \
+    typetag                          0.1.5  9275125decb5d75fe57ebfe92debd119b15757aae27c56d7cb61ecab871960bc \
+    typetag-impl                     0.1.5  dc232cda3b1d82664153e6c95d1071809aa0f1011f306c3d6989f33d8c6ede17 \
+    unicode-segmentation             1.6.0  e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0 \
+    unicode-width                    0.1.8  9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3 \
+    unicode-xid                      0.2.1  f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564 \
+    vec_map                          0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
+    walkdir                          2.3.1  777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d \
+    wasi      0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
+    winapi                           0.2.8  167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
+    winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
+    winapi-build                     0.1.1  2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                      0.1.5  70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    winreg                           0.5.1  a27a759395c1195c4cc5cda607ef6f8f6498f64e78f7900f5de0a127a424704a \
+    ws2_32-sys                       0.2.1  d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e \
+    xi-unicode                       0.2.1  e71b85d8b1b8bfaf4b5c834187554d201a8cd621c2bbfa33efd41a3ecabd48b2


### PR DESCRIPTION
#### Description

New port for [dijo](https://github.com/NerdyPepper/dijo), a command-line habit tracker.

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
