### PR TITLE
fftw-3: add basic support for arm64

### DIFF
--- a/math/fftw-3/Portfile
+++ b/math/fftw-3/Portfile
@@ -96,6 +96,7 @@ configure.cflags-append \
 pre-configure {
     if { [avx_compiler_isset] == 1 } {
         array set merger_configure_args {
+            arm64  ""
             ppc    "--enable-fma"
             ppc64  "--enable-fma"
             i386   "--enable-sse2 --enable-avx"
@@ -103,6 +104,7 @@ pre-configure {
         }
     } else {
         array set merger_configure_args {
+            arm64  ""
             ppc    "--enable-fma"
             ppc64  "--enable-fma"
             i386   "--enable-sse2"
@@ -130,6 +132,7 @@ subport fftw-3-single {
     pre-configure {
         if { [avx_compiler_isset] == 1 } {
             array set merger_configure_args {
+                arm64  "--enable-neon"
                 ppc    "--enable-fma --enable-altivec"
                 ppc64  "--enable-fma --enable-altivec"
                 i386   "--enable-sse --enable-avx"
@@ -137,6 +140,7 @@ subport fftw-3-single {
             }
         } else {
             array set merger_configure_args {
+                arm64  "--enable-neon"
                 ppc    "--enable-fma --enable-altivec"
                 ppc64  "--enable-fma --enable-altivec"
                 i386   "--enable-sse"
@@ -186,6 +190,7 @@ subport fftw-3-long {
 
     pre-configure {
         array set merger_configure_args {
+            arm64  ""
             ppc    ""
             ppc64  ""
             i386   ""
@@ -217,9 +222,16 @@ subport fftw-3-long {
 }
 
 if {${os.arch} eq "i386"} {
+    lappend merger_configure_args(arm64)   "--disable-fortran"
     lappend merger_configure_args(ppc)     "--disable-fortran"
     lappend merger_configure_args(ppc64)   "--disable-fortran"
+} elseif {${os.arch} eq "powerpc"} {
+    lappend merger_configure_args(arm64)   "--disable-fortran"
+    lappend merger_configure_args(i386)    "--disable-fortran"
+    lappend merger_configure_args(x86_64)  "--disable-fortran"
 } else {
+    lappend merger_configure_args(ppc)     "--disable-fortran"
+    lappend merger_configure_args(ppc64)   "--disable-fortran"
     lappend merger_configure_args(i386)    "--disable-fortran"
     lappend merger_configure_args(x86_64)  "--disable-fortran"
 }


### PR DESCRIPTION
All subports pass "make check" on arm64 with these changes.

These are just the basic changes required for arm64 to successfully build all subports.

There might be other changes that would help with optimization on arm64.