### PR TITLE
git: installs_libs no

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -12,6 +12,7 @@ long_description    Git is a fast, scalable, distributed open source version \
 maintainers         {ciserlohn @ci42} openmaintainer
 categories          devel
 license             GPL-2 LGPL-2.1+
+installs_libs       no
 platforms           darwin
 homepage            https://git-scm.com/
 master_sites        https://www.kernel.org/pub/software/scm/git/ \


### PR DESCRIPTION
#### Description

This makes some ports that depend on git, like doxygen, distributable.

Closes: https://trac.macports.org/ticket/59926

I *think* this is correct but please correct me if I'm wrong. I don't see any dylibs being installed by git, but I haven't checked every variant.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
