### PR TITLE
rancid: update to 3.12

### DIFF
--- a/net/rancid/Portfile
+++ b/net/rancid/Portfile
@@ -4,8 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 name                rancid
-version             3.9
-revision            2
+version             3.12
 categories          net
 license             BSD-old
 maintainers         nomaintainer
@@ -20,9 +19,9 @@ long_description    Rancid maintains a CVS/SVN/git repository of router and \
 homepage            https://www.shrubbery.net/${name}
 master_sites        ftp://ftp.shrubbery.net/pub/rancid/
 
-checksums           rmd160  dfbc131246707b06e93b1432ca431a33eff35d6f \
-                    sha256  9db9ba5026c2acae99713c6ee00f8186ea9d14eb2b902dabf40525025e0b1188 \
-                    size    515946
+checksums           rmd160  21d3990c283a425cbbbbe13f7b21be537ff3d893 \
+                    sha256  b1c1415d16ac291e29ff356a3c4f688160f07f1a091869290a95cd1793d4d3fb \
+                    size    522382
 
 perl5.branches      5.28
 depends_lib-append  port:perl${perl5.major} \


### PR DESCRIPTION
#### Description

Update to upstream version 3.12

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G6020
Xcode 11.3.1 11C504

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
