### PR TITLE
chromaprint: use compiler.cxx_standard 2011

### DIFF
--- a/audio/chromaprint/Portfile
+++ b/audio/chromaprint/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.0
-PortGroup           cxx11 1.1
 PortGroup           github 1.0
 
 # don't forget to revbump gstreamer1-gst-plugins-bad if
@@ -26,6 +25,8 @@ checksums           rmd160  aac0edc9b2d4f5280d40ac035b2267978a20e3e1 \
                     sha256  4e14e13a9fbad7bc41ec70d99dd777ecdc18da741c08bd3875549de8b2d5e00e \
                     size    615260
 
+compiler.cxx_standard 2011
+
 depends_build-append  port:gmake
 depends_lib-append  path:lib/libavcodec.dylib:ffmpeg \
                     port:fftw-3
@@ -42,7 +43,6 @@ variant tests description {Enable tests} {
     depends_build-append    port:gtest
 
     # duplicate settings from gtest CMakeLists.txt file
-    compiler.cxx_standard   2011
     configure.args-append   -DCMAKE_CXX_STANDARD=11 \
                             -DCMAKE_CXX_STANDARD_REQUIRED=ON
 


### PR DESCRIPTION
…instead of deprecated cxx11 1.1 portgroup

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
