### PR TITLE
dante: remove defunct mirrors

### DIFF
--- a/net/dante/Portfile
+++ b/net/dante/Portfile
@@ -22,9 +22,7 @@ long_description        Dante is a circuit-level firewall/proxy (socks \
 homepage                https://www.inet.no/dante/
 master_sites            ${homepage}files/ \
                         ftp://ftp.inet.no/pub/socks/ \
-                        ftp://ftp.inet.no/pub/socks/old/ \
-                        http://sorcerer.mirrors.pair.com/mirror/ \
-                        http://dbg.download.sourcemage.org/mirror/
+                        ftp://ftp.inet.no/pub/socks/old/
 
 dist_subdir             ${name}/${version}_1
 checksums               rmd160 d2e01bf899b0df74ef441926c497385ab8040a7c \


### PR DESCRIPTION
Hosts no longer exist (DNS lookup fails with NXDOMAIN)

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
