### PR TITLE
Update py-gacode to version 0.57

### DIFF
--- a/python/py-gacode/Portfile
+++ b/python/py-gacode/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           compilers 1.0
 
 name                py-gacode
-version             0.56
+version             0.57
 python.rootname     pygacode
 
 
@@ -21,10 +21,9 @@ long_description    ${description}
 
 license             MIT
 homepage            https://gacode.io
-
-checksums           rmd160  2ffb74e73190de45a0f477ed980f19af1dc7234a \
-                    sha256  1a9df3f960b0cd2127ba388c9cd6f60cd1decb6d278e6497fc2721ea09701e2c \
-                    size    83512
+checksums           rmd160  aa5658f0251374b9b005fc3a9eba6619200dc857 \
+                    sha256  566a6f4ff3c07eddefd60bf119b4c0beb6b37317f6b2f0d7c3582940281211e2 \
+                    size    82852
 
 patchfiles          patch-setup.py.diff
 


### PR DESCRIPTION
#### Description

Update py-gacode to version 0.57

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G87
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?