### PR TITLE
dosbox-x: fix build on older systems

### DIFF
--- a/emulators/dosbox-x/Portfile
+++ b/emulators/dosbox-x/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           legacysupport 1.0
 PortGroup           app 1.0
 
 github.setup        joncampbell123 dosbox-x 0.83.4 dosbox-x-v
@@ -27,6 +28,9 @@ long_description    DOSBox is a DOS emulator supporting 286/386 realmode, direct
 
 homepage            https://dosbox-x.com
 github.tarball_from archive
+
+patchfiles          patch-futimens.diff \
+                    patch-mactypes.diff
 
 supported_archs     i386 x86_64
 

--- a/emulators/dosbox-x/files/patch-futimens.diff
+++ b/emulators/dosbox-x/files/patch-futimens.diff
@@ -1,0 +1,19 @@
+--- ./src/dos/drive_local.cpp.orig	2020-08-28 17:21:06.000000000 -0700
++++ ./src/dos/drive_local.cpp	2020-08-28 17:28:19.000000000 -0700
+@@ -59,6 +59,16 @@
+ #define MAX_PATH PATH_MAX
+ #endif
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 101300
++#include <sys/time.h>
++int futimens(int filedes, const struct timespec ftsp[2]) {
++    struct timeval ftvp[2];
++    TIMESPEC_TO_TIMEVAL(ftvp, ftsp);
++
++    return (futimes(filedes, ftvp));
++}
++#endif
++
+ #if defined(WIN32)
+ // Windows: Use UTF-16 (wide char)
+ // TODO: Offer an option to NOT use wide char on Windows if directed by config.h

--- a/emulators/dosbox-x/files/patch-mactypes.diff
+++ b/emulators/dosbox-x/files/patch-mactypes.diff
@@ -1,0 +1,12 @@
+--- src/gui/menu_osx.mm.orig	2020-08-28 22:30:31.000000000 -0700
++++ src/gui/menu_osx.mm	2020-08-28 22:31:44.000000000 -0700
+@@ -9,7 +9,9 @@
+ #include "SDL_syswm.h"
+ 
+ #if DOSBOXMENU_TYPE == DOSBOXMENU_NSMENU /* Mac OS X NSMenu / NSMenuItem handle */
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1080
+ # include <MacTypes.h>
++#endif
+ # include <Cocoa/Cocoa.h>
+ # include <Foundation/NSString.h>
+ # include <ApplicationServices/ApplicationServices.h>


### PR DESCRIPTION
runningh this by the CI system

minor tweaks to enable buidling on older systems

replace futimens with futimes
<MacTypes.h> is not needed on older systems

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.7.5 11G63
Xcode 4.6.3 4H1503 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
