### PR TITLE
py-PyYAML: new port

### DIFF
--- a/python/py-PyYAML/Portfile
+++ b/python/py-PyYAML/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-PyYAML
+version             5.3.1
+revision            0
+
+platforms           darwin
+supported_archs     noarch
+license             MIT
+maintainers         nomaintainer
+
+description         The next generation YAML parser and emitter for Python
+long_description    PyYAML - *${description}.
+
+homepage            https://github.com/yaml/pyyaml
+
+checksums           rmd160  be7bb32b55e7957fa54d746d0bab77ee3afb7136 \
+                    sha256  b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d \
+                    size    269377
+
+python.versions     38
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools
+
+    livecheck.type      none
+} else {
+    livecheck.type      pypi
+}


### PR DESCRIPTION
#### Description

py-PyYAML: new port

Dependency for `present`

###### Type(s)

- [x] submission

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vsd install`?
- [x] tested basic functionality of all binary files?

###### Notes

This port is a part of the `present` submission.