### PR TITLE
py-oslo-config: submission (missing dep. of py-openstackclient in #7842)

### DIFF
--- a/python/py-jsonpatch/Portfile
+++ b/python/py-jsonpatch/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-jsonpatch
-version             1.25
+version             1.26
 revision            0
 
 platforms           darwin
@@ -17,11 +17,11 @@ long_description    ${description}
 
 homepage            https://github.com/stefankoegl/python-json-patch
 
-checksums           sha256  ddc0f7628b8bfdd62e3cbfbc24ca6671b0b6265b50d186c2cf3659dc0f78fd6a \
-                    rmd160  00801d372b99b53c17131bb88464f95134275cba \
-                    size    19341
+checksums           sha256  e45df18b0ab7df1925f20671bbc3f6bd0b4b556fb4b9c5d97684b0a7eac01744 \
+                    rmd160  82cf1761dba6d8f319b91b6eb24cdbe3fce09af4 \
+                    size    18641
 
-python.versions     37 38
+python.versions     36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-jsonpointer/Portfile
+++ b/python/py-jsonpointer/Portfile
@@ -21,7 +21,7 @@ checksums           sha256  c192ba86648e05fdae4f08a17ec25180a9aef5008d973407b581
                     rmd160  4fe729b7eef7e220e1bf7015dcc837e330db1582 \
                     size    8699
 
-python.versions     37 38
+python.versions     36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-oslo-config/Portfile
+++ b/python/py-oslo-config/Portfile
@@ -1,0 +1,44 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-oslo-config
+version             8.3.1
+platforms           darwin
+maintainers         nomaintainer
+license             Apache-2
+supported_archs     noarch
+
+description         Oslo Configuration Library
+long_description    ${description}
+homepage            https://docs.openstack.org/oslo.config/latest/
+master_sites        pypi:o/oslo.config/
+distname            oslo.config-${version}
+checksums           md5     f28614f3647fdbf6348f377dada38af2 \
+                    rmd160  3bb48fec41ac70f977286b7ec91226b507ca45e8 \
+                    sha256  dfbb83dc5b4c86ddf8b96f3967252f17586a67f2cef65309df2fd510bf9e87fc \
+                    size    149370
+
+python.versions     36 37 38
+
+if {${subport} ne ${name}} {
+    livecheck.type  none
+
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_run-append \
+                    port:py${python.version}-debtcollector \
+                    port:py${python.version}-netaddr \
+                    port:py${python.version}-stevedore \
+                    port:py${python.version}-oslo-i18n \
+                    port:py${python.version}-rfc3986 \
+                    port:py${python.version}-yaml \
+                    port:py${python.version}-requests \
+                    port:py${python.version}-importlib-metadata
+
+    livecheck.type  none
+} else {
+    livecheck.name  oslo.config
+}


### PR DESCRIPTION
Submission of py-oslo-config (missing dep. of py-openstackclient submitted in #7842)
Update py-jsonpatch to 1.26 with added support for py36

#### Description

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6
Xcode 9.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
