### PR TITLE
mariadb-10.[2345]: avoid clang in Xcode < 9

### DIFF
--- a/databases/mariadb-10.2/Portfile
+++ b/databases/mariadb-10.2/Portfile
@@ -23,8 +23,12 @@ if {$subport eq $name} {
     PortGroup           cmake 1.0
     PortGroup           select 1.0
     PortGroup           github 1.0
+    PortGroup           compiler_blacklist_versions 1.0
 
     compiler.cxx_standard 2011
+
+    # https://trac.macports.org/ticket/60805
+    compiler.blacklist-append {clang < 900}
 
     github.setup        MariaDB server ${version} mariadb-
     revision            ${revision_client}

--- a/databases/mariadb-10.3/Portfile
+++ b/databases/mariadb-10.3/Portfile
@@ -23,8 +23,12 @@ if {$subport eq $name} {
     PortGroup           cmake 1.0
     PortGroup           select 1.0
     PortGroup           github 1.0
+    PortGroup           compiler_blacklist_versions 1.0
 
     compiler.cxx_standard 2011
+
+    # https://trac.macports.org/ticket/60805
+    compiler.blacklist-append {clang < 900}
 
     github.setup        MariaDB server ${version} mariadb-
     revision            ${revision_client}

--- a/databases/mariadb-10.4/Portfile
+++ b/databases/mariadb-10.4/Portfile
@@ -23,8 +23,12 @@ if {$subport eq $name} {
     PortGroup           cmake 1.0
     PortGroup           select 1.0
     PortGroup           github 1.0
+    PortGroup           compiler_blacklist_versions 1.0
 
     compiler.cxx_standard 2011
+
+    # https://trac.macports.org/ticket/60805
+    compiler.blacklist-append {clang < 900}
 
     github.setup        MariaDB server ${version} mariadb-
     revision            ${revision_client}

--- a/databases/mariadb-10.5/Portfile
+++ b/databases/mariadb-10.5/Portfile
@@ -23,8 +23,12 @@ if {$subport eq $name} {
     PortGroup           cmake 1.0
     PortGroup           select 1.0
     PortGroup           github 1.0
+    PortGroup           compiler_blacklist_versions 1.0
 
     compiler.cxx_standard 2011
+
+    # https://trac.macports.org/ticket/60805
+    compiler.blacklist-append {clang < 900}
 
     github.setup        MariaDB server ${version} mariadb-
     revision            ${revision_client}


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/60805

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Untested; see if Travis CI Xcode 7.3 and Xcode 8.3 builders finish any of the ports quickly enough.
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
