### PR TITLE
giflib: disable x11 variant by default

### DIFF
--- a/graphics/giflib/Portfile
+++ b/graphics/giflib/Portfile
@@ -48,7 +48,7 @@ if {![variant_isset doc]} {
     patchfiles-append           patch-no-docs.diff
 }
 
-variant x11 description Include X11 tool for displaying GIF files {
+variant x11 description {Include gif2x11 tool for displaying GIF files in an X window} {
     depends_lib-append          port:xorg-libsm \
                                 port:xorg-libX11
     

--- a/graphics/giflib/Portfile
+++ b/graphics/giflib/Portfile
@@ -48,13 +48,11 @@ if {![variant_isset doc]} {
     patchfiles-append           patch-no-docs.diff
 }
 
-variant x11 {
+variant x11 description Include X11 tool for displaying GIF files {
     depends_lib-append          port:xorg-libsm \
                                 port:xorg-libX11
     
     configure.args-delete       --disable-x11
 }
-
-default_variants +x11
 
 livecheck.regex                 /${name}-(${major}\\.\[0-9.\]+)${extract.suffix}


### PR DESCRIPTION
AFAICT this just includes a single small tool, not likely to be terribly useful for most users. X11 is rather large dependency to pull in…

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
