### PR TITLE
newsboat: update to 2.22.1

### DIFF
--- a/net/newsboat/Portfile
+++ b/net/newsboat/Portfile
@@ -2,432 +2,64 @@
 
 PortSystem          1.0
 PortGroup           cargo_fetch 1.0
-PortGroup           makefile 1.0
+PortGroup           github      1.0
+PortGroup           makefile    1.0
 
-name                newsboat
-version             2.14.1
-revision            2
+github.setup        newsboat newsboat 2.22.1 r
+revision            0
+
+homepage            https://newsboat.org
+
+description         a fork of Newsbeuter, an RSS/Atom feed reader for the text console
+
+long_description    Newsboat is ${description}. The only difference is that \
+                    Newsboat is actively maintained while Newsbeuter isn't.
+
 categories          net www
 platforms           darwin
 license             MIT
-maintainers         {en.sent.com:macports @Raimondi} openmaintainer
-description         a fork of Newsbeuter, an RSS/Atom feed reader for the text console
-long_description    Newsboat is ${description}. The only difference is that \
-                    Newsboat is actively maintained while Newsbeuter isn't.
-homepage            https://newsboat.org/
-master_sites        https://newsboat.org/releases/${version}/
 
-use_xz              yes
+maintainers         {en.sent.com:macports @Raimondi} \
+                    {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
 
-cargo.crates        aho-corasick 0.6.9 1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e \
-                    argon2rs 0.2.5 3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392 \
-                    arrayvec 0.4.9 d18513977c2d8261c448511c5c53dc66b26dfccbc3d4446672dea1e71a7d8a26 \
-                    autocfg 0.1.1 4e5f34df7a019573fb8bdc7e24a2bfebe51a2a1d6bfdbaeccedb3c41fc574727 \
-                    backtrace 0.3.13 b5b493b66e03090ebc4343eb02f94ff944e0cbc9ac6571491d170ba026741eb5 \
-                    backtrace-sys 0.1.26 3fcce89e5ad5c8949caa9434501f7b55415b3e7ad5270cb88c75a8d35e8f1279 \
-                    bitflags 1.0.4 228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12 \
-                    blake2-rfc 0.2.18 5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400 \
-                    cc 1.0.26 389803e36973d242e7fecb092b2de44a3d35ac62524b3b9339e51d577d668e02 \
-                    cfg-if 0.1.6 082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4 \
-                    chrono 0.4.6 45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878 \
-                    cloudabi 0.0.3 ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
-                    constant_time_eq 0.1.3 8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e \
-                    dirs 1.0.4 88972de891f6118092b643d85a0b28e0678e0f948d7f879aa32f2d5aafe97d2a \
-                    failure 0.1.3 6dd377bcc1b1b7ce911967e3ec24fa19c3224394ec05b54aa7b083d498341ac7 \
-                    failure_derive 0.1.3 64c2d913fe8ed3b6c6518eedf4538255b989945c14c2a7d5cbff62a5e2120596 \
-                    fuchsia-zircon 0.3.3 2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
-                    fuchsia-zircon-sys 0.3.3 3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
-                    idna 0.1.5 38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e \
-                    lazy_static 1.2.0 a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1 \
-                    libc 0.2.45 2d2857ec59fadc0773853c664d2d18e7198e83883e7060b63c924cb077bd5c74 \
-                    lock_api 0.1.5 62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c \
-                    matches 0.1.8 7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
-                    memchr 2.1.2 db4c41318937f6e76648f42826b1d9ade5c09cafb5aef7e351240a70f39206e9 \
-                    nodrop 0.1.13 2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945 \
-                    num-integer 0.1.39 e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea \
-                    num-traits 0.2.6 0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1 \
-                    once_cell 0.1.6 d7ce3535d54560c937c1652ba4a0da66bfc63e0f8e07bed127483afb6e5ee925 \
-                    parking_lot 0.6.4 f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5 \
-                    parking_lot_core 0.3.1 ad7f7e6ebdc79edff6fdcb87a55b620174f7a989e3eb31b65231f4af57f00b8c \
-                    percent-encoding 1.0.1 31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831 \
-                    proc-macro2 0.4.24 77619697826f31a02ae974457af0b29b723e5619e113e9397b8b82c6bd253f09 \
-                    quote 0.6.10 53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c \
-                    rand 0.4.3 8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd \
-                    rand 0.5.5 e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c \
-                    rand 0.6.1 ae9d223d52ae411a33cf7e54ec6034ec165df296ccd23533d671a28252b6f66a \
-                    rand_chacha 0.1.0 771b009e3a508cb67e8823dda454aaa5368c7bc1c16829fb77d3e980440dd34a \
-                    rand_core 0.2.2 1961a422c4d189dfb50ffa9320bf1f2a9bd54ecb92792fb9477f99a1045f3372 \
-                    rand_core 0.3.0 0905b6b7079ec73b314d4c748701f6931eb79fd97c668caa3f1899b22b32c6db \
-                    rand_hc 0.1.0 7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4 \
-                    rand_isaac 0.1.1 ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08 \
-                    rand_pcg 0.1.1 086bd09a33c7044e56bb44d5bdde5a60e7f119a9e95b0775f545de759a32fe05 \
-                    rand_xorshift 0.1.0 effa3fcaa47e18db002bdde6060944b6d2f9cfd8db471c30e873448ad9187be3 \
-                    redox_syscall 0.1.44 a84bcd297b87a545980a2d25a0beb72a1f490c31f0a9fde52fca35bfbb1ceb70 \
-                    redox_users 0.2.0 214a97e49be64fd2c86f568dd0cb2c757d2cc53de95b273b6ad0a1c908482f26 \
-                    regex 1.1.0 37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f \
-                    regex-syntax 0.6.4 4e47a2ed29da7a9e1960e1639e7a982e6edc6d49be308a3b02daf511504a16d1 \
-                    remove_dir_all 0.5.1 3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5 \
-                    rustc-demangle 0.1.11 01b90379b8664dd83460d59bdc5dd1fd3172b8913788db483ed1325171eab2f7 \
-                    rustc_version 0.2.3 138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a \
-                    scoped_threadpool 0.1.9 1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8 \
-                    scopeguard 0.3.3 94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27 \
-                    semver 0.9.0 1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403 \
-                    semver-parser 0.7.0 388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
-                    smallvec 0.6.7 b73ea3738b47563803ef814925e69be00799a8c07420be8b996f8e98fb2336db \
-                    syn 0.15.23 9545a6a093a3f0bd59adb472700acc08cad3776f860f16a897dfce8c88721cbc \
-                    synstructure 0.10.1 73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015 \
-                    tempfile 3.0.5 7e91405c14320e5c79b3d148e1c86f40749a36e490642202a31689cb1a3452b2 \
-                    thread_local 0.3.6 c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b \
-                    time 0.1.41 847da467bf0db05882a9e2375934a8a55cffdc9db0d128af1518200260ba1f6c \
-                    ucd-util 0.1.3 535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86 \
-                    unicode-bidi 0.3.4 49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5 \
-                    unicode-normalization 0.1.7 6a0180bc61fc5a987082bfa111f4cc95c4caff7f9799f3e46df09163a937aa25 \
-                    unicode-width 0.1.5 882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526 \
-                    unicode-xid 0.1.0 fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc \
-                    unreachable 1.0.0 382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56 \
-                    url 1.7.2 dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a \
-                    utf8-ranges 1.0.2 796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737 \
-                    version_check 0.1.5 914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd \
-                    void 1.0.2 6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d \
-                    winapi 0.3.6 92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0 \
-                    winapi-i686-pc-windows-gnu 0.4.0 ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
-                    winapi-x86_64-pc-windows-gnu 0.4.0 712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f
+checksums           ${distname}${extract.suffix} \
+                    rmd160  49d0e660d156f65f3b258fac6fac69880909e051 \
+                    sha256  0448e8bdfa0d04fe7af001e3415a5768bb8e709cd4d57bfc75f9e54b9a9b6542 \
+                    size    1106776 \
 
-checksums           ${name}-${version}.tar.xz \
-                    rmd160  76f09fdc7ba7b9032fa50b395eb6cce9c7486c8c \
-                    sha256  4bd0d3b1901a3fc7e0ef73b800587c28181a57b175c36b547dbd84636330df66 \
-                    size    500096 \
-                    aho-corasick-0.6.9.crate \
-                    rmd160  142faa94cfdadb1f547c9aca2409e8f869b6044f \
-                    sha256  1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e \
-                    size    25979 \
-                    argon2rs-0.2.5.crate \
-                    rmd160  50d84e37d2513e8fa2787f642327ac88a825b10e \
-                    sha256  3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392 \
-                    size    353096 \
-                    arrayvec-0.4.9.crate \
-                    rmd160  04a4323c49c6e19124c6a7938d6e687e5c3bcc37 \
-                    sha256  d18513977c2d8261c448511c5c53dc66b26dfccbc3d4446672dea1e71a7d8a26 \
-                    size    26103 \
-                    autocfg-0.1.1.crate \
-                    rmd160  035241c8c510e551f7232115701e65eaa7c061e2 \
-                    sha256  4e5f34df7a019573fb8bdc7e24a2bfebe51a2a1d6bfdbaeccedb3c41fc574727 \
-                    size    10044 \
-                    backtrace-0.3.13.crate \
-                    rmd160  a732c613b1d4f99711de81dae33f17b6409d7764 \
-                    sha256  b5b493b66e03090ebc4343eb02f94ff944e0cbc9ac6571491d170ba026741eb5 \
-                    size    34101 \
-                    backtrace-sys-0.1.26.crate \
-                    rmd160  af70a032f299c02ce314c2be724b6ff7bf53467b \
-                    sha256  3fcce89e5ad5c8949caa9434501f7b55415b3e7ad5270cb88c75a8d35e8f1279 \
-                    size    522529 \
-                    bitflags-1.0.4.crate \
-                    rmd160  fd720dba692f079a1c6662e43677533bb68654de \
-                    sha256  228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12 \
-                    size    15282 \
-                    blake2-rfc-0.2.18.crate \
-                    rmd160  9c0e4ee7978a071709a9ab1e92dc585f70e582d8 \
-                    sha256  5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400 \
-                    size    15676 \
-                    cc-1.0.26.crate \
-                    rmd160  a7512bdbfd8a58ea5cb4273b0754d871db3798a2 \
-                    sha256  389803e36973d242e7fecb092b2de44a3d35ac62524b3b9339e51d577d668e02 \
-                    size    42350 \
-                    cfg-if-0.1.6.crate \
-                    rmd160  f190c1846549b3ad88559ae471cf2828c0bf44d1 \
-                    sha256  082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4 \
-                    size    7411 \
-                    chrono-0.4.6.crate \
-                    rmd160  9ddf038c956cb3db217fcd375fa159a03cb7b610 \
-                    sha256  45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878 \
-                    size    133108 \
-                    cloudabi-0.0.3.crate \
-                    rmd160  4da7ab080c1d18e5881dbcb419d250d0c38387eb \
-                    sha256  ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
-                    size    22156 \
-                    constant_time_eq-0.1.3.crate \
-                    rmd160  42322b052eba5c2311f41bdd60f98d385b981eac \
-                    sha256  8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e \
-                    size    1279 \
-                    dirs-1.0.4.crate \
-                    rmd160  46232082ab3e3600b562fb8c1add2c96aa5d5c29 \
-                    sha256  88972de891f6118092b643d85a0b28e0678e0f948d7f879aa32f2d5aafe97d2a \
-                    size    12844 \
-                    failure-0.1.3.crate \
-                    rmd160  0e17e145e6045d1dc9aa0b7ffac8ae2bf0a07630 \
-                    sha256  6dd377bcc1b1b7ce911967e3ec24fa19c3224394ec05b54aa7b083d498341ac7 \
-                    size    34107 \
-                    failure_derive-0.1.3.crate \
-                    rmd160  487996ef3aea5b083af10f7613655600888089e6 \
-                    sha256  64c2d913fe8ed3b6c6518eedf4538255b989945c14c2a7d5cbff62a5e2120596 \
-                    size    4349 \
-                    fuchsia-zircon-0.3.3.crate \
-                    rmd160  1c6ff549ecff64347e4b53dc8eb95d1444b78647 \
-                    sha256  2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
-                    size    22565 \
-                    fuchsia-zircon-sys-0.3.3.crate \
-                    rmd160  4b9e5d77223362e647972d7ccc66f69236aa1e89 \
-                    sha256  3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
-                    size    7191 \
-                    idna-0.1.5.crate \
-                    rmd160  e4049ab9ac2f8338e23c55d1f948c55a7f265d02 \
-                    sha256  38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e \
-                    size    258735 \
-                    lazy_static-1.2.0.crate \
-                    rmd160  92005f698356b188b35ae897b821137e61642966 \
-                    sha256  a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1 \
-                    size    10840 \
-                    libc-0.2.45.crate \
-                    rmd160  c17367aca854ffad6538751f8a0a00f6d3442416 \
-                    sha256  2d2857ec59fadc0773853c664d2d18e7198e83883e7060b63c924cb077bd5c74 \
-                    size    349425 \
-                    lock_api-0.1.5.crate \
-                    rmd160  ba1a2e7fc818e0cdef3386da54a0041444173327 \
-                    sha256  62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c \
-                    size    16967 \
-                    matches-0.1.8.crate \
-                    rmd160  dc8239e015b64fbc488e1ea9ff74aad38f872a72 \
-                    sha256  7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
-                    size    2216 \
-                    memchr-2.1.2.crate \
-                    rmd160  1973ab2a3624060a2aa1990ccc9b8e4a5b7988df \
-                    sha256  db4c41318937f6e76648f42826b1d9ade5c09cafb5aef7e351240a70f39206e9 \
-                    size    19520 \
-                    nodrop-0.1.13.crate \
-                    rmd160  6478a3dead0c72da1d32615205d0c2f4ab17734a \
-                    sha256  2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945 \
-                    size    7508 \
-                    num-integer-0.1.39.crate \
-                    rmd160  a72bc9c1474befe5ad6ff0e427d2c09cdf736bb2 \
-                    sha256  e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea \
-                    size    17881 \
-                    num-traits-0.2.6.crate \
-                    rmd160  b9711ea18adbc559a892b0741877f5a5a840e3e8 \
-                    sha256  0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1 \
-                    size    39923 \
-                    once_cell-0.1.6.crate \
-                    rmd160  031a78c61b481fc6342427b6745673657e46a844 \
-                    sha256  d7ce3535d54560c937c1652ba4a0da66bfc63e0f8e07bed127483afb6e5ee925 \
-                    size    12432 \
-                    parking_lot-0.6.4.crate \
-                    rmd160  90c4e6cec322cb5cbbdeb7755c1fcdbfb0c22625 \
-                    sha256  f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5 \
-                    size    31890 \
-                    parking_lot_core-0.3.1.crate \
-                    rmd160  4f36cfbdd51c74d67574835a5feb7fb16decaff3 \
-                    sha256  ad7f7e6ebdc79edff6fdcb87a55b620174f7a989e3eb31b65231f4af57f00b8c \
-                    size    26635 \
-                    percent-encoding-1.0.1.crate \
-                    rmd160  68898d3983e831ac02ae8d440a5c6f5a8e395695 \
-                    sha256  31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831 \
-                    size    10057 \
-                    proc-macro2-0.4.24.crate \
-                    rmd160  bbd92a79ca663073f20126fdabdc0edd386d0557 \
-                    sha256  77619697826f31a02ae974457af0b29b723e5619e113e9397b8b82c6bd253f09 \
-                    size    30970 \
-                    quote-0.6.10.crate \
-                    rmd160  baf3e1f9cce4dd4e92a8ae20c4b5ce8ed768b63f \
-                    sha256  53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c \
-                    size    15795 \
-                    rand-0.4.3.crate \
-                    rmd160  0911fc63ee17323176b7806d7ed6db412b32ac0f \
-                    sha256  8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd \
-                    size    76094 \
-                    rand-0.5.5.crate \
-                    rmd160  09a484f5c5e3501d87ec80eb4be990fcb421b9a9 \
-                    sha256  e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c \
-                    size    137359 \
-                    rand-0.6.1.crate \
-                    rmd160  bc44e065c78ffa042de1bf9e12284ec14f1dc9f5 \
-                    sha256  ae9d223d52ae411a33cf7e54ec6034ec165df296ccd23533d671a28252b6f66a \
-                    size    126613 \
-                    rand_chacha-0.1.0.crate \
-                    rmd160  9498af8a4982ffb828ad321616558f8e31ec5c43 \
-                    sha256  771b009e3a508cb67e8823dda454aaa5368c7bc1c16829fb77d3e980440dd34a \
-                    size    11637 \
-                    rand_core-0.2.2.crate \
-                    rmd160  333621510560ad7e8e982e5d6ef1dd5d2b932afb \
-                    sha256  1961a422c4d189dfb50ffa9320bf1f2a9bd54ecb92792fb9477f99a1045f3372 \
-                    size    15450 \
-                    rand_core-0.3.0.crate \
-                    rmd160  a19a998a918f95fcd70748ddd120089a022deda5 \
-                    sha256  0905b6b7079ec73b314d4c748701f6931eb79fd97c668caa3f1899b22b32c6db \
-                    size    20581 \
-                    rand_hc-0.1.0.crate \
-                    rmd160  067ca62839fb5cde9dc018dc0c95db5b6eb3387b \
-                    sha256  7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4 \
-                    size    11644 \
-                    rand_isaac-0.1.1.crate \
-                    rmd160  5d0f0a1a2b0385cd7901ceeda695d31cfacd0cac \
-                    sha256  ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08 \
-                    size    16020 \
-                    rand_pcg-0.1.1.crate \
-                    rmd160  533f5f25ebbaa1a055a09242d0b79246d8dd4933 \
-                    sha256  086bd09a33c7044e56bb44d5bdde5a60e7f119a9e95b0775f545de759a32fe05 \
-                    size    10881 \
-                    rand_xorshift-0.1.0.crate \
-                    rmd160  73d49641dd7df6353bd3dcdf00afa56de5f58010 \
-                    sha256  effa3fcaa47e18db002bdde6060944b6d2f9cfd8db471c30e873448ad9187be3 \
-                    size    9194 \
-                    redox_syscall-0.1.44.crate \
-                    rmd160  6f095223ff38aacfd3e0d7cad2ee344409901300 \
-                    sha256  a84bcd297b87a545980a2d25a0beb72a1f490c31f0a9fde52fca35bfbb1ceb70 \
-                    size    15254 \
-                    redox_users-0.2.0.crate \
-                    rmd160  4480a564575eefcc3e4bc80a09ed88a80f0a5362 \
-                    sha256  214a97e49be64fd2c86f568dd0cb2c757d2cc53de95b273b6ad0a1c908482f26 \
-                    size    11104 \
-                    regex-1.1.0.crate \
-                    rmd160  30c1df865aa99c31b45fcb92df7c2d0454d4f481 \
-                    sha256  37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f \
-                    size    241219 \
-                    regex-syntax-0.6.4.crate \
-                    rmd160  732c501a0998ae07b9e9387c0ef95ad4ff80bbc3 \
-                    sha256  4e47a2ed29da7a9e1960e1639e7a982e6edc6d49be308a3b02daf511504a16d1 \
-                    size    272048 \
-                    remove_dir_all-0.5.1.crate \
-                    rmd160  13b7dcf0ae8c4100d53134d45c32539b7a4debfb \
-                    sha256  3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5 \
-                    size    8726 \
-                    rustc-demangle-0.1.11.crate \
-                    rmd160  05d7b2b197b90dcce9159866a78f387a4a125dbe \
-                    sha256  01b90379b8664dd83460d59bdc5dd1fd3172b8913788db483ed1325171eab2f7 \
-                    size    11579 \
-                    rustc_version-0.2.3.crate \
-                    rmd160  6ca6aa5c736a1f88dd7579eb78d097ec40663173 \
-                    sha256  138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a \
-                    size    10210 \
-                    scoped_threadpool-0.1.9.crate \
-                    rmd160  64a6e9903a469630a2c664fbfece56a6d4add650 \
-                    sha256  1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8 \
-                    size    7800 \
-                    scopeguard-0.3.3.crate \
-                    rmd160  e77508e3d64bc39c22ac5c87f8937906d160019e \
-                    sha256  94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27 \
-                    size    9605 \
-                    semver-0.9.0.crate \
-                    rmd160  f3ba6d2359a3690d316a22586db785538b0e09ac \
-                    sha256  1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403 \
-                    size    17344 \
-                    semver-parser-0.7.0.crate \
-                    rmd160  63f826b792b17493186d587b9887efd93121294b \
-                    sha256  388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
-                    size    10268 \
-                    smallvec-0.6.7.crate \
-                    rmd160  5d41c043dd309a5529c38e38d66e54d18e250d84 \
-                    sha256  b73ea3738b47563803ef814925e69be00799a8c07420be8b996f8e98fb2336db \
-                    size    21450 \
-                    syn-0.15.23.crate \
-                    rmd160  c1b6a1478ccf857727cf522d3b89b3385e936376 \
-                    sha256  9545a6a093a3f0bd59adb472700acc08cad3776f860f16a897dfce8c88721cbc \
-                    size    145369 \
-                    synstructure-0.10.1.crate \
-                    rmd160  93582be7ce86406df4aeafce645bae173e7bec8c \
-                    sha256  73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015 \
-                    size    17836 \
-                    tempfile-3.0.5.crate \
-                    rmd160  508e325878dc220f9b09aca8145d6a329bc5d553 \
-                    sha256  7e91405c14320e5c79b3d148e1c86f40749a36e490642202a31689cb1a3452b2 \
-                    size    23272 \
-                    thread_local-0.3.6.crate \
-                    rmd160  58db38e54f31dc4c247aae31770f73047b17a7db \
-                    sha256  c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b \
-                    size    12388 \
-                    time-0.1.41.crate \
-                    rmd160  b10dddebb7bc21556f278d9e79a0f7d366b9f269 \
-                    sha256  847da467bf0db05882a9e2375934a8a55cffdc9db0d128af1518200260ba1f6c \
-                    size    29991 \
-                    ucd-util-0.1.3.crate \
-                    rmd160  c9eeb795a73b8facbf7679e3877689eb2551fb90 \
-                    sha256  535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86 \
-                    size    25897 \
-                    unicode-bidi-0.3.4.crate \
-                    rmd160  7c16a80cb62bef8cc6d73eb6126d496b46dbad1d \
-                    sha256  49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5 \
-                    size    32228 \
-                    unicode-normalization-0.1.7.crate \
-                    rmd160  4cbee8c9b2979aa0aa93f5a222fd0b72c46e97c6 \
-                    sha256  6a0180bc61fc5a987082bfa111f4cc95c4caff7f9799f3e46df09163a937aa25 \
-                    size    330545 \
-                    unicode-width-0.1.5.crate \
-                    rmd160  360df9e831a6e20931c240d13747f3711dc568d9 \
-                    sha256  882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526 \
-                    size    15761 \
-                    unicode-xid-0.1.0.crate \
-                    rmd160  fc5a8141e55bf6e2660b8c588e1107f179d24bb8 \
-                    sha256  fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc \
-                    size    16000 \
-                    unreachable-1.0.0.crate \
-                    rmd160  00c79ce6e523b3b09978db8766e3110a637c23ec \
-                    sha256  382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56 \
-                    size    6355 \
-                    url-1.7.2.crate \
-                    rmd160  c46442b7903a874b0556861845d5121bfc3b5397 \
-                    sha256  dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a \
-                    size    68597 \
-                    utf8-ranges-1.0.2.crate \
-                    rmd160  472c5b94c5ca826c8788d2e6629b713a9df70fd6 \
-                    sha256  796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737 \
-                    size    8510 \
-                    version_check-0.1.5.crate \
-                    rmd160  0806190559062dc843ecf13393f6c1319367eac1 \
-                    sha256  914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd \
-                    size    8173 \
-                    void-1.0.2.crate \
-                    rmd160  5d76f91beb625f5b645c156ca45ee5138e984e80 \
-                    sha256  6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d \
-                    size    2356 \
-                    winapi-0.3.6.crate \
-                    rmd160  549ef0ff7cd1a0f2aabf915ae603ed2c3c920ab6 \
-                    sha256  92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0 \
-                    size    1029391 \
-                    winapi-i686-pc-windows-gnu-0.4.0.crate \
-                    rmd160  a7d1e9e7f940d2e376a1b6dede7f0a50ad191ab8 \
-                    sha256  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
-                    size    2918815 \
-                    winapi-x86_64-pc-windows-gnu-0.4.0.crate \
-                    rmd160  300417853d251d91cadb9650992a6aa98248619f \
-                    sha256  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
-                    size    2947998
+github.tarball_from         archive
 
-depends_build       port:asciidoc \
-                    port:docbook-xsl-nons \
-                    port:rust \
-                    port:cargo \
-                    port:pkgconfig
+compiler.cxx_standard       2011
 
-depends_lib         port:curl \
-                    port:gettext \
-                    port:json-c \
-                    port:libxml2 \
-                    port:ncurses \
-                    port:sqlite3 \
-                    port:stfl
+configure.cmd               ./config.sh
 
-post-extract {
-    # Fix permissions
-    fs-traverse f ${worksrcpath} {
-        if {[file isdirectory ${f}]} {
-            file attributes ${f} -permissions o+rx
-        } else {
-            file attributes ${f} -permissions o+r
-        }
-    }
-}
+build.env-append            GETTEXT_DIR=${prefix}
 
-compiler.cxx_standard \
-                    2011
+build.pre_args-append       prefix=${prefix}
 
-patchfiles          patch-Makefile.diff \
-                    patch-config.sh.diff
+build.args-append           BUILD_TYPE="release" \
+                            CARGO_BUILD_FLAGS="-v --frozen --release" \
+                            PROFILE=
 
-use_configure       yes
-configure.cmd       ./config.sh
+destroot.pre_args-append    prefix=${prefix}
 
-makefile.prefix_name \
-                    prefix
+use_configure               yes
 
-build.target-append doc
+depends_build               port:asciidoc \
+                            port:asciidoctor \
+                            port:docbook-xsl-nons \
+                            port:rust \
+                            port:cargo \
+                            port:pkgconfig
+
+depends_lib                 port:curl \
+                            port:gettext \
+                            port:json-c \
+                            port:libxml2 \
+                            port:ncurses \
+                            port:sqlite3 \
+                            port:stfl
 
 post-destroot {
     xinstall -d ${destroot}${prefix}/share/${name}
@@ -446,6 +78,101 @@ variant tests description {Enable tests} {
                     -Werror
 }
 
-livecheck.type      regex
-livecheck.url       ${homepage}
-livecheck.regex     {The current version is (\d+(?:\.\d+)*),}
+cargo.crates \
+    addr2line                       0.13.0  1b6a2d3371669ab3ca9797670853d61402b03d0b4b9ebf33d677dfa720203072 \
+    adler                            0.2.3  ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e \
+    aho-corasick                    0.7.13  043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86 \
+    arrayvec                         0.5.1  cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8 \
+    autocfg                          1.0.1  cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a \
+    backtrace                       0.3.50  46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293 \
+    bit-set                          0.5.2  6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de \
+    bit-vec                          0.6.2  5f0dc55f2d8a1a85650ac47858bb001b4c0dd73d79e3c455a842925e68d29cd3 \
+    bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
+    bitvec                          0.19.4  a7ba35e9565969edb811639dbebfe34edc0368e472c5018474c8eb2543397f81 \
+    block                            0.1.6  0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a \
+    byteorder                        1.3.4  08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de \
+    cc                              1.0.60  ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c \
+    cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
+    chrono                          0.4.19  670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73 \
+    clap                            2.33.3  37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002 \
+    codespan-reporting               0.9.5  6e0762455306b1ed42bc651ef6a2197aabda5e1d4a43c34d5eab5c1a3634e81d \
+    curl-sys            0.4.39+curl-7.74.0  07a8ce861e7b68a0b394e814d7ee9f1b2750ff8bd10372c6ad3bacc10e86f874 \
+    cxx                             0.5.10  ebdd48b6a265557715bbbd72e891c6d26fe0cc58d87a881892a54ae47e0a92aa \
+    cxx-build                       0.5.10  42dca43e7e9d853737dc10c2fd8f9d2daaa2ccd1c37b96056e1c492ab34a2004 \
+    cxxbridge-flags                 0.5.10  1348c4c636b17ce60fc700963326ff65b19f0e9ee151bcf0a36a165d50d5dc49 \
+    cxxbridge-macro                 0.5.10  59f75aad3925fade3d141007be05e9e272cf7cf7bbd089d9bb0d2d5621dbb016 \
+    fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
+    form_urlencoded                  1.0.0  ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00 \
+    funty                            1.0.1  0ba62103ce691c2fd80fbae2213dfdda9ce60804973ac6b6e97de818ea7f52c8 \
+    getrandom                       0.1.15  fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6 \
+    gettext-rs                       0.5.0  1b95fa19cca70adf9888150e979839ae9bd58f85a1a42e4753699112875189e1 \
+    gettext-sys                     0.19.9  e034c4ba5bb796730a6cc5eb0d654c16885006a7c3d6c6603581ed809434f153 \
+    gimli                           0.22.0  aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724 \
+    idna                             0.2.0  02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9 \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    lexical-core                     0.7.4  db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616 \
+    libc                            0.2.81  1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb \
+    libz-sys                         1.1.2  602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655 \
+    link-cplusplus                   1.0.4  f96aa785c87218ec773df6c510af203872b34e2df2cf47d6e908e5f36231e354 \
+    locale_config                    0.3.0  08d2c35b16f4483f6c26f0e4e9550717a2f6575bcd6f12a53ff0c490a94a6934 \
+    malloc_buf                       0.0.6  62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb \
+    matches                          0.1.8  7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
+    memchr                           2.3.3  3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400 \
+    miniz_oxide                      0.4.2  c60c0dfe32c10b43a144bad8fc83538c52f58302c92300ea7ec7bf7b38d5a7b9 \
+    natord                           1.0.9  308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c \
+    nom                              6.0.1  88034cfd6b4a0d54dd14f4a507eceee36c0b70e5a02236c4e4df571102be17f0 \
+    num-integer                     0.1.43  8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b \
+    num-traits                      0.2.12  ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611 \
+    objc                             0.2.7  915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1 \
+    objc-foundation                  0.1.1  1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9 \
+    objc_id                          0.1.1  c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b \
+    object                          0.20.0  1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5 \
+    once_cell                        1.5.2  13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0 \
+    openssl-sys                     0.9.58  a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de \
+    percent-encoding                 2.1.0  d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
+    pkg-config                      0.3.18  d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33 \
+    ppv-lite86                       0.2.9  c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20 \
+    proc-macro2                     1.0.24  1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71 \
+    proptest                        0.10.1  12e6c80c1139113c28ee4670dc50cc42915228b51f56a9e407f0ec60f966646f \
+    quick-error                      1.2.3  a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0 \
+    quote                            1.0.7  aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37 \
+    radium                           0.5.3  941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8 \
+    rand                             0.7.3  6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
+    rand_chacha                      0.2.2  f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402 \
+    rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
+    rand_hc                          0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
+    rand_xorshift                    0.2.0  77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8 \
+    redox_syscall                   0.1.57  41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce \
+    regex                            1.3.9  9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6 \
+    regex-syntax                    0.6.18  26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8 \
+    remove_dir_all                   0.5.3  3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7 \
+    rustc-demangle                  0.1.16  4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783 \
+    rusty-fork                       0.3.0  cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f \
+    ryu                              1.0.5  71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e \
+    scratch                          1.0.0  7e114536316b51a5aa7a0e59fc49661fd263c5507dd08bd28de052e57626ce69 \
+    section_testing                  0.0.4  ece4d7d98fdab75ddff5c4fad54a4c7ad0222a13c8a3c6859f1037a1d9e53f28 \
+    static_assertions                1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
+    syn                             1.0.48  cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac \
+    tap                              1.0.0  36474e732d1affd3a6ed582781b3683df3d0563714c59c39591e8ff707cf078e \
+    tempfile                         3.1.0  7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9 \
+    termcolor                        1.1.0  bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f \
+    textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
+    thread_local                     1.0.1  d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14 \
+    time                            0.1.44  6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255 \
+    tinyvec                          0.3.4  238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117 \
+    unicode-bidi                     0.3.4  49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5 \
+    unicode-normalization           0.1.13  6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977 \
+    unicode-width                    0.1.8  9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3 \
+    unicode-xid                      0.2.1  f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564 \
+    url                              2.2.0  5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e \
+    vcpkg                           0.2.10  6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c \
+    version_check                    0.9.2  b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed \
+    wait-timeout                     0.2.0  9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6 \
+    wasi      0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
+    wasi     0.10.0+wasi-snapshot-preview1  1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f \
+    winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                      0.1.5  70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    wyz                              0.2.0  85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214 \
+    xdg                              2.2.0  d089681aa106a86fade1b0128fb5daf07d5867a509ab036d99988dec80429a57


### PR DESCRIPTION
- use sources from Github

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
