### PR TITLE
WIP: hdf5: update to 1.12.0

### DIFF
--- a/gis/kealib/Portfile
+++ b/gis/kealib/Portfile
@@ -3,7 +3,7 @@ PortGroup           cmake 1.0
 PortGroup           bitbucket 1.0
 
 bitbucket.setup     chchrsc kealib 1.4.10
-revision            3
+revision            4
 categories          gis
 license             MIT
 maintainers         {vince @Veence}

--- a/graphics/InsightToolkit-devel/Portfile
+++ b/graphics/InsightToolkit-devel/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.0
 
 name                InsightToolkit-devel
 version             4.8.2
-revision            7
+revision            8
 categories          graphics devel
 platforms           darwin
 license             Apache

--- a/graphics/field3d/Portfile
+++ b/graphics/field3d/Portfile
@@ -5,7 +5,7 @@ PortGroup               github 1.0
 
 github.setup            imageworks Field3D 1.7.2 v
 name                    field3d
-revision                10
+revision                11
 categories              graphics
 maintainers             nomaintainer
 license                 BSD

--- a/graphics/vigra/Portfile
+++ b/graphics/vigra/Portfile
@@ -9,7 +9,7 @@ PortGroup           github 1.0
 
 github.setup        ukoethe vigra 1-11-1 Version-
 version             [strsed ${github.version} {g/-/./}]
-revision            10
+revision            11
 categories          graphics
 platforms           darwin
 license             MIT

--- a/graphics/vips/Portfile
+++ b/graphics/vips/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           gobject_introspection 1.0
 
 github.setup        libvips libvips 8.10.2 v
-revision            0
+revision            1
 name                vips
 distname            vips-${version}
 description         VIPS is an image processing library.

--- a/graphics/vtk/Portfile
+++ b/graphics/vtk/Portfile
@@ -15,7 +15,7 @@ compiler.blacklist-append {clang < 900}
 
 name                vtk
 version             8.2.0
-revision            2
+revision            3
 categories          graphics devel
 platforms           darwin
 license             BSD

--- a/math/caffe/Portfile
+++ b/math/caffe/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 
 github.setup        BVLC caffe 1de4cebfb81d50267d0d8c2595372b14e1408248
 version             20170817
-revision            14
+revision            15
 categories          math science
 maintainers         nomaintainer
 

--- a/math/deal.ii/Portfile
+++ b/math/deal.ii/Portfile
@@ -8,7 +8,7 @@ PortGroup               linear_algebra 1.0
 
 github.setup            dealii dealii 9.2.0 v
 name                    deal.ii
-revision                10
+revision                11
 categories              math science
 license                 LGPL-2.1+
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer

--- a/math/gnudatalanguage/Portfile
+++ b/math/gnudatalanguage/Portfile
@@ -7,7 +7,7 @@ PortGroup                   mpi 1.0
 PortGroup                   github 1.0
 
 github.setup                gnudatalanguage gdl 0.9.9 v
-revision                    7
+revision                    8
 name                        ${github.author}
 epoch                       2
 

--- a/math/mathgl/Portfile
+++ b/math/mathgl/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.0
 
 name                mathgl
 version             2.4.4
-revision            2
+revision            3
 categories          math
 license             GPL-3
 maintainers         {mps @Schamschula} openmaintainer

--- a/math/octave/Portfile
+++ b/math/octave/Portfile
@@ -9,7 +9,7 @@ PortGroup           linear_algebra 1.0
 name                octave
 version             5.2.0
 set package_version 5.x.x
-revision            6
+revision            7
 categories          math science
 platforms           darwin
 license             GPL-3+

--- a/math/shogun-devel/Portfile
+++ b/math/shogun-devel/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake 1.0
 name                shogun-devel
 version             4.0.0
 set branch          [join [lrange [split ${version} .] 0 1] .]
-revision            16
+revision            17
 categories          math science
 platforms           darwin
 license             GPL-3

--- a/math/shogun/Portfile
+++ b/math/shogun/Portfile
@@ -5,9 +5,9 @@ PortGroup           compilers 1.0
 
 name                shogun
 version             2.1.0
-revision            3
+revision            4
 set branch          [join [lrange [split ${version} .] 0 1] .]
-revision            19
+revision            20
 categories          math science
 platforms           darwin
 license             GPL-3

