### PR TITLE
mlt: use compiler.cxx_standard 2011

### DIFF
--- a/multimedia/mlt/Portfile
+++ b/multimedia/mlt/Portfile
@@ -41,13 +41,13 @@ variant qt4 conflicts qt5 description "build Qt4 version of ${name}" {
 
 variant qt5 conflicts qt4 description "build Qt5 version of ${name}" {
     PortGroup       qt5   1.0
-    PortGroup       cxx11 1.1
 
     qt5.min_version 5.6
 
     qt5.depends_component \
                     qtsvg
 
+    compiler.cxx_standard 2011
     configure.cxxflags-append \
                     -std=c++11
 }


### PR DESCRIPTION
…instead of deprecated cxx11 1.1 portgroup

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
