### PR TITLE
eureka: new port

### DIFF
--- a/office/eureka/Portfile
+++ b/office/eureka/Portfile
@@ -1,0 +1,75 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo 1.0
+
+github.setup        simeg eureka 1.7.0 v
+
+categories          office
+platforms           darwin
+license             MIT
+
+description         CLI tool to input and store your ideas without leaving \
+                    the terminal
+
+long_description    eureka is a CLI tool that allows you to quickly write \
+                    down an idea using your preferred editor, and then have \
+                    the idea committed and pushed to your idea git \
+                    repository. Imagine working on something important and \
+                    then having an idea. Instead of letting your idea slip by \
+                    you can just type eureka and you're able to quickly store \
+                    your idea and then continue working.  It is developed by \
+                    and for people who enjoy using the terminal.
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  d19b4041ac838a9d8da4306dd7379d253855fbed \
+                    sha256  13607c28ab3da91a6637c1bb0b59f83c7ed6dfd23ba1c1741035a3b85eb600ac \
+                    size    5445492
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/${name} ${destroot}${prefix}/bin/
+}
+
+cargo.crates \
+    ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
+    arrayref                         0.3.6  a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544 \
+    arrayvec                         0.5.1  cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8 \
+    atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+    autocfg                          1.0.0  f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d \
+    base64                          0.11.0  b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7 \
+    bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
+    blake2b_simd                    0.5.10  d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a \
+    cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
+    clap                            2.33.1  bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129 \
+    constant_time_eq                 0.1.5  245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc \
+    crossbeam-utils                  0.7.2  c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8 \
+    dirs                             2.0.2  13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3 \
+    dirs-sys                         0.3.5  8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a \
+    getrandom                       0.1.14  7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb \
+    hermit-abi                      0.1.13  91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71 \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    libc                            0.2.71  9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49 \
+    proc-macro2                     1.0.18  beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa \
+    quote                            1.0.7  aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37 \
+    redox_syscall                   0.1.56  2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84 \
+    redox_users                      0.3.4  09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431 \
+    rust-argon2                      0.7.0  2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017 \
+    strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
+    syn                             1.0.30  93a56fabc59dce20fe48b6c832cc249c713e7ed88fa28b0ee0a3bfcaae5fe4e2 \
+    termcolor                        1.1.0  bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f \
+    textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
+    thiserror                       1.0.19  b13f926965ad00595dd129fa12823b04bbf866e9085ab0a5f2b05b850fbfc344 \
+    thiserror-impl                  1.0.19  893582086c2f98cde18f906265a65b5030a074b1046c674ae898be6519a7f479 \
+    unicode-width                    0.1.7  caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479 \
+    unicode-xid                      0.2.0  826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c \
+    vec_map                          0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
+    wasi      0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
+    which                            4.0.0  bd3edc3cf5458851a4d6a2329232bd5f42c7f9bbe4c4782c4ef9ce37e5d101b2 \
+    winapi                           0.3.8  8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6 \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                      0.1.5  70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f


### PR DESCRIPTION
#### Description

New port for [eureka](https://github.com/simeg/eureka)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
