### PR TITLE
llvm*: Use known_fail yes correctly

### DIFF
--- a/lang/llvm-10/Portfile
+++ b/lang/llvm-10/Portfile
@@ -348,18 +348,16 @@ platform darwin {
     }
 }
 
-pre-fetch {
-    if {${subport} eq "lldb-${llvm_version}"} {
-        if {${os.platform} eq "darwin" && ${os.major} < 15} {
-            depends_build
-            depends_lib
-            depends_run
-            archive_sites
-            known_fail yes
-            pre-fetch {
-                ui_error "${subport} is not supported on this os version at present."
-                return -code error {unsupported platform}
-            }
+if {${subport} eq "lldb-${llvm_version}"} {
+    if {${os.platform} eq "darwin" && ${os.major} < 15} {
+        depends_build
+        depends_lib
+        depends_run
+        archive_sites
+        known_fail yes
+        pre-fetch {
+            ui_error "${subport} is not supported on this os version at present."
+            return -code error {unsupported platform}
         }
     }
 }

--- a/lang/llvm-3.3/Portfile
+++ b/lang/llvm-3.3/Portfile
@@ -376,7 +376,7 @@ if {${subport} == "llvm-${llvm_version}"} {
         depends_lib
         depends_run
         archive_sites
-        known_fail yes        
+        known_fail yes
         pre-fetch {
             ui_error "${subport} is not supported on macOS Sierra or newer."
             return -code error {unsupported platform}

--- a/lang/llvm-3.4/Portfile
+++ b/lang/llvm-3.4/Portfile
@@ -442,6 +442,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
         depends_lib
         depends_run
         archive_sites
+        known_fail yes
         pre-fetch {
             ui_error "${subport} is not supported on macOS Sierra or newer."
             return -code error {unsupported platform}

--- a/lang/llvm-3.7/Portfile
+++ b/lang/llvm-3.7/Portfile
@@ -489,6 +489,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
         depends_lib
         depends_run
         archive_sites
+        known_fail yes
         pre-fetch {
             ui_error "${subport} is not supported on macOS Mojave or newer."
             return -code error {unsupported platform}

--- a/lang/llvm-5.0/Portfile
+++ b/lang/llvm-5.0/Portfile
@@ -424,18 +424,16 @@ platform darwin {
     configure.cxxflags-append -std=c++11
 }
 
-pre-fetch {
-    if {${subport} eq "lldb-${llvm_version}"} {
-        if {${os.platform} eq "darwin" && ${os.major} < 12} {
-            depends_build
-            depends_lib
-            depends_run
-            archive_sites
-            known_fail yes
-            pre-fetch {
-                ui_error "${subport} is not supported on this os version at present."
-                return -code error {unsupported platform}
-            }
+if {${subport} eq "lldb-${llvm_version}"} {
+    if {${os.platform} eq "darwin" && ${os.major} < 12} {
+        depends_build
+        depends_lib
+        depends_run
+        archive_sites
+        known_fail yes
+        pre-fetch {
+            ui_error "${subport} is not supported on this os version at present."
+            return -code error {unsupported platform}
         }
     }
 }

--- a/lang/llvm-6.0/Portfile
+++ b/lang/llvm-6.0/Portfile
@@ -414,18 +414,16 @@ platform darwin {
     configure.cxxflags-append -std=c++11
 }
 
-pre-fetch {
-    if {${subport} eq "lldb-${llvm_version}"} {
-        if {${os.platform} eq "darwin" && ${os.major} < 12} {
-            depends_build
-            depends_lib
-            depends_run
-            archive_sites
-            known_fail yes
-            pre-fetch {
-                ui_error "${subport} is not supported on this os version at present."
-                return -code error {unsupported platform}
-            }
+if {${subport} eq "lldb-${llvm_version}"} {
+    if {${os.platform} eq "darwin" && ${os.major} < 12} {
+        depends_build
+        depends_lib
+        depends_run
+        archive_sites
+        known_fail yes
+        pre-fetch {
+            ui_error "${subport} is not supported on this os version at present."
+            return -code error {unsupported platform}
         }
     }
 }

--- a/lang/llvm-7.0/Portfile
+++ b/lang/llvm-7.0/Portfile
@@ -423,18 +423,16 @@ platform darwin {
     configure.cxxflags-append -std=c++11
 }
 
-pre-fetch {
-    if {${subport} eq "lldb-${llvm_version}"} {
-        if {${os.platform} eq "darwin" && ${os.major} < 16} {
-            depends_build
-            depends_lib
-            depends_run
-            archive_sites
-            known_fail yes
-            pre-fetch {
-                ui_error "${subport} is not supported on this os version at present."
-                return -code error {unsupported platform}
-            }
+if {${subport} eq "lldb-${llvm_version}"} {
+    if {${os.platform} eq "darwin" && ${os.major} < 16} {
+        depends_build
+        depends_lib
+        depends_run
+        archive_sites
+        known_fail yes
+        pre-fetch {
+            ui_error "${subport} is not supported on this os version at present."
+            return -code error {unsupported platform}
         }
     }
 }

--- a/lang/llvm-8.0/Portfile
+++ b/lang/llvm-8.0/Portfile
@@ -439,18 +439,16 @@ platform darwin {
     configure.cxxflags-append -std=c++11
 }
 
-pre-fetch {
-    if {${subport} eq "lldb-${llvm_version}"} {
-        if {${os.platform} eq "darwin" && ${os.major} < 16} {
-            depends_build
-            depends_lib
-            depends_run
-            archive_sites
-            known_fail yes
-            pre-fetch {
-                ui_error "${subport} is not supported on this os version at present."
-                return -code error {unsupported platform}
-            }
+if {${subport} eq "lldb-${llvm_version}"} {
+    if {${os.platform} eq "darwin" && ${os.major} < 16} {
+        depends_build
+        depends_lib
+        depends_run
+        archive_sites
+        known_fail yes
+        pre-fetch {
+            ui_error "${subport} is not supported on this os version at present."
+            return -code error {unsupported platform}
         }
     }
 }

--- a/lang/llvm-9.0/Portfile
+++ b/lang/llvm-9.0/Portfile
@@ -453,18 +453,16 @@ platform darwin {
     configure.cxxflags-append -std=c++11
 }
 
-pre-fetch {
-    if {${subport} eq "lldb-${llvm_version}"} {
-        if {${os.platform} eq "darwin" && ${os.major} < 16} {
-            depends_build
-            depends_lib
-            depends_run
-            archive_sites
-            known_fail yes
-            pre-fetch {
-                ui_error "${subport} is not supported on this os version at present."
-                return -code error {unsupported platform}
-            }
+if {${subport} eq "lldb-${llvm_version}"} {
+    if {${os.platform} eq "darwin" && ${os.major} < 16} {
+        depends_build
+        depends_lib
+        depends_run
+        archive_sites
+        known_fail yes
+        pre-fetch {
+            ui_error "${subport} is not supported on this os version at present."
+            return -code error {unsupported platform}
         }
     }
 }

--- a/lang/llvm-devel/Portfile
+++ b/lang/llvm-devel/Portfile
@@ -331,14 +331,14 @@ platform darwin {
     }
 }
 
-pre-fetch {
-    if {${subport} eq "lldb-${llvm_version}"} {
-        if {${os.platform} eq "darwin" && ${os.major} < 15} {
-            depends_build
-            depends_lib
-            depends_run
-            archive_sites
-            known_fail yes
+if {${subport} eq "lldb-${llvm_version}"} {
+    if {${os.platform} eq "darwin" && ${os.major} < 15} {
+        depends_build
+        depends_lib
+        depends_run
+        archive_sites
+        known_fail yes
+        pre-fetch {
             ui_error "${subport} is not supported on this os version at present."
             return -code error {unsupported platform}
         }

--- a/lang/llvm-gcc42/Portfile
+++ b/lang/llvm-gcc42/Portfile
@@ -42,6 +42,7 @@ if {${os.platform} eq "darwin" && ${os.major} > 15} {
     depends_lib
     depends_run
     archive_sites
+    known_fail yes
     pre-fetch {
         ui_error "${name} is not supported on macOS Sierra or newer."
         return -code error {unsupported platform}


### PR DESCRIPTION
#### Description

llvm*: Use known_fail yes correctly

known_fail must occur outside of a phase to have an effect.

Same for clearing dependencies and archive_sites.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix
