### PR TITLE
py-thefuck: new port

### DIFF
--- a/python/thefuck/Portfile
+++ b/python/thefuck/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                thefuck
+version             3.30
+revision            0
+
+categories-append   sysutils
+platforms           darwin
+supported_archs     noarch
+license             MIT
+maintainers         nomaintainer
+
+description         a magnificent app that corrects errors in previous console commands
+long_description    The Fuck is {*}${description}.
+
+homepage            https://github.com/nvbn/thefuck
+
+checksums           rmd160  3e6e88f13fbeb30b08e5fe60795b57ad7fab38b3 \
+                    sha256  32b41db4360a810d8e761e80fe09868ce634476ee1829e26869d49484b7a95cc \
+                    size    76888
+
+python.versions     38
+
+depends_build-append    port:py${python.version}-setuptools
+depends_lib-append      port:py${python.version}-colorama \
+                        port:py${python.version}-decorator \
+                        port:py${python.version}-psutil \
+                        port:py${python.version}-pyte
+
+livecheck.type      pypi
+
+notes "
+To configure thefuck fuck alias, add this to your bash file (eg. ~/.bash_profile)
+
+    eval \"\$(thefuck --alias)\"
+"


### PR DESCRIPTION
#### Description

- Depends on #8175
- Closes: https://trac.macports.org/ticket/47535

###### Type(s)

- [x] submission

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vsd install`?
- [x] tested basic functionality of all binary files?