### PR TITLE
py-machfs: new port

### DIFF
--- a/python/py-machfs/Portfile
+++ b/python/py-machfs/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=Portfile:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-machfs
+version             1.2.4
+
+categories          devel
+license             MIT
+platforms           darwin
+supported_archs     noarch
+maintainers         nomaintainer
+
+description         a library for creating and inspecting HFS-format disk images
+long_description    This is {*}${description}. Mac-specific concepts like resource forks \
+                    and type/creator codes are first-class citizens.
+
+homepage            https://github.com/elliotnunn/machfs
+
+python.versions     38
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools
+    depends_lib-append      port:py${python.version}-macresources
+
+    checksums           rmd160  8ac028110e5f4a23efe55dd896ac6e3246b26f9f \
+                        sha256  c5b39773ad4ec73e18c1768b427e45a96b2b0162ee85939e435d48741a38c473 \
+                        size    16380
+
+    livecheck.type      none
+} else {
+    livecheck.type  pypi
+}


### PR DESCRIPTION
#### Description

This is a library for creating and inspecting HFS-format disk images.

- depends on `py-macresources` (#8119)
- Closes: https://trac.macports.org/ticket/58769

###### Type(s)

- [x] submission

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vsd install`?