### PR TITLE
llvm-3.7:  fix fuzz and offset in patch

### DIFF
--- a/lang/llvm-3.7/files/llvm-skip-unittests.patch
+++ b/lang/llvm-3.7/files/llvm-skip-unittests.patch
@@ -1,8 +1,6 @@
-diff --git a/unittests/Makefile.unittest b/unittests/Makefile.unittest
-index bd32aed..993b69a 100644
---- a/unittests/Makefile.unittest
-+++ b/unittests/Makefile.unittest
-@@ -54,7 +54,7 @@ $(LLVMUnitTestExe): $(ObjectsO) $(ProjLibsPaths) $(LLVMLibsPaths)
+--- a/unittests/Makefile.unittest.orig	2020-09-08 20:47:20.000000000 +0200
++++ b/unittests/Makefile.unittest	2020-09-08 20:48:38.000000000 +0200
+@@ -61,7 +61,7 @@
  	$(Echo) ======= Finished Linking $(BuildMode) Unit test $(TESTNAME) \
            $(StripWarnMsg)
  
@@ -10,4 +8,4 @@ index bd32aed..993b69a 100644
 +all::
  
  unitcheck:: $(LLVMUnitTestExe)
- 	$(Run.Shared) $(LLVMUnitTestExe)
+ 	$(LLVMUnitTestExe)


### PR DESCRIPTION
#### Description

When all clangs broke the other day, I noticed there was a patch that had some fuzz, and a 7 line offset.

```
:info:patch patching file unittests/Makefile.unittest
:info:patch Hunk #1 succeeded at 61 with fuzz 1 (offset 7 lines).
```

###### Verification

Have you

- [x] `sudo port -vsdt patch llvm-3.7`?