### PR TITLE
grpcurl: update to 1.7.0

### DIFF
--- a/devel/grpcurl/Portfile
+++ b/devel/grpcurl/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/fullstorydev/grpcurl 1.6.1 v
+go.setup            github.com/fullstorydev/grpcurl 1.7.0 v
 
 categories          devel net
 license             MIT
@@ -24,9 +24,9 @@ long_description    {*}${description}. The main purpose for this tool is to \
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  c2ecf511a22cc49a47bfdcbc2f7cf748eb194f56 \
-                    sha256  eeced70e06fb1357a66ce73ebb338f7ed32ec8105419b4153689c8203d581f86 \
-                    size    122496
+checksums           rmd160  bbfbbc54aa63f15b2d44571b76a3db0990c8f6a6 \
+                    sha256  2e15b03e61e502de7746fbabfd6c04d687ea9fbe2c14a053ae18947b0f168cc8 \
+                    size    127134
 
 build.pre_args      -ldflags \"-X 'main.version=${version}'\"
 build.args          ./cmd/grpcurl


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
