### PR TITLE
pipx: update to 0.15.5.1

### DIFF
--- a/python/pipx/Portfile
+++ b/python/pipx/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        pipxproject pipx 0.15.1.3
+github.setup        pipxproject pipx 0.15.5.1
 categories          python sysutils
 license             MIT
 maintainers         {lbschenkel @lbschenkel} openmaintainer
@@ -14,9 +14,9 @@ platforms           darwin
 description         Execute binaries from Python packages in isolated environments
 long_description    ${description}
 
-checksums           rmd160  64b198d937c3c7b12531a81828c7b813fa9a597a \
-                    sha256  af7f4cf388bfdae6547117a6be222d1d7b7edd3bccd3a77e2c96b8c858ac791f \
-                    size    356746
+checksums           rmd160  c786be7c7375055d69d89cbdb7e36672917bf00c \
+                    sha256  8163804cbcd4f09b400e8c6f0d4ba85d368573bc8eb65535d90b9988959842a2 \
+                    size    357524
 
 github.livecheck.regex  {([\d.]+)}
 
@@ -39,4 +39,5 @@ if {[variant_isset python38]} {
 depends_lib-append \
                     port:py${python.version}-argcomplete \
                     port:py${python.version}-setuptools \
+                    port:py${python.version}-packaging \
                     port:py${python.version}-userpath


### PR DESCRIPTION
- add py-packaging dependency

Related:
* #8342
* #8343

Closes: https://trac.macports.org/ticket/61100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
