### PR TITLE
figlet: Fix implicit declaration of function

### DIFF
--- a/textproc/figlet/Portfile
+++ b/textproc/figlet/Portfile
@@ -23,6 +23,8 @@ patchfiles      patch-Makefile patch-figlet.6
 
 use_configure   no
 
+configure.cflags-append -Dunix
+
 variant universal {}
 
 post-patch {


### PR DESCRIPTION
#### Description

figlet: Fix implicit declaration of function

Defining "unix" causes figlet.c to #include <unistd.h> which is needed to fix "implicit declaration of function 'getopt'".

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G12034
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
