### PR TITLE
Remove my name everywhere

### DIFF
--- a/python/py-astropy/Portfile
+++ b/python/py-astropy/Portfile
@@ -10,7 +10,7 @@ checksums           rmd160  1467fe8bdf74980f46846767514917ec6c68ed5e \
                     sha256  404200e0baa84de09ac563ad9ccab3817e9b9669d0025cee74a8752f4bc2771b \
                     size    8196953
 
-maintainers         {ligo.org:duncan.macleod @duncanmmacleod} openmaintainer
+maintainers         openmaintainer
 categories-append   science
 description         A Community Python Library for Astronomy
 long_description    The Astropy project is a common effort to develop \

--- a/python/py-corner/Portfile
+++ b/python/py-corner/Portfile
@@ -11,7 +11,7 @@ categories-append   science
 platforms           darwin
 supported_archs     noarch
 license             BSD
-maintainers         {danfm.ca:dan @dfm} {ligo.org:duncan.macleod @duncanmmacleod} openmaintainer
+maintainers         {danfm.ca:dan @dfm} openmaintainer
 
 description         Make some beautiful corner plots of samples
 long_description    ${description}

--- a/python/py-dqsegdb2/Portfile
+++ b/python/py-dqsegdb2/Portfile
@@ -7,7 +7,7 @@ name                py-dqsegdb2
 version             1.0.0
 
 categories-append   science
-maintainers         {ligo.org:duncan.macleod @duncanmmacleod} openmaintainer
+maintainers         openmaintainer
 
 platforms           darwin
 license             GPL-3

--- a/python/py-gwdatafind/Portfile
+++ b/python/py-gwdatafind/Portfile
@@ -7,7 +7,7 @@ name                py-gwdatafind
 version             1.0.2
 
 categories-append   science
-maintainers         {ligo.org:duncan.macleod @duncanmmacleod} openmaintainer
+maintainers         openmaintainer
 
 platforms           darwin
 license             GPL-3

--- a/python/py-gwosc/Portfile
+++ b/python/py-gwosc/Portfile
@@ -7,7 +7,7 @@ name                py-gwosc
 version             0.3.3
 
 categories-append   science
-maintainers         {ligo.org:duncan.macleod @duncanmmacleod} openmaintainer
+maintainers         openmaintainer
 
 platforms           darwin
 license             GPL-3

--- a/python/py-gwpy/Portfile
+++ b/python/py-gwpy/Portfile
@@ -8,7 +8,7 @@ github.setup        gwpy gwpy 0.12.2 v
 name                py-gwpy
 
 categories-append   science
-maintainers         {ligo.org:duncan.macleod @duncanmmacleod} openmaintainer
+maintainers         openmaintainer
 
 platforms           darwin
 license             GPL-3

--- a/python/py-kombine/Portfile
+++ b/python/py-kombine/Portfile
@@ -7,7 +7,7 @@ name                py-kombine
 version             0.8.3
 
 categories-append   science
-maintainers         {uoregon.edu:bfarr @bfarr} {ligo.org:duncan.macleod @duncanmmacleod} openmaintainer
+maintainers         {uoregon.edu:bfarr @bfarr} openmaintainer
 
 platforms           darwin
 license             GPL-3

--- a/python/py-ligo-common/Portfile
+++ b/python/py-ligo-common/Portfile
@@ -9,7 +9,7 @@ version            1.0.3
 categories-append  science
 platforms          darwin
 supported_archs    noarch
-maintainers        {ligo.org:duncan.macleod @duncanmmacleod}
+maintainers        openmaintainer
 license            GPL-3+
 
 description        Common package for LIGO Python libraries

--- a/python/py-ligo-segments/Portfile
+++ b/python/py-ligo-segments/Portfile
@@ -8,7 +8,7 @@ version             1.2.0
 revision            1
 
 categories-append   science
-maintainers         {ligo.org:duncan.macleod @duncanmmacleod} openmaintainer
+maintainers         openmaintainer
 
 platforms           darwin
 license             GPL-3

--- a/python/py-ligotimegps/Portfile
+++ b/python/py-ligotimegps/Portfile
@@ -8,7 +8,7 @@ github.setup        gwpy ligotimegps 2.0.0 v
 name                py-ligotimegps
 
 categories-append   science
-maintainers         {ligo.org:duncan.macleod @duncanmmacleod} openmaintainer
+maintainers         openmaintainer
 
 platforms           darwin
 license             GPL-3

--- a/python/py-lscsoft-glue/Portfile
+++ b/python/py-lscsoft-glue/Portfile
@@ -8,8 +8,7 @@ version              2.0.0
 
 categories-append    science
 platforms            darwin
-maintainers          {ligo.org:duncan.macleod @duncanmmacleod} \
-                     {ligo.org:ryan.fisher @rpfisher} \
+maintainers          {ligo.org:ryan.fisher @rpfisher} \
                      openmaintainer
 license              GPL-3+
 


### PR DESCRIPTION
#### Description

I am not maintaining any ports any more, I have added `openmaintainer` where my name was the only one left.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
