### PR TITLE
zettlr: update to 1.7.2

### DIFF
--- a/aqua/zettlr/Portfile
+++ b/aqua/zettlr/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        Zettlr Zettlr 1.7.1 v
+github.setup        Zettlr Zettlr 1.7.2 v
 name                zettlr
 revision            0
 
@@ -32,9 +32,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  48c385ecb3bd12504a7e3f5f70f502b3e0daa912 \
-                    sha256  587e035ad9d8b7f93ae9a22e490c91ad03a8f192df30f6945a25e43fdfc454aa \
-                    size    28211660
+                    rmd160  51ed4c348e53b2e7f7cad7096ed089d779e37e93 \
+                    sha256  6b3d18a92f6a394c53b418eb69888d614b4a62315e6bd42340bb253fcdc45c4b \
+                    size    28197308
 
 set ab_bin_commit   b85740334fec875f5dd8dcd22eb1f729599109db
 
@@ -51,10 +51,10 @@ build {
     system -W ${worksrcpath}        "${build.env} yarn install --frozen-lockfile"
     system -W ${worksrcpath}/source "${build.env} yarn install --frozen-lockfile"
 
-    # Build app-builder-bin locally using Go from ports and insert it into node_modules
-    system "GOPATH=${gopath} GO111MODULE=on go get -v github.com/develar/app-builder@${ab_bin_commit}"
-    file delete ${worksrcpath}/node_modules/app-builder-bin/mac/app-builder
-    file link ${worksrcpath}/node_modules/app-builder-bin/mac/app-builder ${gopath}/bin/app-builder
+#   # Build app-builder-bin locally using Go from ports and insert it into node_modules
+#   system "GOPATH=${gopath} GO111MODULE=on go get -v github.com/develar/app-builder@${ab_bin_commit}"
+#   file delete ${worksrcpath}/node_modules/app-builder-bin/mac/app-builder
+#   file link ${worksrcpath}/node_modules/app-builder-bin/mac/app-builder ${gopath}/bin/app-builder
 
     # Build electron app
     system -W ${worksrcpath} "${build.env} yarn run release:mac --dir"


### PR DESCRIPTION
- attempt to remove workaround for Go app-builder dependency

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
