### PR TITLE
go-migrate: update to 4.12.1

### DIFF
--- a/devel/go-migrate/Portfile
+++ b/devel/go-migrate/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/golang-migrate/migrate 4.11.0 v
+go.setup            github.com/golang-migrate/migrate 4.12.1 v
 name                go-migrate
 
 categories          devel databases
@@ -22,9 +22,9 @@ long_description    {*}${description} Migrate reads migrations from sources \
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  e18987257659ebd27ba4dd4517951451d037bd35 \
-                    sha256  28c65abb86ae6a9d7b56fb77bf69f33956f395490435cbb7d7bc5d4f5e7e7ac6 \
-                    size    143355
+checksums           rmd160  78d0832ad47bd33344ebc2b2df077ea0448a7460 \
+                    sha256  b786c678a510c1a8305f844dfe949322638fe0a13d9dec8c899c73a61550a2c2 \
+                    size    150543
 
 build.cmd           make
 build.pre_args      VERSION=${version}


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
