### PR TITLE
lilypond: fix dependencies

### DIFF
--- a/textproc/lilypond/Portfile
+++ b/textproc/lilypond/Portfile
@@ -16,13 +16,32 @@ long_description    Lilypond is a unix-based automated engraving system that \
                     similar to LaTeX. Lilypond can export sheet music to PDF, \
                     EPS, SVG, and PNG formats, and can also create MIDI files.
 
+
 subport lilypond-devel {
     long_description  The development version of the LilyPond music typesetter.
 }
 
-if {${subport} eq "${name}"} {
+
+variant mactex description {Use MacTeX or non-MacPorts TeX; see\
+    "port notes" for more information} {}
+variant docs description {Build documentation files} {}
+
+
+notes-append "\
+    Pre-installation note for 'mactex' variant:
+
+    MacTeX or another external TeXLive distribution gets used for\
+    installation instead of MacPorts's texlive packages; the path to\
+    the TeX distribution's binary directory (for example\
+    '/Library/TeX/texbin') must be added to 'binpath' in\
+    'macports.conf' *before* installing this port.
+
+    Note that TeX is not needed after installation."
+
+
+if {${subport} eq ${name}} {
     version         2.20.0
-    revision        3
+    revision        4
     conflicts       lilypond-devel
     checksums       rmd160  030ebe2074ad647269c7f8aca40eaee671ddb77f \
                     sha256  595901323fbc88d3039ca4bdbc2d8c5ce46b182edcb3ea9c0940eba849bba661 \
@@ -31,7 +50,7 @@ if {${subport} eq "${name}"} {
     set livecheck_url "source.html"
 } else {
     version         2.21.5
-    revision        0
+    revision        1
     conflicts       lilypond
     checksums       rmd160  fc9107e91a575d0c50fa7dcdb89672a46a0f4c02 \
                     sha256  09d05285fd334113b91b14a9d8d19fc0e086bec5868b69c73a61f9ea218a96cb \
@@ -39,6 +58,7 @@ if {${subport} eq "${name}"} {
 
     set livecheck_url "development.html"
 }
+
 
 set branch          [join [lrange [split ${version} .] 0 1] .]
 homepage            https://lilypond.org
@@ -51,8 +71,8 @@ livecheck.url       ${homepage}/${livecheck_url}
 platforms           darwin
 universal_variant   no
 
+
 depends_build-append \
-                    port:ImageMagick \
                     port:autoconf \
                     port:bison \
                     port:flex \
@@ -63,16 +83,27 @@ depends_build-append \
                     port:p5.28-pod-simple \
                     port:p5.28-podlators \
                     port:p5.28-scalar-list-utils \
-                    port:netpbm \
                     port:pkgconfig \
                     port:t1utils \
                     port:texinfo \
-                    port:texlive-fonts-recommended \
-                    port:texlive-lang-cyrillic \
-                    port:texlive-latex \
-                    port:texlive-metapost \
-                    port:texlive-xetex \
                     port:urw-core35-fonts
+
+if {${subport} eq ${name}} {
+    # Will be gone in next stable release.
+    depends_build-append \
+                    port:netpbm
+}
+if {![variant_isset mactex]} {
+    depends_build-append \
+                    port:texlive-fonts-recommended \
+                    port:texlive-metapost \
+}
+if {[variant_isset docs] && ![variant_isset mactex]} {
+    # For +docs, only bibtex and xetex are needed right now.
+    depends_build-append \
+                    port:texlive-xetex
+}
+
 
 # Either 'pango' or 'pango-devel' will do, thus we depend on its
 # pkgconfig file.
@@ -88,26 +119,14 @@ configure.python    ${prefix}/bin/python3.8
 
 compiler.cxx_standard 2011
 
+
 set lilypond.texgyredir \
     "${prefix}/share/texmf-texlive/fonts/opentype/public/tex-gyre"
 set lilypond.mactex_bin   ""
 set lilypond.temp         ""
 set lilypond.have_texgyre false
 
-notes-append "\
-    Pre-installation note for 'mactex' variant:
-
-    MacTeX or another external TeXLive distribution gets used for\
-    installation instead of MacPorts's texlive packages; the path to\
-    the TeX distribution's binary directory (for example\
-    '/Library/TeX/texbin') must be added to 'binpath' in\
-    'macports.conf' *before* installing this port.
-
-    Note that TeX is not needed after installation."
-
-variant mactex description {Use MacTeX or non-MacPorts TeX; see\
-    "port notes" for more information} {
-
+if {[variant_isset mactex]} {
     # Find the binary directory of the external TeX distribution by
     # searching the kpsewhich program in the path.  We assume that all
     # other binaries of the distribution are in this directory, too.
@@ -148,18 +167,21 @@ variant mactex description {Use MacTeX or non-MacPorts TeX; see\
                 try again"
         }
     }
-
-    depends_build-delete port:texlive-fonts-recommended \
-                         port:texlive-metapost
-
-    configure.args-append --with-texgyre-dir=${lilypond.texgyredir}
 }
 
-configure.args-append   --disable-documentation
+
+if {[variant_isset docs]} {
+    if {${subport} ne ${name}} {
+        # Currently, +docs only builds the info files.  For a complete
+        # documentation build a texi2html 1.82 bundle is necessary,
+        # which doesn't exist yet in MacPorts.
+        configure.args-append   --disable-texi2html
+    }
+} else {
+    configure.args-append   --disable-documentation
+}
 configure.args-append   --with-urwotf-dir=${prefix}/share/fonts/urw-core35-fonts
-if {![variant_isset mactex]} {
-    configure.args-append  --with-texgyre-dir=${lilypond.texgyredir}
-}
+configure.args-append   --with-texgyre-dir=${lilypond.texgyredir}
 
 configure.env-append    GUILE=${prefix}/bin/guile18
 configure.env-append    GUILE_FLAVOR=guile-1.8
@@ -171,6 +193,7 @@ destroot.env-append     PYTHON=${configure.python}
 configure.env-append    LTDL_LIBRARY_PATH=${prefix}/lib
 build.env-append        LTDL_LIBRARY_PATH=${prefix}/lib
 destroot.env-append     LTDL_LIBRARY_PATH=${prefix}/lib
+
 
 post-patch {
     # Use guile18 header files.
@@ -206,19 +229,34 @@ post-patch {
         scripts/auxiliar/translations-status.py \
         scripts/auxiliar/update-snippets.py
 
-    if {${subport} eq "${name}"} {
+    # ImageMagick and xelatex (or pdflatex) are only needed for
+    # complete documentation builds, which +docs doesn't do currently.
+    # Ditto for Cyrillic stuff (i.e., testing for 'fikparm.mf').
+    if {[variant_isset docs]} {
+        reinplace -W ${worksrcpath} \
+            {s|\(IMAGEMAGICK.*\), $DOCUMENTATION_REQUIRED|\1, OPTIONAL|g} \
+            configure.ac
+        reinplace -W ${worksrcpath} \
+            {s|\(PDFLATEX.*\), $DOCUMENTATION_REQUIRED|\1, OPTIONAL|g} \
+            configure.ac
+        reinplace -W ${worksrcpath} \
+            {s|if test "$TEX_FIKPARM" = ""|if false|g} \
+            configure.ac
+    }
+
+    if {${subport} eq ${name}} {
         # Backport upstream commit 250d841a51eb to make dependency on
         # dblatex optional.
         reinplace -W ${worksrcpath} \
-            "s|\\(DBLATEX.*\\), \\\$DOCUMENTATION_REQUIRED,|\\1, OPTIONAL,|g" \
+            {s|\(DBLATEX.*\), $DOCUMENTATION_REQUIRED,|\1, OPTIONAL,|g} \
             configure.ac
 
-        # Currently, +docs only builds the info files.  For a real
+        # Currently, +docs only builds the info files.  For a complete
         # documentation build a texi2html 1.82 bundle is necessary, which
         # doesn't exist yet in MacPorts.
         if {[variant_isset docs]} {
             reinplace -W ${worksrcpath} \
-                "s|\\(TEXI2HTML.*\\), \\\$DOCUMENTATION_REQUIRED,|\\1, OPTIONAL,|g" \
+                {s|\(TEXI2HTML.*\), $DOCUMENTATION_REQUIRED,|\1, OPTIONAL,|g} \
                 configure.ac
         }
 
@@ -226,6 +264,15 @@ post-patch {
             s|/usr/bin/(env\\\ )?python|${configure.python}|g \
             scripts/auxiliar/coverage.py \
             scripts/auxiliar/texi-skeleton-update.py
+    } else {
+        # netpbm is not needed as a run dependency since 2.21.2; it's
+        # not needed for +docs either, and it will be completely gone
+        # in 2.21.6
+        if {[variant_isset docs]} {
+            reinplace -W ${worksrcpath} \
+                {s|\(NETPBM.*\), $DOCUMENTATION_REQUIRED|\1, OPTIONAL|g} \
+                configure.ac
+        }
     }
 }
 
@@ -239,15 +286,4 @@ post-destroot {
     reinplace \
         "s|@@PREFIX@@|${prefix}|g" \
         ${destroot}${prefix}/bin/lilypond
-}
-
-variant docs description {Build documentation files} {
-    configure.args-delete   --disable-documentation
-    configure.args-append   --enable-documentation
-    if {${subport} ne "${name}"} {
-        # Currently, +docs only builds the info files.  For a real
-        # documentation build a texi2html 1.82 bundle is necessary,
-        # which doesn't exist yet in MacPorts.
-        configure.args-append   --disable-texi2html
-    }
 }


### PR DESCRIPTION
Commit a3fdc4321b52f98cbb08a78dfffb6194b5239d9b broke the +mactex variant.

Also improve the vertical flow in the Portfile by setting up the variants at
the top, then using conditionals to avoid scattered information.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
