### PR TITLE
clamav-server: Improve readability with tcl `{` `}` strings where possible

### DIFF
--- a/sysutils/clamav-server/Portfile
+++ b/sysutils/clamav-server/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 
 name                    clamav-server
 version                 0.101.2
-revision                2
+revision                3
 homepage                https://www.clamav.net/
 categories              sysutils
 platforms               darwin
@@ -70,88 +70,88 @@ if {[variant_isset "scan_schedule_access"]} {
     startupitems-append \
         name            ClamavScanSchedule \
         init {
-                        "pidfile=\"\${prefix}/var/run/clamav/ClamavScanSchedule.pid\""
-                        ""
-                        "CLAMAV_SERVER_SCAN_SCHEDULE_TARGETS_DEFAULT=(\"/\")"
-                        "CLAMAV_SERVER_SCAN_SCHEDULE_TARGETS=(\"\${CLAMAV_SERVER_SCAN_SCHEDULE_TARGETS\[@\]:-\${CLAMAV_SERVER_SCAN_SCHEDULE_TARGETS_DEFAULT\[@\]}}\")"
-                        "CLAMAV_SERVER_QUARANTINE=\${CLAMAV_SERVER_QUARANTINE:-\${prefix%/*}/Quarantine}"
-                        "CLAMAV_SERVER_SCAN_SCHEDULE_LOG=\${CLAMAV_SERVER_SCAN_SCHEDULE_LOG:-\${prefix}/var/log/clamav/ClamavScanSchedule.log}"
-                        "DATE=(/bin/date \"+%FT%T\")"
+                        {pidfile="${prefix}/var/run/clamav/ClamavScanSchedule.pid"}
+                        {}
+                        {CLAMAV_SERVER_SCAN_SCHEDULE_TARGETS_DEFAULT=("/")}
+                        {CLAMAV_SERVER_SCAN_SCHEDULE_TARGETS=("${CLAMAV_SERVER_SCAN_SCHEDULE_TARGETS[@]:-${CLAMAV_SERVER_SCAN_SCHEDULE_TARGETS_DEFAULT[@]}}")}
+                        {CLAMAV_SERVER_QUARANTINE=${CLAMAV_SERVER_QUARANTINE:-${prefix%/*}/Quarantine}}
+                        {CLAMAV_SERVER_SCAN_SCHEDULE_LOG=${CLAMAV_SERVER_SCAN_SCHEDULE_LOG:-${prefix}/var/log/clamav/ClamavScanSchedule.log}}
+                        {DATE=(/bin/date "+%FT%T")}
         } \
         start {
                         "\${prefix}/bin/clamdscan --reload \\"
                         "&& ( /bin/test -d \"\${CLAMAV_SERVER_QUARANTINE}\" || /bin/mkdir -p \"\${CLAMAV_SERVER_QUARANTINE}\" ) \\"
                         "&& ( /bin/test -d \"\${CLAMAV_SERVER_SCAN_SCHEDULE_LOG%/*}\" || /bin/mkdir -p \"\${CLAMAV_SERVER_SCAN_SCHEDULE_LOG%/*}\" ) \\"
-                        "&& echo \"Launchdaemon org.macports.ClamavScanSchedule started on `\${DATE\[@\]}` …\" >> \"\${CLAMAV_SERVER_SCAN_SCHEDULE_LOG}\" \\"
+                        "&& echo \"Launchdaemon org.macports.ClamavScanSchedule started on \$(\${DATE\[@\]}) …\" >> \"\${CLAMAV_SERVER_SCAN_SCHEDULE_LOG}\" \\"
                         "&& ( \${prefix}/bin/clamdscan --multiscan --quiet --fdpass \\"
                         "\t--move=\"\${CLAMAV_SERVER_QUARANTINE}\" --log=\"\${CLAMAV_SERVER_SCAN_SCHEDULE_LOG}\" \"\${CLAMAV_SERVER_SCAN_SCHEDULE_TARGETS\[@\]}\" \\"
-                        "\t&& echo \"Launchdaemon org.macports.ClamavScanSchedule completed on `\${DATE\[@\]}`.\" >> \"\${CLAMAV_SERVER_SCAN_SCHEDULE_LOG}\" \\"
-                        "\t|| echo \"Launchdaemon org.macports.ClamavScanSchedule exited with error code \$? on `\${DATE\[@\]}`.\" >> \"\${CLAMAV_SERVER_SCAN_SCHEDULE_LOG}\" )"
+                        "\t&& echo \"Launchdaemon org.macports.ClamavScanSchedule completed on \$(\${DATE\[@\]}).\" >> \"\${CLAMAV_SERVER_SCAN_SCHEDULE_LOG}\" \\"
+                        {	|| echo "Launchdaemon org.macports.ClamavScanSchedule exited with error code $? on $(${DATE[@]})." >> "${CLAMAV_SERVER_SCAN_SCHEDULE_LOG}" )}
         } \
         pidfile         none \
         stop {
-                        "if \[ -f \"\${prefix}/var/run/clamav/ClamavScanSchedule.pid\" \]; then"
-                        "\t/bin/kill `/bin/cat \"\${prefix}/var/run/clamav/ClamavScanSchedule.pid\"` \\"
-                        "\t\t&& /bin/rm -f \"\${prefix}/var/run/clamav/ClamavScanSchedule.pid\""
-                        "else"
-                        "\t/usr/bin/killall -SIGUSR1 clamdscan 2>/dev/null"
-                        "fi"
+                        {if [ -f "${prefix}/var/run/clamav/ClamavScanSchedule.pid" ]; then}
+                        "\t/bin/kill \$(/bin/cat \"\${prefix}/var/run/clamav/ClamavScanSchedule.pid\") \\"
+                        {		&& /bin/rm -f "${prefix}/var/run/clamav/ClamavScanSchedule.pid"}
+                        {else}
+                        {	/usr/bin/killall -SIGUSR1 clamdscan 2>/dev/null}
+                        {fi}
         }
 
     startupitems-append \
         name            ClamavScanOnAccess \
         init {
-                        "pidfile=\"\${prefix}/var/run/clamav/ClamavScanOnAccess.pid\""
-                        ""
-                        "# Default: use clamdscan if clamd is running; otherwise:"
-                        "# clamscan with an explicit configuration imported from \${prefix}/etc/clamd.conf"
-                        "CLAMD_CONF=\"\${prefix}/etc/clamd.conf\""
-                        "IFS=\$'\\n'"
-                        "CROSS_FS=(`/usr/bin/egrep -e '^\[\[:space:\]\]*CrossFilesystems\\b' \"\${CLAMD_CONF}\" | /usr/bin/sed -E -e 's/^\[\[:space:\]\]*CrossFilesystems\[\[:space:\]\]+/--cross-fs=/'`)"
-                        "FOLLOW_DIR_SYMLINKS=(`/usr/bin/egrep -e '^\[\[:space:\]\]*FollowDirectorySymlinks\\b' \"\${CLAMD_CONF}\" | /usr/bin/sed -E -e 's/^\[\[:space:\]\]*FollowDirectorySymlinks\[\[:space:\]\]+/--follow-dir-symlinks=/'`)"
-                        "FOLLOW_FILE_SYMLINKS=(`/usr/bin/egrep -e '^\[\[:space:\]\]*FollowFileSymlinks\\b' \"\${CLAMD_CONF}\" | /usr/bin/sed -E -e 's/^\[\[:space:\]\]*FollowFileSymlinks\[\[:space:\]\]+/--follow-file-symlinks=/'`)"
-                        "EXCLUDE_PATH=(`/usr/bin/egrep -e '^\[\[:space:\]\]*ExcludePath\\b' \"\${CLAMD_CONF}\" | /usr/bin/sed -E -e 's/^\[\[:space:\]\]*ExcludePath\[\[:space:\]\]+/--exclude=/'`)"
-                        "DETECT_PUA=(`/usr/bin/egrep -e '^\[\[:space:\]\]*DetectPUA\\b' \"\${CLAMD_CONF}\" | /usr/bin/sed -E -e 's/^\[\[:space:\]\]*DetectPUA\[\[:space:\]\]+/--detect-pua=/'`)"
-                        "EXCLUDE_PUA=(`/usr/bin/egrep -e '^\[\[:space:\]\]*ExcludePUA\\b' \"\${CLAMD_CONF}\" | /usr/bin/sed -E -e 's/^\[\[:space:\]\]*ExcludePUA\[\[:space:\]\]+/--exclude-pua=/'`)"
-                        "INCLUDE_PUA=(`/usr/bin/egrep -e '^\[\[:space:\]\]*IncludePUA\\b' \"\${CLAMD_CONF}\" | /usr/bin/sed -E -e 's/^\[\[:space:\]\]*IncludePUA\[\[:space:\]\]+/--include-pua=/'`)"
-                        ""
-                        "CLAMAV_SERVER_QUARANTINE=\${CLAMAV_SERVER_QUARANTINE:-\${prefix%/*}/Quarantine}"
-                        "CLAMAV_SERVER_SCAN_ONACCESS_LOG=\${CLAMAV_SERVER_SCAN_ONACCESS_LOG:-\${prefix}/var/log/clamav/ClamavScanOnAccess.log}"
-                        "DATE=(/bin/date \"+%FT%T\")"
+                        {pidfile="${prefix}/var/run/clamav/ClamavScanOnAccess.pid"}
+                        {}
+                        {# Default: use clamdscan if clamd is running; otherwise:}
+                        {# clamscan with an explicit configuration imported from ${prefix}/etc/clamd.conf}
+                        {CLAMD_CONF="${prefix}/etc/clamd.conf"}
+                        {IFS=$'\n'}
+                        {CROSS_FS=($(/usr/bin/egrep -e '^[[:space:]]*CrossFilesystemsb' "${CLAMD_CONF}" | /usr/bin/sed -E -e 's/^[[:space:]]*CrossFilesystems[[:space:]]+/--cross-fs=/'))}
+                        {FOLLOW_DIR_SYMLINKS=($(/usr/bin/egrep -e '^[[:space:]]*FollowDirectorySymlinks\b' "${CLAMD_CONF}" | /usr/bin/sed -E -e 's/^[[:space:]]*FollowDirectorySymlinks[[:space:]]+/--follow-dir-symlinks=/'))}
+                        {FOLLOW_FILE_SYMLINKS=($(/usr/bin/egrep -e '^[[:space:]]*FollowFileSymlinks\b' "${CLAMD_CONF}" | /usr/bin/sed -E -e 's/^[[:space:]]*FollowFileSymlinks[[:space:]]+/--follow-file-symlinks=/'))}
+                        {EXCLUDE_PATH=($(/usr/bin/egrep -e '^[[:space:]]*ExcludePath\b' "${CLAMD_CONF}" | /usr/bin/sed -E -e 's/^[[:space:]]*ExcludePath[[:space:]]+/--exclude=/'))}
+                        {DETECT_PUA=($(/usr/bin/egrep -e '^[[:space:]]*DetectPUA\b' "${CLAMD_CONF}" | /usr/bin/sed -E -e 's/^[[:space:]]*DetectPUA[[:space:]]+/--detect-pua=/'))}
+                        {EXCLUDE_PUA=($(/usr/bin/egrep -e '^[[:space:]]*ExcludePUA\b' "${CLAMD_CONF}" | /usr/bin/sed -E -e 's/^[[:space:]]*ExcludePUA[[:space:]]+/--exclude-pua=/'))}
+                        {INCLUDE_PUA=($(/usr/bin/egrep -e '^[[:space:]]*IncludePUA\b' "${CLAMD_CONF}" | /usr/bin/sed -E -e 's/^[[:space:]]*IncludePUA[[:space:]]+/--include-pua=/'))}
+                        {}
+                        {CLAMAV_SERVER_QUARANTINE=${CLAMAV_SERVER_QUARANTINE:-${prefix%/*}/Quarantine}}
+                        {CLAMAV_SERVER_SCAN_ONACCESS_LOG=${CLAMAV_SERVER_SCAN_ONACCESS_LOG:-${prefix}/var/log/clamav/ClamavScanOnAccess.log}}
+                        {DATE=(/bin/date "+%FT%T")}
         } \
         start {
-                        "IFS=\$'\\n'"
-                        "USER_HOMEDIRS=(`/usr/bin/dscacheutil -q user | /usr/bin/grep -A 3 -B 2 -E -e '^uid: (?:\\d*5\\d\\d|\\d{4,})' | \${prefix}/bin/pcregrep -B 5 -e '^shell: (?!/usr/bin/false).*' | \${prefix}/bin/pcregrep -A 5 -e '^name: (?!_).*' | /usr/bin/grep -e '^dir: .*/Users/' | /usr/bin/sed -e 's/^dir: //'`)"
-                        "USER_DOWNLOADSDIRS=(`for d in \${USER_HOMEDIRS\[@\]}; do echo \"\${d}/Downloads\" ; done`)"
-                        "USER_DESKTOPDIRS=(`for d in \${USER_HOMEDIRS\[@\]}; do echo \"\${d}/Desktop\" ; done`)"
-                        ""
-                        "\[ -d \"\${CLAMAV_SERVER_QUARANTINE}\" \] || /bin/mkdir -p \"\${CLAMAV_SERVER_QUARANTINE}\""
-                        "\[ -d \"\${CLAMAV_SERVER_SCAN_ONACCESS_LOG%/*}\" \] || /bin/mkdir -p \"\${CLAMAV_SERVER_SCAN_ONACCESS_LOG%/*}\""
-                        "( echo \"Launchdaemon org.macports.ClamavScanOnAccess started on `\${DATE\[@\]}` …\" ; echo \"Watched directories:\" ) >> \"\${CLAMAV_SERVER_SCAN_ONACCESS_LOG}\""
-                        "( for d in \"\${USER_DOWNLOADSDIRS\[@\]}\"; do echo \"\\t\${d}\"; done ) >> \"\${CLAMAV_SERVER_SCAN_ONACCESS_LOG}\""
-                        "( for d in \"\${USER_DESKTOPDIRS\[@\]}\"; do echo \"\\t\${d}\"; done ) >> \"\${CLAMAV_SERVER_SCAN_ONACCESS_LOG}\""
-                        "echo \$\$ > \"\${pidfile}\""
+                        {IFS=$'\n'}
+                        {USER_HOMEDIRS=($(/usr/bin/dscacheutil -q user | /usr/bin/grep -A 3 -B 2 -E -e '^uid: (?:\d*5\d\d|\d{4,})' | ${prefix}/bin/pcregrep -B 5 -e '^shell: (?!/usr/bin/false).*' | ${prefix}/bin/pcregrep -A 5 -e '^name: (?!_).*' | /usr/bin/grep -e '^dir: .*/Users/' | /usr/bin/sed -e 's/^dir: //'))}
+                        {USER_DOWNLOADSDIRS=($(for d in ${USER_HOMEDIRS[@]}; do echo "${d}/Downloads" ; done))}
+                        {USER_DESKTOPDIRS=($(for d in ${USER_HOMEDIRS[@]}; do echo "${d}/Desktop" ; done))}
+                        {}
+                        {[ -d "${CLAMAV_SERVER_QUARANTINE}" ] || /bin/mkdir -p "${CLAMAV_SERVER_QUARANTINE}"}
+                        {[ -d "${CLAMAV_SERVER_SCAN_ONACCESS_LOG%/*}" ] || /bin/mkdir -p "${CLAMAV_SERVER_SCAN_ONACCESS_LOG%/*}"}
+                        {( echo "Launchdaemon org.macports.ClamavScanOnAccess started on $(${DATE[@]}) …" ; echo "Watched directories:" ) >> "${CLAMAV_SERVER_SCAN_ONACCESS_LOG}"}
+                        {( for d in "${USER_DOWNLOADSDIRS[@]}"; do echo "\t${d}"; done ) >> "${CLAMAV_SERVER_SCAN_ONACCESS_LOG}"}
+                        {( for d in "${USER_DESKTOPDIRS[@]}"; do echo "\t${d}"; done ) >> "${CLAMAV_SERVER_SCAN_ONACCESS_LOG}"}
+                        {echo $$ > "${pidfile}"}
                         "\${prefix}/bin/fswatch -0 -l 3 -e '/.DS_Store\$' -r \"\${USER_DOWNLOADSDIRS\[@\]}\" \"\${USER_DESKTOPDIRS\[@\]}\" \\"
                         "\t| while read -d \"\" event ; \\"
                         "\t  do \\"
-                        "\t\techo \"Scanning \${event} on `\${DATE\[@\]}`…\" >> \"\${CLAMAV_SERVER_SCAN_ONACCESS_LOG}\" ; \\"
-                        "\t\t! \[ \"`/usr/bin/pgrep -u root clamd`\" == \"\" \] \\"
+                        "\t\techo \"Scanning \${event} on \$(\${DATE\[@\]})…\" >> \"\${CLAMAV_SERVER_SCAN_ONACCESS_LOG}\" ; \\"
+                        "\t\t! \[ \"\$(/usr/bin/pgrep -u root clamd)\" == \"\" \] \\"
                         "\t\t  && ( /usr/bin/nice -n 5 \"\${prefix}/bin/clamdscan\" --multiscan --quiet --fdpass --move=\"\${CLAMAV_SERVER_QUARANTINE}\" --log=\"\${CLAMAV_SERVER_SCAN_ONACCESS_LOG}\" \"\${event}\" \\"
-                        "\t\t\t&& echo \"Done clamdscan \${event} on `\${DATE\[@\]}`.\" >> \"\${CLAMAV_SERVER_SCAN_ONACCESS_LOG}\" \\"
-                        "\t\t\t\t|| echo \"clamdscan exited with error code \$? on `\${DATE\[@\]}`.\" >> \"\${CLAMAV_SERVER_SCAN_ONACCESS_LOG}\" ) \\"
+                        "\t\t\t&& echo \"Done clamdscan \${event} on \$(\${DATE\[@\]}).\" >> \"\${CLAMAV_SERVER_SCAN_ONACCESS_LOG}\" \\"
+                        "\t\t\t\t|| echo \"clamdscan exited with error code \$? on \$(\${DATE\[@\]}).\" >> \"\${CLAMAV_SERVER_SCAN_ONACCESS_LOG}\" ) \\"
                         "\t\t  || ( /usr/bin/nice -n 5 \"\${prefix}/bin/clamscan\" --infected --quiet --move=\"\${CLAMAV_SERVER_QUARANTINE}\" --log=\"\${CLAMAV_SERVER_SCAN_ONACCESS_LOG}\" \\"
                         "\t\t\t\t\"\${CROSS_FS\[@\]}\" \"\${FOLLOW_DIR_SYMLINKS\[@\]}\" \"\${FOLLOW_FILE_SYMLINKS\[@\]}\" \"\${EXCLUDE_PATH\[@\]}\" \"\${DETECT_PUA\[@\]}\" \"\${EXCLUDE_PUA\[@\]}\" \"\${INCLUDE_PUA\[@\]}\" \"\${event}\" \\"
-                        "\t\t\t&& echo \"Done clamscan \${event} on `\${DATE\[@\]}`.\" >> \"\${CLAMAV_SERVER_SCAN_ONACCESS_LOG}\" \\"
-                        "\t\t\t\t|| echo \"clamscan exited with error code \$? on `\${DATE\[@\]}`.\" >> \"\${CLAMAV_SERVER_SCAN_ONACCESS_LOG}\" ) ; \\"
-                        "\t  done"
+                        "\t\t\t&& echo \"Done clamscan \${event} on \$(\${DATE\[@\]}).\" >> \"\${CLAMAV_SERVER_SCAN_ONACCESS_LOG}\" \\"
+                        "\t\t\t\t|| echo \"clamscan exited with error code \$? on \$(\${DATE\[@\]}).\" >> \"\${CLAMAV_SERVER_SCAN_ONACCESS_LOG}\" ) ; \\"
+                        {	  done}
         } \
         pidfile         none \
         stop {
-                        "if \[ -f \"\${pidfile}\" \]; then"
-                        "\t/bin/kill `/bin/cat \"\${pidfile}\"` && /bin/rm -f \"\${pidfile}\""
-                        "else"
-                        "\t/usr/bin/kill -SIGUSR1 `/usr/bin/pgrep -u root fswatch` 2>/dev/null"
-                        "fi"
+                        {if [ -f "${pidfile}" ]; then}
+                        {	/bin/kill $(/bin/cat "${pidfile}") && /bin/rm -f "${pidfile}"}
+                        {else}
+                        {	/usr/bin/kill -SIGUSR1 $(/usr/bin/pgrep -u root fswatch) 2>/dev/null}
+                        {fi}
         }
 }
 
@@ -338,8 +338,8 @@ clamav-server is installed to perform three types of operations.
 
     Configure this service using:
 
-        System Preferences>Keyboard>Shortcuts>Services>Files and Folders
-            >ClamavScanIt
+        System Preferences> Keyboard> Shortcuts> Services>
+            Files and Folders> ClamavScanIt
 
  3. On-Schedule and On-Access scanning. On-Access scans are performed on
     all user ~/Downloads and ~/Desktop directories. Scheduled scans are
@@ -347,6 +347,11 @@ clamav-server is installed to perform three types of operations.
     \$CLAMAV_SERVER_SCAN_SCHEDULE_TARGETS\[@\], whose default is:
 
         CLAMAV_SERVER_SCAN_SCHEDULE_TARGETS=(\"/\")
+
+    On macOS 10.14+ On-Schedule and On-Access scans require enabling
+    Full Disk Access for the MacPorts process \"daemondo\" in:
+
+        System Preferences> Security & Privacy> Full Disk Access
 "
 
 livecheck.type         none


### PR DESCRIPTION
clamav-server: Improve readability with tcl `{` `}` strings where possible

* See https://github.com/macports/macports-ports/pull/7917#issuecomment-677649322
* Add necessary Full Disk Access notes for macOS 10.14+

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.6 11E708 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
