### PR TITLE
OpenJPEG ports: remove obsolete pre-activate

### DIFF
--- a/graphics/openjpeg/Portfile
+++ b/graphics/openjpeg/Portfile
@@ -37,16 +37,3 @@ depends_lib         port:libpng \
                     port:jbigkit
 
 configure.cppflags-replace -I${prefix}/include -isystem${prefix}/include
-
-pre-activate {
-    # openjpeg < 1.5.0 accidentally installed items directly into
-    # ${prefix}/share/man bypassing ${destroot}; remove them if found.
-    foreach m {man1/image_to_j2k.1.gz man1/j2k_dump.1.gz man1/j2k_to_image.1.gz man3/libopenjpeg.3.gz} {
-        set filepath ${prefix}/share/man/${m}
-        if {[file exists ${filepath}] && [registry_file_registered ${filepath}] == "0"} {
-            if {[catch {delete ${filepath}}]} {
-                ui_warn "Cannot delete ${filepath}; please remove it manually"
-            }
-        }
-    }
-}

--- a/graphics/openjpeg15/Portfile
+++ b/graphics/openjpeg15/Portfile
@@ -37,17 +37,4 @@ depends_lib         port:libpng \
 use_autoreconf      yes
 autoreconf.args     -fvi
 
-pre-activate {
-    # openjpeg < 1.5.0 accidentally installed items directly into
-    # ${prefix}/share/man bypassing ${destroot}; remove them if found.
-    foreach m {man1/image_to_j2k.1.gz man1/j2k_dump.1.gz man1/j2k_to_image.1.gz man3/libopenjpeg.3.gz} {
-        set filepath ${prefix}/share/man/${m}
-        if {[file exists ${filepath}] && [registry_file_registered ${filepath}] == "0"} {
-            if {[catch {delete ${filepath}}]} {
-                ui_warn "Cannot delete ${filepath}; please remove it manually"
-            }
-        }
-    }
-}
-
 github.livecheck.regex  {(1\.[0-9.]+)}


### PR DESCRIPTION
Originally added in d2d34ea683 over 8 years ago.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
