### PR TITLE
grepcidr: add the makefile PG

### DIFF
--- a/sysutils/grepcidr/Portfile
+++ b/sysutils/grepcidr/Portfile
@@ -1,10 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           makefile 1.0
 
 name                grepcidr
 version             2.0
-revision            0
+revision            1
 
 categories          sysutils net
 platforms           darwin
@@ -15,7 +16,7 @@ description         Filter IPv4 and IPv6 addresses matching CIDR patterns
 long_description    ${name} can be used to filter a list of IP addresses against\
                     one or more Classless Inter-Domain Routing (CIDR)\
                     specifications. As with grep, there are options to invert\
-                    matching and load patterns from a file. grepcidr is capable\
+                    matching and load patterns from a file. ${name} is capable\
                     of efficiently processing large numbers of IPs and networks.
 
 homepage            http://www.pc-tools.net/unix/grepcidr/
@@ -36,11 +37,7 @@ post-extract {
     }
 }
 
-use_configure       no
-
-pre-build {
-    reinplace "s|/usr/local|${prefix}|" ${worksrcpath}/Makefile
-}
+makefile.override   PREFIX
 
 notes "
 For usage and examples, please refer to the manual:


### PR DESCRIPTION
#### Description

grepcidr: add the makefile PG

  - add the makefile PG
  - use makefile.override to set the PREFIX
  - Closes: https://trac.macports.org/ticket/61123

###### Type(s)

- [x] update

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vsd install`?
- [x] tested basic functionality of all binary files?