### PR TITLE
tree-sitter: new port

### DIFF
--- a/devel/tree-sitter/Portfile
+++ b/devel/tree-sitter/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           makefile 1.0
+
+github.setup        tree-sitter tree-sitter 0.16.9
+
+categories          devel
+platforms           darwin
+license             MIT
+
+homepage            https://tree-sitter.github.io/
+
+description         An incremental parsing system for programming tools
+
+long_description    Tree-sitter is a parser generator tool and an incremental \
+                    parsing library. It can build a concrete syntax tree for \
+                    a source file and efficiently update the syntax tree as \
+                    the source file is edited. Tree-sitter aims to be: \
+                    General enough to parse any programming language, Fast \
+                    enough to parse on every keystroke in a text editor, \
+                    Robust enough to provide useful results even in the \
+                    presence of syntax errors, Dependency-free so that the \
+                    runtime library (which is written in pure C) can be \
+                    embedded in any application
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  e6f24f2dcd83151412bf5295a3f5152cca3d199f \
+                    sha256  b2dec24635eb81f518f3f143417feca84419669796d936af1fc2ac001b311be2 \
+                    size    497333
+
+use_configure       no


### PR DESCRIPTION
#### Description

New port for [tree-sitter](https://tree-sitter.github.io/tree-sitter/)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
