### PR TITLE
apr: Fix bundled libtool for macOS 11

### DIFF
--- a/devel/apr/Portfile
+++ b/devel/apr/Portfile
@@ -3,6 +3,7 @@ PortSystem         1.0
 
 name               apr
 version            1.7.0
+revision           1
 categories         devel
 maintainers        {geeklair.net:dluke @danielluke}
 platforms          darwin
@@ -38,6 +39,7 @@ configure.args     --with-installbuilddir=${prefix}/share/apr-1/build \
                    ac_cv_func_setpgrp_void=no
 
 patchfiles         apr_h_patch.diff \
+                   dynamic_lookup-11.patch \
                    patch-configure.diff
 
 test.run           yes

--- a/devel/apr/files/dynamic_lookup-11.patch
+++ b/devel/apr/files/dynamic_lookup-11.patch
@@ -1,0 +1,47 @@
+Handle macOS 11 and later properly. Copied from libtool port.
+--- build/libtool.m4.orig	2019-04-01 17:56:21.000000000 +0000
++++ build/libtool.m4	2020-08-06 07:33:01.000000000 +0000
+@@ -1067,16 +1067,11 @@
+       _lt_dar_allow_undefined='$wl-undefined ${wl}suppress' ;;
+     darwin1.*)
+       _lt_dar_allow_undefined='$wl-flat_namespace $wl-undefined ${wl}suppress' ;;
+-    darwin*) # darwin 5.x on
+-      # if running on 10.5 or later, the deployment target defaults
+-      # to the OS version, if on x86, and 10.4, the deployment
+-      # target defaults to 10.4. Don't you love it?
+-      case ${MACOSX_DEPLOYMENT_TARGET-10.0},$host in
+-	10.0,*86*-darwin8*|10.0,*-darwin[[91]]*)
+-	  _lt_dar_allow_undefined='$wl-undefined ${wl}dynamic_lookup' ;;
+-	10.[[012]][[,.]]*)
++    darwin*)
++      case ${MACOSX_DEPLOYMENT_TARGET},$host in
++	10.[[012]],*|,*powerpc*)
+ 	  _lt_dar_allow_undefined='$wl-flat_namespace $wl-undefined ${wl}suppress' ;;
+-	10.*)
++	*)
+ 	  _lt_dar_allow_undefined='$wl-undefined ${wl}dynamic_lookup' ;;
+       esac
+     ;;
+--- configure.orig	2019-04-01 17:56:23.000000000 +0000
++++ configure	2020-08-06 07:33:01.000000000 +0000
+@@ -13923,16 +13923,11 @@
+       _lt_dar_allow_undefined='$wl-undefined ${wl}suppress' ;;
+     darwin1.*)
+       _lt_dar_allow_undefined='$wl-flat_namespace $wl-undefined ${wl}suppress' ;;
+-    darwin*) # darwin 5.x on
+-      # if running on 10.5 or later, the deployment target defaults
+-      # to the OS version, if on x86, and 10.4, the deployment
+-      # target defaults to 10.4. Don't you love it?
+-      case ${MACOSX_DEPLOYMENT_TARGET-10.0},$host in
+-	10.0,*86*-darwin8*|10.0,*-darwin[91]*)
+-	  _lt_dar_allow_undefined='$wl-undefined ${wl}dynamic_lookup' ;;
+-	10.[012][,.]*)
++    darwin*)
++      case ${MACOSX_DEPLOYMENT_TARGET},$host in
++	10.[012],*|,*powerpc*)
+ 	  _lt_dar_allow_undefined='$wl-flat_namespace $wl-undefined ${wl}suppress' ;;
+-	10.*)
++	*)
+ 	  _lt_dar_allow_undefined='$wl-undefined ${wl}dynamic_lookup' ;;
+       esac
+     ;;


### PR DESCRIPTION
#### Description

apr: Fix bundled libtool for macOS 11

Closes: https://trac.macports.org/ticket/60794

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.0 20A5343i
Xcode 12.0 12A8169g

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
