### PR TITLE
php: enable file based opcache, and update current versions

### DIFF
--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -134,36 +134,38 @@ switch ${subport_branch} {
     }
     7.2 {
         epoch           2
-        version         7.2.29
+        version         7.2.33
         use_xz          yes
-        checksums       rmd160  2e0bfdbf9b325b02f1a18a2b832d83e002dc49b1 \
-                        sha256  b117de74136bf4b439d663be9cf0c8e06a260c1f340f6b75ccadb609153a7fe8 \
-                        size    12308380
+        checksums       rmd160  83b1f02ef406228ef3a3d1b0371246843d84c26e \
+                        sha256  0f160a3483ffce36be5962fab7bcf09d605ee66c5707df83e4195cb796bbb03a \
+                        size    12310624
     }
     7.3 {
         epoch           2
-        version         7.3.16
+        version         7.3.22
         use_xz          yes
-        checksums       rmd160  d84bfc893aff1230c2d66ffc3bc00003715bacb6 \
-                        sha256  91aaee3dbdc71b69b4f3292f9d99211172a2fa926c3f3bbdb0e85dab03dd2bcb \
-                        size    12113688
+        checksums       rmd160  837bcbaa9e894b05c15772ef885100bf7775611b \
+                        sha256  0e66606d3bdab5c2ae3f778136bfe8788e574913a3d8138695e54d98562f1fb5 \
+                        size    12134212
     }
     7.4 {
         epoch           2
-        version         7.4.4
+        version         7.4.10
         use_xz          yes
-        checksums       rmd160  41fc28033a566a45ebf443e8481b6265a125df8f \
-                        sha256  1873c4cefdd3df9a78dcffb2198bba5c2f0464f55c9c960720c84df483fca74c \
-                        size    10267308
+        checksums       rmd160  e48f95addc513d9cdb515d4e6d0d4728281eec1f \
+                        sha256  c2d90b00b14284588a787b100dee54c2400e7db995b457864d66f00ad64fb010 \
+                        size    10298480
     }
