### PR TITLE
neomutt: Use the right compiler

### DIFF
--- a/mail/neomutt/Portfile
+++ b/mail/neomutt/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 
 github.setup        neomutt neomutt 20200626
-revision            0
+revision            1
 categories          mail
 platforms           darwin
 license             GPL-2+
@@ -65,7 +65,7 @@ configure.args      --disable-idn \
 
 # disable ccache, build issues with autosetup
 configure.ccache     no
-configure.env-append CCACHE=none
+configure.env-append CCACHE=none CC_FOR_BUILD=${configure.cc}
 
 default_variants    +gpgme +idn +mutt
 if {${install.user} ne "root"} {


### PR DESCRIPTION
### Description

See https://trac.macports.org/wiki/UsingTheRightCompiler.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G6020
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
