### PR TITLE
glfw: still needs compiler_blacklist_versions pg

### DIFF
--- a/graphics/glfw/Portfile
+++ b/graphics/glfw/Portfile
@@ -52,6 +52,7 @@ if {${os.platform} eq "darwin" && ${os.major} == 10} {
     # this requirement is now for all modern GLFW.
     compiler.c_standard   2011
     # <stdatomic.h> support was introduced in Xcode 7.0
+    PortGroup compiler_blacklist_versions 1.0
     compiler.blacklist-append {clang < 700}
 
     compiler.cxx_standard 2011


### PR DESCRIPTION
Was removed in cfb71b8681 but shouldn't have been

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
