### PR TITLE
mirror_sites.tcl: remove defunct mirror http://babyname.tips

### DIFF
--- a/_resources/port1.0/fetch/mirror_sites.tcl
+++ b/_resources/port1.0/fetch/mirror_sites.tcl
@@ -614,7 +614,6 @@ set portfetch::mirror_sites::sites(netbsd) {
 set portfetch::mirror_sites::sites(nongnu) {
     http://mirror.csclub.uwaterloo.ca/nongnu/
     ftp://mirror.csclub.uwaterloo.ca/nongnu/
-    http://babyname.tips/mirrors/nongnu/
     http://mirror.netcologne.de/savannah/
     ftp://mirror.netcologne.de/savannah/
     http://ftp.cc.uoc.gr/mirrors/nongnu.org/


### PR DESCRIPTION
Host appears to have been defunct as early as 2017 according to reports online.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
