### PR TITLE
cloudman: new port

### DIFF
--- a/sysutils/cloudman/Portfile
+++ b/sysutils/cloudman/Portfile
@@ -1,0 +1,280 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo 1.0
+
+github.setup        dutchcoders cloudman 0.1.2
+
+categories          sysutils net
+platforms           darwin
+license             MIT
+
+description         Textual user interface to manage ec2 instances.
+
+long_description    Cloudman is a textual user interface (heavily inspired by \
+                    htop) to manage your Amazon EC2 fleet instantly. By using \
+                    Cloudman you'll find an overview of your instances, \
+                    navigate through regions, retrieve instance details, show \
+                    console outputs and connect to instance terminal using SSM.
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  45bd06c899cb8f8588627c954a3682d61e1bdfc0 \
+                    sha256  fbdd215a2d55de67a5017c194c98e002ad1e411637bcd25f71dff0e7b9cd340f \
+                    size    309883
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/${name} ${destroot}${prefix}/bin/
+}
+
+cargo.crates \
+    ahash                            0.3.8  e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217 \
+    aho-corasick                    0.7.10  8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada \
+    arc-swap                         0.4.7  4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034 \
+    array-macro                      1.0.5  06e97b4e522f9e55523001238ac59d13a8603af57f69980de5d8de4bbbe8ada6 \
+    arrayref                         0.3.6  a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544 \
+    arrayvec                         0.5.1  cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8 \
+    async-trait                     0.1.35  89cb5d814ab2a47fd66d3266e9efccb53ca4c740b7451043b8ffcf9a6208f3f8 \
+    atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+    autocfg                          1.0.0  f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d \
+    base-x                           0.2.6  1b20b618342cf9891c292c4f5ac2cde7287cc5c87e87e9c769d617793607dec1 \
+    base64                          0.11.0  b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7 \
+    base64                          0.12.1  53d1ccbaf7d9ec9537465a97bf19edc1a4e158ecb49fc16178202238c569cc42 \
+    bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
+    blake2b_simd                    0.5.10  d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a \
+    block-buffer                     0.7.3  c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b \
+    block-padding                    0.1.5  fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5 \
+    built                            0.4.2  161483ae87631dd826cb40fc696d9e5a9fa94e19c2e69a372dcedd7dc68e7c0a \
+    bumpalo                          3.4.0  2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820 \
+    byte-tools                       0.3.1  e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7 \
+    byteorder                        1.3.4  08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de \
+    bytes                           0.4.12  206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c \
+    bytes                            0.5.4  130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1 \
+    cargo-lock                       4.0.1  8504b63dd1249fd1745b7b4ef9b6f7b107ddeb3c95370043c7dbcc38653a2679 \
+    caseless                         0.2.1  808dab3318747be122cb31d36de18d4d1c81277a76f8332a02b81a3d73463d7f \
+    cc                              1.0.54  7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311 \
+    cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
+    chrono                          0.4.11  80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2 \
+    clap                      3.0.0-beta.1  860643c53f980f0d38a5e25dfab6c3c93b2cb3aa1fe192643d17a293c6c41936 \
+    clap_derive               3.0.0-beta.1  fb51c9e75b94452505acd21d929323f5a5c6c4735a852adbd39ef5fb1b014f30 \
+    cloudabi                         0.0.3  ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
+    const-random                     0.1.8  2f1af9ac737b2dd2d577701e59fd09ba34822f6f2ebdb30a7647405d9e55e16a \
+    const-random-macro               0.1.8  25e4c606eb459dd29f7c57b2e0879f2b6f14ee130918c2b78ccb58a9624e6c7a \
+    constant_time_eq                 0.1.5  245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc \
+    core-foundation                  0.7.0  57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171 \
+    core-foundation-sys              0.7.0  b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac \
+    crossbeam-channel                0.4.2  cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061 \
+    crossbeam-deque                  0.7.3  9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285 \
+    crossbeam-epoch                  0.8.2  058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace \
+    crossbeam-queue                  0.2.3  774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570 \
+    crossbeam-utils                  0.7.2  c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8 \
+    crypto-mac                       0.7.0  4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5 \
+    cursive                         0.15.0  7a9f12332ab2bca26979ef00cfef9a1c2e287db03b787a83d892ad9961f81374 \
+    cursive_core                     0.1.0  7fe232694c965c211d5fbd8111ae89a5939b7b169cefcac4f8b6f83dde889e10 \
+    darling                         0.10.2  0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858 \
+    darling_core                    0.10.2  f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b \
+    darling_macro                   0.10.2  d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72 \
+    digest                           0.8.1  f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5 \
+    dirs                             2.0.2  13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3 \
+    dirs-sys                         0.3.5  8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a \
+    discard                          1.0.4  212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0 \
+    dtoa                             0.4.5  4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3 \
+    enum-map                         0.6.2  70a375f899a53b9848ad9fb459b5bf90e4851ae5d9fea89134b062dc1828b26e \
+    enum-map-derive                  0.4.3  e57001dfb2532f5a103ff869656887fae9a8defa7d236f3e39d2ee86ed629ad7 \
+    enumset                          1.0.0  3691ce759534316ad900d57dd8e688e2c4263f9750c0f7c1e9b9a4516d4ca241 \
+    enumset_derive                   0.5.0  74bef436ac71820c5cf768d7af9ba33121246b09a00e09a55d94ef8095a875ac \
+    fake-simd                        0.1.2  e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed \
+    fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
+    foreign-types                    0.3.2  f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1 \
+    foreign-types-shared             0.1.1  00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b \
+    fuchsia-zircon                   0.3.3  2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
+    fuchsia-zircon-sys               0.3.3  3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
+    futures                         0.1.29  1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef \
+    futures                          0.3.5  1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613 \
+    futures-channel                  0.3.5  f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5 \
+    futures-core                     0.3.5  59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399 \
+    futures-executor                 0.3.5  10d6bb888be1153d3abeb9006b11b02cf5e9b209fda28693c31ae1e4e012e314 \
+    futures-io                       0.3.5  de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789 \
+    futures-macro                    0.3.5  d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39 \
+    futures-sink                     0.3.5  3f2032893cb734c7a05d85ce0cc8b8c4075278e93b24b66f9de99d6eb0fa8acc \
+    futures-task                     0.3.5  bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626 \
+    futures-util                     0.3.5  8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6 \
+    generic-array                   0.12.3  c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec \
+    getrandom                       0.1.14  7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb \
+    h2                               0.2.5  79b7246d7e4b979c03fa093da39cfb3617a96bbeee6310af63991668d7e843ff \
+    hashbrown                        0.7.2  96282e96bfcd3da0d3aa9938bedf1e50df3269b6db08b4876d2da0bb1a0841cf \
+    heck                             0.3.1  20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205 \
+    hermit-abi                      0.1.13  91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71 \
+    hex                              0.4.2  644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35 \
+    hmac                             0.7.1  5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695 \
+    http                             0.2.1  28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9 \
+    http-body                        0.3.1  13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b \
+    httparse                         1.3.4  cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9 \
+    hyper                           0.13.6  a6e7655b9594024ad0ee439f3b5a7299369dc2a3f459b47c696f9ff676f9aa1f \
+    hyper-tls                        0.4.1  3adcd308402b9553630734e9c36b77a7e48b3821251ca2493e8cd596763aafaa \
+    ident_case                       1.0.1  b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39 \
+    idna                             0.2.0  02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9 \
+    indexmap                         1.4.0  c398b2b113b55809ceb9ee3e753fcbac793f1956663f3c36549c1346015c2afe \
+    iovec                            0.1.4  b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e \
+    itoa                             0.4.5  b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e \
+    kernel32-sys                     0.2.2  7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    libc                            0.2.71  9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49 \
+    lock_api                         0.3.4  c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75 \
+    log                              0.4.8  14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7 \
+    maplit                           1.0.2  3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d \
+    matches                          0.1.8  7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
+    maybe-uninit                     2.0.0  60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00 \
+    md5                              0.7.0  490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771 \
+    memchr                           2.3.3  3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400 \
+    memoffset                        0.5.4  b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8 \
+    mio                             0.6.22  fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430 \
+    mio-named-pipes                  0.1.6  f5e374eff525ce1c5b7687c4cef63943e7686524a387933ad27ca7ec43779cb3 \
+    mio-uds                          0.6.8  afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0 \
+    miow                             0.2.1  8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919 \
+    miow                             0.3.5  07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e \
+    native-tls                       0.2.4  2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d \
+    ncurses                         5.99.0  15699bee2f37e9f8828c7b35b2bc70d13846db453f2d507713b758fabe536b82 \
+    net2                            0.2.34  2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7 \
+    num                              0.2.1  b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36 \
+    num-complex                      0.2.4  b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95 \
+    num-integer                     0.1.42  3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba \
+    num-iter                        0.1.40  dfb0800a0291891dd9f4fe7bd9c19384f98f7fbe0cd0f39a2c6b88b9868bbc00 \
+    num-rational                     0.2.4  5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef \
+    num-traits                      0.2.11  c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096 \
+    num_cpus                        1.13.0  05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3 \
+    once_cell                        1.4.0  0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d \
+    opaque-debug                     0.2.3  2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c \
+    openssl                        0.10.29  cee6d85f4cb4c4f59a6a85d5b68a233d280c82e29e822913b9c8b129fbf20bdd \
+    openssl-probe                    0.1.2  77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de \
+    openssl-sys                     0.9.58  a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de \
+    os_str_bytes                     2.3.1  06de47b848347d8c4c94219ad8ecd35eb90231704b067e67e6ae2e36ee023510 \
+    owning_ref                       0.4.1  6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce \
+    parking_lot                      0.9.0  f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252 \
+    parking_lot_core                 0.6.2  b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b \
+    percent-encoding                 2.1.0  d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
+    pin-project                     0.4.22  12e3a6cdbfe94a5e4572812a0201f8c0ed98c1c452c7b8563ce2276988ef9c17 \
+    pin-project-internal            0.4.22  6a0ffd45cf79d88737d7cc85bfd5d2894bee1139b356e616fe85dc389c61aaf7 \
+    pin-project-lite                 0.1.7  282adbf10f2698a7a77f8e983a74b2d18176c19a7fd32a45446139ae7b02b715 \
+    pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
+    pkg-config                      0.3.17  05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677 \
+    ppv-lite86                       0.2.8  237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea \
+    proc-macro-error                0.4.12  18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7 \
+    proc-macro-error-attr           0.4.12  8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de \
+    proc-macro-hack                 0.5.16  7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4 \
+    proc-macro-nested                0.1.6  eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a \
+    proc-macro2                     1.0.18  beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa \
+    pulldown-cmark                   0.7.1  3e142c3b8f49d2200605ee6ba0b1d757310e9e7a72afe78c36ee2ef67300ee00 \
+    quote                            1.0.7  aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37 \
+    rand                             0.7.3  6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
+    rand_chacha                      0.2.2  f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402 \
+    rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
+    rand_hc                          0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
+    redox_syscall                   0.1.56  2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84 \
+    redox_users                      0.3.4  09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431 \
+    regex                            1.3.9  9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6 \
+    regex-syntax                    0.6.18  26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8 \
+    remove_dir_all                   0.5.3  3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7 \
+    rusoto_core                     0.44.0  841ca8f73e7498ba39146ab43acea906bbbb807d92ec0b7ea4b6293d2621f80d \
+    rusoto_credential               0.44.0  60669ddc1bdbb83ce225593649d36b4c5f6bf9db47cc1ab3e81281abffc853f4 \
+    rusoto_ec2                      0.44.0  082c168bf942a7dfc2a28a2ab03422a3b391bcca866f8ba21f540e248648ba83 \
+    rusoto_logs                     0.44.0  b9ce5baac7de9c642a5f3c62d2ff85fbb06b1cfee5b61793c1b06d655884a75b \
+    rusoto_signature                0.44.0  9eddff187ac18c5a91d9ccda9353f30cf531620dce437c4db661dfe2e23b2029 \
+    rust-argon2                      0.7.0  2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017 \
+    rustc_version                    0.2.3  138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a \
+    ryu                              1.0.5  71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e \
+    schannel                        0.1.19  8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75 \
+    scoped-tls                       0.1.2  332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28 \
+    scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
+    security-framework               0.4.4  64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535 \
+    security-framework-sys           0.4.3  17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405 \
+    semver                           0.9.0  1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403 \
+    semver-parser                    0.7.0  388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
+    serde                          1.0.111  c9124df5b40cbd380080b2cc6ab894c040a3070d995f5c9dc77e18c34a8ae37d \
+    serde_derive                   1.0.111  3f2c3ac8e6ca1e9c80b8be1023940162bf81ae3cffbb1809474152f2ce1eb250 \
+    serde_json                      1.0.55  ec2c5d7e739bc07a3e73381a39d61fdb5f671c60c1df26a130690665803d8226 \
+    serde_urlencoded                 0.6.1  9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97 \
+    sha1                             0.6.0  2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d \
+    sha2                             0.8.2  a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69 \
+    shlex                            0.1.1  7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2 \
+    signal-hook                     0.1.15  8ff2db2112d6c761e12522c65f7768548bd6e8cd23d2a9dae162520626629bd6 \
+    signal-hook-registry             1.2.0  94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41 \
+    slab                             0.4.2  c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8 \
+    smallvec                        0.6.13  f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6 \
+    smallvec                         1.4.0  c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4 \
+    socket2                         0.3.12  03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918 \
+    stable_deref_trait               1.1.1  dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8 \
+    standback                        0.2.9  b0437cfb83762844799a60e1e3b489d5ceb6a650fbacb86437badc1b6d87b246 \
+    stdweb                          0.4.20  d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5 \
+    stdweb-derive                    0.5.3  c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef \
+    stdweb-internal-macros           0.2.9  58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11 \
+    stdweb-internal-runtime          0.1.5  213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0 \
+    strsim                           0.9.3  6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c \
+    strsim                          0.10.0  73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623 \
+    subtle                           1.0.0  2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee \
+    syn                             1.0.31  b5304cfdf27365b7585c25d4af91b35016ed21ef88f17ced89c7093b43dba8b6 \
+    syn-mid                          0.5.0  7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a \
+    tempfile                         3.1.0  7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9 \
+    term_size                        0.3.2  1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9 \
+    termcolor                        1.1.0  bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f \
+    textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
+    thread_local                     1.0.1  d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14 \
+    time                            0.1.43  ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438 \
+    time                            0.2.16  3a51cadc5b1eec673a685ff7c33192ff7b7603d0b75446fb354939ee615acb15 \
+    time-macros                      0.1.0  9ae9b6e9f095bc105e183e3cd493d72579be3181ad4004fceb01adbe9eecab2d \
+    time-macros-impl                 0.1.1  e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa \
+    tokio                           0.1.22  5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6 \
+    tokio                           0.2.21  d099fa27b9702bed751524694adbe393e18b36b204da91eb1cbbbbb4a5ee2d58 \
+    tokio-codec                      0.1.2  25b2998660ba0e70d18684de5d06b70b70a3a747469af9dea7618cc59e75976b \
+    tokio-core                      0.1.17  aeeffbbb94209023feaef3c196a41cbcdafa06b4a6f893f68779bb5e53796f71 \
+    tokio-current-thread             0.1.7  b1de0e32a83f131e002238d7ccde18211c0a5397f60cbfffcb112868c2e0e20e \
+    tokio-executor                  0.1.10  fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671 \
+    tokio-fs                         0.1.7  297a1206e0ca6302a0eed35b700d292b275256f596e2f3fea7729d5e629b6ff4 \
+    tokio-io                        0.1.13  57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674 \
+    tokio-macros                     0.2.5  f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389 \
+    tokio-reactor                   0.1.12  09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351 \
+    tokio-sync                       0.1.8  edfe50152bc8164fcc456dab7891fa9bf8beaf01c5ee7e1dd43a397c3cf87dee \
+    tokio-tcp                        0.1.4  98df18ed66e3b72e742f185882a9e201892407957e45fbff8da17ae7a7c51f72 \
+    tokio-threadpool                0.1.18  df720b6581784c118f0eb4310796b12b1d242a7eb95f716a8367855325c25f89 \
+    tokio-timer                     0.2.13  93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296 \
+    tokio-tls                        0.3.1  9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343 \
+    tokio-udp                        0.1.6  e2a0b10e610b39c38b031a2fcab08e4b82f16ece36504988dcbd81dbba650d82 \
+    tokio-uds                        0.2.6  5076db410d6fdc6523df7595447629099a1fdc47b3d9f896220780fa48faf798 \
+    tokio-util                       0.3.1  be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499 \
+    toml                             0.5.6  ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a \
+    tower-service                    0.3.0  e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860 \
+    try-lock                         0.2.2  e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382 \
+    typenum                         1.12.0  373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33 \
+    unicase                          2.6.0  50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6 \
+    unicode-bidi                     0.3.4  49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5 \
+    unicode-normalization           0.1.12  5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4 \
+    unicode-segmentation             1.6.0  e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0 \
+    unicode-width                    0.1.7  caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479 \
+    unicode-xid                      0.2.0  826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c \
+    url                              2.1.1  829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb \
+    utf8parse                        0.2.0  936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372 \
+    vcpkg                           0.2.10  6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c \
+    vec_map                          0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
+    version_check                    0.9.2  b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed \
+    vte                              0.8.0  96cc8a191608603611e78c6ec11dafef37e3cca0775aeef1931824753e81711d \
+    vte_generate_state_changes       0.1.1  d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff \
+    want                             0.3.0  1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0 \
+    wasi      0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
+    wasm-bindgen                    0.2.63  4c2dc4aa152834bc334f506c1a06b866416a8b6697d5c9f75b9a689c8486def0 \
+    wasm-bindgen-backend            0.2.63  ded84f06e0ed21499f6184df0e0cb3494727b0c5da89534e0fcc55c51d812101 \
+    wasm-bindgen-macro              0.2.63  838e423688dac18d73e31edce74ddfac468e37b1506ad163ffaf0a46f703ffe3 \
+    wasm-bindgen-macro-support      0.2.63  3156052d8ec77142051a533cdd686cba889537b213f948cd1d20869926e68e92 \
+    wasm-bindgen-shared             0.2.63  c9ba19973a58daf4db6f352eda73dc0e289493cd29fb2632eb172085b6521acd \
+    winapi                           0.2.8  167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
+    winapi                           0.3.8  8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6 \
+    winapi-build                     0.1.1  2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                      0.1.5  70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    ws2_32-sys                       0.2.1  d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e \
+    xi-unicode                       0.2.0  7395cdb9d0a6219fa0ea77d08c946adf9c1984c72fcd443ace30365f3daadef7 \
+    xml-rs                           0.8.3  b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a \
+    zeroize                          1.1.0  3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8


### PR DESCRIPTION
###### Description

New port for [cloudman](https://github.com/dutchcoders/cloudman)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->