### PR TITLE
spdlog: use compiler.thread_local_storage yes

### DIFF
--- a/devel/spdlog/Portfile
+++ b/devel/spdlog/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 PortGroup           cmake  1.1
 
@@ -18,9 +17,7 @@ long_description    {*}${description}
 # only header files are installed, but C++11 is still required for build tests
 supported_archs     noarch
 compiler.cxx_standard   2011
-# setting "compiler.thread_local_storage yes" does not work, so for now just use blacklisting
-# See: https://lists.macports.org/pipermail/macports-dev/2019-November/041503.html
-compiler.blacklist-append {clang < 800}
+compiler.thread_local_storage yes
 
 checksums           rmd160  d914f91522195e5a2a6f56159100312ed9008a35 \
                     sha256  04f0a81753986095407de87fc9fe852e180e2926ebdf8f555252706d8170ff0c \


### PR DESCRIPTION
macports/macports-base#161 is included in 2.6.3 release
`compiler.blacklist` no longer necessary

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
