### PR TITLE
py-zlmdb: do not export the flatbuffers library out of the zlmdb libr…

### DIFF
--- a/python/py-zlmdb/Portfile
+++ b/python/py-zlmdb/Portfile
@@ -23,6 +23,13 @@ checksums           rmd160  e21331af67be04b87e9cce9930cf845fccf412d6 \
 
 python.versions     38
 
+# Patches:
+#
+#   patch-setup.py.diff:
+#   - do not hardcode numpy to a single hard-coded version number
+#   - do not export the flatbuffers library out of the zlmdb library, we should
+#     use the actual flatbuffers library instead
+#
 patchfiles          patch-setup.py.diff
 
 if {${name} ne ${subport}} {
@@ -33,6 +40,7 @@ if {${name} ne ${subport}} {
     depends_lib-append \
                     port:py${python.version}-cbor2 \
                     port:py${python.version}-click \
+                    port:py${python.version}-flatbuffers \
                     port:py${python.version}-lmdb \
                     port:py${python.version}-numpy \
                     port:py${python.version}-pynacl \

--- a/python/py-zlmdb/files/patch-setup.py.diff
+++ b/python/py-zlmdb/files/patch-setup.py.diff
@@ -1,5 +1,5 @@
---- setup.py.orig	2020-08-16 11:12:59.000000000 -0400
-+++ setup.py	2020-08-16 11:13:10.000000000 -0400
+--- setup.py	2020-08-16 16:19:47.000000000 -0400
++++ setup.py	2020-08-16 16:21:16.000000000 -0400
 @@ -51,7 +51,7 @@
      'pynacl>=1.3.0',
      'pyyaml>=5.3',
@@ -9,3 +9,11 @@
  ]
  
  setup_requirements = ['pytest-runner', ]
+@@ -59,7 +59,6 @@
+ test_requirements = ['pytest', ]
+ 
+ packages = [
+-    'flatbuffers',
+     'zlmdb',
+     'zlmdb.flatbuffers',
+     'zlmdb.flatbuffers.demo',


### PR DESCRIPTION
…ary; use the actual, official flatbuffers library instead

~This won't build until https://github.com/macports/macports-ports/pull/8118 is in, and will need to be rebased once it is.~

`py-zlmdb` is telling Python that _it_ is the provider for the Python `flatbuffers` library, exporting its vendored copy as the `flatbuffers` package.

This change removes the `flatbuffers` package from being provided by `py-zlmdb`, and instead adds the port for `py-flatbuffers` as a dependency proper. 

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
