### PR TITLE
dvisvgm: add dependency xxhashlib, rebuild

### DIFF
--- a/graphics/dvisvgm/Portfile
+++ b/graphics/dvisvgm/Portfile
@@ -30,7 +30,7 @@ if {${subport} eq ${name}} {
     checksums rmd160 763479d0bfdb9e2d720d2651624b2251e9ade539 \
               sha256 29fd95ed19b5c5f4dd04490f1b48aee0abdec80d8989237a70ab9ab3e9410080 \
               size   2633536
-    revision  0
+    revision  1
 
     version 2.10.0
 
@@ -62,11 +62,9 @@ if {${subport} eq ${name}} {
         port:potrace \
         port:texlive-bin \
         port:woff2 \
+        port:xxhashlib \
         port:zlib \
         path:lib/libssl.dylib:openssl
-    # dvisvgm also depends on xxhash which is not yet packaged by MacPorts
-    # but the dependency is bundled with the sources & taken from there
-    #   port:xxhash
 
     # prevent opportunistic dependency on gawk
     configure.env-append \


### PR DESCRIPTION
Now that libxxhash has been ported, dvisvgm prefers
the external dependency over the internal fallback.
Prevents opportunistic linking depending on whether
xxhashlib is installed or not.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G6020
Xcode 11.2.1 11B500 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
