### PR TITLE
wrangler: add livecheck regex

### DIFF
--- a/devel/wrangler/Portfile
+++ b/devel/wrangler/Portfile
@@ -30,6 +30,8 @@ destroot {
                     ${destroot}${prefix}/bin/
 }
 
+github.livecheck.regex {([0-9.]+)}
+
 cargo.crates \
     addr2line                       0.12.2  602d785912f476e480434627e8732e6766b760c045bbf897d9dfaa9f4fbd399c \
     adler32                          1.1.0  567b077b825e468cc974f0020d4082ee6e03132512f207ef1a02fd5d00d1f32d \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
