### PR TITLE
pure-stldict, pure-stllib: use compiler.cxx_standard 2011

### DIFF
--- a/pure/pure-stldict/Portfile
+++ b/pure/pure-stldict/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
-PortGroup               compiler_blacklist_versions 1.0
 PortGroup               pure 1.0
 
 pure.setup              pure-stldict 0.8
@@ -22,8 +21,7 @@ depends_build-append    port:pkgconfig
 patchfiles              patch-Makefile.diff
 patchfiles-append       patch-tr1-support.diff
 
-# Requires C++11.
-compiler.blacklist-append {clang < 137} gcc-* *llvm-gcc*
+compiler.cxx_standard   2011
 
 # These are set in the Makefile but the pure portgroup overrides them.
 configure.cxxflags-append -g -std=c++0x -Wall

--- a/pure/pure-stllib/Portfile
+++ b/pure/pure-stllib/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
-PortGroup               compiler_blacklist_versions 1.0
 PortGroup               pure 1.0
 
 pure.setup              pure-stllib 0.6
@@ -22,8 +21,7 @@ depends_build-append    port:pkgconfig
 patchfiles-append       patch-Makefiles.diff
 patchfiles-append       patch-tr1-support.diff
 
-# Requires C++11.
-compiler.blacklist-append {clang < 137} gcc-* *llvm-gcc*
+compiler.cxx_standard   2011
 
 # These are set in the Makefile but the pure portgroup overrides them.
 configure.cxxflags-append -g -std=c++0x -Wall


### PR DESCRIPTION
…instead of `compiler.blacklist`

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
