### PR TITLE
web-ext: update to 5.0.0

### DIFF
--- a/devel/web-ext/Portfile
+++ b/devel/web-ext/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                web-ext
-version             4.1.0
+version             5.0.0
 revision            0
-checksums           rmd160  4d23463bfcb9113cc8523e741176a9aa17574e3a \
-                    sha256  330e634d988fbafba584fc09ee5fcf42ff058d778373072ea12d7f530b26203c \
-                    size    70866
+checksums           rmd160  f1fd59e05d26f7a4e07f0edbbec3ad77c4f6c602 \
+                    sha256  989a8e5a9654a674714f630be2e23aad2424d6b155297deae800a04ddcb98e7b \
+                    size    75225
 
 categories          devel
 maintainers         nomaintainer
@@ -23,7 +23,7 @@ extract.suffix      .tgz
 
 platforms           darwin
 
-depends_lib-append  path:bin/node:nodejs10
+depends_lib-append  path:bin/node:nodejs14
 
 depends_build-append \
                     path:bin/npm:npm6


### PR DESCRIPTION
###### Tested on
macOS 10.13.6 17G12034
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?