### PR TITLE
py-pipdeptree: Add Python version 37

### DIFF
--- a/python/py-pipdeptree/Portfile
+++ b/python/py-pipdeptree/Portfile
@@ -19,7 +19,7 @@ checksums           rmd160  499e5a353f91ccf9e7b00dd3a80e4006abf142da \
                     sha256  5fe866a38113d28d527033ececc57b8e86df86b7c29edbacb33f41ee50f75b31 \
                     size    13842
 
-python.versions     38
+python.versions     37 38
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
py-pipdeptree: Add Python version 37

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
