### PR TITLE
xorg-scripts: Add support for Apple silicon

### DIFF
--- a/x11/xorg-scripts/Portfile
+++ b/x11/xorg-scripts/Portfile
@@ -26,6 +26,8 @@ checksums           md5     08c7f078fc351196c21db3a8206d482d \
 
 depends_build       port:pkgconfig port:xorg-libX11
 
+patchfiles-append   apple-silicon.diff
+
 configure.args      --mandir=${prefix}/share/man
 
 post-destroot {

--- a/x11/xorg-scripts/files/apple-silicon.diff
+++ b/x11/xorg-scripts/files/apple-silicon.diff
@@ -1,0 +1,19 @@
+--- config.guess.orig	2020-09-07 13:00:56.000000000 -0400
++++ config.guess	2020-09-07 13:01:18.000000000 -0400
+@@ -3,7 +3,7 @@
+ #   Copyright (C) 1992, 1993, 1994, 1995, 1996, 1997, 1998, 1999,
+ #   2000, 2001, 2002, 2003 Free Software Foundation, Inc.
+ 
+-timestamp='2003-06-17'
++timestamp='2020-09-07'
+ 
+ # This file is free software; you can redistribute it and/or modify it
+ # under the terms of the GNU General Public License as published by
+@@ -1152,6 +1152,7 @@
+ 	exit 0 ;;
+     *:Darwin:*:*)
+ 	case `uname -p` in
++	    arm*) UNAME_PROCESSOR=arm ;;
+ 	    *86) UNAME_PROCESSOR=i686 ;;
+ 	    powerpc) UNAME_PROCESSOR=powerpc ;;
+ 	esac


### PR DESCRIPTION
#### Description

The config.guess script for xorg-scripts didn't recognize ARM as a valid CPU type.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 11.0 20A5364e (Beta 6)
Xcode 12.0 12A8189n (Beta 6)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
