### PR TITLE
creduce: use compiler.cxx_standard 2011

### DIFF
--- a/devel/creduce/Portfile
+++ b/devel/creduce/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
-PortGroup               cxx11 1.1
 
 name                    creduce
 version                 2.10.0
@@ -21,11 +20,11 @@ long_description        C-Reduce is a tool that takes a large C, C++, \
                         process source code.
 homepage                http://embed.cs.utah.edu/creduce
 
-# INSTALL notes the specific version of LLVM that is required.
+# INSTALL.md notes the specific version of LLVM that is required.
 set llvm_version        8.0
 set perl5.major         5.28
 
-# INSTALL mentions flex, but the tarball ships with pregenerated parsers.
+# INSTALL.md mentions flex, but the tarball ships with pregenerated parsers.
 depends_build           port:llvm-${llvm_version}
 
 # Required by the LLVM static libraries.
@@ -48,8 +47,11 @@ checksums               rmd160  183be95aec282812724ec66204952ad33dbc923b \
                         sha256  db1c0f123967f24d620b040cebd53001bf3dcf03e400f78556a2ff2e11fea063 \
                         size    779318
 
+compiler.cxx_standard   2011
+
 pre-fetch {
     if {${os.platform} eq "darwin" && ${os.major} <= 9} {
+        known_fail      yes
         ui_error "${name} is only supported on 10.6 or newer."
         return -code error "unsupported macOS version"
     }
@@ -60,7 +62,6 @@ if {${os.platform} eq "darwin" && ${os.major} <= 12} {
     depends_lib-append      port:libcxx
     configure.cxx_stdlib    libc++
     # clang < macOS 10.9 don't work. clang-5.0 tested and works.
-    # cannot use cxx11 1.1 PG due to other issues
     # just whitelist working compilers rather than a long list of blacklisting and fallback additions
     compiler.whitelist      macports-clang-5.0 macports-clang-6.0 macports-clang-7.0
 }


### PR DESCRIPTION
…instead of deprecated `cxx11 1.1` portgroup

Use `known_fail yes` on macOS 10.5 and earlier

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
