### PR TITLE
python27: Support for Apple silicon

### DIFF
--- a/lang/python27/Portfile
+++ b/lang/python27/Portfile
@@ -41,7 +41,8 @@ patchfiles          patch-Makefile.pre.in.diff \
                     patch-libedit.diff \
                     enable-loadable-sqlite-extensions.patch \
                     patch-_osx_support.py.diff \
-                    darwin20.diff
+                    darwin20.diff \
+                    apple-silicon.diff
 
 depends_build       port:pkgconfig
 depends_lib         port:bzip2 \

--- a/lang/python27/files/apple-silicon.diff
+++ b/lang/python27/files/apple-silicon.diff
@@ -1,0 +1,24 @@
+--- configure.orig2	2020-09-05 13:50:10.000000000 -0400
++++ configure	2020-09-05 14:02:36.000000000 -0400
+@@ -8476,6 +8476,9 @@
+     	ppc)
+     		MACOSX_DEFAULT_ARCH="ppc64"
+     		;;
++        arm64)
++                MACOSX_DEFAULT_ARCH="arm64"
++                ;;
+     	*)
+     		as_fn_error $? "Unexpected output of 'arch' on OSX" "$LINENO" 5
+     		;;
+--- Mac/Tools/pythonw.c.orig	2020-09-05 14:18:58.000000000 -0400
++++ Mac/Tools/pythonw.c	2020-09-05 14:17:04.000000000 -0400
+@@ -114,6 +114,9 @@
+ #elif defined(__x86_64__)
+     cpu_types[0] = CPU_TYPE_X86_64;
+ 
++#elif defined(__arm64__)
++    cpu_types[0] = CPU_TYPE_ARM64;
++
+ #elif defined(__ppc__)
+     cpu_types[0] = CPU_TYPE_POWERPC;
+ #elif defined(__i386__)


### PR DESCRIPTION
#### Description

Add support for Apple silicon to python27:

-  Update configure to recognize "arm64" as the output of /usr/bin/arch
-  Update Mac/Tools/pythonw.c to handle the __arm64__ preprocessor definition

Fixes https://trac.macports.org/ticket/60968

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 11.0 20A5364e (Beta 6 on Apple silicon)
Xcode 12.0 12A8189n (Beta 6)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
