### PR TITLE
zettlr: update to 1.7.4

### DIFF
--- a/aqua/zettlr/Portfile
+++ b/aqua/zettlr/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        Zettlr Zettlr 1.7.3 v
+github.setup        Zettlr Zettlr 1.7.4 v
 name                zettlr
 revision            0
 
@@ -32,11 +32,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  957b09b198d6f328e5ab3f5b987e04c9ed86010c \
-                    sha256  e5b607904caa2b2aa1bd53a72302020d2ac69a64dbd725763870c13d02f6850c \
-                    size    28200717
-
-set ab_bin_commit   b85740334fec875f5dd8dcd22eb1f729599109db
+                    rmd160  7bfa1a67ea25458aae6169d512eb23e61c2b04af \
+                    sha256  6ce4c50ca1cb7b277d29faf5a7f89f0eb56eb0ed59726dfb8935b0f23489b7e1 \
+                    size    28201286
 
 depends_build       port:go \
                     port:yarn


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
