### PR TITLE
octave-devel: remove obsolete port

### DIFF
--- a/math/octave/Portfile
+++ b/math/octave/Portfile
@@ -659,9 +659,3 @@ post-activate {
 
 test.run    yes
 test.target check
-
-# please remove on 2020-03-09
-subport ${name}-devel {
-    replaced_by ${name}
-    PortGroup   obsolete 1.0
-}


### PR DESCRIPTION
Replaced by `octave` in 6d31fd8e7d

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
