### PR TITLE
go: add arm64 support

### DIFF
--- a/lang/go-1.4/Portfile
+++ b/lang/go-1.4/Portfile
@@ -34,9 +34,12 @@ checksums           rmd160  b1fbb2805a777c8107e7c946f36a881303ac5e35 \
 set GOROOT          ${worksrcpath}
 set GOROOT_FINAL    ${prefix}/lib/${name}
 
-supported_archs     i386 x86_64
+supported_archs     arm64 i386 x86_64
 
 switch ${build_arch} {
+    arm64 {
+        set GOARCH arm64
+    }
     i386 {
         set GOARCH 386
     }

--- a/lang/go/Portfile
+++ b/lang/go/Portfile
@@ -40,9 +40,12 @@ depends_build       port:go-1.4
 set GOROOT          ${worksrcpath}
 set GOROOT_FINAL    ${prefix}/lib/${name}
 
-supported_archs     i386 x86_64
+supported_archs     arm64 i386 x86_64
 
 switch ${build_arch} {
+    arm64 {
+        set GOARCH arm64
+    }
     i386 {
         set GOARCH 386
     }


### PR DESCRIPTION
Attempts to fix: https://trac.macports.org/ticket/60942

This is untested, as I don't own any target ARM64 hardware. 

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
