### PR TITLE
gitlab-runner: update to 13.3.1

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 13.3.0 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 13.3.1 v
 
 categories          devel
 platforms           darwin
@@ -23,9 +23,9 @@ homepage            https://docs.gitlab.com/runner/
 master_sites        https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v${version}/
 distname            gitlab-runner-v${version}
 
-checksums           rmd160  a3f08b23e3fe8aa5e36b3c92a4e2102c1b95e70b \
-                    sha256  af337ab7b098870b9229441481578e7d87b9d32d22c045113f52dff3b5f4fe43 \
-                    size    7547145
+checksums           rmd160  8e09fa0537aa87daffdbd5de5370b63dcd55f5ae \
+                    sha256  1a0c3f28223b8c409e1e44467f3e4a9d45f07898b28656347b887feb0978a4a1 \
+                    size    7548448
 
 # Reproduce the "build_simple" target from the upstream Makefile
 set go_ldflags      "-X ${go.package}/common.NAME=${go.package} \


### PR DESCRIPTION
#### Description

Update to GitLab Runner 13.3.1.

###### Tested on

macOS 10.15.6 19G2021
Xcode 11.7 11E801a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?