### PR TITLE
ctlang, gdcm2, luminance-hdr, olena: use compiler.cxx_standard 2011

### DIFF
--- a/aqua/luminance-hdr/Portfile
+++ b/aqua/luminance-hdr/Portfile
@@ -3,7 +3,6 @@
 PortSystem              1.0
 PortGroup               cmake 1.1
 PortGroup               qt5 1.0
-PortGroup               cxx11 1.1
 
 name                    luminance-hdr
 version                 2.6.0
@@ -42,6 +41,8 @@ depends_run-append      port:hugin-app
 checksums               rmd160  b1ad15d37434524c5793685e035692c5fff579d6 \
                         sha256  d7d2003e0ef4ead6f4b4c526bc44749a1fb845e795e0c5b7c35a393b0c0518a1 \
                         size    11556372
+
+compiler.cxx_standard   2011
 
 # see ${worksrcpath}/cmake/Version.cmake for LHDR_NAME and LHDR_OSX_EXECUTABLE_NAME values
 set ldhr_name           "Luminance HDR"

--- a/devel/olena/Portfile
+++ b/devel/olena/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem              1.0
 PortGroup               qt4   1.0
-PortGroup               cxx11 1.1
 
 name                    olena
 version                 2.1
@@ -51,6 +50,7 @@ configure.args-append   --with-imagemagickxx=no
 configure.env-append    PYTHON=${prefix}/bin/python2.7
 
 # required by tesseract
+compiler.cxx_standard   2011
 configure.cxxflags-append -std=c++11
 
 livecheck.url           https://www.lrde.epita.fr/dload/olena

--- a/graphics/ctlang/Portfile
+++ b/graphics/ctlang/Portfile
@@ -3,7 +3,6 @@
 PortSystem           1.0
 PortGroup            github 1.0
 PortGroup            cmake 1.1
-PortGroup            cxx11 1.1
 
 github.setup         ampas CTL 1.5.2 ctl-
 revision             5
@@ -28,6 +27,7 @@ patchfiles           patch-OpenEXR_CTL.pc.in.diff
 patchfiles-append    patch-CtlSimdInst.cpp.diff
 
 # see https://trac.macports.org/ticket/57523
+compiler.cxx_standard 2011
 configure.cxxflags-append -std=c++11
 
 depends_build-append     \

--- a/science/gdcm2/Portfile
+++ b/science/gdcm2/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem              1.0
 PortGroup               cmake 1.1
-PortGroup               cxx11 1.1
 
 name                    gdcm2
 version                 2.8.9
@@ -25,6 +24,7 @@ checksums               rmd160  c301428024efd8137ceff84696a55c6ef7f6b80b \
 
 # C++11 required to use socketxx
 patchfiles-append       patch-cxx_standard.diff
+compiler.cxx_standard   2011
 
 depends_build-append    port:pkgconfig
 


### PR DESCRIPTION
…instead of deprecated cxx11 1.1 portgroup

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
