### PR TITLE
ncmpc: add patch for MacOS <= 10.11

### DIFF
--- a/audio/ncmpc/Portfile
+++ b/audio/ncmpc/Portfile
@@ -31,6 +31,7 @@ configure.env-append \
                     LDFLAGS=-lintl
 
 patch.pre_args      -p1
+patchfiles-append   patch-locale.diff
 # temporary workaround for boost 1.66 on macOS >= 10.14
 # (remove once boost is upgraded)
 if {${os.major} >= 18} {

--- a/audio/ncmpc/files/patch-locale.diff
+++ b/audio/ncmpc/files/patch-locale.diff
@@ -1,0 +1,14 @@
+diff --git a/src/util/StringUTF8.hxx b/src/util/StringUTF8.hxx
+index 6786300a..dca35676 100644
+--- a/src/util/StringUTF8.hxx
++++ b/src/util/StringUTF8.hxx
+@@ -31,6 +31,9 @@ public:
+ 
+ 	ScopeInitUTF8(const ScopeInitUTF8 &) = delete;
+ 	ScopeInitUTF8 &operator=(const ScopeInitUTF8 &) = delete;
++#else
++public:
++	ScopeInitUTF8() noexcept {};
+ #endif
+ };
+ 


### PR DESCRIPTION
I'm the maintainer. I'm checking a patch in the build bots before pushing. 
(P.S.: Wrongly created under my work account, but will be pushed under my regular account.)