### PR TITLE
staticcheck: new port

### DIFF
--- a/devel/staticcheck/Portfile
+++ b/devel/staticcheck/Portfile
@@ -21,7 +21,7 @@ long_description    Staticcheck is a state of the art linter for the Go \
                     designed to be useful out of the box, they still provide \
                     configuration where necessary, to fine-tune to your \
                     needs, without overwhelming you with hundreds of options. \
-                    Include with Staticcheck is a collection of tools for \
+                    Included with Staticcheck is a collection of tools for \
                     working with Go code, including linters and static \
                     analysis.
 

--- a/devel/staticcheck/Portfile
+++ b/devel/staticcheck/Portfile
@@ -1,0 +1,54 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/dominikh/go-tools 2020.1.5
+name                staticcheck
+revision            0
+
+homepage            https://staticcheck.io/
+
+description         Staticcheck - The advanced Go linter
+
+long_description    Staticcheck is a state of the art linter for the Go \
+                    programming language. Using static analysis, it finds \
+                    bugs and performance issues, offers simplifications, and \
+                    enforces style rules.  Each of the 100+ checks has been \
+                    designed to be fast, precise and useful. When Staticcheck \
+                    flags code, you can be sure that it isn't wasting your \
+                    time with unactionable warnings. While checks have been \
+                    designed to be useful out of the box, they still provide \
+                    configuration where necessary, to fine-tune to your \
+                    needs, without overwhelming you with hundreds of options. \
+                    Include with Staticcheck is a collection of tools for \
+                    working with Go code, including linters and static \
+                    analysis.
+
+checksums           rmd160  146de260c6d6105c0e92620d2b9a2027cd134c4a \
+                    sha256  e99f2cf2325700863e9b76770fd1df0b683e7329005ed74ada9b7560f30286d2 \
+                    size    406284
+
+categories          devel
+license             MIT
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+installs_libs       no
+
+build.env-append    CGO_ENABLED=0 \
+                    GO111MODULE=on
+
+set _build_path     ${worksrcpath}/build
+
+build.pre_args      -trimpath -o ${_build_path}
+build.args          ./cmd/...
+
+pre-build {
+    file mkdir ${_build_path}
+}
+
+destroot {
+    xinstall -m 755 {*}[glob ${_build_path}/*] ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

New port for [StaticCheck](https://staticcheck.io/)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
