### PR TITLE
guetzli, lirc: use compiler.cxx_standard 2011

### DIFF
--- a/graphics/guetzli/Portfile
+++ b/graphics/guetzli/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
-PortGroup           cxx11 1.1
 
 github.setup        google guetzli 1.0.1 v
 checksums           rmd160  4a427f59e47dfea2cb9d278fcd9ede76b42368a7 \
@@ -23,6 +22,8 @@ maintainers         {ctreleaven @ctreleaven} openmaintainer
 depends_build       port:pkgconfig
 
 depends_lib         port:libpng
+
+compiler.cxx_standard 2011
 
 use_configure       no
 

--- a/sysutils/lirc/Portfile
+++ b/sysutils/lirc/Portfile
@@ -1,5 +1,4 @@
 PortSystem          1.0
-PortGroup           cxx11 1.1
 
 name                lirc
 version             0.9.4d
@@ -30,6 +29,8 @@ set pythonbranch    3.6
 set pythonver       python${pythonbranch}
 set pythonbin       ${prefix}/bin/${pythonver}
 set pymodver        py36
+
+compiler.cxx_standard 2011
 
 use_autoreconf      yes
 autoreconf.cmd      ./autogen.sh


### PR DESCRIPTION
…instead of deprecated cxx11 1.1 portgroup

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
Ports lack `size` in checksums.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
