### PR TITLE
aff4: use compiler.cxx_standard 2011

### DIFF
--- a/security/aff4/Portfile
+++ b/security/aff4/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cxx11 1.1
 PortGroup           github 1.0
 
 github.setup        Velocidex c-aff4 fd984ea3cddc034740d5d03ba510a407a2e451a3
@@ -20,6 +19,8 @@ long_description    The Advanced Forensics File Format 4 (AFF4) is an open sourc
 checksums           rmd160  08295532a5abaa4634e40913af5cf8ed0786f3bf \
                     sha256  9cf9eebd7146191d59feeac182cc00133921d074702d2d5683895ff0ce0c79bf \
                     size    667085
+
+compiler.cxx_standard 2011
 
 depends_lib-append  port:ossp-uuid \
                     port:pcrexx \


### PR DESCRIPTION
…instead of deprecated cxx11 1.1 portgroup

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
