### PR TITLE
microplane: new port

### DIFF
--- a/devel/microplane/Portfile
+++ b/devel/microplane/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/Clever/microplane 0.0.23 v
+
+categories          devel
+license             Apache-2
+platforms           darwin
+
+description         A CLI tool to make git changes across many repos, \
+                    especially useful with Microservices.
+
+long_description    {*}${description}
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  3ed48f7a0b5d61187a390c640a1baae3008ba2f4 \
+                    sha256  2be8ba65d0ac5a5616d3a895d6f622f65606f9a322f07c9ba8948204b5f88dd0 \
+                    size    30223
+
+depends_build-append \
+                    port:dep
+
+build.cmd           make
+build.target        install_deps build
+use_parallel_build  no
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/bin/mp ${destroot}${prefix}/bin/
+
+    set mp_doc_dir ${prefix}/share/doc/${name}
+
+    xinstall -d -m 755 ${destroot}${mp_doc_dir}
+    copy {*}[glob ${worksrcpath}/docs/*] ${destroot}${mp_doc_dir}/
+}


### PR DESCRIPTION
#### Description

New port for [microplane](https://github.com/Clever/microplane)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
