### PR TITLE
dash: update to 0.5.11.1

### DIFF
--- a/shells/dash/Portfile
+++ b/shells/dash/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                dash
-version             0.5.10.2
+version             0.5.11.1
 categories          shells
 license             GPL-2+
 platforms           darwin
@@ -16,9 +16,13 @@ long_description    DASH is a direct descendant of the NetBSD version of ash \
 homepage            http://gondor.apana.org.au/~herbert/dash
 
 master_sites        ${homepage}/files/
-checksums           rmd160  78c61d0a2caea6c1053965608a2083e1b3ab872b \
-                    sha256  3c663919dc5c66ec991da14c7cf7e0be8ad00f3db73986a987c118862b5f6071 \
-                    size    225196
+checksums           rmd160  361ebf870d55287264a0b3a68d702df5aa4a298f \
+                    sha256  73c881f146e329ac54962766760fd62cb8bdff376cd6c2f5772eecc1570e1611 \
+                    size    244439
+
+patchfiles          0001-fix-dirent64-et-al-on-darwin.patch
+
+use_autoreconf      yes
 
 livecheck.url       [lindex ${master_sites} 0]
 livecheck.regex     ${name}-(\\d+(\\.\\d+)+)${extract.suffix}

--- a/shells/dash/files/0001-fix-dirent64-et-al-on-darwin.patch
+++ b/shells/dash/files/0001-fix-dirent64-et-al-on-darwin.patch
@@ -1,0 +1,41 @@
+From 7e75779eaeacdbb46a387a59d9aaf1481a1da3e5 Mon Sep 17 00:00:00 2001
+From: Adrian Gierakowski <agierakowski@gmail.com>
+Date: Sun, 19 Jul 2020 08:38:05 +0100
+Subject: [PATCH] fix dirent64 et al on darwin
+
+---
+ configure.ac | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/configure.ac b/configure.ac
+index b8faca9..cee1e4d 100644
+--- configure.ac
++++ configure.ac
+@@ -139,6 +139,7 @@ if test "$ac_cv_func_signal" != yes; then
+ 				 [klibc has bsd_signal instead of signal])])
+ fi
+ 
++dnl TODO: stat64 is deprecated since macOS 10.6
+ dnl Check for stat64 (dietlibc/klibc).
+ AC_CHECK_FUNC(stat64,, [
+ 	AC_DEFINE(fstat64, fstat, [64-bit operations are the same as 32-bit])
+@@ -155,6 +156,16 @@ AC_CHECK_FUNC(open64,, [
+ 	AC_DEFINE(open64, open, [64-bit operations are the same as 32-bit])
+ ])
+ 
++dnl OS X apparently has stat64 but not readdir64.
++AC_CHECK_FUNC(readdir64,, [
++	AC_DEFINE(readdir64, readdir, [64-bit operations are the same as 32-bit])
++])
++
++dnl OS X apparently has stat64 but not dirent64.
++AC_CHECK_TYPE(struct dirent64,, [
++	AC_DEFINE(dirent64, dirent, [64-bit operations are the same as 32-bit])
++],[#include <dirent.h>])
++
+ dnl Check if struct stat has st_mtim.
+ AC_MSG_CHECKING(for stat::st_mtim)
+ AC_COMPILE_IFELSE(
+-- 
+2.15.1
+


### PR DESCRIPTION
#### Description

Update to 0.5.11.1.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
