### PR TITLE
py-zstd: new port

### DIFF
--- a/python/py-zstd/Portfile
+++ b/python/py-zstd/Portfile
@@ -1,0 +1,44 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           python 1.0
+
+github.setup        indygreg python-zstandard 0.14.0
+github.tarball_from archive
+name                py-zstd
+
+platforms           darwin
+license             BSD
+maintainers         nomaintainer
+
+description         Zstandard compression
+long_description    This extension allows Zstandard compression from Python
+
+homepage            https://github.com/indygreg/python-zstandard
+
+checksums           rmd160  c59be906d3159b4057f5257b3afc08d56e2279c9 \
+                    sha256  cd492899269fe2dd1d574dec436872d52bdfd63232a192f0837dea44be09bbdc \
+                    size    664949
+
+patchfiles          no-cffi.patch
+
+python.versions     27 35 36 37 38
+
+if {${name} ne ${subport}} {
+    depends_build-append port:py${python.version}-setuptools
+
+    depends_lib-append      port:zstd
+
+    configure.args-append   --install-option="--system-zstd"
+
+    post-destroot {
+        xinstall -d ${destroot}${prefix}/share/doc/${subport}
+        xinstall -m 0644 -W ${worksrcpath} LICENSE README.rst \
+             ${destroot}${prefix}/share/doc/${subport}
+    }
+
+    livecheck.type  none
+} else {
+    livecheck.type  pypi
+}

--- a/python/py-zstd/files/no-cffi.patch
+++ b/python/py-zstd/files/no-cffi.patch
@@ -1,0 +1,27 @@
+--- setup.py.old	2020-07-27 18:47:13.000000000 +0200
++++ setup.py	2020-07-27 18:48:13.000000000 +0200
+@@ -18,23 +18,7 @@
+ # garbage collection pitfalls.
+ MINIMUM_CFFI_VERSION = "1.11"
+ 
+-try:
+-    import cffi
+-
+-    # PyPy (and possibly other distros) have CFFI distributed as part of
+-    # them. The install_requires for CFFI below won't work. We need to sniff
+-    # out the CFFI version here and reject CFFI if it is too old.
+-    cffi_version = LooseVersion(cffi.__version__)
+-    if cffi_version < LooseVersion(MINIMUM_CFFI_VERSION):
+-        print(
+-            "CFFI 1.11 or newer required (%s found); "
+-            "not building CFFI backend" % cffi_version,
+-            file=sys.stderr,
+-        )
+-        cffi = None
+-
+-except ImportError:
+-    cffi = None
++cffi = None
+ 
+ import setup_zstd
+ 


### PR DESCRIPTION
#### Description

Create new port py-zstd for Zstandard bindings in python

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G6020
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
