### PR TITLE
cargo: update to 0.46.1

### DIFF
--- a/devel/cargo/Portfile
+++ b/devel/cargo/Portfile
@@ -7,9 +7,9 @@ name                cargo
 if {${subport} ne "${name}-bootstrap"} {
     PortGroup       github 1.0
 
-    github.setup    rust-lang ${name} 0.46.0
+    github.setup    rust-lang ${name} 0.46.1
 } else {
-    version         0.46.0
+    version         0.46.1
 }
 PortGroup           cargo 1.0
 
@@ -41,9 +41,9 @@ if {${subport} ne "${name}-bootstrap"} {
                     port:rust
 
     checksums       ${distname}${extract.suffix} \
-                    rmd160  cbc570528f4820fac3499ad7b67601788a016222 \
-                    sha256  a78e7eb2e8f14bfce3b13c0983c631f0435a8d10991fe5fdaa3d7455384f71cc \
-                    size    1270367
+                    rmd160  64860b02053d07e556e2cd7bd67bfa61d468daf7 \
+                    sha256  48754b91f4670ad0c53114cc2f7a2ed4bd182a5db6edc0fe6d9938b765401cf1 \
+                    size    1270395
 
     pre-configure {
         # create Cargo.lock
@@ -106,9 +106,9 @@ if {${subport} ne "${name}-bootstrap"} {
 
     checksums-append \
         ${name}-${version}-x86_64-apple-darwin${extract.suffix} \
-                    rmd160  5d924c398124e8b70d0c3e1693d08367947a723a \
-                    sha256  a81306558ba470de6d2245982717402ce4517850d9032433e5f14a4785a55eae \
-                    size    5673993
+                    rmd160  98d7f6b7b28302943635e95bb988e8af77084e96 \
+                    sha256  95ca28cdc73deba5cdf29725a0c03aaf1a46e7e1832702cbf5784ce4673db0fb \
+                    size    5671055
 
     set rust_platform [cargo.rust_platform ${build_arch}]
     distfiles  ${name}-${version}-${rust_platform}${extract.suffix}:stage0


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
