### PR TITLE
cgal5: cleanup compilers

### DIFF
--- a/gis/cgal5/Portfile
+++ b/gis/cgal5/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
-PortGroup               compiler_blacklist_versions 1.0
 PortGroup               github  1.0
 PortGroup               cmake   1.0
 
@@ -45,9 +44,6 @@ depends_lib-append      port:boost \
 
 compiler.cxx_standard   2011
 compiler.thread_local_storage yes
-# Work around thread local compiler selection bug. Remove after
-# https://github.com/macports/macports-base/pull/161 is released.
-compiler.blacklist-append {clang < 800}
 
 configure.args-append   -DCGAL_HEADER_ONLY=OFF
 


### PR DESCRIPTION
macports/macports-base#161 is included in 2.6.3 release
`compiler.blacklist` no longer necessary

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
