### PR TITLE
elasticsearch: use LTS Java version as fallback

### DIFF
--- a/databases/elasticsearch/Portfile
+++ b/databases/elasticsearch/Portfile
@@ -39,8 +39,8 @@ build {}
 # Required java version
 # see https://www.elastic.co/support/matrix#matrix_jvm
 java.version        9+
-# JDK port to install if required java not found
-java.fallback       openjdk13
+# LTS JDK port to install if required java not found
+java.fallback       openjdk11
 
 patchfiles          patch-elasticsearch-yml.diff \
                     patch-elasticsearch-env.diff \
@@ -139,7 +139,7 @@ curl -XDELETE \"http://localhost:9200/my_first_index\"
 
 Each Elasticsearch shard is a Lucene index; aim for 10-50 GB per shard.
 
-${name} is tested with the JDK provided in port openjdk${java.version}. Add these
+${name} is tested with the JDK provided in port ${java.fallback}. Add these
 lines to your ~/.profile to set up your java environment and test with
 'java -version':
 


### PR DESCRIPTION
Public updates for openjdk13 ended 2020-03

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Untested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
