### PR TITLE
eksctl: update to 0.26.0

### DIFF
--- a/sysutils/eksctl/Portfile
+++ b/sysutils/eksctl/Portfile
@@ -4,7 +4,7 @@ PortGroup           github 1.0
 
 maintainers         {@szczad gmail.com:szczad} openmaintainer
 
-github.setup        weaveworks eksctl 0.25.0
+github.setup        weaveworks eksctl 0.26.0
 github.tarball_from releases
 
 supported_archs     x86_64
@@ -20,9 +20,9 @@ long_description    eksctl is a simple CLI tool for creating clusters on EKS - A
                     CloudFormation, was created by Weaveworks.
 
 distname            eksctl_Darwin_amd64
-checksums           rmd160  05a18707a66776d9582cc6bbddcfe8bbcf425375 \
-                    sha256  e232f48e4995f711620ea34c09f582b097e5b006f45fbe82a11fc8955636c9c4 \
-                    size    22811045
+checksums           rmd160  7a549a4c59f9c7294a9b65cf1cd2d1c1485f7f6d \
+                    sha256  225d718a2be6b286043b7ef83cced281a1564b0953f69974b2791e6d77782238 \
+                    size    22831412
 dist_subdir         ${name}/${version}
 
 extract.mkdir       yes
@@ -46,3 +46,4 @@ destroot {
         ${destroot}${bashCompletionPrefix}/eksctl.bash
 }
 
+github.livecheck.regex {([0-9.]+)}


### PR DESCRIPTION
- fix livecheck regex

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
