### PR TITLE
ultralist: update to 1.2

### DIFF
--- a/office/ultralist/Portfile
+++ b/office/ultralist/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/ultralist/ultralist 1.1 v
+go.setup            github.com/ultralist/ultralist 1.2
 
 homepage            https://ultralist.io/
 
@@ -22,9 +22,9 @@ installs_libs       no
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  7f4c6b8f35f3e268a86d0885b10cb96fb81f709e \
-                    sha256  7c984df65af5ed48a228606a52855a018341f990cea2509b93b8992b262644c8 \
-                    size    2138183
+checksums           rmd160  cc070d25a9159242ce5b66b97e9a21234c42ceae \
+                    sha256  5e4b848a1ad47dc02f23afa0aca43f960bf4c4131b3d366afb93a5c44d1b1854 \
+                    size    2138218
 
 build.args-append   -o ${workpath}/${name}
 


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->