### PR TITLE
mesos: attempt to fix build on 10.11 and earlier

### DIFF
--- a/devel/mesos/Portfile
+++ b/devel/mesos/Portfile
@@ -2,6 +2,10 @@
 
 PortSystem          1.0
 
+# Need strnlen() on 10.6, fdopendir() on 10.9 and earlier
+PortGroup           legacysupport 1.0
+legacysupport.newest_darwin_requires_legacy 13
+
 name                mesos
 version             1.8.0
 
@@ -22,6 +26,15 @@ checksums           rmd160  9b824a8e1a9cc616ea7e1b478fa0483e7ec5b9a8 \
                     size    72442467
 
 compiler.cxx_standard 2011
+compiler.thread_local_storage yes
+
+if {${os.platform} eq "darwin" && ${os.major} == 15 \
+        && ${configure.cxx_stdlib} eq "libc++"} {
+    # "Mesos cannot be built with optimizations against this version of libcxx (MESOS-5745).
+    # Consider building without optimizations, or changing the used C++ standard library."
+    configure.optflags      -O0
+    configure.args-append   --disable-optimize
+}
 
 configure.args-append --with-svn=${prefix} \
                       --with-apr=${prefix} \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Build failures were observed:
* [10.6](https://build.macports.org/builders/ports-10.6_x86_64-builder/builds/33701/steps/install-port/logs/stdio), [10.6 (i386)](https://build.macports.org/builders/ports-10.6_i386-builder/builds/17068/steps/install-port/logs/stdio): `error: use of undeclared identifier 'strnlen'`
* [10.7](https://build.macports.org/builders/ports-10.7_x86_64-builder/builds/29897/steps/install-port/logs/stdio), [10.9](https://build.macports.org/builders/ports-10.9_x86_64-builder/builds/126046/steps/install-port/logs/stdio): `error: no member named 'fdopendir' in the global namespace`
* [10.9](https://build.macports.org/builders/ports-10.9_x86_64-builder/builds/126046/steps/install-port/logs/stdio), [10.10](https://build.macports.org/builders/ports-10.10_x86_64-builder/builds/122514/steps/install-port/logs/stdio): `error: thread-local storage is not supported for the current target`

Two other failures I'm not aware how to best address:
* [10.8](https://build.macports.org/builders/ports-10.8_x86_64-builder/builds/24869/steps/install-port/logs/stdio): <tt>error: libtool: unknown option character &grave;n' in: -no_warning_for_no_symbols</tt>
* [10.11](https://build.macports.org/builders/ports-10.11_x86_64-builder/builds/120899/steps/install-port/logs/stdio):
```
checking C++ standard library for undefined behaviour with selected optimization level... yes
configure: error: Mesos cannot be built with optimizations against this version of libcxx (MESOS-5745).
                  Consider building without optimizations, or changing the used C++ standard library.
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
