### PR TITLE
py-argcomplete: update to 1.12.0

### DIFF
--- a/python/py-argcomplete/Portfile
+++ b/python/py-argcomplete/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-argcomplete
-version             1.11.1
+version             1.12.0
 platforms           darwin
 license             Apache-2
 maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
@@ -16,11 +16,11 @@ homepage            https://argcomplete.readthedocs.io
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  fb89dbf0238ace2e8ce231368eb6fc32bf2e061b \
-                    sha256  5ae7b601be17bf38a749ec06aa07fb04e7b6b5fc17906948dc1866e7facf3740 \
-                    size    50773
+checksums           rmd160  9fb4b724d2bc2faf9e722ce667948f4ff91bce16 \
+                    sha256  2fbe5ed09fd2c1d727d4199feca96569a5b50d44c71b16da9c742201f7cc295c \
+                    size    53625
 
-python.versions     27 36 37 38
+python.versions     36 37 38
 
 if {${name} ne ${subport}} {
     depends_build   port:py${python.version}-setuptools


### PR DESCRIPTION
- remove support for Python 2.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
