### PR TITLE
org-mode: Avoid literal tab in reinplace

### DIFF
--- a/editors/org-mode/Portfile
+++ b/editors/org-mode/Portfile
@@ -30,7 +30,7 @@ depends_build       port:texinfo
 
 configure {
     system -W ${worksrcpath} "make local.mk"
-    reinplace "s|EMACS	= emacs|EMACS	= ${emacs_binary}|g" ${worksrcpath}/local.mk
+    reinplace "/^EMACS\[\[:space:\]\]*=/s|emacs|${emacs_binary}|g" ${worksrcpath}/local.mk
 }
 
 destroot.destdir    prefix=${destroot}${prefix}/share


### PR DESCRIPTION
#### Description

Rewrite reinplace to avoid using a literal tab character, to avoid a new lint warning in MacPorts 2.6.99.

See: macports/macports-base@24d3bd4