### PR TITLE
influxdb: new port

### DIFF
--- a/sysutils/influxdb/Portfile
+++ b/sysutils/influxdb/Portfile
@@ -1,0 +1,129 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                1.0
+PortGroup                 github 1.0
+
+github.setup              influxdata influxdb 1.8.1 v
+
+categories                sysutils net
+platforms                 darwin
+supported_archs           x86_64 i386
+license                   MIT
+
+homepage                  https://influxdata.com/
+
+description               Scalable datastore for metrics, events, and \
+                          real-time analytics
+
+long_description          InfluxDB is an open source time series platform. \
+                          This includes APIs for storing and querying data, \
+                          processing it in the background for ETL, monitoring \
+                          and/or alerting purposes, user dashboards, \
+                          visualizing and exploring the data and more.
+
+maintainers               {gmail.com:herby.gillot @herbygillot} \
+                          openmaintainer
+
+# Build script (build.py) requires a git checkout
+fetch.type                git
+
+depends_build             port:go \
+                          port:python38
+
+set influxdb_user         ${name}
+set influxdb_conf_dir     ${prefix}/etc/${name}
+set influxdb_data_dir     ${prefix}/var/db/${name}
+set influxdb_log_dir      ${prefix}/var/log/${name}
+set influxdb_share_dir    ${prefix}/share/${name}
+
+set influxdb_conf_file    ${influxdb_conf_dir}/config.toml
+set influxdb_conf_sample  ${influxdb_share_dir}/config.sample.toml
+set influxdb_log_file     ${influxdb_log_dir}/influxdb.log
+set influxdb_plist_src    ${workpath}/org.macports.${name}.plist
+
+installs_libs             no
+use_configure             no
+
+add_users                 ${influxdb_user} \
+                          group=${influxdb_user} \
+                          realname=InfluxDB
+
+switch ${build_arch} {
+    i386                  { set goarch 386 }
+    x86_64                { set goarch amd64 }
+}
+
+build.env                 GOPATH=${workpath} \
+                          PATH=${workpath}/bin:$env(PATH)
+
+build.cmd                 python3.8 ./build.py
+build.pre_args            --arch ${goarch} \
+                          --platform darwin \
+                          --version ${version} \
+                          --parallel ${build.jobs}
+build.args                --release
+
+post-extract {
+    copy ${filespath}/org.macports.influxdb.plist ${influxdb_plist_src}
+
+    reinplace "s|/var/lib/influxdb|${influxdb_data_dir}|g" \
+              ${worksrcpath}/etc/config.sample.toml
+
+    reinplace "s|@NAME@|${name}|g"                    ${influxdb_plist_src}
+    reinplace "s|@USER@|${influxdb_user}|g"           ${influxdb_plist_src}
+    reinplace "s|@GROUP@|${influxdb_user}|g"          ${influxdb_plist_src}
+    reinplace "s|@PREFIX@|${prefix}|g"                ${influxdb_plist_src}
+    reinplace "s|@CONF_FILE@|${influxdb_conf_file}|g" ${influxdb_plist_src}
+    reinplace "s|@LOGFILE@|${influxdb_log_file}|g"    ${influxdb_plist_src}
+}
+
+destroot {
+
+    copy {*}[glob ${worksrcpath}/build/*] ${destroot}${prefix}/bin/
+
+    xinstall  -d -m 755 ${destroot}${influxdb_conf_dir}
+    xinstall  -d -m 755 ${destroot}${influxdb_share_dir}
+    xinstall  -d -m 755 -o ${influxdb_user} -g ${influxdb_user} \
+              ${destroot}${influxdb_data_dir}
+    xinstall  -d -m 755 -g ${influxdb_user} ${destroot}${influxdb_log_dir}
+
+    copy  ${worksrcpath}/etc/config.sample.toml \
+          ${destroot}${influxdb_conf_sample}
+
+    touch ${destroot}${influxdb_log_file}
+    file attributes ${destroot}${influxdb_log_file} -owner ${influxdb_user}
+
+    xinstall -d -m 755 \
+        ${destroot}${prefix}/etc/LaunchDaemons/org.macports.${name}
+
+    xinstall -m 0644 -o root -W ${workpath} org.macports.${name}.plist \
+        ${destroot}${prefix}/etc/LaunchDaemons/org.macports.${name}
+
+    xinstall -d -m 755 ${destroot}/Library/LaunchDaemons
+
+    ln -s ${prefix}/etc/LaunchDaemons/org.macports.${name}/org.macports.${name}.plist \
+        ${destroot}/Library/LaunchDaemons/org.macports.${name}.plist
+}
+
+destroot.keepdirs-append  ${destroot}${influxdb_conf_dir} \
+                          ${destroot}${influxdb_data_dir}
+
+post-activate {
+
+    if {![file exists ${influxdb_conf_file}]} {
+        copy ${influxdb_conf_sample} ${influxdb_conf_file}
+    }
+}
+
+notes "
+To start the InfluxDB service, use `port load`:
+
+    \$ sudo port load ${name}
+    \$ influx
+
+`port unload` will stop and remove the service:
+
+    \$ sudo port unload ${name}
+"
+
+github.livecheck.regex {([0-9.]+)}

--- a/sysutils/influxdb/files/org.macports.influxdb.plist
+++ b/sysutils/influxdb/files/org.macports.influxdb.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>org.macports.@NAME@</string>
+    <key>ProcessType</key>
+    <string>Interactive</string>
+    <key>Disabled</key>
+    <false/>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>SessionCreate</key>
+    <true/>
+    <key>LaunchOnlyOnce</key>
+    <false/>
+    <key>UserName</key>
+    <string>@USER@</string>
+    <key>GroupName</key>
+    <string>@GROUP@</string>
+    <key>ExitTimeOut</key>
+    <integer>600</integer>
+    <key>ProgramArguments</key>
+        <array>
+            <string>@PREFIX@/bin/influxd</string>
+            <string>run</string>
+            <string>-config</string>
+            <string>@CONF_FILE@</string>
+        </array>
+    <key>StandardErrorPath</key>
+    <string>@LOGFILE@</string>
+    <key>StandardOutPath</key>
+    <string>@LOGFILE@</string>
+</dict>
+</plist>


### PR DESCRIPTION
#### Description

New port for the [InfluxDB](https://www.influxdata.com/products/influxdb-overview/) 1.x time series database from [Influxdata](https://www.influxdata.com/)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
