### PR TITLE
gh: add LegacySupport tweaks for OSX <= 10.9

### DIFF
--- a/devel/gh/Portfile
+++ b/devel/gh/Portfile
@@ -2,8 +2,10 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           legacysupport 1.1
 
 github.setup        cli cli 0.11.1 v
+revision            1
 name                gh
 categories          devel
 platforms           darwin
@@ -34,6 +36,14 @@ build {}
 
 destroot {
     xinstall -m 0755 -W ${worksrcpath} bin/gh ${destroot}${prefix}/bin
+
+    # gh works on 10.10 and newer without legacysupport. standard
+    # legacysupport tweaks don't work, since the install here is from
+    # a binary tarball ... have to tweak the binary to use the legacy
+    # support library, which in turn uses the System.B library.
+    if {${os.major} <= 13} {
+        system -W ${destroot}${prefix}/bin "install_name_tool -change /usr/lib/libSystem.B.dylib ${legacysupport.library_name} gh"
+    }
 
     set docdir ${prefix}/share/doc/${name}
     xinstall -d ${destroot}${docdir}


### PR DESCRIPTION
#### Description

'gh' does not currently function at all on OSX <= 10.9, due to some missing symbol that I don't recall & don't have in front of me at the moment. The MP LegacySupport library provides this symbol. Because gh executable is provided as pre-compiled binary, have to use the install_name_tool to correct the library linkage. This change works on OSX 10.9; it might work on earlier OSX too. Won't hurt, since those don't work right now anyway :)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [] enhancement
- [ ] security fix

###### Tested on
Don't have this in front of me, but OSX 10.9 and 10.10, latest OS updates and Xcode and CLT. 'gh' works on 10.10 natively, but requires this tweak for 10.9.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
