### PR TITLE
py-treq: update to 20.4.1

### DIFF
--- a/python/py-treq/Portfile
+++ b/python/py-treq/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-treq
-version             18.6.0
+version             20.4.1
 revision            0
 
 maintainers         nomaintainer
@@ -20,11 +20,11 @@ distname            ${python.rootname}-${version}
 
 license             MIT
 
-checksums           sha256  91e09ff6b524cc90aa5e934b909c8d0d1a9d36ebd618b6c38e37b17013e69f48 \
-                    rmd160  0960e004dc9769df3228915bba439acc41162294 \
-                    size    59156
+checksums           sha256  68fee7d24c94b7f1432ad8077e22d0d15f957bf6fcf9cb771ff4c6acc7e2bc84 \
+                    rmd160  fee959996e5eb2d999a3069c0c618129848d0f06 \
+                    size    59116
 
-python.versions     37 38
+python.versions     38
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
- Remove all Python versions except 3.8

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
