### PR TITLE
ncmpcpp:  Migrate away from cxx11 PortGroup

### DIFF
--- a/audio/ncmpcpp/Portfile
+++ b/audio/ncmpcpp/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem          1.0
 PortGroup           compiler_blacklist_versions 1.0
-PortGroup           cxx11 1.1
 
 name                ncmpcpp
 version             0.8.2
@@ -34,8 +33,7 @@ depends_lib         port:boost \
                     port:taglib
 
 # Requires C++14.
-compiler.blacklist-append \
-                    {clang < 602}
+compiler.cxx_standard 2014
 
 configure.args      --with-boost=${prefix} \
                     --with-taglib=${prefix} \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Migrate away from cxx11 PortGroup

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
