### PR TITLE
py-autobahn: update to 20.7.1

### DIFF
--- a/python/py-autobahn/Portfile
+++ b/python/py-autobahn/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-autobahn
-version             20.2.2
+version             20.7.1
 platforms           darwin
 license             MIT
 maintainers         {mojca @mojca} openmaintainer
@@ -16,15 +16,36 @@ homepage            https://crossbar.io/autobahn
 master_sites        pypi:a/autobahn
 distname            autobahn-${version}
 
-checksums           rmd160  90a33d2f405a0581681cb0be4354507250d46202 \
-                    sha256  8fb9f3e7f6de5b7ee5479a56582873b927cc25d72319d0a86f43d992048d8171 \
-                    size    682775
+checksums           rmd160  d38811290f505c10cc941abd4cbd745e15f3136d \
+                    sha256  86bbce30cdd407137c57670993a8f9bfdfe3f8e994b889181d85e844d5aa8dfb \
+                    size    1260579
 
-python.versions     27 37 38
+python.versions     38
 
 if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
+
+    depends_run-append \
+                    port:py${python.version}-attrs \
+                    port:py${python.version}-cffi \
+                    port:py${python.version}-argon2-cffi \
+                    port:py${python.version}-cbor \
+                    port:py${python.version}-cbor2 \
+                    port:py${python.version}-cryptography \
+                    port:py${python.version}-flatbuffers \
+                    port:py${python.version}-msgpack \
+                    port:py${python.version}-openssl \
+                    port:py${python.version}-passlib \
+                    port:py${python.version}-pynacl \
+                    port:py${python.version}-pyqrcode \
+                    port:py${python.version}-python-snappy \
+                    port:py${python.version}-pytrie \
+                    port:py${python.version}-service_identity \
+                    port:py${python.version}-twisted \
+                    port:py${python.version}-txaio \
+                    port:py${python.version}-u-msgpack-python \
+                    port:py${python.version}-ujson
 
     livecheck.type  none
 } else {


### PR DESCRIPTION
- Remove all Python versions except for 3.8

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
