### PR TITLE
adblock2privoxy: Fix startupitems for MacPorts 2.6.3

### DIFF
--- a/www/adblock2privoxy/Portfile
+++ b/www/adblock2privoxy/Portfile
@@ -5,7 +5,7 @@ PortGroup           haskell_stack 1.0
 
 name                adblock2privoxy
 version             2.0.1
-revision            1
+revision            2
 categories          www haskell
 maintainers         @essandess
 license             GPL-3
@@ -60,6 +60,16 @@ variant initialize_always \
 # relative paths to ${prefix}
 set ab2p_datadir    share/${name}
 
+pre-fetch {
+    # The way that startupitems values are quoted was changed in 2.6.3.
+    # This port now relies on those changes. See:
+    # https://github.com/macports/macports-base/pull/191
+    if {[vercmp [macports_version] 2.6.3] < 0} {
+        ui_error "${name} @${version} requires MacPorts 2.6.3 or later"
+        return -code error "incompatible MacPorts version"
+    }
+}
+
 post-extract {
     # Fix for cabal data-files hardcoded path in binary
     # See:
@@ -106,37 +116,37 @@ post-destroot {
 startupitem.create  yes
 startupitems \
     name            ${name} \
-    start           "( /bin/test -f \"\${prefix}/etc/adblock2privoxy/privoxy/ab2p.task\" \\
-\t&& \"\${prefix}/bin/adblock2privoxy\" -t \"\${prefix}/etc/adblock2privoxy/privoxy/ab2p.task\" \\
-\t|| \"\${prefix}/bin/adblock2privoxy\" -p \"\${prefix}/etc/adblock2privoxy/privoxy\" \\
-\t\t-w \"\${prefix}/etc/adblock2privoxy/css\" \\
-\t\t-d 127.0.0.1:8119 \\
-\t\thttps://easylist.to/easylist/easyprivacy.txt \\
-\t\thttps://easylist.to/easylist/easylist.txt \\
-\t\thttps://easylist.to/easylist/fanboy-annoyance.txt \\
-\t\thttps://easylist.to/easylist/fanboy-social.txt \\
-\t\thttps://easylist-downloads.adblockplus.org/antiadblockfilters.txt \\
-\t\thttps://easylist-downloads.adblockplus.org/malwaredomains_full.txt \\
-\t\thttps://raw.githubusercontent.com/ryanbr/fanboy-adblock/master/fanboy-antifacebook.txt \\
-\t\thttps://raw.githubusercontent.com/Dawsey21/Lists/master/adblock-list.txt \\
-\t) && \"\${prefix}/bin/port\" reload privoxy" \
-    stop            "/usr/bin/kill -SIGUSR1 `/usr/bin/pgrep -u root ${name}` 2>/dev/null" \
+    start           "\"( /bin/test -f \\\"\${prefix}/etc/adblock2privoxy/privoxy/ab2p.task\\\" \\\\
+\t&& \\\"\${prefix}/bin/adblock2privoxy\\\" -t \\\"\${prefix}/etc/adblock2privoxy/privoxy/ab2p.task\\\" \\\\
+\t|| \\\"\${prefix}/bin/adblock2privoxy\\\" -p \\\"\${prefix}/etc/adblock2privoxy/privoxy\\\" \\\\
+\t\t-w \\\"\${prefix}/etc/adblock2privoxy/css\\\" \\\\
+\t\t-d 127.0.0.1:8119 \\\\
+\t\thttps://easylist.to/easylist/easyprivacy.txt \\\\
+\t\thttps://easylist.to/easylist/easylist.txt \\\\
+\t\thttps://easylist.to/easylist/fanboy-annoyance.txt \\\\
+\t\thttps://easylist.to/easylist/fanboy-social.txt \\\\
+\t\thttps://easylist-downloads.adblockplus.org/antiadblockfilters.txt \\\\
+\t\thttps://easylist-downloads.adblockplus.org/malwaredomains_full.txt \\\\
+\t\thttps://raw.githubusercontent.com/ryanbr/fanboy-adblock/master/fanboy-antifacebook.txt \\\\
+\t\thttps://raw.githubusercontent.com/Dawsey21/Lists/master/adblock-list.txt \\\\
+\t) && \\\"\${prefix}/bin/port\\\" reload privoxy\"" \
+    stop            "\"/usr/bin/kill -SIGUSR1 `/usr/bin/pgrep -u root ${name}` 2>/dev/null\"" \
     pidfile         none
 
 startupitems-append \
     name            ${name}-nginx \
-    init            "pidfile=\"\${prefix}/var/run/nginx/nginx-adblock2privoxy.pid\"" \
-    start           "\"\${prefix}/sbin/nginx\" \\
-\t\t-c \\
-\t\t\"\${prefix}/etc/${name}/nginx.conf\" \\
-\t\t-g \\
-\t\t\"daemon off;\"" \
-    stop            "if \[ -f \${pidfile} \]; then
-\t\t/usr/bin/kill `cat \${pidfile}` \\
+    init            "\"pidfile=\\\"\${prefix}/var/run/nginx/nginx-adblock2privoxy.pid\\\"\"" \
+    start           "\"\\\"\${prefix}/sbin/nginx\\\" \\\\
+\t\t-c \\\\
+\t\t\\\"\${prefix}/etc/${name}/nginx.conf\\\" \\\\
+\t\t-g \\\\
+\t\t\\\"daemon off;\\\"\"" \
+    stop            "\"if \[ -f \${pidfile} \]; then
+\t\t/usr/bin/kill `cat \${pidfile}` \\\\
 \t\t\t&& /bin/rm -f \${pidfile} ;
 \telse
 \t\t/usr/bin/kill -SIGUSR1 `/usr/bin/pgrep -u root nginx` 2>/dev/null ;
-\tfi"
+\tfi\""
 
 post-activate {
     # org.macports.adblock2privoxy


### PR DESCRIPTION
#### Description

adblock2privoxy: Fix startupitems for MacPorts 2.6.3

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G12034
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
