### PR TITLE
boost: add basic support for ARM64

### DIFF
--- a/devel/boost/Portfile
+++ b/devel/boost/Portfile
@@ -87,6 +87,10 @@ post-patch {
 # see https://github.com/boostorg/build/issues/440
 patchfiles-append patch-clang_version.diff
 
+# temporary patch to add basic support for arm64,
+# both alone as well as +universal
+patchfiles-append patch-add-support-for-arm64.diff
+
 proc write_jam s {
     global worksrcpath
     set config [open ${worksrcpath}/user-config.jam a]
@@ -376,58 +380,63 @@ if {$subport eq $name} {
 }
 
 if {![variant_isset universal]} {
-    # Honour 'build_arch', if not universal as per #28327
-    if {[lsearch ${build_arch} ppc*] != -1} {
-        build.args-append   architecture=power
-        if {${os.arch} ne "powerpc"} {
-            build.args-append   --disable-long-double
-        }
+    if {[lsearch ${build_arch} arm*] != -1} {
+        build.args-append address-model=64 architecture=arm
     } else {
-        if {[lsearch ${build_arch} *86*] != -1} {
-            build.args-append   architecture=x86
+        if {[lsearch ${build_arch} ppc*] != -1} {
+            build.args-append architecture=power
+            if {${os.arch} ne "powerpc"} {
+                build.args-append --disable-long-double
+            }
         } else {
-            pre-fetch {
-                error "Current value of 'build_arch' is not supported."
+            if {[lsearch ${build_arch} *86*] != -1} {
+                build.args-append architecture=x86
+            } else {
+                pre-fetch {
+                    error "Current value of 'build_arch' (${build_arch}) is not supported."
+                }
+            }
+            if {[lsearch ${build_arch} *64] != -1} {
+                build.args-append address-model=64
+            } else {
+                build.args-append address-model=32
             }
         }
-    }
-    if {[lsearch ${build_arch} *64] != -1} {
-        build.args-append   address-model=64
-    } else {
-        build.args-append   address-model=32
     }
 }
 
 variant universal {
     build.args-append   pch=off
 
-    if {[lsearch ${universal_archs} ppc*] != -1} {
-        if {[lsearch ${universal_archs} *86*] != -1} {
-            build.args-append   architecture=combined
-        } else {
-            build.args-append   architecture=power
-        }
-
-        if {${os.arch} ne "powerpc"} {
-            build.args-append   --disable-long-double
-        }
+    if {[lsearch ${universal_archs} arm*] != -1} {
+        build.args-append address-model=64 architecture=combined
     } else {
-        build.args-append   architecture=x86
-    }
-
-    if {[lsearch ${universal_archs} *64] != -1} {
-        if {[lsearch ${universal_archs} i386] != -1 || [lsearch ${universal_archs} ppc] != -1} {
-            build.args-append   address-model=32_64
-            if {[lsearch ${universal_archs} ppc64] == -1} {
-                post-patch {
-                    reinplace "/local support-ppc64 =/s/= 1/= /" ${worksrcpath}/tools/build/src/tools/darwin.jam
-                }
+        if {[lsearch ${universal_archs} ppc*] != -1} {
+            if {[lsearch ${universal_archs} *86*] != -1} {
+                build.args-append architecture=combined
+            } else {
+                build.args-append architecture=power
+            }
+            if {${os.arch} ne "powerpc"} {
+                build.args-append --disable-long-double
             }
         } else {
-            build.args-append   address-model=64
+            build.args-append architecture=x86
         }
-    } else {
-        build.args-append   address-model=32
+        if {[lsearch ${universal_archs} *64] != -1} {
+            if {[lsearch ${universal_archs} i386] != -1 || [lsearch ${universal_archs} ppc] != -1} {
+                build.args-append address-model=32_64
+                if {[lsearch ${universal_archs} ppc64] == -1} {
+                    post-patch {
+                        reinplace "/local support-ppc64 =/s/= 1/= /" ${worksrcpath}/tools/build/src/tools/darwin.jam
+                    }
+                }
+            } else {
+                build.args-append address-model=64
+            }
+        } else {
+            build.args-append address-model=32
+        }
     }
 }
 

--- a/devel/boost/files/patch-add-support-for-arm64.diff
+++ b/devel/boost/files/patch-add-support-for-arm64.diff
@@ -1,0 +1,56 @@
+--- tools/build/src/tools/darwin.jam.orig
++++ tools/build/src/tools/darwin.jam
+@@ -431,6 +431,7 @@
+     local support-ppc64 = 1 ;
+     
+     osx-version ?= $(.host-osx-version) ;
++    local osx-version-split = [ regex.split $(osx-version) \\. ] ;
+ 
+     switch $(osx-version)
+     {
+@@ -440,7 +441,7 @@
+         }
+         
+         case * :
+-        if $(osx-version) && ! [ version.version-less [ regex.split $(osx-version) \\. ] : 10 6 ]
++        if $(osx-version) && ! [ version.version-less $(osx-version-split) : 10 6 ]
+         {
+             # When targeting 10.6:
+             # - gcc 4.2 will give a compiler errir if ppc64 compilation is requested
+@@ -452,7 +453,16 @@
+     {
+         case combined : 
+         {
+-            if $(address-model) = 32_64 {
++            if ! [ version.version-less $(osx-version-split) : 11 0 ]
++            {
++                # macOS 11.0 "Big Sur" and later is always 64-bit ...
++                if ( $(address_model) = 32 || $(address_model) = 32_64 ) {
++                    echo "'address_model' contains 32; macOS 11 or later builds 64 only; overriding" ;
++                    address-model = 64 ;
++                }
++                # ... and "combined" means Intel and ARM
++                options = -arch x86_64 -arch arm64 ;
++            } else if $(address-model) = 32_64 {
+                 if $(support-ppc64) {
+                     options = -arch i386 -arch ppc -arch x86_64 -arch ppc64 ;                    
+                 } else {
+@@ -500,8 +510,18 @@
+         
+         case arm :
+         {
++            if ! [ version.version-less $(osx-version-split) : 11 0 ]
++            {
++                # macOS 11.0 "Big Sur" and later is always 64-bit
++                if ( $(address_model) = 32 || $(address_model) = 32_64 ) {
++                    echo "'address_model' contains 32; macOS 11 or later builds 64 only; overriding" ;
++                    address-model = 64 ;
++                }
++            }
+             if $(instruction-set) {
+                 options = -arch$(_)$(instruction-set) ;
++            } else if $(address-model) = 64 {
++                options = -arch arm64 ;
+             } else {
+                 options = -arch arm ;
+             }


### PR DESCRIPTION
#### Description

boost: add basic support for ARM64 ... both alone and +universal ... hopefully on both account  ... tested alone and it builds cleanly & dependencies find it and build too and function. Some +universal dependencies don't work yet, so not sure about that side.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.0 20A5354i
Xcode 12.0 12A8189h
macOS 10.14.6 18G6020
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
