### PR TITLE
bandit: new port

### DIFF
--- a/python/bandit/Portfile
+++ b/python/bandit/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                bandit
+version             1.6.2
+platforms           darwin
+license             Apache-2
+categories          python security
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+description         Security oriented static analyser for python code.
+
+long_description    {*}${description}. Bandit is a tool designed to find \
+                    common security issues in Python code. To do this Bandit \
+                    processes each file, builds an AST from it, and runs \
+                    appropriate plugins against the AST nodes. Once Bandit \
+                    has finished scanning all the files it generates a report.
+
+homepage            https://bandit.readthedocs.io/en/latest/
+
+checksums           rmd160  ee8fe03518cf75da38cdeb649438e0d5b6b21e94 \
+                    sha256  41e75315853507aa145d62a78a2a6c5e3240fe14ee7c601459d0df9418196065 \
+                    size    498567
+
+python.default_version  38
+
+depends_build-append    port:py${python.version}-pbr \
+                        port:py${python.version}-setuptools
+
+depends_run-append      port:py${python.version}-colorama \
+                        port:py${python.version}-gitpython \
+                        port:py${python.version}-six \
+                        port:py${python.version}-stevedore \
+                        port:py${python.version}-yaml \


### PR DESCRIPTION
New port for the [Bandit](https://bandit.readthedocs.io/en/latest/) Python security scanner.

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
