### PR TITLE
rust 1.45.2: Bugfix - use rust internal llvm - #61082

### DIFF
--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                rust
 version             1.45.2
-revision            0
+revision            1
 categories          lang devel
 platforms           darwin
 supported_archs     x86_64
@@ -30,19 +30,14 @@ homepage            https://www.rust-lang.org/
 set ruststd_version 1.44.0
 set rustc_version   1.44.0
 set cargo_version   0.45.0
-set llvm_version    9.0
 
 # can use cmake or cmake-devel; default to cmake.
 depends_build       path:bin/cmake:cmake \
                     bin:python2.7:python27
 
-depends_lib         port:llvm-${llvm_version}
-
 master_sites        https://static.rust-lang.org/dist
 
 distname            ${name}c-${version}-src
-
-patchfiles          patch-src-librustc-llvm-lib.diff
 
 distfiles-append    rust-std-${ruststd_version}-${build_arch}-apple-${os.platform}${extract.suffix} \
                     rustc-${rustc_version}-${build_arch}-apple-${os.platform}${extract.suffix} \
@@ -92,7 +87,6 @@ configure.args          --enable-vendor \
                         --disable-codegen-tests \
                         --disable-docs \
                         --release-channel=stable \
-                        --llvm-root=${prefix}/libexec/llvm-${llvm_version} \
                         --build=${rust_platform} \
                         --local-rust-root=${rust_root} \
                         --set=target.${rust_platform}.cc=${configure.cc} \

--- a/lang/rust/files/patch-src-librustc-llvm-lib.diff
+++ b/lang/rust/files/patch-src-librustc-llvm-lib.diff
@@ -1,8 +1,0 @@
---- src/librustc_llvm/lib.rs.orig	2019-09-23 21:15:52.000000000 +0000
-+++ src/librustc_llvm/lib.rs	2019-10-09 05:55:05.000000000 +0000
-@@ -106,3 +106,5 @@
-                  LLVMInitializeWebAssemblyTargetMC,
-                  LLVMInitializeWebAssemblyAsmPrinter);
- }
-+
-+#[link(name = "ffi")] extern {}


### PR DESCRIPTION
#### Description

This patch removes the current configure option to use the
default llvm which is installed by macports. Instead the
rust internal llvm which is provided and maintained by the
rust team is used. The problem

https://trac.macports.org/ticket/61082

is fixed by using the rust internal llvm. Probably there
are more changes which the rust team considers worth maintaining
its own fork of llvm. So maybe it is in general a good idea to use the rust internal llvm instead of the default llvm.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6 17G14019
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?

there are two tests failing but the same tests fail without the patch
```
failures:
    [ui] ui/macros/restricted-shadowing-legacy.rs
    [ui] ui/wait-forked-but-failed-child.rs

test result: FAILED. 10219 passed; 2 failed; 72 ignored; 0 measured; 0 filtered out
```
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
Run "Hello World!"...
