### PR TITLE
rust: update to 1.45.2

### DIFF
--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -3,13 +3,15 @@
 PortSystem          1.0
 
 name                rust
-version             1.45.0
+version             1.45.2
 revision            0
 categories          lang devel
 platforms           darwin
 supported_archs     x86_64
 license             {MIT Apache-2} BSD zlib NCSA Permissive
-maintainers         {g5pw @g5pw} openmaintainer
+maintainers         {g5pw @g5pw} \
+                    {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
 
 description         A safe, concurrent, practical language
 
@@ -47,9 +49,9 @@ distfiles-append    rust-std-${ruststd_version}-${build_arch}-apple-${os.platfor
                     cargo-${cargo_version}-${build_arch}-apple-${os.platform}${extract.suffix}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  7a55f13406b8fc510d32cce735c7c3ad97200a06 \
-                    sha256  ba0495f12c7d4e8735f3fa9e036bfafd1ae58c26910393201e95b9d13c80cd7c \
-                    size    141692525
+                    rmd160  5c912683356937d4334e6f6de12a7f4df071ad23 \
+                    sha256  b7a3fc1e3ee367260ef945da867da0957f8983705f011ba2a73715375e50e308 \
+                    size    141671717
 
 checksums-append \
                     rust-std-${ruststd_version}-x86_64-apple-${os.platform}${extract.suffix} \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
