### PR TITLE
py-mistune-devel: new port for mistune v2

### DIFF
--- a/python/py-mistune-devel/Portfile
+++ b/python/py-mistune-devel/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+set real_name       mistune
+name                py-${real_name}-devel
+version             2.0.0a5
+revision            0
+
+categories-append   devel textproc
+platforms           darwin
+license             BSD
+maintainers         nomaintainer
+conflicts           py-${real_name}
+
+python.versions     38
+
+description         The fastest markdown parser in pure Python.
+long_description    ${description}
+
+homepage            https://github.com/lepture/mistune
+
+master_sites        pypi:[string index ${real_name} 0]/${real_name}
+distname            ${real_name}-${version}
+
+checksums           rmd160  617f39003987727adcac340215f5c1ba424fca66 \
+                    sha256  e948b34687bb89dc6f9776f4ad7e654e37b93b09ff30291b06de2e0e4acb80ed \
+                    size    71440
+
+if {${name} ne ${subport}} {
+    conflicts               py${python.version}-${real_name}
+
+    depends_build-append    port:py${python.version}-setuptools \
+                            port:py${python.version}-cython
+
+    livecheck.type          none
+}


### PR DESCRIPTION
#### Description

py-mistune-devel: new port for mistune v2

In order to use `present`, this port need to be updated to v2.

###### Type(s)

- [x] submission

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

###### Notes

This port update is a part of the `present` submission.