### PR TITLE
py-rbtools: update to 1.0.3, (+ add subports)

### DIFF
--- a/python/py-rbtools/Portfile
+++ b/python/py-rbtools/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-rbtools
 set cap_name        RBTools
-version             0.4.3
+version             1.0.3
 revision            0
 
 set branch          [join [lrange [split ${version} .] 0 1] .]
@@ -26,16 +26,14 @@ homepage            http://www.reviewboard.org/
 master_sites        http://downloads.reviewboard.org/releases/${cap_name}/${branch}
 distname            ${cap_name}-${version}
 
-checksums           rmd160 fc6b3e470ca7142ecb1165d02e1a04d0daca2be3 \
-                    sha256 7c35271b7d65e8ab72ae1a10b0c65e8dbf718f31391fff44034f0bc4262a0917
+checksums           rmd160  8849369c10b2656b2f363ea0e8560db574875c79 \
+                    sha256  ff4cea3ad7b2d1b1666b811021cf5047f1fbe9417428fb5133a40ede81e3e83c \
+                    size    206634
 
-python.versions     27
+python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
     depends_lib-append      port:py${python.version}-setuptools
-    if {${python.version} <= 25} {
-        depends_lib-append      port:py${python.version}-simplejson
-    }
     livecheck.type      none
 } else {
     livecheck.type      regex

--- a/python/py-rbtools/Portfile
+++ b/python/py-rbtools/Portfile
@@ -1,23 +1,26 @@
-PortSystem      1.0
-PortGroup       python 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name            py-rbtools
-set cap_name    RBTools
-version         0.4.3
-python.versions 27
-set branch      [join [lrange [split ${version} .] 0 1] .] 
-categories-append     devel
-maintainers     nomaintainer
-platforms       darwin
-supported_archs noarch
-license         MIT
-description     Tools for Review Board integration
+PortSystem          1.0
+PortGroup           python 1.0
 
-long_description \
-    Tools for integrating with Review Board, a powerful web-based code review \
-    tool that offers developers an easy way to handle code reviews. \
-    This package provides \"post-review\", a command-line tool that simplifies \
-    both creating and updating review requests.
+name                py-rbtools
+set cap_name        RBTools
+version             0.4.3
+revision            0
+
+set branch          [join [lrange [split ${version} .] 0 1] .]
+
+categories-append   devel
+maintainers         nomaintainer
+platforms           darwin
+supported_archs     noarch
+license             MIT
+
+description         Tools for Review Board integration
+long_description    Tools for integrating with Review Board, a powerful web-based \
+                    code review tool that offers developers an easy way to handle \
+                    code reviews. This package provides \"post-review\", a command-line \
+                    tool that simplifies both creating and updating review requests.
 
 homepage            http://www.reviewboard.org/
 master_sites        http://downloads.reviewboard.org/releases/${cap_name}/${branch}
@@ -25,6 +28,8 @@ distname            ${cap_name}-${version}
 
 checksums           rmd160 fc6b3e470ca7142ecb1165d02e1a04d0daca2be3 \
                     sha256 7c35271b7d65e8ab72ae1a10b0c65e8dbf718f31391fff44034f0bc4262a0917
+
+python.versions     27
 
 if {${name} ne ${subport}} {
     depends_lib-append      port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

  - Update to version: 1.0.3
  - In order to have duplicity to use python38, this port
    needs a py38 subport.

###### Type(s)

- [x] update
- [x] enhancement

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port install`?

###### Notes

To PR is a part of the `duplicity` update.