### PR TITLE
meson: find default pkg-config and cmake when cross building

### DIFF
--- a/devel/meson/Portfile
+++ b/devel/meson/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 
 github.setup        mesonbuild meson 0.55.0
 
-revision            1
+revision            2
 
 github.tarball_from releases
 license             Apache-2
@@ -60,6 +60,11 @@ patchfiles-append   patch-meson-search-prefix-for-cross-files.diff
 post-patch {
     reinplace "s|@@PREFIX@@|${prefix}|g" ${worksrcpath}/data/shell-completions/bash/meson \
                                          ${worksrcpath}/mesonbuild/coredata.py
+
+    # https://trac.macports.org/ticket/60987
+    # when cross building, we want meson to find our default cmake and pkg-config
+    reinplace "s|allow_default_for_cross=False|allow_default_for_cross=True|g" ${worksrcpath}/mesonbuild/dependencies/base.py \
+                                                                               ${worksrcpath}/mesonbuild/cmake/executor.py
 }
 
 post-destroot {


### PR DESCRIPTION
in response to a niche build issue, messon recently
changed how it found cmake and pkg-config when cross building.

This change makes the default pkg-config and cmake no longer
found, and requires these (at least, at present) to be specified
in the cross files when cross building.

As MacPorts cross-builds frequently when building universal,
and as all other build systems use the default pkg-config and
cmake, we revert meson back to the traditional behaviour.

cmake and pkg-config can still be overridden in a cross file
by a user if they require a different one than the default

see: https://github.com/mesonbuild/meson/issues/7276
closes: https://trac.macports.org/ticket/60987

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.13.6 17G14019
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
