### PR TITLE
zmq: fix location of docs directory

### DIFF
--- a/devel/zmq/Portfile
+++ b/devel/zmq/Portfile
@@ -28,7 +28,7 @@ if {${name} eq ${subport}} {
     checksums rmd160 6bfdb9378428accf70719bfac23e4f5debe35f42 \
               sha256 8b1778a6d51944c0394d80e3c708bdc3ce58de44119bab4096b0d7e78348a8cf \
               size   836825
-    revision  1
+    revision  2
 
     conflicts    zmq-devel zmq22 zmq3
     configure.args-append \
@@ -39,6 +39,7 @@ if {${name} eq ${subport}} {
     patch.pre_args -p1
     patchfiles-append patch-cxx11.release.diff
     patchfiles-append patch-c11.release.diff
+    patchfiles-append patch-fix-docs-dir.diff
 
     # overload the github livecheck regex to look for versions that
     # are just numbers and '.', no letters (e.g., "3.7.3_rc2").

--- a/devel/zmq/files/patch-fix-docs-dir.diff
+++ b/devel/zmq/files/patch-fix-docs-dir.diff
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt	2020-08-04 02:04:45.000000000 -0400
++++ b/CMakeLists.txt	2020-08-04 02:06:14.000000000 -0400
+@@ -1389,7 +1389,7 @@
+ 
+ if(WITH_DOC)
+   if(NOT ZMQ_BUILD_FRAMEWORK)
+-    install(FILES ${html-docs} DESTINATION doc/zmq COMPONENT RefGuide)
++    install(FILES ${html-docs} DESTINATION share/doc/zmq COMPONENT RefGuide)
+   endif()
+ endif()
+ 


### PR DESCRIPTION
- fixes: https://trac.macports.org/ticket/60744

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
