### PR TITLE
aalib: fix livecheck

### DIFF
--- a/graphics/aalib/Portfile
+++ b/graphics/aalib/Portfile
@@ -8,6 +8,7 @@ revision            5
 categories          graphics
 license             LGPL
 maintainers         nomaintainer
+
 description         Portable ascii art GFX library
 long_description    AA-lib is a low level gfx library just as many other \
                     libraries are. The main difference is that AA-lib does \
@@ -18,6 +19,7 @@ long_description    AA-lib is a low level gfx library just as many other \
                     at secondary display (yes! Like Win95 does:) AA-lib API \
                     is designed to be similar to other graphics libraries. \
                     Learning a new API would be a piece of cake!
+
 homepage            http://aa-project.sourceforge.net/aalib/
 master_sites        sourceforge:aa-project freebsd
 
@@ -36,8 +38,10 @@ configure.args      --without-x --with-ncurses \
 configure.cppflags-append \
                     -DNCURSES_OPAQUE=0
 
-patchfiles          automake.patch malloc.patch \
-                    patch-aacurkbd.c.diff patch-aacurses.c.diff \
+patchfiles          automake.patch \
+                    malloc.patch \
+                    patch-aacurkbd.c.diff \
+                    patch-aacurses.c.diff \
                     patch-aalib.m4.diff
 
 depends_lib         port:ncurses
@@ -52,4 +56,5 @@ variant x11 {
 use_autoreconf      yes
 autoreconf.args     -fvi
 
-livecheck.type      none
+# Add 'a-z' to regex to match: '1.4rc5'
+livecheck.regex     /${name}-(\[a-z0-9.\]+)${extract.suffix}


### PR DESCRIPTION
#### Description

  - Add 'a-z' to regex to match: '1.4rc5'
    Closes: https://trac.macports.org/ticket/57048
  - Portlint: Rename patches to follow the patch naming policy "patch-*.diff"

###### Type(s)

- [x] bugfix

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port install`?
