### PR TITLE
mariadb-10.5: move conflicting VERSION files

### DIFF
--- a/databases/mariadb-10.5/Portfile
+++ b/databases/mariadb-10.5/Portfile
@@ -186,7 +186,8 @@ if {$subport eq $name} {
                    patch-libmariadb_libmariadb_CMakeLists.txt.diff \
                    patch-libmariadb_mariadb_config_CMakeLists.txt.diff \
                    patch-server_storage_perfschema_my_thread.h.diff \
-                   patch-cmake_mysql_version.cmake.diff
+                   patch-cmake_mysql_version.cmake.diff \
+                   patch-cmake_mysql_columnstore_version.cmake.diff
 
     post-patch {
         reinplace "s|@NAME@|${name_mysql}|g" \
@@ -200,6 +201,8 @@ if {$subport eq $name} {
             ${cmake.build_dir}/macports/macports-default.cnf \
             ${cmake.build_dir}/macports/my.cnf
         move ${worksrcpath}/VERSION ${worksrcpath}/VERSION.txt
+        move ${worksrcpath}/storage/columnstore/columnstore/VERSION ${worksrcpath}/storage/columnstore/columnstore/VERSION.txt
+        move ${worksrcpath}/storage/maria/libmarias3/VERSION ${worksrcpath}/storage/maria/libmarias3/VERSION.txt
     }
 
     configure.args-delete \

--- a/databases/mariadb-10.5/files/patch-cmake_mysql_columnstore_version.cmake.diff
+++ b/databases/mariadb-10.5/files/patch-cmake_mysql_columnstore_version.cmake.diff
@@ -1,0 +1,20 @@
+--- a/storage/columnstore/columnstore/cmake/columnstore_version.cmake.orig	2020-08-06 08:47:37.000000000 -0700
++++ b/storage/columnstore/columnstore/cmake/columnstore_version.cmake	2020-08-24 22:19:07.000000000 -0700
+@@ -2,7 +2,7 @@
+ 
+ # Generate "something" to trigger cmake rerun when VERSION changes
+ CONFIGURE_FILE(
+-    ${ENGINE_SRC_DIR}/VERSION
++    ${ENGINE_SRC_DIR}/VERSION.txt
+   ${CMAKE_BINARY_DIR}/VERSION.dep
+ )
+ 
+@@ -10,7 +10,7 @@
+ 
+ MACRO(COLUMNSTORE_GET_CONFIG_VALUE keyword var)
+  IF(NOT ${var})
+-     FILE (STRINGS ${ENGINE_SRC_DIR}/VERSION str REGEX "^[ ]*${keyword}=")
++     FILE (STRINGS ${ENGINE_SRC_DIR}/VERSION.txt str REGEX "^[ ]*${keyword}=")
+    IF(str)
+      STRING(REPLACE "${keyword}=" "" str ${str})
+      STRING(REGEX REPLACE  "[ ].*" ""  str "${str}")


### PR DESCRIPTION
fixes build with newer compilers like clang-9.0
that default to c++17

together with https://github.com/macports/macports-ports/pull/8195 this fixes the build on older systems (10.6.8 tested):
```
port -v installed mariadb-10.5
The following ports are currently installed:
  mariadb-10.5 @10.5.5_0 (active) platform='darwin 10' archs='x86_64' date='2020-08-24T23:15:36-0700'
```

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.6.8
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
