### PR TITLE
libxdg-basedir: update to 1.2.2

### DIFF
--- a/devel/libxdg-basedir/Portfile
+++ b/devel/libxdg-basedir/Portfile
@@ -1,8 +1,8 @@
 PortSystem      1.0
+PortGroup       github 1.0
 
-name            libxdg-basedir
-version         1.0.2
-maintainers     kpricorn.org:macports openmaintainer
+github.setup    davmac314 libxdg-basedir 1.2.2 v
+maintainers     nomaintainer
 categories      devel
 license         MIT
 platforms       darwin
@@ -14,13 +14,20 @@ long_description \
     provides a few higher-level functions for use \
     with the specification.
 
-homepage        http://n.ethz.ch/student/nevillm/download/${name}/
-master_sites    ${homepage}
+checksums       rmd160  b81656222bed2090ca04a8e0788ef1e6ae6d5f7a \
+                sha256  fb95e36927dc34a04659935235d513baddd1a77c7898fe850475e32881b0b579 \
+                size    30882
 
-checksums       md5     944202425e5359666f268d18671303d4 \
-                sha1    8c75931d0abcf7fefae50f22d06299ca1f06d1da \
-                rmd160  d0794d8eb6c853c5ef80755df718450c81935754
+use_autoreconf  yes
+autoreconf.cmd  ./autogen.sh
+autoreconf.args
 
 configure.args  --disable-doxygen-doc \
                 --disable-doxygen-dot \
                 --disable-doxygen-html
+
+depends_build-append \
+                port:autoconf \
+                port:automake \
+                port:libtool \
+                port:pkgconfig


### PR DESCRIPTION
* switch to Github fork provided by davmac314/libxdg-basedir
* use recommended checksum types
* add proper build and lib dependencies
* use autoconf in build process

Closes: https://trac.macports.org/ticket/60990

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
