### PR TITLE
libgit2: update to 1.0.1

### DIFF
--- a/devel/libgit2/Portfile
+++ b/devel/libgit2/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake 1.1
 PortGroup           legacysupport 1.0
 
 # don't forget to update py-pygit2 and libgit2-glib as well
-github.setup        libgit2 libgit2 0.28.5 v
+github.setup        libgit2 libgit2 1.0.1 v
 revision            0
 epoch               1
 categories          devel
@@ -24,9 +24,9 @@ long_description    libgit2 is a portable, pure C implementation of the \
 
 homepage            https://libgit2.org/
 
-checksums           rmd160  1f974a955bb153e81617ffc07938e8ae088e6441 \
-                    sha256  7cd398cdb55961be529b5ae2034952693165dfa06e9ebc9e87ebf0d773629d0d \
-                    size    4992907
+checksums           rmd160  3f9ced0e0dff170a8156e4aa8fcb0abce66c8f60 \
+                    sha256  5dae7cb32b6977cd95ed849d24f3692f0b7e9eb9b0ee9ffaa14baebb9cac76e1 \
+                    size    5304918
 
 depends_build-append \
                     port:pkgconfig


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/60998

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
