### PR TITLE
VLC ports: correct licenses, use known_fail yes, attempt to fix activation

### DIFF
--- a/multimedia/VLC/Portfile
+++ b/multimedia/VLC/Portfile
@@ -51,7 +51,7 @@ supported_archs     x86_64
 
 version             3.0.11
 revision            0
-license             GPL-2
+license             GPL-2+ LGPL-2.1+
 
 platforms           darwin
 
@@ -147,6 +147,7 @@ platform darwin {
     # VLC calls ibtools which isn't part of the commandline tools
     use_xcode yes
     if {${os.major} < 13} {
+        known_fail  yes
         pre-fetch {
             ui_error "${name} ${version} requires Mac OS X 10.9 or greater."
             return -code error "incompatible Mac OS X version"

--- a/multimedia/VLC2/Portfile
+++ b/multimedia/VLC2/Portfile
@@ -54,7 +54,7 @@ supported_archs         x86_64
 if {(${subport} eq ${name}) || (${subport} eq "lib${name}")} {
     version             2.2.8
     revision            7
-    license             GPL-2+
+    license             GPL-2+ LGPL-2.1+
 
     platforms           darwin
 
@@ -147,8 +147,9 @@ if {(${subport} eq ${name}) || (${subport} eq "lib${name}")} {
                     --prefix=${vlcprefix}
     configure.args-append \
                     --bindir=${prefix}/bin
-    pre-fetch {
-        if {${os.platform} eq "darwin" && ${os.major} < 10} {
+    if {${os.platform} eq "darwin" && ${os.major} < 10} {
+        known_fail  yes
+        pre-fetch {
             ui_error "${name} ${version} requires Mac OS X 10.6 or greater."
             return -code error "incompatible Mac OS X version"
         }
@@ -475,7 +476,7 @@ if {(${subport} eq ${name}) || (${subport} eq "lib${name}")} {
                 ${destroot}${vlcprefix}/lib/pkgconfig/vlc-plugin.pc
         }
         post-activate {
-            system "${prefix}/lib/vlc/vlc-cache-gen -f ${prefix}/lib/vlc"
+            system "${vlcprefix}/lib/vlc/vlc-cache-gen ${vlcprefix}/lib/vlc"
         }
     }
     notes-append "MIDI support requires installing one or more SoundFont files,\


### PR DESCRIPTION
#### Description

GPL-licensed portions of VLC/libVLC are licensed under version 2 **or later**. Remaining libVLC portions are instead licensed under LGPL 2.1 or later.

The builders currently do not publish binary archives for VLC/libVLC: `"libVLC" is not distributable because its license "GPL-2" conflicts with license "LGPL-3+" of dependency "gmp"`. Correcting the license may affect availability of binary archives for these ports. Can someone manually reschedule a build/archive publishing, or do the revisions need to be increased?

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
```
--->  Verifying Portfile for VLC
Error: Line 40 repeats inclusion of PortGroup obsolete
--->  1 errors and 0 warnings found.
--->  Verifying Portfile for VLC2
Error: Line 39 repeats inclusion of PortGroup obsolete
Warning: missing recommended checksum type: size
--->  1 errors and 1 warnings found.
--->  Verifying Portfile for libVLC
Error: Line 40 repeats inclusion of PortGroup obsolete
--->  1 errors and 0 warnings found.
--->  Verifying Portfile for libVLC2
Error: Line 39 repeats inclusion of PortGroup obsolete
Warning: missing recommended checksum type: size
--->  1 errors and 1 warnings found.
```
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
