### PR TITLE
Aerial: add port

### DIFF
--- a/aqua/Aerial/Portfile
+++ b/aqua/Aerial/Portfile
@@ -1,0 +1,87 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               xcode 1.0
+PortGroup               github 1.0
+
+github.setup            JohnCoates Aerial 2.0.5 v
+
+categories              aqua
+license                 MIT
+platforms               macosx
+maintainers             {danchr @danchr} openmaintainer
+
+description             Apple TV Aerial Screensaver for Mac
+
+long_description        Aerial is a Mac screensaver based on the new \
+                        Apple TV screensaver that displays the Aerial \
+                        movies Apple shot over New York, San \
+                        Francisco, Hawaii, China, etc.
+
+# uses git submodules, not included in archive
+fetch.type              git
+
+post-fetch {
+    # fetch the only required submodule; cloning Sparkle fails
+    system -W ${worksrcpath} "git submodule update --depth 1 --init Extern/OAuthSwift"
+}
+
+# although the binary works on 10.9 and later, it doesn't build on
+# anything earlier than 10.15
+if {${os.major} == 19} {
+    patchfiles-append  patch-tintconfiguration.diff
+} elseif {${os.major} < 19} {
+    known_fail         yes
+
+    pre-fetch {
+        ui_error "${name} ${version} cannot build on macOS 10.14 and earlier."
+        return -code error "incompatible macOS version"
+    }
+}
+
+# add missing internal dependency to simplify build
+# https://github.com/JohnCoates/Aerial/pull/1085
+patchfiles-append      patch-xcode-dependency.diff
+
+if {[vercmp $xcodeversion 12.0] < 0} {
+    patchfiles-append  patch-explicit-self.diff
+}
+
+# this port installs a symlink into "/Library/Screen Savers"
+destroot.violate_mtree  yes
+
+set screen_saver_dir    "/Library/Screen Savers"
+
+# this is horrible, but anything within ${prefix} causes permission
+# errors, even without trace mode; my best guess is that Xcode does
+# some internal sandboxing, see also:
+# https://trac.macports.org/ticket/57234
+set custom_build_dir    /tmp/macports-${distname}
+
+xcode.build.settings-append \
+                        BUILD_DIR=${custom_build_dir}
+
+build.pre_args-append   -derivedDataPath ${custom_build_dir}
+
+pre-build {
+    ui_warn "Using custom build directory ${custom_build_dir}"
+}
+
+post-clean {
+    ui_info "Removing custom build directory ${custom_build_dir}"
+    file delete -force ${custom_build_dir}
+}
+
+xcode.scheme            Aerial
+xcode.configuration     Release
+xcode.build.settings-append \
+                        CODE_SIGN_IDENTITY= \
+                        CODE_SIGNING_REQUIRED=NO
+
+destroot {
+    xinstall -d "${destroot}${prefix}${screen_saver_dir}"
+    xinstall -d "${destroot}${screen_saver_dir}"
+
+    file copy ${custom_build_dir}/${xcode.configuration}/${name}.saver "${destroot}${prefix}${screen_saver_dir}"
+    ln -s "${prefix}${screen_saver_dir}/${name}.saver" "${destroot}${screen_saver_dir}"
+}

--- a/aqua/Aerial/Portfile
+++ b/aqua/Aerial/Portfile
@@ -56,7 +56,7 @@ set screen_saver_dir    "/Library/Screen Savers"
 # errors, even without trace mode; my best guess is that Xcode does
 # some internal sandboxing, see also:
 # https://trac.macports.org/ticket/57234
-set custom_build_dir    /tmp/macports-${distname}
+set custom_build_dir    ${worksrcpath}/build
 
 xcode.build.settings-append \
                         BUILD_DIR=${custom_build_dir}

