### PR TITLE
ffmpeg: enable support for dav1d.

### DIFF
--- a/multimedia/ffmpeg-devel/Portfile
+++ b/multimedia/ffmpeg-devel/Portfile
@@ -20,6 +20,7 @@ name                ffmpeg-devel
 conflicts           ffmpeg
 epoch               1
 version             ${git_release}-${git_date}
+revision            1
 license             LGPL-2.1+
 categories          multimedia
 maintainers         {devans @dbevans} {jeremyhu @jeremyhu} openmaintainer
@@ -66,7 +67,8 @@ depends_build       port:pkgconfig \
                     port:gmake \
                     port:texinfo
 
-depends_lib         port:lame \
+depends_lib         port:dav1d \
+                    port:lame \
                     port:libiconv \
                     port:libvorbis \
                     port:libopus \
@@ -118,6 +120,7 @@ configure.cflags-append -DHAVE_LRINTF ${configure.cppflags}
 configure.args      --enable-swscale \
                     --enable-avfilter \
                     --enable-avresample \
+                    --enable-libdav1d \
                     --enable-libmp3lame \
                     --enable-libvorbis \
                     --enable-libopus \

--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -5,6 +5,7 @@ PortGroup           xcodeversion 1.0
 PortGroup           muniversal 1.0
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           active_variants 1.1
+
 # https://trac.macports.org/ticket/59246
 PortGroup           xcode_workaround 1.0
 
@@ -13,6 +14,7 @@ conflicts           ffmpeg-devel
 # Please increase the revision of mpv whenever ffmpeg's version is updated.
 epoch               1
 version             4.2.4
+revision            1
 license             LGPL-2.1+
 categories          multimedia
 maintainers         {devans @dbevans} {jeremyhu @jeremyhu} openmaintainer
@@ -63,7 +65,8 @@ depends_build       port:pkgconfig \
                     port:ld64 \
                     port:texinfo
 
-depends_lib         port:lame \
+depends_lib         port:dav1d \
+                    port:lame \
                     port:libiconv \
                     port:libvorbis \
                     port:libopus \
@@ -115,6 +118,7 @@ configure.cflags-append -DHAVE_LRINTF ${configure.cppflags}
 configure.args      --enable-swscale \
                     --enable-avfilter \
                     --enable-avresample \
+                    --enable-libdav1d \
                     --enable-libmp3lame \
                     --enable-libvorbis \
                     --enable-libopus \


### PR DESCRIPTION
#### Description

This enables support for `dav1d`, which is needed to be able to manage files downloaded with `youtube-dl` for example.

`ffplay` plays files with `avc1`, but not `av01`. (see: the vcodecs from YouTube)

```
# Example
136     mp4    1280x720   720p  461k , avc1.4d401f, …
398     mp4    1280x720   720p  963k , av01.0.05M.08, …
```


###### Type(s)

- [x] update
- [x] enhancement


###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503


###### Verification

Have you:

-   [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
-   [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
-   [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
-   [x] checked your Portfile with `port lint --nitpick`?
-   [x] tried a full install with `sudo port install`?
