### PR TITLE
google-cloud-sdk: update to 309.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             308.0.0
+version             309.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  693e15cd29e5619a5e196fba454699a813db40d5 \
-                    sha256  c3291537c8458be1f9b86b5e8da846c96794760766afe3af565f44f7bd6a0ef2 \
-                    size    84489704
+    checksums       rmd160  13f4bb0c00e16c0a89fdbea880978bdce085ecaf \
+                    sha256  dc6a5fc8e289ba9a28872f16c7573c9a220a901c95e41856d0008b7180a3d65c \
+                    size    84581806
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  21d6668b833d7fad7ac99e7eea7a3fa00e288b09 \
-                    sha256  077c473929c2305fc7fada19319e139762b6088580ac9b5aac8b3ed8c18b78a5 \
-                    size    85503322
+    checksums       rmd160  ee7f384dbccba5fa1a7b058bd18e483d4f1b662c \
+                    sha256  8bc50a56668148db72623f6f3e8af87c56fe8c058729ebfc17b0374c0ef0a012 \
+                    size    85595443
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 309.0.0.

###### Tested on

macOS 10.15.6 19G2021
Xcode 11.7 11E801a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?