### PR TITLE
oniguruma6: update to v6.9.5_rev1

### DIFF
--- a/devel/oniguruma6/Portfile
+++ b/devel/oniguruma6/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        kkos oniguruma 6.9.5 v
+github.setup        kkos oniguruma 6.9.5_rev1 v
 revision            0
 name                oniguruma6
 maintainers         {mps @Schamschula} openmaintainer
@@ -17,9 +17,9 @@ long_description    Oniguruma is a regular expressions library in which \
                     different character encoding can be specified for every \
                     expression. Supports Unicode Porperty/Script.
 
-checksums           rmd160  364fbbc8c2d59bea2a5fea4fd979f298e02606a4 \
-                    sha256  3b951f876ff409d137b3f2f512fc870278d1b27ae44ba1624e00c4c06e4070e7 \
-                    size    612886
+checksums           rmd160  af6e42ffa2bdb9c50cc7c5b060297310fa7f772b \
+                    sha256  3898f1906eef059371d10b0bccc5bf850ba3a9eabc37a61c050c7b5dcf1d0291 \
+                    size    613061
 
 conflicts           oniguruma5
 


### PR DESCRIPTION
#### Description

Update to latest release version with bugfix of https://github.com/kkos/oniguruma/issues/192

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.13.6 17G14019
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
