### PR TITLE
py-lscsoft-glue: update to 2.0.0

### DIFF
--- a/python/py-lscsoft-glue/Portfile
+++ b/python/py-lscsoft-glue/Portfile
@@ -4,7 +4,7 @@ PortSystem           1.0
 PortGroup            python 1.0
 
 name                 py-lscsoft-glue
-version              1.60.0
+version              2.0.0
 
 categories-append    science
 platforms            darwin
@@ -18,12 +18,12 @@ long_description \
   LSC codes on the grid.
 
 homepage             https://git.ligo.org/lscsoft/glue/
-master_sites         http://software.ligo.org/lscsoft/source/
+master_sites         pypi:l/lscsoft-glue
 distname             lscsoft-glue-${version}
 
-checksums            rmd160  08ad85a70e86960a6baa4bf1c283c7b0fda80498 \
-                     sha256  89d8e55c7e9d9abacec0abac9f91090f0bb0789279309b530c5e4d9fe1a8e687 \
-                     size    2490073
+checksums            rmd160  98055a86e6c2f5eae1749338e4d895204eef121e \
+                     sha256  9bdfaebe4c921d83d1e3d1ca24379a644665e9d7530e7070665f387767c66923 \
+                     size    1618606
 
 python.versions      27 36 37 38
 python.default_version 27
@@ -38,15 +38,9 @@ if {${name} ne ${subport}} {
         depends_lib-append port:py${python.version}-cjson
     }
     depends_build-append port:py${python.version}-setuptools
+
+    livecheck.type   none
 }
 
 # py-pyrxp is not universal
 universal_variant no
-
-if {${name} eq ${subport}} {
-    livecheck.type   regex
-    livecheck.url    ${master_sites}
-    livecheck.regex  {lscsoft-glue-(\d+(?:\.\d+)*).tar.gz}
-} else {
-    livecheck.type   none
-}


### PR DESCRIPTION
#### Description

Update py-lscsoft-glue to 2.0.0. Note, I would be happy to volunteer as a co-maintainer for this port. I also suggest making it openmaintainer.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.6 19G73
Xcode 11.6 11E708 