-    7.5 {
+    8.0 {
         # When this becomes a stable version, remove the overrides for homepage,
         # master_sites and livecheck, and update php.latest_stable_branch in the
         # php-1.1 portgroup.
+        #
+        # php-8.0.0: release is set to Nov 26, 2020
         epoch           0
-        version         7.5.0alpha1
+        version         8.0.0beta3
         homepage        https://qa.php.net/
-        master_sites    https://downloads.php.net/~cmb/
+        master_sites    https://downloads.php.net/~carusogabriel/
         use_xz          yes
         checksums       rmd160  0 \
                         sha256  0 \
@@ -174,7 +176,7 @@ switch ${subport_branch} {
 }
 
 # https://www.php.net/eol.php
-set php.oldest_supported_branch 7.1
+set php.oldest_supported_branch 7.2
 
 # Iterate through branches in reverse order, so that the list of subports in
 # "port info" will show newer versions before older versions.
@@ -360,9 +362,9 @@ subport ${php} {
         5.6.40              {revision 4}
         7.0.33              {revision 3}
         7.1.33              {revision 1}
-        7.2.29              {revision 1}
-        7.3.16              {revision 1}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
     
     depends_run             port:php_select
@@ -507,9 +509,9 @@ subport ${php}-apache2handler {
         5.6.40              {revision 1}
         7.0.33              {revision 1}
         7.1.33              {revision 1}
-        7.2.29              {revision 1}
-        7.3.16              {revision 1}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
     
     description             ${php} Apache 2 Handler SAPI
@@ -565,9 +567,9 @@ subport ${php}-cgi {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.33              {revision 0}
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
 
     description             ${php} CGI SAPI
@@ -605,9 +607,9 @@ subport ${php}-fpm {
         5.6.40              {revision 1}
         7.0.33              {revision 1}
         7.1.33              {revision 1}
-        7.2.29              {revision 1}
-        7.3.16              {revision 1}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
 
     description             ${php} FPM SAPI
@@ -674,9 +676,9 @@ subport ${php}-calendar {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.33              {revision 0}
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
 
     description             a PHP extension for converting between different \
@@ -694,9 +696,9 @@ subport ${php}-curl {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.33              {revision 0}
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
 
     categories-append       net www
@@ -726,9 +728,9 @@ subport ${php}-dba {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.33              {revision 0}
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
 
     categories-append       databases
@@ -758,9 +760,9 @@ subport ${php}-enchant {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.33              {revision 0}
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
 
     categories-append       textproc devel
@@ -803,9 +805,9 @@ subport ${php}-exif {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.33              {revision 0}
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
 
     categories-append       graphics
@@ -824,9 +826,9 @@ subport ${php}-ftp {
         5.6.40              {revision 2}
         7.0.33              {revision 1}
         7.1.33              {revision 0}
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
 
     categories-append       net
@@ -859,9 +861,9 @@ subport ${php}-gd {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.33              {revision 0}
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
 
     categories-append       graphics
@@ -921,9 +923,9 @@ subport ${php}-gettext {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.33              {revision 0}
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
 
     categories-append       devel
@@ -947,9 +949,9 @@ subport ${php}-gmp {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.33              {revision 0}
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
 
     categories-append       devel math
@@ -978,9 +980,9 @@ subport ${php}-iconv {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.33              {revision 0}
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
 
     categories-append       textproc
@@ -1004,9 +1006,9 @@ subport ${php}-imap {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.33              {revision 0}
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
 
     categories-append       mail
@@ -1041,9 +1043,9 @@ subport ${php}-intl {
         5.6.40              {revision 2}
         7.0.33              {revision 2}
         7.1.33              {revision 1}
-        7.2.29              {revision 1}
-        7.3.16              {revision 1}
-        7.4.4               {revision 1}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
     
     categories-append       devel
@@ -1084,9 +1086,9 @@ subport ${php}-ipc {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.33              {revision 0}
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
 
     php.extensions          shmop sysvmsg sysvsem sysvshm
@@ -1106,9 +1108,9 @@ subport ${php}-ldap {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.33              {revision 0}
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
 
     categories-append       databases
@@ -1142,9 +1144,9 @@ subport ${php}-mbstring {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.33              {revision 0}
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
 
     categories-append       textproc
@@ -1227,9 +1229,9 @@ subport ${php}-mysql {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.33              {revision 0}
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
 
     php.extensions          mysqli pdo_mysql
@@ -1390,9 +1392,9 @@ subport ${php}-odbc {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.33              {revision 0}
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
 
     php.extensions          odbc pdo_odbc
@@ -1450,9 +1452,9 @@ if {[vercmp ${branch} 5.5] >= 0} {
             5.6.40              {revision 1}
             7.0.33              {revision 1}
             7.1.33              {revision 1}
-            7.2.29              {revision 1}
-            7.3.16              {revision 1}
-            7.4.4               {revision 1}
+            7.2.33              {revision 0}
+            7.3.22              {revision 0}
+            7.4.10              {revision 0}
         }
 
         php.extensions.zend opcache
@@ -1489,9 +1491,9 @@ subport ${php}-openssl {
         5.6.40              {revision 2}
         7.0.33              {revision 1}
         7.1.33              {revision 0}
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
 
     categories-append       devel security
@@ -1543,9 +1545,9 @@ subport ${php}-oracle {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.33              {revision 0}
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
 
     php.extensions          oci8 pdo_oci
@@ -1581,9 +1583,9 @@ subport ${php}-pcntl {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.33              {revision 0}
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
 
     categories-append       sysutils
@@ -1610,9 +1612,9 @@ subport ${php}-posix {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.33              {revision 0}
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
 
     categories-append       sysutils
@@ -1633,9 +1635,9 @@ subport ${php}-postgresql {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.33              {revision 0}
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
 
     php.extensions          pgsql pdo_pgsql
@@ -1754,9 +1756,9 @@ subport ${php}-pspell {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.33              {revision 0}
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
 
     categories-append       textproc
@@ -1780,9 +1782,9 @@ subport ${php}-snmp {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.33              {revision 0}
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
 
     categories-append       sysutils
@@ -1806,9 +1808,9 @@ subport ${php}-soap {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.33              {revision 0}
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
 
     categories-append       net
@@ -1835,9 +1837,9 @@ subport ${php}-sockets {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.33              {revision 0}
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
 
     categories-append       net
@@ -1851,9 +1853,9 @@ subport ${php}-sockets {
 if {[vercmp ${branch} 7.2] >= 0} {
 subport ${php}-sodium {
     switch -- ${version} {
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
 
     php.extensions          sodium
@@ -1886,9 +1888,9 @@ subport ${php}-sqlite {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.33              {revision 0}
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
 
     php.extensions          sqlite sqlite3 pdo_sqlite
@@ -1934,9 +1936,9 @@ subport ${php}-tidy {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.33              {revision 0}
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
     
     categories-append       www
@@ -1966,8 +1968,8 @@ subport ${php}-wddx {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.33              {revision 0}
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
     }
 
     categories-append       textproc
@@ -1993,9 +1995,9 @@ subport ${php}-xmlrpc {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.33              {revision 0}
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
 
     categories-append       textproc
@@ -2034,9 +2036,9 @@ subport ${php}-xsl {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.33              {revision 0}
-        7.2.29              {revision 0}
-        7.3.16              {revision 0}
-        7.4.4               {revision 0}
+        7.2.33              {revision 0}
+        7.3.22              {revision 0}
+        7.4.10              {revision 0}
     }
 
     categories-append       textproc

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -351,7 +351,7 @@ if {[is_sapi_subport]} {
 subport ${php} {
     PortGroup               muniversal 1.0
     PortGroup               select 1.0
-    
+
     switch -- ${version} {
         5.2.17              {revision 15}
         5.3.29              {revision 6}
@@ -1448,11 +1448,11 @@ if {[vercmp ${branch} 5.5] >= 0} {
         switch -- ${version} {
             5.5.38              {revision 1}
             5.6.40              {revision 1}
-            7.0.33              {revision 0}
-            7.1.33              {revision 0}
-            7.2.29              {revision 0}
-            7.3.16              {revision 0}
-            7.4.4               {revision 0}
+            7.0.33              {revision 1}
+            7.1.33              {revision 1}
+            7.2.29              {revision 1}
+            7.3.16              {revision 1}
+            7.4.4               {revision 1}
         }
 
         php.extensions.zend opcache
@@ -1463,8 +1463,13 @@ if {[vercmp ${branch} 5.5] >= 0} {
         
         long_description    ${description}
         
-        configure.args-append --enable-opcache
-        
+        configure.args-append   --enable-opcache
+
+        # file based opcode cache was added in 7.0 (3abde432)
+        if {[vercmp ${branch} 7.0] >= 0} {
+            configure.args-append   --enable-opcache-file
+        }
+
         post-destroot {
             set docdir ${destroot}${prefix}/share/doc/${subport}
             xinstall -d ${docdir}


### PR DESCRIPTION
#### Description

###### commit 1

php: enable file based opcache

  - This enables the settings for file based opcache in ini
  - Closes: https://trac.macports.org/ticket/60105

###### commit 2

php: update to 7.{3.22,2.33,4.10}

  - Update current versions to 7.{3.22,2.33,4.10}
  - Update versions in subports, and reset the revision

###### Type(s)

- [x] enhancement
- [x] update

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality?

###### Notes

While adding the file based opcache, I also noticed the current versions wasn't up to date. Added a 2'nd commit for that.

I have test installed all 3 with: `sudo port -vst install`, but not the subports.
