### PR TITLE
util-linux: Update master_sites.

### DIFF
--- a/devel/util-linux/Portfile
+++ b/devel/util-linux/Portfile
@@ -19,7 +19,7 @@ long_description    ${name} contains miscellaneous utility programs \
                     and messages. This port contains ONLY those parts \
                     of ${name} that run on Darwin.
 
-master_sites        https://www.kernel.org/pub/linux/utils/util-linux/v${branch}/
+master_sites        https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v${branch}/
 use_xz              yes
 
 checksums           rmd160  81c26b1da8e7e4ce065ed93639bcc2d5aba3baa8 \


### PR DESCRIPTION
Fetches were failing due to the location having moved and curl's not
following the 301 redirect.  This updates the master_sites based on
the new location from the redirect.

Note that fetches still fail on older macOS versions due to the usual
SSL certificate problem, but that problem should go away once the
distfile mirrors can successfully mirror the file.

TESTED:
On macOS 10.13, "port checksum util-linux" now succeeds.  It fails on
10.9 as noted above.  Testing across all OS versions is unnecessary
for this type of change.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.13


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
