### PR TITLE
tektoncd-cli: update to 0.11.0

### DIFF
--- a/devel/tektoncd-cli/Portfile
+++ b/devel/tektoncd-cli/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/tektoncd/cli 0.10.0 v
+go.setup            github.com/tektoncd/cli 0.11.0 v
 name                tektoncd-cli
 
 categories          devel
@@ -23,9 +23,9 @@ long_description    The Tekton Pipelines cli project provides a CLI for \
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  74c692dcace7b499612798a80b8e88e95b5a0c97 \
-                    sha256  150344c4997db792594a8683da27fa66ef0ca70c7a69494496af90e98067a0b2 \
-                    size    6964051
+checksums           rmd160  a5d215039835960e12cca87136fa885f30d071c4 \
+                    sha256  253ad979eda621ffd251988f02b29cea556cc340f956c2406841fafbf6d40371 \
+                    size    7231312
 
 if {${build_arch} eq "x86_64"} {
     set tektoncd_target amd64


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
