### PR TITLE
p5-dbd-mysql: Add variant mariadb10_5

### DIFF
--- a/perl/p5-dbd-mysql/Portfile
+++ b/perl/p5-dbd-mysql/Portfile
@@ -26,50 +26,56 @@ if {${perl5.major} != ""} {
     depends_lib-append \
                     port:p${perl5.major}-dbi
 
-    variant mysql56 conflicts mysql57 mysql8 mariadb10_1 mariadb10_2 \
-                    mariadb10_2 mariadb10_3 mariadb10_4 percona description {build with mysql56 port} {
+    variant mysql56 conflicts mysql57 mysql8 mariadb10_1 mariadb10_2 mariadb10_3 \
+                    mariadb10_4 mariadb10_5 percona description {build with mysql56 port} {
         depends_lib-append      port:mysql56
         configure.args-append   --mysql_config=${prefix}/lib/mysql56/bin/mysql_config
     }
 
-    variant mysql57 conflicts mysql56 mysql8 mariadb10_1 mariadb10_2 \
-                    mariadb10_3 mariadb10_4 percona description {build with mysql57 port} {
+    variant mysql57 conflicts mysql56 mysql8 mariadb10_1 mariadb10_2 mariadb10_3 \
+                    mariadb10_4 mariadb10_5 percona description {build with mysql57 port} {
         depends_lib-append      port:mysql57
         configure.args-append   --mysql_config=${prefix}/lib/mysql57/bin/mysql_config
     }
 
-    variant mysql8 conflicts mysql56 mysql57 mariadb10_1 mariadb10_2 \
-                    mariadb10_3 mariadb10_4 percona description {build with mysql8 port} {
+    variant mysql8  conflicts mysql56 mysql57 mariadb10_1 mariadb10_2 mariadb10_3 \
+                    mariadb10_4 mariadb10_5 percona description {build with mysql8 port} {
         depends_lib-append      port:mysql8
         configure.args-append   --mysql_config=${prefix}/lib/mysql8/bin/mysql_config
     }
 
-    variant mariadb10_1 conflicts mysql56 mysql57 mysql8 mariadb10_2 \
-                        mariadb10_3 mariadb10_4 percona description {build with mariadb-10.1 port} {
+    variant mariadb10_1 conflicts mysql56 mysql57 mysql8 mariadb10_2 mariadb10_3 mariadb10_4 \
+                        mariadb10_5 percona description {build with mariadb-10.1 port} {
         depends_lib-append      port:mariadb-10.1
         configure.args-append   --mysql_config=${prefix}/lib/mariadb-10.1/bin/mysql_config
     }
 
-    variant mariadb10_2 conflicts mysql56 mysql57 mysql8 mariadb10_1 \
-                        mariadb10_3 mariadb10_4 percona description {build with mariadb-10.2 port} {
+    variant mariadb10_2 conflicts mysql56 mysql57 mysql8 mariadb10_1 mariadb10_3 mariadb10_4 \
+                        mariadb10_5 percona description {build with mariadb-10.2 port} {
         depends_lib-append      port:mariadb-10.2
         configure.args-append   --mysql_config=${prefix}/lib/mariadb-10.2/bin/mysql_config
     }
 
-    variant mariadb10_3 conflicts mysql56 mysql57 mysql8 mariadb10_1 \
-                        mariadb10_2 mariadb10_4 percona description {build with mariadb-10.3 port} {
+    variant mariadb10_3 conflicts mysql56 mysql57 mysql8 mariadb10_1 mariadb10_2 mariadb10_4 \
+                        mariadb10_5 percona description {build with mariadb-10.3 port} {
         depends_lib-append      port:mariadb-10.3
         configure.args-append   --mysql_config=${prefix}/lib/mariadb-10.3/bin/mysql_config
     }
 
-    variant mariadb10_4 conflicts mysql56 mysql57 mysql8 mariadb10_1 \
-                        mariadb10_2 mariadb10_3 percona description {build with mariadb-10.4 port} {
+    variant mariadb10_4 conflicts mysql56 mysql57 mysql8 mariadb10_1 mariadb10_2 mariadb10_3 \
+                        mariadb10_5 percona description {build with mariadb-10.4 port} {
         depends_lib-append      port:mariadb-10.4
         configure.args-append   --mysql_config=${prefix}/lib/mariadb-10.4/bin/mysql_config
     }
 
-    variant percona conflicts mysql56 mysql57 mysql8 mariadb10_1 \
-                    mariadb10_2 mariadb10_3 mariadb10_4 description {build with percona port} {
+    variant mariadb10_5 conflicts mysql56 mysql57 mysql8 mariadb10_1 mariadb10_2 mariadb10_3 \
+                        mariadb10_4 percona description {build with mariadb-10.5 port} {
+        depends_lib-append      port:mariadb-10.5
+        configure.args-append   --mysql_config=${prefix}/lib/mariadb-10.5/bin/mysql_config
+    }
+
+    variant percona conflicts mysql56 mysql57 mysql8 mariadb10_1 mariadb10_2 mariadb10_3 \
+                    mariadb10_4 mariadb10_5 description {build with percona port} {
         depends_lib-append      port:percona
         configure.args-append   --mysql_config=${prefix}/lib/percona/bin/mysql_config
     }
@@ -81,6 +87,7 @@ if {${perl5.major} != ""} {
         && ![variant_isset mariadb10_2]
         && ![variant_isset mariadb10_3]
         && ![variant_isset mariadb10_4]
+        && ![variant_isset mariadb10_5]
         && ![variant_isset percona]
     } {
         if {${os.major} > 12} {


### PR DESCRIPTION
#### Description

Add variant: mariadb10_5

###### Type(s)

- [+] enhancement

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?