### PR TITLE
cgit: update dependencies

### DIFF
--- a/www/cgit/Portfile
+++ b/www/cgit/Portfile
@@ -1,13 +1,16 @@
-# -*- mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
 
 name                cgit
 version             1.2.3
+revision            1
 
 # See Makefile GIT_VER
 set git_version     2.25.1
+
 categories          www devel
+platforms           darwin
 license             GPL-2
 maintainers         nomaintainer
 
@@ -19,8 +22,6 @@ long_description    cgit is an attempt to create a fast web interface for the Gi
 homepage            https://git.zx2c4.com/cgit/
 master_sites        ${homepage}snapshot:cgit \
                     https://www.kernel.org/pub/software/scm/git:git
-
-platforms           darwin
 
 dist_subdir         git
 use_xz              yes
@@ -40,12 +41,18 @@ checksums           ${cgit_distfile} \
                     size    5875548
 
 # Patch for memrch: https://trac.macports.org/ticket/60967
-patchfiles          patch-add-memrchr.diff
+patchfiles          patch-add-memrchr.diff \
+                    patch-config-mak-uname.diff
 
-depends_lib         port:git \
-                    path:lib/libssl.dylib:openssl \
-                    port:zlib \
-                    port:libiconv
+depends_lib         port:libiconv \
+                    port:zlib
+
+depends_run         path:lib/libssl.dylib:openssl \
+                    port:bzip2 \
+                    port:git \
+                    port:lzip \
+                    port:xz \
+                    port:zstd
 
 post-extract {
     delete ${worksrcpath}/git

--- a/www/cgit/files/patch-config-mak-uname.diff
+++ b/www/cgit/files/patch-config-mak-uname.diff
@@ -1,0 +1,11 @@
+--- ./git/config.mak.uname.orig 2020-08-18 05:34:19.000000000 +0200
++++ ./git/config.mak.uname	2020-08-18 05:43:50.000000000 +0200
+@@ -133,8 +133,6 @@
+	HAVE_BSD_SYSCTL = YesPlease
+	FREAD_READS_DIRECTORIES = UnfortunatelyYes
+	HAVE_NS_GET_EXECUTABLE_PATH = YesPlease
+-	BASIC_CFLAGS += -I/usr/local/include
+-	BASIC_LDFLAGS += -L/usr/local/lib
+ endif
+ ifeq ($(uname_S),SunOS)
+	NEEDS_SOCKET = YesPlease


### PR DESCRIPTION
#### Description

In the latest version of CGit they have added support for: `lz, xz, zstd` [»»»](https://git.zx2c4.com/cgit/log/)

By replacing `zlib` and `libiconv` with `libarchive` and `lzip`… CGit will get full support for all the new archive types, incl the replaced dependencies. It'll also make sure `zx` and `zstd` is not on the system as a runtime– &/or extract dependency through another port.

```bash
$ grep Library <(port deps libarchive)
Library Dependencies: bzip2, zlib, libxml2, xz, lzo2, libiconv, lz4, zstd
```

###### Type(s)

- [x] enhancement

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vsd install`?

###### Notes

I bumped the revision, but perhaps it's not needed?