### PR TITLE
golangci-lint: update version to 1.30.0

### DIFF
--- a/devel/golangci-lint/Portfile
+++ b/devel/golangci-lint/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/golangci/golangci-lint 1.18.0 v
+go.setup            github.com/golangci/golangci-lint 1.30.0 v
 
 platforms           darwin
 categories          devel
@@ -19,9 +19,9 @@ long_description    GolangCI-Lint is a linters aggregator. It's fast: on \
                     integrate and use, has nice output and has a minimum \
                     number of false positives. It supports go modules.
 
-checksums           rmd160  274b8bb58c6e6d6d20d7995d41928f635010e7d0 \
-                    sha256  2d6c0f0e5f5e81ad6a72a150edfefad342a27ba92a045ca3a923af4a9f36fd0f \
-                    size    3927480
+checksums           rmd160  141616b6e6b3efef6ded3a61e55cdc5aacf5ef6d \
+                    sha256  b4a14d460b49cfbf6babbb93001d0f9d7438e8f19c3ba06d42aa16f47c8eaae6 \
+                    size    1243290
 
 build.args          ./cmd/golangci-lint
 


### PR DESCRIPTION
#### Description

Update golangci-lint version up to 1.30.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.5 19F101
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
