### PR TITLE
gimp-save-for-web: new port

### DIFF
--- a/graphics/gimp-save-for-web/Portfile
+++ b/graphics/gimp-save-for-web/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+# Use latest commit (from 2017)
+github.setup        auris gimp-save-for-web a95134d1
+version             0.29.3
+revision            0
+
+license             MIT
+maintainers         {iefdev.se:eric @iefdev} openmaintainer
+categories          graphics
+platforms           darwin
+
+description         Save for Web plug-in for GIMP
+long_description    The Save for Web plug-in allows you to export your images\
+                    into various popular web format options. It shows an\
+                    automatically updated preview and file size statistics.\n
+
+checksums           rmd160  fa071b851c52ced37dbdd2d4fe08d9cb8e373b01 \
+                    sha256  3933f62bf31229a0f170d7145ee74cf2dadb7062dda9630ef6f3544b1de3fafc \
+                    size    67035
+
+patchfiles          patch-autogen.sh.diff
+
+depends_build       port:pkgconfig \
+                    port:intltool \
+                    port:autoconf \
+                    port:automake \
+                    port:libtool
+
+depends_lib         path:lib/pkgconfig/gimp-2.0.pc:gimp2
+
+configure.cmd       ./autogen.sh
+
+notes "You'll find this plugin in the File menu as \"Export for web...\"."

--- a/graphics/gimp-save-for-web/files/patch-autogen.sh.diff
+++ b/graphics/gimp-save-for-web/files/patch-autogen.sh.diff
@@ -1,0 +1,96 @@
+This patch updates the versions to current the ones (as
+of 2020-09-01), and removes some of the hardcoded versions
+to be able to use newer versions later on.
+
+--- autogen.sh.orig
++++ autogen.sh
+@@ -8,16 +8,16 @@
+ # tools and you shouldn't use this script.  Just call ./configure
+ # directly.
+ 
+-ACLOCAL=${ACLOCAL-aclocal-1.9}
++ACLOCAL=${ACLOCAL-aclocal-1.16}
+ AUTOCONF=${AUTOCONF-autoconf}
+ AUTOHEADER=${AUTOHEADER-autoheader}
+-AUTOMAKE=${AUTOMAKE-automake-1.9}
++AUTOMAKE=${AUTOMAKE-automake-1.16}
+ LIBTOOLIZE=${LIBTOOLIZE-libtoolize}
+ 
+-AUTOCONF_REQUIRED_VERSION=2.54
+-AUTOMAKE_REQUIRED_VERSION=1.9.6
+-INTLTOOL_REQUIRED_VERSION=0.36.3
+-LIBTOOL_REQUIRED_VERSION=1.5
++AUTOCONF_REQUIRED_VERSION=2.69
++AUTOMAKE_REQUIRED_VERSION=1.16.2
++INTLTOOL_REQUIRED_VERSION=0.51.0
++LIBTOOL_REQUIRED_VERSION=2.4.6
+ 
+ 
+ PROJECT="GIMP Save for Web plug-in"
+@@ -101,27 +101,27 @@ echo -n "checking for automake >= $AUTOMAKE_REQUIRED_VERSION ... "
+ if ($AUTOMAKE --version) < /dev/null > /dev/null 2>&1; then
+    AUTOMAKE=$AUTOMAKE
+    ACLOCAL=$ACLOCAL
+-elif (automake-1.15 --version) < /dev/null > /dev/null 2>&1; then
+-   AUTOMAKE=automake-1.15
+-   ACLOCAL=aclocal-1.15
+-elif (automake-1.14 --version) < /dev/null > /dev/null 2>&1; then
+-   AUTOMAKE=automake-1.14
+-   ACLOCAL=aclocal-1.14
+-elif (automake-1.13 --version) < /dev/null > /dev/null 2>&1; then
+-   AUTOMAKE=automake-1.13
+-   ACLOCAL=aclocal-1.13
+-elif (automake-1.12 --version) < /dev/null > /dev/null 2>&1; then
+-   AUTOMAKE=automake-1.12
+-   ACLOCAL=aclocal-1.12
+-elif (automake-1.11 --version) < /dev/null > /dev/null 2>&1; then
+-   AUTOMAKE=automake-1.11
+-   ACLOCAL=aclocal-1.11
+-elif (automake-1.10 --version) < /dev/null > /dev/null 2>&1; then
+-   AUTOMAKE=automake-1.10
+-   ACLOCAL=aclocal-1.10
+-elif (automake-1.9 --version) < /dev/null > /dev/null 2>&1; then
+-   AUTOMAKE=automake-1.9
+-   ACLOCAL=aclocal-1.9
++elif (automake --version) < /dev/null > /dev/null 2>&1; then
++   AUTOMAKE=automake
++   ACLOCAL=aclocal
++elif (automake --version) < /dev/null > /dev/null 2>&1; then
++   AUTOMAKE=automake
++   ACLOCAL=aclocal
++elif (automake --version) < /dev/null > /dev/null 2>&1; then
++   AUTOMAKE=automake
++   ACLOCAL=aclocal
++elif (automake --version) < /dev/null > /dev/null 2>&1; then
++   AUTOMAKE=automake
++   ACLOCAL=aclocal
++elif (automake --version) < /dev/null > /dev/null 2>&1; then
++   AUTOMAKE=automake
++   ACLOCAL=aclocal
++elif (automake --version) < /dev/null > /dev/null 2>&1; then
++   AUTOMAKE=automake
++   ACLOCAL=aclocal
++elif (automake --version) < /dev/null > /dev/null 2>&1; then
++   AUTOMAKE=automake
++   ACLOCAL=aclocal
+ else
+     echo
+     echo "  You must have automake $AUTOMAKE_REQUIRED_VERSION or newer installed to compile $PROJECT."
+@@ -170,7 +170,7 @@ test $TEST_TYPE $FILE || {
+ echo
+ echo "I am going to run ./configure with the following arguments:"
+ echo
+-echo "  --enable-maintainer-mode $AUTOGEN_CONFIGURE_ARGS $@"
++echo "  $AUTOGEN_CONFIGURE_ARGS $@"
+ echo
+ 
+ if test -z "$*"; then
+@@ -219,7 +219,7 @@ intltoolize --automake || exit 1
+ 
+ cd $ORIGDIR
+ 
+-$srcdir/configure --enable-maintainer-mode $AUTOGEN_CONFIGURE_ARGS "$@"
++$srcdir/configure $AUTOGEN_CONFIGURE_ARGS "$@"
+ RC=$?
+ if test $RC -ne 0; then
+   echo


### PR DESCRIPTION
#### Description

gimp-save-for-web: new port

###### Type(s)

- [x] submission
- [x] enhancement

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

…with `gimp-2.10.20`

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vsd install`?
- [x] tested basic functionality of all binary files?

###### Notes

Using the latest commit (from 2017) since the latest release is quite older.