### PR TITLE
present: new port

### DIFF
--- a/python/present/Portfile
+++ b/python/present/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                present
+version             0.6.0
+revision            0
+
+categories-append   office
+platforms           darwin
+supported_archs     noarch
+license             Apache-2
+maintainers         nomaintainer
+
+description         A terminal-based presentation tool with colors and effects
+long_description    {*}${description}.
+
+homepage            https://github.com/vinayak-mehta/present
+
+checksums           rmd160  7d5bad52b3219b2af95c86816fafdbda7227f75a \
+                    sha256  97d5b92f82c3f6a468deb2c192077623f6836a3fae7226f951883e5f845883a7 \
+                    size    13076
+
+python.versions     38
+
+depends_build-append    port:py${python.version}-setuptools
+depends_lib-append      port:py${python.version}-asciimatics \
+                        port:py${python.version}-click \
+                        port:py${python.version}-mistune-devel \
+                        port:py${python.version}-pyfiglet \
+                        port:py${python.version}-yaml


### PR DESCRIPTION
#### Description

[Present][p] is a terminal-based presentation tool with colors and effects.

[p]: https://github.com/vinayak-mehta/present

###### Type(s)

- [x] submission

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vsd install`?
- [x] tested basic functionality of all binary files?

###### Notes

This port will fail the checks due to missing deps:

- `py-asciimatics` (#8271)
- `py-pyfiglet` (#8270)

The `py-mistune` update (#8269) is also a part of this submission.