### PR TITLE
doctl: update to 1.46.0

### DIFF
--- a/www/doctl/Portfile
+++ b/www/doctl/Portfile
@@ -3,12 +3,12 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/digitalocean/doctl 1.42.0 v
+go.setup            github.com/digitalocean/doctl 1.46.0 v
 revision            0
 
-checksums           rmd160  f5d8cfa2458900c8ad3a7c056e81b9e2b6b7b735 \
-                    sha256  b35f599bab94b0571f59c89aa3b1a263cd785e49edb5a20962f6016267b230ab \
-                    size    4304953
+checksums           rmd160  2d75b2653bf2ef5404c8a3ac082b8186e12c7b37 \
+                    sha256  9fd4c0e28ff5512fd293e4a4317137553857579c37a3576b2b4b90fcc6c14005 \
+                    size    4637812
 
 categories          www devel
 platforms           darwin


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
