### PR TITLE
py-repoze.lru: add py3{7..9} subports

### DIFF
--- a/python/py-repoze.lru/Portfile
+++ b/python/py-repoze.lru/Portfile
@@ -6,22 +6,20 @@ PortGroup           python 1.0
 name                py-repoze.lru
 version             0.7
 revision            0
+
 categories-append   devel
 platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 35 36
+python.versions     27 35 36 37 38 39
 
 maintainers         {stromnov @stromnov} openmaintainer
 
 description         A tiny LRU cache implementation and decorator.
-long_description    ${description}
+long_description    {*}${description}
 
 homepage            http://www.repoze.org/
-master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
-
-distname            ${python.rootname}-${version}
 
 checksums           rmd160  7ddad7fdbcf013e9c6d1b30583ab386d8bd6d4f8 \
                     sha256  0429a75e19380e4ed50c0694e26ac8819b4ea7851ee1fc7583c8572db80aff77 \


### PR DESCRIPTION
#### Description

py-repoze.lru: add py3{7..9} subports

###### Type(s)

- [x] update

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?