### PR TITLE
vlc: fix patch for 10.11 and earlier

### DIFF
--- a/multimedia/VLC/files/patch-build-on-pre-1012.diff
+++ b/multimedia/VLC/files/patch-build-on-pre-1012.diff
@@ -37,10 +37,10 @@ index 38777226cfe56211aa0bd1efc9623ac7ca4cf650..d31f2168885b9b2d68d7dc562ea7a484
  
          input = [AVCaptureDeviceInput deviceInputWithDevice:(__bridge AVCaptureDevice *)p_sys->device error:&o_returnedError];
  
-diff --git a/modules/access/avaudiocapture.m b/modules/access/avaudiocapture.m
+diff --git modules/access/avaudiocapture.m modules/access/avaudiocapture.m
 index e20d8aadf382ee493f2cdfe0cf91a7d9bf951b51..4d6587314c390055836bfe5e9f375aaa08fd3874 100644
---- a/modules/access/avaudiocapture.m
-+++ b/modules/access/avaudiocapture.m
+--- modules/access/avaudiocapture.m
++++ modules/access/avaudiocapture.m
 @@ -45,14 +45,6 @@
  #import <CoreMedia/CoreMedia.h>
  
@@ -76,10 +76,10 @@ index e20d8aadf382ee493f2cdfe0cf91a7d9bf951b51..4d6587314c390055836bfe5e9f375aaa
  
          NSError *error = nil;
          AVCaptureDeviceInput *input = [AVCaptureDeviceInput deviceInputWithDevice:device error:&error];
-diff --git a/modules/audio_output/coreaudio_common.c b/modules/audio_output/coreaudio_common.c
+diff --git modules/audio_output/coreaudio_common.c modules/audio_output/coreaudio_common.c
 index 69fd47137050a1d21ac7eadfbfaafe6f557b8ee9..4a58744104a945d1d11014f9b9948f3dd28dde34 100644
---- a/modules/audio_output/coreaudio_common.c
-+++ b/modules/audio_output/coreaudio_common.c
+--- modules/audio_output/coreaudio_common.c
++++ modules/audio_output/coreaudio_common.c
 @@ -25,6 +25,28 @@
  #import "coreaudio_common.h"
  #import <CoreAudio/CoreAudioTypes.h>
@@ -120,10 +120,10 @@ index 69fd47137050a1d21ac7eadfbfaafe6f557b8ee9..4a58744104a945d1d11014f9b9948f3d
  
      assert(p_sys->tinfo.denom != 0 && p_sys->tinfo.numer != 0);
  
-diff --git a/modules/video_output/caopengllayer.m b/modules/video_output/caopengllayer.m
+diff --git modules/video_output/caopengllayer.m modules/video_output/caopengllayer.m
 index bff225525d9eb68dace1d5839857fd61e3fd83cf..ce11bdfbc182632592c5e0ba19058187d22b8d20 100644
---- a/modules/video_output/caopengllayer.m
-+++ b/modules/video_output/caopengllayer.m
+--- modules/video_output/caopengllayer.m
++++ modules/video_output/caopengllayer.m
 @@ -40,6 +40,18 @@
  #include <vlc_atomic.h>
  


### PR DESCRIPTION
Remove prefixes added during update in 8d50572a4d
Fixes: https://trac.macports.org/ticket/61040

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Untested. I would've said to wait and see if the Travis CI 10.11+Xcode 7.3 builder works, but I don't know how to trigger that without touching the portfile (which this PR does not need to do).
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
```
--->  Verifying Portfile for VLC
Error: Line 40 repeats inclusion of PortGroup obsolete
--->  1 errors and 0 warnings found.
```
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
