### PR TITLE
emacs: Add support for Apple silicon

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -84,6 +84,8 @@ if {$subport eq $name || $subport eq "emacs-app"} {
     version         27.1
     revision        1
 
+    patchfiles-append  apple-silicon.diff
+
     checksums       rmd160  9ddfd28ab54c4aee168eeecb783d13599e5b5288 \
                     sha256  ffbfa61dc951b92cf31ebe3efc86c5a9d4411a1222b8a4ae6716cfd0e2a584db \
                     size    65782481
@@ -98,6 +100,8 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
     git.url         https://github.com/emacs-mirror/emacs.git
     git.branch      2a47ef86e95fad1dcc14a02e7471ba5d9cad4b9b
 
+    patchfiles-append  apple-silicon-devel.diff
+    
     pre-configure {
         system -W ${worksrcpath} "sh ./autogen.sh"
     }

--- a/editors/emacs/files/apple-silicon-devel.diff
+++ b/editors/emacs/files/apple-silicon-devel.diff
@@ -1,0 +1,10 @@
+--- configure.ac.orig	2020-09-06 11:42:39.000000000 -0400
++++ configure.ac	2020-09-06 11:43:22.000000000 -0400
+@@ -709,6 +709,7 @@
+     case "${canonical}" in
+       *-apple-darwin[0-9].*) unported=yes ;;
+       i[3456]86-* | x86_64-* )  ;;
++      arm-* | aarch64-* )  ;;
+       * )            unported=yes ;;
+     esac
+     opsys=darwin

--- a/editors/emacs/files/apple-silicon.diff
+++ b/editors/emacs/files/apple-silicon.diff
@@ -1,0 +1,10 @@
+--- configure.orig	2020-09-05 16:39:18.000000000 -0400
++++ configure	2020-09-05 16:40:53.000000000 -0400
+@@ -4979,6 +4979,7 @@
+     case "${canonical}" in
+       *-apple-darwin[0-9].*) unported=yes ;;
+       i[3456]86-* | x86_64-* )  ;;
++      arm-* | aarch64-* ) ;;
+       * )            unported=yes ;;
+     esac
+     opsys=darwin


### PR DESCRIPTION
#### Description

Add support for Apple silicon to the emacs port.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 11.0 20A5364e (Beta 6)
Xcode 12.0 12A8189n (Beta 6)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
