### PR TITLE
db*: disable livecheck

### DIFF
--- a/databases/db46/Portfile
+++ b/databases/db46/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 PortGroup  muniversal 1.0
 
@@ -144,7 +146,7 @@ if {$subport == $name} {
     }
 
     variant compat185 description {build with db185 compatibility mode} {
-	configure.args-append	--enable-compat185
+        configure.args-append   --enable-compat185
     }
 } else {
     # There is no Java specific install target, so delete everything
@@ -188,6 +190,4 @@ if { [variant_isset universal] } {
     }
 }
 
-livecheck.type  regex
-livecheck.url   http://www.oracle.com/technetwork/database/berkeleydb/downloads/index-082944.html
-livecheck.regex {(4\.6(?:\.\d+)*)\.tar\.gz}
+livecheck.type  none

--- a/databases/db47/Portfile
+++ b/databases/db47/Portfile
@@ -122,6 +122,4 @@ if { [variant_isset universal] } {
     }
 }
 
-livecheck.type  regex
-livecheck.url   http://www.oracle.com/technetwork/database/berkeleydb/downloads/index-082944.html
-livecheck.regex {(4\.7(?:\.\d+)*)\.tar\.gz}
+livecheck.type  none

--- a/databases/db48/Portfile
+++ b/databases/db48/Portfile
@@ -98,6 +98,4 @@ if { [variant_isset universal] } {
     }
 }
 
-livecheck.type  regex
-livecheck.url   http://www.oracle.com/technetwork/database/berkeleydb/downloads/index-082944.html
-livecheck.regex {(4\.8(?:\.\d+)*)\.tar\.gz}
+livecheck.type  none

--- a/databases/db53/Portfile
+++ b/databases/db53/Portfile
@@ -117,6 +117,4 @@ if { [variant_isset universal] } {
     }
 }
 
-livecheck.type  regex
-livecheck.url   http://www.oracle.com/technetwork/database/berkeleydb/downloads/index-082944.html
-livecheck.regex {(5\.3(?:\.\d+)*)\.tar\.gz}
+livecheck.type  none

--- a/databases/db60/Portfile
+++ b/databases/db60/Portfile
@@ -112,6 +112,4 @@ if { [variant_isset universal] } {
     }
 }
 
-livecheck.type  regex
-livecheck.url   http://www.oracle.com/technetwork/database/berkeleydb/downloads/index-082944.html
-livecheck.regex {(6\.0(?:\.\d+)*)\.tar\.gz}
+livecheck.type  none

--- a/databases/db62/Portfile
+++ b/databases/db62/Portfile
@@ -111,6 +111,4 @@ if { [variant_isset universal] } {
     }
 }
 
-livecheck.type  regex
-livecheck.url   http://www.oracle.com/technetwork/database/berkeleydb/downloads/index-082944.html
-livecheck.regex {(6\.2(?:\.\d+)*)\.tar\.gz}
+livecheck.type  none


### PR DESCRIPTION
Oracle no longer maintains these versions of Berkeley DB and
have removed them from their Open Source software index. Download
still works for now for the current versions (if you know the URL)
but attempting to access livecheck.url returns 404 leading to
"regex doesn't match."

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.6 11E708 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
