### PR TITLE
zip: update Portfile

### DIFF
--- a/archivers/zip/Portfile
+++ b/archivers/zip/Portfile
@@ -5,33 +5,31 @@ PortSystem          1.0
 name                zip
 version             3.00
 revision            1
+
 categories          archivers
 license             BSD
 installs_libs       no
 platforms           darwin freebsd
-description         compression utility
 maintainers         nomaintainer
 
-long_description    Zip is different from gzip in that it allows packing \
-                    multiple files into a single archive (without the \
-                    assistance of tar). It is compatible with pkzip, \
-                    pkunzip, and other Windows zip utilities.  This \
-                    utility is necessary to install several packages in a \
-                    pure Darwin installation, as Darwin does not come \
-                    with zip/unzip.
+description         compression utility
+long_description    Zip is a compression/decompression utility. It is \
+                    different from gzip in that it allows packing multiple \
+                    files into a single archive (without the assistance of \
+                    tar). It is compatible with pkzip, pkunzip, and other \
+                    Windows zip utilities.
 
-homepage            http://www.info-zip.org/
+homepage            http://infozip.sourceforge.net/
 master_sites        ftp://ftp.info-zip.org/pub/infozip/src/
 
-distname                ${name}30
-
-checksums               md5     7b74551e63f8ee6aab6fbc86676c0d37 \
-                        sha1    c9f4099ecf2772b53c2dd4a8e508064ce015d182 \
-                        rmd160  1fc99daf3e36494ba392c7514a714fe3d258d232
-
-depends_lib     port:bzip2
-
+distname            ${name}30
 extract.suffix      .tgz
+
+checksums           rmd160  1fc99daf3e36494ba392c7514a714fe3d258d232 \
+                    sha256  f0e8bb1f9b7eb0b01285495a2699df3a4b766784c1765a8f1aeedf63c0806369 \
+                    size    1118845
+
+depends_lib         port:bzip2
 
 set args            "-f unix/Makefile"
 

--- a/archivers/zip/Portfile
+++ b/archivers/zip/Portfile
@@ -1,27 +1,27 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem			1.0
+PortSystem          1.0
 
-name				zip
-version				3.00
-revision			1
-categories			archivers
-license				BSD
-installs_libs		no
-platforms			darwin freebsd
-description			compression utility
-maintainers			nomaintainer
+name                zip
+version             3.00
+revision            1
+categories          archivers
+license             BSD
+installs_libs       no
+platforms           darwin freebsd
+description         compression utility
+maintainers         nomaintainer
 
-long_description	Zip is different from gzip in that it allows packing \
-					multiple files into a single archive (without the \
-					assistance of tar). It is compatible with pkzip, \
-					pkunzip, and other Windows zip utilities.  This \
-					utility is necessary to install several packages in a \
-					pure Darwin installation, as Darwin does not come \
+long_description    Zip is different from gzip in that it allows packing \
+                    multiple files into a single archive (without the \
+                    assistance of tar). It is compatible with pkzip, \
+                    pkunzip, and other Windows zip utilities.  This \
+                    utility is necessary to install several packages in a \
+                    pure Darwin installation, as Darwin does not come \
                     with zip/unzip.
 
-homepage			http://www.info-zip.org/
-master_sites		ftp://ftp.info-zip.org/pub/infozip/src/
+homepage            http://www.info-zip.org/
+master_sites        ftp://ftp.info-zip.org/pub/infozip/src/
 
 distname                ${name}30
 
@@ -29,51 +29,51 @@ checksums               md5     7b74551e63f8ee6aab6fbc86676c0d37 \
                         sha1    c9f4099ecf2772b53c2dd4a8e508064ce015d182 \
                         rmd160  1fc99daf3e36494ba392c7514a714fe3d258d232
 
-depends_lib		port:bzip2
+depends_lib     port:bzip2
 
-extract.suffix		.tgz
+extract.suffix      .tgz
 
-set args			"-f unix/Makefile"
+set args            "-f unix/Makefile"
 
-configure.cmd		${build.cmd}
-configure.dir		${worksrcpath}
-configure.pre_args	CC=\"\${CC}\" flags \
-					${args}
+configure.cmd       ${build.cmd}
+configure.dir       ${worksrcpath}
+configure.pre_args  CC=\"\${CC}\" flags \
+                    ${args}
 
 # The automake-specific --disable-dependency-tracking is added to all configure arguments
 # when +universal is enabled -- we work around this behavior by removing the flag
 # explicitly.
 configure.universal_args-delete --disable-dependency-tracking
 
-build.target		generic
-build.args			${args}
+build.target        generic
+build.args          ${args}
 
-destroot.args		${args} \
-					BINDIR=${destroot}${prefix}/bin \
-					MANDIR=${destroot}${prefix}/share/man/man1
+destroot.args       ${args} \
+                    BINDIR=${destroot}${prefix}/bin \
+                    MANDIR=${destroot}${prefix}/share/man/man1
 
 post-destroot {
-	set docdir ${prefix}/share/doc/${name}-${version}
-	xinstall -d ${destroot}${docdir}
-	xinstall -m 0644 -W ${worksrcpath} BUGS CHANGES LICENSE README TODO WHATSNEW \
-		${destroot}${docdir}
+    set docdir ${prefix}/share/doc/${name}-${version}
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} BUGS CHANGES LICENSE README TODO WHATSNEW \
+        ${destroot}${docdir}
 }
 
 variant universal {
-	configure.args	"LOCAL_ZIP=\"${configure.universal_cflags}\""
+    configure.args  "LOCAL_ZIP=\"${configure.universal_cflags}\""
 
-	post-patch {
-		reinplace -E "s|(LFLAGS1=')|\\1${configure.universal_ldflags}|" \
-			${worksrcpath}/unix/configure
-	}
+    post-patch {
+        reinplace -E "s|(LFLAGS1=')|\\1${configure.universal_ldflags}|" \
+            ${worksrcpath}/unix/configure
+    }
 
-	post-configure {
-		reinplace "s/-DASMV -DASM_CRC//" ${worksrcpath}/flags
-		reinplace "s/match.o//g" ${worksrcpath}/flags
-		reinplace "s/crc_i386.o//g" ${worksrcpath}/flags
-	}
+    post-configure {
+        reinplace "s/-DASMV -DASM_CRC//" ${worksrcpath}/flags
+        reinplace "s/match.o//g" ${worksrcpath}/flags
+        reinplace "s/crc_i386.o//g" ${worksrcpath}/flags
+    }
 }
 
-livecheck.type	regex
-livecheck.url	${homepage}
-livecheck.regex	">Zip.nbsp.(\\d+(?:\\.\\d+)*)<"
+livecheck.type  regex
+livecheck.url   ${homepage}
+livecheck.regex ">Zip.nbsp.(\\d+(?:\\.\\d+)*)<"


### PR DESCRIPTION
#### Description

Zip have moved to SourceForge.

_1st commit is for whitespace. It was all mixed tabs/spaces._

###### Type(s)

- [x] update

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -ds install`?
- [x] tested basic functionality of all binary files?

###### Notes

Added the livecheck, who reports a _“new version: 30”_ - which is ok I guess. That's the file name (zip30)

There's an old ticket: [trac::#17860](https://trac.macports.org/ticket/17860). If they haven't upgraded zip since 2008, I guess they won't fix that either. Can it be closed?