### PR TITLE
grpcurl: new port

### DIFF
--- a/devel/grpcurl/Portfile
+++ b/devel/grpcurl/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/fullstorydev/grpcurl 1.6.1 v
+
+categories          devel net
+license             MIT
+
+description         Like cURL, but for gRPC: Command-line tool for \
+                    interacting with gRPC servers
+
+long_description    {*}${description}. The main purpose for this tool is to \
+                    invoke RPC methods on a gRPC server from the \
+                    command-line. gRPC servers use a binary encoding on the \
+                    wire (protocol buffers, or "protobufs" for short). So \
+                    they are basically impossible to interact with using \
+                    regular curl (and older versions of curl that do not \
+                    support HTTP/2 are of course non-starters). This program \
+                    accepts messages using JSON encoding, which is much more \
+                    friendly for both humans and scripts.
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  c2ecf511a22cc49a47bfdcbc2f7cf748eb194f56 \
+                    sha256  eeced70e06fb1357a66ce73ebb338f7ed32ec8105419b4153689c8203d581f86 \
+                    size    122496
+
+build.pre_args      -ldflags \"-X 'main.version=${version}'\"
+build.args          ./cmd/grpcurl
+installs_libs       no
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}
+
+github.livecheck.regex {([0-9.]+)}


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
