### PR TITLE
alacritty: fix checksum for 0.5.0

### DIFF
--- a/aqua/alacritty/Portfile
+++ b/aqua/alacritty/Portfile
@@ -19,9 +19,9 @@ long_description    Alacritty is the fastest terminal emulator in existence. \
                     supports macOS, Linux, BSD, and Windows.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  d04dc788a7ad1c27085ad0b561bf2d52fa19d1ab \
-                    sha256  5dbf2d17a08e17926b642ba9933af43eda25bc913a94760e2eb65199477db29f \
-                    size    1500531
+                    rmd160  308ef7756060ba7efc1357df28afccc86068afa2 \
+                    sha256  419029f7da1abb8d422b22ab116940e0a32b2bbc545010313d536f70778adce0 \
+                    size    1500516
 
 set al_app_name     Alacritty.app
 set al_app_dir      ${applications_dir}/${al_app_name}


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
