### PR TITLE
snowleopardfixes: remove obsolete port

### DIFF
--- a/devel/snowleopardfixes/Portfile
+++ b/devel/snowleopardfixes/Portfile
@@ -1,9 +1,0 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
-
-PortSystem          1.0
-PortGroup           obsolete 1.0
-categories          devel
-# delete after 20200808
-name                snowleopardfixes
-version             20190808
-replaced_by         legacy-support


### PR DESCRIPTION
Obsoleted in 5954255010, replaced by legacy-support in 06eb2a2911

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
