### PR TITLE
gitlab-runner: update to 13.2.2

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 13.2.1 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 13.2.2 v
 
 categories          devel
 platforms           darwin
@@ -23,9 +23,9 @@ homepage            https://docs.gitlab.com/runner/
 master_sites        https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v${version}/
 distname            gitlab-runner-v${version}
 
-checksums           rmd160  4ead2bec9d7bf6a0056f239d84cd5ad8f3bf3872 \
-                    sha256  98ab212244a6c11294c1fe4ca15ef37e6935f6056a30e51404cddf8e2f9f2655 \
-                    size    7430579
+checksums           rmd160  39d884452f05d40ade75bac6a89af3a38e1dda85 \
+                    sha256  23d8a8de5062bdeb0781ff4aa0121efce289db3ec39e6f6140d82e5b306d3173 \
+                    size    7430093
 
 # Reproduce the "build_simple" target from the upstream Makefile
 set go_ldflags      "-X ${go.package}/common.NAME=${go.package} \


### PR DESCRIPTION
#### Description

Update to GitLab Runner 13.2.2.

###### Tested on

macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?