### PR TITLE
mercurial: Update to 5.4.2 and to py3 instead of py2

### DIFF
--- a/devel/mercurial/Portfile
+++ b/devel/mercurial/Portfile
@@ -8,7 +8,7 @@ name                mercurial
 # don't forget to update dependents for mercurial:
 # port echo rdepends:mercurial and \( name:hg or name:mercurial \) | grep -v 'py[[:digit:]]'
 version             5.4.2
-revision            1
+revision            0
 categories          devel python
 license             GPL-2+
 maintainers         nomaintainer

--- a/devel/mercurial/Portfile
+++ b/devel/mercurial/Portfile
@@ -7,7 +7,7 @@ PortGroup           bitbucket 1.0
 name                mercurial
 # don't forget to update dependents for mercurial:
 # port echo rdepends:mercurial and \( name:hg or name:mercurial \) | grep -v 'py[[:digit:]]'
-version             5.3
+version             5.4.2
 revision            1
 categories          devel python
 license             GPL-2+
@@ -30,18 +30,18 @@ long_description    Mercurial is a fast, lightweight Source Control Management \
 homepage            http://www.mercurial-scm.org
 platforms           darwin
 master_sites        https://www.mercurial-scm.org/release/
-checksums           rmd160  cd7e8fb08f8423413e689a0836ebab4961c05214 \
-                    sha256  e57ff61d6b67695149dd451922b40aa455ab02e01711806a131a1e95c544f9b9 \
-                    size    7499903
+checksums           rmd160  96668cbce8c870da560732c8e2c2b1275728d4ec \
+                    sha256  5c8b93da701ee39e312da9e35a7f3163e17ed173a4707857bc467c3b3ab74853 \
+                    size    7730738
 
-depends_build       port:py27-docutils
+depends_build       port:py38-docutils
 
 depends_run         path:share/curl/curl-ca-bundle.crt:curl-ca-bundle \
-                    port:py27-gnureadline
+                    port:py38-gnureadline
 
 patchfiles          patch-setup.py.diff
 
-python.default_version 27
+python.default_version 38
 
 build.cmd           make
 build.target        all PYTHON=${python.bin}
@@ -57,8 +57,8 @@ post-build {
     system -W ${worksrcpath}/contrib/chg "${build.cmd} CC=\"${configure.cc} \
         [get_canonical_archflags]\" CFLAGS=\"${configure.cflags}\" \
         HGPATH=${prefix}/bin/hg \
-        PYTHON=${prefix}/bin/python2.7 HG=${prefix}/bin/hg \
-        HGEXTDIR=${frameworks_dir}/Python.framework/Versions/2.7/lib/python2.7/site-packages/hgext"
+        PYTHON=${prefix}/bin/python3.8 HG=${prefix}/bin/hg \
+        HGEXTDIR=${frameworks_dir}/Python.framework/Versions/3.8/lib/python3.8/site-packages/hgext"
 }
 
 post-destroot {


### PR DESCRIPTION
#### Description

Switched from deprecated Python2.x to the current Python3.8. Also updated to the latest mercurial version 5.4.2

###### Type(s)
- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?