### PR TITLE
yq: new port

### DIFF
--- a/textproc/yq/Portfile
+++ b/textproc/yq/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/mikefarah/yq 3.3.2
+
+categories          textproc sysutils
+license             MIT
+platforms           darwin
+
+homepage            https://mikefarah.gitbook.io/yq/
+
+description         yq is a portable command-line YAML processor
+
+long_description    {*}${description}. The aim of the project is to be the jq \
+                    or sed of yaml files.
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  60f8a97e6d3d7801be15aff3ac8ea4bce138f75d \
+                    sha256  83d090d102b4bc3ec016570d6a35f4abd357b90d8c8e5ffd261f904368109e14 \
+                    size    724339
+
+build.target        github.com/mikefarah/yq/v3
+installs_libs       no
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
New port for the [yq](https://mikefarah.gitbook.io/yq/) YAML query processor.

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
