### PR TITLE
libqalculate, qalculate-gtk: Update to 3.12.1

### DIFF
--- a/math/libqalculate/Portfile
+++ b/math/libqalculate/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        qalculate libqalculate 3.12.0 v
-revision            1
+github.setup        qalculate libqalculate 3.12.1 v
+revision            0
 
 categories          math
 platforms           darwin
@@ -24,9 +24,9 @@ long_description \
 
 github.tarball_from releases
 
-checksums           rmd160  66895f824ab2586bb41ae12d8d1831f5e1cd9a88 \
-                    sha256  ff6b56c2afbed4c37b37869fde3b45610722fa4bb4b802c84f7cb387968fbc68 \
-                    size    2272693
+checksums           rmd160  b6647326829ac10887ddb675a1da5c8524c46ca1 \
+                    sha256  28c46dc8dd975f253627d80c55a6feab7c44d965dce3ceffefc3cafc9a97c457 \
+                    size    2275290
 
 # autoreconf to reconfigure for intltool; use package's autogen script to avoid
 # conflict with gettext

--- a/math/qalculate-gtk/Portfile
+++ b/math/qalculate-gtk/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        qalculate qalculate-gtk 3.12.0 v
+github.setup        qalculate qalculate-gtk 3.12.1 v
 revision            0
 
 categories          math
@@ -20,9 +20,9 @@ long_description    Qalculate! is a multi-purpose desktop calculator. \
 
 github.tarball_from releases
 
-checksums           rmd160  5734326f7da8fbbbf8f9370f577acbe179c30ffe \
-                    sha256  463151f21720c5596571b9c80036612c8fbc156e9e2d85a617d715fdd2964d51 \
-                    size    2682154
+checksums           rmd160  d1c6a132208d5b59039c4d0e6d4dade21f323bf2 \
+                    sha256  1be087dace97c96c94cd0a032be103d8506001919a0ecc1cdd222445f5708596 \
+                    size    2682176
 
 # autoreconf to reconfigure for intltool
 use_autoreconf      yes


### PR DESCRIPTION
#### Description
Update libqalculate and qalculate-gtk from 3.12 to 3.12.1
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] update
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6
Xcode 11.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
