### PR TITLE
py-publicsuffix2: new port

### DIFF
--- a/python/py-publicsuffix2/Portfile
+++ b/python/py-publicsuffix2/Portfile
@@ -1,0 +1,44 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           python 1.0
+
+github.setup        nexB python-publicsuffix2 2.2019-12-21 release-
+github.tarball_from archive
+name                py-publicsuffix2
+version             [string map {{-} {}} ${github.version}]
+
+categories-append   net
+platforms           darwin
+license             {MIT MPL-2}
+maintainers         nomaintainer
+
+description         Get a public suffix for a domain name using the Public Suffix List
+long_description    ${description}
+
+homepage            https://github.com/nexB/python-publicsuffix2
+
+checksums           rmd160  54344704c8e8315db56e1296d6b8244af5d4e0d8 \
+                    sha256  b4ef022fccd7b4968151af208b0f890e55c00b24892a1a826b2b7a381215bafa \
+                    size    98142
+
+python.versions     27 35 36 37 38
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools \
+                    port:py${python.version}-requests
+
+    post-destroot {
+        xinstall -d ${destroot}${prefix}/share/doc/${subport}
+        xinstall -m 0644 -W ${worksrcpath} CHANGELOG.rst publicsuffix2.LICENSE \
+            README.rst ${destroot}${prefix}/share/doc/${subport}
+    }
+
+    test.run        yes
+
+    livecheck.type  none
+} else {
+    livecheck.type  pypi
+}


### PR DESCRIPTION
#### Description

Create new port py-publicsuffix2

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G6020
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
