### PR TITLE
MariaDB ports: remove obsolete pre-activate

### DIFF
--- a/databases/mariadb-10.0/Portfile
+++ b/databases/mariadb-10.0/Portfile
@@ -149,18 +149,6 @@ if {$subport eq $name} {
         }
     }
 
-    pre-activate {
-        # The macports-default.cnf is installed by ${name_mysql}.
-        # Early versions of ${name_mysql}-server installed macports-default.cnf so for a
-        # reasonable period we need to deactivate older versions of the ${name_mysql}-server.
-        if { [file exists ${prefix}/etc/${name_mysql}/macports-default.cnf]
-            && ![catch {set vers [lindex [registry_active ${name_mysql}-server] 0]}]
-            && [vercmp [lindex $vers 1] 5.5.24] < 0 } {
-
-            registry_deactivate_composite ${name_mysql}-server "" [list ports_nodepcheck 1]
-        }
-    }
-
     post-activate {
         if {![file exists ${prefix}/etc/${name_mysql}/my.cnf]} {
             copy ${prefix}/share/${name_mysql}/support-files/macports/my.cnf \

--- a/databases/mariadb-10.1/Portfile
+++ b/databases/mariadb-10.1/Portfile
@@ -148,18 +148,6 @@ if {$subport eq $name} {
         }
     }
 
-    pre-activate {
-        # The macports-default.cnf is installed by ${name_mysql}.
-        # Early versions of ${name_mysql}-server installed macports-default.cnf so for a
-        # reasonable period we need to deactivate older versions of the ${name_mysql}-server.
-        if { [file exists ${prefix}/etc/${name_mysql}/macports-default.cnf]
-            && ![catch {set vers [lindex [registry_active ${name_mysql}-server] 0]}]
-            && [vercmp [lindex $vers 1] 5.5.24] < 0 } {
-
-            registry_deactivate_composite ${name_mysql}-server "" [list ports_nodepcheck 1]
-        }
-    }
-
     post-activate {
         if {![file exists ${prefix}/etc/${name_mysql}/my.cnf]} {
             copy ${prefix}/share/${name_mysql}/support-files/macports/my.cnf \

--- a/databases/mariadb-10.2/Portfile
+++ b/databases/mariadb-10.2/Portfile
@@ -175,18 +175,6 @@ if {$subport eq $name} {
         }
     }
 
-    pre-activate {
-        # The macports-default.cnf is installed by ${name_mysql}.
-        # Early versions of ${name_mysql}-server installed macports-default.cnf so for a
-        # reasonable period we need to deactivate older versions of the ${name_mysql}-server.
-        if { [file exists ${prefix}/etc/${name_mysql}/macports-default.cnf]
-            && ![catch {set vers [lindex [registry_active ${name_mysql}-server] 0]}]
-            && [vercmp [lindex $vers 1] 5.5.24] < 0 } {
-
-            registry_deactivate_composite ${name_mysql}-server "" [list ports_nodepcheck 1]
-        }
-    }
-
     post-activate {
         if {![file exists ${prefix}/etc/${name_mysql}/my.cnf]} {
             copy ${prefix}/share/${name_mysql}/support-files/macports/my.cnf \

--- a/databases/mariadb-10.3/Portfile
+++ b/databases/mariadb-10.3/Portfile
@@ -175,18 +175,6 @@ if {$subport eq $name} {
         }
     }
 
-    pre-activate {
-        # The macports-default.cnf is installed by ${name_mysql}.
-        # Early versions of ${name_mysql}-server installed macports-default.cnf so for a
-        # reasonable period we need to deactivate older versions of the ${name_mysql}-server.
-        if { [file exists ${prefix}/etc/${name_mysql}/macports-default.cnf]
-            && ![catch {set vers [lindex [registry_active ${name_mysql}-server] 0]}]
-            && [vercmp [lindex $vers 1] 5.5.24] < 0 } {
-
-            registry_deactivate_composite ${name_mysql}-server "" [list ports_nodepcheck 1]
-        }
-    }
-
     post-activate {
         if {![file exists ${prefix}/etc/${name_mysql}/my.cnf]} {
             copy ${prefix}/share/${name_mysql}/support-files/macports/my.cnf \

--- a/databases/mariadb-10.4/Portfile
+++ b/databases/mariadb-10.4/Portfile
@@ -217,18 +217,6 @@ if {$subport eq $name} {
         }
     }
 
-    pre-activate {
-        # The macports-default.cnf is installed by ${name_mysql}.
-        # Early versions of ${name_mysql}-server installed macports-default.cnf so for a
-        # reasonable period we need to deactivate older versions of the ${name_mysql}-server.
-        if { [file exists ${prefix}/etc/${name_mysql}/macports-default.cnf]
-            && ![catch {set vers [lindex [registry_active ${name_mysql}-server] 0]}]
-            && [vercmp [lindex $vers 1] 5.5.24] < 0 } {
-
-            registry_deactivate_composite ${name_mysql}-server "" [list ports_nodepcheck 1]
-        }
-    }
-
     post-activate {
         if {![file exists ${prefix}/etc/${name_mysql}/my.cnf]} {
             copy ${prefix}/share/${name_mysql}/support-files/macports/my.cnf \

--- a/databases/mariadb-10.5/Portfile
+++ b/databases/mariadb-10.5/Portfile
@@ -257,18 +257,6 @@ if {$subport eq $name} {
         }
     }
 
-    pre-activate {
-        # The macports-default.cnf is installed by ${name_mysql}.
-        # Early versions of ${name_mysql}-server installed macports-default.cnf so for a
-        # reasonable period we need to deactivate older versions of the ${name_mysql}-server.
-        if { [file exists ${prefix}/etc/${name_mysql}/macports-default.cnf]
-            && ![catch {set vers [lindex [registry_active ${name_mysql}-server] 0]}]
-            && [vercmp [lindex $vers 1] 5.5.24] < 0 } {
-
-            registry_deactivate_composite ${name_mysql}-server "" [list ports_nodepcheck 1]
-        }
-    }
-
     post-activate {
         if {![file exists ${prefix}/etc/${name_mysql}/my.cnf]} {
             copy ${prefix}/share/${name_mysql}/support-files/macports/my.cnf \

--- a/databases/mariadb/Portfile
+++ b/databases/mariadb/Portfile
@@ -144,18 +144,6 @@ if {$subport eq $name} {
         }
     }
 
-    pre-activate {
-        # The macports-default.cnf is installed by ${name_mysql}.
-        # Early versions of ${name_mysql}-server installed macports-default.cnf so for a
-        # reasonable period we need to deactivate older versions of the ${name_mysql}-server.
-        if { [file exists ${prefix}/etc/${name_mysql}/macports-default.cnf]
-            && ![catch {set vers [lindex [registry_active ${name_mysql}-server] 0]}]
-            && [vercmp [lindex $vers 1] 5.5.24] < 0 } {
-
-            registry_deactivate_composite ${name_mysql}-server "" [list ports_nodepcheck 1]
-        }
-    }
-
     post-activate {
         if {![file exists ${prefix}/etc/${name_mysql}/my.cnf]} {
             copy ${prefix}/share/${name_mysql}/support-files/macports/my.cnf \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

(Ancient pre-activate was originally added to mariadb in 2012: 66ac0763af.)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
