### PR TITLE
nomaintainer ports: use LTS JDK

### DIFF
--- a/devel/soprano/Portfile
+++ b/devel/soprano/Portfile
@@ -26,8 +26,8 @@ checksums           rmd160  b5e8db32a77ab9fed5dac74783cb137259d91bb2 \
 
 # Required java version.
 java.version        11+
-# JDK port to install if required java not found
-java.fallback       openjdk12
+# LTS JDK port to install if required java not found
+java.fallback       openjdk11
 
 depends_lib-append  port:strigi \
                     port:raptor2 \

--- a/games/MultiMC5/Portfile
+++ b/games/MultiMC5/Portfile
@@ -34,7 +34,8 @@ post-patch {
         libraries/launcher/CMakeLists.txt
 }
 
-java.fallback       openjdk12
+# Use LTS Java as fallback
+java.fallback       openjdk11
 java.version        1.8+
 
 compiler.blacklist-append  *gcc* {clang < 700} {macports-clang-3.[0-9]}

--- a/math/mallet/Portfile
+++ b/math/mallet/Portfile
@@ -25,8 +25,8 @@ checksums           rmd160  3007048a099bd5870d8566c2b6b9b691f85048ba \
                     sha256  5b2d6fb9bcf600b1836b09881821a6781dd45a7d3032e61d7500d027a5b34faf \
                     size    14868234
 
-# JDK port to install if required java not found
-java.fallback       openjdk13
+# LTS JDK port to install if required java not found
+java.fallback       openjdk11
 
 patchfiles          patch-mallet.diff
 

--- a/python/py-stanfordnlp/Portfile
+++ b/python/py-stanfordnlp/Portfile
@@ -31,8 +31,8 @@ checksums           rmd160  95e41e706e48120a6c3923c987404538b3da37af \
 
 # Required java version
 java.version        1.8+
-# JDK port to install if required java not found
-java.fallback       openjdk13
+# LTS JDK port to install if required java not found
+java.fallback       openjdk11
 
 # Support python versions
 python.versions     27 37 38

--- a/textproc/stanford-corenlp/Portfile
+++ b/textproc/stanford-corenlp/Portfile
@@ -67,8 +67,8 @@ use_configure       no
 
 # Required java version
 java.version        1.8+
-# JDK port to install if required java not found
-java.fallback       openjdk13
+# LTS JDK port to install if required java not found
+java.fallback       openjdk11
 
 set dest_java ${destroot}${prefix}/share/java/${name}
 set dest_doc ${destroot}${prefix}/share/doc/${name}


### PR DESCRIPTION
Public updates for openjdk12 ended 2019-09
Public updates for openjdk13 ended 2020-03

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Untested.
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
