### PR TITLE
varnish: update to 6.4.0

### DIFF
--- a/www/varnish/Portfile
+++ b/www/varnish/Portfile
@@ -4,7 +4,7 @@ PortSystem            1.0
 
 name                  varnish
 epoch                 20110709
-version               4.1.9
+version               6.4.0
 categories            www
 platforms             darwin
 maintainers           {wohner.eu:normen @Gminfly} openmaintainer
@@ -18,15 +18,19 @@ homepage              https://varnish-cache.org/
 master_sites          ${homepage}_downloads/
 extract.suffix        .tgz
 
-checksums             rmd160  b4bd7bae346c5ae187dfbad646d0c1f9087d70ae \
-                      sha256  22d884aad87e585ce5f3b4a6d33442e3a855162f27e48358c7c93af1b5f2fc87
+checksums             rmd160  9f6e74b4fa9bd49477ef1506e4bd3a0de3c4276f \
+                      sha256  f636ba2d881b146f480fb52efefae468b36c2c3e6620d07460f9ccbe364a76c2 \
+                      size    3404617
 
 depends_build         port:pkgconfig \
-                      port:py27-docutils
+                      port:py38-docutils \
+                      port:py38-sphinx
 
 depends_lib           port:pcre
 
-configure.args-append --with-rst2man=${prefix}/bin/rst2man-2.7.py
+configure.args-append --with-rst2man=${prefix}/bin/rst2man-3.8.py \
+                      --with-rst2html=${prefix}/bin/rst2html-3.8.py \
+                      --with-sphinx-build=${prefix}/bin/sphinx-build-3.8
 
 startupitem.create    yes
 startupitem.pidfile   auto "${prefix}/var/run/${name}/${name}.pid"


### PR DESCRIPTION
- switch from py27-docutils to py38-docutils
- add dependency for py38-sphinx
- use recommended checksum types

Closes: https://trac.macports.org/ticket/59047

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
