### PR TITLE
kitlist: use compiler.cxx_standard 2011

### DIFF
--- a/office/kitlist/Portfile
+++ b/office/kitlist/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem         1.0
-PortGroup          cxx11 1.1
 
 name               kitlist
 version            0.8.0
@@ -32,4 +31,5 @@ depends_lib        port:libxmlxx2 \
 configure.args     --disable-build-docs \
                    --without-gconf
 
+compiler.cxx_standard 2011
 configure.cxxflags-append -std=c++11


### PR DESCRIPTION
…instead of deprecated cxx11 1.1 portgroup

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
```
--->  Verifying Portfile for kitlist
Warning: missing recommended checksum type: sha256
Warning: missing recommended checksum type: size
--->  0 errors and 2 warnings found.
```


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
