### PR TITLE
ade, chipmunk, geos, libdynd: use compiler.cxx_standard

### DIFF
--- a/devel/ade/Portfile
+++ b/devel/ade/Portfile
@@ -3,7 +3,6 @@
 PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           compiler_blacklist_versions 1.0
-PortGroup           cxx11 1.1
 PortGroup           github 1.0
 
 github.setup        opencv ade 0.1.1f v
@@ -22,6 +21,8 @@ homepage            https://github.com/opencv/ade
 checksums           rmd160  7b0f61fbe8a791c2f8725e6039cdbd8b8193e59a \
                     sha256  6a202007b0f08bb3c1aab42d31109515fed57e46a4642fa2f1f35284683f2ba2 \
                     size    116075
+
+compiler.cxx_standard 2011
 
 compiler.blacklist-append *gcc* {clang < 900} {macports-clang-3.[0-9]} {macports-clang-[4-6].0}
 compiler.fallback-append  macports-clang-8.0 macports-clang-7.0

--- a/devel/chipmunk/Portfile
+++ b/devel/chipmunk/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.0
-PortGroup           cxx11 1.1
 
 name                chipmunk
 version             7.0.3
@@ -27,6 +26,8 @@ checksums           rmd160  29d617a1ce16eac77530661f847942e4c5133007 \
                     size    1015496
 
 use_parallel_build  yes
+
+compiler.cxx_standard 2011
 
 configure.args-append   -DBUILD_DEMOS:BOOL=OFF \
                         -DINSTALL_DEMOS:BOOL=OFF \

--- a/devel/libdynd/Portfile
+++ b/devel/libdynd/Portfile
@@ -2,8 +2,6 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.1
-PortGroup           compiler_blacklist_versions 1.0
-PortGroup           cxx11 1.1
 PortGroup           github 1.0
 
 set git_sha1        341d6d91931fdb04ad657d27ed740cf533fc925b
@@ -30,9 +28,7 @@ post-patch {
     reinplace "s|@@DYND_VERSION_STRING@@|v${version}|g" ${worksrcpath}/CMakeLists.txt
 }
 
-# Requires C++14
-compiler.blacklist-append \
-                    {clang < 602}
+compiler.cxx_standard 2014
 
 configure.args-append \
                     -DDYND_SHARED_LIB:BOOL=ON \

--- a/science/geos/Portfile
+++ b/science/geos/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cxx11 1.1
 PortGroup           compiler_blacklist_versions 1.0
 
 name                geos
@@ -29,7 +28,12 @@ checksums           rmd160  16b9b4dba1c772c561bace8e3e7c514f78fd4037 \
                     sha256  4258af4308deb9dbb5047379026b4cd9838513627cb943a44e16c40e42ae17f7 \
                     size    2505407
 
-compiler.blacklist  llvm-gcc-4.2 macports-llvm-gcc-4.2 {clang < 600}
+compiler.cxx_standard 2011
+
+# Avoid compilation errors observed for Xcode 4.6.3 (clang 425) on 10.7
+# and linking errors observed for Xcode 5.1.1 (clang 503) on 10.8.
+# See https://github.com/macports/macports-ports/pull/6159
+compiler.blacklist-append {clang < 600}
 
 use_parallel_build  yes
 


### PR DESCRIPTION
…instead of deprecated cxx11 1.1 portgroup

`geos`: use `compiler.blacklist-append`, cleanup and explain

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
