### PR TITLE
rust: update to 1.46.0

### DIFF
--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                rust
-version             1.45.2
+version             1.46.0
 revision            0
 categories          lang devel
 platforms           darwin
@@ -27,9 +27,9 @@ long_description    Rust is a curly-brace, block-structured expression \
 homepage            https://www.rust-lang.org/
 
 # Get from src/stage0.txt
-set ruststd_version 1.44.0
-set rustc_version   1.44.0
-set cargo_version   0.45.0
+set ruststd_version 1.45.2
+set rustc_version   1.45.2
+set cargo_version   0.46.0
 set llvm_version    9.0
 
 # can use cmake or cmake-devel; default to cmake.
@@ -49,23 +49,23 @@ distfiles-append    rust-std-${ruststd_version}-${build_arch}-apple-${os.platfor
                     cargo-${cargo_version}-${build_arch}-apple-${os.platform}${extract.suffix}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  5c912683356937d4334e6f6de12a7f4df071ad23 \
-                    sha256  b7a3fc1e3ee367260ef945da867da0957f8983705f011ba2a73715375e50e308 \
-                    size    141671717
+                    rmd160  be052e3ebefd880f1738dca8f96dc946359dfd53 \
+                    sha256  2d6a3b7196db474ba3f37b8f5d50a1ecedff00738d7846840605b42bfc922728 \
+                    size    149449054  
 
 checksums-append \
                     rust-std-${ruststd_version}-x86_64-apple-${os.platform}${extract.suffix} \
-                    rmd160  3e7f199649fce71dfa8f1c6a80c99ea6efaadad9 \
-                    sha256  af58f742764949765e09bb60bd1c16025a79a1be8152996fd5b3a44e5df90311 \
-                    size    23855414 \
+                    rmd160  b769e20421103ebb675394c46007db22410b120a \
+                    sha256  2a6e3b89f7f68d3b38bc1c255e20fa801b0159e2f81c588deb5734f7765f4799 \
+                    size    22623191 \
                     rustc-${rustc_version}-x86_64-apple-${os.platform}${extract.suffix} \
-                    rmd160  cb31619748218c3d5100ad3b6bd896524fd58857 \
-                    sha256  4fd09afcae85f656d4a545ee415e19546e03e34f1ca23be5eaa68c489e3186ab \
-                    size    86233080 \
+                    rmd160  64373db4741f3798c3b62c1b7b808a7b1a86a8a4 \
+                    sha256  84cc63d2213a05a5007290199d9043092e3bab6f19b8b03ec56d875e2c31cf59 \
+                    size    71529658 \
                     cargo-${cargo_version}-x86_64-apple-${os.platform}${extract.suffix} \
-                    rmd160  67ec0a5627d820a6f6be257b825a9abe89d97fdf \
-                    sha256  3a618459c8a22773a299d683e4ea0355e615372ae573300933caf6d00019bdd3 \
-                    size    5690025
+                    rmd160  5d924c398124e8b70d0c3e1693d08367947a723a \
+                    sha256  a81306558ba470de6d2245982717402ce4517850d9032433e5f14a4785a55eae \
+                    size    5673993
 
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
     known_fail yes


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
