### PR TITLE
FAudio: Update to 20.08

### DIFF
--- a/audio/FAudio/Portfile
+++ b/audio/FAudio/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cmake 1.1
 
-github.setup            FNA-XNA FAudio 20.07
+github.setup            FNA-XNA FAudio 20.08
 revision                0
 
 license                 zlib
@@ -18,23 +18,26 @@ long_description        an XAudio reimplementation that focuses solely on develo
 
 depends_lib-append      port:libsdl2
 
-checksums               rmd160  eca88c3b235e6815c7c17bf6392c2ffdc30d9a25 \
-                        sha256  5846d61f088cd7b4450e6424a21bc4cff8f6074ab0cee702586b2a3b784bfdf6 \
-                        size    1131873
+checksums               rmd160  e24c9e179d5a806ad63d324a63a4200f6a6b321e \
+                        sha256  8aef339e0ddef9ca963a2903407e6ed254dbf8427fdb2977df6f47e99047f700 \
+                        size    1131793
 
 # remove set deployment target and hard-coded RPATH setting
 patchfiles              patch-faudio-remove-deployment-target.diff
 
-configure.args          -DFFMPEG=OFF \
+configure.args          -DGSTREAMER=OFF \
                         -DBUILD_UTILS=OFF \
                         -DBUILD_TESTS=ON \
                         -DXNASONG=ON
 
-variant ffmpeg description "Use ffmpeg for additional xWMA support - note license changes" {
-    license                GPL-2+
-    depends_lib-append     path:lib/libavcodec.dylib:ffmpeg
-    configure.args-replace -DFFMPEG=OFF -DFFMPEG=ON
+variant wma description "Use gstreamer1-gst-libav for additional xWMA support - note license changes" {
+    license                   GPL-2+
+    depends_lib-append        port:gstreamer1-gst-libav
+    configure.args-replace    -DGSTREAMER=OFF -DGSTREAMER=ON
 }
+
+# This legacy compatibility variant can be removed after August 2021.
+variant ffmpeg requires wma description {Legacy compatibility variant} {}
 
 #pre-destroot {
 #    there are some utilities to consider, but the facttool segfaulted when I tried to open an audio engine


### PR DESCRIPTION
FAudio no longer uses ffmpeg for xWMA, gstreamer1-gst-libav is now used instead.

Changed ffmpeg variant to wma

#### Description

What would be the correct way to handle changing from `+ffmpeg` to `+wma` variant?

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G6020
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->