### PR TITLE
dav1d: allow universal build

### DIFF
--- a/multimedia/dav1d/Portfile
+++ b/multimedia/dav1d/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           meson 1.0
+PortGroup           muniversal 1.0
 
 name                dav1d
 version             0.7.1
@@ -53,9 +54,6 @@ post-destroot {
         THANKS.md \
         ${destroot}${docdir}
 }
-
-# fails attempting to build for i386 due to sse2 code
-universal_variant   no
 
 livecheck.url       https://download.videolan.org/pub/videolan/${name}/
 livecheck.regex     {>([0-9.]+)/<}

--- a/multimedia/dav1d/Portfile
+++ b/multimedia/dav1d/Portfile
@@ -28,6 +28,14 @@ depends_build-append  port:nasm
 configure.args-append \
                     -Denable_tests=false
 
+if {[variant_isset universal]} {
+    lappend merger_configure_env(i386)      LDFLAGS=-Wl,-read_only_relocs,suppress,-no_compact_unwind
+} else {
+    if {${build_arch} eq "i386"} {
+        configure.env-append                LDFLAGS=-Wl,-read_only_relocs,suppress,-no_compact_unwind
+    }
+}
+
 # developer docs are automatically built if doxygen and dot (graphviz) are present
 # but are not installed
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.13
Xcode 10

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

Only works after the related meson fixes are in the port tree.