### PR TITLE
ffmpeg: fix for no universal variant in dav1d

### DIFF
--- a/multimedia/ffmpeg-devel/Portfile
+++ b/multimedia/ffmpeg-devel/Portfile
@@ -67,8 +67,7 @@ depends_build       port:pkgconfig \
                     port:gmake \
                     port:texinfo
 
-depends_lib         port:dav1d \
-                    port:lame \
+depends_lib         port:lame \
                     port:libiconv \
                     port:libvorbis \
                     port:libopus \
@@ -120,7 +119,6 @@ configure.cflags-append -DHAVE_LRINTF ${configure.cppflags}
 configure.args      --enable-swscale \
                     --enable-avfilter \
                     --enable-avresample \
-                    --enable-libdav1d \
                     --enable-libmp3lame \
                     --enable-libvorbis \
                     --enable-libopus \
@@ -183,11 +181,17 @@ platform darwin {
         configure.args-replace --disable-audiotoolbox --enable-audiotoolbox
     }
 
-    # libsdl2 requires minimum Xcode 10.7 SDK to build successfully
-    # but builds on Snow Leopard
     if {${os.major} > 9} {
+        # libsdl2 requires minimum Xcode 10.7 SDK to build successfully
+        # but builds on Snow Leopard
         configure.args-replace --disable-sdl2 --enable-sdl2
         depends_lib-append     port:libsdl2
+
+        # Dav1d: 10.6+ No PowerPC or Apple Silicon (for now)
+        if {![regexp -all (arm64|ppc*) [get_canonical_archs]]} {
+            configure.args-append   --enable-libdav1d
+            depends_lib-append      port:dav1d
+        }
     }
 
     # VideoToolbox, a new hardware acceleration framework, is supported on 10.8+ and "here to stay".

--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -65,8 +65,7 @@ depends_build       port:pkgconfig \
                     port:ld64 \
                     port:texinfo
 
-depends_lib         port:dav1d \
-                    port:lame \
+depends_lib         port:lame \
                     port:libiconv \
                     port:libvorbis \
                     port:libopus \
@@ -118,7 +117,6 @@ configure.cflags-append -DHAVE_LRINTF ${configure.cppflags}
 configure.args      --enable-swscale \
                     --enable-avfilter \
                     --enable-avresample \
-                    --enable-libdav1d \
                     --enable-libmp3lame \
                     --enable-libvorbis \
                     --enable-libopus \
@@ -181,11 +179,17 @@ platform darwin {
         configure.args-replace --disable-audiotoolbox --enable-audiotoolbox
     }
 
-    # libsdl2 requires minimum Xcode 10.7 SDK to build successfully
-    # but builds on Snow Leopard
     if {${os.major} > 9} {
+        # libsdl2 requires minimum Xcode 10.7 SDK to build successfully
+        # but builds on Snow Leopard
         configure.args-replace --disable-sdl2 --enable-sdl2
         depends_lib-append     port:libsdl2
+
+        # Dav1d: 10.6+ No PowerPC or Apple Silicon (for now)
+        if {![regexp -all (arm64|ppc*) [get_canonical_archs]]} {
+            configure.args-append   --enable-libdav1d
+            depends_lib-append      port:dav1d
+        }
     }
 
     # VideoToolbox, a new hardware acceleration framework, is supported on 10.8+ and "here to stay".


### PR DESCRIPTION
#### Description
    
~`dav1d` does not have a universal variant.~

`dav1d` does have a universal variant now, but does not build on `arm` or `powerpc`.
    
Closes: https://trac.macports.org/ticket/60947

###### Type(s)

- [x] bugfix

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port install`?
- [x] tested basic functionality of all binary files?

###### Notes

Perhaps the revbump is unnecessary since it was added just the other day, and this really doesn't change anything more than shielding `dav1d` from the universal variant?
_(Removed it for now, after discussion in the ticket. […»»](https://trac.macports.org/ticket/60947#comment:7))._