### PR TITLE
fluent-bit: update to 1.5.2

### DIFF
--- a/sysutils/fluent-bit/Portfile
+++ b/sysutils/fluent-bit/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 
 name                fluent-bit
-version             1.3.9
+version             1.5.2
 categories          sysutils
 platforms           darwin
 license             Apache-2
@@ -20,9 +20,9 @@ homepage            https://fluentbit.io/
 set branch          [join [lrange [split ${version} .] 0 1] .]
 master_sites        ${homepage}releases/${branch}/
 
-checksums           rmd160  5dd08888b66daa8e4be8f392cd6fbfda214bf093 \
-                    sha256  0b39d09c5be1242061b602c2ea03013b3530493b125f26bb1dd749944c339940 \
-                    size    12018367
+checksums           rmd160  049ef637888e0089e223b7b3a8305b8df2a0bd90 \
+                    sha256  148ad83b34be1b0caf5cf9275d4baec6189b686e07f18e7eaba1f7667af1ad5d \
+                    size    12748943
 
 depends_build-append \
                     port:bison


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
