### PR TITLE
apache-solr8: use LTS Java version as fallback

### DIFF
--- a/java/apache-solr8/Portfile
+++ b/java/apache-solr8/Portfile
@@ -31,8 +31,8 @@ checksums           rmd160  cd4e7e551316e95522bf3f387913893abdc6444d \
 
 # see https://lucene.apache.org/solr/guide/8_1/solr-system-requirements.html
 java.version        9+
-# JDK port to install if required java not found
-java.fallback       openjdk13
+# LTS JDK port to install if required java not found
+java.fallback       openjdk11
 
 set solrGroup       solr
 set solrUser        solr
@@ -122,7 +122,7 @@ export SOLR_HEAP=${solr_heap}
 export SOLR_LOG_PRESTART_ROTATION=${solr_log_prestart_rotation}
 export SOLR_ULIMIT_CHECKS=${solr_ulimit_checks}
 
-${name} is tested with the JDK provided in port openjdk13. Add these\
+${name} is tested with the JDK provided in port ${java.fallback}. Add these\
 lines to your ~/.profile to set up your java environment and test with\
 'java -version':
 


### PR DESCRIPTION
Public updates for openjdk13 ended 2020-03
Public updates for openjdk11 will continue at least until 2023

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Untested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
