### PR TITLE
angle-grinder: update to 0.14.1

### DIFF
--- a/sysutils/angle-grinder/Portfile
+++ b/sysutils/angle-grinder/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        rcoh angle-grinder 0.13.0 v
+github.setup        rcoh angle-grinder 0.14.1 v
 
 categories          sysutils textproc
 license             MIT
@@ -21,9 +21,9 @@ long_description    Angle-grinder allows you to parse, aggregate, sum, \
                     but still want to be able to do sophisticated analytics.
 
 checksums-append    ${distfiles} \
-                    rmd160  a1ea0096f442a286b464b324df6e7dfeaec7fbb7 \
-                    sha256  04edeef87dfdde8a746c4c2498c8491b6b4625ff09696d496be4a580b583a458 \
-                    size    934367
+                    rmd160  d15e1f132e6311bc9ea7f80045c2e48e267bf653 \
+                    sha256  3a02ef5b4c2c3d4d654f248c9d83d414fab92069f26acc7cc0a12097a7595bec \
+                    size    938146
 
 depends_lib-append  path:lib/libssl.dylib:openssl
 
@@ -58,6 +58,7 @@ cargo.crates \
     bzip2                            0.3.3  42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b \
     bzip2-sys                        0.1.7  6584aa36f5ad4c9247f5323b0a42f37802b37a836f0ad87084d7a33961abe25f \
     c2-chacha                        0.2.3  214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb \
+    cargo-husky                      1.5.0  7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad \
     cast                             0.2.3  4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0 \
     cc                              1.0.50  95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd \
     cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
@@ -77,8 +78,8 @@ cargo.crates \
     crossbeam-deque                  0.7.2  c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca \
     crossbeam-epoch                  0.8.0  5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac \
     crossbeam-queue                  0.2.1  c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db \
-    crossbeam-utils                  0.7.0  ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4 \
     crossbeam-utils                  0.6.6  04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6 \
+    crossbeam-utils                  0.7.0  ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4 \
     csv                              1.1.3  00affe7f6ab566df61b4be3ce8cf16bc2576bca0963ceb0955e45d514bf9a279 \
     csv-core                         0.1.6  9b5cadb6b25c77aeff80ba701712494213f4a8418fcda2ee11b6560c3ad0bf4c \
     difference                       2.0.0  524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198 \
@@ -96,6 +97,7 @@ cargo.crates \
     fnv                              1.0.6  2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3 \
     foreign-types                    0.3.2  f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1 \
     foreign-types-shared             0.1.1  00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b \
+    fs_extra                         1.1.0  5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674 \
     fuchsia-cprng                    0.1.1  a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba \
     fuchsia-zircon                   0.3.3  2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
     fuchsia-zircon-sys               0.3.3  3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
@@ -104,6 +106,7 @@ cargo.crates \
     getopts                         0.2.21  14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5 \
     getrandom                       0.1.14  7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb \
     glob                            0.2.11  8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb \
+    glob                             0.3.0  9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574 \
     globset                          0.4.4  925aa2cac82d8834e2b2a4415b6f6879757fb5c0928fc445ae76461a12eed8f2 \
     globwalk                         0.3.1  ce5d04da8cf35b507b2cbec92bbf2d5085292d07cd87637994fd437fe1617bbb \
     h2                              0.1.26  a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462 \
@@ -127,6 +130,8 @@ cargo.crates \
     iovec                            0.1.4  b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e \
     itertools                        0.8.2  f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484 \
     itoa                             0.4.5  b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e \
+    jemalloc-sys                     0.3.2  0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45 \
+    jemallocator                     0.3.2  43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69 \
     js-sys                          0.3.35  7889c7c36282151f6bf465be4700359318aef36baa951462382eae49e9577cf9 \
     kernel32-sys                     0.2.2  7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d \
     language-tags                    0.2.2  a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a \
@@ -157,7 +162,7 @@ cargo.crates \
     openssl                        0.10.28  973293749822d7dd6370d6da1e523b0d1db19f06c459134c658b2a4261378b52 \
     openssl-probe                    0.1.2  77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de \
     openssl-sys                     0.9.54  1024c0a59774200a555087a6da3f253a9095a5f344e353b212ac4c8b8e450986 \
-    ordered-float                    1.0.2  18869315e81473c951eb56ad5558bbc56978562d3ecfb87abb7a1e944cea4518 \
+    ordered-float                    2.0.0  9fe9037165d7023b1228bc4ae9a2fa1a2b0095eca6c2998c624723dfd01314a5 \
     os_type                          2.2.0  7edc011af0ae98b7f88cf7e4a83b70a54a75d2b8cb013d6efd02e5956207e9eb \
     parking_lot                      0.9.0  f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252 \
     parking_lot_core                 0.6.2  b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b \
@@ -177,18 +182,18 @@ cargo.crates \
     quantiles                        0.7.1  c10fa813fb26fb6c321a6f3085b5ade4cb4730d08d0b9e70a3759136940957f2 \
     quick-error                      1.2.3  a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0 \
     quicli                           0.4.0  9e8539e98d5a5e3cb0398aedac3e9642ead7d3047a459893526710cb5ad86f6c \
-    quote                            1.0.2  053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe \
     quote                           0.6.13  6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1 \