--- a/perl/p5-pdl-io-hdf5/Portfile
+++ b/perl/p5-pdl-io-hdf5/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28 5.30
 perl5.setup         PDL-IO-HDF5 0.73
-revision            8
+revision            9
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
 description         PDL::IO::HDF5 - PDL Interface to the HDF5 Data Format.

--- a/python/py-h5py/Portfile
+++ b/python/py-h5py/Portfile
@@ -13,7 +13,7 @@ if {${python.version} >= 36} {
         sha256  91000a731669ae2689867078212fec88ca9b5eddae3dd1768093cd18a788e493 \
         size    390571
     # h5py needs to be re-built after hdf5 upgrades
-    revision                0
+    revision                1
     depends_lib-append      port:py${python.version}-cached-property
 } else {
     github.setup            h5py h5py 2.10.0
@@ -22,7 +22,7 @@ if {${python.version} >= 36} {
         sha256  f1a2ed05943845480a4bb9b5907600ffa24bb9c199f3b520f2b811b847e7178d \
         size    314470
     # h5py needs to be re-built after hdf5 upgrades
-    revision                2
+    revision                3
 }
 
 platforms               darwin

--- a/python/py-isce2/Portfile
+++ b/python/py-isce2/Portfile
@@ -7,7 +7,7 @@ PortGroup           active_variants 1.1
 PortGroup           compilers 1.0
 
 github.setup        isce-framework isce2 2.3.2 v
-revision            2
+revision            3
 name                py-isce2
 platforms           darwin
 license             Apache

--- a/python/py-netcdf4/Portfile
+++ b/python/py-netcdf4/Portfile
@@ -7,7 +7,7 @@ PortGroup           mpi 1.0
 name                py-netcdf4
 python.rootname     netCDF4
 version             1.5.3
-revision            2
+revision            3
 
 categories-append   science
 platforms           darwin

--- a/python/py-nio/Portfile
+++ b/python/py-nio/Portfile
@@ -6,7 +6,7 @@ PortGroup compilers 1.0
 
 name                py-nio
 version             1.3.0b1
-revision            18
+revision            19
 categories-append   science
 platforms           darwin
 license             PyNIO

--- a/python/py-pyne/Portfile
+++ b/python/py-pyne/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 
 github.setup        pyne pyne 0.4.1
 
-revision            10
+revision            11
 name                py-pyne
 categories-append   science
 platforms           darwin

--- a/python/py-stfio/Portfile
+++ b/python/py-stfio/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-stfio
 version             0.15.8
-revision            3
+revision            4
 categories          python science
 platforms           darwin
 license             GPL-2

--- a/python/py-tables/Portfile
+++ b/python/py-tables/Portfile
@@ -6,7 +6,7 @@ PortGroup           mpi 1.0
 
 name                py-tables
 version             3.6.1
-revision            0
+revision            1
 categories-append   science
 platforms           darwin
 license             BSD
@@ -36,7 +36,7 @@ if {${name} ne ${subport}} {
     # Last version that supports python 2.7
     if {${python.version} eq 27} {
         version        3.5.2
-        revision       2
+        revision       3
         distname       ${python.rootname}-${version}
         checksums      rmd160  9e5aa9f3b270888c853eb5f30cd6461a362bb1c1 \
                        sha256  b220e32262bab320aa41d33125a7851ff898be97c0de30b456247508e2cc33c2 \

--- a/science/ALPSCore/Portfile
+++ b/science/ALPSCore/Portfile
@@ -7,7 +7,7 @@ PortGroup           mpi 1.0
 PortGroup           cxx11 1.1
 
 github.setup        ALPSCore ALPSCore 2.2.0 v
-revision            5
+revision            6
 
 categories          science
 platforms           darwin

--- a/science/ALPSMaxent/Portfile
+++ b/science/ALPSMaxent/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 name                ALPSMaxent
 
 github.setup        CQMP Maxent 1.0 v
-revision            9
+revision            10
 categories          science
 platforms           darwin
 license             GPL-2

--- a/science/H5Part/Portfile
+++ b/science/H5Part/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                H5Part
 version             1.6.6
-revision            15
+revision            16
 categories          science
 maintainers         lbl.gov:ghweber
 license             BSD

--- a/science/HDF5-External-Filter-Plugins/Portfile
+++ b/science/HDF5-External-Filter-Plugins/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 PortGroup           cmake 1.0
 
 github.setup        nexusformat HDF5-External-Filter-Plugins 0.1.0 v
-revision            4
+revision            5
 categories          science
 platforms           darwin
 license             BSD MIT

--- a/science/abinit/Portfile
+++ b/science/abinit/Portfile
@@ -6,7 +6,7 @@ PortGroup           linear_algebra 1.0
 
 name                abinit
 version             9.0.4
-revision            1
+revision            2
 categories          science
 platforms           darwin
 license             GPL-3

--- a/science/alps/Portfile
+++ b/science/alps/Portfile
@@ -6,7 +6,7 @@ PortGroup               compilers 1.0
 
 name                    alps
 version                 2.3.0
-revision                9
+revision                10
 checksums               rmd160  40a04447f7c6d26aff0124a3b0f879aedc981ed9 \
                         sha256  a40963811a05ad874e9f02747c532a4873095b94e183ecd31869199f58be1f65 \
                         size    127625225

--- a/science/armadillo/Portfile
+++ b/science/armadillo/Portfile
@@ -6,7 +6,7 @@ PortGroup                       mpi 1.0
 
 name                            armadillo
 version                         10.1.2
-revision                        0
+revision                        1
 categories                      science
 platforms                       darwin
 maintainers                     {mps @Schamschula} openmaintainer

--- a/science/cdo/Portfile
+++ b/science/cdo/Portfile
@@ -5,7 +5,7 @@ PortGroup                   mpi 1.0
 
 name                        cdo
 version                     1.9.9
-revision                    0
+revision                    1
 platforms                   darwin
 maintainers                 {takeshi @tenomoto} openmaintainer
 license                     GPL-2

--- a/science/cgnslib/Portfile
+++ b/science/cgnslib/Portfile
@@ -7,7 +7,7 @@ PortGroup                   mpi        1.0
 PortGroup                   muniversal 1.0
 
 github.setup                CGNS CGNS 4.1.1 v
-revision                    1
+revision                    2
 name                        cgnslib
 categories                  science
 platforms                   darwin

--- a/science/crystfel/Portfile
+++ b/science/crystfel/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                crystfel
 version             0.6.1
-revision            10
+revision            11
 categories          science
 platforms           darwin
 license             GPL-3

--- a/science/digital_rf/Portfile
+++ b/science/digital_rf/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 PortGroup           cxx11 1.1
 
 github.setup        MITHaystack digital_rf 2.6.1
-revision            9
+revision            10
 
 categories          science
 license             BSD

--- a/science/flann/Portfile
+++ b/science/flann/Portfile
@@ -6,7 +6,7 @@ PortGroup           mpi 1.0
 PortGroup           github 1.0
 
 github.setup        mariusmuja flann 1.9.1
-revision            7
+revision            8
 categories          science devel
 maintainers         nomaintainer
 description         Fast Library for Approximate Nearest Neighbors

--- a/science/gds/Portfile
+++ b/science/gds/Portfile
@@ -7,7 +7,7 @@ PortGroup     python 1.0
 
 name          gds
 version       2.18.7
-revision      6
+revision      7
 categories    science
 platforms     darwin
 maintainers   {ligo.org:ed.maros @emaros} openmaintainer

--- a/science/gmsh/Portfile
+++ b/science/gmsh/Portfile
@@ -8,7 +8,7 @@ PortGroup               muniversal     1.0
 
 name                    gmsh
 version                 4.5.6
-revision                2
+revision                3
 categories              science
 platforms               darwin
 license                 GPL-2+

--- a/science/gmtk/Portfile
+++ b/science/gmtk/Portfile
@@ -7,7 +7,7 @@ wxWidgets.use       wxWidgets-3.0
 
 name                gmtk
 version             1.4.3
-revision            9
+revision            10
 categories          science
 platforms           darwin
 license             OSL-3

--- a/science/gmtsar/Portfile
+++ b/science/gmtsar/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                gmtsar
 version             5.7
-revision            3
+revision            4
 categories          science
 platforms           darwin
 license             GPL-3

--- a/science/grads/Portfile
+++ b/science/grads/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                grads
 version             2.2.1
-revision            9
+revision            10
 set branch          [join [lrange [split ${version} .] 0 1] .]
 platforms           darwin
 maintainers         {takeshi @tenomoto}

--- a/science/h4h5tools/Portfile
+++ b/science/h4h5tools/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 
 name            h4h5tools
 version         2.2.3
-revision        9
+revision        10
 categories      science
 # Equivalent to BSD + explicitly requiring modifications to be documented
 license         Permissive

--- a/science/h5utils/Portfile
+++ b/science/h5utils/Portfile
@@ -5,7 +5,7 @@ PortGroup           mpi 1.0
 
 name                h5utils
 version             1.12.1
-revision            18
+revision            19
 categories          science
 platforms           darwin
 maintainers         ece.pdx.edu:higginja openmaintainer

--- a/science/hdf5-lz4-plugin/Portfile
+++ b/science/hdf5-lz4-plugin/Portfile
@@ -19,7 +19,7 @@ long_description    ${description} Provides very high throughput compression \
 set commit          8fa813aa369c15127c551cfdeebe4cbc090b4687
 github.setup        dectris HDF5Plugin ${commit}
 version             20130903
-revision            10
+revision            11
 
 checksums \
     rmd160  03229c8803b5ba198cca61bab8788353d0cc00a2 \

--- a/science/hdf5/Portfile
+++ b/science/hdf5/Portfile
@@ -5,7 +5,7 @@ PortGroup           muniversal 1.0
 PortGroup           mpi 1.0
 
 name                hdf5
-version             1.10.7
+version             1.12.0
 revision            0
 set shortversion    [join [lrange [split ${version} .] 0 1] .]
 categories          science
@@ -26,9 +26,9 @@ platforms           darwin
 master_sites \
     https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${shortversion}/hdf5-${version}/src
 checksums \
-    rmd160  6da25b3aee83ad2aba421ac7b7026aa1f8c1d38f \
-    sha256  02018fac7e5efc496d9539a303cfb41924a5dadffab05df9812096e273efa55e \
-    size    8957844
+    rmd160  56356ac0814da104d988e33eed88e6819a2e5d37 \
+    sha256  97906268640a6e9ce0cde703d5a71c9ac3092eded729591279bf2e3ca9765f61 \
+    size    9081988
 mpi.setup           -gcc44 -gcc45
 
 use_bzip2           yes
@@ -36,6 +36,16 @@ depends_lib         port:zlib
 use_parallel_build  yes
 
 patchfiles          patch-tools-src-misc-h5cc.in.diff
+
+post-patch {
+    reinplace -E {s/^(EXAMPLE(TOP)?DIR) = \$\(ex/\1 = ${DESTDIR}$(ex/} \
+        c++/examples/Makefile.in \
+        hl/c++/examples/Makefile.in \
+        hl/examples/Makefile.in \
+        hl/fortran/examples/Makefile.in \
+        examples/Makefile.in \
+        fortran/examples/Makefile.in
+}
 
 # llvm-gcc-4.2 produced code fails type conversion tests
 # Upstream suggestion is use -O0. Clang-produced code passes all tests.
@@ -54,7 +64,9 @@ configure.args      --with-zlib=yes \
                     --enable-build-mode=production --disable-fortran \
                     --disable-cxx --disable-hl --enable-shared --enable-static \
                     --disable-parallel --disable-threadsafe \
-                    --with-default-plugindir=${prefix}/lib/hdf5
+                    --with-default-plugindir=${prefix}/lib/hdf5 \
+                    --enable-build-mode=production \
+                    --with-default-api-version=v110
 
 # http://mail.hdfgroup.org/pipermail/hdf-forum_hdfgroup.org/2010-March/002682.html
 license             NCSA

--- a/science/hdf5/Portfile
+++ b/science/hdf5/Portfile
@@ -65,7 +65,6 @@ configure.args      --with-zlib=yes \
                     --disable-cxx --disable-hl --enable-shared --enable-static \
                     --disable-parallel --disable-threadsafe \
                     --with-default-plugindir=${prefix}/lib/hdf5 \
-                    --enable-build-mode=production \
                     --with-default-api-version=v110
 
 # http://mail.hdfgroup.org/pipermail/hdf-forum_hdfgroup.org/2010-March/002682.html

--- a/science/hdf5/files/update_revs.sh
+++ b/science/hdf5/files/update_revs.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+PFILES=$(find $(port dir hdf5)/../.. -name Portfile \
+           -exec grep -l 'port[^ ]*hdf5' '{}' '+')
+echo -n "Checking: "
+for x in $PFILES; do
+  echo -n "$x"
+  pushd $(dirname $x) > /dev/null
+  port info | grep -Eq '(Dependencies.*hdf5|Sub-ports)'
+  if [ $? -ne 0 ]; then
+    popd > /dev/null
+    echo
+    continue
+  fi
+  popd > /dev/null
+  grep -q revision $x || { echo " NO REVISION" ; continue ; }
+  echo " (bumping)"
+  awk '/revision/{sub($2, $2+1)} {print}' < $x > $x.revup && mv $x.revup $x
+done
+echo 'Done!'

--- a/science/hdfeos5/Portfile
+++ b/science/hdfeos5/Portfile
@@ -6,7 +6,7 @@ PortGroup           mpi 1.0
 
 name                hdfeos5
 version             1.16
-revision            4
+revision            5
 categories          science
 platforms           darwin
 license             public-domain

--- a/science/ismrmrd/Portfile
+++ b/science/ismrmrd/Portfile
@@ -7,7 +7,7 @@ PortGroup               cxx11 1.1
 PortGroup               conflicts_build 1.0
 
 github.setup            ismrmrd ismrmrd 1.4.2.1 v
-revision                1
+revision                2
 categories              science
 maintainers             {eborisch @eborisch} openmaintainer
 license                 permissive

--- a/science/lal/Portfile
+++ b/science/lal/Portfile
@@ -4,7 +4,7 @@ PortSystem    1.0
 
 name          lal
 version       7.0.0
-revision      0
+revision      1
 
 description   LSC Algorithm Library
 long_description \

--- a/science/libmed/Portfile
+++ b/science/libmed/Portfile
@@ -6,6 +6,8 @@ PortGroup               cmake     1.1
 
 name                    libmed
 version                 4.0.0
+# Must rebuild afer upgrading HDF5. Keep revision number even if 0.
+revision                1
 categories              science devel
 platforms               darwin
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer

--- a/science/lscsoft-deps/Portfile
+++ b/science/lscsoft-deps/Portfile
@@ -4,6 +4,8 @@ PortSystem      1.0
 
 name            lscsoft-deps
 version         20200805
+# Must rebuild afer upgrading HDF5. Keep revision number even if 0.
+revision        1
 categories      science
 maintainers     {aronnax @lpsinger} {ligo.org:ed.maros @emaros}
 platforms       darwin

--- a/science/magicspp/Portfile
+++ b/science/magicspp/Portfile
@@ -12,7 +12,7 @@ perl5.branches      5.28
 
 name                magicspp
 version             4.5.1
-revision            0
+revision            1
 platforms           darwin
 maintainers         {takeshi @tenomoto}
 license             Apache-2

--- a/science/metview/Portfile
+++ b/science/metview/Portfile
@@ -6,7 +6,7 @@ PortGroup mpi       1.0
 
 name                metview
 version             5.10.1
-revision            0
+revision            1
 platforms           darwin
 maintainers         {takeshi @tenomoto}
 license             Apache-2

--- a/science/ncarg/Portfile
+++ b/science/ncarg/Portfile
@@ -11,7 +11,7 @@ compilers.allow_arguments_mismatch \
 
 name                        ncarg
 version                     6.6.2
-revision                    4
+revision                    5
 epoch                       1
 set version_no_dot [join [split ${version} "."] ""]
 categories                  science

--- a/science/nco/Portfile
+++ b/science/nco/Portfile
@@ -5,7 +5,7 @@ PortGroup           compilers 1.0
 PortGroup           github 1.0
 
 github.setup        nco nco 4.9.3
-revision            1
+revision            2
 platforms           darwin
 maintainers         {takeshi @tenomoto}
 license             GPL-3

--- a/science/netcdf/Portfile
+++ b/science/netcdf/Portfile
@@ -7,7 +7,7 @@ PortGroup                   cmake 1.0
 PortGroup                   muniversal 1.0
 
 github.setup                Unidata netcdf-c 4.7.4 v
-revision                    1
+revision                    2
 epoch                       3
 name                        netcdf
 maintainers                 {takeshi @tenomoto} openmaintainer

--- a/science/paraview/Portfile
+++ b/science/paraview/Portfile
@@ -10,7 +10,7 @@ PortGroup           xcodeversion 1.0
 
 name                paraview
 version             5.6.2
-revision            5
+revision            6
 
 categories          science graphics
 platforms           darwin

--- a/science/silo/Portfile
+++ b/science/silo/Portfile
@@ -5,7 +5,7 @@ PortGroup           compilers 1.0
 
 name                silo
 version             4.10.2
-revision            10
+revision            11
 categories          science
 platforms           darwin
 license             BSD

--- a/science/stimfit/Portfile
+++ b/science/stimfit/Portfile
@@ -5,7 +5,7 @@ PortGroup           wxWidgets 1.0
 
 name                stimfit
 version             0.15.8
-revision            3
+revision            4
 categories          science
 platforms           darwin
 license             GPL-2

--- a/science/swarm/Portfile
+++ b/science/swarm/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                swarm
 version             2.4.1
-revision            19
+revision            20
 categories          science
 maintainers         nomaintainer
 license             GPL-2

--- a/science/vapor/Portfile
+++ b/science/vapor/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                vapor
 version             2.2.4
-revision            22
+revision            23
 categories          science
 maintainers         nomaintainer
 description         interactive 3D scientific visualization environment

--- a/science/wgrib2/Portfile
+++ b/science/wgrib2/Portfile
@@ -9,7 +9,7 @@ legacysupport.newest_darwin_requires_legacy 10
 
 name                wgrib2
 version             2.0.8
-revision            5
+revision            6
 platforms           darwin
 maintainers         {takeshi @tenomoto}
 license             public-domain

--- a/science/xdmf/Portfile
+++ b/science/xdmf/Portfile
@@ -5,7 +5,7 @@ PortGroup               cmake 1.1
 
 name                    xdmf
 version                 3.0.0
-revision                2
+revision                3
 categories              science devel
 # cannot find license, assume same as ParaView
 license                 BSD


### PR DESCRIPTION
Maintainer update, but...

PLEASE NOTE:

> Applications that were created with earlier HDF5 releases may not compile with 1.12 by default.
> 
> The API Compatibility Macros in HDF5 allow users to work around this issue. Users can specify a compatibility macro mapping for the version of HDF5 that an application was built with. For example, a 1.10 application can be built with 1.12 using either an application or library mapping as follows:
> 
> 1) To compile an application built with a version of HDF5 that includes deprecated symbols (the default), specify: -DH5_USE_110_API (autotools) or –DH5_USE_110_API:BOOL=ON (CMake)
> 2) To build an HDF5 library with the 1.10 APIs specify --with-default-api-version=v110 (Autotools) or -DDEFAULT_API_VERSION:STRING=v110 (CMake).
> 
>However, users will not be able to take advantage of some of the new features in 1.12 if using these compatibility mappings.

This patch represents building a vanilla 1.12.0 (i.e. not defaulting to 1.10 API); if this causes too much upheaval (builds fail and the **-DH5_USE_110_API**  compatibility macro / option 1 approach doesn't work), we'll try the other route (building with deprecated symbols / option 2) until dependencies catch up.

**Tagging maintainers of ports with direct hdf5 dependencies; please consider applying this patch and testing with 1.12.0 and reporting back here if you have success/failure!**

@BSeppke
@MarcusCalhoun-Lopez
@Schamschula
@Veence
@danieljprice
@dstrubbe
@egull
@emaros
@galexv
@jcupitt
@johndesanto
@jswhit
@jswoboda
@lpsinger
@mtorrent
@neurodroid
@petrrr
@piyushrpt
@stromnov
@tenomoto

for ports: '+' = builds without -D macro; '-' = builds with -D macro; 'x' = will not build

- ALPSCore
- ALPSMaxent
- H5Part
- HDF5-External-Filter-Plugins : +
- InsightToolkit-devel
- abinit
- alembic
- alps
- armadillo
- berkeleygw
- caffe
- cdo
- cgnslib
- crystfel
- deal.ii
- digital_rf
- dolfin
- field3d
- flann
- gdal
- gds
- gmsh
- gmtk
- gmtsar
- gnudatalanguage
- grads
- h4h5tools
- h5utils
- hdf5-lz4-plugin : +
- hdfeos5
- ismrmrd : +
- kealib
- lal
- libmed
- lscsoft-deps
- magicspp
- mathgl
- metview
- ncarg
- nco
- netcdf
- octave
- p5-pdl-io-hdf5
- paraview
- petsc
- py-h5py : x / Requires head version of h5py (as of 8/5/2020) to compile (and then +).
- py-isce2
- py-netcdf4
- py-nio
- py-pyne
- py-stfio
- py-tables
- shogun
- shogun-devel
- silo
- splash
- stimfit
- swarm
- vapor
- vigra
- vips
- vtk
- wgrib2
- xdmf
