### PR TITLE
notmuch: Update to 0.31

### DIFF
--- a/mail/notmuch/Portfile
+++ b/mail/notmuch/Portfile
@@ -5,7 +5,7 @@ PortGroup           compiler_blacklist_versions 1.0
 PortGroup           conflicts_build             1.0
 
 name                notmuch
-version             0.30
+version             0.31
 categories          mail
 platforms           darwin
 license             GPL-3+
@@ -20,9 +20,9 @@ long_description    \"Not much mail\" is what Notmuch thinks about your email \
 homepage            https://notmuchmail.org
 master_sites        ${homepage}/releases/
 use_xz              yes
-checksums           rmd160  4da6cab55d63ada840ece2fdfc4a14581cb62986 \
-                    sha256  5e3baa6fe11d65c67e26ae488be11b320bae04e336acc9c64621f7e3449096fa \
-                    size    711904
+checksums           rmd160  fb81323f925597cd6dbcb7bc555138d4ed492e40 \
+                    sha256  571fa0e1539c86612b1f2b2c80a398e08ecfef52e27ef7e48cf8e3b84fa18394 \
+                    size    713144
 
 depends_build       port:pkgconfig \
                     port:python38 \


### PR DESCRIPTION
Technical changes in Notmuch release 0.31 include support for Emacs 27.1 and Xapian 1.5 (the current development version).