### PR TITLE
ranger: update to 1.9.3

### DIFF
--- a/sysutils/ranger/Portfile
+++ b/sysutils/ranger/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        ranger ranger 1.9.2 v
+github.setup        ranger ranger 1.9.3 v
 maintainers         {g5pw @g5pw} openmaintainer
 
 categories          sysutils
@@ -20,12 +20,12 @@ supported_archs     noarch
 
 homepage            https://ranger.github.io
 
-checksums           rmd160  48b1c16779bc4e1806237f8542232626860bb6ec \
-                    sha256  51b1a0b6370e0b03e6428895daba9e0386909da729e6a8fd92850dc9fc777a73 \
-                    size    265320
+checksums           rmd160  dcbc16b41d723a20e58ab581f07aef37b8a4e95b \
+                    sha256  d0d7d224c2d75a76a7e87eb20f073f163e203a14a7b6178d956a629bc0a803dc \
+                    size    279996
 
 post-destroot {
     ln -s "${python.prefix}/share/man/man1/${name}.1" "${destroot}${prefix}/share/man/man1/${name}.1"
 }
 
-python.default_version 27
+python.default_version 38


### PR DESCRIPTION
- switch from 2.7 to 3.8 as default Python version

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
