### PR TITLE
the_silver_searcher: use compiler.thread_local_storage yes

### DIFF
--- a/textproc/the_silver_searcher/Portfile
+++ b/textproc/the_silver_searcher/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           legacysupport 1.0
 
 # requires legacysupport
@@ -30,21 +29,7 @@ depends_lib         port:pcre \
 
 build.args-append   V=1
 
-# requires basic thread-local storage -- Looking forward to the
-# new streamlined compiler selection coming in base which should replace this
-# src/print.c:34: error: thread-local storage not supported for this target
-compiler.blacklist-append *gcc-3.* *gcc-4.* cc
-compiler.blacklist-append { clang < 318 } macports-clang-3.3
-if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
-    compiler.blacklist-append macports-clang-3.4 macports-clang-3.7
-}
-platform darwin i386 {
-    compiler.fallback-append  macports-clang-5.0 macports-clang-6.0 macports-clang-7.0
-}
-platform darwin powerpc {
-    compiler.fallback-append macports-gcc-6 macports-gcc-7 macports-gcc-5
-}
-
+compiler.thread_local_storage yes
 
 post-destroot {
     xinstall -d -m 755 ${destroot}${prefix}/share/bash-completion/completions


### PR DESCRIPTION
macports/macports-base#161 is included in 2.6.3 release
`compiler.blacklist` no longer necessary

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
