### PR TITLE
py-git-review: new port

### DIFF
--- a/python/py-git-review/Portfile
+++ b/python/py-git-review/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-git-review
+version             1.28.0
+platforms           darwin
+license             Apache-2
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+description         Tool to submit code to Gerrit
+long_description    {*}${description}
+
+homepage            http://docs.openstack.org/infra/git-review/
+
+checksums           rmd160  16e673e3c2eafc2b7b0ce0dcf216611a723f9390 \
+                    sha256  8e3aabb7b9484063e49c2504d137609401e32ad5128ff2a5cf43e98d5d3dc15a \
+                    size    60496
+
+python.versions     38
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-pbr \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-requests \
+                    port:py${python.version}-six
+}


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
