### PR TITLE
racket: new port

### DIFF
--- a/lang/racket/Portfile
+++ b/lang/racket/Portfile
@@ -1,0 +1,44 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               makefile 1.0
+
+name                    racket
+version                 7.8
+
+categories              lang
+platforms               darwin
+
+license                 Apache-2 \
+                        LGPL-3 \
+                        MIT
+
+homepage                https://racket-lang.org/
+
+description             Racket, the Language-Oriented Programming Language
+
+long_description        Racket is a dialect of Lisp and a descendant of \
+                        Scheme, a family of programming languages which are \
+                        variants of Racket, and a set of tools for using this \
+                        family of languages.
+
+checksums               rmd160  15ba11149310d8ccee59a936040a4a33a77d1dbe \
+                        sha256  69b22b7f2054d5adb557fde42e6a3cf2f730bbc705ae7b8e5cba8c867f66c700 \
+                        size    21202793
+
+maintainers             {gmail.com:herby.gillot @herbygillot} \
+                        openmaintainer
+
+master_sites            https://mirror.racket-lang.org/installers/${version}/
+distname                racket-minimal-${version}-src-builtpkgs
+extract.suffix          .tgz
+
+depends_build-append    port:libffi
+
+configure.dir           ${worksrcpath}/src
+build.dir               ${worksrcpath}/src
+
+configure.args-append   --disable-docs \
+                        --enable-xonx
+
+use_configure           yes


### PR DESCRIPTION
#### Description

New port for the [Racket Programming Language](https://racket-lang.org/)

Closes: https://trac.macports.org/ticket/28291

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
