### PR TITLE
macos-fortress: Fix startupitems for MacPorts 2.6.3

### DIFF
--- a/net/macos-fortress/Portfile
+++ b/net/macos-fortress/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                macos-fortress
 version             2020.06.18
-revision            0
+revision            1
 
 categories          net security
 platforms           darwin
@@ -162,6 +162,16 @@ sudo apachectl start
 \t${proxy_hostname}:3128
 \thttp://${proxy_hostname}/proxy.pac"
 
+pre-fetch {
+    # The way that startupitems values are quoted was changed in 2.6.3.
+    # This port now relies on those changes. See:
+    # https://github.com/macports/macports-base/pull/191
+    if {[vercmp [macports_version] 2.6.3] < 0} {
+        ui_error "${name} @${version} requires MacPorts 2.6.3 or later"
+        return -code error "incompatible MacPorts version"
+    }
+}
+
 if {${name} eq ${subport}} {
     description     Firewall, Blackhole, and Privatizing Proxy for Trackers, Attackers, Malware, Adware, and Spammers
     long_description    \
@@ -287,30 +297,32 @@ subport ${name}-pf {
     startupitems \
         name        ${subport} \
         init        "PF_CONF=\"\${PF_CONF:-${pf_conf_prefix}}\"" \
-        start       "for tt in {1..4}; do \\
-\t\tif \[\[ `/sbin/ifconfig | \${prefix}/bin/pcregrep -M -o '^\[^\\t:\]+:(\[^\\n\]|\\n\\t)*status: active' | egrep -o -m 1 '^\[^\\t:\]+'` = '' \]\]; then \\
-\t\t\tsleep 45; \\
-\t\telse \\
-\t\t\t/sbin/pfctl -Fall \\
-\t\t\t&& /sbin/pfctl -ef \${PF_CONF}; \\
-\t\t\tbreak; \\
-\t\tfi; \\
-\tdone" \
-        stop        "/sbin/pfctl -d" \
+        start {
+                    "for tt in {1..4}; do \\"
+                    "\tif \[\[ `/sbin/ifconfig | \${prefix}/bin/pcregrep -M -o '^\[^\\t:\]+:(\[^\\n\]|\\n\\t)*status: active' | egrep -o -m 1 '^\[^\\t:\]+'` = '' \]\]; then \\"
+                    "\t\tsleep 45; \\"
+                    "\telse \\"
+                    "\t\t/sbin/pfctl -Fall \\"
+                    "\t\t&& /sbin/pfctl -ef \${PF_CONF}; \\"
+                    "\t\tbreak; \\"
+                    "\tfi; \\"
+                    "done"
+        } \
+        stop        { "/sbin/pfctl -d" } \
         pidfile     none \
         name        ${subport}.brutexpire \
         executable  /sbin/pfctl \
         pidfile     none \
         name        ${subport}.subports \
-        start \
-                    "\${prefix}/bin/port load ${name}-dshield
-\t\${prefix}/bin/port load ${name}-emergingthreats" \
-        stop \
-                    "\${prefix}/bin/port unload ${name}-dshield
-\t\${prefix}/bin/port unload ${name}-emergingthreats" \
-        restart \
-                    "\${prefix}/bin/port reload ${name}-dshield
-\t\${prefix}/bin/port reload ${name}-emergingthreats" \
+        start [list \
+                    "\${prefix}/bin/port -p load ${name}-dshield ${name}-emergingthreats" \
+        ] \
+        stop [list \
+                    "\${prefix}/bin/port -p unload ${name}-dshield unload ${name}-emergingthreats" \
+        ] \
+        restart [list \
+                    "\${prefix}/bin/port -p reload ${name}-dshield ${name}-emergingthreats" \
+        ] \
         pidfile     none
 
     post-activate {
@@ -554,21 +566,15 @@ subport ${name}-proxy {
                     yes
     startupitems \
         name        ${subport} \
-        start       "\${prefix}/bin/port load ${name}-hosts
-\t\${prefix}/bin/port load squid4
-\t\${prefix}/bin/port load privoxy
-\t\${prefix}/bin/port load adblock2privoxy
-\t\${prefix}/bin/port load ${name}-easylistpac" \
-        stop        "\${prefix}/bin/port unload ${name}-hosts
-\t\${prefix}/bin/port unload squid4
-\t\${prefix}/bin/port unload privoxy
-\t\${prefix}/bin/port unload adblock2privoxy
-\t\${prefix}/bin/port unload ${name}-easylistpac" \
-        restart     "\${prefix}/bin/port reload ${name}-hosts
-\t\${prefix}/bin/port reload squid4
-\t\${prefix}/bin/port reload privoxy
-\t\${prefix}/bin/port reload adblock2privoxy
-\t\${prefix}/bin/port reload ${name}-easylistpac" \
+        start [list \
+                    "\${prefix}/bin/port -p load ${name}-hosts squid4 privoxy adblock2privoxy ${name}-easylistpac" \
+        ] \
+        stop [list \
+                    "\${prefix}/bin/port -p unload ${name}-hosts squid4 privoxy adblock2privoxy ${name}-easylistpac" \
+        ] \
+        restart [list \
+                    "\${prefix}/bin/port -p reload ${name}-hosts squid4 privoxy adblock2privoxy ${name}-easylistpac" \
+        ] \
         pidfile     none \
         name        ${subport}.squid-rotate \
         executable  ${prefix}/sbin/squid \


### PR DESCRIPTION
macos-fortress: Fix startupitems for MacPorts 2.6.3

* Fixes: https://trac.macports.org/ticket/60924

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708 


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
