### PR TITLE
p5-dbd-mariadb: new port

### DIFF
--- a/perl/p5-dbd-mariadb/Portfile
+++ b/perl/p5-dbd-mariadb/Portfile
@@ -1,0 +1,73 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.branches      5.26 5.28 5.30
+perl5.setup         DBD-MariaDB 1.21
+
+categories-append   sysutils www
+platforms           darwin
+license             {Artistic-1 GPL}
+maintainers         nomaintainer
+
+description         Perl DBI driver for access to MariaDB and MySQL databases
+long_description    DBD::MariaDB is the Perl5 Database Interface driver for MariaDB \
+                    and MySQL databases. In other words: DBD::MariaDB is an interface \
+                    between the Perl programming language and the MariaDB/MySQL \
+                    programming API that comes with the MariaDB/MySQL relational \
+                    database management system. Most functions provided by this \
+                    programming API are supported. Some rarely used functions are \
+                    missing, mainly because no-one ever requested them.
+
+checksums           rmd160  19ea4294350baab350492b72197b1882c793798d \
+                    sha256  f5972b337a0d1d4726b2471eb79f23ee0cdd034bf43f4e13f2b5162597271419 \
+                    size    179911
+
+if {${perl5.major} != ""} {
+    # use Time::HiRes 1.9739+ for Sierra compatibility
+    depends_build-append \
+                    port:p${perl5.major}-devel-checklib \
+                    port:p${perl5.major}-test-deep \
+                    port:p${perl5.major}-time-hires
+
+    depends_lib-append \
+                    port:p${perl5.major}-dbi
+
+    variant mariadb10_1 conflicts mariadb10_2 mariadb10_3 mariadb10_4 mariadb10_5 \
+                        description {Build with mariadb-10.1 port} {
+        depends_lib-append      port:mariadb-10.1
+        # There's no mariadb_config in mentioned in 10.1, use mysql_config
+        configure.args-append   --mariadb_config=${prefix}/lib/mariadb-10.1/bin/mysql_config
+    }
+
+    variant mariadb10_2 conflicts mariadb10_1 mariadb10_3 mariadb10_4 mariadb10_5 \
+                        description {Build with mariadb-10.2 port} {
+        depends_lib-append      port:mariadb-10.2
+        configure.args-append   --mariadb_config=${prefix}/lib/mariadb-10.2/bin/mariadb_config
+    }
+
+    variant mariadb10_3 conflicts mariadb10_1 mariadb10_2 mariadb10_4 mariadb10_5 \
+                        description {Build with mariadb-10.3 port} {
+        depends_lib-append      port:mariadb-10.3
+        configure.args-append   --mariadb_config=${prefix}/lib/mariadb-10.3/bin/mariadb_config
+    }
+
+    variant mariadb10_4 conflicts mariadb10_1 mariadb10_2 mariadb10_3 mariadb10_5 \
+                        description {Build with mariadb-10.4 port} {
+        depends_lib-append      port:mariadb-10.4
+        configure.args-append   --mariadb_config=${prefix}/lib/mariadb-10.4/bin/mariadb_config
+    }
+
+    variant mariadb10_5 conflicts mariadb10_1 mariadb10_2 mariadb10_3 mariadb10_4 \
+                        description {Build with mariadb-10.5 port} {
+        depends_lib-append      port:mariadb-10.5
+        configure.args-append   --mariadb_config=${prefix}/lib/mariadb-10.5/bin/mariadb_config
+    }
+
+    if {![variant_isset mariadb10_1] && ![variant_isset mariadb10_2] &&
+        ![variant_isset mariadb10_3] && ![variant_isset mariadb10_4] &&
+        ![variant_isset mariadb10_5]} {
+        default_variants +mariadb10_5
+    }
+}


### PR DESCRIPTION
#### Description

[DBD-MariaDB](https://metacpan.org/release/DBD-MariaDB)

> “This is the Perl DBI driver for access to MariaDB and MySQL databases.
>
> The goal of our effort was to fix MariaDB compatibility, Perl Unicode support and security related bugs.
>
> This Perl DBI driver is a fork of the DBD::mysql driver and was created because said issues in the original DBD::mysql have not been addressed for more than a year.”
> _— [README.pod](https://metacpan.org/pod/distribution/DBD-MariaDB/README.pod)_

—

I saw that the bundled version of `mytop` was updated (1.9.1 -> 1.99) in `mariadb-10.5`, and noticed they're using a new DBD. This port is for that one.

As mention [here](https://github.com/MariaDB/server/commit/5cc2096f#diff-e90d6da0): _“Perl DBD::MariaDB driver is available CPAN and is already used in production environment.”_

The Portfile is based on `p5-bdb-mysql`, but I've cleaned out the mysql/percona variants and adjusted the values/parameters.


###### Type(s)

- [x] submission


###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vsd install`?
- [x] tested basic functionality of all binary files?
