### PR TITLE
dvdauthor: explicitly depend on icu, rebuild

### DIFF
--- a/multimedia/dvdauthor/Portfile
+++ b/multimedia/dvdauthor/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                dvdauthor
 version             0.7.2
-revision            1
+revision            2
 categories          multimedia
 platforms           darwin
 maintainers         {perry.ch:maurice @robbyn}
@@ -34,6 +34,7 @@ depends_lib         port:libdvdread \
                     port:zlib \
                     port:libpng \
                     port:libiconv \
+                    port:icu \
                     port:freetype \
                     port:fontconfig \
                     port:ImageMagick


### PR DESCRIPTION
This port implicitly links with recently updated icu, dependency possibly
inherited from one of its dependencies.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
