### PR TITLE
p5-dbd-mysql: update variants

### DIFF
--- a/perl/p5-dbd-mysql/Portfile
+++ b/perl/p5-dbd-mysql/Portfile
@@ -26,70 +26,79 @@ if {${perl5.major} != ""} {
     depends_lib-append \
                     port:p${perl5.major}-dbi
 
-    variant mysql4 conflicts mysql5 mysql51 mysql55 mysql56 mysql57 mariadb mariadb10_0 mariadb10_1 mariadb10_2 percona description {build with mysql4 port} {
-        depends_lib-append      port:mysql4
+    foreach version {4 5 51 55} {
+        variant mysql${version} requires mysql57 description {Legacy compatibility variant} {}
     }
 
-    variant mysql5 conflicts mysql4 mysql51 mysql55 mysql56 mysql57 mariadb mariadb10_0 mariadb10_1 mariadb10_2 percona description {build with mysql5 port} {
-        depends_lib-append      path:bin/mysql_config5:mysql5
-        configure.args-append   --mysql_config=${prefix}/bin/mysql_config5
-    }
-
-    variant mysql51 conflicts mysql4 mysql5 mysql55 mysql56 mysql57 mariadb mariadb10_0 mariadb10_1 mariadb10_2 percona description {build with mysql51 port} {
-        depends_lib-append      port:mysql51
-        configure.args-append   --mysql_config=${prefix}/lib/mysql51/bin/mysql_config
-    }
-
-    variant mysql55 conflicts mysql4 mysql5 mysql51 mysql56 mysql57 mariadb mariadb10_0 mariadb10_1 mariadb10_2 percona description {build with mysql55 port} {
-        depends_lib-append      port:mysql55
-        configure.args-append   --mysql_config=${prefix}/lib/mysql55/bin/mysql_config
-    }
-
-    variant mysql56 conflicts mysql4 mysql5 mysql51 mysql55 mysql57 mariadb mariadb10_0 mariadb10_1 mariadb10_2 percona description {build with mysql56 port} {
+    variant mysql56 conflicts mysql57 mysql8 mariadb mariadb10_0 mariadb10_1 mariadb10_2 \
+                    mariadb10_2 mariadb10_3 mariadb10_4 percona description {build with mysql56 port} {
         depends_lib-append      port:mysql56
         configure.args-append   --mysql_config=${prefix}/lib/mysql56/bin/mysql_config
     }
 
-    variant mysql57 conflicts mysql4 mysql5 mysql51 mysql55 mysql56 mariadb mariadb10_0 mariadb10_1 mariadb10_2 percona description {build with mysql57 port} {
+    variant mysql57 conflicts mysql56 mysql8 mariadb mariadb10_0 mariadb10_1 mariadb10_2 \
+                    mariadb10_3 mariadb10_4 percona description {build with mysql57 port} {
         depends_lib-append      port:mysql57
         configure.args-append   --mysql_config=${prefix}/lib/mysql57/bin/mysql_config
     }
 
-    variant mariadb conflicts mysql4 mysql5 mysql51 mysql55 mysql56 mysql57 mariadb10_0 mariadb10_1 mariadb10_2 percona description {build with mariadb port} {
+    variant mysql8 conflicts mysql56 mysql57 mariadb mariadb10_0 mariadb10_1 mariadb10_2 \
+                    mariadb10_3 mariadb10_4 percona description {build with mysql8 port} {
+        depends_lib-append      port:mysql8
+        configure.args-append   --mysql_config=${prefix}/lib/mysql8/bin/mysql_config
+    }
+
+    variant mariadb conflicts mysql56 mysql57 mysql8 mariadb10_0 mariadb10_1 mariadb10_2 \
+                    mariadb10_3 mariadb10_4 percona description {build with mariadb port} {
         depends_lib-append      port:mariadb
         configure.args-append   --mysql_config=${prefix}/lib/mariadb/bin/mysql_config
     }
 
-    variant mariadb10_0 conflicts mysql4 mysql5 mysql51 mysql55 mysql56 mysql57 mariadb mariadb10_1 mariadb10_2 percona description {build with mariadb-10.0 port} {
+    variant mariadb10_0 conflicts mysql56 mysql57 mysql8 mariadb mariadb10_1 mariadb10_2 \
+                        mariadb10_3 mariadb10_4 percona description {build with mariadb-10.0 port} {
         depends_lib-append      port:mariadb-10.0
         configure.args-append   --mysql_config=${prefix}/lib/mariadb-10.0/bin/mysql_config
     }
 
-    variant mariadb10_1 conflicts mysql4 mysql5 mysql51 mysql55 mysql56 mysql57 mariadb mariadb10_0 mariadb10_2 percona description {build with mariadb-10.1 port} {
+    variant mariadb10_1 conflicts mysql56 mysql57 mysql8 mariadb mariadb10_0 mariadb10_2 \
+                        mariadb10_3 mariadb10_4 percona description {build with mariadb-10.1 port} {
         depends_lib-append      port:mariadb-10.1
         configure.args-append   --mysql_config=${prefix}/lib/mariadb-10.1/bin/mysql_config
     }
 
-    variant mariadb10_2 conflicts mysql4 mysql5 mysql51 mysql55 mysql56 mysql57 mariadb mariadb10_0 mariadb10_1 percona description {build with mariadb-10.2 port} {
+    variant mariadb10_2 conflicts mysql56 mysql57 mysql8 mariadb mariadb10_0 mariadb10_1 \
+                        mariadb10_3 mariadb10_4 percona description {build with mariadb-10.2 port} {
         depends_lib-append      port:mariadb-10.2
         configure.args-append   --mysql_config=${prefix}/lib/mariadb-10.2/bin/mysql_config
     }
 
-    variant percona conflicts mysql4 mysql5 mysql51 mysql55 mysql56 mariadb description {build with percona port} {
+    variant mariadb10_3 conflicts mysql56 mysql57 mysql8 mariadb mariadb10_0 mariadb10_1 \
+                        mariadb10_2 mariadb10_4 percona description {build with mariadb-10.3 port} {
+        depends_lib-append      port:mariadb-10.3
+        configure.args-append   --mysql_config=${prefix}/lib/mariadb-10.3/bin/mysql_config
+    }
+
+    variant mariadb10_4 conflicts mysql56 mysql57 mysql8 mariadb mariadb10_0 mariadb10_1 \
+                        mariadb10_2 mariadb10_3 percona description {build with mariadb-10.4 port} {
+        depends_lib-append      port:mariadb-10.4
+        configure.args-append   --mysql_config=${prefix}/lib/mariadb-10.4/bin/mysql_config
+    }
+
+    variant percona conflicts mysql56 mysql57 mysql8 mariadb mariadb10_0 mariadb10_1 \
+                    mariadb10_2 mariadb10_3 mariadb10_4 description {build with percona port} {
         depends_lib-append      port:percona
         configure.args-append   --mysql_config=${prefix}/lib/percona/bin/mysql_config
     }
 
-    if {   ![variant_isset mysql4]
-        && ![variant_isset mysql5]
-        && ![variant_isset mysql51]
-        && ![variant_isset mysql55]
-        && ![variant_isset mysql56]
+    if {   ![variant_isset mysql56]
         && ![variant_isset mysql57]
+        && ![variant_isset mysql8]
         && ![variant_isset mariadb]
         && ![variant_isset mariadb10_0]
         && ![variant_isset mariadb10_1]
         && ![variant_isset mariadb10_2]
+        && ![variant_isset mariadb10_3]
+        && ![variant_isset mariadb10_4]
         && ![variant_isset percona]
     } {
         if {${os.major} > 12} {


### PR DESCRIPTION
#### Description
    
-   Add variants: `maria10_{3,4}`
-   Remove older legacy variant (< `mysql57`)
    See: https://trac.macports.org/ticket/43431
    
—
    
This one also closes an old ticket – which looks fixed, but forgotten about?
    
-   Closes: https://trac.macports.org/ticket/44484


###### Type(s)

- [x] update
- [x] enhancement

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503 

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
