### PR TITLE
py-brotli: Add python 3.8

### DIFF
--- a/python/py-brotli/Portfile
+++ b/python/py-brotli/Portfile
@@ -26,7 +26,7 @@ checksums           rmd160  2820a6e61bc8de3385b461032632b9d749697228 \
                     sha256  3c91248512e8ed142fca873d2cca3c5f7f5edd6ac3a23df994b2943486587ed7 \
                     size    23829515
 
-python.versions     27 36 37
+python.versions     27 36 37 38
 
 if {$subport ne $name} {
     depends_build-append port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

Add python 3.8 subport to py-brotli

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G6020
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
