### PR TITLE
google-cloud-sdk: update to 303.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             302.0.0
+version             303.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  de1b9313f778984493cc8cfcfcebd6192f4c9f40 \
-                    sha256  b6a51f2fd463fa17a6bdd3e333abed84bbb030908c45ecc85533c6c6993cfaaf \
-                    size    77875663
+    checksums       rmd160  53263f6720114e2ebdc1dcde796663663827b1b1 \
+                    sha256  7dc35ffc13722324a21fbcec7d63e42ae52ddf869214f60d90b2901f4a99ff37 \
+                    size    78948492
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  640f26ef2286a12df0b12bd694271941b3a64f07 \
-                    sha256  c0c97641e98179289f5eba1bdbfd019d3617bc33788857dc24df0106bdae2954 \
-                    size    78892268
+    checksums       rmd160  53263f6720114e2ebdc1dcde796663663827b1b1 \
+                    sha256  7dc35ffc13722324a21fbcec7d63e42ae52ddf869214f60d90b2901f4a99ff37 \
+                    size    78948492
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 303.0.0.

###### Tested on

macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?