### PR TITLE
py-pygit2: drop py27 py35 subports

### DIFF
--- a/python/py-pygit2/Portfile
+++ b/python/py-pygit2/Portfile
@@ -22,19 +22,9 @@ checksums           rmd160  a19977b0a5caff654b8e7109211d8dad9ca11bd2 \
                     sha256  9cf6bf39dbecc691d1d5d855d0e5d2d1dacb125ae8155feac1987e944e072199 \
                     size    3016546
 
-python.versions     27 35 36 37 38
+python.versions     36 37 38
 
 if {${name} ne ${subport}} {
-    if {${python.version} == 27} {
-        github.setup    libgit2 pygit2 0.28.2 v
-        checksums   rmd160  92e6de5bc13bf827209f890c932b63e774212ff8 \
-                    sha256  7a803f179a50ad0fd3d9c527608c2efa00afa82c77ce9df81493fd6daf5dd00a \
-                    size    509246
-
-        depends_lib-append \
-                    port:py${python.version}-six
-    }
-
     depends_build-append \
                     port:py${python.version}-setuptools
 


### PR DESCRIPTION
Current version only supports python 3.6+ and pypy3 7.2+.
    
See https://trac.macports.org/ticket/61053

This is a draft PR for discussion.  IMO this is the right thing to do with py-pygit2 but puts the onus on gitless to
port to python3 as mentioned in the ticket.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G6020
Xcode 11.2.1 11B500 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
