### PR TITLE
KeePassXC: update to version 2.6.1

### DIFF
--- a/security/KeePassXC/Portfile
+++ b/security/KeePassXC/Portfile
@@ -20,7 +20,7 @@ platforms               darwin
 license                 GPL-2+
 license_noconflict      openssl
 
-github.setup            keepassxreboot keepassxc 2.6.0
+github.setup            keepassxreboot keepassxc 2.6.1
 github.tarball_from     releases
 distname                keepassxc-${version}-src
 use_xz                  yes
@@ -28,12 +28,12 @@ distfiles-append        ${distname}${extract.suffix}.sig
 
 # See keepassxc-${version}-src.tar.xz.DIGEST on upstream GitHub releases page for SHA256 sums
 checksums               ${distname}${extract.suffix} \
-                        rmd160  edeb9d4f61a7af05da46577242bf9307e2003c34 \
-                        sha256  d0d23d97a73ac1cbf59bfca2f5d1506ae36dfcd4fbfb4225efe19931f035fd3a \
-                        size    5628800 \
+                        rmd160  9991c0fc9251cf9d9e144877d3e581e7e599d05c \
+                        sha256  b466759947fcd71a59b8d498a1f154cb7b85b4f2a0a417c92a75845d8bac8cc8 \
+                        size    5715948 \
                         ${distname}${extract.suffix}.sig \
-                        rmd160  28f39119f9da098268cfd3c8e0970609daa29adb \
-                        sha256  49fba6442d484389803c66ae2fb8da7cc80b8eb17bc29a4f47599f865efa3c91 \
+                        rmd160  3d6866b726c37dc0fac03e2680b19b3c6f14d40b \
+                        sha256  0fa18ed84c90a0ca95636668e7a1b900e50b5636d37a6be05580f7880222d174 \
                         size    488
 
 gpg_verify.use_gpg_verification \


### PR DESCRIPTION
#### Description

* update to version 2.6.1
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G6020
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
