### PR TITLE
PothosFlow: use compiler.thread_local_storage yes

### DIFF
--- a/science/PothosFlow/Portfile
+++ b/science/PothosFlow/Portfile
@@ -4,7 +4,6 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 PortGroup           qt5 1.0
-PortGroup           compiler_blacklist_versions 1.0
 
 platforms           darwin macosx
 categories          science
@@ -22,8 +21,7 @@ revision            0
 
 compiler.cxx_standard 2011
 
-# require a compiler that supports thread_local storage
-compiler.blacklist-append { clang < 800 }
+compiler.thread_local_storage yes
 
 depends_lib-append \
     port:PothosCore \


### PR DESCRIPTION
…instead of `compiler.blacklist` as macports/macports-base#161 is included in 2.6.3 release

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
