### PR TITLE
cherokee: update to 1.2.204

### DIFF
--- a/www/cherokee/Portfile
+++ b/www/cherokee/Portfile
@@ -1,80 +1,100 @@
 PortSystem      1.0
 PortGroup       old_openssl 1.0
+PortGroup       github      1.0
 
+github.setup    cherokee webserver 1.2.104 v
 name            cherokee
-version         1.2.101
-revision        2
-set branch      [join [lrange [split ${version} .] 0 1] .]
+revision        0
+
 categories      www
 platforms       darwin
 maintainers     nomaintainer
 license         GPL-2
 
+homepage        https://www.cherokee-project.com/
+
 description     Cherokee web server
+
 long_description \
   Cherokee is a relatively new HTTP server designed to be as\
   performant as Apache and lighttpd, but much easier to \
   configure and maintain.  It ships out-of-the-box SCGI \
   support, making it ideal for deploying dynamic websites.
-homepage        http://www.cherokee-project.com/
-master_sites    ${homepage}download/${branch}/${version}
 
-checksums       md5     ef47003355a2e368e4d9596cd070ef23 \
-                sha1    b27f149c7d7111207ac8c3cd8a4856c05490d136 \
-                rmd160  dd3dedc352ba17bdcefd8e200143b8ffa19ad035
+checksums       rmd160  f5271b4b6f6be3cf70a88a3933fd90597862b289 \
+                sha256  5cbd00ff48503eaf90356b2975e311c02977f9166927e57fc23f541a109efd98 \
+                size    5312997
+
+set ck_wwwroot  ${prefix}/var/www/htdocs
+set ck_cgibin   ${prefix}/var/www/cgi-bin
+set ck_lcl_bin  ${workpath}/bin
+
+post-extract {
+    reinplace -W ${worksrcpath} \
+        "s|/Library/WebServer/Documents|${ck_wwwroot}|g" \
+        admin/util.py configure.ac
+
+    reinplace -W ${worksrcpath} \
+        "s|/Library/WebServer/CGI-Executables|${ck_cgibin}|g" configure.ac
+
+    file mkdir ${ck_lcl_bin}
+    # cherokee's autogen.sh seeks a python2 symlink
+    ln -s ${prefix}/bin/python2.7 ${ck_lcl_bin}/python2
+}
+
+configure.env-append    PATH=${ck_lcl_bin}:$env(PATH)
+
+configure.cmd   ./autogen.sh
+configure.args-append \
+                --with-wwwroot=${ck_wwwroot} \
+                --with-cgiroot=${ck_cgibin} \
+                --with-python=${prefix}/bin/python2.7 \
+                --without-ffmpeg \
+                --without-mysql \
+                --without-ldap
+
+depends_build-append \
+                port:automake \
+                port:autoconf \
+                port:libtool
 
 depends_lib     port:pcre \
                 port:zlib \
                 port:libgeoip \
+                port:python27 \
                 port:rrdtool
 
 openssl.branch 1.0
 openssl.configure build_flags
 
 # Startup item.
-set cherokee_config_name   cherokee.conf
-set cherokee_config        ${prefix}/etc/${name}/${cherokee_config_name}
-set cherokee_pidfile_name  cherokee.pid
-set cherokee_pidfile       ${prefix}/var/run/${cherokee_pidfile_name}
+set cherokee_config_name    cherokee.conf
+set cherokee_config         ${prefix}/etc/${name}/${cherokee_config_name}
+set cherokee_pidfile_name   cherokee.pid
+set cherokee_pidfile        ${prefix}/var/run/${cherokee_pidfile_name}
 
-startupitem.create  yes
-startupitem.init    "PIDFILE=${cherokee_pidfile}"
-startupitem.start   "${prefix}/sbin/cherokee -C ${cherokee_config}"
-startupitem.stop    "kill \$(cat \$PIDFILE)"
+startupitem.create          yes
+startupitem.init            PIDFILE=${cherokee_pidfile}
+startupitem.start           ${prefix}/sbin/cherokee -C ${cherokee_config}
+startupitem.stop            kill \$(cat \$PIDFILE)
 
-variant no_startupitem description {Do not create a startup item} {
-    startupitem.create  no
+variant ffmpeg description {Enable ffmpeg support} {
+    depends_lib-append      path:bin/ffmpeg:ffmpeg
+    configure.args-replace  --without-ffmpeg --with-ffmpeg
 }
 
-variant no_ipv6 description {Disable IPv6 support} {
-    configure.args-append --disable-ipv6
-}
-
-variant no_pam description {Disable PAM support} {
-    configure.args-append --disable-pam
-}
-
-variant trace description {Allows debugging options} {
-    configure.args-append --enable-trace
-}
-
-variant no_epoll description {Disable epoll() support} {
-    configure.args-append --disable-epoll
-}
-
-variant no_pthread description {Disable threading support} {
-    configure.args-append --disable-pthread
-}
-
-variant no_readdir_r description {Disable readdir_r usage} {
-    configure.args-append --disable-readdir_r
-}
-
-variant no_admin description {Skips cherokee-admin installation} {
-    configure.args-append --disable-admin
+variant ldap description {Enable LDAP support} {
+    depends_lib-append      port:openldap
+    configure.args-replace  --without-ldap --with-ldap
 }
 
 pre-destroot {
     xinstall -m 755 -d ${destroot}${prefix}/var/log
     destroot.keepdirs-append ${destroot}${prefix}/var/log
 }
+
+github.tarball_from archive
+
+notes "
+    Cherokee's web root is located at: ${ck_wwwroot}
+"


### PR DESCRIPTION
- use distfiles from Github as official site points to Github-hosted assets
- use recommended checksum types
- patch and configure to use $prefix/var/www as www root
- remove all variants, add new variants for ffmpeg and LDAP
- add Python2 as build dep for autogen script
- use automake/autoconf/libtool in build process

Closes: https://trac.macports.org/ticket/30324
Closes: https://trac.macports.org/ticket/33768
Closes: https://trac.macports.org/ticket/44766
See:    https://trac.macports.org/ticket/33767
See:    https://trac.macports.org/ticket/43704

Notes:
* Have not tested universal, so not sure if https://trac.macports.org/ticket/33766 is fixed
* Same for https://trac.macports.org/ticket/33767, there may still be lingering issues with implicit deps, haven't tested extensively enough to see all
* May need to add variants for Python & PHP, but when Python is explicitly disabled, the build process breaks as Python is needed to generate documentation

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.7 11E801a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
