### PR TITLE
folderify: new port

### DIFF
--- a/python/folderify/Portfile
+++ b/python/folderify/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           python 1.0
+
+github.setup        lgarron folderify 1.2.3 v
+github.tarball_from archive
+
+categories          python amusements
+platforms           darwin
+license             MIT
+
+maintainers         {@harens gmail.com:harensdeveloper} \
+                    openmaintainer
+description         Generate pretty, beveled macOS folder icons
+long_description    Generate a native macOS folder icon from a mask file
+
+checksums           rmd160 d8360360574827ad2852116d6e0127e708f56c12 \
+                    sha256 3a9eaadf1f2a9dde3ab58bb07ea5b1a5f5a182f62fe19e2cd79a88f6abe00f7e \
+                    size   4382181
+
+python.versions     38
+depends_lib-append  port:ImageMagick
+
+test {
+    system -W ${worksrcpath} "folderify"
+}


### PR DESCRIPTION
#### Description

Adds a new port for [folderify](https://github.com/lgarron/folderify) v1.2.3

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix
- [x] submission

###### Tested on

macOS 10.15.6 19G73
xcode-select version 2373

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
