### PR TITLE
oauth2-proxy: new port

### DIFF
--- a/security/oauth2-proxy/Portfile
+++ b/security/oauth2-proxy/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 
 github.setup            oauth2-proxy oauth2-proxy 6.0.0 v
-                        
+revision                0
 
 categories              security
 license                 MIT

--- a/security/oauth2-proxy/Portfile
+++ b/security/oauth2-proxy/Portfile
@@ -1,0 +1,104 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+
+github.setup            oauth2-proxy oauth2-proxy 6.0.0 v
+                        
+
+categories              security
+license                 MIT
+platforms               darwin
+
+homepage                https://oauth2-proxy.github.io/oauth2-proxy
+
+description             A reverse proxy that provides authentication with \
+                        Google, Github or other providers.
+
+long_description        A reverse proxy and static file server that provides \
+                        authentication using Providers (Google, GitHub, and \
+                        others) to validate accounts by email, domain or group.
+
+maintainers             {gmail.com:herby.gillot @herbygillot} \
+                        openmaintainer
+
+checksums               rmd160  a1f544f779f3f8d295cdb89730f69fc10f6e1f5c \
+                        sha256  cb220d85ed27d21611cc0466140a1b0a41879253d9965b00e41ad740db363d73 \
+                        size    380452
+
+set o2p_conf_dir        ${prefix}/etc/${name}
+set o2p_log_dir         ${prefix}/var/log/${name}
+set o2p_share_dir       ${prefix}/share/${name}
+
+set o2p_config_file     ${o2p_conf_dir}/${name}.cfg
+set o2p_example_src     ${worksrcpath}/contrib/${name}.cfg.example
+set o2p_example_file    ${o2p_share_dir}/${name}.cfg.example
+set o2p_log_file        ${o2p_log_dir}/${name}.log
+set o2p_user            oauth2proxy
+
+build.cmd               make
+build.pre_args          VERSION=${version}
+build.args              ${name}
+
+depends_build           port:go
+use_configure           no
+
+add_users               ${o2p_user} \
+                        group=${o2p_user} \
+                        realname="Oauth2-Proxy"
+
+destroot.keepdirs-append \
+                        ${destroot}${o2p_conf_dir} \
+                        ${destroot}${o2p_log_dir}
+
+post-extract {
+    copy  ${filespath}/org.macports.${name}.plist \
+          ${workpath}/org.macports.${name}.plist
+
+    reinplace "s|@NAME@|${name}|g"      ${workpath}/org.macports.${name}.plist
+    reinplace "s|@USER@|${o2p_user}|g"  ${workpath}/org.macports.${name}.plist
+    reinplace "s|@GROUP@|${o2p_user}|g" ${workpath}/org.macports.${name}.plist
+    reinplace "s|@PREFIX@|${prefix}|g"  ${workpath}/org.macports.${name}.plist
+
+    reinplace "s|@CONF_FILE@|${o2p_config_file}|g" \
+        ${workpath}/org.macports.${name}.plist
+
+    reinplace "s|@LOGFILE@|${o2p_log_file}|g" \
+        ${workpath}/org.macports.${name}.plist
+}
+
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+    xinstall -d -m 755 -o ${o2p_user} ${destroot}${o2p_log_dir}
+    xinstall -d -m 755 ${destroot}${o2p_conf_dir}
+    xinstall -d -m 755 ${destroot}${o2p_share_dir}
+    copy ${o2p_example_src} ${destroot}${o2p_example_file}
+
+    xinstall -d -m 755 \
+        ${destroot}${prefix}/etc/LaunchDaemons/org.macports.${name}
+
+    xinstall -m 0644 -o root -W ${workpath} org.macports.${name}.plist \
+        ${destroot}${prefix}/etc/LaunchDaemons/org.macports.${name}
+
+    xinstall -d -m 755 ${destroot}/Library/LaunchDaemons
+
+    ln -s ${prefix}/etc/LaunchDaemons/org.macports.${name}/org.macports.${name}.plist \
+        ${destroot}/Library/LaunchDaemons/org.macports.${name}.plist
+}
+
+post-activate {
+    if {![file exists ${o2p_config_file}]} {
+        copy ${o2p_example_file} ${o2p_config_file}
+    }
+}
+
+notes "
+    Please edit the configuration for ${name} at: ${o2p_config_file}
+
+    Once done, start the service with: \$ sudo port load ${name}
+
+    ${name} will log to: ${o2p_log_file}
+
+    To stop and remove the service, do: \$ sudo port unload ${name}
+"

--- a/security/oauth2-proxy/files/org.macports.oauth2-proxy.plist
+++ b/security/oauth2-proxy/files/org.macports.oauth2-proxy.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>org.macports.@NAME@</string>
+    <key>ProcessType</key>
+    <string>Interactive</string>
+    <key>Disabled</key>
+    <false/>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>SessionCreate</key>
+    <true/>
+    <key>LaunchOnlyOnce</key>
+    <false/>
+    <key>UserName</key>
+    <string>@USER@</string>
+    <key>GroupName</key>
+    <string>@GROUP@</string>
+    <key>ExitTimeOut</key>
+    <integer>600</integer>
+    <key>ProgramArguments</key>
+        <array>
+            <string>@PREFIX@/bin/@NAME@</string>
+            <string>--config=@CONF_FILE@</string>
+        </array>
+    <key>StandardErrorPath</key>
+    <string>@LOGFILE@</string>
+    <key>StandardOutPath</key>
+    <string>@LOGFILE@</string>
+</dict>
+</plist>


### PR DESCRIPTION
- fixes: https://trac.macports.org/ticket/60948

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
