### PR TITLE
qt59-qtlocation: add patch to fix header removed in Xcode 11

### DIFF
--- a/aqua/qt59/Portfile
+++ b/aqua/qt59/Portfile
@@ -1358,6 +1358,12 @@ foreach {module module_info} [array get modules] {
                 # see https://bugreports.qt.io/browse/QTBUG-67810
                 patchfiles-append patch-qtlocation-no-cxx17.diff
 
+                # <experimental/optional> deprecated in Xcode 10.2, removed in Xcode 11
+                # https://trac.macports.org/ticket/61031
+                if { [vercmp ${xcodeversion} {10.2}] >= 0 } {
+                    patchfiles-append patch-qtlocation-xcode-optional.diff
+                }
+
                 # avoid unnecessary dependency on OpenSSL
                 configure.args-append "QMAKE_LIBS_OPENSSL="
 

--- a/aqua/qt59/files/patch-qtlocation-xcode-optional.diff
+++ b/aqua/qt59/files/patch-qtlocation-xcode-optional.diff
@@ -1,0 +1,14 @@
+<experimental/optional> is deprecated in Xcode 10.2 and no longer available
+in Xcode 11.0; replacement is to use <optional>
+See https://trac.macports.org/ticket/61031
+
+--- src/3rdparty/mapbox-gl-native/include/mbgl/util/optional.hpp.orig
++++ src/3rdparty/mapbox-gl-native/include/mbgl/util/optional.hpp
+@@ -1,6 +1,6 @@
+ #pragma once
+ 
+-#include <experimental/optional>
++#include <optional>
+ 
+ namespace mbgl {
+ 


### PR DESCRIPTION
See: https://trac.macports.org/ticket/61031

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Untested; only verified that the patch can be applied.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

```
--->  Verifying Portfile for qt59-qtlocation
Error: Line 841 repeats inclusion of PortGroup qt5
Error: Line 1584 repeats inclusion of PortGroup qmake5
Error: Line 1626 repeats inclusion of PortGroup qmake5
--->  3 errors and 0 warnings found.
```

- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
