### PR TITLE
narrow libodbc conflict

### DIFF
--- a/databases/unixODBC/Portfile
+++ b/databases/unixODBC/Portfile
@@ -3,7 +3,10 @@
 PortSystem          1.0
 
 name                unixODBC
-conflicts           libiodbc virtuoso virtuoso-7
+conflicts           virtuoso virtuoso-7
+if {[file exists ${prefix}/lib/libodbc.a]} {
+    conflicts-append libiodbc
+}
 version             2.3.7
 revision            1
 checksums           rmd160  ebbd9e9cee6888779e572b8a32596f49a8bdad2d \

--- a/devel/libiodbc/Portfile
+++ b/devel/libiodbc/Portfile
@@ -4,12 +4,10 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           active_variants 1.1
 
-conflicts           unixODBC
-
 github.setup        openlink iODBC 3.52.13 v
 #override name (keep it lowercase)
 name                libiodbc
-revision            1
+revision            2
 categories          devel
 maintainers         {snc @nerdling} openmaintainer
 license             BSD
@@ -31,8 +29,9 @@ patchfiles-append   patch-iodbcinst-unicode.h.diff
 
 configure.args-append   --disable-libodbc
 
-variant libodbc description {install extra libodbc.so library} {
+variant libodbc description {install extra libodbc.a library} {
     configure.args-replace --disable-libodbc --enable-libodbc
+    conflicts           unixODBC
 }
 
 variant x11 {
@@ -63,12 +62,13 @@ variant x11 {
     configure.args-delete   --disable-gui
 }
 
-default_variants +x11 +libiodbc
+default_variants +x11 +libodbc
 
 pre-configure {
     system -W ${worksrcpath} "sh ./autogen.sh"
 }
 configure.args-append   --disable-gui \
+                        --includedir=${prefix}/include/${name} \
                         --with-iodbc-inidir=${prefix}/etc
 
 # make[2]: *** No rule to make target `../iodbcadm/libiodbcadm.la', needed by `iodbcadm-gtk'.  Stop.


### PR DESCRIPTION
#### Description

Narrows the conflicts between libiodbc and unixODBC.

Fixes https://trac.macports.org/ticket/55661

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.6
Xcode 11.3.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
