### PR TITLE
libsdl2: Fix build on arm64 Macs

### DIFF
--- a/devel/libsdl2/Portfile
+++ b/devel/libsdl2/Portfile
@@ -27,7 +27,8 @@ checksums       rmd160 0f2c979da6151b622a6445e7fc8d4e3ea8987105 \
                 sha256 349268f695c02efbc9b9148a70b85e58cefbbf704abd3e91be654db7f1e2c863
 
 patchfiles      NSOperatingSystemVersion.patch \
-                sdl2-config.cmake.in-fix.patch
+                sdl2-config.cmake.in-fix.patch \
+                arm.patch
 
 configure.args  --without-x
 build.args      V=1

--- a/devel/libsdl2/files/arm.patch
+++ b/devel/libsdl2/files/arm.patch
@@ -1,0 +1,45 @@
+Properly identify Apple Silicon Macs.
+
+This is a combination of three upstream commits:
+
+https://hg.libsdl.org/SDL/rev/af22dd6c0787
+https://hg.libsdl.org/SDL/rev/8a12de07fc37
+https://hg.libsdl.org/SDL/rev/ac567246864a
+--- configure.orig	2020-03-10 20:36:18.000000000 -0500
++++ configure	2020-09-04 00:03:44.000000000 -0500
+@@ -21667,7 +21667,7 @@
+           #import <Metal/Metal.h>
+           #import <QuartzCore/CAMetalLayer.h>
+ 
+-          #if !TARGET_CPU_X86_64
++          #if TARGET_CPU_X86
+           #error Metal doesn't work on this configuration
+           #endif
+ 
+@@ -22570,7 +22570,7 @@
+                   #include <Metal/Metal.h>
+                   #include <QuartzCore/CAMetalLayer.h>
+ 
+-                  #if !TARGET_CPU_X86_64
++                  #if TARGET_CPU_X86
+                   #error Vulkan doesn't work on this configuration
+                   #endif
+ 
+@@ -24222,7 +24222,7 @@
+     # so we'll just use libusb when it's available.
+     case "$host" in
+         # libusb does not support iOS
+-        arm*-apple-darwin* | *-ios-* )
++        *-ios-* )
+             skiplibusb=yes
+             ;;
+         # On the other hand, *BSD specifically uses libusb only
+@@ -25072,7 +25072,7 @@
+ fi
+ 
+         ;;
+-    arm*-apple-darwin*|*-ios-*)
++    *-ios-*)
+         ARCH=ios
+ 
+         CheckVisibilityHidden


### PR DESCRIPTION
#### Description

libsdl2: Fix build on arm64 Macs (don't misidentify arm64 Macs as iOS)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.0 20A5354i
Xcode 12.0 12A8189n

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
