### PR TITLE
py-boto: add subport py38-boto

### DIFF
--- a/python/py-boto/Portfile
+++ b/python/py-boto/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  f141b0cd09909e9976f044fe4c6f076d3a91afe9 \
                     sha256  ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a \
                     size    1478498
 
-python.versions     27 35 36 37
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
     post-destroot {


### PR DESCRIPTION
#### Description

In order to have duplicity to use python38, this port
needs a py38 subport.

###### Type(s)

- [x] enhancement

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port install`?

###### Notes

To PR is a part of the `duplicity` update.