### PR TITLE
scw: new Portfile for Scaleway command line

### DIFF
--- a/net/scw/Portfile
+++ b/net/scw/Portfile
@@ -15,7 +15,8 @@ maintainers         {gmail.com:davidriod @dgsb} openmaintainer
 
 description         Command Line Interface for Scaleway
 
-long_description    Scaleway CLI is a tool to help you pilot your Scaleway infrastructure directly from your terminal.
+long_description    Scaleway CLI is a tool to help you pilot your Scaleway \
+                    infrastructure directly from your terminal.
 
 checksums           rmd160  0eb6264e82b9e6118c80f3ec046d40830e986c5d \
                     sha256  510e5ec1394999d0bb8261203ada7c199a4978278bb357d45047606d217a1a2f \

--- a/net/scw/Portfile
+++ b/net/scw/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/scaleway/scaleway-cli 2.0.0 v
+name                scw
+
+platforms           darwin
+categories          net
+license             Apache-2
+installs_libs       no
+
+maintainers         {gmail.com:davidriod @dgsb} openmaintainer
+
+description         Command Line Interface for Scaleway
+
+long_description    Scaleway CLI is a tool to help you pilot your Scaleway infrastructure directly from your terminal.
+
+checksums           rmd160  0eb6264e82b9e6118c80f3ec046d40830e986c5d \
+                    sha256  510e5ec1394999d0bb8261203ada7c199a4978278bb357d45047606d217a1a2f \
+                    size    1566580
+
+build.args          ./cmd/scw
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}
+}


### PR DESCRIPTION
#### Description

Add the Scaleway command line tool package.
https://github.com/scaleway/scaleway-cli

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.5 19F101
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
