### PR TITLE
doxygen: update to 1.8.19

### DIFF
--- a/textproc/doxygen/Portfile
+++ b/textproc/doxygen/Portfile
@@ -6,7 +6,7 @@ PortGroup               conflicts_build 1.0
 PortGroup               legacysupport 1.0
 
 name                    doxygen
-version                 1.8.18
+version                 1.8.19
 revision                0
 categories              textproc devel
 maintainers             nomaintainer
@@ -32,14 +32,13 @@ long_description        It can generate an on-line documentation browser \
 
 platforms               darwin
 
-homepage                http://www.doxygen.org/
-master_sites            http://doxygen.nl/files
+homepage                https://www.doxygen.nl
+master_sites            ${homepage}/files
 distfiles               ${distname}.src${extract.suffix}
 
-checksums               rmd160  6c3b82a0aae271dfeaf89e31db186447b2813280 \
-                        sha256  18173d9edc46d2d116c1f92a95d683ec76b6b4b45b817ac4f245bb1073d00656 \
-                        size    5188787
-
+checksums               rmd160  3959c119169566be83607515a47f1c77d025a2cc \
+                        sha256  ac15d111615251ec53d3f0e54ac89c9d707538f488be57184245adef057778d3 \
+                        size    5130185
 installs_libs           no
 
 # 59037
@@ -67,6 +66,8 @@ patchfiles              patch-src-portable_c.c.diff \
 
 # see #59372
 compiler.cxx_standard   2011
+
+compiler.thread_local_storage yes
 
 # see #50342
 configure.args-append   -DPython_ADDITIONAL_VERSIONS=3.8 \
@@ -162,5 +163,7 @@ variant qt5 conflicts qt4 description {Include the GUI wizard based on Qt5} {
 }
 
 livecheck.type          regex
-livecheck.url           http://www.doxygen.nl/download.html
+livecheck.url           ${homepage}/download.html
 livecheck.regex         {latest version of doxygen is (\d+(?:\.\d+)*)}
+
+test.run                yes

--- a/textproc/doxygen/Portfile
+++ b/textproc/doxygen/Portfile
@@ -125,6 +125,8 @@ if {[string match *clang* ${configure.cxx}]} {
 # build fails out of source :/
 cmake.out_of_source     no
 
+test.run                yes
+
 destroot.args           INSTALL=${prefix} \
                         DOCDIR=${prefix}/share/doc/doxygen \
                         MAN1DIR=share/man/man1
@@ -165,5 +167,3 @@ variant qt5 conflicts qt4 description {Include the GUI wizard based on Qt5} {
 livecheck.type          regex
 livecheck.url           ${homepage}/download.html
 livecheck.regex         {latest version of doxygen is (\d+(?:\.\d+)*)}
-
-test.run                yes


### PR DESCRIPTION
Require thread-local storage

Enable tests

Set `homepage`, `master_sites`, and `livecheck` to use https://www.doxygen.nl

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6
Xcode command line tools 12 beta 3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?

```
The following tests FAILED:
	 12 - 012_cite (Failed)
```

- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
