### PR TITLE
beekeeper-studio: update to 1.6.11

### DIFF
--- a/aqua/beekeeper-studio/Portfile
+++ b/aqua/beekeeper-studio/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        beekeeper-studio beekeeper-studio 1.6.10 v
+github.setup        beekeeper-studio beekeeper-studio 1.6.11 v
 revision            0
 
 homepage            https://beekeeperstudio.io/
@@ -29,14 +29,16 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  50a371610190cd4bf7b9db3141aa758ceaf4d2cb \
-                    sha256  f78ac338e6ee1dc1a5cfadf229a64b840a6e2451cbe8b32d3ee11e4b422f8ff7 \
-                    size    44141282
+                    rmd160  4b3d0ba03b5fcc52cb532d6ad16bdfedae475be7 \
+                    sha256  1b40191021ff3ab6663a4fc0e6f40fec7b22b5c7456945db264692970a77bbd0 \
+                    size    44142374
 
 depends_build       port:go \
                     port:yarn
 
 use_configure       no
+
+build.env-append    CSC_IDENTITY_AUTO_DISCOVERY=false
 
 build {
     set gopath ${workpath}/go
@@ -44,16 +46,16 @@ build {
     # Set up all JS dependencies
     system -W ${worksrcpath} "yarn --frozen-lockfile"
 
-    # Workaround for: https://trac.macports.org/ticket/60555
-    # Build app-builder-bin locally and insert it into node_modules
-    system "GOPATH=${gopath} go get -v github.com/develar/app-builder"
-    file delete ${worksrcpath}/node_modules/app-builder-bin/mac/app-builder
-    file link ${worksrcpath}/node_modules/app-builder-bin/mac/app-builder \
-              ${gopath}/bin/app-builder
+#   # Workaround for: https://trac.macports.org/ticket/60555
+#   # Build app-builder-bin locally and insert it into node_modules
+#   system "GOPATH=${gopath} go get -v github.com/develar/app-builder"
+#   file delete ${worksrcpath}/node_modules/app-builder-bin/mac/app-builder
+#   file link ${worksrcpath}/node_modules/app-builder-bin/mac/app-builder \
+#             ${gopath}/bin/app-builder
 
     # Build electron app
     system -W ${worksrcpath} \
-        "CSC_IDENTITY_AUTO_DISCOVERY=false yarn run electron:build --mac dir --publish never"
+        "${build.env} yarn run electron:build --mac dir --publish never"
 }
 
 destroot {


### PR DESCRIPTION
- attempt to remove Go app-builder workaround

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
