### PR TITLE
librsvg: require python38

### DIFF
--- a/graphics/librsvg/Portfile
+++ b/graphics/librsvg/Portfile
@@ -5,7 +5,7 @@ PortGroup           gobject_introspection 1.0
 
 name                librsvg
 version             2.48.8
-revision            0
+revision            1
 license             {GPL-2+ LGPL-2+}
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          graphics gnome
@@ -36,7 +36,7 @@ license_noconflict  gobject-introspection \
                     rust \
                     vala
 
-set pyversion 2.7
+set pyversion 3.8
 depends_run         port:python[join [split ${pyversion} "."] ""]
 
 # cargo does not build on 10.7 or earlier


### PR DESCRIPTION
#### Description

librsvg only requires python because gobject-introspection requires python, and it requires python38.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15
Xcode 11

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
