### PR TITLE
terraform: add sub-port for terraform-0.13

### DIFF
--- a/sysutils/terraform/Portfile
+++ b/sysutils/terraform/Portfile
@@ -15,7 +15,15 @@ maintainers             {emcrisostomo @emcrisostomo} \
                         openmaintainer
 
 # *NOTE* Remember to update `latestVersion` on a version upgrade.
-set latestVersion       terraform-0.12
+set latestVersion       terraform-0.13
+
+subport terraform-0.13 {
+    set patchNumber     0
+    checksums           rmd160  0f7158500903d4067e5b76105a14066a2b916709 \
+                        sha256  080af0420732cd08941aa4c0d2b4693056b24366724faa11b107bf052f7de203 \
+                        size    35631250
+}
+
 subport terraform-0.12 {
     set patchNumber     29
     checksums           rmd160  44524dfc91b58a87da550bb810215083784be3b6 \
@@ -36,7 +44,7 @@ if {${subport} eq ${name}} {
     PortGroup           obsolete 1.0
 
     replaced_by         ${latestVersion}
-    version             0.12.29
+    version             0.13.0
     revision            0
 
 } elseif {${subport} eq "terraform_select"} {


### PR DESCRIPTION
#### Description

Add sub-port for [Terraform 0.13](https://github.com/hashicorp/terraform/blob/v0.13.0/CHANGELOG.md)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
