### PR TITLE
py-lmdb: new port

### DIFF
--- a/python/py-lmdb/Portfile
+++ b/python/py-lmdb/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-lmdb
+version             0.99
+platforms           darwin
+license             BSD
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+description         Universal Python binding for the LMDB Lightning Database
+long_description    ${description}
+
+homepage            https://lmdb.readthedocs.io/en/release/
+
+checksums           rmd160  5de4b0681066d0caa42923225678fe57be6869c2 \
+                    sha256  f9eb844aaaacc8a4bc175e1c1f8a8fb538c330e378fd9eb40e8708d4dca7dc89 \
+                    size    995175
+
+python.versions     38
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+}

--- a/python/py-lmdb/Portfile
+++ b/python/py-lmdb/Portfile
@@ -11,7 +11,7 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 description         Universal Python binding for the LMDB Lightning Database
-long_description    ${description}
+long_description    {*}${description}
 
 homepage            https://lmdb.readthedocs.io/en/release/
 


### PR DESCRIPTION
New port for the [lmdb](https://lmdb.readthedocs.io/en/release/) Python library

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
