### PR TITLE
libgit2: Enable NTLM client for 10.9 and earlier and use muniversal portgroup

### DIFF
--- a/devel/libgit2/Portfile
+++ b/devel/libgit2/Portfile
@@ -7,7 +7,7 @@ PortGroup           legacysupport 1.0
 
 # don't forget to update py-pygit2 and libgit2-glib as well
 github.setup        libgit2 libgit2 1.0.1 v
-revision            0
+revision            1
 epoch               1
 categories          devel
 platforms           darwin
@@ -37,26 +37,11 @@ depends_lib         port:curl \
                     path:lib/libssl.dylib:openssl \
                     port:zlib
 
+patchfiles-append   htonll.patch
+
 configure.args-append \
                     -DTHREADSAFE:BOOL=OFF \
                     -DUSE_ICONV:BOOL=ON
-
-platform darwin {
-# macro htonll() not defined on 10.9 and earlier
-# ntlm.c:1129:16: warning: implicit declaration of function 'htonll' is invalid in C99 [-Wimplicit-function-declaration]
-#        local_nonce = htonll(ntlm->nonce);
-# Undefined symbols for architecture x86_64:
-#   "_htonll", referenced from:
-#       _ntlm_client_response in ntlm.c.o
-# disable NTLM client support on these patforms until this is fixed upstream
-# https://trac.macports.org/ticket/61057
-# https://github.com/libgit2/libgit2/issues/5613
-# https://github.com/libgit2/libgit2/pull/5614
-    if {${os.major} < 14} {
-        configure.args-append \
-                    -DUSE_NTLMCLIENT:BOOL=OFF
-    }
-}
 
 variant threadsafe description {Build with threadsafe option} {
     configure.args-replace \

--- a/devel/libgit2/Portfile
+++ b/devel/libgit2/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 PortGroup           legacysupport 1.0
+PortGroup           muniversal 1.0
 
 # don't forget to update py-pygit2 and libgit2-glib as well
 github.setup        libgit2 libgit2 1.0.1 v

--- a/devel/libgit2/files/htonll.patch
+++ b/devel/libgit2/files/htonll.patch
@@ -1,0 +1,93 @@
+Use a private implementation of htonll to accommodate systems that don't
+have one (like OS X 10.9 and earlier).
+https://github.com/libgit2/libgit2/issues/5613
+https://github.com/libgit2/libgit2/pull/5614
+--- deps/ntlmclient/CMakeLists.txt.orig	2020-06-04 03:46:58.000000000 -0500
++++ deps/ntlmclient/CMakeLists.txt	2020-08-24 09:58:38.000000000 -0500
+@@ -1,9 +1,16 @@
++INCLUDE(TestBigEndian)
++
+ FILE(GLOB SRC_NTLMCLIENT "ntlm.c" "unicode_builtin.c" "util.c")
+ 
+ ADD_DEFINITIONS(-DNTLM_STATIC=1)
+ 
+ DISABLE_WARNINGS(implicit-fallthrough)
+ 
++TEST_BIG_ENDIAN(BIG_ENDIAN)
++IF(BIG_ENDIAN)
++	ADD_DEFINITIONS(-DNTLM_BIG_ENDIAN)
++ENDIF()
++
+ IF (HTTPS_BACKEND STREQUAL "SecureTransport")
+ 	ADD_DEFINITIONS(-DCRYPT_COMMONCRYPTO)
+ 	SET(SRC_NTLMCLIENT_CRYPTO "crypt_commoncrypto.c")
+--- deps/ntlmclient/compat.h.orig	2020-06-04 03:46:58.000000000 -0500
++++ deps/ntlmclient/compat.h	2020-08-24 10:00:04.000000000 -0500
+@@ -21,31 +21,20 @@
+ # include <stdbool.h>
+ #endif
+ 
+-#ifdef __linux__
+-/* See man page endian(3) */
+-# include <endian.h>
+-# define htonll htobe64
+-#elif defined(__NetBSD__) || defined(__OpenBSD__)
+-/* See man page htobe64(3) */
+-# include <endian.h>
+-# define htonll htobe64
+-#elif defined(__FreeBSD__)
+-/* See man page bwaps64(9) */
+-# include <sys/endian.h>
+-# define htonll htobe64
+-#elif defined(sun) || defined(__sun)
+-/* See man page byteorder(3SOCKET) */
+-# include <sys/types.h>
+-# include <netinet/in.h>
+-# include <inttypes.h>
+-
+-# if !defined(htonll)
+-#  if defined(_BIG_ENDIAN)
+-#   define htonll(x) (x)
+-#  else
+-#   define htonll(x) ((((uint64_t)htonl(x)) << 32) + htonl((uint64_t)(x) >> 32))
+-#  endif
+-# endif
++#if defined(NTLM_BIG_ENDIAN)
++static inline uint64_t ntlm_htonll(uint64_t value)
++{
++	return value;
++}
++#else
++
++# include <arpa/inet.h>
++
++static inline uint64_t ntlm_htonll(uint64_t value)
++{
++	return ((uint64_t)htonl(value) << 32) + htonl((uint64_t)value >> 32);
++}
++
+ #endif
+ 
+ #ifndef MIN
+--- deps/ntlmclient/ntlm.c.orig	2020-06-04 03:46:58.000000000 -0500
++++ deps/ntlmclient/ntlm.c	2020-08-24 09:57:15.000000000 -0500
+@@ -1126,7 +1126,7 @@
+ 	size_t lm2_len = 16;
+ 	uint64_t local_nonce;
+ 
+-	local_nonce = htonll(ntlm->nonce);
++	local_nonce = ntlm_htonll(ntlm->nonce);
+ 
+ 	if (!ntlm_hmac_ctx_reset(ntlm->hmac_ctx) ||
+ 		!ntlm_hmac_md5_init(ntlm->hmac_ctx,
+@@ -1198,8 +1198,8 @@
+ 
+ 	/* the blob's integer values are in network byte order */
+ 	signature = htonl(0x01010000);
+-	timestamp = htonll(ntlm->timestamp);
+-	nonce = htonll(ntlm->nonce);
++	timestamp = ntlm_htonll(ntlm->timestamp);
++	nonce = ntlm_htonll(ntlm->nonce);
+ 
+ 	/* construct the blob */
+ 	memcpy(&blob[0], &signature, 4);


### PR DESCRIPTION
#### Description

Enable NTLM client for 10.9 and earlier

See: https://trac.macports.org/ticket/61057

Use muniversal portgroup

See: https://github.com/libgit2/libgit2/pull/5614#issuecomment-680021114

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G12034
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [X] tried a full install with `sudo port -vst install`?
