### PR TITLE
tcp_wrappers: Add prototype of hosts_ctl to tcpd.h

### DIFF
--- a/net/tcp_wrappers/Portfile
+++ b/net/tcp_wrappers/Portfile
@@ -1,7 +1,7 @@
 PortSystem              1.0
 name                    tcp_wrappers
 version                 20
-revision                3
+revision                4
 categories              net
 license                 Permissive
 maintainers             {jeremyhu @jeremyhu} openmaintainer

--- a/net/tcp_wrappers/files/fix-prototypes.patch
+++ b/net/tcp_wrappers/files/fix-prototypes.patch
@@ -1,5 +1,5 @@
---- tcpd.h
-+++ tcpd.h
+--- tcpd.h.orig	2009-10-05 16:17:07.000000000 -0500
++++ tcpd.h	2020-08-07 03:49:33.000000000 -0500
 @@ -4,6 +4,11 @@
    * Author: Wietse Venema, Eindhoven University of Technology, The Netherlands.
    */
@@ -12,7 +12,7 @@
  /* Structure to describe one communications endpoint. */
  
  #define STRING_LENGTH	128		/* hosts, users, processes */
-@@ -29,10 +38,10 @@ struct request_info {
+@@ -92,10 +97,10 @@
      char    pid[10];			/* access via eval_pid(request) */
      struct host_info client[1];		/* client endpoint info */
      struct host_info server[1];		/* server endpoint info */
@@ -27,7 +27,7 @@
      struct netconfig *config;		/* netdir handle */
  };
  
-@@ -70,20 +79,22 @@ extern void fromhost();			/* get/validat
+@@ -137,20 +142,23 @@
  #define fromhost sock_host		/* no TLI support needed */
  #endif
  
@@ -43,6 +43,7 @@
 -extern int numeric_addr();		/* IP4/IP6 inet_addr (restricted) */
 -extern struct hostent *tcpd_gethostbyname();
 +extern int hosts_access(struct request_info *request);	/* access control */
++extern int hosts_ctl(char *daemon, char *name, char *addr, char *user);			/* wrapper around request_init() */
 +extern void shell_cmd(char *);		/* execute shell command */
 +extern char *percent_x(char *, int, char *, struct request_info *);
 +					/* do %<char> expansion */
@@ -55,14 +56,14 @@
 +extern unsigned long dot_quad_addr(char *);	/* restricted inet_addr() */
 +extern int numeric_addr(char *str, union gen_addr *addr, int *af, int *len);		/* IP4/IP6 inet_addr (restricted) */
 +extern struct hostent *tcpd_gethostbyname(char *host, int af);
-					/* IP4/IP6 gethostbyname */
+ 					/* IP4/IP6 gethostbyname */
  #ifdef HAVE_IPV6
 -extern char *skip_ipv6_addrs();		/* skip over colons in IPv6 addrs */
 +extern char *skip_ipv6_addrs(char *str);		/* skip over colons in IPv6 addrs */
  #else
  #define skip_ipv6_addrs(x)	x
  #endif
-@@ -121,20 +139,23 @@ extern struct request_info *request_set(
+@@ -196,20 +204,23 @@
    * host_info structures serve as caches for the lookup results.
    */
  
@@ -95,7 +96,7 @@
  #define sock_methods(r) \
  	{ (r)->hostname = sock_hostname; (r)->hostaddr = sock_hostaddr; }
  
-@@ -182,7 +203,7 @@ extern struct tcpd_context tcpd_context;
+@@ -257,7 +268,7 @@
    * behavior.
    */
  
@@ -104,16 +105,16 @@
  extern int dry_run;			/* verification flag */
  
  /* Bug workarounds. */
-@@ -221,3 +242,6 @@ extern char *fix_strtok();
+@@ -296,3 +307,6 @@
  #define strtok	my_strtok
  extern char *my_strtok();
  #endif
 +
 +__END_DECLS
 +
---- scaffold.c	2005-03-09 18:22:04.000000000 +0100
-+++ scaffold.c	2005-03-09 18:20:47.000000000 +0100
-@@ -237,10 +237,12 @@ struct request_info *request;
+--- scaffold.c.orig	2009-10-05 16:17:07.000000000 -0500
++++ scaffold.c	2020-08-07 03:47:57.000000000 -0500
+@@ -179,10 +179,12 @@
  
  /* ARGSUSED */
  


### PR DESCRIPTION
#### Description

tcp_wrappers: Add prototype of hosts_ctl to tcpd.h

Fixes "implicit declaration of function 'hosts_ctl' is invalid in C99" in software that uses tcp_wrappers, such as openldap.

The same fix has been made in other systems years ago, such as:

https://www.illumos.org/issues/4385
https://www.funkthat.com/gitea/jmg/freebsd/commit/42209922ff3dc9d65e9ddb3ef6f1da42e818ccf0
https://build.opensuse.org/package/view_file/openSUSE:Factory/tcpd/tcp_wrappers_7.6-hosts_ctl.diff

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G12034
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
