### PR TITLE
dar, gdash, openal-soft, php-swoole: cleanup

### DIFF
--- a/archivers/dar/Portfile
+++ b/archivers/dar/Portfile
@@ -36,6 +36,7 @@ depends_lib         port:bzip2 \
                     port:zlib
 
 compiler.cxx_standard 2011
+compiler.thread_local_storage yes
 
 universal_variant   no
 

--- a/archivers/dar/Portfile
+++ b/archivers/dar/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           compiler_blacklist_versions 1.0
 
 name                dar
 version             2.6.10
@@ -37,9 +36,6 @@ depends_lib         port:bzip2 \
                     port:zlib
 
 compiler.cxx_standard 2011
-
-# error: unknown type name 'thread_local'
-compiler.blacklist-append {clang < 800}
 
 universal_variant   no
 

--- a/audio/openal-soft/Portfile
+++ b/audio/openal-soft/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem              1.0
 PortGroup               cmake 1.1
-PortGroup               compiler_blacklist_versions 1.0
 if {${subport} eq "openal-soft" && [variant_isset gui]} {
 PortGroup               qt5 1.0
 }
@@ -46,8 +45,6 @@ depends_lib-append      port:libmysofa
 
 compiler.cxx_standard   2011
 compiler.thread_local_storage   yes
-# needs thread_local, not just __thread or _Thread_local
-compiler.blacklist      {clang < 800}
 
 configure.args-append   -DALSOFT_EXAMPLES=OFF \
                         -DALSOFT_TESTS=OFF \

--- a/games/gdash/Portfile
+++ b/games/gdash/Portfile
@@ -3,7 +3,6 @@
 PortSystem          1.0
 PortGroup           app 1.0
 PortGroup           bitbucket 1.0
-PortGroup           compiler_blacklist_versions 1.0
 
 bitbucket.setup     czirkoszoltan gdash 20180129unstable
 categories          games
@@ -31,8 +30,6 @@ depends_lib         port:gtk2 \
                     port:mesa
 
 compiler.cxx_standard 2014
-# Work around MacPorts base 2.6.2 C++14 compiler selection bug
-compiler.blacklist-append {clang < 602}
 
 configure.args      --disable-sdltest \
                     --disable-silent-rules

--- a/php/php-swoole/Portfile
+++ b/php/php-swoole/Portfile
@@ -59,10 +59,6 @@ if {${name} ne ${subport}} {
 
     if {[vercmp ${version} 4.5.0] >= 0} {
         compiler.thread_local_storage yes
-        # Work around thread local compiler selection bug. Remove after
-        # https://github.com/macports/macports-base/pull/161 is released.
-        PortGroup       compiler_blacklist_versions 1.0
-        compiler.blacklist-append {clang < 800}
     }
 
     depends_lib-append  port:hiredis \


### PR DESCRIPTION
macports/macports-base#161 and macports/macports-base#162 are included in 2.6.3 release

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
