### PR TITLE
copilot: new port

### DIFF
--- a/devel/copilot/Portfile
+++ b/devel/copilot/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/aws/copilot-cli 0.3.0 v
+name                copilot
+
+categories          devel
+license             Apache-2
+platforms           darwin
+
+homepage            https://aws.github.io/copilot-cli/
+
+description         AWS Copilot CLI allows developers to build, release and \
+                    operate containerized applications on Amazon ECS and AWS \
+                    Fargate.
+
+long_description    The AWS Copilot CLI is a tool for developers to create, \
+                    release and manage production ready containerized \
+                    applications on Amazon ECS and AWS Fargate. From getting \
+                    started, pushing to a test environment and releasing to \
+                    production, Copilot helps you through the entire life of \
+                    your app development.
+
+checksums           rmd160  2c9eb664b40b20a590ee899e01f3849e065a6a44 \
+                    sha256  b1127e303b77fd981c9eae946661f4d390278555eab2ddfa977c743ce4c922e3 \
+                    size    1020926
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+depends_build-append port:npm6
+
+build.cmd           make
+build.pre_args      VERSION=${version}
+build.args          release
+use_parallel_build  no
+
+patch {
+    # Remove Windows and Linux builds for the release target
+    reinplace -E {/^release:/ s/compile-(linux|windows)[[:space:]]+//g} \
+        ${worksrcpath}/Makefile
+}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/bin/local/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

New port for [AWS Copilot](https://github.com/aws/copilot-cli)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
