### PR TITLE
k9s: update to 0.21.7

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.21.4 v
+go.setup            github.com/derailed/k9s 0.21.7 v
 homepage            https://k9scli.io
 
 categories          sysutils devel
@@ -20,9 +20,9 @@ platforms           darwin
 supported_archs     x86_64
 license             Apache-2
 
-checksums           rmd160  e8a65bac6c520a64521f62ec7873eda3f2cf38c4 \
-                    sha256  1e68d0838e1b661bba46418ccc56d7715c06d4871ad6607affcb6abec5882a03 \
-                    size    6080640
+checksums           rmd160  f049bf298a5b4b8049f3989416a9021aae046b2c \
+                    sha256  576418b30b175861022e27e970f40698d5bf4bf8f013592fb50fc1975aecf237 \
+                    size    6082738
 
 # Reproduce the "build" target from the upstream Makefile
 set go_ldflags      "-w -X ${go.package}/cmd.version=${version} \


### PR DESCRIPTION
#### Description

Update to k9s 0.21.7.

###### Tested on

macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?