### PR TITLE
telegraf: new port

### DIFF
--- a/net/telegraf/Portfile
+++ b/net/telegraf/Portfile
@@ -1,0 +1,122 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                1.0
+PortGroup                 github 1.0
+
+github.setup              influxdata telegraf 1.15.1 v
+
+categories                net sysutils
+platforms                 darwin
+license                   MIT
+
+description               The plugin-driven server agent for collecting & \
+                          reporting metrics.
+
+long_description          Telegraf is an agent for collecting, processing, \
+                          aggregating, and writing metrics.  Design goals are \
+                          to have a minimal memory footprint with a plugin \
+                          system so that developers in the community can \
+                          easily add support for collecting metrics. Telegraf \
+                          is plugin-driven and has the concept of 4 distinct \
+                          plugin types: input plugins, processor plugins, \
+                          aggregator plugins, and output plugins.
+
+maintainers               {gmail.com:herby.gillot @herbygillot} \
+                          openmaintainer
+
+# Build process wants git checkout
+fetch.type                git
+
+depends_build             port:go
+
+set telegraf_user         ${name}
+set telegraf_conf_dir     ${prefix}/etc/${name}
+set telegraf_data_dir     ${prefix}/var/db/${name}
+set telegraf_lib_dir      ${prefix}/lib/${name}
+set telegraf_log_dir      ${prefix}/var/log/${name}
+set telegraf_run_dir      ${prefix}/var/run/${name}
+
+set telegraf_conf_file    ${telegraf_conf_dir}/telegraf.conf
+set telegraf_log_file     ${telegraf_log_dir}/telegraf.log
+set telegraf_pid_file     ${telegraf_run_dir}/telegraf.pid
+set telegraf_plist_src    ${workpath}/org.macports.${name}.plist
+
+installs_libs             no
+use_configure             no
+
+add_users                 ${telegraf_user} \
+                          group=${telegraf_user} \
+                          realname=Telegraf
+
+build.env                 GOPATH=${workpath} \
+                          PATH=${workpath}/bin:$env(PATH)
+build.target              all
+
+post-extract {
+
+    reinplace "s|/etc/telegraf/telegraf.conf|${telegraf_conf_file}|g" \
+              ${worksrcpath}/config/config.go
+
+    copy ${filespath}/org.macports.${name}.plist      ${telegraf_plist_src}
+    reinplace "s|@NAME@|${name}|g"                    ${telegraf_plist_src}
+    reinplace "s|@USER@|${name}|g"                    ${telegraf_plist_src}
+    reinplace "s|@GROUP@|${name}|g"                   ${telegraf_plist_src}
+    reinplace "s|@PREFIX@|${prefix}|g"                ${telegraf_plist_src}
+    reinplace "s|@CONF_DIR@|${telegraf_conf_dir}|g"   ${telegraf_plist_src}
+    reinplace "s|@PID_FILE@|${telegraf_pid_file}|g"   ${telegraf_plist_src}
+    reinplace "s|@LOGFILE@|${telegraf_log_file}|g"    ${telegraf_plist_src}
+}
+
+destroot {
+
+    copy ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+
+    xinstall  -d -m 755 ${telegraf_conf_dir}
+    xinstall  -d -m 755 -g ${telegraf_user} ${telegraf_log_dir}
+
+    xinstall  -d -m 755 -o ${telegraf_user} -g ${telegraf_user} \
+              ${telegraf_data_dir}
+
+    xinstall  -d -m 755 -o ${telegraf_user} -g ${telegraf_user} \
+              ${telegraf_lib_dir}
+
+    xinstall  -d -m 755 -o ${telegraf_user} -g ${telegraf_user} \
+              ${telegraf_run_dir}
+
+    touch ${telegraf_log_file}
+    file  attributes ${telegraf_log_file} -owner ${telegraf_user} \
+          -group ${telegraf_user}
+
+    xinstall -d -m 755 \
+        ${destroot}${prefix}/etc/LaunchDaemons/org.macports.${name}
+
+    xinstall -m 0644 -o root -W ${workpath} org.macports.${name}.plist \
+        ${destroot}${prefix}/etc/LaunchDaemons/org.macports.${name}
+
+    xinstall -d -m 755 ${destroot}/Library/LaunchDaemons
+
+    ln -s ${prefix}/etc/LaunchDaemons/org.macports.${name}/org.macports.${name}.plist \
+        ${destroot}/Library/LaunchDaemons/org.macports.${name}.plist
+}
+
+destroot.keepdirs-append  ${destroot}${telegraf_conf_dir} \
+                          ${destroot}${telegraf_data_dir} \
+                          ${destroot}${telegraf_lib_dir} \
+                          ${destroot}${telegraf_run_dir}
+
+post-activate {
+
+    if {![file exists ${telegraf_conf_file}]} {
+        system "telegraf config > ${telegraf_conf_file}"
+    }
+}
+
+notes "
+To start the Telegraf service, use `port load`: \$ sudo port load ${name}
+
+Once running, the service will log to: ${telegraf_log_file}
+
+Stop and remove the service with: \$ sudo port unload ${name}
+"
+
+github.livecheck.regex {([0-9.]+)}

--- a/net/telegraf/files/org.macports.telegraf.plist
+++ b/net/telegraf/files/org.macports.telegraf.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>org.macports.@NAME@</string>
+    <key>ProcessType</key>
+    <string>Interactive</string>
+    <key>Disabled</key>
+    <false/>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>SessionCreate</key>
+    <true/>
+    <key>LaunchOnlyOnce</key>
+    <false/>
+    <key>UserName</key>
+    <string>@USER@</string>
+    <key>GroupName</key>
+    <string>@GROUP@</string>
+    <key>ExitTimeOut</key>
+    <integer>600</integer>
+    <key>ProgramArguments</key>
+        <array>
+            <string>@PREFIX@/bin/telegraf</string>
+            <string>--config-directory</string>
+            <string>@CONF_DIR@</string>
+            <string>--pidfile</string>
+            <string>@PID_FILE@</string>
+        </array>
+    <key>StandardErrorPath</key>
+    <string>@LOGFILE@</string>
+    <key>StandardOutPath</key>
+    <string>@LOGFILE@</string>
+</dict>
+</plist>


### PR DESCRIPTION
#### Description

New port for Influxdata's [Telegraf](https://www.influxdata.com/time-series-platform/telegraf/)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
