### PR TITLE
aspectj: remove defunct mirrors

### DIFF
--- a/java/aspectj/Portfile
+++ b/java/aspectj/Portfile
@@ -10,9 +10,7 @@ long_description	${description}
 
 homepage		http://www.eclipse.org/aspectj/
 master_sites	http://download.eclipse.org/tools/aspectj/ \
-				http://ftp-stud.fht-esslingen.de/pub/Mirrors/eclipse/tools/aspectj/ \
-				http://sunsite.informatik.rwth-aachen.de:3080/eclipse/tools/aspectj/ \
-				ftp://ftp.wh2.tu-dresden.de/pub/mirrors/eclipse/tools/aspectj/
+				http://ftp-stud.fht-esslingen.de/pub/Mirrors/eclipse/tools/aspectj/
 checksums		sha1 5312911e7db01c78f74dbb2b9d7820c55bfd095f
 use_zip			yes
 extract.suffix	.jar


### PR DESCRIPTION
Hosts are live but appear to no longer mirror `aspectj` (nor other Eclipse projects).

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
