### PR TITLE
libsodium: Update to 1.0.18-20200728

### DIFF
--- a/devel/libsodium/Portfile
+++ b/devel/libsodium/Portfile
@@ -3,9 +3,15 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           muniversal 1.0
-PortGroup           cxx11 1.1
 
-github.setup        jedisct1 libsodium 1.0.18-RELEASE
+# Upstream recommends using the stable branch:
+# https://doc.libsodium.org/installation
+github.setup        jedisct1 libsodium d37afd6015fa246b967aa216611874883e5670c1
+version             1.0.18-20200728
+revision            0
+checksums           rmd160  154e61138bc9e14f6823caed62c3841b5fb180e0 \
+                    sha256  b9d55bdc55bf4bbea83c614558a5a3dd0af1cec7fd1d0e2a6081a77064a086c3 \
+                    size    2041012
 
 categories          devel security
 platforms           darwin
@@ -18,14 +24,23 @@ description         Portable and packageable NaCl-based crypto library
 long_description    libsodium is a library for network communication, \
                     encryption, decryption, signatures, etc.
 
-checksums           rmd160  48941eaf00afe9061796a4753ed320e81a8be95e \
-                    sha256  34f0c6a2c05ea5e5968d2231f2fd2ea35c29b8d9119045563deb64e680c7da99 \
-                    size    2046708
+github.tarball_from archive
 
 depends_build-append \
                     port:pkgconfig
+
+compiler.cxx_standard \
+                    2011
 
 configure.args      --disable-silent-rules
 
 test.run            yes
 test.target         check
+
+github.livecheck.branch \
+                    stable
+
+#livecheck.type      regex
+#livecheck.version   ${version}
+#livecheck.url       http://www.ryandesign.com/macports/version.php/${name}
+#livecheck.regex     {^([^-]+-\d{8})}


### PR DESCRIPTION
#### Description

It has been over a year since the 1.0.18 release, but the project recommends using the stable branch which has further fixes. Rework the Portfile to accommodate this.

The github portgroup livecheck tells you if the latest commit hash is different. A custom livecheck on my server tells you the latest version and date by checking the releases directory on their server. I wasn't sure which one of these was more useful so I've left both in the Portfile with the former activated for now.

Closes: https://trac.macports.org/ticket/48579

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G12034
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
