### PR TITLE
py-tmuxp: update to 1.5.5

### DIFF
--- a/python/py-tmuxp/Portfile
+++ b/python/py-tmuxp/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-tmuxp
-version             1.5.0a1
+version             1.5.5
 categories-append   devel
 license             MIT
 platforms           darwin
@@ -18,7 +18,7 @@ long_description    ${description}
 homepage            https://github.com/tmux-python/tmuxp/
 master_sites        pypi:t/${python.rootname}/
 distname            ${python.rootname}-${version}
-python.versions     27 36 37
+python.versions     27 36 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
@@ -28,11 +28,9 @@ if {${name} ne ${subport}} {
                             port:py${python.version}-kaptan \
                             port:py${python.version}-libtmux
 
-    patchfiles          patch-requirements.diff
-
-    checksums           rmd160  76767f98ff0b84921a5908ec049ef647cee4faa9 \
-                        sha256  88b6ece3ff59a0882b5c5bff169cc4c1d688161fe61e5553b0a0802ff64b6da8 \
-                        size    67218
+    checksums           rmd160  88ec8b28cf74405c3551de49ddb073145fc12fd5 \
+                        sha256  cd9724b2738a3032f29784ce2e37332ca5f80104e05182502dcdadf7b08f7fc9 \
+                        size    75028
     livecheck.type      none
 } else {
     livecheck.type  pypi

--- a/python/py-tmuxp/files/patch-requirements.diff
+++ b/python/py-tmuxp/files/patch-requirements.diff
@@ -1,8 +1,0 @@
---- requirements/base.txt.orig
-+++ requirements/base.txt
-@@ -1,4 +1,4 @@
- kaptan>=0.5.10
- libtmux==0.8.0
- click>=7<8
--colorama==0.3.9
-+colorama>=0.3.9


### PR DESCRIPTION
* add py38 subport

#### Description

Please note that the following upstream tests are failing for both Python 3.7 and 3.8:

* `test_workspacebuilder.py::test_window_options_after` (marked as flaky)
* `test_workspacebuilder.py::test_automatic_rename_option`

I didn't test with Python 3.6 or earlier.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

- [x] tried upstream tests with `pytest`

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
