### PR TITLE
squid4: "ssl bump" and "native" variants

### DIFF
--- a/net/squid4/Portfile
+++ b/net/squid4/Portfile
@@ -133,16 +133,8 @@ if {![variant_isset gnutls]} {
     default_variants    +openssl
 }
 
-variant sslbump conflicts gnutls description "Enable SSL Bump support" {
-    default_variants-append +openssl
+variant sslbump requires openssl description "Enable SSL Bump support" {
     configure.args-append   --enable-ssl-crtd
-    configure.args-append   --enable-http-violations
-    configure.args-append   --enable-security-cert-validators
-    configure.args-append   --enable-security-cert-generators
-    configure.args-append   --enable-follow-x-forwarded-for
-    configure.args-append   --enable-forw-via-db
-    configure.args-append   --disable-eui
-    configure.args-append   --enable-url-rewrite-helpers    
 }
 
 variant native description "Build native arch" {

--- a/net/squid4/Portfile
+++ b/net/squid4/Portfile
@@ -133,6 +133,22 @@ if {![variant_isset gnutls]} {
     default_variants    +openssl
 }
 
+variant sslbump conflicts gnutls description "Enable SSL Bump support" {
+    default_variants-append +openssl
+    configure.args-append   --enable-ssl-crtd
+    configure.args-append   --enable-http-violations
+    configure.args-append   --enable-security-cert-validators
+    configure.args-append   --enable-security-cert-generators
+    configure.args-append   --enable-follow-x-forwarded-for
+    configure.args-append   --enable-forw-via-db
+    configure.args-append   --disable-eui
+    configure.args-append   --enable-url-rewrite-helpers    
+}
+
+variant native description "Build native arch" {
+    configure.args-delete   --disable-arch-native
+}
+
 variant gnutls conflicts openssl description "Enable SSL/TLS support using GnuTLS (experimental)" {
     depends_lib-append      port:gnutls
     configure.args-delete   --without-gnutls


### PR DESCRIPTION
#### Description

Added support for "SSL Bump", and "native" architecture build option.
(tested on squid4 - 4.1.2, 4.1.3)
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.13.6 17G14019
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? (squid4 has no tests turned on.)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
