### PR TITLE
octave-lalinference: drop deleted patch

### DIFF
--- a/science/lalinference/Portfile
+++ b/science/lalinference/Portfile
@@ -161,9 +161,6 @@ subport octave-${name} {
   depends_build-append  port:swig-octave
   depends_lib-prepend   port:octave port:${name}
 
-  # do not prepend ${prefix} to Octave directory
-  patchfiles-append     patch-configure.diff
-
   configure.args-replace --disable-swig-octave --enable-swig-octave
 
   # Only install SWIG bindings, Python libraries, and Python scripts


### PR DESCRIPTION
Patch was deleted in bf5c734e02 but didn't get removed from Portfile
Fixes: https://trac.macports.org/ticket/61035

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Untested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
