### PR TITLE
meson: specify pkg-config and cmake when cross building

### DIFF
--- a/devel/meson/Portfile
+++ b/devel/meson/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 
 github.setup        mesonbuild meson 0.55.0
 
-revision            1
+revision            2
 
 github.tarball_from releases
 license             Apache-2
@@ -70,6 +70,10 @@ post-destroot {
     # install our MacPorts cross files
     xinstall -m 755 -d ${destroot}${prefix}/share/meson/
     copy ${filespath}/cross ${destroot}${prefix}/share/meson/
+
+    fs-traverse f ${destroot}${prefix}/share/meson/cross/ {
+        reinplace "s|@@PREFIX@@|${prefix}|g" ${f}
+    }
 }
 
 # the following block avoids requiring users to 'sudo port select python3 python37'

--- a/devel/meson/files/cross/i386-darwin
+++ b/devel/meson/files/cross/i386-darwin
@@ -3,3 +3,7 @@ system = 'darwin'
 cpu_family = 'x86'
 cpu = 'i386'
 endian = 'little'
+
+[binaries]
+pkgconfig = '@@PREFIX@@/bin/pkg-config'
+cmake = '@@PREFIX@@/bin/cmake'

--- a/devel/meson/files/cross/x86_64-darwin
+++ b/devel/meson/files/cross/x86_64-darwin
@@ -3,3 +3,7 @@ system = 'darwin'
 cpu_family = 'x86_64'
 cpu = 'x86_64'
 endian = 'little'
+
+[binaries]
+pkgconfig = '@@PREFIX@@/bin/pkg-config'
+cmake = '@@PREFIX@@/bin/cmake'


### PR DESCRIPTION
meson requires pkg-config and cmake to be specified
in the cross files when cross building.

see: https://github.com/mesonbuild/meson/issues/7276
closes: https://trac.macports.org/ticket/60987

alternative fix to #8107 

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.13.6 17G14019
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
