### PR TITLE
google-cloud-sdk: update to 308.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             307.0.0
+version             308.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  aa2b435924e55835878e44e8f1e90c3c2b879c2d \
-                    sha256  645315d5948f99579fd1181f55f926663d3ab6d4e2cdc3f08a26c170f713810b \
-                    size    84428981
+    checksums       rmd160  693e15cd29e5619a5e196fba454699a813db40d5 \
+                    sha256  c3291537c8458be1f9b86b5e8da846c96794760766afe3af565f44f7bd6a0ef2 \
+                    size    84489704
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  66d578545f1e8112f9b4d58db25981cf7adf4adc \
-                    sha256  98d6503d2c0ccaf9c042d09c7f223f2179b731965c54691fc18810dc08979ba4 \
-                    size    85441304
+    checksums       rmd160  21d6668b833d7fad7ac99e7eea7a3fa00e288b09 \
+                    sha256  077c473929c2305fc7fada19319e139762b6088580ac9b5aac8b3ed8c18b78a5 \
+                    size    85503322
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 308.0.0.

###### Tested on

macOS 10.15.6 19G2021
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?