### PR TITLE
mysql51, mysql55: remove obsolete pre-activate

### DIFF
--- a/databases/mysql51/Portfile
+++ b/databases/mysql51/Portfile
@@ -152,19 +152,6 @@ if {${subport} eq ${name}} {
         }
     }
 
-    pre-activate {
-        # The macports-default.cnf is installed by ${name_mysql}.
-        # Early versions of ${name_mysql}-server installed macports-default.cnf so for a
-        # reasonable period we need to deactivate older versions of the ${name_mysql}-server.
-        if { [file exists ${prefix}/etc/${name_mysql}/macports-default.cnf]
-            && ![catch {set vers [lindex [registry_active ${name_mysql}-server] 0]}]
-            && [vercmp [lindex $vers 1] 5.1.63] < 1
-            && [vercmp [lindex $vers 2] 3] < 0 } {
-
-            registry_deactivate_composite ${name_mysql}-server "" [list ports_nodepcheck 1]
-        }
-    }
-
     post-activate {
         if {![file exists ${prefix}/etc/${name_mysql}/my.cnf]} {
             copy ${prefix}/share/${name_mysql}/support-files/macports/my.cnf \

--- a/databases/mysql55/Portfile
+++ b/databases/mysql55/Portfile
@@ -127,18 +127,6 @@ if {$subport eq $name} {
         }
     }
 
-    pre-activate {
-        # The macports-default.cnf is installed by ${name_mysql}.
-        # Early versions of ${name_mysql}-server installed macports-default.cnf so for a
-        # reasonable period we need to deactivate older versions of the ${name_mysql}-server.
-        if { [file exists ${prefix}/etc/${name_mysql}/macports-default.cnf]
-            && ![catch {set vers [lindex [registry_active ${name_mysql}-server] 0]}]
-            && [vercmp [lindex $vers 1] 5.5.25] < 0 } {
-
-            registry_deactivate_composite ${name_mysql}-server "" [list ports_nodepcheck 1]
-        }
-    }
-
     post-activate {
         if {![file exists ${prefix}/etc/${name_mysql}/my.cnf]} {
             copy ${prefix}/share/${name_mysql}/support-files/macports/my.cnf \


### PR DESCRIPTION
Originally added in 35e5cd40ef and 43a05a4df9 respectively 8 years ago.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
