### PR TITLE
pass-otp, pass-update: update to 1.2.0, 2.1

### DIFF
--- a/security/pass-otp/Portfile
+++ b/security/pass-otp/Portfile
@@ -1,24 +1,29 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8::et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        tadfisher pass-otp 1.1.1 v
+github.setup        tadfisher pass-otp 1.2.0 v
+github.tarball_from releases
+
 categories          security
 platforms           darwin
 supported_archs     noarch
-license             GPL-3+
-maintainers         {loicp.eu:loic-github @lpefferkorn} openmaintainer
+license             GPL-3
+maintainers         {loicp.eu:loic-github @lpefferkorn} \
+                    {judaew.com:judaew @judaew} \
+                    openmaintainer
 
 description         A pass extension for managing one-time-password (OTP) tokens
 long_description    ${description}
 
-checksums           rmd160  850dd63a85bbf7b92a091e75601c4e37c230b73a \
-                    sha256  d5137cffa4cb9dccb38765a340be109a9ae9350979045a1f449cf72a5c4e3c1c \
-                    size    46296
+checksums           rmd160  3ac479108fa4717af3142f7468e6abb2e57622f4 \
+                    sha256  5720a649267a240a4f7ba5a6445193481070049c1d08ba38b00d20fc551c3a67 \
+                    size    46789
 
-depends_run         port:pass \
-                    port:oath-toolkit
+depends_run         port:oath-toolkit \
+                    port:pass \
+                    port:qrencode
 
 use_configure       no
 build {}

--- a/security/pass-update/Portfile
+++ b/security/pass-update/Portfile
@@ -1,30 +1,29 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8::et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        roddhjav pass-update 1.0 v
-maintainers         nomaintainer
+github.setup        roddhjav pass-update 2.1 v
+github.tarball_from releases
+
 categories          security
-description         A pass extension that provides a convenient solution to update an existing password.
-long_description    ${description}
 platforms           darwin
 supported_archs     noarch
-license             GPL-2+
+license             GPL-2
+maintainers         {judaew.com:judaew @judaew} openmaintainer
+
+description         A pass extension that provides a convenient solution to update an existing password.
+long_description    ${description}
 
 depends_lib         port:pass
 
-checksums           rmd160  f669bf26394e0711a4ad9dff7c121b72241ff00e \
-                    sha256  e3d15bdc1d9dc239aa71c17236934ce1510c859a467fe7f7b4591e59dfe3705c
+checksums           rmd160  d43ac1ff688871c635140e8beafb5472fcc0f1e7 \
+                    sha256  2b0022102238e022e7ee945b7622f4c270810cda46508084fcb193582aafaf6f \
+                    size    46200
 
-# uses gnu install for destroot
-depends_build-append port:coreutils
+depends_run         port:pass
 
 use_configure       no
 build {}
-
-post-extract {
-    reinplace "s,@install,@ginstall,g" ${worksrcpath}/Makefile
-}
 
 destroot.env-append PREFIX=${prefix}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Update pass-otp (1.1.1 -> 1.2.0) and pass-update (1.0 -> 2.1)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] update
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6
Xcode 11.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
