### PR TITLE
py-txtorcon: new port

### DIFF
--- a/python/py-txtorcon/Portfile
+++ b/python/py-txtorcon/Portfile
@@ -13,9 +13,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 description         Twisted based Tor controller client with state tracking \
                     and configuration abstractions.
 
-long_description    ${description}
+long_description    {*}${description}
 
-homepage            https //txtorcon.readthedocs.org
+homepage            https://txtorcon.readthedocs.org
 
 checksums           rmd160  bfe72404f5a649addd8b60d0fafe92e1e99dc25f \
                     sha256  122cd081786396f57718adda1c1a5eb01b8e9a4832fcd140918b45c10359377a \

--- a/python/py-txtorcon/Portfile
+++ b/python/py-txtorcon/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-txtorcon
+version             20.0.0
+platforms           darwin
+license             MIT
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+description         Twisted based Tor controller client with state tracking \
+                    and configuration abstractions.
+
+long_description    ${description}
+
+homepage            https //txtorcon.readthedocs.org
+
+checksums           rmd160  bfe72404f5a649addd8b60d0fafe92e1e99dc25f \
+                    sha256  122cd081786396f57718adda1c1a5eb01b8e9a4832fcd140918b45c10359377a \
+                    size    306139
+
+python.versions     38
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                        port:py${python.version}-setuptools
+}


### PR DESCRIPTION
New port for the [txtorcon](https://txtorcon.readthedocs.io/en/latest/) Python library

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
