### PR TITLE
py-rsa: update to 4.6

### DIFF
--- a/python/py-rsa/Portfile
+++ b/python/py-rsa/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-rsa
-version             3.4.2
+version             4.6
 platforms           darwin
 license             Apache-2
 maintainers         nomaintainer
@@ -16,12 +16,10 @@ long_description    ${description}.\
     Python library as well as on the commandline.
 
 homepage            http://stuvel.eu/rsa
-master_sites        pypi:r/rsa
-distname            rsa-${version}
 
-checksums           rmd160  ed031a093373ab3c1a6d27d2d9e58235c0058809 \
-                    sha256  25df4e10c263fb88b5ace923dd84bf9aa7f5019687b5e55382ffcdb8bede9db5 \
-                    size    40956
+checksums           rmd160  399e2100a851fc00984b814ab614b6d5292a4f7a \
+                    sha256  109ea5a66744dd859bf16fe904b8d8b627adafb9408753161e766a92e7d681fa \
+                    size    46954
 
 python.versions     27 35 36 37 38
 

--- a/python/py-rsa/Portfile
+++ b/python/py-rsa/Portfile
@@ -10,12 +10,12 @@ license             Apache-2
 maintainers         nomaintainer
 
 description         Pure Python RSA implementation
-long_description    ${description}.\
+long_description    {*}${description}.\
     It supports encryption and decryption, signing and verifying signatures,\
     and key generation according to PKCS#1 version 1.5. It can be used as a\
     Python library as well as on the commandline.
 
-homepage            http://stuvel.eu/rsa
+homepage            https://stuvel.eu/software/rsa/
 
 checksums           rmd160  399e2100a851fc00984b814ab614b6d5292a4f7a \
                     sha256  109ea5a66744dd859bf16fe904b8d8b627adafb9408753161e766a92e7d681fa \


### PR DESCRIPTION
- Remove all Python versions except for 3.8

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
