### PR TITLE
quartz-wm: Enable Xplugin dock support on 10.8+

### DIFF
--- a/x11/quartz-wm/Portfile
+++ b/x11/quartz-wm/Portfile
@@ -2,6 +2,7 @@ PortSystem 1.0
 PortGroup       github 1.0
 
 github.setup    XQuartz quartz-wm 1.3.2 quartz-wm-
+revision        1
 categories	x11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
 description     Apple's Window Manager for X11
@@ -47,5 +48,8 @@ platform macosx {
     if {${os.major} < 10} {
         # Xplugin.h is missing on Tiger and incorrect on Leopard
         configure.cppflags-append -I${filespath}/include
+    }
+    if {${os.major} > 11} {
+        configure.args-append --enable-xplugin-dock-support
     }
 }

--- a/x11/quartz-wm/Portfile
+++ b/x11/quartz-wm/Portfile
@@ -32,7 +32,7 @@ if {${os.arch} eq "powerpc"} {
         reinplace "/install_name_tool/d" ${worksrcpath}/lib/Makefile.in
     }
 } elseif {${os.major} < 10} {
-    depends_build port:cctools
+    depends_build-append port:cctools
     depends_skip_archcheck-append cctools
 }
 

--- a/x11/quartz-wm/Portfile
+++ b/x11/quartz-wm/Portfile
@@ -6,11 +6,11 @@ revision        1
 categories	x11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
 description     Apple's Window Manager for X11
-homepage	http://www.xquartz.org
 platforms	macosx
 long_description quartz-wm is the XQuartz window-manager.
 license         APSL-2
 
+homepage        https://www.xquartz.org
 github.tarball_from releases
 
 checksums       sha1    9e43d795b9c996b9204cdb2d4b9e922f243e4028 \

--- a/x11/quartz-wm/Portfile
+++ b/x11/quartz-wm/Portfile
@@ -1,15 +1,16 @@
 PortSystem 1.0
+PortGroup       github 1.0
 
-name		quartz-wm
-version		1.3.2
+github.setup    XQuartz quartz-wm 1.3.2 quartz-wm-
 categories	x11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
 description     Apple's Window Manager for X11
 homepage	http://www.xquartz.org
 platforms	macosx
 long_description quartz-wm is the XQuartz window-manager.
-master_sites	https://github.com/XQuartz/quartz-wm/releases/download/quartz-wm-${version}
 license         APSL-2
+
+github.tarball_from releases
 
 checksums       sha1    9e43d795b9c996b9204cdb2d4b9e922f243e4028 \
                 rmd160  aff2fce05bc75497de665a5fa6b64b99e498a5c3 \
@@ -47,7 +48,3 @@ platform macosx {
 }
 
 configure.args  --with-bundle-id-prefix=org.macports
-
-livecheck.type  regex
-livecheck.url   https://github.com/XQuartz/quartz-wm/releases
-livecheck.regex ${name}-(\[0-9.\]+)${extract.suffix}

--- a/x11/quartz-wm/Portfile
+++ b/x11/quartz-wm/Portfile
@@ -40,11 +40,12 @@ if {${os.arch} eq "powerpc"} {
 # http://trac.macports.org/ticket/36043
 compiler.blacklist-append gcc-4.0
 
+configure.args  --disable-silent-rules \
+                --with-bundle-id-prefix=org.macports
+
 platform macosx {
     if {${os.major} < 10} {
         # Xplugin.h is missing on Tiger and incorrect on Leopard
         configure.cppflags-append -I${filespath}/include
     }
 }
-
-configure.args  --with-bundle-id-prefix=org.macports

--- a/x11/quartz-wm/Portfile
+++ b/x11/quartz-wm/Portfile
@@ -41,8 +41,8 @@ if {${os.arch} eq "powerpc"} {
 compiler.blacklist-append gcc-4.0
 
 platform macosx {
-    if { ![file exists /usr/include/Xplugin.h] } {
-        # Xplugin.h is missing on Tiger
+    if {${os.major} < 10} {
+        # Xplugin.h is missing on Tiger and incorrect on Leopard
         configure.cppflags-append -I${filespath}/include
     }
 }

--- a/x11/quartz-wm/Portfile
+++ b/x11/quartz-wm/Portfile
@@ -1,14 +1,17 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
 PortGroup       github 1.0
 
 github.setup    XQuartz quartz-wm 1.3.2 quartz-wm-
 revision        1
-categories	x11
-maintainers	{jeremyhu @jeremyhu} openmaintainer
-description     Apple's Window Manager for X11
-platforms	macosx
-long_description quartz-wm is the XQuartz window-manager.
+categories      x11
+platforms       macosx
+maintainers     {jeremyhu @jeremyhu} openmaintainer
 license         APSL-2
+
+description     Apple's Window Manager for X11
+long_description quartz-wm is the XQuartz window-manager.
 
 homepage        https://www.xquartz.org
 github.tarball_from releases


### PR DESCRIPTION
#### Description

This PR makes several fixes in the quartz-wm port. Most important, it enables Xplugin dock support on 10.8+, per suggestion of @jeremyhu, making it no longer use the bundled binary of libquartz-wm-ds.dylib on 10.8+, which is good for arm64 since the bundled binary of libquartz-wm-ds.dylib isn't compiled for arm64.

For the Xplugin.h change, I wrote:

```
    if {${os.major} < 10} {
        # Xplugin.h is missing on Tiger and incorrect on Leopard
```

as was previously done in xorg-server, xorg-server-devel and xorg-server-1.18, but another possibility is:

```
    if {${os.major} < 9} {
        # Xplugin.h is missing on Tiger
```

as was done in mesa. I wasn't sure which was correct.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 11.0 20A5354i
Xcode 12.0 12A8189n

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
