### PR TITLE
grepcidr: use MP flags

### DIFF
--- a/sysutils/grepcidr/Portfile
+++ b/sysutils/grepcidr/Portfile
@@ -5,7 +5,7 @@ PortGroup           makefile 1.0
 
 name                grepcidr
 version             2.0
-revision            1
+revision            2
 
 categories          sysutils net
 platforms           darwin
@@ -37,7 +37,9 @@ post-extract {
     }
 }
 
-makefile.override   PREFIX
+patchfiles          patch-ldflags.diff
+
+makefile.override   PREFIX CFLAGS LDFLAGS
 
 notes "
 For usage and examples, please refer to the manual:

--- a/sysutils/grepcidr/files/patch-ldflags.diff
+++ b/sysutils/grepcidr/files/patch-ldflags.diff
@@ -1,0 +1,11 @@
+--- Makefile.orig	2020-09-06 09:46:30.000000000 +0200
++++ Makefile	2020-09-06 09:46:36.000000000 +0200
+@@ -15,7 +15,7 @@
+ all: grepcidr
+ 
+ grepcidr: grepcidr.o
+-	$(CC) $(CFLAGS) grepcidr.o -o grepcidr
++	$(CC) $(CFLAGS) $(LDFLAGS) grepcidr.o -o grepcidr
+ 
+ doc: grepcidr.1
+ 


### PR DESCRIPTION
#### Description

  - Add LDFLAGS to build
  - Use CFLAGS and LDFLAGS from MP
  - Closes: https://trac.macports.org/ticket/61123

###### Type(s)

- [x] update

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?