### PR TITLE
wireguard-tools: update to 1.0.20200820

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-tools
-version             1.0.20200513
+version             1.0.20200820
 revision            0
-checksums           rmd160  111502a4d2ee8861c341efb0c46df65927b3d7a8 \
-                    sha256  e73409a9fb8c90506db241d1e1a4e7372a60dbfa400e37f4ab2fd70a92ba495f \
-                    size    94500
+checksums           rmd160  9480d398b2a9df791b1f0b2cf5d8cb58eca34a1f \
+                    sha256  7735a04c68fffb101a10a67e3bd97a171f2b8eb47e9ddce2be68eb6538b013d0 \
+                    size    94812
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
###### Tested on
macOS 10.13.6 17G12034
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?