### PR TITLE
gnutls: remove license_noconflict

### DIFF
--- a/devel/gnutls/Portfile
+++ b/devel/gnutls/Portfile
@@ -21,8 +21,6 @@ description     GNU Transport Layer Security Library
 homepage        http://www.gnutls.org/
 platforms       darwin
 
-license_noconflict gtk-doc
-
 long_description \
     GnuTLS is a portable ANSI C based library which implements the TLS 1.2, \
     TLS 1.1, TLS 1.0, SSL 3.0, and Datagram TLS protocols. The library does \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

I made some blind changes with `license_noconflict` in #8091 and #8058, turns out it doesn't affect distributability at all judging from what [was built in buildbot](https://ports.macports.org/port/gnutls/builds).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
