### PR TITLE
swig-java, swig3-java: migrate to Java portgroup

### DIFF
--- a/devel/swig/Portfile
+++ b/devel/swig/Portfile
@@ -55,7 +55,7 @@ array set bindings {
     d           {port:phobos            d}
     go          {port:go                go}
     guile       {port:guile             guile}
-    java        {bin:java:kaffe         java}
+    java        {{}                     java}
     lua         {port:lua               lua}
     ocaml       {port:ocaml             ocaml}
     octave      {path:bin/octave:octave octave}
@@ -88,6 +88,14 @@ foreach lang [lsort [array names bindings]] {
     if {${swig.lang} != $arg_name} {
         configure.args-append --without-${arg_name}
     }
+}
+
+subport swig-java {
+    PortGroup               java 1.0
+
+    java.version            1.4+
+    # Set fallback to an LTS Java version
+    java.fallback           openjdk8
 }
 
 subport swig-php {

--- a/devel/swig3/Portfile
+++ b/devel/swig3/Portfile
@@ -58,7 +58,7 @@ array set bindings {
     d           {port:phobos            d}
     go          {port:go                go}
     guile       {port:guile             guile}
-    java        {bin:java:kaffe         java}
+    java        {{}                     java}
     lua         {port:lua               lua}
     ocaml       {port:ocaml             ocaml}
     octave      {path:bin/octave:octave octave}
@@ -90,6 +90,14 @@ foreach lang [lsort [array names bindings]] {
     if {${swig.lang} != $arg_name} {
         configure.args-append --without-${arg_name}
     }
+}
+
+subport swig3-java {
+    PortGroup               java 1.0
+
+    java.version            1.4+
+    # Set fallback to an LTS Java version
+    java.fallback           openjdk8
 }
 
 subport swig3-php {


### PR DESCRIPTION
Set fallback to an LTS Java version

Avoid fallback dependency on `kaffe`
See: https://trac.macports.org/ticket/60206

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Untested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
