### PR TITLE
dovecot: update to 2.3.11.3

### DIFF
--- a/mail/dovecot/Portfile
+++ b/mail/dovecot/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 github.setup        dovecot core 2.3.11.3
 name                dovecot
 revision            0
-epoch               20060723
+epoch               20060722
 set core_version    ${version}
 
 categories          mail

--- a/mail/dovecot/Portfile
+++ b/mail/dovecot/Portfile
@@ -3,10 +3,10 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        dovecot core 2.3.10.1
+github.setup        dovecot core 2.3.11.3
 name                dovecot
 revision            0
-epoch               20060722
+epoch               20060723
 set core_version    ${version}
 
 categories          mail
@@ -21,12 +21,12 @@ long_description    Dovecot is an IMAP and POP3 server for Linux/UNIX-like\
                     it is written in C, it uses several coding techniques to\
                     avoid most of the common pitfalls.
 
-checksums           rmd160  8391e5111ca11a20ba8bfe3b1102ecb770d151bb \
-                    sha256  c0f2b73ddf462988acd13ede66dc64dc53766992a06b9399514109b9cf272f08 \
-                    size    3736583
+checksums           rmd160  78920585b85a6ff582711f4d3b1ea9be9254197f \
+                    sha256  242ecbf563b07ce9c5201464f1d0c42ec0df8511de0eda46129b6c42d5b97fe2 \
+                    size    3815047
 
 subport ${name}-sieve {
-    github.setup    dovecot pigeonhole 0.5.10
+    github.setup    dovecot pigeonhole 0.5.11
     revision        0
 
     description     Pigeonhole sieve and managesieve plugins for dovecot
@@ -67,9 +67,9 @@ subport ${name}-sieve {
 
     distname        dovecot-${core_version}-pigeonhole-${version}
 
-    checksums       rmd160  e5a00a86aefb7cb6a4bef42ff65e7bac7e6f414c \
-                    sha256  9769d9fb14fed571deb4994a21c2c0ac3a1c9ab7f0d1bd115fdaba75e36f555b \
-                    size    1044145
+    checksums       rmd160  410524bb4a11c592e1c641453d285804d1216b64 \
+                    sha256  b900eadbd53119032a86dc04284ee82e96a4bd8f5e57cf658451feda9808c5bf \
+                    size    1044337
 
     depends_lib-append \
                     port:${name} \


### PR DESCRIPTION
* Update to version 2.3.11.3
* Also update dovecot pigeonhole to 0.5.11

#### Description

Update dovecot to 2.3.11.3. Also update dovecot-sieve to dovecot pigeonhole to 0.5.11.

This fixes several security issues, e.g. CVE-2020-12100

###### Type(s)
- [X] security fix

###### Tested on
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
