### PR TITLE
py-priority: new port

### DIFF
--- a/python/py-priority/Portfile
+++ b/python/py-priority/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-priority
+version             1.3.0
+platforms           darwin
+license             MIT
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+description         A pure Python implementation of the HTTP/2 priority tree
+long_description    ${description}
+
+homepage            https://pypi.org/project/priority/
+
+checksums           rmd160  65e0bab05dd5452489c266f7405dcf4ce5801ed2 \
+                    sha256  6bc1961a6d7fcacbfc337769f1a382c8e746566aaa365e78047abe9f66b2ffbe \
+                    size    13827
+
+python.versions     38
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+}

--- a/python/py-priority/Portfile
+++ b/python/py-priority/Portfile
@@ -11,7 +11,7 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 description         A pure Python implementation of the HTTP/2 priority tree
-long_description    ${description}
+long_description    {*}${description}
 
 homepage            https://pypi.org/project/priority/
 


### PR DESCRIPTION
New port for 
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
