### PR TITLE
gitless: drop Python 2.7, switch to 3.8

### DIFF
--- a/devel/gitless/Portfile
+++ b/devel/gitless/Portfile
@@ -21,9 +21,7 @@ checksums           rmd160  bee4c60e28cc698cf006c645583ca9e19355ae65 \
                     sha256  a5f145f5c8aa56fbd08c4d2f8291a016a2ad00295efb7d1e5df082e03ad75b14 \
                     size    42454
 
-# git depends on python27; using the same to reduce dependencies,
-# although python3x would be supported
-python.default_version 27
+python.default_version 38
 
 depends_build-append \
                     port:py${python.version}-setuptools


### PR DESCRIPTION
Requires #8222 

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
