### PR TITLE
mxml: new port

### DIFF
--- a/devel/mxml/Portfile
+++ b/devel/mxml/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           muniversal 1.0
+PortGroup           github 1.0
+
+github.setup        michaelrsweet mxml 3.1 v
+
+categories          devel textproc
+platforms           darwin
+license             Apache-2
+maintainers         nomaintainer
+
+description         a tiny library for reading and writing XML data
+long_description    Mini-XML is a tiny XML library that you can use to read and write \
+                    XML and XML-like data files in your application without requiring \
+                    large non-standard libraries. Mini-XML only requires an ANSI C \
+                    compatible compiler (GCC works, as do most vendors’ ANSI C compilers) \
+                    and a make program. \
+                    \n\nThe Mini-XML library is licensed under the Apache License Version 2.0 \
+                    with an exception to allow linking against GPL2/LGPL2-only software.\n
+
+homepage            https://www.msweet.org/mxml/
+
+checksums           rmd160  9dcdb46e427ce5f57fd23fbfec55fc7ad9efe8d3 \
+                    sha256  0ad3cf45a6d4a100be6a743887bba9eca58266849e996b5cd83f2cd525295bb5 \
+                    size    9267294
+
+destroot.args       DSTROOT=${destroot}


### PR DESCRIPTION
#### Description

[`mxml`](https://github.com/michaelrsweet/mxml), per user request.

- `universal_variant no`, for now. It builds fine _(x86_64 i386, 10.7)_, but I don't know if it works for <= 10.6, ppc, etc. If someone can test that later perhaps, and it can be removed.
- Closes: https://trac.macports.org/ticket/28859 _(2011-03-21)_

###### Type(s)

- [x] submission

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vsd install`?
- [ ] tested basic functionality of all binary files?
