### PR TITLE
z3: add sub-port py38-z3

### DIFF
--- a/math/z3/Portfile
+++ b/math/z3/Portfile
@@ -219,7 +219,7 @@ subport ${name}-fstar {
     }
 }
 
-set pyversions {27 37}
+set pyversions {27 37 38}
 
 # Create a top-level Python binding metaport
 subport py-${name} {


### PR DESCRIPTION
#### Description

Add new sub-port py38-z3.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G6020
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

`port lint` has exactly the same issues with and without this (trivial) patch and should likely be fixed by a separate patch by someone more knowledgeable about Portfiles.

There are no defined tests for the Python wrapper.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
