### PR TITLE
scid: update to 4.7.0

### DIFF
--- a/games/scid/Portfile
+++ b/games/scid/Portfile
@@ -3,7 +3,7 @@
 PortSystem              1.0
 
 name                    scid
-version                 4.6.4
+version                 4.7.0
 categories              games
 platforms               darwin
 license                 GPL-2
@@ -13,12 +13,16 @@ long_description        Scid is an open source application to view, edit, and \
                         manage collections of chess games.
 homepage                http://scid.sourceforge.net/
 master_sites            sourceforge
-checksums               rmd160  7245036f6be164955c8fedf0dd22b5f67f37c2da \
-                        sha256  4fde535051786c0f8b13e6a2a20b306e7ba29e7af7394f5e510aae4f87e223e6 \
-                        size    12248886
+checksums               rmd160  2770906e46c4459b837b33cce59489fab223fa76 \
+                        sha256  2ed25781ec3c82d60fcee85259c19fd8934feae2547f9464304cdb01960f86da \
+                        size    15782104
 
+distname                ${name}-code-${version}
 use_zip                 yes
-depends_lib             port:tcl port:tcllib port:zlib port:tDOM port:tk port:tklib
+depends_lib             port:tcl \
+                        port:tcl-tls \
+                        port:tDOM \
+                        port:tk
 
 patchfiles              patch-Makefile.conf.diff
 
@@ -28,13 +32,14 @@ configure.post_args     BINDIR="${prefix}/bin" SHAREDIR="${prefix}/share/${name}
 build.args-append       CC=${configure.cc} \
                         CXX=${configure.cxx} \
                         CPP=${configure.cpp}
+compiler.cxx_standard   2014
 
 destroot.target         install_scid
 destroot.target-append  install_engines
 destroot.target-append  install_mac
 
 post-patch {
-    reinplace "s|x\\.x|${version}|g" ${worksrcpath}/Info.plist
+    reinplace "s|x\\.x|${version}|g" ${worksrcpath}/resources/macos/Info.plist
 }
 
 post-destroot {

--- a/games/scid/files/patch-Makefile.conf.diff
+++ b/games/scid/files/patch-Makefile.conf.diff
@@ -1,9 +1,9 @@
 --- Makefile.conf
 +++ Makefile.conf
-@@ -212,7 +212,6 @@ install_mac: all
+@@ -193,7 +193,6 @@ install_mac: all
  	ditto ./img dist/Scid.app/Contents/Resources/share/scid/img
  	ditto ./html dist/Scid.app/Contents/Resources/share/scid/html
- 	install -m 666 Info.plist dist/Scid.app/Contents/
+ 	install -m 666 resources/macos/Info.plist dist/Scid.app/Contents/
 -	perl -pi -e "s|x\.x\</string\>|$(SCID_VERSION)</string\>|" dist/Scid.app/Contents/Info.plist
  	cd dist/Scid.app/Contents/Resources/bin/ && ln -sf ../share/scid/sounds
  	cd dist/Scid.app/Contents/Resources/bin/ && ln -sf ../share/scid/html


### PR DESCRIPTION
No longer uses zlib
tklib dependency is bundled

Add tcl-tls dependency

#### Description
https://sourceforge.net/p/scid/code/ci/3be6240684f0e6921898ae8aabae4b1fac89525f/tree/ChangeLog

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5
Xcode command line tools 12 beta 3
Tcl/Tk Aqua (`tk +quartz`) 8.6.10

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
No tests.
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
/Applications/MacPorts/Scid.app opens (I don't know how to use it, though).
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
