### PR TITLE
rdfind: update to 1.4.1

### DIFF
--- a/sysutils/rdfind/Portfile
+++ b/sysutils/rdfind/Portfile
@@ -1,10 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 
-name                rdfind
-version             1.3.5
-revision            1
+github.setup        pauldreik rdfind 1.4.1 releases/
+
+revision            0
 categories          sysutils
 license             GPL-2
 maintainers         nomaintainer
@@ -13,15 +14,21 @@ long_description    finds and optionally deletes, or symlinks equal files \
                     on a filesystem
 homepage            https://rdfind.pauldreik.se
 platforms           darwin
-master_sites        ${homepage}
 
-checksums           rmd160  0aff1111278d9b350a1131670dd5e8a7afc6e80e \
-                    sha1    b860b96c156f6dde5c6e3ff52047a20defe21b9d \
-                    sha256  c36e0a1ea35b06ddf1d3d499de4c2e4287984ae47c44a8512d384ecea970c344 \
-                    size    125805
+checksums           rmd160  014778800de9e36ae116d09b5bceb47d4cb98c2e \
+                    sha256  b3e2beeef30b623d75f8b054a514b32183c3ad919f582b23a45506b53095a51e \
+                    size    53719
+
+depends_build-append \
+                    port:automake \
+                    port:autoconf \
+                    port:autoconf-archive
 
 depends_lib         port:nettle
 
-configure.args     CPPFLAGS=-I${prefix}/include/ \
-                   LDFLAGS=-L${prefix}/lib
+configure.args      CPPFLAGS=-I${prefix}/include/ \
+                    LDFLAGS=-L${prefix}/lib
 
+use_automake        yes
+automake.cmd        ./bootstrap.sh
+automake.args


### PR DESCRIPTION
- switch to Github
- add additional build requirements

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
