### PR TITLE
py-pypng: new port

### DIFF
--- a/python/py-pypng/Portfile
+++ b/python/py-pypng/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-pypng
+version             0.0.20
+platforms           darwin
+license             MIT
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+description         Pure Python PNG image encoder/decoder
+long_description    {*}${description}
+
+homepage            https://github.com/drj11/pypng
+
+checksums           rmd160  cbc12a8c877ad7161ba3cf541dfe967bd73c2995 \
+                    sha256  1032833440c91bafee38a42c38c02d00431b24c42927feb3e63b104d8550170b \
+                    size    649538
+
+python.versions     38
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+}


### PR DESCRIPTION
New port for [pypng](https://github.com/drj11/pypng)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
