### PR TITLE
gimp2{,-devel}: add patch to fix building on <= 10.7

### DIFF
--- a/graphics/gimp2-devel/Portfile
+++ b/graphics/gimp2-devel/Portfile
@@ -96,6 +96,7 @@ compiler.cxx_standard 2014
 compiler.blacklist-append *gcc-3.* *gcc-4.* {clang < 700}
 
 patchfiles          patch-etc-gimprc.in.diff \
+                    patch-mach-task-info.diff \
                     patch-quartz-32bit.diff \
                     MYPAINT_BRUSHES_DIR.patch
 

--- a/graphics/gimp2-devel/files/patch-mach-task-info.diff
+++ b/graphics/gimp2-devel/files/patch-mach-task-info.diff
@@ -1,0 +1,16 @@
+--- app/widgets/gimpdashboard.c.orig	2020-08-29 17:02:04.000000000 +0200
++++ app/widgets/gimpdashboard.c	2020-08-29 17:55:26.000000000 +0200
+@@ -2398,6 +2398,13 @@
+
+ #ifdef HAVE_MEMORY_GROUP
+ #ifdef PLATFORM_OSX
++  #if MAC_OS_X_VERSION_MAX_ALLOWED < 1080
++    #define MACH_TASK_BASIC_INFO_COUNT TASK_BASIC_INFO_COUNT
++    #define mach_task_basic_info_data_t task_basic_info_data_t
++
++    #define MACH_TASK_BASIC_INFO TASK_BASIC_INFO
++    #define mach_task_basic_info task_basic_info
++  #endif
+ static void
+ gimp_dashboard_sample_memory_used (GimpDashboard *dashboard,
+                                    Variable       variable)

--- a/graphics/gimp2/Portfile
+++ b/graphics/gimp2/Portfile
@@ -94,6 +94,7 @@ compiler.cxx_standard 2014
 compiler.blacklist-append *gcc-3.* *gcc-4.* {clang < 700}
 
 patchfiles          patch-etc-gimprc.in.diff \
+                    patch-mach-task-info.diff \
                     patch-quartz-32bit.diff \
                     MYPAINT_BRUSHES_DIR.patch
 

--- a/graphics/gimp2/files/MYPAINT_BRUSHES_DIR.patch
+++ b/graphics/gimp2/files/MYPAINT_BRUSHES_DIR.patch
@@ -5,29 +5,29 @@ See: https://github.com/mypaint/mypaint-brushes/issues/5
 +++ app/config/gimpcoreconfig.c	2020-06-02 21:37:55.000000000 -0500
 @@ -51,6 +51,9 @@
  #include "gimp-intl.h"
- 
- 
+
+
 +#define _QUOTE(x) #x
 +#define QUOTE(x) _QUOTE(x)
 +
  #define GIMP_DEFAULT_BRUSH         "2. Hardness 050"
  #define GIMP_DEFAULT_DYNAMICS      "Dynamics Off"
  #define GIMP_DEFAULT_PATTERN       "Pine"
-@@ -313,7 +316,7 @@
+@@ -314,7 +317,7 @@
                                        "share", "mypaint-data",
                                        "1.0", "brushes", NULL);
  #else
 -  mypaint_brushes = g_strdup (MYPAINT_BRUSHES_DIR);
 +  mypaint_brushes = g_strdup (QUOTE(MYPAINT_BRUSHES_DIR));
  #endif
- 
+
    path = g_build_path (G_SEARCHPATH_SEPARATOR_S,
 --- app/core/gimpdata.c.orig	2020-02-23 12:21:08.000000000 -0600
 +++ app/core/gimpdata.c	2020-06-02 21:38:28.000000000 -0500
 @@ -36,6 +36,9 @@
  #include "gimp-intl.h"
- 
- 
+
+
 +#define _QUOTE(x) #x
 +#define QUOTE(x) _QUOTE(x)
 +

--- a/graphics/gimp2/files/patch-etc-gimprc.in.diff
+++ b/graphics/gimp2/files/patch-etc-gimprc.in.diff
@@ -1,6 +1,6 @@
 --- etc/gimprc.in.orig	2020-02-16 07:04:57.000000000 -0800
 +++ etc/gimprc.in	2020-02-22 17:04:36.000000000 -0800
-@@ -821,11 +821,13 @@
+@@ -831,11 +831,13 @@
  # string value.
  # 
  # (help-locales "")
@@ -14,7 +14,7 @@
  
  # When enabled, a search of actions will also return inactive actions. 
  # Possible values are yes and no.
-@@ -852,6 +854,7 @@
+@@ -862,6 +864,7 @@
  # windows.  Possible values are normal, utility and keep-above.
  # 
  # (dock-window-hint utility)

--- a/graphics/gimp2/files/patch-mach-task-info.diff
+++ b/graphics/gimp2/files/patch-mach-task-info.diff
@@ -1,0 +1,16 @@
+--- app/widgets/gimpdashboard.c.orig	2020-08-29 17:02:04.000000000 +0200
++++ app/widgets/gimpdashboard.c	2020-08-29 17:55:26.000000000 +0200
+@@ -2398,6 +2398,13 @@
+
+ #ifdef HAVE_MEMORY_GROUP
+ #ifdef PLATFORM_OSX
++  #if MAC_OS_X_VERSION_MAX_ALLOWED < 1080
++    #define MACH_TASK_BASIC_INFO_COUNT TASK_BASIC_INFO_COUNT
++    #define mach_task_basic_info_data_t task_basic_info_data_t
++
++    #define MACH_TASK_BASIC_INFO TASK_BASIC_INFO
++    #define mach_task_basic_info task_basic_info
++  #endif
+ static void
+ gimp_dashboard_sample_memory_used (GimpDashboard *dashboard,
+                                    Variable       variable)


### PR DESCRIPTION
#### Description

gimp2{,-devel}: add patch to fix building on <= 10.7

- add patch to fix building on <= 10.7
- fix patches for (2) offsets
- Closes: https://trac.macports.org/ticket/60508

###### Type(s)

- [x] bugfix

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?

###### Notes

Since gimp2-devel, is an older version (2.10.19-...), I left out the other patches as is - in case the line numbers were updated in 2.10.20.