### PR TITLE
cctools: Use +xcode variant on arm

### DIFF
--- a/devel/cctools/Portfile
+++ b/devel/cctools/Portfile
@@ -76,6 +76,11 @@ proc some_llvm_variant_set {} {
     return no
 }
 
+platform arm {
+    # The llvm ports don't support arm yet.
+    default_variants +xcode
+}
+
 if { ![some_llvm_variant_set] && ![variant_isset xcode] } {
     if {${os.major} == 14 || ${os.major} == 15} {
         default_variants +llvm90


### PR DESCRIPTION
#### Description

cctools: Use +xcode variant on arm

The llvm ports don't support arm yet.

See: https://trac.macports.org/ticket/60941

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.0 20A5354i
Xcode 12.0 12A8189h

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [X] tried a full install with `sudo port -vst install`?
