### PR TITLE
vapoursynth: new port

### DIFF
--- a/multimedia/vapoursynth/Portfile
+++ b/multimedia/vapoursynth/Portfile
@@ -1,0 +1,53 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+
+github.setup            vapoursynth vapoursynth 52 R
+
+categories              multimedia python
+platforms               darwin
+license                 LGPL-2.1+
+
+description             A video processing framework with simplicity in mind
+
+long_description        VapourSynth is an application for video manipulation. \
+                        Or a plugin. Or a library. It’s hard to tell because \
+                        it has a core library written in C++ and a Python \
+                        module to allow video scripts to be created. The \
+                        software has been heavily inspired by Avisynth.
+
+checksums               rmd160  f7cc76d07892f3e70afe7e369da6ca0fd6e3c896 \
+                        sha256  4d5dc7950f4357da695d29708bc98013bc3e0bd72fc5d697f8c91ce3c4a4b2ac \
+                        size    618942
+
+maintainers             {gmail.com:herby.gillot @herbygillot} \
+                        openmaintainer
+
+set python_branch       3.8
+set python_version      [string map {. {}} ${python_branch}]
+
+use_autoreconf          yes
+autoreconf.cmd          ./autogen.sh
+autoreconf.args
+
+depends_build-append    port:autoconf \
+                        port:automake \
+                        port:libtool \
+                        port:pkgconfig \
+                        port:py${python_version}-cython
+
+depends_lib-append      port:ffmpeg \
+                        port:ImageMagick \
+                        port:libass \
+                        port:libiconv \
+                        port:python${python_version} \
+                        port:zimg
+
+configure.args          --with-cython=${prefix}/bin/cython-${python_branch}
+
+configure.python        ${prefix}/bin/python${python_branch}
+
+build.env-append        PYTHON=${configure.python}
+
+github.tarball_from     archive


### PR DESCRIPTION
See: https://trac.macports.org/ticket/61003

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
