### PR TITLE
openjdk8: update to 8u265

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -3,10 +3,10 @@
 PortSystem       1.0
 
 name             openjdk8
-version          8u262
+version          8u265
 revision         0
 
-set build        10
+set build        01
 set major        8
 
 subport openjdk8-graalvm {
@@ -17,19 +17,19 @@ subport openjdk8-graalvm {
 }
 
 subport openjdk8-openj9 {
-    version      8u262
+    version      8u265
     revision     0
 
-    set build    10
+    set build    01
     set major    8
     set openj9_version 0.21.0
 }
 
 subport openjdk8-openj9-large-heap {
-    version      8u262
+    version      8u265
     revision     0
 
-    set build    10
+    set build    01
     set major    8
     set openj9_version 0.21.0
 }
@@ -188,9 +188,9 @@ if {${os.platform} eq "darwin" && ${os.major} < 14} {
 if {${subport} eq "openjdk8"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}/
 
-    checksums    rmd160  b6d468109e432ba536b5523a5709fc37ab37d34c \
-                 sha256  787c37e286d76d42adc8938399a1411da8035d2c283298acb625f3e7b21baf06 \
-                 size    101389824
+    checksums    rmd160  c663ab3056c3731c1e780bd3e37fe59321576330 \
+                 sha256  f316b154e8c4a99b95bc3d07add3c9b19609c541a2f297112f274c1abce1efb4 \
+                 size    101998442
 
     distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}b${build}
     worksrcdir   jdk${version}-b${build}
@@ -214,9 +214,9 @@ if {${subport} eq "openjdk8"} {
 } elseif {${subport} eq "openjdk8-openj9"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
 
-    checksums    rmd160  0491fa0163996174ac94db6a65eec4f9e153c60e \
-                 sha256  a200abbeb5e01a642bf6405f4706e78a1e0a31bf5f4d5359e93ffdd983a2a104 \
-                 size    113716716
+    checksums    rmd160  060f6aa970f9343ee1f303f62a719e5166f0ac40 \
+                 sha256  963683189fe2ab6d35f00d6ad9562fc7e9790e7e82fe3d1b01e6c80bde910c63 \
+                 size    114361837
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}b${build}_openj9-${openj9_version}
     worksrcdir   jdk${version}-b${build}
@@ -231,9 +231,9 @@ if {${subport} eq "openjdk8"} {
 } elseif {${subport} eq "openjdk8-openj9-large-heap"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
 
-    checksums    rmd160  e4319b6783f0a98e4ac75d7092a1e21501c83e3f \
-                 sha256  d13f8622cba393989517da258af1cba08e5bcc23302c337841348ee573c9304a \
-                 size    114370050
+    checksums    rmd160  b869a0877dcb5f294d211a3809eaacda1fbd5213 \
+                 sha256  2b804a0ac732df6076965b76ac32064ba5eeba205f06d2b4bdefc4356b15069d \
+                 size    113721837
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}b${build}_openj9-${openj9_version}
     worksrcdir   jdk${version}-b${build}


### PR DESCRIPTION
#### Description

Update to AdoptOpenJDK 8u265, which fixes two bugs in the recent OpenJDK 8u262 release: https://mail.openjdk.java.net/pipermail/jdk8u-dev/2020-July/012284.html

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?