### PR TITLE
py-pyte: new port

### DIFF
--- a/python/py-pyte/Portfile
+++ b/python/py-pyte/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-pyte
+version             0.8.0
+revision            0
+
+platforms           darwin
+supported_archs     noarch
+license             MIT
+maintainers         nomaintainer
+
+description         an in memory VTXXX-compatible terminal emulator
+long_description    It’s {*}${description}. XXX stands for a series of video terminals, \
+                    developed by DEC between 1970 and 1995. The first, and probably the \
+                    most famous one, was VT100 terminal, which is now a de-facto standard \
+                    for all virtual terminal emulators. pyte follows the suit.
+
+homepage            https://github.com/selectel/pyte
+
+checksums           rmd160  70ba987e0527e4e05001a3d19de16a6c0606391d \
+                    sha256  7e71d03e972d6f262cbe8704ff70039855f05ee6f7ad9d7129df9c977b5a88c5 \
+                    size    50415
+
+python.versions     38
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools \
+                            port:py${python.version}-pytest-runner
+    depends_lib-append      port:py${python.version}-wcwidth
+
+    livecheck.type      none
+} else {
+    livecheck.type  pypi
+}


### PR DESCRIPTION
#### Description

- Dependency for py-thefuck
- See: https://trac.macports.org/ticket/47535

###### Type(s)

- [x] submission

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vsd install`?
- [x] tested basic functionality of all binary files?