### PR TITLE
skaffold: update to 1.13.2

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 1.13.1 v
+github.setup        GoogleContainerTools skaffold 1.13.2 v
 revision            0
 
 categories          devel
@@ -23,9 +23,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  09aed5d6a59413c49036d304800501a349aa3a86 \
-                    sha256  6dca88942d86fd50286d08dc665bfdd3af945934414e7d809fd772e028a552ca \
-                    size    27340085
+checksums           rmd160  1cfd1041728382f19275866efe45c29cd294bcb9 \
+                    sha256  423c7c2ded124be77b54e7c9df0ad380bcbee373b8488d0fdbc1c9a8e8f2e6cc \
+                    size    27342889
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 1.13.2.

###### Tested on

macOS 10.15.6 19G2021
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?