### PR TITLE
py-asciimatics: new port

### DIFF
--- a/python/py-asciimatics/Portfile
+++ b/python/py-asciimatics/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-asciimatics
+version             1.11.0
+revision            0
+
+platforms           darwin
+supported_archs     noarch
+license             Apache-2
+maintainers         nomaintainer
+
+description         a package to help people create full-screen text UIs
+long_description    Asciimatics is {*}${description} (from interactive \
+                    forms to ASCII animations) on any platform. It is \
+                    licensed under the Apache Software Foundation License 2.0.
+
+homepage            https://github.com/peterbrittain/asciimatics
+
+checksums           rmd160  5e7e10fe1beafd24d018f508d975fce6619c678d \
+                    sha256  1d0871133c95fa15c603d471ebb77e39b3389877e2ff2ad5ab3bc906d81b5e8c \
+                    size    1542478
+
+python.versions     38
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools_scm
+    depends_lib-append      port:py${python.version}-future \
+                            port:py${python.version}-Pillow \
+                            port:py${python.version}-pyfiglet \
+                            port:py${python.version}-wcwidth
+
+    livecheck.type      none
+} else {
+    livecheck.type  pypi
+}

--- a/python/py-asciimatics/Portfile
+++ b/python/py-asciimatics/Portfile
@@ -14,8 +14,7 @@ maintainers         nomaintainer
 
 description         a package to help people create full-screen text UIs
 long_description    Asciimatics is {*}${description} (from interactive \
-                    forms to ASCII animations) on any platform. It is \
-                    licensed under the Apache Software Foundation License 2.0.
+                    forms to ASCII animations) on any platform.
 
 homepage            https://github.com/peterbrittain/asciimatics
 
@@ -32,7 +31,7 @@ if {${name} ne ${subport}} {
                             port:py${python.version}-pyfiglet \
                             port:py${python.version}-wcwidth
 
-    livecheck.type      none
+    livecheck.type  none
 } else {
     livecheck.type  pypi
 }


### PR DESCRIPTION
#### Description

py-asciimatics: new port

Dependency for 'present'

###### Type(s)

- [x] submission

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vsd install`?
- [x] tested basic functionality of all binary files?

###### Notes

This port is a part of the `present` submission.

The checks will fail due to the missing dep: py-pyfiglet (#8270)