### PR TITLE
wireguard-tools: update to 1.0.20200827

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-tools
-version             1.0.20200820
+version             1.0.20200827
 revision            0
-checksums           rmd160  9480d398b2a9df791b1f0b2cf5d8cb58eca34a1f \
-                    sha256  7735a04c68fffb101a10a67e3bd97a171f2b8eb47e9ddce2be68eb6538b013d0 \
-                    size    94812
+checksums           rmd160  4e3bc2439fb7bdca127d8a75051eced78774729f \
+                    sha256  51bc85e33a5b3cf353786ae64b0f1216d7a871447f058b6137f793eb0f53b7fd \
+                    size    94788
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
###### Tested on
macOS 10.13.6 17G12034
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?