### PR TITLE
bd: new port

### DIFF
--- a/sysutils/bd/Portfile
+++ b/sysutils/bd/Portfile
@@ -1,0 +1,53 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+# Using the latest commit, since there was
+# a fix for Mac OSX after the release.
+github.setup        vigneshwaranr bd c497fe7d
+
+version             1.0.2
+revision            0
+
+categories          sysutils
+platforms           darwin
+supported_archs     noarch
+license             MIT
+maintainers         nomaintainer
+
+description         a tool to cd into parent directories, instead of ../../.., etc
+long_description    Quickly go back to a specific parent directory in bash \
+                    instead of typing \"cd ../../..\" redundantly.
+
+checksums           rmd160  7c65faa1995763309454b2ab5e879aa150af9697 \
+                    sha256  37e72b32d8dcb65951c7239a1c665fcd9efee144299405621b65c42ecfd2caaa \
+                    size    143089
+
+depends_lib-append  port:bash-completion
+
+use_configure       no
+build {}
+
+destroot {
+    set bash_completion ${destroot}/${prefix}/share/bash-completion/completions
+    set completion_dir  ${prefix}/share/${name}/completion
+    set doc_dir         ${destroot}${prefix}/share/doc/${name}
+
+    xinstall -d -m 755  ${bash_completion} ${destroot}${completion_dir} ${doc_dir}/screenshot
+    xinstall -m 755     ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}
+    xinstall -m 644     ${worksrcpath}/bash_completion.d/${name} ${destroot}${completion_dir}
+    xinstall -m 644     ${worksrcpath}/screenshot/${name}.png ${doc_dir}/screenshot
+    xinstall -m 644 -W  ${worksrcpath} LICENSE README.md ${doc_dir}
+
+    ln -s ${completion_dir}/${name} ${bash_completion}/${name}
+}
+
+notes "
+If this is a new install... To complete the installation,\
+add this alias to your bash file:
+
+    alias bd='. bd -si'
+
+Read more: ${prefix}/share/doc/${name}/README.md
+"


### PR DESCRIPTION
#### Description

[`bd`][gh] is a simple tool to `cd` into parent directories, instead of using `../../..`, etc.

I've been using it for quite some time now. It's really an easy and convenient tool - especially for our sometimes long deep paths in MacPorts.

```bash
# Example:
$ pwd
/opt/local/var/macports/sources/github.com/macports/macports-ports/

# bd m + [TAB] expands to macports
$ bd macports
/opt/local/var/macports/
```

[gh]: https://github.com/vigneshwaranr/bd

###### Type(s)

- [x] submission

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vsd install`?
- [x] tested basic functionality of all binary files?