### PR TITLE
recoll: use compiler.cxx_standard 2011

### DIFF
--- a/textproc/recoll/Portfile
+++ b/textproc/recoll/Portfile
@@ -3,7 +3,6 @@
 PortSystem          1.0
 PortGroup           app 1.0
 PortGroup           qt5 1.0
-PortGroup           cxx11 1.1
 
 qt5.depends_component qtwebkit
 
@@ -40,6 +39,8 @@ depends_run         port:antiword \
 patchfiles          patch-sampleconf-mimeview.diff \
     patch-mkin-no-no-undefined.diff \
     patch-rclinit-set-path.diff
+
+compiler.cxx_standard 2011
 
 # Note: this is probably not the right way to configure QMAKE
 configure.args      QMAKE=${prefix}/libexec/qt5/bin/qmake \


### PR DESCRIPTION
…instead of deprecated cxx11 1.1 portgroup

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
