### PR TITLE
graphtage: new port

### DIFF
--- a/textproc/graphtage/Portfile
+++ b/textproc/graphtage/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                graphtage
+version             0.2.1
+platforms           darwin
+license             LGPL-3
+categories          textproc python
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+description         A semantic diff utility and library for tree-like files \
+                    such as JSON, JSON5, XML, HTML, YAML, and CSV.
+
+long_description    {*}${description} Its name is a portmanteau of \“graph\” \
+                    and \“graftage\”—the latter being the horticultural \
+                    practice of joining two trees together such that they \
+                    grow as one.
+
+homepage            https://github.com/trailofbits/graphtage
+
+checksums           rmd160  c290dc2fe523ca9856e5c035798aaf536a85e1f3 \
+                    sha256  e696d783b22a03534b7ad7a2ed23f99a241efdc2728fbb9c106c7a0c8ea05f65 \
+                    size    83033
+
+python.default_version  38
+
+depends_build-append    port:py${python.version}-setuptools
+
+depends_lib-append      port:py${python.version}-colorama \
+                        port:py${python.version}-intervaltree \
+                        port:py${python.version}-json5 \
+                        port:py${python.version}-scipy \
+                        port:py${python.version}-tqdm \
+                        port:py${python.version}-typing_extensions \
+                        port:py${python.version}-yaml
+


### PR DESCRIPTION
#### Description

New port for [Graphtage](https://github.com/trailofbits/graphtage), a semantic diffing tool across JSON, YAML, XML, CSV, etc.

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
