### PR TITLE
gnss-sdr, volk-gnss-sdr: cleanup compilers

### DIFF
--- a/science/gnss-sdr/Portfile
+++ b/science/gnss-sdr/Portfile
@@ -3,7 +3,6 @@
 PortSystem          1.0
 
 PortGroup           cmake 1.0
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 PortGroup           active_variants 1.1
 
@@ -17,9 +16,6 @@ platforms           darwin
 dist_subdir         gnss-sdr
 
 compiler.cxx_standard 2014
-# Remove this once base's compiler selection for C++14 is fixed:
-# https://github.com/macports/macports-base/pull/162
-compiler.blacklist-append {clang < 602}
 
 if {${subport} eq "gnss-sdr"} {
 

--- a/science/volk-gnss-sdr/Portfile
+++ b/science/volk-gnss-sdr/Portfile
@@ -3,7 +3,6 @@
 PortSystem          1.0
 
 PortGroup           cmake 1.0
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 PortGroup           active_variants 1.1
 
@@ -17,9 +16,6 @@ platforms           darwin
 dist_subdir         gnss-sdr
 
 compiler.cxx_standard 2014
-# Remove this once base's compiler selection for C++14 is fixed:
-# https://github.com/macports/macports-base/pull/162
-compiler.blacklist-append {clang < 602}
 
 if {${subport} eq "volk-gnss-sdr"} {
 


### PR DESCRIPTION
macports/macports-base#162 is included in 2.6.3 release

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
