### PR TITLE
duplicity: update to 0.8.15

### DIFF
--- a/sysutils/duplicity/Portfile
+++ b/sysutils/duplicity/Portfile
@@ -6,36 +6,35 @@ PortGroup           python 1.0
 name                duplicity
 categories          sysutils
 
-version             0.7.17
+version             0.8.15
 
 set stable_series   [join [lrange [split ${version} .] 0 1] .]-series
 platforms           darwin
 license             GPL-2
 maintainers         nomaintainer
 
-description   Encrypted bandwidth-efficient backup.
+description         Encrypted bandwidth-efficient backup.
+long_description    Duplicity backs up directories by producing encrypted \
+                    tar-format volumes and uploading them to a remote or local file \
+                    server. Because duplicity uses librsync, the incremental archives \
+                    are space efficient and only record the parts of files that have \
+                    changed since the last backup. Because duplicity uses GnuPG to \
+                    encrypt and/or sign these archives, they will be safe from spying \
+                    and/or modification by the server.
 
-long_description  Duplicity backs up directories by producing encrypted \
-      tar-format volumes and uploading them to a remote or local file \
-      server. Because duplicity uses librsync, the incremental archives \
-      are space efficient and only record the parts of files that have \
-      changed since the last backup. Because duplicity uses GnuPG to \
-      encrypt and/or sign these archives, they will be safe from spying \
-      and/or modification by the server.
-
-distname            duplicity-${version}
+distname            ${name}-${version}
 homepage            http://duplicity.nongnu.org/
 master_sites        https://launchpad.net/duplicity/${stable_series}/${version}/+download
 
-checksums           rmd160  20d6e1d63d3da925009709cafd3e721af68bcc2e \
-                    sha256  3724c5f1f839e584e49154ee0ff137e6f3450eedbd7f3886f31d2093001cb04a \
-                    size    1719145
+checksums           rmd160  bbd3dcc5a067cfadfe067af1f90abdf2565b0b8f \
+                    sha256  ac69ff68b88b6c15c222f8334bb447fbe529c6849a6c9ac33e4995d7eb31e4cd \
+                    size    1482647
 
-python.default_version 27
+python.default_version 38
 
 post-patch {
     foreach f {duplicity rdiffdir} {
-        reinplace "s|^#!/usr/bin/env python2$|#!${python.bin}|" ${worksrcpath}/bin/$f
+        reinplace "s|^#!/usr/bin/env python3$|#!${python.bin}|" ${worksrcpath}/bin/${f}
     }
 }
 
@@ -54,6 +53,7 @@ depends_build-append    port:py${python.version}-setuptools \
 
 depends_run-append  port:py${python.version}-boto \
                     port:py${python.version}-fasteners \
+                    port:py${python.version}-future \
                     port:py${python.version}-lockfile \
                     port:py${python.version}-paramiko \
                     port:ncftp

--- a/sysutils/duplicity/Portfile
+++ b/sysutils/duplicity/Portfile
@@ -22,7 +22,6 @@ long_description    Duplicity backs up directories by producing encrypted \
                     encrypt and/or sign these archives, they will be safe from spying \
                     and/or modification by the server.
 
-distname            ${name}-${version}
 homepage            http://duplicity.nongnu.org/
 master_sites        https://launchpad.net/duplicity/${stable_series}/${version}/+download
 


### PR DESCRIPTION
#### Description

  - Update to version: 0.8.15
  - Use python38
  - Closes: https://trac.macports.org/ticket/60824

###### Type(s)

- [x] update

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port install`?

###### Notes

The PR's for `py38-boto` (#8034) and `py38-rbtools` (#8035) is a part of this update.