### PR TITLE
ptpython: new port

### DIFF
--- a/python/ptpython/Portfile
+++ b/python/ptpython/Portfile
@@ -9,7 +9,7 @@ platforms           darwin
 license             BSD
 maintainers         nomaintainer
 
-description         Python REPL build on top of prompt_toolkit
+description         Python REPL built on top of prompt_toolkit
 long_description    {*}${description}
 
 homepage            https://github.com/prompt-toolkit/ptpython

--- a/python/ptpython/Portfile
+++ b/python/ptpython/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                ptpython
+version             3.0.5
+platforms           darwin
+license             BSD
+maintainers         nomaintainer
+
+description         Python REPL build on top of prompt_toolkit
+long_description    {*}${description}
+
+homepage            https://github.com/prompt-toolkit/ptpython
+
+checksums           rmd160  e4ca2c65f3c353b3e3d99fd9ef787926bdb64413 \
+                    sha256  5094e7e4daa77453d3c33eb7b7ebbf1060be4446521865a94e698bc85ff15930 \
+                    size    52739
+
+python.default_version      38
+
+depends_build-append        port:py${python.version}-setuptools
+
+depends_lib-append          port:py${python.version}-appdirs \
+                            port:py${python.version}-jedi \
+                            port:py${python.version}-prompt_toolkit \
+                            port:py${python.version}-pygments


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
