### PR TITLE
alacritty: update to 0.5.0

### DIFF
--- a/aqua/alacritty/Portfile
+++ b/aqua/alacritty/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        alacritty alacritty 0.4.3 v
+github.setup        alacritty alacritty 0.5.0 v
 categories          aqua shells
 platforms           darwin
 maintainers         {gmail.com:herby.gillot @herbygillot} \
@@ -19,9 +19,9 @@ long_description    Alacritty is the fastest terminal emulator in existence. \
                     supports macOS, Linux, BSD, and Windows.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  3595194c41db61abbdbf2ee471c849dc5897f4d2 \
-                    sha256  bdf6117f79a71606b44572c161ea1676e541d215c268929cec0588a152c1f0d6 \
-                    size    1488640
+                    rmd160  d04dc788a7ad1c27085ad0b561bf2d52fa19d1ab \
+                    sha256  5dbf2d17a08e17926b642ba9933af43eda25bc913a94760e2eb65199477db29f \
+                    size    1500531
 
 set al_app_name     Alacritty.app
 set al_app_dir      ${applications_dir}/${al_app_name}
@@ -40,30 +40,31 @@ destroot {
 github.livecheck.regex {([0-9.]+)}
 
 cargo.crates \
-    adler32                          1.0.4  5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2 \
-    aho-corasick                    0.7.10  8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada \
+    adler                            0.2.2  ccc9a9dd069569f212bc4330af9f17c4afb5e8ce185e83dbb14f1349dda18b10 \
+    adler32                          1.1.0  567b077b825e468cc974f0020d4082ee6e03132512f207ef1a02fd5d00d1f32d \
+    aho-corasick                    0.7.13  043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86 \
     andrew                           0.2.1  9b7f09f89872c2b6b29e319377b1fbe91c6f5947df19a25596e121cf19a7b35e \
     android_glue                     0.2.3  000444226fcff248f2bc4c7625be32c63caccfecc2723a2b9f78a7487a49c407 \
     android_log-sys                  0.1.2  b8052e2d8aabbb8d556d6abbcce2a22b9590996c5f849b9c7ce4544a2e3b984e \
     ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
     approx                           0.3.2  f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3 \
-    arc-swap                         0.4.6  b585a98a234c46fc563103e9278c9391fde1f4e6850334da895d27edb9580f62 \
+    arc-swap                         0.4.7  4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034 \
     arrayref                         0.3.6  a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544 \
-    arrayvec                        0.4.12  cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9 \
     arrayvec                         0.5.1  cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8 \
     atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
     autocfg                          1.0.0  f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d \
     base64                          0.11.0  b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7 \
-    bindgen                         0.53.2  6bb26d6a69a335b8cb0e7c7e9775cd5666611dc50a37177c3f2cedcfc040e8c8 \
+    base64                          0.12.3  3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff \
+    bindgen                         0.53.3  c72a978d268b1d70b0e963217e60fdabd9523a941457a6c42a7315d15c7e89e5 \
     bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
     blake2b_simd                    0.5.10  d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a \
     block                            0.1.6  0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a \
     bytemuck                         1.2.0  37fa13df2292ecb479ec23aa06f4507928bef07839be9ef15281411076629431 \
     byteorder                        1.3.4  08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de \
     bzip2                            0.3.3  42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b \
-    bzip2-sys                  0.1.8+1.0.8  05305b41c5034ff0e93937ac64133d109b5a2660114ec45e9760bc6816d83038 \
+    bzip2-sys                  0.1.9+1.0.8  ad3b39a260062fca31f7b0b12f207e8f2590a67d32ec7d59c20484b07ea7285e \
     calloop                          0.4.4  7aa2097be53a00de9e8fc349fea6d76221f398f5c4fa550d420669906962d160 \
-    cc                              1.0.53  404b1fe4f65288577753b17e3b36a04596ee784493ec249bf81c7f2d2acd751c \
+    cc                              1.0.58  f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518 \
     cexpr                            0.4.0  f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27 \
     cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
     cgl                              0.3.2  0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff \
@@ -71,44 +72,41 @@ cargo.crates \
     clap                            2.33.1  bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129 \
     clipboard-win                    2.2.0  e3a093d6fed558e5fe24c3dfc85a68bb68f1c824f440d3ba5aca189e2998786b \
     cloudabi                         0.0.3  ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
-    cmake                           0.1.43  49f97562167906afc51aa3fd7e6c83c10a5c96d33bd18f98a4c06a1413134caa \
-    cocoa                           0.19.1  f29f7768b2d1be17b96158e3285951d366b40211320fb30826a76cb7a0da6400 \
-    cocoa                           0.20.0  0a4736c86d51bd878b474400d9ec888156f4037015f5d09794fab9f26eab1ad4 \
+    cmake                           0.1.44  0e56268c17a6248366d66d4a47a3381369d068cce8409bb1716ed77ea32163bb \
+    cocoa                           0.20.2  0c49e86fc36d5704151f5996b7b3795385f50ce09e3be0f47a0cfde869681cf8 \
     constant_time_eq                 0.1.5  245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc \
-    copypasta                        0.6.3  865e9675691e2a7dfc806b16ef2dd5dd536e26ea9b8046519767d79be03aeb6a \
-    core-foundation                  0.6.4  25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d \
+    copypasta                        0.7.0  cbc2322d35c17d340f7017e4c1be24c6f0d6e09423adb51d182d7a9c122f2e6c \
     core-foundation                  0.7.0  57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171 \
-    core-foundation-sys              0.6.2  e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b \
     core-foundation-sys              0.7.0  b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac \
-    core-graphics                   0.17.3  56790968ab1c8a1202a102e6de05fc6e1ec87da99e4e93e9a7d13efbfc1e95a9 \
-    core-graphics                   0.19.0  59e78b2e0aaf43f08e7ae0d6bc96895ef72ff0921c7d4ff4762201b2dba376dd \
+    core-graphics                   0.19.2  b3889374e6ea6ab25dba90bb5d96202f61108058361f6dc72e8b03e6f8bbe923 \
     core-text                       15.0.0  131b3fd1f8bd5db9f2b398fa4fdb6008c64afc04d447c306ac2c7e98fba2a61d \
     core-video-sys                   0.1.4  34ecad23610ad9757664d644e369246edde1803fcb43ed72876565098a5d3828 \
     crc32fast                        1.2.0  ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1 \
     crossbeam-utils                  0.7.2  c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8 \
-    deflate                          0.8.4  e7e5d2a2273fed52a7f947ee55b092c4057025d7a3e04e5ecdbd25d6c3fb1bd7 \
+    crossfont                        0.1.0  fb710de01349371230ec5f5e65410826682448dfad14d97b473a69d850f686bd \
+    deflate                          0.8.6  73770f8e1fe7d64df17ca66ad28994a0a623ea497fa69486e14984e715c5d174 \
     derivative                       2.1.1  cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f \
     dirs                             2.0.2  13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3 \
-    dirs-sys                         0.3.4  afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b \
+    dirs-sys                         0.3.5  8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a \
     dispatch                         0.2.0  bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b \
-    dlib                             0.4.1  77e51249a9d823a4cb79e3eca6dcd756153e8ed0157b6c04775d04bf1b13b76a \
-    downcast-rs                      1.1.1  52ba6eb47c2131e784a38b726eb54c1e1484904f013e576a25354d0124161af6 \
-    dtoa                             0.4.5  4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3 \
-    dwrote                           0.9.0  0bd1369e02db5e9b842a9b67bce8a2fcc043beafb2ae8a799dd482d46ea1ff0d \
+    dlib                             0.4.2  b11f15d1e3268f140f68d390637d5e76d849782d971ae7063e0da69fe9709a76 \
+    downcast-rs                      1.2.0  9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650 \
+    dtoa                             0.4.6  134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b \
+    dwrote                          0.11.0  439a1c2ba5611ad3ed731280541d36d2e9c4ac5e7fb818a27b604bdc5a6aa65b \
     embed-resource                   1.3.3  1f6b0b4403da80c2fd32333937dd468292c001d778c587ae759b75432772715d \
     env_logger                       0.7.1  44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36 \
-    euclid                         0.20.11  667703ececa1ac04d1d40ae0c0fd6401b91d8caccfda3a65458ca8ee5dfedf1c \
+    euclid                         0.20.14  2bb7ef65b3777a325d1eeefefab5b6d4959da54747e33bd6258e789640f307ad \
     expat-sys                        2.1.6  658f19728920138342f68408b7cf7644d90d4784353d8ebc32e7e8663dbe45fa \
     filetime                        0.2.10  affc17579b132fc2461adf7c575cc6e8b134ebca52c51f5411388965227dc695 \
-    flate2                          1.0.14  2cfff41391129e0a856d6d822600b8d71179d46879e310417eb9c762eb178b42 \
+    flate2                          1.0.16  68c90b0fc46cf89d227cc78b40e494ff81287a92dd07631e5af0d06fe3cf885e \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
     foreign-types                    0.3.2  f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1 \
     foreign-types                    0.5.0  d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965 \
     foreign-types-macros             0.2.1  63f713f8b2aa9e24fec85b0e290c56caee12e3b6ae0aeeda238a75b28251afd6 \
     foreign-types-shared             0.1.1  00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b \
     foreign-types-shared             0.3.0  7684cf33bb7f28497939e8c7cf17e3e4e3b8d9a0080ffa4f8ae2f515442ee855 \
-    freetype-rs                     0.23.0  ad4e4ba31012a428040fde05907b42ee7d62b093457f4b2280a0294e0835d61b \
-    freetype-sys                     0.9.0  7dc687b58f0c77150b0aca7d9a1dc93522303570458e1aa36b4fb367584f60c4 \
+    freetype-rs                     0.26.0  74eadec9d0a5c28c54bb9882e54787275152a4e36ce206b45d7451384e5bf5fb \
+    freetype-sys                    0.13.1  a37d4011c0cc628dfa766fcc195454f4b068d7afdc2adfd28861191d866e731a \
     fsevent                          0.4.0  5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6 \
     fsevent-sys                      2.0.1  f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0 \
     fuchsia-zircon                   0.3.3  2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
@@ -117,49 +115,46 @@ cargo.crates \
     gl_generator                    0.13.1  ca98bbde17256e02d17336a6bdb5a50f7d0ccacee502e191d3e3d0ec2f96f84a \
     gl_generator                    0.14.0  1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d \
     glob                             0.3.0  9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574 \
-    glutin                          0.24.0  611023dea5047f3e9047aecb9e361852dcfd0881129daf5d110106ca2b14f3f3 \
+    glutin                          0.24.1  9a9666c8fd9afd008f6559e2468c35e11aad1d110d525bb3b354e4138ec0e20f \
     glutin_egl_sys                   0.1.4  772edef3b28b8ad41e4ea202748e65eefe8e5ffd1f4535f1219793dbb20b3d4c \
     glutin_emscripten_sys            0.1.1  80de4146df76e8a6c32b03007bc764ff3249dcaeb4f675d68a06caf1bac363f1 \
     glutin_gles2_sys                 0.1.4  07e853d96bebcb8e53e445225c3009758c6f5960d44f2543245f6f07b567dae0 \
     glutin_glx_sys                   0.1.6  08c243de74d6cf5ea100c788826d2fb9319de315485dd4b310811a663b3809c3 \
     glutin_wgl_sys                   0.1.4  a93dba7ee3a0feeac0f437141ff25e71ce2066bcf1a706acab1559ffff94eb6a \
-    hermit-abi                      0.1.13  91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71 \
+    hermit-abi                      0.1.15  3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9 \
     http_req                         0.5.5  ef9a6b5b2cd80630d9c6bda175408a86908d8a9c1eb5b2857206529d88d063a3 \
     humantime                        1.3.0  df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f \
-    idna                             0.2.0  02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9 \
-    image                           0.23.4  9117f4167a8f21fa2bb3f17a652a760acd7572645281c98e3b612a26242c96ee \
-    inflate                          0.4.5  1cdb29978cc5797bd8dcc8e5bf7de604891df2a8dc576973d71a281e916db2ff \
-    inotify                          0.7.0  24e40d6fd5d64e2082e0c796495c8ef5ad667a96d03e5aaa0becfd9d47bcbfb8 \
+    image                           0.23.6  b5b0553fec6407d63fe2975b794dfb099f3f790bdc958823851af37b26404ab4 \
+    inotify                          0.7.1  4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f \
     inotify-sys                      0.1.3  e74a1aa87c59aeff6ef2cc2fa62d41bc43f54952f55652656b18a02fd5e356c0 \
-    instant                          0.1.3  f7152d2aed88aa566e7a342250f21ba2222c1ae230ad577499dbfa3c18475b80 \
+    instant                          0.1.6  5b141fdc7836c525d4d594027d318c84161ca17aaf8113ab1f81ab93ae897485 \
     iovec                            0.1.4  b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e \
-    itoa                             0.4.5  b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e \
+    itoa                             0.4.6  dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6 \
     jni-sys                          0.3.0  8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130 \
     jobserver                       0.1.21  5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2 \
     kernel32-sys                     0.2.2  7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d \
     khronos_api                      3.1.0  e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
     lazycell                         1.2.1  b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f \
-    lexical-core                     0.6.2  d7043aa5c05dd34fb73b47acb8c3708eac428de4545ea3682ed2f11293ebd890 \
-    libc                            0.2.70  3baa92041a6fec78c687fa0cc2b3fae8884f743d672cf551bed1d6dac6988d0f \
+    libc                            0.2.72  a9f8082297d534141b30c8d39e9b1773713ab50fdbe4ff30f750d063b3bfd701 \
     libloading                       0.5.2  f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753 \
-    libz-sys                        1.0.25  2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe \
+    libloading                       0.6.2  2cadb8e769f070c45df05c78c7520eb4cd17061d4ab262e43cfc68b4d00ac71c \
     line_drawing                     0.7.0  5cc7ad3d82c845bdb5dde34ffdcc7a5fb4d2996e1e1ee0f19c33bc80e15196b9 \
     linked-hash-map                  0.5.3  8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a \
     lock_api                         0.3.4  c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75 \
     log                              0.4.8  14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7 \
     malloc_buf                       0.0.6  62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb \
-    matches                          0.1.8  7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
     maybe-uninit                     2.0.0  60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00 \
     memchr                           2.3.3  3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400 \
     memmap                           0.7.0  6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b \
-    miniz_oxide                      0.3.6  aa679ff6578b1cddee93d7e82e263b94a575e0bfced07284eb0c037c1d2416a5 \
+    miniz_oxide                      0.3.7  791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435 \
+    miniz_oxide                      0.4.0  be0f75932c1f6cfae3c04000e40114adf955636e19040f9c0a2c380702aa1c7f \
     mio                             0.6.22  fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430 \
     mio-anonymous-pipes              0.1.0  f8c274c3c52dcd1d78c5d7ed841eca1e9ea2db8353f3b8ec25789cc62c471aaf \
     mio-extras                       2.0.6  52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19 \
-    mio-named-pipes                  0.1.6  f5e374eff525ce1c5b7687c4cef63943e7686524a387933ad27ca7ec43779cb3 \
+    mio-named-pipes                  0.1.7  0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656 \
     miow                             0.2.1  8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919 \
-    miow                             0.3.3  396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226 \
+    miow                             0.3.5  07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e \
     native-tls                       0.2.4  2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d \
     ndk                              0.1.0  95a356cafe20aee088789830bfea3a61336e84ded9e545e00d3869ce95dcb80c \
     ndk-glue                         0.1.0  d1730ee2e3de41c3321160a6da815f008c4006d71b095880ea50e17cf52332b8 \
@@ -167,22 +162,22 @@ cargo.crates \
     net2                            0.2.34  2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7 \
     nix                             0.14.1  6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce \
     nix                             0.17.0  50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363 \
-    nodrop                          0.1.14  72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb \
-    nom                              5.1.1  0b471253da97532da4b61552249c521e01e736071f71c1a4f7ebbfbf0a06aad6 \
+    nom                              5.1.2  ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af \
     notify                          4.0.15  80ae4a7688d1fab81c5bf19c64fc8db920be8d519ce6336ed4e7efe024724dbd \
-    num-integer                     0.1.42  3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba \
-    num-iter                        0.1.40  dfb0800a0291891dd9f4fe7bd9c19384f98f7fbe0cd0f39a2c6b88b9868bbc00 \
-    num-rational                     0.2.4  5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef \
-    num-traits                      0.2.11  c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096 \
+    num-integer                     0.1.43  8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b \
+    num-iter                        0.1.41  7a6e6b7c748f995c4c29c5f5ae0248536e04a5739927c74ec0fa564805094b9f \
+    num-rational                     0.3.0  a5b4d7360f362cfb50dde8143501e6940b22f644be75a4cc90b2d81968908138 \
+    num-traits                      0.2.12  ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611 \
     num_enum                         0.4.3  ca565a7df06f3d4b485494f25ba05da1435950f4dc263440eda7a6fa9b8e36e4 \
     num_enum_derive                  0.4.3  ffa5a33ddddfee04c0283a7653987d634e880347e96b5b2ed64de07efb59db9d \
     objc                             0.2.7  915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1 \
     objc-foundation                  0.1.1  1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9 \
     objc_id                          0.1.1  c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b \
-    openssl                        0.10.29  cee6d85f4cb4c4f59a6a85d5b68a233d280c82e29e822913b9c8b129fbf20bdd \
+    once_cell                        1.4.0  0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d \
+    openssl                        0.10.30  8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4 \
     openssl-probe                    0.1.2  77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de \
-    openssl-sys                     0.9.56  f02309a7f127000ed50594f0b50ecc69e7c654e16d41b4e8156d1b3df8e0b52e \
-    ordered-float                    1.0.2  18869315e81473c951eb56ad5558bbc56978562d3ecfb87abb7a1e944cea4518 \
+    openssl-sys                     0.9.58  a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de \
+    ordered-float                    1.1.0  3741934be594d77de1c8461ebcbbe866f585ea616a9753aa78f2bdc69f0e4579 \
     osmesa-sys                       0.1.2  88cfece6e95d2e717e0872a7f53a8684712ad13822a7979bc760b9c77ec0013b \
     parking_lot                     0.10.2  d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e \
     parking_lot_core                 0.7.2  d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3 \
@@ -193,15 +188,15 @@ cargo.crates \
     phf_generator                    0.8.0  17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526 \
     phf_shared                       0.8.0  c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7 \
     pkg-config                      0.3.17  05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677 \
-    png                             0.16.3  2c68a431ed29933a4eb5709aca9800989758c97759345860fa5db3cfced0b65d \
-    podio                            0.1.6  780fb4b6698bbf9cf2444ea5d22411cef2953f0824b98f33cf454ec5615645bd \
-    ppv-lite86                       0.2.7  d1e4df3c96bec4c7ce0e32fe5960c98ffc869443ec9592a0411ca1ee96e5e2f0 \
+    png                             0.16.6  c150bf7479fafe3dd8740dbe48cc33b2a3efb7b0fe3483aced8bbc39f6d0238d \
+    podio                            0.1.7  b18befed8bc2b61abc79a457295e7e838417326da1586050b919414073977f19 \
+    ppv-lite86                       0.2.8  237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea \
     proc-macro-crate                 0.1.4  e10d4b51f154c8a7fb96fd6dad097cb74b863943ec010ac94b9fd1be8861fe1e \
     proc-macro2                     0.4.30  cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759 \
-    proc-macro2                     1.0.13  53f5ffe53a6b28e37c9c1ce74893477864d64f74778a93a4beb43c8fa167f639 \
+    proc-macro2                     1.0.18  beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa \
     quick-error                      1.2.3  a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0 \
     quote                           0.6.13  6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1 \
-    quote                            1.0.5  42934bc9c8ab0d3b273a16d8551c8f0fcff46be73276ca083ec2414c15c4ba5e \
+    quote                            1.0.7  aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37 \
     rand                             0.7.3  6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
     rand_chacha                      0.2.2  f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402 \
     rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
@@ -210,63 +205,59 @@ cargo.crates \
     raw-window-handle                0.3.3  0a441a7a6c80ad6473bd4b74ec1c9a4c951794285bf941c2126f607c72e48211 \
     redox_syscall                   0.1.56  2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84 \
     redox_users                      0.3.4  09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431 \
-    regex                            1.3.7  a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692 \
-    regex-syntax                    0.6.17  7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae \
-    remove_dir_all                   0.5.2  4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e \
+    regex                            1.3.9  9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6 \
+    regex-automata                   0.1.9  ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4 \
+    regex-syntax                    0.6.18  26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8 \
+    remove_dir_all                   0.5.3  3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7 \
     rust-argon2                      0.7.0  2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017 \
     rustc-hash                       1.1.0  08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2 \
     rustc_tools_util                 0.2.0  b725dadae9fabc488df69a287f5a99c5eaf5d10853842a8a3dfac52476f544ee \
-    rustc_version                    0.2.3  138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a \
     rusttype                         0.7.9  310942406a39981bed7e12b09182a221a29e0990f3e7e0c971f131922ed135d5 \
     rusttype                         0.8.3  9f61411055101f7b60ecf1041d87fb74205fb20b0c7a723f07ef39174cf6b4c0 \
-    ryu                              1.0.4  ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1 \
+    ryu                              1.0.5  71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     schannel                        0.1.19  8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75 \
+    scoped-tls                       1.0.0  ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2 \
     scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
     security-framework               0.4.4  64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535 \
     security-framework-sys           0.4.3  17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405 \
-    semver                           0.9.0  1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403 \
-    semver-parser                    0.7.0  388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
-    serde                          1.0.110  99e7b308464d16b56eba9964e4972a3eee817760ab60d88c3f86e1fecb08204c \
-    serde_derive                   1.0.110  818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984 \
-    serde_json                      1.0.53  993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2 \
-    serde_yaml                      0.8.12  16c7a592a1ec97c9c1c68d75b6e537dcbf60c7618e038e7841e00af1d9ccf0c4 \
-    servo-fontconfig                 0.4.0  a088f8d775a5c5314aae09bd77340bc9c67d72b9a45258be34c83548b4814cd9 \
-    servo-fontconfig-sys             4.0.9  62b3e166450f523f4db06c14f02a2d39e76d49b5d8cbd224338d93e3595c156c \
+    serde                          1.0.114  5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3 \
+    serde_derive                   1.0.114  2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e \
+    serde_json                      1.0.56  3433e879a558dde8b5e8feb2a04899cf34fdde1fafb894687e52105fc1162ac3 \
+    serde_yaml                      0.8.13  ae3e2dd40a7cdc18ca80db804b7f461a39bb721160a85c9a1fa30134bf3c02a5 \
+    servo-fontconfig                 0.5.1  c7e3e22fe5fd73d04ebf0daa049d3efe3eae55369ce38ab16d07ddd9ac5c217c \
+    servo-fontconfig-sys             5.1.0  e36b879db9892dfa40f95da1c38a835d41634b825fbd8c4c418093d53c24b388 \
     shared_library                   0.1.9  5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11 \
     shlex                            0.1.1  7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2 \
-    signal-hook                     0.1.15  8ff2db2112d6c761e12522c65f7768548bd6e8cd23d2a9dae162520626629bd6 \
+    signal-hook                     0.1.16  604508c1418b99dfe1925ca9224829bb2a8a9a04dda655cc01fcad46f4ab05ed \
     signal-hook-registry             1.2.0  94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41 \
     siphasher                        0.3.3  fa8f3741c7372e75519bd9346068370c9cdaabcc1f9599cbcf2a2719352286b7 \
     slab                             0.4.2  c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8 \
-    smallvec                         1.4.0  c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4 \
+    smallvec                         1.4.1  3757cb9d89161a2f24e1cf78efa0c1fcff485d18e3f55e0aa3480824ddaa0f3f \
+    smithay-client-toolkit          0.10.0  abfcf0ec41b4e51b8780b59d026f3ea98d6c06838e8c5046dcbd06fd9bfa529e \
     smithay-client-toolkit           0.6.6  421c8dc7acf5cb205b88160f8b4cc2c5cfabe210e43b2f80f009f4c1ef910f1d \
-    smithay-clipboard                0.4.0  917e8ec7f535cd1a6cbf749c8866c24d67c548a80ac48c8e88a182eab5c07bd1 \
+    smithay-clipboard                0.5.1  ba6209a44384ee0452c7f3f150556bdfa0fab300f09231971d88d525c8ae18da \
     socket2                         0.3.12  03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918 \
     spsc-buffer                      0.1.1  be6c3f39c37a4283ee4b43d1311c828f2e1fb0541e76ea0cb1a2abd9ef2f5b3b \
-    static_assertions                0.3.4  7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3 \
     stb_truetype                     0.3.1  f77b6b07e862c66a9f3e62a07588fee67cd90a9135a2b942409f195507b4fb51 \
     strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
-    syn                             1.0.22  1425de3c33b0941002740a420b1a906a350b88d08b82b2c8a01035a3f9447bac \
+    syn                             1.0.33  e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd \
     tempfile                         3.1.0  7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9 \
     termcolor                        1.1.0  bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f \
-    terminfo                         0.7.2  12064715207074ac562f450722884f981268a916ce1eb21c5bda2c806c8fecfc \
+    terminfo                         0.7.3  76971977e6121664ec1b960d1313aacfa75642adc93b9d4d53b247bd4cb1747e \
     textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
     thread_local                     1.0.1  d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14 \
     time                            0.1.43  ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438 \
     toml                             0.5.6  ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a \
     unicase                          2.6.0  50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6 \
-    unicode-bidi                     0.3.4  49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5 \
-    unicode-normalization           0.1.12  5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4 \
-    unicode-width                    0.1.7  caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479 \
+    unicode-width                    0.1.8  9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3 \
     unicode-xid                      0.1.0  fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc \
-    unicode-xid                      0.2.0  826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c \
-    url                              2.1.1  829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb \
-    urlocator                        0.1.3  317bb1e85e87e72c11cb9cda7cb8909ca174a21d0abeb0f6955b8f6b0178b164 \
+    unicode-xid                      0.2.1  f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564 \
+    urlocator                        0.1.4  14e39a4f106dafb0a748b951494667a44e62b55fd7942b4fc12706d63cc535a0 \
     utf8parse                        0.2.0  936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372 \
-    vcpkg                            0.2.8  3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168 \
+    vcpkg                           0.2.10  6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c \
     vec_map                          0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
-    version_check                    0.9.1  078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce \
+    version_check                    0.9.2  b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed \
     void                             1.0.2  6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d \
     vswhom                           0.1.0  be979b7f07507105799e854203b470ff7c78a1639e330a58f183b5fea574608b \
     vswhom-sys                       0.1.0  fc2f5402d3d0e79a069714f7b48e3ecc60be7775a2c049cb839457457a239532 \
@@ -275,13 +266,19 @@ cargo.crates \
     walkdir                          2.3.1  777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d \
     wasi      0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
     wayland-client                  0.23.6  af1080ebe0efabcf12aef2132152f616038f2d7dcbbccf7b2d8c5270fe14bcda \
+    wayland-client                  0.27.0  ab702fefbcd6d6f67fb5816e3a89a3b5a42a94290abbc015311c9a30d1068ae4 \
     wayland-commons                 0.23.6  bb66b0d1a27c39bbce712b6372131c6e25149f03ffb0cd017cf8f7de8d66dbdb \
+    wayland-commons                 0.27.0  e972e9336ad5a9dd861b4e21ff35ad71d3e5c6b4803d65c39913612f851b95f1 \
+    wayland-cursor                  0.27.0  539f346e1a3f706f38c8ccbe1196001e2fb1c9b3e6b605c27d665db2f5b60d41 \
     wayland-protocols               0.23.6  6cc286643656742777d55dc8e70d144fa4699e426ca8e9d4ef454f4bf15ffcf9 \
+    wayland-protocols               0.27.0  f3d6fc54b17b98b5083bc21ae3a30e6d75cb4b01647360e4c3a04648bcf8781d \
     wayland-scanner                 0.23.6  93b02247366f395b9258054f964fe293ddd019c3237afba9be2ccbe9e1651c3d \
+    wayland-scanner                 0.27.0  030f56009d932bd9400bb472764fea8109be1b0fc482d9cd75496c943ac30328 \
     wayland-sys                     0.23.6  d94e89a86e6d6d7c7c9b19ebf48a03afaac4af6bc22ae570e9a24124b75358f4 \
+    wayland-sys                     0.27.0  8bdeffbbb474477dfa2acb45ac7479e5fe8f741c64ab032c5d11b94d07edc269 \
     which                            3.1.1  d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724 \
     winapi                           0.2.8  167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
-    winapi                           0.3.8  8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6 \
+    winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-build                     0.1.1  2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
     winapi-util                      0.1.5  70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
@@ -290,11 +287,13 @@ cargo.crates \
     winpty                           0.2.0  92c5a39bb2408a307dd5ab774039ec3f2c68d052970ae4dacc346101abe202b2 \
     winpty-sys                       0.5.0  ed8a179a59760dc51d30b5e6eaf1bd6da88461f72f2616e962ddebef7e413210 \
     winreg                           0.6.2  b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9 \
+    wio                              0.2.2  5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5 \
     ws2_32-sys                       0.2.1  d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e \
     x11-clipboard                    0.5.1  e5e937afd03b64b7be4f959cc044e09260a47241b71e56933f37db097bf7859d \
     x11-dl                          2.18.5  2bf981e3a5b3301209754218f962052d4d9ee97e478f4d26d4a6eced34c1fef8 \
     xcb                              0.9.0  62056f63138b39116f82a540c983cc11f1c90cd70b3d492a70c25eaa50bd22a6 \
+    xcursor                          0.3.2  d3a481cfdefd35e1c50073ae33a8000d695c98039544659f5dc5dd71311b0d01 \
     xdg                              2.2.0  d089681aa106a86fade1b0128fb5daf07d5867a509ab036d99988dec80429a57 \
-    xml-rs                           0.8.0  541b12c998c5b56aa2b4e6f18f03664eef9a4fd0a246a55594efae6cc2d964b5 \
-    yaml-rust                        0.4.3  65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d \
-    zip                              0.5.5  6df134e83b8f0f8153a094c7b0fd79dfebe437f1d76e7715afa18ed95ebe2fd7
+    xml-rs                           0.8.3  b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a \
+    yaml-rust                        0.4.4  39f0c922f1a334134dc2f7a8b67dc5d25f0735263feec974345ff706bcf20b0d \
+    zip                              0.5.6  58287c28d78507f5f91f2a4cf1e8310e2c76fd4c6932f93ac60fd1ceb402db7d


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
