### PR TITLE
libtapi: Use python38

### DIFF
--- a/devel/libtapi/Portfile
+++ b/devel/libtapi/Portfile
@@ -41,9 +41,9 @@ post-extract {
     system -W ${worksrcpath} "ln -s ../../tapi ${worksrcpath}/clang/tools/tapi"
 }
 
-depends_build-append    port:python27
-configure.args-append   -DPYTHON_EXECUTABLE=${prefix}/bin/python2.7
-depends_skip_archcheck-append python27
+depends_build-append    port:python38
+configure.args-append   -DPYTHON_EXECUTABLE=${prefix}/bin/python3.8
+depends_skip_archcheck-append python38
 
 # remove need for port:libxml2 dependency
 configure.args-append -DLIBXML2_LIBRARIES=IGNORE

--- a/devel/libtapi/Portfile
+++ b/devel/libtapi/Portfile
@@ -37,8 +37,7 @@ worksrcdir              tapi_build
 post-extract {
     move ${workpath}/llvm-project-llvmorg-${llvm_version} ${workpath}/${worksrcdir}
     move ${workpath}/tapi-${version} ${worksrcpath}/tapi
-#   can't quite sort out the built-in "ln" command to do this
-    system -W ${worksrcpath} "ln -s ../../tapi ${worksrcpath}/clang/tools/tapi"
+    ln -s ../../tapi ${worksrcpath}/clang/tools/tapi
 }
 
 depends_build-append    port:python38


### PR DESCRIPTION
#### Description

Two small fixes for libtapi:

1. use python38 because python27 is eol
2. use MacPorts ln procedure rather than calling the ln executable through system

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G12034
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
