### PR TITLE
procmail: remove defunct mirror

### DIFF
--- a/mail/procmail/Portfile
+++ b/mail/procmail/Portfile
@@ -42,7 +42,6 @@ homepage            http://www.procmail.org/
 master_sites        ftp://ftp.procmail.org/pub/procmail/ \
                     ftp://ftp.psg.com/pub/unix/procmail/ \
                     ftp://ftp.ucsb.edu/pub/mirrors/procmail/ \
-                    ftp://ftp.informatik.rwth-aachen.de/pub/packages/procmail/ \
                     ftp://ftp.fu-berlin.de/pub/unix/mail/procmail/ \
                     ftp://ftp.net.ohio-state.edu/pub/networking/mail/procmail/ \
                     ftp://ftp.fdt.net/pub/unix/packages/procmail/ \


### PR DESCRIPTION
Host is live but appears to no longer mirror `procmail` (directory is empty)

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
