### PR TITLE
update syncthing to 1.9.0-rc4

### DIFF
--- a/net/syncthing/Portfile
+++ b/net/syncthing/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/syncthing/syncthing 1.7.1 v
+go.setup            github.com/syncthing/syncthing 1.9.0-rc.4 v
 categories          net
 platforms           darwin
 license             MPL-2
@@ -17,9 +17,9 @@ long_description    Syncthing replaces proprietary sync and cloud services \
                     and how it's transmitted over the Internet.
 homepage            https://syncthing.net
 
-checksums           rmd160  2aee8c720ca5c095413cf3c9b75794dc0277dd58 \
-                    sha256  c93822d10885a00c0ad1d5ef22cd3a4fd73ca80f921d07dc4611c5ec30b99302 \
-                    size    4856384
+checksums           rmd160  4bebf65dd219c2cbd7e81fbed404ae159b696734 \
+                    sha256  5cfd20af879c71768a25bf7c4bad3e11a87acc6c2aa0eb8170e2bb299580919d \
+                    size    4859101
 
 build.env-append    GO111MODULE=on
 build.cmd           ${go.bin} run build.go


### PR DESCRIPTION
#### Description

Skip 1.8.0 due to [syncthing#6867](https://github.com/syncthing/syncthing/issues/6867) and update syncthing to 1.9.0-rc4.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
