### PR TITLE
skaffold: update to 1.13.0

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 1.12.1 v
+github.setup        GoogleContainerTools skaffold 1.13.0 v
 revision            0
 
 categories          devel
@@ -23,9 +23,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  e6fbe2c793b04adf266efd43b50041f1459dd0f3 \
-                    sha256  2fba4aa35fe639d8f89c354b07205e7e3271297a7e31517ec73f8087b6c65a99 \
-                    size    27252390
+checksums           rmd160  d0414fd7189254a8b540d86a14e0997cc5b0c837 \
+                    sha256  c106158af55157519ffdb78746939ae57c7e402c0d59295645a069c915b43d58 \
+                    size    27333996
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 1.13.0.

###### Tested on

macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?