### PR TITLE
py-virtualenv-clone: update to 0.5.4

### DIFF
--- a/python/py-virtualenv-clone/Portfile
+++ b/python/py-virtualenv-clone/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-virtualenv-clone
-version             0.5.3
+version             0.5.4
 revision            0
 platforms           darwin
 categories-append   devel
@@ -19,9 +19,9 @@ homepage            https://github.com/edwardgeorge/${python.rootname}/
 master_sites        pypi:v/${python.rootname}/
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  b7c61d8f0fdf36d297577266cb896d4ca95fee7a \
-                    sha256  c88ae171a11b087ea2513f260cdac9232461d8e9369bcd1dc143fc399d220557 \
-                    size    6226
+checksums           rmd160  8a925f8a77ec381aba988d03f0ef2f8792be929b \
+                    sha256  665e48dd54c84b98b71a657acb49104c54e7652bce9c1c4f6c6976ed4c827a29 \
+                    size    6169
 
 python.versions     27 35 36 37 38
 


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
