### PR TITLE
ispc{-clang}: extend legacy-support to 10.11

### DIFF
--- a/lang/ispc/Portfile
+++ b/lang/ispc/Portfile
@@ -8,8 +8,10 @@ PortGroup                cmake                         1.1
 
 # link legacysupport statically for compilers
 legacysupport.use_static                       yes
-# limit legacysupport to OSX 10.10 and older
-legacysupport.newest_darwin_requires_legacy    14
+# limit legacysupport to OSX 10.11 and older (need clock_gettime())
+legacysupport.newest_darwin_requires_legacy    15
+# Note: getattrlistat() is also needed, which will be provided in a future
+# release of legacy-support; see https://trac.macports.org/ticket/60671
 
 name                     ispc
 categories               lang parallel               


### PR DESCRIPTION
Still needs `getattrlistat()`, which a future `legacy-support` will provide
See: https://trac.macports.org/ticket/60671
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
