### PR TITLE
unbound: enable support for dnscrypt, dnstap

### DIFF
--- a/net/unbound/Portfile
+++ b/net/unbound/Portfile
@@ -5,6 +5,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                unbound
 version             1.11.0
+revision            1
 categories          net
 license             BSD
 maintainers         {snc @nerdling} openmaintainer
@@ -13,8 +14,11 @@ description         Validating, recursive, and caching DNS resolver.
 
 homepage            https://nlnetlabs.nl/projects/unbound/
 platforms           darwin
+
 depends_build       port:flex
-depends_lib         path:lib/libssl.dylib:openssl port:expat
+depends_lib         path:lib/libssl.dylib:openssl \
+                    port:libsodium \
+                    port:expat
 
 set unbounduser     unbound
 set unboundgroup    unbound
@@ -38,7 +42,10 @@ checksums           rmd160  ead50566c56158b95f78ae26bc412e535cadc298 \
 configure.args-append   --with-pidfile=${prefix}/var/run/${name}/${name}.pid \
                         --with-ssl=${prefix} \
                         --with-rootkey-file=${prefix}/etc/${name}/root.key \
-                        --with-libexpat=${prefix}
+                        --with-libexpat=${prefix} \
+                        --with-libsodium=${prefix} \
+                        --enable-dnscrypt \
+                        --disable-dsa
 
 if {${os.major} == 10} {
     compiler.blacklist  *llvm-gcc-4.2 *gcc-4.0 gcc-3.3 clang
@@ -47,6 +54,12 @@ if {${os.major} == 10} {
 variant libevent description {Build with libevent (slower, but allows use of large outgoing port ranges)} {
     depends_lib-append      port:libevent
     configure.args-append   --with-libevent=${prefix}
+}
+
+variant dnstap description {Enable dnstap support (a binary log format for DNS software)} {
+    depends_lib-append      port:protobuf-c
+    configure.args-append   --enable-dnstap \
+                            --with-protobuf-c=${prefix}
 }
 
 test.run            yes
@@ -79,3 +92,7 @@ startupitem.stop	"(/bin/kill \$(cat ${prefix}/var/run/${name}/unbound.pid) 2>&1)
 startupitem.pidfile	clean ${prefix}/var/run/${name}/${name}.pid
 
 notes-append        "An example configuration is provided at ${prefix}/etc/${name}/${name}.conf-dist."
+
+livecheck.type      regex
+livecheck.url       ${homepage}about/
+livecheck.regex     {>Unbound ([0-9.]+)<}


### PR DESCRIPTION
#### Description

  - Enable support for dnscrypt, dnstap
  - Add variant for dnstap
  - Disable dsa

###### Type(s)

- [x] enhancement

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vsd install`?