### PR TITLE
grepcidr: new port

### DIFF
--- a/sysutils/grepcidr/Portfile
+++ b/sysutils/grepcidr/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                grepcidr
+version             2.0
+revision            0
+
+categories          sysutils net
+platforms           darwin
+maintainers         nomaintainer
+license             GPL
+
+description         Filter IPv4 and IPv6 addresses matching CIDR patterns
+long_description    ${name} can be used to filter a list of IP addresses against\
+                    one or more Classless Inter-Domain Routing (CIDR)\
+                    specifications. As with grep, there are options to invert\
+                    matching and load patterns from a file. grepcidr is capable\
+                    of efficiently processing large numbers of IPs and networks.
+
+homepage            http://www.pc-tools.net/unix/grepcidr/
+master_sites        http://www.pc-tools.net/files/unix/
+
+checksums           rmd160  e4d7e90ab82506b2e46ba203f2c2d11d13c10f0f \
+                    sha256  61886a377dabf98797145c31f6ba95e6837b6786e70c932324b7d6176d50f7fb \
+                    size    16557
+
+post-extract {
+    # Fix permissions
+    fs-traverse item ${worksrcpath} {
+        if {[file isdirectory ${item}]} {
+            file attributes ${item} -permissions a+rx
+        } elseif {[file isfile ${item}]} {
+            file attributes ${item} -permissions a+r
+        }
+    }
+}
+
+use_configure       no
+
+pre-build {
+    reinplace "s|/usr/local|${prefix}|" ${worksrcpath}/Makefile
+}
+
+notes "
+For usage and examples, please refer to the manual:
+    \$ man ${name}
+"


### PR DESCRIPTION
#### Description

grepcidr: new port

[grepcidr][home] 2.0 – Filter IPv4 and IPv6 addresses matching CIDR patterns
[home]: http://www.pc-tools.net/unix/grepcidr/

###### Type(s)

- [x] submission

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vsd install`?
- [x] tested basic functionality of all binary files?
