### PR TITLE
1password-cli: update to 1.4.0

### DIFF
--- a/security/1password-cli/Portfile
+++ b/security/1password-cli/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                1password-cli
-version             1.1.1
+version             1.4.0
 
 categories          security
 license             Restrictive/Distributable
@@ -31,9 +31,9 @@ extract.suffix      .pkg
 master_sites        https://cache.agilebits.com/dist/1P/op/pkg/v${version}/
 distfiles           ${archive}${version}${extract.suffix}
 
-checksums           rmd160  6c68dd619684ecc9e9c048aed261b373ea3152a0 \
-                    sha256  f55e62a140a714542249346037c793af5d35110d2aab7d32e59df89967e7369a \
-                    size    4276763
+checksums           rmd160  1d7efb1dd6cabdaa28bf71c7b0f6ebf460f64647 \
+                    sha256  03783d00d586dc0d9b899226cb44a34daba1b2eb7c67f9245407e2ba9bf25786 \
+                    size    4484922
 
 # Pre-built binary
 use_configure       no


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
