### PR TITLE
py-crank: new port

### DIFF
--- a/python/py-crank/Portfile
+++ b/python/py-crank/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-crank
+version             0.8.1
+revision            0
+
+platforms           darwin
+supported_archs     noarch
+license             MIT
+maintainers         nomaintainer
+
+description         Generalized Object based Dispatch mechanism for use across frameworks
+long_description    {*}${description}.
+
+homepage            https://github.com/TurboGears/crank
+
+checksums           rmd160  9b3a788eadcfdf64515f5651e3be67e191f09fec \
+                    sha256  c22b94ab6e9d27be47733002bd143b3b79d1e8c030cba0b18691cbc1b5907d7f \
+                    size    10655
+
+python.versions     38
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools
+
+    livecheck.type  none
+} else {
+    livecheck.type  pypi
+}


### PR DESCRIPTION
#### Description

[crank](https://github.com/TurboGears/crank/): Generalized Object based Dispatch mechanism for use across frameworks.

###### Type(s)

- [x] submission

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?