### PR TITLE
newreleases: update to 0.1.5

### DIFF
--- a/devel/newreleases/Portfile
+++ b/devel/newreleases/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/newreleasesio/cli-go 0.1.4 v
+go.setup            github.com/newreleasesio/cli-go 0.1.5 v
 name                newreleases
 
 description         A command line client for managing NewReleases \
@@ -11,9 +11,9 @@ description         A command line client for managing NewReleases \
 
 long_description    {*}${description}
 
-checksums           rmd160  acba7f18026fe7e6310bcc8d759be5d2bdc61e8f \
-                    sha256  93ec1d36b298311502bf16d5241dce290f40c436c46b864fe23306fcfd49d2da \
-                    size    39553
+checksums           rmd160  c2a5d37ebd133bfc1aa453dca43d75ac4d1b7903 \
+                    sha256  8fef9323510b5351a08e2a8e2c3ca48b37c43ce9f8d722e8393d94cf03b774d6 \
+                    size    39575
 
 categories          devel
 license             BSD


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
