### PR TITLE
py-prompt_toolkit: update to 3.0.7

### DIFF
--- a/python/py-prompt_toolkit/Portfile
+++ b/python/py-prompt_toolkit/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-prompt_toolkit
-version             2.0.10
+version             3.0.7
 revision            0
 license             BSD
 platforms           darwin
@@ -18,9 +18,9 @@ python.versions     27 35 36 37 38
 homepage            https://github.com/prompt-toolkit/python-prompt-toolkit
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
-checksums           rmd160  7fef3cdd4d9c419124244191777ff0767bb6cb8f \
-                    sha256  f15af68f66e664eaa559d4ac8a928111eebd5feda0c11738b5998045224829db \
-                    size    347981
+checksums           rmd160  a783264901566c5554881a596162b3f4ad4bdbe7 \
+                    sha256  822f4605f28f7d2ba6b0b09a31e25e140871e96364d1d377667b547bb3bf4489 \
+                    size    3018359
 
 if {${name} ne ${subport}} {
     if {${python.version} eq 27} {


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
