### PR TITLE
xpdf: replacing ghostcript fonts with urw-fonts

### DIFF
--- a/graphics/xpdf/Portfile
+++ b/graphics/xpdf/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                xpdf
 version             3.04
-revision            2
+revision            3
 description         Xpdf is a viewer for PDF files.
 long_description    Xpdf is a viewer for Portable Document Format \
                     (PDF) files.  These are also sometimes also called \
@@ -31,7 +31,8 @@ master_sites        ftp://ftp.funet.fi/pub/TeX/CTAN/support/xpdf/ \
                     ftp://ftp.foolabs.com/pub/xpdf/
 
 checksums           rmd160  fb29aad21054d5d3b349aec4806262feeca1bd8e \
-                    sha256  11390c74733abcb262aaca4db68710f13ffffd42bfe2a0861a5dfc912b2977e5
+                    sha256  11390c74733abcb262aaca4db68710f13ffffd42bfe2a0861a5dfc912b2977e5 \
+                    size    825519
 
 depends_lib         port:xorg-libXp \
                     port:xpm \
@@ -40,14 +41,14 @@ depends_lib         port:xorg-libXp \
                     port:libpaper \
                     lib:libXm:openmotif
 
-depends_run         path:share/ghostscript/fonts:ghostscript
+depends_run         path:share/fonts/urw-fonts:urw-fonts
 
 patch.post_args     -p1
 patchfiles          patch-xpdf-NameToUnicodeTable.h.diff \
                     patch-xpdf-UnicodeMapTables.h.diff
 
 post-patch {
-    reinplace "s|/usr/local|${prefix}|g" \
+    reinplace "s|/usr/local/share/ghostscript/fonts|/usr/local/share/fonts/urw-fonts|g;s|/usr/local|${prefix}|g" \
         ${worksrcpath}/doc/sample-xpdfrc ${worksrcpath}/xpdf/GlobalParams.cc
 }
 


### PR DESCRIPTION
See: https://trac.macports.org/ticket/26057

#### Description

Drop dependency to ghostscript (for its fonts), that are useless now, and replace with dependency to urw-fonts . Allows xpdf to display correctly out of the box documents which use Times-Roman, Helvetica etc.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.6 19G2021
Xcode 11.6 11E708 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
