### PR TITLE
itstool: Default to python38 (python27 is EOL)

### DIFF
--- a/textproc/itstool/Portfile
+++ b/textproc/itstool/Portfile
@@ -57,7 +57,7 @@ variant python38 conflicts python27 python37 description {Use Python 3.8 (experi
 }
 
 if {![variant_isset python27] && ![variant_isset python37] && ![variant_isset python38]} {
-    default_variants +python27
+    default_variants +python38
 }
 
 livecheck.type      regex


### PR DESCRIPTION
#### Description

itstool: Default to python38 (python27 is EOL)

The python37 and python38 variants have the remark "(experimental, still a few bugs)". What are the bugs and can we fix them?

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G12034
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
