### PR TITLE
gnucash:  update webkit-gtk dependency

### DIFF
--- a/gnome/gnucash/Portfile
+++ b/gnome/gnucash/Portfile
@@ -8,7 +8,7 @@ name              gnucash
 conflicts         gnucash gnucash-devel
 conflicts-delete  ${subport}
 version           4.1
-revision          1
+revision          2
 perl5.branches    5.28
 categories        gnome x11
 license           GPL-2+
@@ -45,6 +45,7 @@ patchfiles-append patch-python-include-dirs-typo-fix.diff
 post-patch {
     reinplace "s|set(HAVE_OSX_KEYCHAIN 1)||" ${worksrcpath}/CMakeLists.txt
     reinplace "s|-Werror||" ${worksrcpath}/CMakeLists.txt
+    reinplace "s|if (WIN32 OR APPLE)|if (WIN32)|" ${worksrcpath}/CMakeLists.txt
     
     # Drop in a patched version of glibconfig.h via
     # https://git.gnome.org/browse/gtk-osx/plain/patches/glib-gint64-long-long.patch
@@ -78,7 +79,7 @@ depends_lib       port:guile \
                   port:p${perl5.major}-finance-quote \
                   port:boost \
                   port:gtk3 \
-                  path:${prefix}/libpkgconfig/webkitgtk-3.0.pc:webkit-gtk3 \
+                  port:webkit2-gtk \
                   port:libdbi \
                   port:libdbi-drivers \
                   port:aqbanking6-gtk3 \


### PR DESCRIPTION
* change webkit-gtk3 dependency to webkit2-gtk
* add post-patch reinplace to enable webkit2-gtk

Closes: https://trac.macports.org/ticket/52404

#### Description

I changed the path dependency to a direct port dependency. If it should remain a path dependency for webkit2-gtk, just let me know what it should be and I will amend the commit. I also labeled it `bugfix` because of https://trac.macports.org/ticket/60977 .

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
