### PR TITLE
xorg-libxcb: mark Python as non-conflicting

### DIFF
--- a/x11/xorg-libxcb/Portfile
+++ b/x11/xorg-libxcb/Portfile
@@ -61,21 +61,25 @@ variant docs description "Install extra documentation" {
 
 variant python35 conflicts python36 python37 python38 description {Use python 3.5} {
     depends_build-append    port:python35
+    license_noconflict      python35
     configure.python        ${prefix}/bin/python3.5
 }
 
 variant python36 conflicts python35 python37 python38 description {Use python 3.6} {
     depends_build-append    port:python36
+    license_noconflict      python36
     configure.python        ${prefix}/bin/python3.6
 }
 
 variant python37 conflicts python35 python36 python38 description {Use python 3.7} {
     depends_build-append    port:python37
+    license_noconflict      python37
     configure.python        ${prefix}/bin/python3.7
 }
 
 variant python38 conflicts python35 python36 python37 description {Use python 3.8} {
     depends_build-append    port:python38
+    license_noconflict      python38
     configure.python        ${prefix}/bin/python3.8
 }
 


### PR DESCRIPTION
#### Description

AFAICT this is just a build dependency, isn't it? Without this, GPL ports that depend on X11 won't get binary archives.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
