### PR TITLE
ports maintained by michaelld: cleanup compilers

### DIFF
--- a/aqua/qt4-mac/Portfile
+++ b/aqua/qt4-mac/Portfile
@@ -1179,12 +1179,7 @@ variant openvg description {Build with support for OpenVG} {
 
 variant cxx11 description {Add library support for C++11 (EXPERIMENTAL; does not work with libc++)} {
 
-    # Block compilers that do not support C++11. This variant seems to
-    # work with MacPorts' clang 3.0 or newer and Apple clang newer
-    # than 318.0.58 (but, not that version, which is already blocked).
-
-    compiler.blacklist-append \
-        apple-gcc-4.2 gcc-4.2 llvm-gcc-4.2
+    compiler.cxx_standard 2011
 
     pre-fetch {
 

--- a/graphics/glfw/Portfile
+++ b/graphics/glfw/Portfile
@@ -14,6 +14,7 @@ platforms           darwin macosx
 # glfw does not build on Mac OS X 10.5 or prior due to CoreGraphics
 # references that are 10.6+.
 if {${os.platform} eq "darwin" && ${os.major} < 10} {
+    known_fail      yes
     pre-fetch {
         ui_error "$name does not build on Mac OS X 10.5 'Leopard' or prior."
         error "unsupported platform"
@@ -48,19 +49,10 @@ if {${os.platform} eq "darwin" && ${os.major} == 10} {
 
     # requires c11 support as of 82ca58da (20190305) for
     # <stdatomic.h>; 3.3 was released shortly after this change, so
-    # this requirement is now for all modern GLFW. hopefully the
-    # following force a C11 compliant compiler to be used! require GCC
-    # >= 4.6 (4.9 for full C11) or MacPorts' Clang >= 3.1 or
-    # AppleClang >= 700. MacPorts' Clang starts at 3.3, so nothing to
-    # block there!
-
-    PortGroup compiler_blacklist_versions 1.0
-
-    compiler.blacklist-append macports-gcc-4.3 macports-gcc-4.4 macports-gcc-4.5 \
-        macports-gcc macports-gcc-4.6 macports-gcc-4.7 macports-gcc-4.8 \
-        macports-llvm-gcc-4.2 macports-dragonegg-3.3 macports-dragonegg-3.4 \
-        apple-gcc-4.0 apple-gcc-4.2 gcc-3.3 gcc-4.0 llvm-gcc-4.2 gcc cc \
-        {clang < 700} macports-clang-3.*
+    # this requirement is now for all modern GLFW.
+    compiler.c_standard   2011
+    # <stdatomic.h> support was introduced in Xcode 7.0
+    compiler.blacklist-append {clang < 700}
 
     compiler.cxx_standard 2011
 
@@ -122,7 +114,7 @@ if {${os.platform} eq "darwin" && ${os.major} == 10} {
 
 # use the real home page, not github's
 
-homepage            http://www.glfw.org/
+homepage            https://www.glfw.org
 
 # do VPATH (out of source tree) build
 

--- a/python/py-scipy/Portfile
+++ b/python/py-scipy/Portfile
@@ -5,7 +5,6 @@ PortGroup               python 1.0
 PortGroup               active_variants 1.1
 PortGroup               github 1.0
 PortGroup               compilers 1.0
-PortGroup               compiler_blacklist_versions 1.0
 
 github.setup            scipy scipy 1.5.2 v
 checksums               rmd160  3eecdb6fde97b55f6dd7531501011c2473b4a616 \
@@ -59,9 +58,6 @@ if {${name} ne ${subport}} {
 
         # require thread_local storage as of 1.4.0
         compiler.thread_local_storage yes
-        # Work around thread local compiler selection bug. Remove after
-        # https://github.com/macports/macports-base/pull/161 is released.
-        compiler.blacklist-append {clang < 800}
     }
 
     if {${python.version} == 35} {

--- a/science/uhd/Portfile
+++ b/science/uhd/Portfile
@@ -4,7 +4,6 @@ PortSystem  1.0
 PortGroup   cmake 1.1
 PortGroup   github 1.0
 PortGroup   muniversal 1.0
-PortGroup   compiler_blacklist_versions 1.0
 PortGroup   active_variants 1.1
 
 name        uhd
@@ -153,7 +152,7 @@ if {${subport} ne "uhd-39lts"} {
     # require a compiler that supports thread_local storage,
     # which was introduced in 3.11.0.0.
     # see also < https://trac.macports.org/ticket/55980 >
-    compiler.blacklist-append { clang < 800 }
+    compiler.thread_local_storage yes
 
 }
 


### PR DESCRIPTION
`qt4-mac +cxx11`: use `compiler.cxx_standard 2011` instead of `compiler.blacklist`

`py-scipy`: macports/macports-base#162 is included in 2.6.3 release

`uhd`: macports/macports-base#161 is included in 2.6.3 release; can use `compiler.thread_local_storage yes` instead of `compiler.blacklist`

`glfw`: use `known_fail yes` on macOS ≤ 10.5, HTTPS homepage, use `compiler.c_standard 2011` to cleanup `compiler.blacklist` while keeping it to check for Xcode clang with stdatomic.h

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
