### PR TITLE
gmt6: update to 6.1.1

### DIFF
--- a/science/gmt5/Portfile
+++ b/science/gmt5/Portfile
@@ -10,8 +10,8 @@ github.tarball_from releases
 distname            ${github.project}-${github.version}-src
 revision            6
 subport gmt6 {
-    github.setup    GenericMappingTools gmt 6.1.0
-    revision        1
+    github.setup    GenericMappingTools gmt 6.1.1
+    revision        0
     epoch           1
 }
 categories          science
@@ -43,9 +43,9 @@ if {${subport} eq "gmt5"} {
                         sha256  078d4997507cb15344c74a874568985e45bdbd6d3a72d330c74c47f4c0359bb1 \
                         size    59175704
 } else {
-    checksums           rmd160  11c0d9edfd8e524f1cb30203458d3e4b10a40802 \
-                        sha256  ad02780153c53a1116ae0cc7945b6f533f066af44c30d7f95ff138cfede1867c \
-                        size    53811392
+    checksums           rmd160  cbedfd353f7d6b38c9e6625f02129da4f655e365 \
+                        sha256  d476cba999340648146ef53ab4a3f64858cbd2f5511cdec9f7f06f3fb7896625 \
+                        size    54252072
 }
 
 depends_lib         port:curl \


### PR DESCRIPTION
#### Description

Update to version 6.1.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.7 11E801a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
