### PR TITLE
shellharden: new port

### DIFF
--- a/devel/shellharden/Portfile
+++ b/devel/shellharden/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo 1.0
+
+github.setup        anordal shellharden 4.1.2 v
+categories          devel sysutils
+platforms           darwin
+license             MPL-2
+
+description         The corrective bash syntax highlighter
+
+long_description    Shellharden is a syntax highlighter and a tool to \
+                    semi-automate the rewriting of scripts to ShellCheck \
+                    conformance, mainly focused on quoting.  The default mode \
+                    of operation is like cat, but with syntax highlighting in \
+                    foreground colors and suggestive changes in background \
+                    colors.
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums   rmd160  d6d5f8e25c8b850882c5168ecf888165bcd531ba \
+            sha256  7a7cb05573f1aabd2bb92df6788b826fa5a6ea5ac0ebf4b6eb47d339544c54a7 \
+            size    184363
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/${name} \
+                    ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.7 11E801a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
