### PR TITLE
bamtools: new port

### DIFF
--- a/devel/bamtools/Portfile
+++ b/devel/bamtools/Portfile
@@ -1,0 +1,47 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        pezmaster31 bamtools 2.5.1 v
+
+categories          devel
+license             MIT
+platforms           darwin
+maintainers         nomaintainer
+
+description         a programmer's API and an end-user's toolkit for handling BAM files
+long_description    BamTools provides both {*}${description}.
+
+checksums           rmd160  a537678aaad8ea323f7d8f86d92983353220d0fc \
+                    sha256  a933067515bd36ee6edea2379bc156a38d54c67e4c11243eea6cb56a1ebb1ae3 \
+                    size    549902
+
+depends_lib-append          path:lib/libjsoncpp.dylib:jsoncpp
+
+compiler.cxx_standard       2011
+
+# the C++11 requirement is being imposed by jsoncpp
+configure.cxxflags-append   -std=c++11
+configure.args-append       -DBUILD_SHARED_LIBS=ON
+
+cmake.build_type [expr {[variant_isset debug] eq 1 ? "Debug" : "Release"}]
+
+variant nodejs12    conflicts nodejs13 nodejs14 \
+                    description {If you plan to run in Node.js (v12) environment} {
+    configure.args-append   -DEnableNodeJS=true
+    depends_lib-append      port:nodejs12
+}
+
+variant nodejs13    conflicts nodejs12 nodejs14 \
+                    description {If you plan to run in Node.js (v13) environment} {
+    configure.args-append   -DEnableNodeJS=true
+    depends_lib-append      port:nodejs13
+}
+
+variant nodejs14    conflicts nodejs12 nodejs13 \
+                    description {If you plan to run in Node.js (v14) environment} {
+    configure.args-append   -DEnableNodeJS=true
+    depends_lib-append      port:nodejs14
+}


### PR DESCRIPTION
#### Description

API and toolkit for handling BAM files

- with the option to use this in a node.js environment, I also
  added variants for the 3 latest versions: nodejs{12..14}
- Closes: https://trac.macports.org/ticket/41590

###### Type(s)

- [x] submission

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vsd install`,
      and `sudo port upgrade --enforce-variants bamtools +nodejs14`
