### PR TITLE
haproxy: update to 2.2.2

### DIFF
--- a/net/haproxy/Portfile
+++ b/net/haproxy/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           legacysupport 1.1
 
 name                haproxy
-version             2.2.1
+version             2.2.2
 revision            0
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          net
@@ -27,9 +27,9 @@ homepage            https://www.haproxy.org/
 master_sites        ${homepage}download/${branch}/src/ \
                     https://sources.openwrt.org/
 
-checksums           rmd160  0db946d9de5d226e04df976fe61d8a844016a447 \
-                    sha256  536552af1316807c01de727ad3dac84b3a2f5285db32e9bfdfe234e47ff9d124 \
-                    size    2868436
+checksums           rmd160  6aeb5f52e9d1072bd167291f05ab690ffbd1c184 \
+                    sha256  391c705a46c6208a63a67ea842c6600146ca24618531570c89c7915b0c6a54d6 \
+                    size    2869005
 
 depends_lib         path:lib/libssl.dylib:openssl \
                     port:pcre \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
