### PR TITLE
py-awscli: update to 1.18.120

### DIFF
--- a/python/py-awscli/Portfile
+++ b/python/py-awscli/Portfile
@@ -14,7 +14,7 @@ license             Apache-2
 maintainers         nomaintainer
 
 description         Universal Command Line Environment for AWS.
-long_description    ${description}
+long_description    {*}${description}
 
 homepage            https://aws.amazon.com/cli/
 

--- a/python/py-awscli/Portfile
+++ b/python/py-awscli/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-awscli
-version             1.18.26
+version             1.18.120
 revision            0
 
 platforms           darwin
@@ -18,11 +18,11 @@ long_description    ${description}
 
 homepage            https://aws.amazon.com/cli/
 
-checksums           rmd160  38c31b6c62bf17e9a078f256e83c4c61cd34e4fe \
-                    sha256  2447b9ac845e280724bee659b5c73127cfb1c089c81943e21f80cf141d6ed875 \
-                    size    1191588
+checksums           rmd160  51b904b188ed71f1cf4dafcec1f772eef48a0484 \
+                    sha256  3d21dcb0a17b8b623e7b7fd3528ede7d445c485fa4ca6cacfbaf4910a1d17944 \
+                    size    1296872
 
-python.versions     27 35 36 37 38
+python.versions     38
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
- Remove all Python versions except for 3.8

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
