### PR TITLE
deco: update to 1.6.4

### DIFF
--- a/archivers/deco/Portfile
+++ b/archivers/deco/Portfile
@@ -1,23 +1,24 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 
-name                deco
-version             1.6.3
+github.setup        peha deco 1.6.4
 categories          archivers
 license             GPL-3
 platforms           darwin
 maintainers         nomaintainer
+
 description         file extraction framework
+
 long_description    deco is a Un*x program, written in SUSv3-compliant C99, \
                     that is able to extract various archive file formats. \
                     It focuses on consistent behavior and has a modular \
                     pluggable extraction engine backend.
-homepage            http://hartlich.com/deco/
-master_sites        ${homepage}download/
 
-checksums           rmd160  be0dfab0339b863ee47687a3b183f127f542acc9 \
-                    sha256  18caa51d3a967076a93d4f287f70071cc40c06eb68cc7f663e9ce3269ddad6f5
+checksums           rmd160  69ffd4f863ee2fff48f591650ac291d657950154 \
+                    sha256  0f83cecc45b866edcb00f0f1322bcf23ea5a4255583d944dc4eaced0a39c5b22 \
+                    size    23168
 
 depends_run         port:deco-archive
 
@@ -31,7 +32,3 @@ build.args-append   CC="${configure.cc} [get_canonical_archflags cc]" \
                     LDFLAGS="${configure.ldflags}" PREFIX="${prefix}"
 
 destroot.args       PREFIX=${prefix}
-
-livecheck.type      regex
-livecheck.url       ${master_sites}
-livecheck.regex     $name-(\\d+(?:\\.\\d+)*)


### PR DESCRIPTION
- switch to Github using github portgroup
- use recommended checksum types
- remove livecheck options, use portgroup default

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.7 11E801a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
