### PR TITLE
kubeseal: new port

### DIFF
--- a/sysutils/kubeseal/Portfile
+++ b/sysutils/kubeseal/Portfile
@@ -1,40 +1,37 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
 PortGroup           github 1.0
 
 name                kubeseal
-version             0.12.5
-
-description         Kubernetes tool for one-way encrypted Secrets
-long_description    CLI for {*}${description}
-homepage            https://github.com/bitnami-labs/sealed-secrets
-
 github.setup        bitnami-labs sealed-secrets 0.12.5 v
+revision            0
 categories          sysutils
 platforms           darwin
 supported_archs     x86_64
 license             Apache-2
+
+description         Kubernetes tool for one-way encrypted Secrets
+long_description    CLI for {*}${description}
 
 maintainers         @tux-o-matic \
                     openmaintainer
 
 github.tarball_from releases
 distfiles           kubeseal-darwin-amd64
+dist_subdir         ${name}/${version}
 
-
-checksums           kubeseal-darwin-amd64 \
-                    rmd160  436086b254cb2ec8f40d4a8e8321108d52b09d1d \
+checksums           rmd160  436086b254cb2ec8f40d4a8e8321108d52b09d1d \
                     sha256  238a1d290f80527ead1c521e0bb01d42df6e025fdcd711c5d30a039bc4d6c2fd \
                     size    34790936
 
 use_configure       no
 
-build {
-}
+build {}
+
 destroot {
     xinstall ${distpath}/kubeseal-darwin-amd64 \
              ${destroot}${prefix}/bin/kubeseal
 }
 
-
-github.livecheck.regex  {([\d\.]+)}
+github.livecheck.regex  {([\d.]+)}

--- a/sysutils/kubeseal/Portfile
+++ b/sysutils/kubeseal/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+PortSystem          1.0
+PortGroup           github 1.0
+
+name                kubeseal
+version             0.12.5
+
+description         Kubernetes tool for one-way encrypted Secrets
+long_description    CLI for {*}${description}
+homepage            https://github.com/bitnami-labs/sealed-secrets
+
+github.setup        bitnami-labs sealed-secrets 0.12.5 v
+categories          sysutils
+platforms           darwin
+supported_archs     x86_64
+license             Apache-2
+
+maintainers         @tux-o-matic \
+                    openmaintainer
+
+github.tarball_from releases
+distfiles           kubeseal-darwin-amd64
+
+
+checksums           kubeseal-darwin-amd64 \
+                    rmd160  436086b254cb2ec8f40d4a8e8321108d52b09d1d \
+                    sha256  238a1d290f80527ead1c521e0bb01d42df6e025fdcd711c5d30a039bc4d6c2fd \
+                    size    34790936
+
+use_configure       no
+
+build {
+}
+destroot {
+    xinstall ${distpath}/kubeseal-darwin-amd64 \
+             ${destroot}${prefix}/bin/kubeseal
+}
+
+
+github.livecheck.regex  {([\d\.]+)}


### PR DESCRIPTION
#### Description

CLI for Sealed Secrets.

###### Tested on
macOS 10.15.5 19F101

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port install`?
- [x] tested basic functionality of all binary files?
