### PR TITLE
py-h2: Update version to 3.2.0

### DIFF
--- a/python/py-h2/Portfile
+++ b/python/py-h2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-h2
-version             3.1.1
+version             3.2.0
 revision            0
 
 categories-append   net www
@@ -29,9 +29,9 @@ homepage            https://python-hyper.org/projects/${python.rootname}/
 distname            ${python.rootname}-${version}
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}/
 
-checksums           rmd160  b65a0b4dcc2ad03b1021648eb35d01b364fc7e1c \
-                    sha256  b8a32bd282594424c0ac55845377eea13fa54fe4a8db012f3a198ed923dc3ab4 \
-                    size    2214612
+checksums           rmd160  21731cd61668464d4a69b39a5fad657bb760a83f \
+                    sha256  875f41ebd6f2c44781259005b157faed1a5031df3ae5aa7bcb4628a6c0782f14 \
+                    size    2215889
 
 python.versions     27 35 36 37 38
 


### PR DESCRIPTION
#### Description

Update py-h2 to version 3.2.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G6020
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
