### PR TITLE
meetingbar: new port

### DIFF
--- a/office/meetingbar/Portfile
+++ b/office/meetingbar/Portfile
@@ -1,0 +1,47 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        leits MeetingBar 1.3 v
+name                meetingbar
+
+platforms           darwin
+categories          office aqua
+supported_archs     x86_64
+license             Apache-2
+
+homepage            https://meetingbar.onrender.com/
+
+description         Your next meeting always before your eyes in macOS menu \
+                    bar.
+
+long_description    MeetingBar is a menu bar app for your calendar meetings. \
+                    Integrated with Google Meet and Zoom so you can quickly \
+                    join meetings from event or create ad hoc meeting.
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  18d24d964eaa8148c8d8a241f50584e82a633af2 \
+                    sha256  ab1309ffa0f00ca590951d8ae827c2c54180ea48b6b327e209d9261427361097 \
+                    size    301497
+
+github.tarball_from releases
+
+distname            MeetingBar
+use_configure       no
+use_dmg             yes
+
+if {${os.major} < 19} {
+    return -code error "${name} runs on macOS 10.15+"
+}
+
+# Extract only
+build {}
+
+destroot {
+    copy ${workpath}/MeetingBar/MeetingBar.app ${destroot}${applications_dir}/
+}
+
+github.livecheck.regex {([0-9.]+)}


### PR DESCRIPTION
#### Description

New port for [MeetingBar](https://meetingbar.onrender.com/)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
