### PR TITLE
MySQL ports: use mirror_sites.tcl, add missing mysql55 dependency to mysql55-connector-cpp

### DIFF
--- a/databases/mysql-connector-odbc/Portfile
+++ b/databases/mysql-connector-odbc/Portfile
@@ -18,12 +18,7 @@ long_description \
     (previously called MyODBC drivers) that provide access to a MySQL database \
     using the industry standard Open Database Connectivity (ODBC) API.
 
-master_sites \
-    http://mysql.mirrors.pair.com/Downloads/Connector-ODBC/${branch}/ \
-    http://mysql.he.net/Downloads/Connector-ODBC/${branch}/ \
-    http://mirrors.sunsite.dk/mysql/Downloads/Connector-ODBC/${branch}/ \
-    http://sunsite.informatik.rwth-aachen.de/mysql/Downloads/Connector-ODBC/${branch}/ \
-    http://ftp.plusline.de/mysql/Downloads/Connector-ODBC/${branch}/
+master_sites            mysql:Connector-ODBC/${branch}/
 
 checksums               sha1    2272075c66712cf7a05e50eeb4520f7c504c3ae8 \
                         rmd160  0db5c4d42c7377f7fc1fa2ad569f50f9a497511e

--- a/databases/mysql4/Portfile
+++ b/databases/mysql4/Portfile
@@ -25,21 +25,7 @@ long_description \
     MySQL is an open-source, multi-threaded SQL database \
     with a command syntax very similar to mSQL.
 
-set sitedir             Downloads/MySQL-4.1/
-master_sites \
-    https://www.mirrorservice.org/sites/ftp.mysql.com/${sitedir} \
-    http://www.softagency.co.jp/MySQL/${sitedir} \
-    http://mirrors.tilian.co.uk/mysql.com/${sitedir} \
-    ftp://planetmirror.com/pub/mysql/${sitedir} \
-    ftp://sunsite.dk/mirrors/mysql/${sitedir} \
-    http://mirror.facebook.net/mysql/${sitedir} \
-    http://mysql.mediatraffic.fi/${sitedir} \
-    ftp://filepile.tiscali.de/mirror/mysql/${sitedir} \
-    ftp://ftp.rtfm.no/pub/mysql/${sitedir} \
-    http://www.mysql.cz/${sitedir} \
-    ftp://ftp.u-paris10.fr/mysql.com/${sitedir} \
-    http://mysql.oms-net.nl/${sitedir} \
-    ftp://ftp.free.fr/pub/MySQL\${sitedir}
+master_sites            mysql:MySQL-4.1/
 
 checksums \
     md5 37b4479951fa0cf052269d27c41ca200

--- a/databases/mysql55-connector-cpp/Portfile
+++ b/databases/mysql55-connector-cpp/Portfile
@@ -13,13 +13,8 @@ platforms           darwin
 maintainers         nomaintainer
 license             GPL-2
 
-set mirror_dir      Downloads/Connector-C++
 homepage            https://www.mysql.com/products/connector/
-master_sites        http://mysql.mirrors.pair.com/${mirror_dir} \
-                    http://mysql.he.net/${mirror_dir} \
-                    http://mirrors.sunsite.dk/mysql/${mirror_dir} \
-                    http://sunsite.informatik.rwth-aachen.de/mysql/${mirror_dir} \
-                    http://ftp.plusline.de/mysql/${mirror_dir}
+master_sites        mysql:Connector-C++/
 
 distname            ${name_package}-${version}
 checksums           rmd160  2445b7c3aab96e459bf8726963fbc7e203af7e6e \

--- a/databases/mysql55-connector-cpp/Portfile
+++ b/databases/mysql55-connector-cpp/Portfile
@@ -5,6 +5,7 @@ PortGroup           cmake 1.0
 
 name                mysql55-connector-cpp
 set name_package    mysql-connector-c++
+# when updating, remove separate revision for mysql55-connector-cpp below
 version             1.1.9
 revision            0
 set branch          [join [lrange [split ${version} .] 0 1] .]
@@ -68,6 +69,7 @@ post-destroot {
 
 set mp.ports {
     mysql51
+    mysql55
     mysql56
     mysql57
     mariadb
@@ -83,6 +85,8 @@ foreach mp.name ${mp.names} {
     set mp.conflicts  [lreplace ${mp.names} $idx $idx]
 
     if {[string compare ${mp.name} ${name}] == 0 && [string compare ${mp.name} ${subport}] == 0} {
+        # remove revision here when port is updated
+        revision            1
         description         The MySQL Connector/C++ for ${mp.port}.
         long_description    {*}${description} \
                             Standardized MySQL database driver for C++ development.

--- a/java/mysql-connector-java/Portfile
+++ b/java/mysql-connector-java/Portfile
@@ -20,7 +20,7 @@ long_description	MySQL Connector/J is a native Java driver that converts JDBC \
 					the capabilities of MySQL.
 homepage			https://dev.mysql.com/doc/refman/${branch}/en/connector-j.html
 
-master_sites		http://ftp.plusline.de/mysql/Downloads/Connector-J/
+master_sites		mysql:Connector-J/
 
 checksums           md5     d2f836c761614a3fdf39f7a6c7c1acb5 \
                     sha1    e63fed86be594a6166eaf4abf69375747042dcc6 \


### PR DESCRIPTION
`mysql4`, `mysql-connector-odbc`, `mysql55-connector-cpp`, `mysql-connector-java`: use mysql mirror sites for `master_sites`

<s>
Use HTTPS for mirrors.sunsite.dk

Move to mysql mirror sites:
http://mirror.facebook.net
https://mirrors.sunsite.dk

DNS lookup fails (e.g. `NXDOMAIN`) for
mysql.he.net
mirrors.tilian.co.uk
planetmirror.com
mysql.mediatraffic.fi
filepile.tiscali.de
ftp.rtfm.no
mysql.oms-net.nl

Live hosts which no longer appear to mirror MySQL:
http://sunsite.informatik.rwth-aachen.de
http://ftp.plusline.de
http://www.softagency.co.jp
ftp://ftp.u-paris10.fr
http://www.mysql.cz
ftp://ftp.free.fr

http://mysql.mirrors.pair.com refuses connections
Closes: https://trac.macports.org/ticket/25674
</s>
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
