### PR TITLE
cmake: Fix build on 10.4.

### DIFF
--- a/devel/cmake/files/patch-cmake-leopard-tiger.diff
+++ b/devel/cmake/files/patch-cmake-leopard-tiger.diff
@@ -72,6 +72,15 @@
        defined(__DragonFly__)       || \
        defined(__FreeBSD__)         || \
        defined(__FreeBSD_kernel__)
+@@ -1035,7 +1035,7 @@
+   ts[0] = uv__fs_to_timespec(req->atime);
+   ts[1] = uv__fs_to_timespec(req->mtime);
+   return utimensat(AT_FDCWD, req->path, ts, AT_SYMLINK_NOFOLLOW);
+-#elif defined(__APPLE__)          ||                                          \
++#elif defined(__APPLE__) && MAC_OS_X_VERSION_MAX_ALLOWED >= 1050 ||           \
+       defined(__DragonFly__)      ||                                          \
+       defined(__FreeBSD__)        ||                                          \
+       defined(__FreeBSD_kernel__) ||                                          \
 @@ -1286,7 +1286,7 @@
    dst->st_blksize = src->st_blksize;
    dst->st_blocks = src->st_blocks;


### PR DESCRIPTION
The 10.4 build was failing due to an attempt to use lutimes(), which
didn't exist until 10.5.  There's another portion of the cmake code
that includes a configure test for lutimes(), but it doesn't apply to
this area.  The fix is to add an OS version check to the existing
conditionals.

Checks of this form should more correctly use MIN_REQUIRED rather than
MAX_ALLOWED, but this uses the latter for consistency with the other
places, both in the patches and upstream.

Since this only fixes broken builds, there is no need for a revbump.

TESTED:
Built on 10.4-10.5 ppc, 10.4-10.6 i386, and 10.6-10.15 x86_64.
Did not test variants, due to dependency complications, and the low
likelihood of an interaction with this change.
Built libaes_siv as a test case.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14019, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G5033, x86_64, Xcode 10.3 10G8
macOS 10.15.4 19E287, x86_64, Xcode 11.7 11E801a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [N/A] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
