### PR TITLE
mail-server: Fix startupitems with MacPorts 2.6.3

### DIFF
--- a/mail/mail-server/Portfile
+++ b/mail/mail-server/Portfile
@@ -5,7 +5,7 @@ PortGroup               active_variants 1.1
 
 name                    mail-server
 version                 1.2
-revision                1
+revision                2
 categories              mail net
 platforms               darwin
 supported_archs         noarch
@@ -821,60 +821,52 @@ in ${prefix}/etc/dovecot/sieve*/*.sieve are compiled with sievec.
     }
 }
 
+pre-fetch {
+    # The way that startupitems values are quoted was changed in 2.6.3.
+    # This port now relies on those changes. See:
+    # https://github.com/macports/macports-base/pull/191
+    if {[vercmp [macports_version] 2.6.3] < 0} {
+        ui_error "${name} @${version} requires MacPorts 2.6.3 or later"
+        return -code error "incompatible MacPorts version"
+    }
+}
+
 startupitem.create      yes
+startupitems \
+        name            ${name} \
+        start {
+                        "port load clamav-server"
+                        "port load apache-solr8"
+                        "port load redis"
+                        "port load dcc"
+                        "port load postfix"
+                        "port load dovecot"
+                        "port load rspamd"
+        } \
+        stop {
+                        "port unload apache-solr8"
+                        "port unload dcc"
+                        "port unload postfix"
+                        "port unload dovecot"
+                        "port unload rspamd"
+        } \
+        restart {
+                        "port reload apache-solr8"
+                        "port reload redis"
+                        "port reload dcc"
+                        "port unload postfix"
+                        "sleep 1"
+                        "port load postfix"
+                        "port unload dovecot"
+                        "sleep 1"
+                        "port load dovecot"
+                        "port reload rspamd"
+        }
 
 if { [variant_isset "logrotate"] } {
-    startupitems \
-            name        ${name} \
-            start       "port load clamav-server
-\tport load apache-solr8
-\tport load redis
-\tport load dcc
-\tport load postfix
-\tport load dovecot
-\tport load rspamd" \
-            stop        "port unload apache-solr8
-\tport unload dcc
-\tport unload postfix
-\tport unload dovecot
-\tport unload rspamd" \
-            restart     "port reload apache-solr8
-\tport reload redis
-\tport reload dcc
-\tport unload postfix ; \\
-\tsleep 1 ; \\
-\tport load postfix
-\tport unload dovecot ; \\
-\tsleep 1 ; \\
-\tport load dovecot
-\tport reload rspamd" \
-            name        ${name}.logrotate \
-            executable  ${prefix}/sbin/logrotate
-} else {
-    startupitem.start   "port load clamav-server
-\tport load apache-solr8
-\tport load redis
-\tport load dcc
-\tport load postfix
-\tport load dovecot
-\tport load rspamd"
-
-    startupitem.stop    "port unload apache-solr8
-\tport unload dcc
-\tport unload postfix
-\tport unload dovecot
-\tport unload rspamd"
-
-    startupitem.restart "port reload apache-solr8
-\tport reload redis
-\tport reload dcc
-\tport unload postfix ; \\
-\tsleep 1 ; \\
-\tport load postfix
-\tport unload dovecot ; \\
-\tsleep 1 ; \\
-\tport load dovecot
-\tport reload rspamd"
+    startupitems-append \
+        name            ${name}.logrotate \
+        executable      ${prefix}/sbin/logrotate
 }
 
 notes "A mail server is a complex, interdependent set of tools that must\


### PR DESCRIPTION
#### Description

mail-server: Fix startupitems with MacPorts 2.6.3

I also removed what appeared to be redundant startupitem creation code.

While I believe these changes preserve the existing intention of the startupitems, I believe the code can be cleaned up further; see https://trac.macports.org/ticket/60923.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G12034
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
