### PR TITLE
openimageio: use compiler.thread_local_storage yes

### DIFF
--- a/graphics/openimageio/Portfile
+++ b/graphics/openimageio/Portfile
@@ -27,8 +27,8 @@ compiler.cxx_standard   2011
 # http://lists.llvm.org/pipermail/llvm-bugs/2013-November/031552.html
 # Seen on OSX 10.9 and older.
 compiler.blacklist-append {clang < 700}
-# error: thread-local storage is not supported for the current target
-compiler.blacklist-append {clang < 800}
+
+compiler.thread_local_storage yes
 
 github.master_sites     ${github.homepage}/archive
 distname                Release-${version}


### PR DESCRIPTION
…instead of `compiler.blacklist-append {clang < 800}` since macports/macports-base#161 is included in 2.6.3 release

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
