### PR TITLE
apache-ant(-1.9): update to 1.10.8/1.9.15

### DIFF
--- a/devel/apache-ant-1.9/Portfile
+++ b/devel/apache-ant-1.9/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 PortGroup               java 1.0
 
 name                    apache-ant-1.9
-version                 1.9.14
+version                 1.9.15
 set branch              [join [lrange [split ${version} .] 0 1] .]
 categories              devel java
 license                 Apache-2 W3C
@@ -25,9 +25,9 @@ distname                apache-ant-${version}-bin
 master_sites            apache:ant/
 master_sites.mirror_subdir        binaries
 # Remember also to update the checksums in the source variant below.
-checksums               rmd160  2bc64a1799a3c4421f34759e731ce2285c852fff \
-                        sha256  efad74bd98d9eb72b080a3e08f5b17118e05372d22e3aa3bc0bd1686aa71361c \
-                        size    4493049
+checksums               rmd160  c7dd248c6904ef9709e469f63e25002078fdb48a \
+                        sha256  b91eb0c7412f7d4d7c205ea189cf3bfede4bed6a168144b2a222bcbc352edd79 \
+                        size    4495797
 
 worksrcdir              apache-ant-${version}
 set workTarget          ""
@@ -47,9 +47,9 @@ build {}
 variant source description "build from source; not recommended" {
         distname                        apache-ant-${version}-src
         master_sites.mirror_subdir      source
-        checksums                       rmd160  b084661f57b51e4e5a957322e009e055562765f6 \
-                                        sha256  b032f732f941ce44bb7bc512377c755e4017aa826ae7bc97f4edd8adcb7c75a6 \
-                                        size    3956853
+        checksums                       rmd160  3544e6c47c8a52d610afafc2a5e92b7c4bb3e55c \
+                                        sha256  7f7251009dc53e60afac47d0df6bd7e7d3cdba9fa7fec67b7a95412e8becdc8b \
+                                        size    3956366
         set workTarget                  /apache-ant
 
         build.cmd                       ./build.sh

--- a/devel/apache-ant/Portfile
+++ b/devel/apache-ant/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 PortGroup               java 1.0
 
 name                    apache-ant
-version                 1.10.7
+version                 1.10.8
 categories              devel java
 license                 Apache-2 W3C
 maintainers             nomaintainer
@@ -24,9 +24,9 @@ distname                ${name}-${version}-bin
 master_sites            apache:ant/
 master_sites.mirror_subdir        binaries
 # Remember also to update the checksums in the source variant below.
-checksums               rmd160  9d439a52fea1b98bd2fbf548a26a09a9591fa319 \
-                        sha256  925fa954d82b6edf5cfd51fc66659d6e02cf1a6a082c3c41fe83f604c2d17c02 \
-                        size    4989904
+checksums               rmd160  bb83f61036b06c71b37d42bca2bfcbae4a097209 \
+                        sha256  8be685aacf2bfe8515a1249fbebb0ccd861dfe05ee2c027c89fd7912c1ce2c2a \
+                        size    5011528
 
 worksrcdir              ${name}-${version}
 set workTarget          ""
@@ -47,9 +47,9 @@ variant source description "build from source; not recommended" {
         java.version                    1.8+
         distname                        ${name}-${version}-src
         master_sites.mirror_subdir      source
-        checksums                       rmd160  a8ca528e26737a1778652a0e731bc2675e6d117b \
-                                        sha256  c8d68b396d9e44b49668bafe0c82f8c89497915254b5395d73d6f6e41d7a0e25 \
-                                        size    4271380
+        checksums                       rmd160  718a0e42db8867cc20432978c8e56b82606cb18c \
+                                        sha256  40570314bad3b46abe4ee0669a8f8feb56fe767f1642a801fa7fd4fafcd362ca \
+                                        size    4509004
         set workTarget                  /${name}
 
         build.cmd                       ./build.sh


### PR DESCRIPTION
#### Description
See https://ant.apache.org/antnews.html
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6
`+source` variant untested

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