--- a/aqua/Aerial/files/patch-explicit-self.diff
+++ b/aqua/Aerial/files/patch-explicit-self.diff
@@ -1,0 +1,24 @@
+diff --git Aerial/Source/Views/AerialView.swift Aerial/Source/Views/AerialView.swift
+--- Aerial/Source/Views/AerialView.swift
++++ Aerial/Source/Views/AerialView.swift
+@@ -497,16 +497,16 @@ final class AerialView: ScreenSaverView,
+ 
+                 // Descriptions and fades are set when we begin playback
+                 if !self.observerWasSet {
+-                    observerWasSet = true
+-                    playerLayer.addObserver(self, forKeyPath: "readyForDisplay", options: .initial, context: nil)
++                    self.observerWasSet = true
++                    self.playerLayer.addObserver(self, forKeyPath: "readyForDisplay", options: .initial, context: nil)
+                 }
+ 
+-                setNotifications(currentItem)
++                self.setNotifications(currentItem)
+ 
+                 player.actionAtItemEnd = AVPlayer.ActionAtItemEnd.none
+ 
+                 // Let's never download stuff in preview...
+-                if !isPreview {
++                if !self.isPreview {
+                     Cache.fillOrRollCache()
+                 }
+             }

--- a/aqua/Aerial/files/patch-tintconfiguration.diff
+++ b/aqua/Aerial/files/patch-tintconfiguration.diff
@@ -1,0 +1,23 @@
+diff --git Resources/MainUI/SidebarViewController.swift Resources/MainUI/SidebarViewController.swift
+--- Resources/MainUI/SidebarViewController.swift
++++ Resources/MainUI/SidebarViewController.swift
+@@ -256,19 +256,6 @@ extension SidebarViewController: NSOutli
+         }
+     }
+ 
+-    @available(OSX 10.16, *)
+-    func outlineView(_ outlineView: NSOutlineView, tintConfigurationForItem item: Any) -> NSTintConfiguration? {
+-        if let entry = item as? Sidebar.MenuEntry {
+-            if entry.name == "Favorites" {
+-                return NSTintConfiguration(fixedColor: .init(red: 0.996, green: 0.741, blue: 0.066, alpha: 1.0))
+-            } else {
+-                return NSTintConfiguration.default
+-            }
+-        }
+-
+-        return nil
+-    }
+-
+ }
+ 
+ // Right click menu

--- a/aqua/Aerial/files/patch-xcode-dependency.diff
+++ b/aqua/Aerial/files/patch-xcode-dependency.diff
@@ -1,0 +1,37 @@
+diff --git Aerial.xcodeproj/project.pbxproj Aerial.xcodeproj/project.pbxproj
+--- Aerial.xcodeproj/project.pbxproj
++++ Aerial.xcodeproj/project.pbxproj
+@@ -822,6 +822,13 @@
+ 			remoteGlobalIDString = C4D50DF71BFB693F0053B624;
+ 			remoteInfo = OAuthSwiftTests;
+ 		};
++		37F36D7524F416130076F3C2 /* PBXContainerItemProxy */ = {
++			isa = PBXContainerItemProxy;
++			containerPortal = 03D2A40A2447401D003ABD30 /* OAuthSwift.xcodeproj */;
++			proxyType = 1;
++			remoteGlobalIDString = C48B28011AFA598D00C7DEF6;
++			remoteInfo = OAuthSwiftMacOS;
++		};
+ 		FA7199731D94EC5A00FBC99B /* PBXContainerItemProxy */ = {
+ 			isa = PBXContainerItemProxy;
+ 			containerPortal = FACAF19C1BD9FC6000E539DC /* Project object */;
+@@ -1841,6 +1848,7 @@
+ 			buildRules = (
+ 			);
+ 			dependencies = (
++				37F36D7624F416130076F3C2 /* PBXTargetDependency */,
+ 			);
+ 			name = Aerial;
+ 			productName = Aerial;
+@@ -2816,6 +2824,11 @@
+ /* End PBXSourcesBuildPhase section */
+ 
+ /* Begin PBXTargetDependency section */
++		37F36D7624F416130076F3C2 /* PBXTargetDependency */ = {
++			isa = PBXTargetDependency;
++			name = OAuthSwiftMacOS;
++			targetProxy = 37F36D7524F416130076F3C2 /* PBXContainerItemProxy */;
++		};
+ 		FA7199741D94EC5A00FBC99B /* PBXTargetDependency */ = {
+ 			isa = PBXTargetDependency;
+ 			target = FA143CD51BDA3E880041A82B /* AerialApp */;


### PR DESCRIPTION
#### Description

This is a new port. I'm doing this via a PR for review; I had to do some horrible trickery with relocating the build to `/tmp` due to permission errors. Is that acceptable?

See also https://trac.macports.org/ticket/57234

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
