### PR TITLE
uboot-tools: Specify C standard for compiler and enable extensions

### DIFF
--- a/devel/uboot-tools/Portfile
+++ b/devel/uboot-tools/Portfile
@@ -3,8 +3,12 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
+# Need strndup()
+PortGroup           legacysupport 1.0
+legacysupport.newest_darwin_requires_legacy 10
+
 name                uboot-tools
-github.setup        u-boot u-boot 2020.07 v
+github.setup        u-boot u-boot 2020.10 v
 revision            0
 github.tarball_from archive
 license             GPL-2
@@ -17,13 +21,15 @@ long_description    U-Boot is a boot loader for Embedded boards based on \
                     port compiles some binary tools that can be used to \
                     deploy u-boot on embedded devices.
 
-checksums           rmd160  124de3a5355915ccb2291b4a01f21e7710290521 \
-                    sha256  616b446e15d1cd1ab6461ebb61ac6655a2b13e902fe0601f36c4affb3949d416 \
-                    size    19630685
+checksums           rmd160  25357e70695de9aac1cee2a752cb4fd82def66ed \
+                    sha256  0c022ca6796aa8c0689faae8b515eb62ac84519c31de3153257a9ee0f446618f \
+                    size    20176030
 
 depends_build       port:gmake
 
 depends_lib         path:lib/libssl.dylib:openssl
+
+compiler.c_standard 2011
 
 configure.cmd       gmake defconfig
 configure.pre_args


### PR DESCRIPTION
This should fix the following error on old systems:
```
In file included from scripts/kconfig/zconf.tab.c:2613:
scripts/kconfig/util.c: In function ‘xstrndup’:
scripts/kconfig/util.c:125: warning: implicit declaration of function ‘strndup’
scripts/kconfig/util.c:125: warning: incompatible implicit declaration of built-in function ‘strndup’
```

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
