### PR TITLE
mariadb-10.5: stdint.h needed on 10.8 and earlier

### DIFF
--- a/databases/mariadb-10.5/Portfile
+++ b/databases/mariadb-10.5/Portfile
@@ -185,6 +185,7 @@ if {$subport eq $name} {
                    patch-libmariadb_cmake_install.cmake.diff \
                    patch-libmariadb_libmariadb_CMakeLists.txt.diff \
                    patch-libmariadb_mariadb_config_CMakeLists.txt.diff \
+                   patch-server_storage_perfschema_my_thread.h.diff \
                    patch-cmake_mysql_version.cmake.diff
 
     post-patch {

--- a/databases/mariadb-10.5/files/patch-server_storage_perfschema_my_thread.h.diff
+++ b/databases/mariadb-10.5/files/patch-server_storage_perfschema_my_thread.h.diff
@@ -1,0 +1,15 @@
+Attempt to fix build error `unknown type name 'uint64_t'`
+observed on macOS 10.8 and earlier.
+
+Upstream-Status: Pending
+--- server/storage/perfschema/my_thread.h.orig
++++ server/storage/perfschema/my_thread.h
+@@ -13,6 +13,8 @@
+ #ifdef HAVE_PTHREAD_GETTHREADID_NP
+ #include <pthread_np.h>
+ #endif
++
++#include <stdint.h>
+ 
+ typedef pthread_key_t thread_local_key_t;
+ typedef pthread_t my_thread_handle;


### PR DESCRIPTION
#### Description

Build failure was observed on the [10.7](https://build.macports.org/builders/ports-10.7_x86_64-builder/builds/28718/steps/install-port/logs/stdio) and [10.8](https://build.macports.org/builders/ports-10.8_x86_64-builder/builds/24252/steps/install-port/logs/stdio) builders (10.6 fails sooner due to separate issues):

```
/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_databases_mariadb-10.5/mariadb-10.5/work/server-mariadb-10.5.5/storage/perfschema/my_thread.h:49:3: error: unknown type name 'uint64_t'
  uint64_t tid64;
  ^
```

I believe this is fixed by manually including `<stdint.h>`.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Only the patch phase has been tested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
