### PR TITLE
lighttpd: remove legacy variants

### DIFF
--- a/www/lighttpd/Portfile
+++ b/www/lighttpd/Portfile
@@ -116,10 +116,6 @@ post-activate {
     }
 }
 
-# Remove after 2020-08-04
-variant mysql4 requires mysql57 description {Legacy compatibility variant} {}
-variant mysql5 requires mysql57 description {Legacy compatibility variant} {}
-
 variant mysql57 description {Enable MySQL 5.7 support} {
     depends_lib-append      port:mysql57
     configure.args-append   --with-mysql=${prefix}/lib/mysql57/bin/mysql_config


### PR DESCRIPTION
#### Description

Remove the legacy variants, as per comment.

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?