### PR TITLE
lang/ecl:  blacklist clang for now

### DIFF
--- a/lang/ecl/Portfile
+++ b/lang/ecl/Portfile
@@ -35,11 +35,13 @@ extract.suffix      .tgz
 configure.args          --enable-boehm=included 
 
 # ecl-16.1.3 fails in (asdf:test-op :hunchentoot) with an "Illegal
-# Instruction: 4" error This error is an "internal Apple error", so we
-# blacklist the failing versions clang, in favor of gcc.  
-compiler.blacklist      { clang < 300 }
-#compiler.whitelist      macports-gcc-4.9
-#compiler.whitelist       cc
+# Instruction: 4" error This error is an "internal Apple error"
+# blacklist the failing version of clang
+compiler.blacklist-append  { clang < 300 } 
+
+# ecl-20.4.24 fails to configure with clang 12.0.0:
+#   configure:7792: error: There is no appropiate integer type for the cl_fixnum type
+compiler.blacklist-append  clang
 
 livecheck.regex         /${name}-(\[0-9.\]+)${extract.suffix}
 


### PR DESCRIPTION
Build failing with clang-1200.0.31.1, and I can't quite seem to
understand the syntax for proper compiler blacklist, so just avoid
building with clang for now.

