### PR TITLE
Update devel/mono port from 6.8.0.123 to 6.10.0.104 stable

### DIFF
--- a/devel/mono/Portfile
+++ b/devel/mono/Portfile
@@ -52,6 +52,8 @@ test.target             check
 
 compiler.cxx_standard   2011
 
+configure.python        ${prefix}/bin/python3
+
 # avoid conflict with port brotli
 configure.cppflags-delete -I${prefix}/include
 configure.ldflags-delete  -L${prefix}/lib

--- a/devel/mono/Portfile
+++ b/devel/mono/Portfile
@@ -34,7 +34,8 @@ depends_build           path:bin/cmake:cmake \
                         port:ninja \
                         port:pkgconfig \
                         bin:perl:perl5 \
-                        port:cctools
+                        port:cctools \
+                        bin:python:python3
 
 depends_lib             port:zlib \
                         port:libiconv \

--- a/devel/mono/Portfile
+++ b/devel/mono/Portfile
@@ -5,7 +5,7 @@ PortGroup               legacysupport 1.0
 
 name                    mono
 # please update msbuild when updating mono
-version                 6.8.0.123
+version                 6.10.0.104
 revision                0
 epoch                   1
 categories              devel lang mono
@@ -21,9 +21,9 @@ master_sites            https://download.mono-project.com/sources/mono/
 use_xz                  yes
 universal_variant       no
 
-checksums               rmd160  27770536a239d6a194566b35004fba1501ccc0af \
-                        sha256  e2e42d36e19f083fc0d82f6c02f7db80611d69767112af353df2f279744a2ac5 \
-                        size    243827664
+checksums               rmd160  8285b273ddcc00840bba17df4da11b8b668ed804 \
+                        sha256  b8d6eb70a252d2efad8384d66b529883dc59e581565d617fa57f8e79317e332c \
+                        size    292616252
 
 patchfiles-append       patch-aot-compiler.c.diff
 if {!${configure.ccache}} {

--- a/devel/mono/Portfile
+++ b/devel/mono/Portfile
@@ -35,7 +35,7 @@ depends_build           path:bin/cmake:cmake \
                         port:pkgconfig \
                         bin:perl:perl5 \
                         port:cctools \
-                        bin:python:python3
+                        port:python38
 
 depends_lib             port:zlib \
                         port:libiconv \

--- a/devel/mono/Portfile
+++ b/devel/mono/Portfile
@@ -52,7 +52,7 @@ test.target             check
 
 compiler.cxx_standard   2011
 
-configure.python        ${prefix}/bin/python3
+configure.python        ${prefix}/bin/python3.8
 
 # avoid conflict with port brotli
 configure.cppflags-delete -I${prefix}/include


### PR DESCRIPTION

#### Description

https://trac.macports.org/ticket/60838

Update port from 6.8.0.123 to 6.10.0.104 stable

###### Type(s)
Update devel/mono/Portfile to current stable from mono project.

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.6 19G73
Xcode 11.6 11E708 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
