### PR TITLE
gh: update to 0.11.1

### DIFF
--- a/devel/gh/Portfile
+++ b/devel/gh/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        cli cli 0.11.0 v
+github.setup        cli cli 0.11.1 v
 name                gh
 categories          devel
 platforms           darwin
@@ -23,9 +23,9 @@ homepage            https://cli.github.com/
 github.tarball_from releases
 distname            gh_${version}_macOS_amd64
 
-checksums           rmd160  7d72ace2776de55cecc64a74a88ef83242ceb45c \
-                    sha256  e30ba748a0e0d3a155c93027616520593a40ad50711b59c61f8335badcc3f4bc \
-                    size    6230604
+checksums           rmd160  d1cdf2ce7645ba8e0cff43710f163ec64b18ea80 \
+                    sha256  6634c0cce8eba7a3d394d90cec5af99f79c815704adf3cde81ea7394ce0fb440 \
+                    size    6339012
 
 use_configure       no
 installs_libs       no


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
