### PR TITLE
htop: update to 3.0.0

### DIFF
--- a/sysutils/htop/Portfile
+++ b/sysutils/htop/Portfile
@@ -3,22 +3,23 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        hishamhm htop 2.2.0
-checksums           rmd160  13d2fc4d5414db6ac5653ef87a6216f4e2090bbf \
-                    sha256  4de06703fb8583216a7c5a7797c9568b382208333676e750db6dac896cb7d4ea \
-                    size    172940
-
+github.setup        htop-dev htop 3.0.0
+revision            0
 epoch               1
-name                htop
+
 categories          sysutils
 platforms           darwin
 maintainers         {cal @neverpanic} openmaintainer
 license             GPL-2
 
-description         htop is an interactive text-mode process viewer for Unix \
-                    systems. It aims to be a better 'top'. 
+description         an interactive text-mode process viewer for Unix
+long_description    ${name} is {*}${description} systems. It aims to be a better 'top'.
 
-long_description    ${description}
+homepage            https://htop.dev
+
+checksums           rmd160  11470b5616acc9d4ced6ba7c964a5123f3310bcc \
+                    sha256  151a767e62bdaf7e33af88cf5b6a949f7d9bfd3b4f6dd5ba425f7f786f6ef19d \
+                    size    179411
 
 depends_build       port:autoconf \
                     port:automake \
@@ -29,6 +30,13 @@ depends_lib         port:ncurses
 
 pre-configure {
     system -W ${worksrcpath} "sh autogen.sh"
+}
+
+post-destroot {
+    # Delete the .png and .desktop files
+    foreach dir [list applications pixmaps] {
+        delete ${destroot}${prefix}/share/${dir}
+    }
 }
 
 # Exclude beta releases from livecheck


### PR DESCRIPTION
#### Description

htop: update to 3.0.0

  - htop-3.0.0 is a fork of htop-2.*, with new maintainers, etc
      » https://groups.io/g/htop/topic/htop_3_0_0_released/76441967
  - also added a post-destroot section to remove the unused
    .png and .desktop files.

###### Type(s)

- [x] update

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vsd install`?
- [x] tested basic functionality of all binary files?

###### Notes

The `epoch` stays, right?