### PR TITLE
py-macresources: new port

### DIFF
--- a/python/py-macresources/Portfile
+++ b/python/py-macresources/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=Portfile:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-macresources
+version             1.2
+
+categories          devel
+license             MIT
+platforms           darwin
+supported_archs     noarch
+maintainers         nomaintainer
+
+description         a library for working with legacy Macintosh resource forks
+long_description    A Python library and command line tools to work with Classic MacOS \
+                    resource forks on a modern machine.
+
+homepage            https://github.com/elliotnunn/macresources
+
+python.versions     38
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools
+
+    checksums           rmd160  79ce782f5cf4282da7fa69ddaf0ba757ddd4cea3 \
+                        sha256  f5a1465e02b11e6bc2cb9f2221e0cfac90d57d294b6baa73c28035b000c3dec4 \
+                        size    23609
+
+    livecheck.type      none
+} else {
+    livecheck.type  pypi
+}


### PR DESCRIPTION
#### Description

Library for working with legacy Macintosh resource forks.

  - dependency of py-machfs

###### Type(s)

- [x] submission

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vsd install`?

###### Notes

This PR is a part of the `py-machfs` submission.