### PR TITLE
cgit: update to v1.2.3

### DIFF
--- a/www/cgit/Portfile
+++ b/www/cgit/Portfile
@@ -2,47 +2,50 @@
 
 PortSystem 1.0
 
-name            cgit
-version         1.2.1
-revision        1
+name                cgit
+version             1.2.3
 
 # See Makefile GIT_VER
-set git_version 2.18.0
-categories      www devel
-license         GPL-2
-maintainers     nomaintainer
-description     A fast web interface for the git source code management system
-platforms       darwin
+set git_version     2.25.1
+categories          www devel
+license             GPL-2
+maintainers         nomaintainer
 
-long_description \
-    cgit is an attempt to create a fast web interface for the git scm, using a \
-    builtin cache to decrease server io-pressure. It can run on any \
-    CGI-capable web server.
+description         A hyperfast web frontend for git repositories written in C.
+long_description    cgit is an attempt to create a fast web interface for the Git SCM \
+                    (Source Code Management) using a builtin cache to decrease server \
+                    io-pressure. It can run on any CGI-capable web server.
 
 homepage            https://git.zx2c4.com/cgit/
 master_sites        ${homepage}snapshot:cgit \
                     https://www.kernel.org/pub/software/scm/git:git
 
+platforms           darwin
+
 dist_subdir         git
 use_xz              yes
+
 set cgit_distfile   ${distfiles}
 set git_distname    git-${git_version}
 set git_distfile    ${git_distname}${extract.suffix}
-distfiles       ${cgit_distfile}:cgit ${git_distfile}:git
+distfiles           ${cgit_distfile}:cgit ${git_distfile}:git
 
 checksums           ${cgit_distfile} \
-                    rmd160  8057b3cbfde51d64272e01bf7325084677634a8e \
-                    sha256  3c547c146340fb16d4134326e7524bfb28ffa681284f1e3914bde1c27a9182bf \
-                    size    89648 \
+                    rmd160  4884b999302eb89afa67c73f07e8853f9402e681 \
+                    sha256  5a5f12d2f66bd3629c8bc103ec8ec2301b292e97155d30a9a61884ea414a6da4 \
+                    size    90632 \
                     ${git_distfile} \
-                    rmd160  2fc27cb7eaf9d74d0d305ef97fc1c6f7ea14a75f \
-                    sha256  8b40be383a603147ae29337136c00d1c634bdfdc169a30924a024596a7e30e92 \
-                    size    5102264
+                    rmd160  a8ab476982440c2cc94c7d21f619320d74f117d2 \
+                    sha256  222796cc6e3bf2f9fd765f8f097daa3c3999bb7865ac88a8c974d98182e29f26 \
+                    size    5875548
 
