### PR TITLE
evans: fix checksums

### DIFF
--- a/devel/evans/Portfile
+++ b/devel/evans/Portfile
@@ -21,9 +21,9 @@ categories          devel
 license             MIT
 installs_libs       no
 
-checksums           rmd160  616a15ea9e8a88dc3bed2f87ac36641d85a9c094 \
-                    sha256  203cf60b24c2a65672f19f4e256b664f973fba5a7eb7c18c9cccd6489c73415d \
-                    size    34528799
+checksums           rmd160  69f027d174220132e2a5be04b292795bea281842 \
+                    sha256  7f5309d86df5971b50e563ab20ba92aaac73aba1161a330da6de615995922c8f \
+                    size    34534181
 
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
Didn't get updated for 0.9.1 in d876866a57

#### Description
Builds currently [fail](https://build.macports.org/builders/ports-10.14_x86_64-builder/builds/66613/steps/install-port/logs/stdio) due to incorrect checksums.
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->