### PR TITLE
py-exifread: update to 2.3.1

### DIFF
--- a/python/py-exifread/Portfile
+++ b/python/py-exifread/Portfile
@@ -2,7 +2,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        ianare exif-py 2.2.0
+github.setup        ianare exif-py 2.3.1
 name                py-exifread
 revision            0
 license             BSD
@@ -15,11 +15,11 @@ long_description    Exchangeable Image File Format for Digital Still \
                     in tiff or jpeg image files. EXIF.py is a Python \
                     interface to this data.
 
-checksums           rmd160  deaea5d19bf9532b3a31e8c745a381a78d549830 \
-                    sha256  673cabc0ca73656494efbf9f1e0bcaf493892c8e8748f67710a53b9ebeed72cc \
-                    size    35326
+checksums           rmd160  d47d8ac3ff153761b228eb74d162b1a94150ab71 \
+                    sha256  055901f9412bf5215dc994966b0b290430cd8b30c103abea4def2d21f0d0f643 \
+                    size    42608
 
-python.versions     27 37
+python.versions     27 37 38
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
Add Python 3.8 subport

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6
Python 3.8.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