-depends_lib     port:git \
-                path:lib/libssl.dylib:openssl \
-                port:zlib \
-                port:libiconv
+# Patch for memrch: https://trac.macports.org/ticket/60967
+patchfiles          patch-add-memrchr.diff
+
+depends_lib         port:git \
+                    path:lib/libssl.dylib:openssl \
+                    port:zlib \
+                    port:libiconv
 
 post-extract {
     delete ${worksrcpath}/git
@@ -56,13 +59,9 @@ post-patch {
     reinplace "s|@GIT_URL@|file://${distpath}/${git_distfile}|g" ${worksrcpath}/cgit.conf
 }
 
-set user _www
-set group _www
-
-if {${os.platform} eq "darwin" && ${os.major} <= 8} {
-    set user www
-    set group www
-}
+set user_group  [expr {${os.platform} eq "darwin" && ${os.major} <= 8 ? "www" : "_www"}]
+set user        ${user_group}
+set group       ${user_group}
 
 post-destroot {
     xinstall -m 444 ${worksrcpath}/cgitrc.5.txt ${destroot}${prefix}/etc/cgitrc.sample
@@ -88,3 +87,8 @@ destroot.env {*}${build.env}
 livecheck.type  regex
 livecheck.url   ${homepage}log/?h=master
 livecheck.regex {>v([0-9.]+)<}
+
+notes "
+A sample config file have been placed in:
+  » ${prefix}/etc/cgitrc.sample
+"

--- a/www/cgit/files/patch-add-memrchr.diff
+++ b/www/cgit/files/patch-add-memrchr.diff
@@ -1,0 +1,100 @@
+Comments from the original patch:
+    macOS doesn't come with a memrchr() of its own, so let's provide an
+    implementation it can use.
+
+    memrchr.c was taken from Apple's own open source site.
+
+    https://opensource.apple.com/source/sudo/sudo-87.80.2/sudo/lib/util/memrchr.c
+
+    It was minimally modified, so it would work for cgit:
+    - Removed #include "sudo_compat.h"
+    - Renamed function from sudo_memrchr() to memrchr()
+
+We can use this patch for now, until upstream has fixed it.
+
+--- ../cgit-1.2.3.orig/cgit.h	2020-03-14 00:49:52.000000000 +0100
++++ ./cgit.h	2020-08-08 20:46:19.000000000 +0200
+@@ -395,4 +395,8 @@
+
+ extern char *get_mimetype_for_filename(const char *filename);
+
++#ifdef NEED_MEMRCHR
++extern void *memrchr(const void *s, int c, size_t n);
++#endif
++
+ #endif /* CGIT_H */
+diff -Naur ../cgit-1.2.3.orig/cgit.mk ./cgit.mk
+--- ../cgit-1.2.3.orig/cgit.mk	2020-03-14 00:49:52.000000000 +0100
++++ ./cgit.mk	2020-08-08 20:49:02.000000000 +0200
+@@ -63,10 +63,19 @@
+ 	HAVE_LINUX_SENDFILE = YesPlease
+ endif
+
++ifeq ($(uname_S),Darwin)
++	IS_DARWIN = yes
++endif
++
+ ifdef HAVE_LINUX_SENDFILE
+ 	CGIT_CFLAGS += -DHAVE_LINUX_SENDFILE
+ endif
+
++ifdef IS_DARWIN
++	CGIT_CFLAGS += -DNEED_MEMRCHR
++	CGIT_OBJ_NAMES += memrchr.o
++endif
++
+ CGIT_OBJ_NAMES += cgit.o
+ CGIT_OBJ_NAMES += cache.o
+ CGIT_OBJ_NAMES += cmd.o
+--- /dev/null
++++ ./memrchr.c	2020-08-08 21:17:00.000000000 +0200
+@@ -0,0 +1,49 @@
++/*
++ * SPDX-License-Identifier: ISC
++ *
++ * Copyright (c) 2007, 2010-2014
++ *	Todd C. Miller <Todd.Miller@sudo.ws>
++ *
++ * Permission to use, copy, modify, and distribute this software for any
++ * purpose with or without fee is hereby granted, provided that the above
++ * copyright notice and this permission notice appear in all copies.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
++ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
++ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
++ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
++ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
++ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
++ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
++ */
++
++/*
++ * This is an open source non-commercial project. Dear PVS-Studio, please check it.
++ * PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
++ */
++
++#include <config.h>
++
++#ifndef HAVE_MEMRCHR
++
++#include <sys/types.h>
++
++/*
++ * Reverse memchr()
++ * Find the last occurrence of 'c' in the buffer 's' of size 'n'.
++ */
++void *
++memrchr(const void *s, int c, size_t n)
++{
++	const unsigned char *cp;
++
++	if (n != 0) {
++	cp = (unsigned char *)s + n;
++	do {
++		if (*(--cp) == (unsigned char)c)
++			return (void *)cp;
++		} while (--n != 0);
++	}
++	return (void *)0;
++}
++#endif /* HAVE_MEMRCHR */


### PR DESCRIPTION
#### Description

Upgrade `cgit` to `v1.2.3`.

Closes: https://trac.macports.org/ticket/60967
Closes: https://trac.macports.org/ticket/56970


###### Type(s)

- [x] update

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port install`?
