### PR TITLE
py-pyfiglet: new port

### DIFF
--- a/python/py-pyfiglet/Portfile
+++ b/python/py-pyfiglet/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-pyfiglet
+version             0.8.post1
+revision            0
+
+platforms           darwin
+supported_archs     noarch
+license             MIT
+maintainers         nomaintainer
+
+description         a full port of FIGlet into pure python
+long_description    pyfiglet is a full port of FIGlet (http://www.figlet.org/) \
+                    into pure python. It takes ASCII text and renders it in ASCII \
+                    art fonts (like the title above, which is the 'block' font).
+
+homepage            https://github.com/pwaller/pyfiglet
+
+checksums           rmd160  dcc389a910487830cb5a34253e061ed7dc6f33ee \
+                    sha256  c6c2321755d09267b438ec7b936825a4910fec696292139e664ca8670e103639 \
+                    size    634618
+
+python.versions     38
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools
+
+    livecheck.type      none
+} else {
+    livecheck.type      pypi
+}


### PR DESCRIPTION
#### Description

py-pyfiglet: new ports

Dependency for `present`

###### Type(s)

- [x] submission

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vsd install`?
- [x] tested basic functionality of all binary files?

###### Notes

This port is a part of the `present` submission.