### PR TITLE
google-cloud-sdk: update to 307.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             306.0.0
+version             307.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  5900d0de141bf80934c1724aa9d034aca5e29cc7 \
-                    sha256  3802093ff0fbd5538cb11ce271c37d8ac1a05ad0fc86cc9ca0cd624e28583c01 \
-                    size    84296060
+    checksums       rmd160  aa2b435924e55835878e44e8f1e90c3c2b879c2d \
+                    sha256  645315d5948f99579fd1181f55f926663d3ab6d4e2cdc3f08a26c170f713810b \
+                    size    84428981
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  e2293148e347c52f3919c32499f2c993fa98c054 \
-                    sha256  613e65c5596b8218ec827cf9ed78b87e9e445905f57991f3eb07c6efdf4d59d0 \
-                    size    85308518
+    checksums       rmd160  66d578545f1e8112f9b4d58db25981cf7adf4adc \
+                    sha256  98d6503d2c0ccaf9c042d09c7f223f2179b731965c54691fc18810dc08979ba4 \
+                    size    85441304
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 307.0.0.

###### Tested on

macOS 10.15.6 19G2021
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?