### PR TITLE
libmtp: update to 1.1.17

### DIFF
--- a/multimedia/libmtp/Portfile
+++ b/multimedia/libmtp/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                libmtp
-version             1.1.14
+version             1.1.17
 categories          multimedia
 license             LGPL-2+
 maintainers         nomaintainer
@@ -17,8 +17,9 @@ platforms           darwin
 depends_build       port:pkgconfig
 depends_lib         port:libiconv port:libusb
 
-checksums           rmd160  5b450b0a7c643ca6022ff899053666a91e96eeba \
-                    sha256  3817d3e296be8f1bc527385585780e70984e8e0d6a0d00349240d67e3df412e8
+checksums           rmd160  a6ee084464d610a307388701f56f014c9669c8bb \
+                    sha256  f8a34cf52d9f9b9cb8c7f26b12da347d4af7eb904c13189602e4c6b62d1a79dc \
+                    size    829529
 
 # Avoid opportunistic use of libgcrypt and subsequent build failure due to duplicate symbols.
 configure.args-append --disable-mtpz


### PR DESCRIPTION
#### Description

Update `multimedia/libmtp` from 1.1.14 to 1.1.17

###### Type(s)
- [x] update

###### Tested on
macOS 10.13.6 17G14019
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
