### PR TITLE
xedit: Add support for Apple silicon

### DIFF
--- a/x11/xedit/Portfile
+++ b/x11/xedit/Portfile
@@ -22,6 +22,8 @@ depends_build       port:pkgconfig
 
 depends_lib         port:xorg-libXaw
 
+patchfiles-append   apple-silicon.diff
+
 livecheck.type      regex
 livecheck.regex     ${name}-(\[\\d.\]+)${extract.suffix}
 livecheck.url       https://xorg.freedesktop.org/archive/individual/app/?C=M&O=D

--- a/x11/xedit/files/apple-silicon.diff
+++ b/x11/xedit/files/apple-silicon.diff
@@ -1,0 +1,44 @@
+--- lisp/core.c.orig	2020-09-07 13:09:19.000000000 -0400
++++ lisp/core.c	2020-09-07 13:10:23.000000000 -0400
+@@ -62,7 +62,7 @@
+ 	    break;							\
+     }
+ 
+-#ifdef __UNIXOS2__
++#if defined(__UNIXOS2__) || defined(__arm64__)
+ # define finite(x) isfinite(x)
+ #endif
+ 
+--- lisp/read.c.orig	2020-09-07 13:09:06.000000000 -0400
++++ lisp/read.c	2020-09-07 13:10:10.000000000 -0400
+@@ -62,7 +62,7 @@
+ #define READ_ERROR_FIXNUM()	READ_ERROR0("number is not a fixnum")
+ #define READ_ERROR_INVARG()	READ_ERROR0("invalid argument")
+ 
+-#ifdef __UNIXOS2__
++#if defined(__UNIXOS2__) || defined(__arm64__)
+ # define finite(x) isfinite(x)
+ #endif
+ 
+--- lisp/math.c.orig	2020-09-07 13:09:12.000000000 -0400
++++ lisp/math.c	2020-09-07 13:09:55.000000000 -0400
+@@ -32,7 +32,7 @@
+ #include "lisp/math.h"
+ #include "lisp/private.h"
+ 
+-#ifdef __UNIXOS2__
++#if defined(__UNIXOS2__) || defined(__arm64__)
+ # define finite(x) isfinite(x)
+ #endif
+ 
+--- lisp/mp/mpi.c.orig	2020-09-07 13:09:02.000000000 -0400
++++ lisp/mp/mpi.c	2020-09-07 13:09:47.000000000 -0400
+@@ -31,7 +31,7 @@
+ 
+ #include "mp.h"
+ 
+-#ifdef __UNIXOS2__
++#if defined(__UNIXOS2__) || defined(__arm64__)
+ # define finite(x) isfinite(x)
+ #endif
+ 


### PR DESCRIPTION
When running on macOS 11.0 (or later), define finite(x) as a macro that invokes the
isfinite(x) builtin. (Can't include <math.h> as suggested by the compiler error as
<math.h> only defines finite for Intel platforms.)

#### Description

Attempting to build xedit on Apple silicon fails with compiler errors because the builtin finite(x) isn't defined. The error message suggests including <math.h> to correct the error. However, that header file only defines finite(x) for Intel platforms. Instead, I defined finite(x) as a macro which expands into the isfinite(x) builtin.

I verified that, with this change, xedit functions on macOS Big Sur running on both Intel and Apple silicon.

I'm in the process of porting a legacy app which uses X windows for its UI to Apple silicon. (The app is the Symbolics Ivory emulator also known as Open Genera and/or Portable Genera.) I'm still working on the rest of the xorg port.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
