### PR TITLE
py-zlmdb: new port

### DIFF
--- a/python/py-zlmdb/Portfile
+++ b/python/py-zlmdb/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-zlmdb
+version             20.8.1
+platforms           darwin
+license             MIT
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+description         Object relational zero copy in memory database layer for \
+                    LMDB.
+long_description    {*}${description}
+
+homepage            https://github.com/crossbario/zlmdb
+
+checksums           rmd160  e21331af67be04b87e9cce9930cf845fccf412d6 \
+                    sha256  9fde9e94d272c344b8437355af94b1cb76e3707d8d6c77488f9df2e749c1353f \
+                    size    129680
+
+python.versions     38
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-pytest-runner \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-cbor2 \
+                    port:py${python.version}-click \
+                    port:py${python.version}-lmdb \
+                    port:py${python.version}-numpy \
+                    port:py${python.version}-pynacl \
+                    port:py${python.version}-txaio \
+                    port:py${python.version}-yaml
+}


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
