### PR TITLE
fluent-bit: update to 1.5.5

### DIFF
--- a/sysutils/fluent-bit/Portfile
+++ b/sysutils/fluent-bit/Portfile
@@ -4,25 +4,32 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 
 name                fluent-bit
-version             1.5.2
+version             1.5.5
 categories          sysutils
 platforms           darwin
 license             Apache-2
-maintainers         {l2dy @l2dy} openmaintainer
+
+homepage            https://fluentbit.io/
+
 description         Fast and Lightweight Log processor and forwarder
+
 long_description    Fluent Bit is a Data Forwarder for Linux, Embedded Linux, \
                     OSX and BSD family operating systems. It's part of the \
                     Fluentd Ecosystem.  Fluent Bit allows collection of \
                     information from different sources, buffering and \
                     dispatching them to different outputs such as Fluentd, \
                     Elasticsearch, Nats or any HTTP end-point within others.
-homepage            https://fluentbit.io/
+
+maintainers         {l2dy @l2dy} \
+                    {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
 set branch          [join [lrange [split ${version} .] 0 1] .]
 master_sites        ${homepage}releases/${branch}/
 
-checksums           rmd160  049ef637888e0089e223b7b3a8305b8df2a0bd90 \
-                    sha256  148ad83b34be1b0caf5cf9275d4baec6189b686e07f18e7eaba1f7667af1ad5d \
-                    size    12748943
+checksums           rmd160  c4c999be2ef6592733dde6aaade207b3827b8943 \
+                    sha256  8af3f998bdf940f2a31a94db1f9a20001f2ad1cc0c0d040b79894c10387c58f0 \
+                    size    12759507
 
 depends_build-append \
                     port:bison


### PR DESCRIPTION
- use Github
- add @herbygillot as secondary maintainer

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.7 11E801a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
