### PR TITLE
libraw: fix patch fuzz and offset

### DIFF
--- a/graphics/libraw/files/patch-libraw-no-libstdcxx.diff
+++ b/graphics/libraw/files/patch-libraw-no-libstdcxx.diff
@@ -1,13 +1,11 @@
-diff --git Makefile.dist Makefile.dist
-index cb2f159..3605b94 100644
---- Makefile.dist
-+++ Makefile.dist
-@@ -81,10 +81,10 @@ bin/mem_image: lib/libraw.a samples/mem_image.cpp
- 	${CXX} -DLIBRAW_NOTHREADS  ${CFLAGS} -o bin/mem_image samples/mem_image.cpp -L./lib -lraw  -lm  ${LDADD}
+--- Makefile.dist.orig	2020-08-21 04:29:19.000000000 +0200
++++ Makefile.dist	2020-08-21 04:32:30.000000000 +0200
+@@ -159,10 +159,10 @@
+ 	${CXX} -DLIBRAW_NOTHREADS  ${CFLAGS} -o bin/mem_image samples/mem_image_sample.cpp -L./lib -lraw  -lm  ${LDADD}
  
  bin/dcraw_half: lib/libraw.a object/dcraw_half.o
 -	${CC} -DLIBRAW_NOTHREADS  ${CFLAGS} -o bin/dcraw_half object/dcraw_half.o -L./lib -lraw  -lm -lstdc++  ${LDADD}
-+	${CC} -DLIBRAW_NOTHREADS  ${CFLAGS} -o bin/dcraw_half object/dcraw_half.o -L./lib -lraw  -lm ${LDADD}
++	${CC} -DLIBRAW_NOTHREADS  ${CFLAGS} -o bin/dcraw_half object/dcraw_half.o -L./lib -lraw  -lm  ${LDADD}
  
  bin/half_mt: lib/libraw_r.a object/half_mt.o
 -	${CC}   -pthread ${CFLAGS} -o bin/half_mt object/half_mt.o -L./lib -lraw_r  -lm -lstdc++  ${LDADD}
@@ -15,8 +13,6 @@ index cb2f159..3605b94 100644
  
  bin/dcraw_emu: lib/libraw.a samples/dcraw_emu.cpp
  	${CXX} -DLIBRAW_NOTHREADS  ${CFLAGS} -o bin/dcraw_emu samples/dcraw_emu.cpp -L./lib -lraw  -lm  ${LDADD}
-diff --git libraw.pc.in libraw.pc.in
-index 0e530b2..9844828 100644
 --- libraw.pc.in
 +++ libraw.pc.in
 @@ -7,5 +7,5 @@ Name: libraw
@@ -26,8 +22,6 @@ index 0e530b2..9844828 100644
 -Libs: -L${libdir} -lraw -lstdc++@PC_OPENMP@
 +Libs: -L${libdir} -lraw @PC_OPENMP@
  Cflags: -I${includedir}/libraw -I${includedir}
-diff --git libraw_r.pc.in libraw_r.pc.in
-index a7f4535..cf48381 100644
 --- libraw_r.pc.in.orig	2020-07-23 04:48:54.000000000 -0500
 +++ libraw_r.pc.in	2020-07-24 15:16:29.000000000 -0500
 @@ -7,5 +7,5 @@


### PR DESCRIPTION
#### Description

The patch had fuzz and a 78 lines offset

```
:info:patch patching file Makefile.dist
:info:patch Hunk #1 succeeded at 159 with fuzz 1 (offset 78 lines).
```

###### Type(s)

- [x] bugfix

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?