### PR TITLE
nsis: use version from variable

### DIFF
--- a/devel/nsis/Portfile
+++ b/devel/nsis/Portfile
@@ -26,11 +26,11 @@ use_bzip2           yes
 distfiles-append    nsis-${version}.zip
 extract.only-delete nsis-${version}.zip
 
-checksums           nsis-3.06.1-src.tar.bz2 \
+checksums           nsis-${version}-src.tar.bz2 \
                     rmd160  7673c3097e03fb9b812836a896d00a437034ab55 \
                     sha256  9b5d68bf1874a7b393432410c7e8c376f174d2602179883845d2508152153ff0 \
                     size    1771333 \
-                    nsis-3.06.1.zip \
+                    nsis-${version}.zip \
                     rmd160  3a291267bfd93fd0cd9c6bfe49ea22bcafcc7491 \
                     sha256  d463ad11aa191ab5ae64edb3a439a4a4a7a3e277fcb138254317254f7111fba7 \
                     size    2326512


### PR DESCRIPTION
I was wondering whether there's a specific reason for using a hardcoded version string in the checksum block, when the version variable could be used. There hasn't been a single case, where the file-names used a different naming-scheme.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
