### PR TITLE
tcsh: update to 6.22.02

### DIFF
--- a/shells/tcsh/Portfile
+++ b/shells/tcsh/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem      1.0
 PortGroup       github 1.0
 

--- a/shells/tcsh/Portfile
+++ b/shells/tcsh/Portfile
@@ -1,25 +1,25 @@
 PortSystem      1.0
+PortGroup       github 1.0
 
-name            tcsh
-version         6.20.00
+github.setup    tcsh-org tcsh 6_22_02 TCSH
+version         [string map {_ .} ${github.version}]
 categories      shells
 maintainers     nomaintainer
 license         BSD
 
+homepage        https://www.tcsh.org/
+
 description     C shell with file name completion and command line editing
+
 long_description \
     Tcsh is a version of the Berkeley C-Shell, with the addition of: a  \
     command line editor, command and file name completion, listing, etc.\
     and a bunch of small additions to the shell itself.
 
-homepage        https://www.tcsh.org/
+checksums       rmd160  9a9f09648f460f07fa08c13e19c8052fd3d76522 \
+                sha256  f4f1ba643a5b36718f80709dadf81ded65356e3c82d3f548c68f57e9f61295b6 \
+                size    1006470
 platforms       darwin
-master_sites    ftp://ftp.funet.fi/pub/unix/shells/${name}/ \
-                ftp://ftp.astron.com/pub/${name}/ \
-                ftp://ftp.gw.com/pub/unix/${name}/ 
-
-checksums       rmd160  3f119421ef3500cea1bebe2edf35c6d81ca1c8f3 \
-                sha256  b89de7064ab54dac454a266cfe5d8bf66940cb5ed048d0c30674ea62e7ecef9d
 
 patchfiles      patch-Makefile.in.diff
 
@@ -27,6 +27,5 @@ destroot.target install install.man
 depends_lib     port:libiconv \
                 port:ncurses
 
-livecheck.type  regex
-livecheck.url   https://www.tcsh.org/
-livecheck.regex {>([0-9.]+)<}
+github.tarball_from \
+                archive

--- a/shells/tcsh/Portfile
+++ b/shells/tcsh/Portfile
@@ -4,10 +4,9 @@ PortGroup       github 1.0
 github.setup    tcsh-org tcsh 6_22_02 TCSH
 version         [string map {_ .} ${github.version}]
 categories      shells
+platforms       darwin
 maintainers     nomaintainer
 license         BSD
-
-homepage        https://www.tcsh.org/
 
 description     C shell with file name completion and command line editing
 
@@ -16,16 +15,16 @@ long_description \
     command line editor, command and file name completion, listing, etc.\
     and a bunch of small additions to the shell itself.
 
+homepage        https://www.tcsh.org/
+github.tarball_from \
+                archive
+
 checksums       rmd160  9a9f09648f460f07fa08c13e19c8052fd3d76522 \
                 sha256  f4f1ba643a5b36718f80709dadf81ded65356e3c82d3f548c68f57e9f61295b6 \
                 size    1006470
-platforms       darwin
 
 patchfiles      patch-Makefile.in.diff
 
 destroot.target install install.man
 depends_lib     port:libiconv \
                 port:ncurses
-
-github.tarball_from \
-                archive


### PR DESCRIPTION
- switch to Github, using github portgroup

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.7 11E801a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