+    quote                            1.0.2  053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe \
     rand                             0.4.6  552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293 \
     rand                             0.6.5  6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca \
     rand                             0.7.3  6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
     rand_chacha                      0.1.1  556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef \
     rand_chacha                      0.2.1  03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853 \
     rand_core                        0.3.1  7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b \
-    rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
     rand_core                        0.4.2  9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc \
-    rand_hc                          0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
+    rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
     rand_hc                          0.1.0  7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4 \
+    rand_hc                          0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
     rand_isaac                       0.1.1  ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08 \
     rand_jitter                      0.1.4  1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b \
     rand_os                          0.1.3  7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071 \
@@ -222,25 +227,26 @@ cargo.crates \
     serde_urlencoded                 0.5.5  642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a \
     sized-chunks                     0.3.1  f01db57d7ee89c8e053245deb77040a6cc8508311f381c88749c33d4b9b78785 \
     slab                             0.4.2  c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8 \
-    smallvec                         1.2.0  5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc \
     smallvec                        0.6.13  f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6 \
+    smallvec                         1.2.0  5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc \
     sourcefile                       0.1.4  4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3 \
     strfmt                           0.1.6  b278b244ef7aa5852b277f52dd0c6cac3a109919e1f6d699adde63251227a30f \
     string                           0.2.1  d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d \
     strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
     structopt                       0.2.18  16c2cdbf9cc375f15d1b4141bc48aeef444806655cd0e904207edc8d68d86ed7 \
     structopt-derive                0.2.18  53010261a84b37689f9ed7d395165029f9cc7abb9f56bbfe86bee2597ed25107 \
-    syn                             1.0.14  af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5 \
     syn                             0.14.9  261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741 \
     syn                            0.15.44  9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5 \
+    syn                             1.0.14  af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5 \
     synstructure                    0.12.3  67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545 \
     tar                             0.4.26  b3196bfbffbba3e57481b6ea32249fbaf590396a52505a2615adbb79d9d826d3 \
     tempdir                          0.3.7  15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8 \
     tempfile                         3.1.0  7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9 \
     termcolor                        0.3.6  adc4587ead41bf016f11af03e55a624c06568b5a19db4e90fde573d805074f83 \
     termcolor                        1.1.0  bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f \
-    terminal_size                   0.1.10  e25a60e3024df9029a414be05f46318a77c22538861a22170077d0388c0e926e \
+    terminal_size                   0.1.12  8038f95fc7a6f351163f4b964af631bd26c9e828f7db085f2a84aca56f70d13b \
     termion                          1.5.5  c22cec9d8978d906be5ac94bceb5a010d885c626c4c8855721a4dbd20e3ac905 \
+    test-generator                   0.3.0  ea97be90349ab3574f6e74d1566e1c5dd3a4bc74b89f4af4cc10ca010af103c0 \
     textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
     thread_local                     1.0.1  d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14 \
     time                            0.1.42  db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f \
@@ -264,19 +270,19 @@ cargo.crates \
     unicode-normalization           0.1.12  5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4 \
     unicode-segmentation             1.6.0  e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0 \
     unicode-width                    0.1.7  caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479 \
-    unicode-xid                      0.2.0  826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c \
     unicode-xid                      0.1.0  fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc \
+    unicode-xid                      0.2.0  826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c \
     url                              1.7.2  dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a \
     url                              2.1.1  829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb \
     uuid                             0.6.5  e1436e58182935dcd9ce0add9ea0b558e8a87befe01c1a301e6020aeb0876363 \
     uuid                             0.7.4  90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a \
     vcpkg                            0.2.8  3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168 \
     vec_map                          0.8.1  05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a \
-    version_check                    0.9.1  078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce \
     version_check                    0.1.5  914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd \
+    version_check                    0.9.1  078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce \
     walkdir                          2.3.1  777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d \
     want                             0.2.0  b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230 \
-    wasi                          0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
+    wasi      0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
     wasm-bindgen                    0.2.58  5205e9afdf42282b192e2310a5b463a6d1c1d774e30dc3c791ac37ab42d2616c \
     wasm-bindgen-backend            0.2.58  11cdb95816290b525b32587d76419facd99662a07e59d3cdb560488a819d9a45 \
     wasm-bindgen-macro              0.2.58  574094772ce6921576fb6f2e3f7497b8a76273b6db092be18fc48a082de09dc3 \
@@ -285,8 +291,8 @@ cargo.crates \
     wasm-bindgen-webidl             0.2.58  ef012a0d93fc0432df126a8eaf547b2dce25a8ce9212e1d3cbeef5c11157975d \
     web-sys                         0.3.35  aaf97caf6aa8c2b1dac90faf0db529d9d63c93846cca4911856f78a83cebf53b \
     weedle                          0.10.0  3bb43f70885151e629e2a19ce9e50bd730fd436cfd4b666894c9ce4de9141164 \
-    winapi                           0.3.8  8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6 \
     winapi                           0.2.8  167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
+    winapi                           0.3.8  8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6 \
     winapi-build                     0.1.1  2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
     winapi-util                      0.1.3  4ccfbf554c6ad11084fb7517daca16cfdcaccbdadba4fc336f032a8b12c2ad80 \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
