### PR TITLE
meson: don't run reinplace on directories

### DIFF
--- a/devel/meson/Portfile
+++ b/devel/meson/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 
 github.setup        mesonbuild meson 0.55.1
 
-revision            0
+revision            1
 
 github.tarball_from releases
 license             Apache-2
@@ -72,7 +72,9 @@ post-destroot {
     copy ${filespath}/cross ${destroot}${prefix}/share/meson/
 
     fs-traverse f ${destroot}${prefix}/share/meson/cross/ {
-        reinplace "s|@@PREFIX@@|${prefix}|g" ${f}
+        if ![file isdirectory ${f}] {
+            reinplace "s|@@PREFIX@@|${prefix}|g" ${f}
+        }
     }
 }
 


### PR DESCRIPTION
only the cross files.

I did not notice that it was running the reinplace on the directory files, sorry. Minor thing, really, but it leaves cruft behind.

three updates to meson in one day is kind of stupid, to be honest.