### PR TITLE
pipenv: update to 2020.8.13

### DIFF
--- a/python/pipenv/Portfile
+++ b/python/pipenv/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                pipenv
-version             2020.6.2
+version             2020.8.13
 revision            0
 categories-append   devel
 platforms           darwin
@@ -34,9 +34,9 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  d0e5b85c0b58486325dedfa15841e525a2f7bc65 \
-                    sha256  7dd49a7345fa5da7843907bab42a996dece474e45dd309dbd7619739dc60478b \
-                    size    5153157
+checksums           rmd160  35a3af49ee09b66ec9f6ed7faa61fcd31938c6a4 \
+                    sha256  eff0e10eadb330f612edfa5051d3d8e775e9e0e918c3c50361da703bd0daa035 \
+                    size    5153905
 
 
 python.default_version 38


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
