### PR TITLE
redland: remove legacy variants

### DIFF
--- a/www/redland/Portfile
+++ b/www/redland/Portfile
@@ -80,15 +80,6 @@ variant db48 conflicts db46 db47 description {Enable Berkeley DB 4.8 backend sto
     depends_lib-append      port:db48
 }
 
-# Remove after 2020-08-03
-variant mysql4       requires mysql57      description {Legacy compatibility variant} {}
-variant mysql5       requires mysql57      description {Legacy compatibility variant} {}
-variant postgresql7  requires postgresql11 description {Legacy compatibility variant} {}
-variant postgresql80 requires postgresql11 description {Legacy compatibility variant} {}
-variant postgresql81 requires postgresql11 description {Legacy compatibility variant} {}
-variant postgresql82 requires postgresql11 description {Legacy compatibility variant} {}
-variant postgresql83 requires postgresql11 description {Legacy compatibility variant} {}
-
 variant mysql57 {
     configure.args-delete --with-mysql=no
     configure.args-append --with-mysql=${prefix}/lib/mysql57/bin/mysql_config


### PR DESCRIPTION
Replaced by `+mysql57` and `+postgresql11` in a8a25cd135
See: https://trac.macports.org/ticket/43431

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
