### PR TITLE
git-delta: update to 0.4.1

### DIFF
--- a/textproc/git-delta/Portfile
+++ b/textproc/git-delta/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        dandavison delta 0.4.0
+github.setup        dandavison delta 0.4.1
 name                git-delta
 categories          textproc
 platforms           darwin
@@ -18,9 +18,9 @@ long_description    Delta provides language syntax-highlighting, within-line \
                     output for git on the command line.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  f3df7418d1a48e5a208bb90f547b841fa2e20db9 \
-                    sha256  50b243564ecfad54770530076f1b20d64b4a975d7823a94829f05dbea07e3b1c \
-                    size    869673
+                    rmd160  dbf9680e44bb516b9898ae607590e666f637cf2e \
+                    sha256  d40c9b247ace761c594dc1e52445445c20ea78fc791777abe07b082d6431244a \
+                    size    1019384
 
 destroot {
     xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/delta \
@@ -71,7 +71,7 @@ cargo.crates \
     dirs-sys                         0.3.5  8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a \
     either                           1.5.3  bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3 \
     encode_unicode                   0.3.5  90b2c9496c001e8cb61827acdefad780795c42264c137744cae6f7d9e3450abd \
-    error-chain                     0.12.2  d371106cc88ffdfb1eabd7111e432da544f16f3e2d7bf1dfe8bf575f1df045cd \
+    error-chain                     0.12.4  2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc \
     failure                          0.1.6  f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9 \
     failure_derive                   0.1.6  0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08 \
     flate2                          1.0.12  ad3c5233c9a940c8719031b423d7e6c16af66e031cb0420b0896f5245bf181d3 \
@@ -128,13 +128,13 @@ cargo.crates \
     shell-words                      1.0.0  b6fa3938c99da4914afedd13bf3d79bcb6c277d1b2c398d23257a304d9e1b074 \
     smallvec                         1.4.0  c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4 \
     strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
-    structopt                       0.3.15  de2f5e239ee807089b62adce73e48c625e0ed80df02c7ab3f068f5db5281065c \
-    structopt-derive                 0.4.8  510413f9de616762a4fbeab62509bf15c729603b72d7cd71280fbca431b1c118 \
+    structopt                       0.3.16  de5472fb24d7e80ae84a7801b7978f95a19ec32cb1876faea59ab711eb901976 \
+    structopt-derive                 0.4.9  1e0eb37335aeeebe51be42e2dc07f031163fbabfa6ac67d7ea68b5c2f68d5f99 \
     syn                            0.15.43  ee06ea4b620ab59a2267c6b48be16244a3389f8bfa0986bdd15c35b890b00af3 \
     syn                             1.0.11  dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238 \
     syn-mid                          0.5.0  7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a \
     synstructure                    0.12.3  67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545 \
-    syntect                          4.2.0  83b43a6ca1829ccb0c933b615c9ea83ffc8793ae240cecbd15119b13d741161d \
+    syntect                          4.3.0  b57a45fdcf4891bc79f635be5c559210a4cfa464891f969724944c713282eedb \
     terminal_size                   0.1.12  8038f95fc7a6f351163f4b964af631bd26c9e828f7db085f2a84aca56f70d13b \
     termios                          0.3.1  72b620c5ea021d75a735c943269bb07d30c9b77d6ac6b236bc8b5c496ef05625 \
     textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
