### PR TITLE
jtc: cleanup compilers

### DIFF
--- a/textproc/jtc/Portfile
+++ b/textproc/jtc/Portfile
@@ -30,10 +30,6 @@ checksums           rmd160  1704af5fb08d4986afbe8a33293117ee79cd479b \
 
 compiler.cxx_standard 2014
 
-# Remove this once base's compiler selection for C++14 is fixed:
-# https://github.com/macports/macports-base/pull/162
-compiler.blacklist-append {clang < 602}
-
 # Fails on 10.10 and 10.11 as well with
 # /Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/map:634:11: error: no matching constructor for initialization of 'value_type' (aka 'pair<const std::__1::basic_string<char>, Json::JnEntry>')
 #        : __cc(std::forward<_Args>(__args)...) {}


### PR DESCRIPTION
macports/macports-base#162 is included in 2.6.3 release

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
