### PR TITLE
deco-archive: update to 1.7

### DIFF
--- a/archivers/deco-archive/Portfile
+++ b/archivers/deco-archive/Portfile
@@ -1,28 +1,25 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 
-name                deco-archive
-version             1.6
+github.setup        peha deco-archive 1.7
 categories          archivers
 license             GPL-3
 platforms           darwin
 supported_archs     noarch
 maintainers         nomaintainer
+
 description         provides support for popular archive formats to deco
+
 long_description    deco-archive provides support for popular archive formats \
                     to the deco file extraction framework.
-homepage            http://hartlich.com/deco/archive/
-master_sites        ${homepage}download/
 
-checksums           rmd160  09482ab28c92e09161160f5240d0c967435074cd \
-                    sha256  128253a1b232ac10993d7a20b6cb31dfc1f4ad9d9015b0483a33fb6ea558844d
+checksums           rmd160  5902b87b3ccca677ab8467b7808dd667a8bac3b2 \
+                    sha256  54a3fbc4855e0998244e0d56ec6d7a6c302b22d853d3955b8857402cd7e26b5f \
+                    size    17654
 
 use_configure       no
 build               {}
 
 destroot.args       PREFIX=${prefix}
-
-livecheck.type      regex
-livecheck.url       ${master_sites}
-livecheck.regex     $name-(\\d+(?:\\.\\d+)*)


### PR DESCRIPTION
- switch to Github using github portgroup
- use recommended checksum types
- remove explicit livecheck options, use portgroup default

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.7 11E801a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
