### PR TITLE
croc: new port

### DIFF
--- a/net/croc/Portfile
+++ b/net/croc/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/schollz/croc 8.3.0 v
+
+categories          net sysutils
+license             MIT
+
+homepage            https://schollz.com/blog/croc6/
+
+description         Easily and securely send things from one computer to \
+                    another
+
+long_description    croc is a tool that allows any two computers to simply \
+                    and securely transfer files and folders. AFAIK, croc is \
+                    the only CLI file-transfer tool that: allows any two \
+                    computers to transfer data (using a relay), provides \
+                    end-to-end encryption (using PAKE), enables easy \
+                    cross-platform transfers (Windows, Linux, Mac), allows \
+                    multiple file transfers, allows resuming transfers that \
+                    are interrupted, does not need a local server or \
+                    port-forwarding, is faster than wormhole, rsync, scp \
+                    through compression and multiplexing (speedups 1.5x to \
+                    4x), and supports IPv6.
+
+checksums           rmd160  832f8a913b7b54ba7d8ea7d7edee7356d29efaec \
+                    sha256  adfbe70bb7aee32ed06e89f4006ff4fe38db21df7dfbcb863ffdd9e9c3d4e55f \
+                    size    496541
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+installs_libs       no
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

New port for [croc](https://schollz.com/blog/croc6/)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.7 11E801a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
