### PR TITLE
tsduck: New port

### DIFF
--- a/multimedia/tsduck/Portfile
+++ b/multimedia/tsduck/Portfile
@@ -1,0 +1,51 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           makefile 1.0
+PortGroup           github 1.0
+PortGroup           legacysupport 1.1
+
+github.setup        tsduck tsduck 3.22-1953 v
+
+categories          multimedia
+license             BSD
+maintainers         {mit.edu:quentin @quentinmit} \
+                    openmaintainer
+description         MPEG Transport Stream Toolkit
+long_description    MPEG Transport Stream Toolkit
+
+homepage            https://tsduck.io/
+platforms           darwin
+
+checksums           sha1    cedc70686415a9062bee8c3b1f43af8ea74f2127 \
+                    rmd160  5a7c0b73ab1b6aa9d88b9d6ecde9befb00747f0f \
+                    sha256  ca4e0af170616eb7ea25b3555a2519b94b8443b3135a4681993b5ae54316f5d9 \
+                    size    13567538
+
+depends_build-append port:gsed
+
+depends_lib-append  port:curl
+
+# clock_gettime
+legacysupport.newest_darwin_requires_legacy 15
+
+# PCSC requires pcsc-lite
+# SRT requires libsrt
+# Neither of these are currently available in macports
+# Makefile.tsduck sets -install_name @rpath/$(notdir $@) and
+# -rpath @executable_path, which are not compatible with the installed
+# layout in $prefix.
+set args            "NOPCSC=true NOSRT=true CFLAGS_EXTRA='-Wno-unknown-warning-option -Wno-unknown-pragmas' CXXFLAGS_EXTRA='-Wno-unknown-warning-option -Wno-unknown-pragmas' LDFLAGS_EXTRA=-Wl,-rpath,@executable_path/../lib"
+
+build.target        default
+build.args          NOTEST=true ${args}
+
+destroot.target     install install-devel
+destroot.args       NOTEST=true ${args} "SYSROOT=${destroot}" "SYSPREFIX=${prefix}"
+post-destroot {
+    file mkdir ${destroot}${prefix}/share/doc/${name}
+    copy ${worksrcpath}/doc/tsduck.pdf ${destroot}${prefix}/share/doc/${name}/tsduck.pdf
+}
+
+test.run        yes
+test.args       ${args} LDFLAGS_EXTRA=-Wl,-rpath,@executable_path


### PR DESCRIPTION
#### Description

tsduck is a suite of tools for manipulating MPEG Transport Streams

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G103
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
