### PR TITLE
bzflag: use compiler.cxx_standard 2011

### DIFF
--- a/games/bzflag/Portfile
+++ b/games/bzflag/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem          1.0
 PortGroup           app 1.0
-PortGroup           cxx11 1.1
 
 name                bzflag
 version             2.4.18
@@ -30,6 +29,8 @@ depends_lib         port:c-ares \
                     port:libsdl2 \
                     port:ncurses \
                     port:zlib
+
+compiler.cxx_standard 2011
 
 configure.args      --libdir=${prefix}/lib/${name} \
                     --disable-sdltest


### PR DESCRIPTION
…instead of deprecated cxx11 1.1 portgroup

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
