### PR TITLE
Remove an "automagic" dependency upon liblzo

### DIFF
--- a/databases/mariadb-10.1/Portfile
+++ b/databases/mariadb-10.1/Portfile
@@ -11,7 +11,7 @@ set version_branch  [join [lrange [split ${version} .] 0 1] .]
 # Please set revision_client and revision_server to 0 if you bump
 # version; these can be changed independently for the 2 subports, but
 # can be changed at the same time if that's what's required.
-set revision_client 0
+set revision_client 1
 set revision_server 0
 categories          databases
 platforms           darwin
@@ -96,6 +96,7 @@ if {$subport eq $name} {
                         -DDEFAULT_COLLATION:STRING=utf8_general_ci \
                         -DWITH_EMBEDDED_SERVER:BOOL=ON \
                         -DWITH_ZLIB:STRING=system \
+                        -DWITH_INNODB_LZO=OFF \
                         -DWITH_UNIT_TESTS:BOOL=ON \
                         -DWITHOUT_TOKUDB_STORAGE_ENGINE:BOOL=ON \
                         -DWITHOUT_MROONGA_STORAGE_ENGINE:BOOL=ON \


### PR DESCRIPTION
Tell MariaDB to not build against liblzo, even if it is installed, because it is not declared as a dependency.

See https://trac.macports.org/ticket/57798

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
