### PR TITLE
util-linux: Fix fetch failures on <10.12.

### DIFF
--- a/devel/util-linux/Portfile
+++ b/devel/util-linux/Portfile
@@ -19,7 +19,20 @@ long_description    ${name} contains miscellaneous utility programs \
                     and messages. This port contains ONLY those parts \
                     of ${name} that run on Darwin.
 
+# master_sites        https://www.kernel.org/pub/linux/utils/util-linux/v${branch}/
+# The above site redirects permanently (301) to mirrors.edge.kernel.org
 master_sites        https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v${branch}/
+
+# mirrors.edge.kernel.org doesn't work with some earlier Apple root CAs,
+# so we need to disable the certificate check.  This isn't much of a risk,
+# since the distfile has to pass the checksum/size checks, anyway.
+#
+# When updating the port to a new version, some extra manual checking
+# of the distfile would be desirable, by performing a certificate-validated
+# check and/or checking the PGP signature.  Note that the .sign file
+# applies to the uncompressed tarball in this case.
+fetch.ignore_sslcert    yes
+
 use_xz              yes
 
 checksums           rmd160  81c26b1da8e7e4ce065ed93639bcc2d5aba3baa8 \


### PR DESCRIPTION
The redirection addressed by 974bc5f6bc0 was actually a red herring.
The real problem wasn't the redirection per se, but the SSL cert
pickiness of the final server (post-redirect), which doesn't work with
Apple's curl prior to 10.12.  The only straightforward fix for this is
to disable the SSL certificate check, which there's precedent for in
other Portfiles.  In theory, this is only necessary for older OS
versions, but the definition of "older" changes with time, and the
certificate check isn't terribly important, given that the distfile
needs to pass checksum and size checks, anyway.  It does suggest more
careful checking of the distfile when updating the port, as now
indicated in the Portfile comments.

The master_sites update in 974bc5f6bc0 is still appropriate, given
that it honors the intent of "301 Moved Permanently".  But the
upstream doc is still referencing the pre-redirect site, so this
change adds back the old upstream-consistent master_sites as a
comment, along with a comment explaining why the real master_sites
differs from upstream.  This can be removed when the upstream doc is
appropriately updated, but given that the upstream files have almost
300 references to "www.kernel.org", that isn't likely to happen soon.

Since the MacPorts distfile mirror servers run 10.11, this issue explains
why they haven't mirrored the two latest versions, and that should be
fixed by this change.

TESTED:
Verified PGP signature on current distfile.
Ran "port checksum" successfully on 10.5-10.13 (after "port clean
--all").

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Mac OS X 10.5.8 9L34, i386, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14019, x86_64, Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
