### PR TITLE
ttfautohint: fix livecheck

### DIFF
--- a/graphics/ttfautohint/Portfile
+++ b/graphics/ttfautohint/Portfile
@@ -42,3 +42,9 @@ variant qt5 conflicts qt4 description {Enable GUI based on QT 5} {
     configure.env-append   QMAKESPEC=[option qt_qmake_spec]
     qt5.depends_component  qtbase
 }
+
+# Ensure the livecheck looks at ttfautohint specifically, not the freetype
+# project. URL gets overwritten with project RSS if it's identical to
+# ${homepage}.
+livecheck.regex   ${name} (\[0-9.\]+)
+livecheck.url     ${homepage}/index.html


### PR DESCRIPTION
#### Description

Fix livecheck for ttfautohint: currently it checks the version of its parent project, freetype, which is version 2.10.2 and thus gives a false out-of-date result.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.6 19G2021
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
