### PR TITLE
openjdk8: update GraalVM to 20.2.0

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -10,7 +10,7 @@ set build        01
 set major        8
 
 subport openjdk8-graalvm {
-    version      20.1.0
+    version      20.2.0
     revision     0
 
     set major    8
@@ -51,7 +51,7 @@ subport openjdk11 {
 }
 
 subport openjdk11-graalvm {
-    version      20.1.0
+    version      20.2.0
     revision     0
 
     set major    11
@@ -201,9 +201,9 @@ if {${subport} eq "openjdk8"} {
     distname     graalvm-ce-java${major}-darwin-amd64-${version}
     worksrcdir   graalvm-ce-java${major}-${version}
 
-    checksums    rmd160  4bb85efe5021a9a88758a2815d9f1d35a3e6d542 \
-                 sha256  3b9fd8ce84c9162a188fde88907c66990db22af0ff6ae2c04430113253a9a634 \
-                 size    334191214
+    checksums    rmd160  0bf3977fec6ad8a12fbdb5b1f0b52453d2fe19d7 \
+                 sha256  a1f524788354cfd2434566f0de972372f4a7743919bae49a9d508f2080385e7b \
+                 size    330118707
 
     description  GraalVM Community Edition based on OpenJDK ${major}
     long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, \
@@ -280,9 +280,9 @@ if {${subport} eq "openjdk8"} {
     distname     graalvm-ce-java${major}-darwin-amd64-${version}
     worksrcdir   graalvm-ce-java${major}-${version}
 
-    checksums    rmd160  a076d4fdef59fb3a44b8b38193214d496f7984ea \
-                 sha256  04efcb7bdd2e94715d0f3fddcc754594da032887e6aec94a3701bd4774d1a92e \
-                 size    428722016
+    checksums    rmd160  829239c28ecee8be0b8206645d597819684b895b \
+                 sha256  e9df2caace6f90fcfbc623c184ef1bbb053de20eb4cf5b002d708c609340ba7a \
+                 size    422700256
 
     description  GraalVM Community Edition based on OpenJDK ${major}
     long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, \


### PR DESCRIPTION
#### Description

Update to GraalVM Community Edition 20.2.0.

###### Tested on

macOS 10.15.6 19G2021
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?