### PR TITLE
clib: new port

### DIFF
--- a/devel/clib/Portfile
+++ b/devel/clib/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           makefile 1.0
+
+github.setup        clibs clib 2.1.13
+
+categories          devel
+license             MIT
+platforms           darwin linux
+
+homepage            https://www.clibs.org
+
+description         Package manager for the C programming language.
+
+long_description    {*}${description} Basically the lazy-man’s copy/paste \
+                    promoting smaller C utilities, also serving as a nice way \
+                    to discover these sort of libraries. The goal of clibs is \
+                    to provide stand-alone “micro” C libraries for developers \
+                    to quickly install without coupling to large frameworks. \
+                    You should use clib(1) to fetch these files for you and \
+                    check them into your repository, the end-user and \
+                    contributors should not require having clib(1) installed. \
+                    This allows clib(1) to fit into any new or existing C \
+                    workflow without friction.
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  472d543ea3bb4646bafd77dbda53cfa142849e18 \
+                    sha256  502db9fa5876aa03580f492dbba55f0259b0d23da1eac79129c7157b345e8fbe \
+                    size    166649
+
+makefile.has_destdir no


### PR DESCRIPTION
New port for the [clib](https://www.clibs.org/) "package manager".

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
