### PR TITLE
bazel: minor adjustments

### DIFF
--- a/devel/bazel/Portfile
+++ b/devel/bazel/Portfile
@@ -3,13 +3,8 @@
 PortSystem                                            1.0
 PortGroup             github                          1.0
 PortGroup             java                            1.0
-PortGroup             compilers                       1.0
-PortGroup             xcodeversion                    1.0
 PortGroup             compiler_blacklist_versions     1.0
 
-# epoch unfortunately needed to go back to 0.18.0 as 0.19.0
-# built tensorflow badily, giving runtime seg. faults...
-# Now resolved, but epoch must NOT be removed though now.
 epoch                 1
 
 # List of all bazel sub-ports ( e.g. as required by tensorflow )
@@ -25,10 +20,6 @@ foreach b ${bazel_subports} { subport $b {} }
 foreach b [lsearch -inline -all -not -exact $all_bazels ${subport}] {
     conflicts-append $b
 }
-
-# Java PG settings. Potentially changed in sub-port specifics below.
-set java_v 11+
-set java_f openjdk13
 
 # Min supported Darwin version
 set min_darwin 16
@@ -68,9 +59,6 @@ if { ${name} eq ${subport} } {
     checksums         rmd160  cfff49a4be85f7693ae615c293b13d0a447b80d7 \
                       sha256  7456032199852c043e6c5b3e4c71dd8089c1158f72ec554e6ec1c77007f0ab51 \
                       size    275804130
-    
-    # Java fallback
-    set java_f openjdk12
 
     # min OS
     set min_darwin 14
@@ -88,18 +76,18 @@ if { ${os.platform} eq "darwin" && ${os.major} < ${min_darwin} } {
 }
 
 # Required java version.
-java.version          ${java_v}
-# JDK port to install if required java not found
-java.fallback         ${java_f}
+java.version          11+
+# LTS JDK port to install if required java not found
+java.fallback         openjdk11
 # JDK only needed at build time, but java PG sets lib dependency so
 # declare no conflict to allow redistribution of binaries.
-license_noconflict    ${java_f}
+license_noconflict    ${java.fallback}
 
 github.tarball_from   releases
 
 categories            devel
 
-maintainers           {tfmnet.com:mohamed.issa @RootFunction} \
+maintainers           {tfmnet.com:mohamed.issa @missa-prime} \
                       {jonesc @cjones051073} \
                       openmaintainer
 
@@ -121,13 +109,21 @@ patch.pre_args        -p1
 # The oldest Xcode version to use default Xcode compiler
 # Note setting here should be in sync with that in py-tensorflow
 set bazel_min_xcode   9.0
-# Work out if we should be using macports clang
-set use_mp_clang [ expr ( [ string match macports-clang-* ${configure.compiler} ] || [ vercmp ${xcodeversion} ${bazel_min_xcode} ] < 0 ) ]
 
 # Even though bazel can build without Xcode, mark use Xcode for now since it fails to
 # build with tracemode on latest master if both CLT and Xcode are available.
 # Better solution is to respect MacPorts environment configure.developer_dir
 use_xcode             yes
+
+# Blacklist too old system compilers
+compiler.blacklist-append {clang < 710}
+
+# Clang 7, 8 and 9 fail with missing libarclite on older systems (e.g. 10.10)
+# ../usr/bin/xcrun /opt/local/bin/clang-mp-8.0 -fobjc-arc -framework CoreServices -framework Foundation -o /opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_devel_bazel/bazel26/work/.tmp/bazel_4sKHinCP/archive/_embedded_binaries/xcode-locator tools/osx/xcode_locator.m
+# ld: file not found: /opt/local/libexec/llvm-8.0/lib/arc/libarclite_macosx.a
+compiler.blacklist-append {macports-clang-[7-9].0}
+
+compiler.cxx_standard 2011
 
 # python versions. Build needs both 'python2' and 'python3'
 set py3ver 3.8
@@ -180,21 +176,14 @@ post-patch {
     }
 }
 
-# Blacklist too old system compilers
-compiler.blacklist-append {clang < 710}
-
-# Clang 7, 8 and 9 fail with missing libarclite on older systems (e.g. 10.10)
-# ../usr/bin/xcrun /opt/local/bin/clang-mp-8.0 -fobjc-arc -framework CoreServices -framework Foundation -o /opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_devel_bazel/bazel26/work/.tmp/bazel_4sKHinCP/archive/_embedded_binaries/xcode-locator tools/osx/xcode_locator.m
-# ld: file not found: /opt/local/libexec/llvm-8.0/lib/arc/libarclite_macosx.a
-compiler.blacklist-append {macports-clang-[7-9].0}
-
-# require c++11
-compiler.cxx_standard 2011
-
 build.env-append  CC=${configure.cc} \
                  CXX=${configure.cxx} \
               TMPDIR=${workpath}/tmp \
            JAVA_HOME=${java.home}
+
+# Work out if we should be using macports clang
+set use_mp_clang [ expr ( [ string match macports-clang-* ${configure.compiler} ] || [ vercmp ${xcodeversion} ${bazel_min_xcode} ] < 0 ) ]
+
 # Disable Xcode detection on older OSes, as we want the
 # MP provided commandline utilities to be used instead.
 if { ${use_mp_clang} } {


### PR DESCRIPTION
Use LTS Java as fallback
Public updates for `openjdk12` ended 2019-09
Public updates for `openjdk13` ended 2020-03
`openjdk11` is supported at least until 2023

Reorder compiler settings to be completely set before being read

Remove redundant comments, unused portgroups

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
