### PR TITLE
libvpx: update to v1.9.0

### DIFF
--- a/multimedia/libvpx/Portfile
+++ b/multimedia/libvpx/Portfile
@@ -5,7 +5,7 @@ PortGroup           compiler_blacklist_versions 1.0
 PortGroup           muniversal 1.0
 
 name                libvpx
-version             1.8.2
+version             1.9.0
 categories          multimedia
 maintainers         {devans @dbevans} openmaintainer
 platforms           darwin

--- a/multimedia/libvpx/files/patch-build-make-configure.sh.diff
+++ b/multimedia/libvpx/files/patch-build-make-configure.sh.diff
@@ -1,6 +1,6 @@
---- build/make/configure.sh.orig      2019-09-25 18:44:14.000000000 -0400
-+++ build/make/configure.sh   2019-10-23 15:07:31.000000000 -0500
-@@ -885,7 +885,7 @@ process_common_toolchain() {
+--- build/make/configure.sh.orig	2020-08-01 00:27:21.000000000 +0200
++++ build/make/configure.sh	2020-08-01 00:29:56.000000000 +0200
+@@ -854,7 +854,7 @@
        fi
        ;;
      x86*-darwin*)


### PR DESCRIPTION
#### Description

This updates `libvpx` to [`v1.9.0`][tag] _(July 30, 2020)_

[tag]: https://chromium.googlesource.com/webm/libvpx/+/refs/tags/v1.9.0


###### Type(s)

- [x] update


###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503


###### Verification

Have you:

-   [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
-   [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
-   [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
-   [x] checked your Portfile with `port lint --nitpick`?
-   [x] tried existing tests with `sudo port test`?
-   [ ] tried a full install with `sudo port -vst install`?
    ```
    Warning: The following existing file was hidden from the build system by trace mode:
      /usr/local/bin/make
    ```
-   [x] tried a full install with `sudo port install`?
