### PR TITLE
google-cloud-sdk: update to 305.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             304.0.0
+version             305.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  4d4e8761ac15152e6f7276ccf26f81a66a09ad6c \
-                    sha256  49b716e74890ad0a4198ca6b100561d927e9c87c7aa0d0df279aa2c0c7d90475 \
-                    size    79042333
+    checksums       rmd160  b08bb89681130c82f712502e1d603cca9a393658 \
+                    sha256  ede4491fc7ec59d491a40623f1e39be3d1d48f36ebb9fd5a8085acbe63a6a9ab \
+                    size    78163014
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  4d4e8761ac15152e6f7276ccf26f81a66a09ad6c \
-                    sha256  49b716e74890ad0a4198ca6b100561d927e9c87c7aa0d0df279aa2c0c7d90475 \
-                    size    79042333
+    checksums       rmd160  4fbe4c136067aa5902214143aec210dfd1732aca \
+                    sha256  b86dbe3c0f8b0510c1fe2719818efd8e46396b8be9083e1cedae12e787f3aeea \
+                    size    79179626
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 305.0.0.

###### Tested on

macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?