### PR TITLE
php: whitespace and cleanup

### DIFF
--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -926,88 +926,88 @@ ${phpinidir}/php-fpm.conf.default.
         }
     }
 
-subport ${php}-gettext {
-    switch -- ${version} {
-        5.2.17              {revision 0}
-        5.3.29              {revision 0}
-        5.4.45              {revision 0}
-        5.5.38              {revision 0}
-        5.6.40              {revision 0}
-        7.0.33              {revision 0}
-        7.1.33              {revision 0}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
+    subport ${php}-gettext {
+        switch -- ${version} {
+            5.2.17              {revision 0}
+            5.3.29              {revision 0}
+            5.4.45              {revision 0}
+            5.5.38              {revision 0}
+            5.6.40              {revision 0}
+            7.0.33              {revision 0}
+            7.1.33              {revision 0}
+            7.2.34              {revision 0}
+            7.3.23              {revision 0}
+            7.4.11              {revision 0}
+        }
+
+        categories-append       devel
+
+        description             a PHP interface to the gettext natural language \
+                                support functions
+
+        long_description        ${description}
+
+        depends_lib-append      port:gettext
+
+        configure.args-append   --with-gettext=${prefix}
     }
 
-    categories-append       devel
+    subport ${php}-gmp {
+        switch -- ${version} {
+            5.2.17              {revision 0}
+            5.3.29              {revision 0}
+            5.4.45              {revision 0}
+            5.5.38              {revision 0}
+            5.6.40              {revision 0}
+            7.0.33              {revision 0}
+            7.1.33              {revision 0}
+            7.2.34              {revision 0}
+            7.3.23              {revision 0}
+            7.4.11              {revision 0}
+        }
 
-    description             a PHP interface to the gettext natural language \
-                            support functions
+        categories-append       devel math
 
-    long_description        ${description}
+        description             a PHP interface to GMP, the GNU multiprocessing \
+                                library through which you can work with \
+                                arbitrary-length integers
 
-    depends_lib-append      port:gettext
+        long_description        ${description}
 
-    configure.args-append   --with-gettext=${prefix}
-}
+        depends_lib-append      port:gmp
 
-subport ${php}-gmp {
-    switch -- ${version} {
-        5.2.17              {revision 0}
-        5.3.29              {revision 0}
-        5.4.45              {revision 0}
-        5.5.38              {revision 0}
-        5.6.40              {revision 0}
-        7.0.33              {revision 0}
-        7.1.33              {revision 0}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
+        if {[vercmp ${branch} 5.2] <= 0} {
+            patchfiles-append   patch-${php}-ext-gmp-gmp.c.diff
+        }
+
+        configure.args-append   --with-gmp=${prefix}
     }
 
-    categories-append       devel math
+    subport ${php}-iconv {
+        switch -- ${version} {
+            5.2.17              {revision 0}
+            5.3.29              {revision 0}
+            5.4.45              {revision 0}
+            5.5.38              {revision 0}
+            5.6.40              {revision 0}
+            7.0.33              {revision 0}
+            7.1.33              {revision 0}
+            7.2.34              {revision 0}
+            7.3.23              {revision 0}
+            7.4.11              {revision 0}
+        }
 
-    description             a PHP interface to GMP, the GNU multiprocessing \
-                            library through which you can work with \
-                            arbitrary-length integers
+        categories-append       textproc
 
-    long_description        ${description}
+        description             a PHP interface to the libiconv character encoding \
+                                conversion functions
 
-    depends_lib-append      port:gmp
+        long_description        ${description}
 
-    if {[vercmp ${branch} 5.2] <= 0} {
-        patchfiles-append   patch-${php}-ext-gmp-gmp.c.diff
+        depends_lib-append      port:libiconv
+
+        configure.args-append   --with-iconv=${prefix}
     }
-
-    configure.args-append   --with-gmp=${prefix}
-}
-
-subport ${php}-iconv {
-    switch -- ${version} {
-        5.2.17              {revision 0}
-        5.3.29              {revision 0}
-        5.4.45              {revision 0}
-        5.5.38              {revision 0}
-        5.6.40              {revision 0}
-        7.0.33              {revision 0}
-        7.1.33              {revision 0}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
-    }
-
-    categories-append       textproc
-
-    description             a PHP interface to the libiconv character encoding \
-                            conversion functions
-
-    long_description        ${description}
-
-    depends_lib-append      port:libiconv
-
-    configure.args-append   --with-iconv=${prefix}
-}
 
 subport ${php}-imap {
     switch -- ${version} {

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -6,6 +6,7 @@ PortGroup               compiler_blacklist_versions 1.0
 PortGroup               old_openssl 1.0
 
 name                    php
+
 platforms               darwin freebsd
 maintainers             {ryandesign @ryandesign}
 license                 PHP-3.01
@@ -20,7 +21,6 @@ long_description        PHP is a widely-used general-purpose scripting \
                         web sites, but can also be used for command-line \
                         scripting.
 
-# The list of PHP branches this port provides.
 php.branches            5.2 5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4
 
 # Fix for users specifying the subport name with the wrong case.
@@ -196,13 +196,13 @@ if {[vercmp ${major} 5] > 0} {
 }
 
 if {[is_sapi_subport]} {
-    
+
     depends_build       port:pkgconfig
-    
+
     if {${subport} ne ${php}} {
         depends_lib     port:${php}
     }
-    
+
     depends_lib-append  path:bin/gsed:gsed \
                         port:libiconv \
                         port:libxml2 \
@@ -215,7 +215,7 @@ if {[is_sapi_subport]} {
     } else {
         depends_lib-append  port:pcre2
     }
-    
+
     # Use -p1 to accommodate the Suhosin patch
     patch.pre_args      -p1
     patchfiles-append   patch-${php}-scripts-php-config.in.diff
@@ -241,7 +241,7 @@ if {[is_sapi_subport]} {
 
     set phpinidir       ${prefix}/etc/${php}
     set extraphpinidir  ${prefix}/var/db/${php}
-    
+
     configure.args      --mandir=${prefix}/share/man \
                         --infodir=${prefix}/share/info \
                         --program-suffix=[php.suffix_from_branch ${branch}] \
@@ -283,33 +283,33 @@ if {[is_sapi_subport]} {
     configure.env       LEX=true \
                         RE2C=true \
                         YACC=true
-    
+
     if {[vercmp ${branch} 5.3] >= 0} {
         configure.args-append \
                         --enable-fileinfo \
                         --enable-phar \
                         --disable-fpm
-        
+
         # ${php}-mysql +mysqlnd needs mysqlnd support compiled into the SAPI
         configure.env-append \
                         PHP_MYSQLND_ENABLED=yes
     }
-    
+
     if {[vercmp ${branch} 5.4] == 0} {
         # https://bugs.php.net/bug.php?id=68114
         configure.args-append ac_cv_decimal_fp_supported=no
     }
-    
+
     configure.universal_args-delete --disable-dependency-tracking
-    
+
     test.run            yes
-    
+
     destroot.destdir    INSTALL_ROOT=${destroot}
-    
+
     variant debug description {Enable debug support (useful to analyze a PHP-related core dump)} {
         configure.args-append   --enable-debug
     }
-    
+
     if {[vercmp ${branch} 5.3] <= 0} {
     variant suhosin description {Add Suhosin patch} {
         pre-fetch {
@@ -339,11 +339,11 @@ if {[is_sapi_subport]} {
         }
     }
     }
-    
+
     if {${subport} ne ${php}} {
         notes-append "If this is your first install, you need to enable ${subport} in your web server."
     }
-    
+
 }
 
 }
@@ -366,12 +366,12 @@ subport ${php} {
         7.3.23              {revision 0}
         7.4.11              {revision 0}
     }
-    
+
     depends_run             port:php_select
-    
+
     select.group            php
     select.file             ${filespath}/${subport}
-    
+
     if {[vercmp ${branch} 5.3] == 0} {
         patchfiles-append   patch-${php}-C++11.diff
     }
@@ -388,13 +388,13 @@ subport ${php} {
         # Ensure the build date is the same for all universal archs.
         reinplace "s|^PHP_BUILD_DATE=.*$|PHP_BUILD_DATE=[clock format [clock seconds] -format {%Y-%m-%d}]|g" ${worksrcpath}/configure
     }
-    
+
     configure.args-replace  --disable-cli --enable-cli
-    
+
     destroot.target         install-cli install-build install-headers install-programs
-    
+
     destroot.keepdirs       ${destroot}${extraphpinidir}
-    
+
     post-destroot {
         # Copy the default php.ini files.
         xinstall -m 755 -d ${destroot}${phpinidir}
@@ -409,14 +409,14 @@ subport ${php} {
                 php.ini-recommended \
                 ${destroot}${phpinidir}
         }
-        
+
         if {[vercmp ${branch} 5.3] >= 0} {
             # Copy mysqlnd headers.
             xinstall -d ${destroot}${prefix}/include/${php}/php/ext/mysqlnd
             xinstall -m 644 {*}[glob ${worksrcpath}/ext/mysqlnd/*.h] ${destroot}${prefix}/include/${php}/php/ext/mysqlnd
         }
     }
-    
+
     # Include the readline extension https://www.php.net/readline directly in
     # the PHP CLI SAPI because until PHP 6 the interactive mode "php -a" won't
     # work with a separately built readline extension.
@@ -440,7 +440,7 @@ subport ${php} {
     if {![variant_isset readline]} {
         default_variants +libedit
     }
-    
+
     if {[vercmp ${branch} ${php.oldest_supported_branch}] < 0} {
         notes-append "
 PHP ${branch} has reached end-of-life. Please upgrade to PHP ${php.oldest_supported_branch} or newer. The newest stable version is ${php.latest_stable_branch}.
@@ -452,11 +452,11 @@ To learn how to update your code, please read the following guide:
 
 "
     }
-    
+
     if {[vercmp ${branch} ${php.latest_stable_branch}] > 0} {
         notes-append "${php} @${version} is a development preview—do not use it in production!\n\n\n"
     }
-    
+
     if {![file exists ${phpinidir}/php.ini]} {
         if {[vercmp ${branch} 5.3] >= 0} {
             notes-append "
@@ -487,7 +487,7 @@ ${phpinidir}/php.ini-recommended.
 "
         }
     }
-    
+
     # Enable livecheck for all supported PHP branches and the development branch.
     if {[vercmp ${branch} ${php.oldest_supported_branch}] >= 0} {
         livecheck.type      regex
@@ -513,25 +513,25 @@ subport ${php}-apache2handler {
         7.3.23              {revision 0}
         7.4.11              {revision 0}
     }
-    
+
     description             ${php} Apache 2 Handler SAPI
-    
+
     long_description        ${description}
-    
+
     homepage                https://www.php.net/install.unix.apache2
-    
+
     depends_lib-append      port:apache2
-    
+
     require_active_variants apache2 preforkmpm
-    
+
     set apxs ${prefix}/bin/apxs
     set confdir ${prefix}/etc/apache2
     set moduledir ${prefix}/lib/apache2/modules
-    
+
     configure.args-append   --with-apxs2=${apxs}
-    
+
     build.target            libs/libphp${major}.bundle
-    
+
     if {[vercmp ${branch} 5.3] < 0} {
         # PHP earlier than 5.3 is not compatible with Apache 2.4 or later, and
         # earlier versions of Apache were removed from MacPorts. Might be able
@@ -539,14 +539,14 @@ subport ${php}-apache2handler {
         # report: https://bugs.php.net/bug.php?id=62267
         known_fail          yes
     }
-    
+
     destroot {
         xinstall -m 755 -d ${destroot}${moduledir} ${destroot}${confdir}/extra
         xinstall -m 644 ${worksrcpath}/libs/libphp${major}.so ${destroot}${moduledir}/mod_${php}.so
         xinstall -m 644 ${filespath}/mod_php.conf.in ${destroot}${confdir}/extra/mod_${php}.conf
         reinplace s/@MAJOR@/${major}/g ${destroot}${confdir}/extra/mod_${php}.conf
     }
-    
+
     notes-append "
 
 To enable ${subport}, run:
@@ -573,18 +573,18 @@ subport ${php}-cgi {
     }
 
     description             ${php} CGI SAPI
-    
+
     long_description        ${description}
-    
+
     homepage                https://www.php.net/install.unix.commandline
-    
+
     configure.args-delete   --disable-cgi
     if {[vercmp ${branch} 5.3] >= 0} {
         configure.args-append --enable-cgi
     } else {
         configure.args-append --enable-fastcgi --enable-force-cgi-redirect
     }
-    
+
     if {[vercmp ${branch} 5.4] >= 0} {
         build.target        cgi
         destroot.target     install-cgi
@@ -593,7 +593,7 @@ subport ${php}-cgi {
             xinstall ${worksrcpath}/sapi/cgi/php-cgi ${destroot}${prefix}/bin/php-cgi[php.suffix_from_branch ${branch}]
         }
     }
-    
+
 }
 
 ### FPM SAPI ###
@@ -613,40 +613,40 @@ subport ${php}-fpm {
     }
 
     description             ${php} FPM SAPI
-    
+
     long_description        ${description}
-    
+
     homepage                https://www.php.net/install.fpm
-    
+
     set fpmuser             nobody
     set fpmgroup            nobody
-    
+
     patchfiles-append       patch-${php}-sapi-fpm-php-fpm.conf.in.diff
-    
+
     post-patch {
         reinplace "s|@PHP@|${php}|g" ${worksrcpath}/sapi/fpm/php-fpm.conf.in
     }
-    
+
     configure.args-replace  --disable-fpm --enable-fpm
     configure.args-append   --datadir=${prefix}/share/examples/${php} \
                             --sysconfdir=${phpinidir} \
                             --with-fpm-user=${fpmuser} \
                             --with-fpm-group=${fpmgroup}
-    
+
     build.target            fpm
-    
+
     destroot.target         install-fpm
-    
+
     destroot.keepdirs       ${destroot}${prefix}/var/log/${php} \
                             ${destroot}${prefix}/var/run/${php}
-    
+
     post-destroot {
         xinstall -d -o ${fpmuser} -g ${fpmgroup} ${destroot}${prefix}/var/log/${php} ${destroot}${prefix}/var/run/${php}
     }
-    
+
     startupitem.create      yes
     startupitem.executable  ${prefix}/sbin/php-fpm[php.suffix_from_branch ${branch}]
-    
+
     if {![file exists ${phpinidir}/php-fpm.conf]} {
         notes-append "
 
@@ -683,7 +683,7 @@ subport ${php}-calendar {
 
     description             a PHP extension for converting between different \
                             calendar formats
-    
+
     long_description        ${description}
 }
 
@@ -702,12 +702,12 @@ subport ${php}-curl {
     }
 
     categories-append       net www
-    
+
     description             a PHP interface to the curl library, which lets you \
                             download files from servers with a variety of protocols
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:curl
 
     if {[vercmp ${branch} 7.4] < 0} {
@@ -734,17 +734,17 @@ subport ${php}-dba {
     }
 
     categories-append       databases
-    
+
     description             a PHP interface for accessing DBM databases such as \
                             BerkeleyDB
-    
+
     long_description        ${description}
-    
+
     variant gdbm conflicts qdbm description {Add GDBM support} {
         depends_lib-append      port:gdbm
         configure.args-append   --with-gdbm=${prefix}
     }
-    
+
     variant qdbm conflicts gdbm description {Add QDBM support} {
         depends_lib-append      port:qdbm
         configure.args-append   --with-qdbm=${prefix}
@@ -766,11 +766,11 @@ subport ${php}-enchant {
     }
 
     categories-append       textproc devel
-    
+
     description             a PHP interface to enchant
-    
+
     long_description        ${name} is ${description}, a common API for many spell libraries.
-    
+
     depends_lib-append      port:enchant
 
     if {[vercmp ${branch} 7.4] < 0} {
@@ -785,7 +785,7 @@ subport ${php}-enchant {
         set docdir ${prefix}/share/doc/${subport}
         xinstall -d ${destroot}${docdir}
         xinstall -m 644 -W ${destroot.dir} CREDITS ${destroot}${docdir}
-        
+
         if {[vercmp ${branch} 7.3] < 0} {
         set examplesdir ${prefix}/share/examples/${subport}
         xinstall -d ${destroot}${examplesdir}
@@ -811,9 +811,9 @@ subport ${php}-exif {
     }
 
     categories-append       graphics
-    
+
     description             a PHP interface to the EXIF image metadata functions
-    
+
     long_description        ${description}
 }
 
@@ -832,14 +832,14 @@ subport ${php}-ftp {
     }
 
     categories-append       net
-    
+
     description             a PHP extension for accessing file servers using the \
                             File Transfer Protocol
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      path:lib/libssl.dylib:openssl
-    
+
     if {[vercmp ${branch} 7.4] >= 0} {
         depends_build-append \
                             port:pkgconfig
@@ -867,11 +867,11 @@ subport ${php}-gd {
     }
 
     categories-append       graphics
-    
+
     description             a PHP interface to the gd library
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:freetype \
                             port:jpeg \
                             port:libpng \
@@ -905,7 +905,7 @@ subport ${php}-gd {
                                 --with-jpeg \
                                 --with-webp
     }
-    
+
     if {[vercmp ${branch} 7.0] < 0} {
     variant t1lib description {Add PostScript Type 1 font support with t1lib} {
         depends_lib-append      port:t1lib
@@ -929,14 +929,14 @@ subport ${php}-gettext {
     }
 
     categories-append       devel
-    
+
     description             a PHP interface to the gettext natural language \
                             support functions
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:gettext
-    
+
     configure.args-append   --with-gettext=${prefix}
 }
 
@@ -955,19 +955,19 @@ subport ${php}-gmp {
     }
 
     categories-append       devel math
-    
+
     description             a PHP interface to GMP, the GNU multiprocessing \
                             library through which you can work with \
                             arbitrary-length integers
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:gmp
-    
+
     if {[vercmp ${branch} 5.2] <= 0} {
         patchfiles-append   patch-${php}-ext-gmp-gmp.c.diff
     }
-    
+
     configure.args-append   --with-gmp=${prefix}
 }
 
@@ -986,14 +986,14 @@ subport ${php}-iconv {
     }
 
     categories-append       textproc
-    
+
     description             a PHP interface to the libiconv character encoding \
                             conversion functions
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:libiconv
-    
+
     configure.args-append   --with-iconv=${prefix}
 }
 
@@ -1012,16 +1012,16 @@ subport ${php}-imap {
     }
 
     categories-append       mail
-    
+
     description             a PHP interface to the IMAP protocol
-    
+
     long_description        ${description}
-    
+
     depends_build-append    port:cclient
-    
+
     depends_lib-append      port:kerberos5 \
                             port:libcomerr
-    
+
     configure.args-append   --with-imap=${prefix} \
                             --with-imap-ssl=${prefix} \
                             --with-kerberos=${prefix}
@@ -1047,11 +1047,11 @@ subport ${php}-intl {
         7.3.23              {revision 0}
         7.4.11              {revision 0}
     }
-    
+
     categories-append       devel
-    
+
     description             internationalization extension for PHP
-    
+
     long_description        Internationalization extension implements ICU \
                             library functionality in PHP.
 
@@ -1092,9 +1092,9 @@ subport ${php}-ipc {
     }
 
     php.extensions          shmop sysvmsg sysvsem sysvshm
-    
+
     description             interprocess communication extensions for PHP
-    
+
     long_description        PHP extensions for interprocess communication (IPC), including the \
                             shmop, sysvmsg, sysvsem, and sysvshm extensions.
 }
@@ -1114,13 +1114,13 @@ subport ${php}-ldap {
     }
 
     categories-append       databases
-    
+
     description             a PHP interface to LDAP
 
     long_description        ${subport} is ${description}, the Lightweight Directory \
                             Access Protocol, which is used to access Directory \
                             Servers.
-    
+
     depends_lib-append      port:openldap \
                             port:cyrus-sasl2
 
@@ -1150,10 +1150,10 @@ subport ${php}-mbstring {
     }
 
     categories-append       textproc
-    
+
     description             a PHP extension for manipulating strings in multibyte \
                             encodings
-    
+
     long_description        ${description}
 
     if {[vercmp ${branch} 7.4] >= 0} {
@@ -1178,18 +1178,18 @@ subport ${php}-mcrypt {
     }
 
     categories-append       security
-    
+
     description             a PHP interface to the mcrypt library, which offers \
                             a wide variety of algorithms
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:libmcrypt
-    
+
     # The mcrypt extension may be using libtool unnecessarily; monitor
     # https://bugs.php.net/bug.php?id=54500
     depends_lib-append      port:libtool
-    
+
     configure.args-append   --with-mcrypt=${prefix}
 }
 }
@@ -1205,16 +1205,16 @@ subport ${php}-mssql {
     }
 
     php.extensions          mssql pdo_dblib
-    
+
     categories-append       databases
-    
+
     description             a PHP interface to MSSQL using FreeTDS, including \
                             the mssql and pdo_dblib extensions
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:freetds
-    
+
     configure.args-append   --with-mssql=${prefix} \
                             --with-pdo-dblib=${prefix}
 }
@@ -1238,29 +1238,29 @@ subport ${php}-mysql {
     if {[vercmp ${branch} 7] < 0} {
         php.extensions-prepend mysql
     }
-    
+
     categories-append       databases
-    
+
     description             a PHP interface to MySQL databases, including the
     if {[vercmp ${branch} 7] < 0} {
         description-append  mysql,
     }
     description-append      mysqli and pdo_mysql extensions
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:zlib
-    
+
     configure.args-append   --with-zlib-dir=${prefix}
-    
+
     if {[vercmp ${branch} 5.3] >= 0} {
     variant mysqlnd conflicts mysql4 mysql5 mysql51 mysql55 mysql56 mariadb percona description {Use MySQL Native Driver} {
         configure.args-append   --with-mysql=mysqlnd \
                                 --with-mysqli=mysqlnd \
                                 --with-pdo-mysql=mysqlnd
-        
+
         configure.cppflags-append   -I${worksrcpath}
-        
+
         set phpini ${prefix}/etc/${php}/php.ini
         notes "
 To use mysqlnd with a local MySQL server, edit ${phpini} and set\
@@ -1276,104 +1276,104 @@ For percona, use ${prefix}/var/run/percona/mysqld.sock
 "
     }
     }
-    
+
     variant mysql4 conflicts mysqlnd mysql5 mysql51 mysql55 mysql56 mariadb percona description {Use MySQL 4 libraries} {
         depends_lib-append      port:mysql4
-        
+
         configure.args-append   --with-mysql=${prefix} \
                                 --with-pdo-mysql=${prefix}
     }
-    
+
     variant mysql5 conflicts mysqlnd mysql4 mysql51 mysql55 mysql56 mariadb percona description {Use MySQL 5 libraries} {
         depends_lib-append      path:bin/mysql_config5:mysql5
-        
+
         post-extract {
             file mkdir ${workpath}/mysql5
             file link -symbolic ${workpath}/mysql5/lib ${prefix}/lib/mysql5
             file link -symbolic ${workpath}/mysql5/include ${prefix}/include/mysql5
         }
-        
+
         configure.args-append   --with-mysql=${workpath}/mysql5 \
                                 --with-mysqli=${prefix}/bin/mysql_config5 \
                                 --with-pdo-mysql=${prefix}/bin/mysql_config5 \
                                 --with-mysql-sock=${prefix}/var/run/mysql5/mysqld.sock
     }
-    
+
     variant mysql51 conflicts mysqlnd mysql4 mysql5 mysql55 mysql56 mariadb percona description {Use MySQL 5.1 libraries} {
         depends_lib-append      port:mysql51
-        
+
         post-extract {
             file mkdir ${workpath}/mysql51
             file link -symbolic ${workpath}/mysql51/lib ${prefix}/lib/mysql51
             file link -symbolic ${workpath}/mysql51/include ${prefix}/include/mysql51
         }
-        
+
         configure.args-append   --with-mysql=${workpath}/mysql51 \
                                 --with-mysqli=${prefix}/lib/mysql51/bin/mysql_config \
                                 --with-pdo-mysql=${prefix}/lib/mysql51/bin/mysql_config \
                                 --with-mysql-sock=${prefix}/var/run/mysql51/mysqld.sock
     }
-    
+
     variant mysql55 conflicts mysqlnd mysql4 mysql5 mysql51 mysql56 mariadb percona description {Use MySQL 5.5 libraries} {
         depends_lib-append      port:mysql55
-        
+
         post-extract {
             file mkdir ${workpath}/mysql55
             file link -symbolic ${workpath}/mysql55/lib ${prefix}/lib/mysql55
             file link -symbolic ${workpath}/mysql55/include ${prefix}/include/mysql55
         }
-        
+
         configure.args-append   --with-mysql=${workpath}/mysql55 \
                                 --with-mysqli=${prefix}/lib/mysql55/bin/mysql_config \
                                 --with-pdo-mysql=${prefix}/lib/mysql55/bin/mysql_config \
                                 --with-mysql-sock=${prefix}/var/run/mysql55/mysqld.sock
     }
-    
+
     variant mysql56 conflicts mysqlnd mysql4 mysql5 mysql51 mysql55 mariadb percona description {Use MySQL 5.6 libraries} {
         depends_lib-append      port:mysql56
-        
+
         post-extract {
             file mkdir ${workpath}/mysql56
             file link -symbolic ${workpath}/mysql56/lib ${prefix}/lib/mysql56
             file link -symbolic ${workpath}/mysql56/include ${prefix}/include/mysql56
         }
-        
+
         configure.args-append   --with-mysql=${workpath}/mysql56 \
                                 --with-mysqli=${prefix}/lib/mysql56/bin/mysql_config \
                                 --with-pdo-mysql=${prefix}/lib/mysql56/bin/mysql_config \
                                 --with-mysql-sock=${prefix}/var/run/mysql56/mysqld.sock
     }
-    
+
     variant mariadb conflicts mysqlnd mysql4 mysql5 mysql51 mysql55 mysql56 percona description {Use MariaDB libraries} {
         depends_lib-append      port:mariadb
-        
+
         post-extract {
             file mkdir ${workpath}/mariadb
             file link -symbolic ${workpath}/mariadb/lib ${prefix}/lib/mariadb
             file link -symbolic ${workpath}/mariadb/include ${prefix}/include/mariadb
         }
-        
+
         configure.args-append   --with-mysql=${workpath}/mariadb \
                                 --with-mysqli=${prefix}/lib/mariadb/bin/mysql_config \
                                 --with-pdo-mysql=${prefix}/lib/mariadb/bin/mysql_config \
                                 --with-mysql-sock=${prefix}/var/run/mariadb/mysqld.sock
     }
-    
+
     variant percona conflicts mysqlnd mysql4 mysql5 mysql51 mysql55 mysql56 mariadb description {Use Percona libraries} {
         depends_lib-append      port:percona
-        
+
         post-extract {
             file mkdir ${workpath}/percona
             file link -symbolic ${workpath}/percona/lib ${prefix}/lib/percona
             file link -symbolic ${workpath}/percona/include ${prefix}/include/percona
         }
-        
+
         configure.args-append   --with-mysql=${workpath}/percona \
                                 --with-mysqli=${prefix}/lib/percona/bin/mysql_config \
                                 --with-pdo-mysql=${prefix}/lib/percona/bin/mysql_config \
                                 --with-mysql-sock=${prefix}/var/run/percona/mysqld.sock
     }
-    
+
     if {![variant_isset mysql4] && ![variant_isset mysql5] && ![variant_isset mysql51] && ![variant_isset mysql55] && ![variant_isset mysql56] && ![variant_isset mariadb] && ![variant_isset percona]} {
         if {[vercmp ${branch} 5.3] >= 0} {
             default_variants +mysqlnd
@@ -1398,18 +1398,18 @@ subport ${php}-odbc {
     }
 
     php.extensions          odbc pdo_odbc
-    
+
     categories-append       databases
-    
+
     description             a PHP interface for accessing databases via Open \
                             DataBase Connectivity (ODBC)
-    
+
     long_description        ${description}
-    
+
     if {[vercmp ${branch} 5.3] >= 0} {
     variant iodbc conflicts unixodbc description {Use iODBC} {
         depends_lib-append      port:libiodbc
-        
+
         patchfiles-append       patch-${php}-iODBC.diff
 
         configure.args-append   --with-pdo-odbc=iODBC,${prefix}
@@ -1421,7 +1421,7 @@ subport ${php}-odbc {
             configure.args-append   --with-iODBC
         }
     }
-    
+
     variant unixodbc conflicts iodbc description {Use unixODBC} {}
 
     if {![variant_isset iodbc] && ![variant_isset unixodbc]} {
@@ -1431,7 +1431,7 @@ subport ${php}-odbc {
 
     if {[variant_isset unixodbc] || [vercmp ${branch} 5.3] < 0} {
         depends_lib-append      port:unixODBC
-        
+
         patchfiles-append       patch-${php}-unixODBC.diff
 
         configure.args-append   --with-pdo-odbc=unixODBC,${prefix}
@@ -1458,13 +1458,13 @@ if {[vercmp ${branch} 5.5] >= 0} {
         }
 
         php.extensions.zend opcache
-        
+
         description         OPcache improves PHP performance by storing precompiled \
                             script bytecode in shared memory, thereby removing the \
                             need for PHP to load and parse scripts on each request.
-        
+
         long_description    ${description}
-        
+
         configure.args-append   --enable-opcache
 
         # file based opcode cache was added in 7.0 (3abde432)
@@ -1497,21 +1497,21 @@ subport ${php}-openssl {
     }
 
     categories-append       devel security
-    
+
     description             a PHP interface to OpenSSL signature-generation \
                             and -verification and data-encryption and \
                             -decryption functions
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:kerberos5 \
                             port:libcomerr \
                             path:lib/libssl.dylib:openssl
-    
+
     post-extract {
         move ${php.build_dirs}/config0.m4 ${php.build_dirs}/config.m4
     }
-    
+
     configure.args-append   --with-kerberos=${prefix}
 
     if {[vercmp ${branch} 5.6] <= 0} {
@@ -1551,20 +1551,20 @@ subport ${php}-oracle {
     }
 
     php.extensions          oci8 pdo_oci
-    
+
     categories-append       databases
-    
+
     description             a PHP interface to Oracle, including the oci8 and \
                             pdo_oci extensions
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:oracle-instantclient
-    
+
     if {[vercmp ${branch} 5.2] <= 0} {
         patchfiles-append   patch-${php}-ext-pdo_oci-config.m4.diff
     }
-    
+
     set lib_dir             ${prefix}/lib/oracle
     pre-configure {
         regexp {\.dylib\.(.+)$} [glob -directory ${lib_dir} libclntsh.dylib.*] -> library_version
@@ -1589,13 +1589,13 @@ subport ${php}-pcntl {
     }
 
     categories-append       sysutils
-    
+
     description             a PHP interface to Unix-style process creation, \
                             program execution, signal handling and process \
                             termination functions
-    
+
     long_description        ${description}
-    
+
     notes "
 ${subport} should not be enabled within a web server environment.\
 Unexpected results may occur if any process control functions are used within\
@@ -1618,9 +1618,9 @@ subport ${php}-posix {
     }
 
     categories-append       sysutils
-    
+
     description             a PHP interface to additional POSIX functions
-    
+
     long_description        a PHP interface to those functions defined in the \
                             IEEE 1003.1 (POSIX.1) standards document which are \
                             not accessible through other means
@@ -1641,82 +1641,82 @@ subport ${php}-postgresql {
     }
 
     php.extensions          pgsql pdo_pgsql
-    
+
     categories-append       databases
-    
+
     homepage                https://www.php.net/pgsql
-    
+
     description             a PHP interface to PostgreSQL, including \
                             the pgsql and pdo_pgsql extensions
-    
+
     long_description        ${description}
-    
+
     variant postgresql82 conflicts postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 8.2 libraries} {
         depends_lib-append      port:postgresql82
-        
+
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql82/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql82/bin
     }
-    
+
     variant postgresql83 conflicts postgresql82 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 8.3 libraries} {
         depends_lib-append      port:postgresql83
-        
+
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql83/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql83/bin
     }
-    
+
     variant postgresql84 conflicts postgresql82 postgresql83 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 8.4 libraries} {
         depends_lib-append      port:postgresql84
-        
+
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql84/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql84/bin
     }
-    
+
     variant postgresql90 conflicts postgresql82 postgresql83 postgresql84 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 9.0 libraries} {
         depends_lib-append      port:postgresql90
-        
+
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql90/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql90/bin
     }
-    
+
     variant postgresql91 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 9.1 libraries} {
         depends_lib-append      port:postgresql91
-        
+
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql91/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql91/bin
     }
-    
+
     variant postgresql92 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 9.2 libraries} {
         depends_lib-append      port:postgresql92
-        
+
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql92/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql92/bin
     }
-    
+
     variant postgresql93 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 9.3 libraries} {
         depends_lib-append      port:postgresql93
-        
+
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql93/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql93/bin
     }
-    
+
     variant postgresql94 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 9.4 libraries} {
         depends_lib-append      port:postgresql94
-        
+
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql94/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql94/bin
     }
-    
+
     variant postgresql95 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 9.5 libraries} {
         depends_lib-append      port:postgresql95
-        
+
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql95/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql95/bin
     }
-    
+
     variant postgresql96 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 9.6 libraries} {
         depends_lib-append      port:postgresql96
-        
+
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql96/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql96/bin
     }
@@ -1741,7 +1741,7 @@ subport ${php}-postgresql {
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql12/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql12/bin
     }
-    
+
     if {![variant_isset postgresql82] && ![variant_isset postgresql83] && ![variant_isset postgresql84] && ![variant_isset postgresql90] && ![variant_isset postgresql91] && ![variant_isset postgresql92] && ![variant_isset postgresql93] && ![variant_isset postgresql94] && ![variant_isset postgresql95] && ![variant_isset postgresql96] && ![variant_isset postgresql10] && ![variant_isset postgresql11] && ![variant_isset postgresql12]} {
         default_variants +postgresql12
     }
@@ -1762,14 +1762,14 @@ subport ${php}-pspell {
     }
 
     categories-append       textproc
-    
+
     description             a PHP interface to the aspell library, which lets you \
                             check spelling and offer spelling suggestions
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:aspell
-    
+
     configure.args-append   --with-pspell=${prefix}
 }
 
@@ -1788,14 +1788,14 @@ subport ${php}-snmp {
     }
 
     categories-append       sysutils
-    
+
     description             a PHP interface to the Simple Network Management \
                             Protocol (SNMP)
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:net-snmp
-    
+
     configure.args-append   --with-snmp=${prefix}
 }
 
@@ -1814,11 +1814,11 @@ subport ${php}-soap {
     }
 
     categories-append       net
-    
+
     description             a PHP extension for writing SOAP clients and servers
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:libxml2
 
     if {[vercmp ${branch} 7.4] < 0} {
@@ -1843,10 +1843,10 @@ subport ${php}-sockets {
     }
 
     categories-append       net
-    
+
     description             a PHP interface to BSD socket communication \
                             functions
-    
+
     long_description        ${description}
 }
 
@@ -1894,21 +1894,21 @@ subport ${php}-sqlite {
     }
 
     php.extensions          sqlite sqlite3 pdo_sqlite
-    
+
     categories-append       databases
-    
+
     description             a PHP interface to SQLite, including the sqlite, sqlite3 \
                             and pdo_sqlite extensions
-    
+
     if {[vercmp ${branch} 5.4] >= 0} {
         php.extensions-delete sqlite
         description-delete "sqlite,"
     }
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:sqlite3
-    
+
     post-extract {
         move ${worksrcpath}/ext/sqlite3/config0.m4 ${worksrcpath}/ext/sqlite3/config.m4
     }
@@ -1940,20 +1940,20 @@ subport ${php}-tidy {
         7.3.23              {revision 0}
         7.4.11              {revision 0}
     }
-    
+
     categories-append       www
-    
+
     description             a PHP interface to tidy, the HTML cleaning and \
                             repair utility
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:tidy
-    
+
     if {[vercmp ${branch} 7.0] <= 0} {
         patchfiles-append   patch-${php}-ext-tidy-tidy.c.diff
     }
-    
+
     configure.args-append   --with-tidy=${prefix}
 }
 
@@ -1973,14 +1973,14 @@ subport ${php}-wddx {
     }
 
     categories-append       textproc
-    
+
     description             a PHP interface to Web Distributed Data Exchange
-    
+
     long_description        ${description}
-    
+
     depends_build-append    port:expat \
                             port:libxml2
-    
+
     configure.args-append   --with-libexpat-dir=${prefix} \
                             --with-libxml-dir=${prefix}
 }
@@ -2001,14 +2001,14 @@ subport ${php}-xmlrpc {
     }
 
     categories-append       textproc
-    
+
     description             a PHP extension for writing XML-RPC clients and servers
-    
+
     long_description        ${description}
-    
+
     depends_build-append    port:libiconv \
                             port:libxml2
-    
+
     depends_lib-append      port:expat
 
     configure.args-append   --with-iconv-dir=${prefix}
@@ -2042,12 +2042,12 @@ subport ${php}-xsl {
     }
 
     categories-append       textproc
-    
+
     description             a PHP interface to libxslt, which implements the XSL \
                             standard and lets you perform XSL transformations
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:libxslt
 
     if {[vercmp ${branch} 7.4] < 0} {
@@ -2099,7 +2099,7 @@ proc get_default_php_extensions {} {
 if {[is_extension_subport]} {
     default php.extensions {[get_default_php_extensions]}
     default homepage    https://www.php.net/${php.rootname}
-    
+
     php.build_dirs
     set pdo no
     foreach extension [concat ${php.extensions} ${php.extensions.zend}] {
@@ -2111,19 +2111,19 @@ if {[is_extension_subport]} {
                 ln -s ${worksrcpath}/ext/pdo ${worksrcpath}/ext/${extension}/ext
             }
         }
-        
+
         # Speed up extraction by extracting only the modules we're going to be building.
         extract.post_args-append ${worksrcdir}/ext/${extension}
-        
+
         # Run phpize, configure, build and destroot in each extension's directory.
         php.build_dirs-append ${worksrcpath}/ext/${extension}
     }
-    
+
     if {${pdo}} {
         # The PDO extensions need the PDO headers.
         extract.post_args-append ${worksrcdir}/ext/pdo
     }
-    
+
     pre-configure {
         set php_version [exec ${php.config} --version 2>/dev/null]
         if {${version} ne ${php_version}} {
@@ -2131,8 +2131,8 @@ if {[is_extension_subport]} {
             return -code error "incompatible ${php} installation"
         }
     }
-    
+
     destroot.target     install-modules install-headers
-    
+
     php.add_port_code
 }

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -1970,9 +1970,36 @@ a web server environment.
         configure.args-append   --with-tidy=${prefix}
     }
 
-if {[vercmp ${branch} 7.4] < 0} {
-    # wddx was evicted from PHP core in version 7.4
-    subport ${php}-wddx {
+    if {[vercmp ${branch} 7.4] < 0} {
+        # wddx was evicted from PHP core in version 7.4
+        subport ${php}-wddx {
+            switch -- ${version} {
+                5.2.17              {revision 0}
+                5.3.29              {revision 0}
+                5.4.45              {revision 0}
+                5.5.38              {revision 0}
+                5.6.40              {revision 0}
+                7.0.33              {revision 0}
+                7.1.33              {revision 0}
+                7.2.34              {revision 0}
+                7.3.23              {revision 0}
+            }
+
+            categories-append       textproc
+
+            description             a PHP interface to Web Distributed Data Exchange
+
+            long_description        ${description}
+
+            depends_build-append    port:expat \
+                                    port:libxml2
+
+            configure.args-append   --with-libexpat-dir=${prefix} \
+                                    --with-libxml-dir=${prefix}
+        }
+    }
+
+    subport ${php}-xmlrpc {
         switch -- ${version} {
             5.2.17              {revision 0}
             5.3.29              {revision 0}
@@ -1983,97 +2010,71 @@ if {[vercmp ${branch} 7.4] < 0} {
             7.1.33              {revision 0}
             7.2.34              {revision 0}
             7.3.23              {revision 0}
+            7.4.11              {revision 0}
         }
 
         categories-append       textproc
 
-        description             a PHP interface to Web Distributed Data Exchange
+        description             a PHP extension for writing XML-RPC clients and servers
 
         long_description        ${description}
 
-        depends_build-append    port:expat \
+        depends_build-append    port:libiconv \
                                 port:libxml2
 
-        configure.args-append   --with-libexpat-dir=${prefix} \
-                                --with-libxml-dir=${prefix}
-    }
-}
+        depends_lib-append      port:expat
 
-subport ${php}-xmlrpc {
-    switch -- ${version} {
-        5.2.17              {revision 0}
-        5.3.29              {revision 0}
-        5.4.45              {revision 0}
-        5.5.38              {revision 0}
-        5.6.40              {revision 0}
-        7.0.33              {revision 0}
-        7.1.33              {revision 0}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
-    }
+        configure.args-append   --with-iconv-dir=${prefix}
 
-    categories-append       textproc
+        if {[vercmp ${branch} 7.4] < 0} {
+            configure.args-append   --with-libexpat-dir=${prefix} \
+                                    --with-libxml-dir=${prefix}
+        } else {
+            depends_build-append    port:pkgconfig
 
-    description             a PHP extension for writing XML-RPC clients and servers
+            configure.args-append   --with-expat
+        }
 
-    long_description        ${description}
-
-    depends_build-append    port:libiconv \
-                            port:libxml2
-
-    depends_lib-append      port:expat
-
-    configure.args-append   --with-iconv-dir=${prefix}
-
-    if {[vercmp ${branch} 7.4] < 0} {
-        configure.args-append   --with-libexpat-dir=${prefix} \
-                                --with-libxml-dir=${prefix}
-    } else {
-        depends_build-append    port:pkgconfig
-
-        configure.args-append   --with-expat
+        pre-configure {
+            configure.cppflags-append [exec ${prefix}/bin/xml2-config --cflags]
+        }
     }
 
-    pre-configure {
-        configure.cppflags-append [exec ${prefix}/bin/xml2-config --cflags]
-    }
-}
+    subport ${php}-xsl {
+        switch -- ${version} {
+            5.2.17              {revision 0}
+            5.3.29              {revision 0}
+            5.4.45              {revision 0}
+            5.5.38              {revision 0}
+            5.6.40              {revision 0}
+            7.0.33              {revision 0}
+            7.1.33              {revision 0}
+            7.2.34              {revision 0}
+            7.3.23              {revision 0}
+            7.4.11              {revision 0}
+        }
 
-subport ${php}-xsl {
-    switch -- ${version} {
-        5.2.17              {revision 0}
-        5.3.29              {revision 0}
-        5.4.45              {revision 0}
-        5.5.38              {revision 0}
-        5.6.40              {revision 0}
-        7.0.33              {revision 0}
-        7.1.33              {revision 0}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
-    }
+        categories-append       textproc
 
-    categories-append       textproc
+        description             a PHP interface to libxslt, which implements the XSL \
+                                standard and lets you perform XSL transformations
 
-    description             a PHP interface to libxslt, which implements the XSL \
-                            standard and lets you perform XSL transformations
+        long_description        ${description}
 
-    long_description        ${description}
+        depends_lib-append      port:libxslt
 
-    depends_lib-append      port:libxslt
+        if {[vercmp ${branch} 7.4] < 0} {
+            configure.args-append   --with-xsl=${prefix}
+        } else {
+            depends_build-append    port:pkgconfig
 
-    if {[vercmp ${branch} 7.4] < 0} {
-        configure.args-append   --with-xsl=${prefix}
-    } else {
-        depends_build-append    port:pkgconfig
+            configure.args-append   --with-xsl
+        }
 
-        configure.args-append   --with-xsl
+        configure.cppflags-append   -I${prefix}/include/${php}/php/ext/dom
     }
 
-    configure.cppflags-append   -I${prefix}/include/${php}/php/ext/dom
-}
-
+# end while
 }
 
 # These variables are not only required by the subsequent code but also by

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -1760,108 +1760,108 @@ a web server environment.
         }
     }
 
-subport ${php}-pspell {
-    switch -- ${version} {
-        5.2.17              {revision 0}
-        5.3.29              {revision 0}
-        5.4.45              {revision 0}
-        5.5.38              {revision 0}
-        5.6.40              {revision 0}
-        7.0.33              {revision 0}
-        7.1.33              {revision 0}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
+    subport ${php}-pspell {
+        switch -- ${version} {
+            5.2.17              {revision 0}
+            5.3.29              {revision 0}
+            5.4.45              {revision 0}
+            5.5.38              {revision 0}
+            5.6.40              {revision 0}
+            7.0.33              {revision 0}
+            7.1.33              {revision 0}
+            7.2.34              {revision 0}
+            7.3.23              {revision 0}
+            7.4.11              {revision 0}
+        }
+
+        categories-append       textproc
+
+        description             a PHP interface to the aspell library, which lets you \
+                                check spelling and offer spelling suggestions
+
+        long_description        ${description}
+
+        depends_lib-append      port:aspell
+
+        configure.args-append   --with-pspell=${prefix}
     }
 
-    categories-append       textproc
+    subport ${php}-snmp {
+        switch -- ${version} {
+            5.2.17              {revision 1}
+            5.3.29              {revision 1}
+            5.4.45              {revision 1}
+            5.5.38              {revision 1}
+            5.6.40              {revision 0}
+            7.0.33              {revision 0}
+            7.1.33              {revision 0}
+            7.2.34              {revision 0}
+            7.3.23              {revision 0}
+            7.4.11              {revision 0}
+        }
 
-    description             a PHP interface to the aspell library, which lets you \
-                            check spelling and offer spelling suggestions
+        categories-append       sysutils
 
-    long_description        ${description}
+        description             a PHP interface to the Simple Network Management \
+                                Protocol (SNMP)
 
-    depends_lib-append      port:aspell
+        long_description        ${description}
 
-    configure.args-append   --with-pspell=${prefix}
-}
+        depends_lib-append      port:net-snmp
 
-subport ${php}-snmp {
-    switch -- ${version} {
-        5.2.17              {revision 1}
-        5.3.29              {revision 1}
-        5.4.45              {revision 1}
-        5.5.38              {revision 1}
-        5.6.40              {revision 0}
-        7.0.33              {revision 0}
-        7.1.33              {revision 0}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
+        configure.args-append   --with-snmp=${prefix}
     }
 
-    categories-append       sysutils
+    subport ${php}-soap {
+        switch -- ${version} {
+            5.2.17              {revision 0}
+            5.3.29              {revision 0}
+            5.4.45              {revision 0}
+            5.5.38              {revision 0}
+            5.6.40              {revision 0}
+            7.0.33              {revision 0}
+            7.1.33              {revision 0}
+            7.2.34              {revision 0}
+            7.3.23              {revision 0}
+            7.4.11              {revision 0}
+        }
 
-    description             a PHP interface to the Simple Network Management \
-                            Protocol (SNMP)
+        categories-append       net
 
-    long_description        ${description}
+        description             a PHP extension for writing SOAP clients and servers
 
-    depends_lib-append      port:net-snmp
+        long_description        ${description}
 
-    configure.args-append   --with-snmp=${prefix}
-}
+        depends_lib-append      port:libxml2
 
-subport ${php}-soap {
-    switch -- ${version} {
-        5.2.17              {revision 0}
-        5.3.29              {revision 0}
-        5.4.45              {revision 0}
-        5.5.38              {revision 0}
-        5.6.40              {revision 0}
-        7.0.33              {revision 0}
-        7.1.33              {revision 0}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
+        if {[vercmp ${branch} 7.4] < 0} {
+            configure.args-append   --with-libxml-dir=${prefix}
+        } else {
+            depends_build-append    port:pkgconfig
+        }
     }
 
-    categories-append       net
+    subport ${php}-sockets {
+        switch -- ${version} {
+            5.2.17              {revision 0}
+            5.3.29              {revision 0}
+            5.4.45              {revision 0}
+            5.5.38              {revision 0}
+            5.6.40              {revision 0}
+            7.0.33              {revision 0}
+            7.1.33              {revision 0}
+            7.2.34              {revision 0}
+            7.3.23              {revision 0}
+            7.4.11              {revision 0}
+        }
 
-    description             a PHP extension for writing SOAP clients and servers
+        categories-append       net
 
-    long_description        ${description}
+        description             a PHP interface to BSD socket communication \
+                                functions
 
-    depends_lib-append      port:libxml2
-
-    if {[vercmp ${branch} 7.4] < 0} {
-        configure.args-append   --with-libxml-dir=${prefix}
-    } else {
-        depends_build-append    port:pkgconfig
+        long_description        ${description}
     }
-}
-
-subport ${php}-sockets {
-    switch -- ${version} {
-        5.2.17              {revision 0}
-        5.3.29              {revision 0}
-        5.4.45              {revision 0}
-        5.5.38              {revision 0}
-        5.6.40              {revision 0}
-        7.0.33              {revision 0}
-        7.1.33              {revision 0}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
-    }
-
-    categories-append       net
-
-    description             a PHP interface to BSD socket communication \
-                            functions
-
-    long_description        ${description}
-}
 
 if {[vercmp ${branch} 7.2] >= 0} {
     subport ${php}-sodium {

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -235,7 +235,8 @@ while {[incr i -1] >= 0} {
             }
 
             # https://trac.macports.org/ticket/31590
-            # Tested all subports (except oracle) and they built with clang-425.  The reported failure was with Xcode 4.2.
+            # Tested all subports (except oracle) and they built with clang-425.
+            # The reported failure was with Xcode 4.2.
             # Xcode 4.3 may work, but leaving it blacklisted due to lack of testing
             compiler.blacklist  {clang < 400}
 
@@ -345,7 +346,8 @@ while {[incr i -1] >= 0} {
 
             if {${subport} ne ${php}} {
                 notes-append "
-If this is your first install, you need to enable ${subport} in your web server.
+If this is your first install, you need to enable ${subport}\
+in your web server.
                 "
             }
         }
@@ -780,8 +782,8 @@ ${phpinidir}/php-fpm.conf.default.
             categories-append       textproc devel
 
             description             a PHP interface to enchant
-
-            long_description        ${name} is ${description}, a common API for many spell libraries.
+            long_description        ${name} is ${description}, a common API for many \
+                                    spell libraries.
 
             depends_lib-append      port:enchant
 
@@ -1106,9 +1108,8 @@ ${phpinidir}/php-fpm.conf.default.
         php.extensions          shmop sysvmsg sysvsem sysvshm
 
         description             interprocess communication extensions for PHP
-
-        long_description        PHP extensions for interprocess communication (IPC), including the \
-                                shmop, sysvmsg, sysvsem, and sysvshm extensions.
+        long_description        PHP extensions for interprocess communication (IPC), \
+                                including the shmop, sysvmsg, sysvsem, and sysvshm extensions.
     }
 
     subport ${php}-ldap {
@@ -1290,14 +1291,15 @@ For percona, use ${prefix}/var/run/percona/mysqld.sock
             }
         }
 
-        variant mysql4 conflicts mysqlnd mysql5 mysql51 mysql55 mysql56 mariadb percona description {Use MySQL 4 libraries} {
+        variant mysql4  conflicts mysqlnd mysql5 mysql51 mysql55 mysql56 mariadb percona \
+                        description {Use MySQL 4 libraries} {
             depends_lib-append      port:mysql4
-
             configure.args-append   --with-mysql=${prefix} \
                                     --with-pdo-mysql=${prefix}
         }
 
-        variant mysql5 conflicts mysqlnd mysql4 mysql51 mysql55 mysql56 mariadb percona description {Use MySQL 5 libraries} {
+        variant mysql5  conflicts mysqlnd mysql4 mysql51 mysql55 mysql56 mariadb percona \
+                        description {Use MySQL 5 libraries} {
             depends_lib-append      path:bin/mysql_config5:mysql5
 
             post-extract {
@@ -1312,7 +1314,8 @@ For percona, use ${prefix}/var/run/percona/mysqld.sock
                                     --with-mysql-sock=${prefix}/var/run/mysql5/mysqld.sock
         }
 
-        variant mysql51 conflicts mysqlnd mysql4 mysql5 mysql55 mysql56 mariadb percona description {Use MySQL 5.1 libraries} {
+        variant mysql51 conflicts mysqlnd mysql4 mysql5 mysql55 mysql56 mariadb percona \
+                        description {Use MySQL 5.1 libraries} {
             depends_lib-append      port:mysql51
 
             post-extract {
@@ -1327,7 +1330,8 @@ For percona, use ${prefix}/var/run/percona/mysqld.sock
                                     --with-mysql-sock=${prefix}/var/run/mysql51/mysqld.sock
         }
 
-        variant mysql55 conflicts mysqlnd mysql4 mysql5 mysql51 mysql56 mariadb percona description {Use MySQL 5.5 libraries} {
+        variant mysql55 conflicts mysqlnd mysql4 mysql5 mysql51 mysql56 mariadb percona \
+                        description {Use MySQL 5.5 libraries} {
             depends_lib-append      port:mysql55
 
             post-extract {
@@ -1342,7 +1346,8 @@ For percona, use ${prefix}/var/run/percona/mysqld.sock
                                     --with-mysql-sock=${prefix}/var/run/mysql55/mysqld.sock
         }
 
-        variant mysql56 conflicts mysqlnd mysql4 mysql5 mysql51 mysql55 mariadb percona description {Use MySQL 5.6 libraries} {
+        variant mysql56 conflicts mysqlnd mysql4 mysql5 mysql51 mysql55 mariadb percona \
+                        description {Use MySQL 5.6 libraries} {
             depends_lib-append      port:mysql56
 
             post-extract {
@@ -1357,7 +1362,8 @@ For percona, use ${prefix}/var/run/percona/mysqld.sock
                                     --with-mysql-sock=${prefix}/var/run/mysql56/mysqld.sock
         }
 
-        variant mariadb conflicts mysqlnd mysql4 mysql5 mysql51 mysql55 mysql56 percona description {Use MariaDB libraries} {
+        variant mariadb conflicts mysqlnd mysql4 mysql5 mysql51 mysql55 mysql56 percona \
+                        description {Use MariaDB libraries} {
             depends_lib-append      port:mariadb
 
             post-extract {
@@ -1372,7 +1378,8 @@ For percona, use ${prefix}/var/run/percona/mysqld.sock
                                     --with-mysql-sock=${prefix}/var/run/mariadb/mysqld.sock
         }
 
-        variant percona conflicts mysqlnd mysql4 mysql5 mysql51 mysql55 mysql56 mariadb description {Use Percona libraries} {
+        variant percona conflicts mysqlnd mysql4 mysql5 mysql51 mysql55 mysql56 mariadb \
+                        description {Use Percona libraries} {
             depends_lib-append      port:percona
 
             post-extract {
@@ -1387,7 +1394,10 @@ For percona, use ${prefix}/var/run/percona/mysqld.sock
                                     --with-mysql-sock=${prefix}/var/run/percona/mysqld.sock
         }
 
-        if {![variant_isset mysql4] && ![variant_isset mysql5] && ![variant_isset mysql51] && ![variant_isset mysql55] && ![variant_isset mysql56] && ![variant_isset mariadb] && ![variant_isset percona]} {
+        if {![variant_isset mysql4] && ![variant_isset mysql5] &&
+            ![variant_isset mysql51] && ![variant_isset mysql55] &&
+            ![variant_isset mysql56] && ![variant_isset mariadb] &&
+            ![variant_isset percona]} {
             if {[vercmp ${branch} 5.3] >= 0} {
                 default_variants +mysqlnd
             } else {
@@ -1611,8 +1621,8 @@ For percona, use ${prefix}/var/run/percona/mysqld.sock
 
         notes "
 ${subport} should not be enabled within a web server environment.\
-Unexpected results may occur if any process control functions are used within\
-a web server environment.
+Unexpected results may occur if any process control functions are\
+used within a web server environment.
         "
     }
 
@@ -1662,100 +1672,86 @@ a web server environment.
         description             a PHP interface to PostgreSQL, including \
                                 the pgsql and pdo_pgsql extensions
 
-        long_description        ${description}
+        variant postgresql82    conflicts postgresql83 postgresql84 postgresql90 postgresql91 \
+                                postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 \
+                                postgresql10 postgresql11 postgresql12 \
+                                description {Use PostgreSQL 8.2 libraries} {}
 
-        variant postgresql82 conflicts postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 8.2 libraries} {
-            depends_lib-append      port:postgresql82
+        variant postgresql83    conflicts postgresql82 postgresql84 postgresql90 postgresql91 \
+                                postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 \
+                                postgresql10 postgresql11 postgresql12 \
+                                description {Use PostgreSQL 8.3 libraries} {}
 
-            configure.args-append   --with-pgsql=${prefix}/lib/postgresql82/bin \
-                                    --with-pdo-pgsql=${prefix}/lib/postgresql82/bin
+        variant postgresql84    conflicts postgresql82 postgresql83 postgresql90 postgresql91 \
+                                postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 \
+                                postgresql10 postgresql11 postgresql12 \
+                                description {Use PostgreSQL 8.4 libraries} {}
+
+        variant postgresql90    conflicts postgresql82 postgresql83 postgresql84 postgresql91 \
+                                postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 \
+                                postgresql10 postgresql11 postgresql12 \
+                                description {Use PostgreSQL 9.0 libraries} {}
+
+        variant postgresql91    conflicts postgresql82 postgresql83 postgresql84 postgresql90 \
+                                postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 \
+                                postgresql10 postgresql11 postgresql12 \
+                                description {Use PostgreSQL 9.1 libraries} {}
+
+        variant postgresql92    conflicts postgresql82 postgresql83 postgresql84 postgresql90 \
+                                postgresql91 postgresql93 postgresql94 postgresql95 postgresql96 \
+                                postgresql10 postgresql11 postgresql12 \
+                                description {Use PostgreSQL 9.2 libraries} {}
+
+        variant postgresql93    conflicts postgresql82 postgresql83 postgresql84 postgresql90 \
+                                postgresql91 postgresql92 postgresql94 postgresql95 postgresql96 \
+                                postgresql10 postgresql11 postgresql12 \
+                                description {Use PostgreSQL 9.3 libraries} {}
+
+        variant postgresql94    conflicts postgresql82 postgresql83 postgresql84 postgresql90 \
+                                postgresql91 postgresql92 postgresql93 postgresql95 postgresql96 \
+                                postgresql10 postgresql11 postgresql12 \
+                                description {Use PostgreSQL 9.4 libraries} {}
+
+        variant postgresql95    conflicts postgresql82 postgresql83 postgresql84 postgresql90 \
+                                postgresql91 postgresql92 postgresql93 postgresql94 postgresql96 \
+                                postgresql10 postgresql11 postgresql12 \
+                                description {Use PostgreSQL 9.5 libraries} {}
+
+        variant postgresql96    conflicts postgresql82 postgresql83 postgresql84 postgresql90 \
+                                postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 \
+                                postgresql10 postgresql11 postgresql12 \
+                                description {Use PostgreSQL 9.6 libraries} {}
+
+        variant postgresql10    conflicts postgresql82 postgresql83 postgresql84 postgresql90 \
+                                postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 \
+                                postgresql96 postgresql11 postgresql12 \
+                                description {Use PostgreSQL 10 libraries} {}
+
+        variant postgresql11    conflicts postgresql82 postgresql83 postgresql84 postgresql90 \
+                                postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 \
+                                postgresql96 postgresql10 postgresql12 \
+                                description {Use PostgreSQL 11 libraries} {}
+
+        variant postgresql12    conflicts postgresql82 postgresql83 postgresql84 postgresql90 \
+                                postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 \
+                                postgresql96 postgresql10 postgresql11 \
+                                description {Use PostgreSQL 12 libraries} {}
+
+        foreach v [list 82 83 84 90 91 92 93 94 95 96 10 11 12] {
+            if {[variant_isset postgresql${v}]} {
+                depends_lib-append      port:postgresql${v}
+                configure.args-append   --with-pgsql=${prefix}/lib/postgresql${v}/bin \
+                                        --with-pdo-pgsql=${prefix}/lib/postgresql${v}/bin
+            }
         }
 
-        variant postgresql83 conflicts postgresql82 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 8.3 libraries} {
-            depends_lib-append      port:postgresql83
-
-            configure.args-append   --with-pgsql=${prefix}/lib/postgresql83/bin \
-                                    --with-pdo-pgsql=${prefix}/lib/postgresql83/bin
-        }
-
-        variant postgresql84 conflicts postgresql82 postgresql83 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 8.4 libraries} {
-            depends_lib-append      port:postgresql84
-
-            configure.args-append   --with-pgsql=${prefix}/lib/postgresql84/bin \
-                                    --with-pdo-pgsql=${prefix}/lib/postgresql84/bin
-        }
-
-        variant postgresql90 conflicts postgresql82 postgresql83 postgresql84 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 9.0 libraries} {
-            depends_lib-append      port:postgresql90
-
-            configure.args-append   --with-pgsql=${prefix}/lib/postgresql90/bin \
-                                    --with-pdo-pgsql=${prefix}/lib/postgresql90/bin
-        }
-
-        variant postgresql91 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 9.1 libraries} {
-            depends_lib-append      port:postgresql91
-
-            configure.args-append   --with-pgsql=${prefix}/lib/postgresql91/bin \
-                                    --with-pdo-pgsql=${prefix}/lib/postgresql91/bin
-        }
-
-        variant postgresql92 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 9.2 libraries} {
-            depends_lib-append      port:postgresql92
-
-            configure.args-append   --with-pgsql=${prefix}/lib/postgresql92/bin \
-                                    --with-pdo-pgsql=${prefix}/lib/postgresql92/bin
-        }
-
-        variant postgresql93 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 9.3 libraries} {
-            depends_lib-append      port:postgresql93
-
-            configure.args-append   --with-pgsql=${prefix}/lib/postgresql93/bin \
-                                    --with-pdo-pgsql=${prefix}/lib/postgresql93/bin
-        }
-
-        variant postgresql94 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 9.4 libraries} {
-            depends_lib-append      port:postgresql94
-
-            configure.args-append   --with-pgsql=${prefix}/lib/postgresql94/bin \
-                                    --with-pdo-pgsql=${prefix}/lib/postgresql94/bin
-        }
-
-        variant postgresql95 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 9.5 libraries} {
-            depends_lib-append      port:postgresql95
-
-            configure.args-append   --with-pgsql=${prefix}/lib/postgresql95/bin \
-                                    --with-pdo-pgsql=${prefix}/lib/postgresql95/bin
-        }
-
-        variant postgresql96 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 9.6 libraries} {
-            depends_lib-append      port:postgresql96
-
-            configure.args-append   --with-pgsql=${prefix}/lib/postgresql96/bin \
-                                    --with-pdo-pgsql=${prefix}/lib/postgresql96/bin
-        }
-
-        variant postgresql10 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql11 postgresql12 description {Use PostgreSQL 10 libraries} {
-            depends_lib-append      port:postgresql10
-
-            configure.args-append   --with-pgsql=${prefix}/lib/postgresql10/bin \
-                                    --with-pdo-pgsql=${prefix}/lib/postgresql10/bin
-        }
-
-        variant postgresql11 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql12 description {Use PostgreSQL 11 libraries} {
-            depends_lib-append      port:postgresql11
-
-            configure.args-append   --with-pgsql=${prefix}/lib/postgresql11/bin \
-                                    --with-pdo-pgsql=${prefix}/lib/postgresql11/bin
-        }
-
-        variant postgresql12 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 description {Use PostgreSQL 12 libraries} {
-            depends_lib-append      port:postgresql12
-
-            configure.args-append   --with-pgsql=${prefix}/lib/postgresql12/bin \
-                                    --with-pdo-pgsql=${prefix}/lib/postgresql12/bin
-        }
-
-        if {![variant_isset postgresql82] && ![variant_isset postgresql83] && ![variant_isset postgresql84] && ![variant_isset postgresql90] && ![variant_isset postgresql91] && ![variant_isset postgresql92] && ![variant_isset postgresql93] && ![variant_isset postgresql94] && ![variant_isset postgresql95] && ![variant_isset postgresql96] && ![variant_isset postgresql10] && ![variant_isset postgresql11] && ![variant_isset postgresql12]} {
+        if {![variant_isset postgresql82] && ![variant_isset postgresql83] &&
+            ![variant_isset postgresql84] && ![variant_isset postgresql90] &&
+            ![variant_isset postgresql91] && ![variant_isset postgresql92] &&
+            ![variant_isset postgresql93] && ![variant_isset postgresql94] &&
+            ![variant_isset postgresql95] && ![variant_isset postgresql96] &&
+            ![variant_isset postgresql10] && ![variant_isset postgresql11] &&
+            ![variant_isset postgresql12]} {
             default_variants +postgresql12
         }
     }
@@ -2077,6 +2073,7 @@ a web server environment.
 # end while
 }
 
+
 # These variables are not only required by the subsequent code but also by
 # preceding code in phase blocks.
 set branch              ${subport_branch}
@@ -2141,7 +2138,8 @@ if {[is_extension_subport]} {
     pre-configure {
         set php_version [exec ${php.config} --version 2>/dev/null]
         if {${version} ne ${php_version}} {
-            ui_error "${subport} @${version} requires ${php} @${version} but you have ${php} @${php_version}."
+            ui_error "${subport} @${version} requires ${php} @${version} but\
+                      you have ${php} @${php_version}."
             return -code error "incompatible ${php} installation"
         }
     }

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -1495,149 +1495,149 @@ For percona, use ${prefix}/var/run/percona/mysqld.sock
         }
     }
 
-subport ${php}-openssl {
-    switch -- ${version} {
-        5.2.17              {revision 2}
-        5.3.29              {revision 2}
-        5.4.45              {revision 2}
-        5.5.38              {revision 2}
-        5.6.40              {revision 2}
-        7.0.33              {revision 1}
-        7.1.33              {revision 0}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
-    }
-
-    categories-append       devel security
-
-    description             a PHP interface to OpenSSL signature-generation \
-                            and -verification and data-encryption and \
-                            -decryption functions
-
-    long_description        ${description}
-
-    depends_lib-append      port:kerberos5 \
-                            port:libcomerr \
-                            path:lib/libssl.dylib:openssl
-
-    post-extract {
-        move ${php.build_dirs}/config0.m4 ${php.build_dirs}/config.m4
-    }
-
-    configure.args-append   --with-kerberos=${prefix}
-
-    if {[vercmp ${branch} 5.6] <= 0} {
-        openssl.branch 1.0
-        openssl.configure pkgconfig
-
-        # This patch is for reordering -I and -L flags during the build to make
-        # openssl-1.0 directories appear before others
-        patchfiles-append       patch-${php}-ext-openssl-config.m4.diff
-
-        post-patch {
-            reinplace "s|@PREFIX@|${prefix}|g" ${worksrcpath}/ext/openssl/config.m4
+    subport ${php}-openssl {
+        switch -- ${version} {
+            5.2.17              {revision 2}
+            5.3.29              {revision 2}
+            5.4.45              {revision 2}
+            5.5.38              {revision 2}
+            5.6.40              {revision 2}
+            7.0.33              {revision 1}
+            7.1.33              {revision 0}
+            7.2.34              {revision 0}
+            7.3.23              {revision 0}
+            7.4.11              {revision 0}
         }
 
-        configure.args-append   --with-openssl=shared
-    } elseif {[vercmp ${branch} 7.4] < 0} {
-        configure.args-append   --with-openssl=${prefix}
-    } else {
-        depends_build-append    port:pkgconfig
+        categories-append       devel security
 
-        configure.args-append   --with-openssl
-    }
-}
+        description             a PHP interface to OpenSSL signature-generation \
+                                and -verification and data-encryption and \
+                                -decryption functions
 
-subport ${php}-oracle {
-    switch -- ${version} {
-        5.2.17              {revision 0}
-        5.3.29              {revision 0}
-        5.4.45              {revision 0}
-        5.5.38              {revision 0}
-        5.6.40              {revision 0}
-        7.0.33              {revision 0}
-        7.1.33              {revision 0}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
-    }
+        long_description        ${description}
 
-    php.extensions          oci8 pdo_oci
+        depends_lib-append      port:kerberos5 \
+                                port:libcomerr \
+                                path:lib/libssl.dylib:openssl
 
-    categories-append       databases
+        post-extract {
+            move ${php.build_dirs}/config0.m4 ${php.build_dirs}/config.m4
+        }
 
-    description             a PHP interface to Oracle, including the oci8 and \
-                            pdo_oci extensions
+        configure.args-append   --with-kerberos=${prefix}
 
-    long_description        ${description}
+        if {[vercmp ${branch} 5.6] <= 0} {
+            openssl.branch 1.0
+            openssl.configure pkgconfig
 
-    depends_lib-append      port:oracle-instantclient
+            # This patch is for reordering -I and -L flags during the build to make
+            # openssl-1.0 directories appear before others
+            patchfiles-append       patch-${php}-ext-openssl-config.m4.diff
 
-    if {[vercmp ${branch} 5.2] <= 0} {
-        patchfiles-append   patch-${php}-ext-pdo_oci-config.m4.diff
-    }
+            post-patch {
+                reinplace "s|@PREFIX@|${prefix}|g" ${worksrcpath}/ext/openssl/config.m4
+            }
 
-    set lib_dir             ${prefix}/lib/oracle
-    pre-configure {
-        regexp {\.dylib\.(.+)$} [glob -directory ${lib_dir} libclntsh.dylib.*] -> library_version
-        configure.args-append \
-                            --with-oci8=instantclient,${lib_dir} \
-                            --with-pdo-oci=instantclient,${lib_dir},${library_version}
-    }
-}
+            configure.args-append   --with-openssl=shared
+        } elseif {[vercmp ${branch} 7.4] < 0} {
+            configure.args-append   --with-openssl=${prefix}
+        } else {
+            depends_build-append    port:pkgconfig
 
-subport ${php}-pcntl {
-    switch -- ${version} {
-        5.2.17              {revision 0}
-        5.3.29              {revision 0}
-        5.4.45              {revision 0}
-        5.5.38              {revision 0}
-        5.6.40              {revision 0}
-        7.0.33              {revision 0}
-        7.1.33              {revision 0}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
+            configure.args-append   --with-openssl
+        }
     }
 
-    categories-append       sysutils
+    subport ${php}-oracle {
+        switch -- ${version} {
+            5.2.17              {revision 0}
+            5.3.29              {revision 0}
+            5.4.45              {revision 0}
+            5.5.38              {revision 0}
+            5.6.40              {revision 0}
+            7.0.33              {revision 0}
+            7.1.33              {revision 0}
+            7.2.34              {revision 0}
+            7.3.23              {revision 0}
+            7.4.11              {revision 0}
+        }
 
-    description             a PHP interface to Unix-style process creation, \
-                            program execution, signal handling and process \
-                            termination functions
+        php.extensions          oci8 pdo_oci
 
-    long_description        ${description}
+        categories-append       databases
 
-    notes "
+        description             a PHP interface to Oracle, including the oci8 and \
+                                pdo_oci extensions
+
+        long_description        ${description}
+
+        depends_lib-append      port:oracle-instantclient
+
+        if {[vercmp ${branch} 5.2] <= 0} {
+            patchfiles-append   patch-${php}-ext-pdo_oci-config.m4.diff
+        }
+
+        set lib_dir             ${prefix}/lib/oracle
+        pre-configure {
+            regexp {\.dylib\.(.+)$} [glob -directory ${lib_dir} libclntsh.dylib.*] -> library_version
+            configure.args-append \
+                                --with-oci8=instantclient,${lib_dir} \
+                                --with-pdo-oci=instantclient,${lib_dir},${library_version}
+        }
+    }
+
+    subport ${php}-pcntl {
+        switch -- ${version} {
+            5.2.17              {revision 0}
+            5.3.29              {revision 0}
+            5.4.45              {revision 0}
+            5.5.38              {revision 0}
+            5.6.40              {revision 0}
+            7.0.33              {revision 0}
+            7.1.33              {revision 0}
+            7.2.34              {revision 0}
+            7.3.23              {revision 0}
+            7.4.11              {revision 0}
+        }
+
+        categories-append       sysutils
+
+        description             a PHP interface to Unix-style process creation, \
+                                program execution, signal handling and process \
+                                termination functions
+
+        long_description        ${description}
+
+        notes "
 ${subport} should not be enabled within a web server environment.\
 Unexpected results may occur if any process control functions are used within\
 a web server environment.
-"
-}
-
-subport ${php}-posix {
-    switch -- ${version} {
-        5.2.17              {revision 0}
-        5.3.29              {revision 0}
-        5.4.45              {revision 0}
-        5.5.38              {revision 0}
-        5.6.40              {revision 0}
-        7.0.33              {revision 0}
-        7.1.33              {revision 0}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
+        "
     }
 
-    categories-append       sysutils
+    subport ${php}-posix {
+        switch -- ${version} {
+            5.2.17              {revision 0}
+            5.3.29              {revision 0}
+            5.4.45              {revision 0}
+            5.5.38              {revision 0}
+            5.6.40              {revision 0}
+            7.0.33              {revision 0}
+            7.1.33              {revision 0}
+            7.2.34              {revision 0}
+            7.3.23              {revision 0}
+            7.4.11              {revision 0}
+        }
 
-    description             a PHP interface to additional POSIX functions
+        categories-append       sysutils
 
-    long_description        a PHP interface to those functions defined in the \
-                            IEEE 1003.1 (POSIX.1) standards document which are \
-                            not accessible through other means
-}
+        description             a PHP interface to additional POSIX functions
+
+        long_description        a PHP interface to those functions defined in the \
+                                IEEE 1003.1 (POSIX.1) standards document which are \
+                                not accessible through other means
+    }
 
 subport ${php}-postgresql {
     switch -- ${version} {

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -1089,91 +1089,91 @@ ${phpinidir}/php-fpm.conf.default.
         }
     }
 
-subport ${php}-ipc {
-    switch -- ${version} {
-        5.2.17              {revision 0}
-        5.3.29              {revision 0}
-        5.4.45              {revision 0}
-        5.5.38              {revision 0}
-        5.6.40              {revision 0}
-        7.0.33              {revision 0}
-        7.1.33              {revision 0}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
+    subport ${php}-ipc {
+        switch -- ${version} {
+            5.2.17              {revision 0}
+            5.3.29              {revision 0}
+            5.4.45              {revision 0}
+            5.5.38              {revision 0}
+            5.6.40              {revision 0}
+            7.0.33              {revision 0}
+            7.1.33              {revision 0}
+            7.2.34              {revision 0}
+            7.3.23              {revision 0}
+            7.4.11              {revision 0}
+        }
+
+        php.extensions          shmop sysvmsg sysvsem sysvshm
+
+        description             interprocess communication extensions for PHP
+
+        long_description        PHP extensions for interprocess communication (IPC), including the \
+                                shmop, sysvmsg, sysvsem, and sysvshm extensions.
     }
 
-    php.extensions          shmop sysvmsg sysvsem sysvshm
+    subport ${php}-ldap {
+        switch -- ${version} {
+            5.2.17              {revision 0}
+            5.3.29              {revision 0}
+            5.4.45              {revision 0}
+            5.5.38              {revision 0}
+            5.6.40              {revision 0}
+            7.0.33              {revision 0}
+            7.1.33              {revision 0}
+            7.2.34              {revision 0}
+            7.3.23              {revision 0}
+            7.4.11              {revision 0}
+        }
 
-    description             interprocess communication extensions for PHP
+        categories-append       databases
 
-    long_description        PHP extensions for interprocess communication (IPC), including the \
-                            shmop, sysvmsg, sysvsem, and sysvshm extensions.
-}
+        description             a PHP interface to LDAP
 
-subport ${php}-ldap {
-    switch -- ${version} {
-        5.2.17              {revision 0}
-        5.3.29              {revision 0}
-        5.4.45              {revision 0}
-        5.5.38              {revision 0}
-        5.6.40              {revision 0}
-        7.0.33              {revision 0}
-        7.1.33              {revision 0}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
+        long_description        ${subport} is ${description}, the Lightweight Directory \
+                                Access Protocol, which is used to access Directory \
+                                Servers.
+
+        depends_lib-append      port:openldap \
+                                port:cyrus-sasl2
+
+        configure.args-append   --with-ldap=${prefix}
+
+        if {[vercmp ${branch} 7.4] < 0} {
+            configure.args-append   --with-ldap-sasl=${prefix}
+        } else {
+            depends_build-append    port:pkgconfig
+
+            configure.args-append   --with-ldap-sasl
+        }
     }
 
-    categories-append       databases
+    subport ${php}-mbstring {
+        switch -- ${version} {
+            5.2.17              {revision 0}
+            5.3.29              {revision 0}
+            5.4.45              {revision 0}
+            5.5.38              {revision 0}
+            5.6.40              {revision 0}
+            7.0.33              {revision 0}
+            7.1.33              {revision 0}
+            7.2.34              {revision 0}
+            7.3.23              {revision 0}
+            7.4.11              {revision 0}
+        }
 
-    description             a PHP interface to LDAP
+        categories-append       textproc
 
-    long_description        ${subport} is ${description}, the Lightweight Directory \
-                            Access Protocol, which is used to access Directory \
-                            Servers.
+        description             a PHP extension for manipulating strings in multibyte \
+                                encodings
 
-    depends_lib-append      port:openldap \
-                            port:cyrus-sasl2
+        long_description        ${description}
 
-    configure.args-append   --with-ldap=${prefix}
+        if {[vercmp ${branch} 7.4] >= 0} {
+            depends_build-append    port:pkgconfig
 
-    if {[vercmp ${branch} 7.4] < 0} {
-        configure.args-append   --with-ldap-sasl=${prefix}
-    } else {
-        depends_build-append    port:pkgconfig
-
-        configure.args-append   --with-ldap-sasl
+            depends_lib-append      port:oniguruma6
+        }
     }
-}
-
-subport ${php}-mbstring {
-    switch -- ${version} {
-        5.2.17              {revision 0}
-        5.3.29              {revision 0}
-        5.4.45              {revision 0}
-        5.5.38              {revision 0}
-        5.6.40              {revision 0}
-        7.0.33              {revision 0}
-        7.1.33              {revision 0}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
-    }
-
-    categories-append       textproc
-
-    description             a PHP extension for manipulating strings in multibyte \
-                            encodings
-
-    long_description        ${description}
-
-    if {[vercmp ${branch} 7.4] >= 0} {
-        depends_build-append    port:pkgconfig
-
-        depends_lib-append      port:oniguruma6
-    }
-}
 
 if {[vercmp ${branch} 7.2] < 0} {
     # mcrypt was evicted from PHP core in version 7.2; php72-mcrypt and later

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -183,173 +183,173 @@ set php.oldest_supported_branch 7.2
 set i [llength ${php.branches}]
 while {[incr i -1] >= 0} {
 
-set branch              [lindex ${php.branches} ${i}]
-set major               [lindex [split ${branch} .] 0]
-set php                 php[php.suffix_from_branch ${branch}]
+    set branch              [lindex ${php.branches} ${i}]
+    set major               [lindex [split ${branch} .] 0]
+    set php                 php[php.suffix_from_branch ${branch}]
 
-if {[regexp "^${php}" ${subport}]} {
+    if {[regexp "^${php}" ${subport}]} {
 
-    if {[vercmp ${major} 5] > 0} {
-        dist_subdir         ${php}
-    } else {
-        dist_subdir         php${major}
-    }
-
-    if {[is_sapi_subport]} {
-
-        depends_build       port:pkgconfig
-
-        if {${subport} ne ${php}} {
-            depends_lib     port:${php}
-        }
-
-        depends_lib-append  path:bin/gsed:gsed \
-                            port:libiconv \
-                            port:libxml2 \
-                            port:bzip2 \
-                            port:mhash \
-                            port:zlib
-
-        if {[vercmp ${branch} 7.3] < 0} {
-            depends_lib-append  port:pcre
+        if {[vercmp ${major} 5] > 0} {
+            dist_subdir         ${php}
         } else {
-            depends_lib-append  port:pcre2
+            dist_subdir         php${major}
         }
 
-        # Use -p1 to accommodate the Suhosin patch
-        patch.pre_args      -p1
-        patchfiles-append   patch-${php}-scripts-php-config.in.diff
+        if {[is_sapi_subport]} {
 
-        if {[vercmp ${branch} 7.4] >= 0} {
-            patchfiles-append \
-                            patch-${php}-bison-re2c-version.diff
-        }
-        if {[vercmp ${branch} 5.3] <= 0} {
-            patchfiles-append \
-                            patch-${php}-configure.diff
-        }
-        if {[vercmp ${branch} 5.2] <= 0} {
-            patchfiles-append \
-                            patch-${php}-libxml-2.9.diff \
-                            patch-${php}-pcre-8.30.diff
-        }
+            depends_build       port:pkgconfig
 
-        # https://trac.macports.org/ticket/31590
-        # Tested all subports (except oracle) and they built with clang-425.  The reported failure was with Xcode 4.2.
-        # Xcode 4.3 may work, but leaving it blacklisted due to lack of testing
-        compiler.blacklist  {clang < 400}
+            if {${subport} ne ${php}} {
+                depends_lib     port:${php}
+            }
 
-        set phpinidir       ${prefix}/etc/${php}
-        set extraphpinidir  ${prefix}/var/db/${php}
+            depends_lib-append  path:bin/gsed:gsed \
+                                port:libiconv \
+                                port:libxml2 \
+                                port:bzip2 \
+                                port:mhash \
+                                port:zlib
 
-        configure.args      --mandir=${prefix}/share/man \
-                            --infodir=${prefix}/share/info \
-                            --program-suffix=[php.suffix_from_branch ${branch}] \
-                            --includedir=${prefix}/include/${php} \
-                            --libdir=${prefix}/lib/${php} \
-                            --with-config-file-path=${phpinidir} \
-                            --with-config-file-scan-dir=${extraphpinidir} \
-                            --disable-all \
-                            --enable-bcmath \
-                            --enable-ctype \
-                            --enable-dom \
-                            --enable-filter \
-                            --enable-json \
-                            --enable-pdo \
-                            --enable-session \
-                            --enable-simplexml \
-                            --enable-tokenizer \
-                            --enable-xml \
-                            --enable-xmlreader \
-                            --enable-xmlwriter \
-                            --with-bz2=${prefix} \
-                            --with-mhash=${prefix} \
-                            --with-zlib=${prefix} \
-                            --disable-cgi \
-                            --disable-cli
+            if {[vercmp ${branch} 7.3] < 0} {
+                depends_lib-append  port:pcre
+            } else {
+                depends_lib-append  port:pcre2
+            }
 
-        if {[vercmp ${branch} 7.4] < 0} {
-            configure.args-append   --enable-hash \
-                                    --enable-libxml \
-                                    --with-libxml-dir=${prefix} \
-                                    --with-pcre-regex=${prefix} \
-                                    --without-pear
-        } else {
-            configure.args-append   --with-libxml \
-                                    --with-external-pcre=${prefix}
-        }
+            # Use -p1 to accommodate the Suhosin patch
+            patch.pre_args      -p1
+            patchfiles-append   patch-${php}-scripts-php-config.in.diff
 
-        # Ensure we don't regenerate the parsers even if flex/re2c/bison are installed.
-        configure.env       LEX=true \
-                            RE2C=true \
-                            YACC=true
+            if {[vercmp ${branch} 7.4] >= 0} {
+                patchfiles-append \
+                                patch-${php}-bison-re2c-version.diff
+            }
+            if {[vercmp ${branch} 5.3] <= 0} {
+                patchfiles-append \
+                                patch-${php}-configure.diff
+            }
+            if {[vercmp ${branch} 5.2] <= 0} {
+                patchfiles-append \
+                                patch-${php}-libxml-2.9.diff \
+                                patch-${php}-pcre-8.30.diff
+            }
 
-        if {[vercmp ${branch} 5.3] >= 0} {
-            configure.args-append \
-                            --enable-fileinfo \
-                            --enable-phar \
-                            --disable-fpm
+            # https://trac.macports.org/ticket/31590
+            # Tested all subports (except oracle) and they built with clang-425.  The reported failure was with Xcode 4.2.
+            # Xcode 4.3 may work, but leaving it blacklisted due to lack of testing
+            compiler.blacklist  {clang < 400}
 
-            # ${php}-mysql +mysqlnd needs mysqlnd support compiled into the SAPI
-            configure.env-append \
-                            PHP_MYSQLND_ENABLED=yes
-        }
+            set phpinidir       ${prefix}/etc/${php}
+            set extraphpinidir  ${prefix}/var/db/${php}
 
-        if {[vercmp ${branch} 5.4] == 0} {
-            # https://bugs.php.net/bug.php?id=68114
-            configure.args-append ac_cv_decimal_fp_supported=no
-        }
+            configure.args      --mandir=${prefix}/share/man \
+                                --infodir=${prefix}/share/info \
+                                --program-suffix=[php.suffix_from_branch ${branch}] \
+                                --includedir=${prefix}/include/${php} \
+                                --libdir=${prefix}/lib/${php} \
+                                --with-config-file-path=${phpinidir} \
+                                --with-config-file-scan-dir=${extraphpinidir} \
+                                --disable-all \
+                                --enable-bcmath \
+                                --enable-ctype \
+                                --enable-dom \
+                                --enable-filter \
+                                --enable-json \
+                                --enable-pdo \
+                                --enable-session \
+                                --enable-simplexml \
+                                --enable-tokenizer \
+                                --enable-xml \
+                                --enable-xmlreader \
+                                --enable-xmlwriter \
+                                --with-bz2=${prefix} \
+                                --with-mhash=${prefix} \
+                                --with-zlib=${prefix} \
+                                --disable-cgi \
+                                --disable-cli
 
-        configure.universal_args-delete --disable-dependency-tracking
+            if {[vercmp ${branch} 7.4] < 0} {
+                configure.args-append   --enable-hash \
+                                        --enable-libxml \
+                                        --with-libxml-dir=${prefix} \
+                                        --with-pcre-regex=${prefix} \
+                                        --without-pear
+            } else {
+                configure.args-append   --with-libxml \
+                                        --with-external-pcre=${prefix}
+            }
 
-        test.run            yes
+            # Ensure we don't regenerate the parsers even if flex/re2c/bison are installed.
+            configure.env       LEX=true \
+                                RE2C=true \
+                                YACC=true
 
-        destroot.destdir    INSTALL_ROOT=${destroot}
+            if {[vercmp ${branch} 5.3] >= 0} {
+                configure.args-append \
+                                --enable-fileinfo \
+                                --enable-phar \
+                                --disable-fpm
 
-        variant debug description {Enable debug support (useful to analyze a PHP-related core dump)} {
-            configure.args-append   --enable-debug
-        }
+                # ${php}-mysql +mysqlnd needs mysqlnd support compiled into the SAPI
+                configure.env-append \
+                                PHP_MYSQLND_ENABLED=yes
+            }
 
-        if {[vercmp ${branch} 5.3] <= 0} {
-            variant suhosin description {Add Suhosin patch} {
-                pre-fetch {
-                    if {${os.platform} eq "darwin" && ${os.major} < 9} {
-                        ui_error "The suhosin variant requires Mac OS X 10.5 or greater."
-                        return -code error "incompatible Mac OS X version"
+            if {[vercmp ${branch} 5.4] == 0} {
+                # https://bugs.php.net/bug.php?id=68114
+                configure.args-append ac_cv_decimal_fp_supported=no
+            }
+
+            configure.universal_args-delete --disable-dependency-tracking
+
+            test.run            yes
+
+            destroot.destdir    INSTALL_ROOT=${destroot}
+
+            variant debug description {Enable debug support (useful to analyze a PHP-related core dump)} {
+                configure.args-append   --enable-debug
+            }
+
+            if {[vercmp ${branch} 5.3] <= 0} {
+                variant suhosin description {Add Suhosin patch} {
+                    pre-fetch {
+                        if {${os.platform} eq "darwin" && ${os.major} < 9} {
+                            ui_error "The suhosin variant requires Mac OS X 10.5 or greater."
+                            return -code error "incompatible Mac OS X version"
+                        }
+                        if {!${suhosin_available}} {
+                            ui_error "There is no suhosin patch for PHP ${version} yet.\
+                                      Please check back later."
+                        }
+                        if {![file exists ${extraphpinidir}/suhosin.ini]} {
+                            ui_msg "You may also be interested in the suhosin\
+                                    extension, a related but different piece of\
+                                    software. See the ${php}-suhosin port."
+                        }
+                        if {!${suhosin_available}} {
+                            return -code error "unavailable variant"
+                        }
                     }
-                    if {!${suhosin_available}} {
-                        ui_error "There is no suhosin patch for PHP ${version} yet.\
-                                  Please check back later."
-                    }
-                    if {![file exists ${extraphpinidir}/suhosin.ini]} {
-                        ui_msg "You may also be interested in the suhosin\
-                                extension, a related but different piece of\
-                                software. See the ${php}-suhosin port."
-                    }
-                    if {!${suhosin_available}} {
-                        return -code error "unavailable variant"
-                    }
-                }
-                patch_sites-append          http://download.suhosin.org/
-                if {${suhosin_available}} {
-                    if {[vercmp ${branch} 5.3] >= 0} {
-                        patchfiles-append   patch-${php}-suhosin-before.diff
-                    }
-                    patchfiles-append       ${suhosin_patch}
-                    if {[vercmp ${branch} 5.3] >= 0} {
-                        patchfiles-append   patch-${php}-suhosin-after.diff
+                    patch_sites-append          http://download.suhosin.org/
+                    if {${suhosin_available}} {
+                        if {[vercmp ${branch} 5.3] >= 0} {
+                            patchfiles-append   patch-${php}-suhosin-before.diff
+                        }
+                        patchfiles-append       ${suhosin_patch}
+                        if {[vercmp ${branch} 5.3] >= 0} {
+                            patchfiles-append   patch-${php}-suhosin-after.diff
+                        }
                     }
                 }
             }
-        }
 
-        if {${subport} ne ${php}} {
-            notes-append "
-    If this is your first install, you need to enable ${subport} in your web server.
-            "
+            if {${subport} ne ${php}} {
+                notes-append "
+If this is your first install, you need to enable ${subport} in your web server.
+                "
+            }
         }
     }
-}
 
 ### CLI SAPI ###
 

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -864,67 +864,67 @@ ${phpinidir}/php-fpm.conf.default.
         configure.args-append   --with-openssl-dir=${prefix}
     }
 
-subport ${php}-gd {
-    switch -- ${version} {
-        5.2.17              {revision 0}
-        5.3.29              {revision 0}
-        5.4.45              {revision 0}
-        5.5.38              {revision 0}
-        5.6.40              {revision 0}
-        7.0.33              {revision 0}
-        7.1.33              {revision 0}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
-    }
+    subport ${php}-gd {
+        switch -- ${version} {
+            5.2.17              {revision 0}
+            5.3.29              {revision 0}
+            5.4.45              {revision 0}
+            5.5.38              {revision 0}
+            5.6.40              {revision 0}
+            7.0.33              {revision 0}
+            7.1.33              {revision 0}
+            7.2.34              {revision 0}
+            7.3.23              {revision 0}
+            7.4.11              {revision 0}
+        }
 
-    categories-append       graphics
+        categories-append       graphics
 
-    description             a PHP interface to the gd library
+        description             a PHP interface to the gd library
 
-    long_description        ${description}
+        long_description        ${description}
 
-    depends_lib-append      port:freetype \
-                            port:jpeg \
-                            port:libpng \
-                            port:zlib
+        depends_lib-append      port:freetype \
+                                port:jpeg \
+                                port:libpng \
+                                port:zlib
 
-    if {[vercmp ${branch} 5.2] <= 0} {
-        patchfiles-append   patch-${php}-jpeg-9.diff
-    }
+        if {[vercmp ${branch} 5.2] <= 0} {
+            patchfiles-append   patch-${php}-jpeg-9.diff
+        }
 
-    configure.args-append   --enable-gd-native-ttf
-
-    if {[vercmp ${branch} 7.0] >= 0} {
-        depends_lib-append  port:webp
-    }
-
-    if {[vercmp ${branch} 7.4] < 0} {
-        patchfiles-append       patch-${php}-ext-gd-config.m4.diff
-
-        configure.args-append   --with-freetype-dir=${prefix} \
-                                --with-jpeg-dir=${prefix} \
-                                --with-png-dir=${prefix} \
-                                --with-zlib-dir=${prefix}
+        configure.args-append   --enable-gd-native-ttf
 
         if {[vercmp ${branch} 7.0] >= 0} {
-            configure.args-append --with-webp-dir=${prefix}
+            depends_lib-append  port:webp
         }
-    } else {
-        depends_build-append    port:pkgconfig
 
-        configure.args-append   --with-freetype \
-                                --with-jpeg \
-                                --with-webp
-    }
+        if {[vercmp ${branch} 7.4] < 0} {
+            patchfiles-append       patch-${php}-ext-gd-config.m4.diff
 
-    if {[vercmp ${branch} 7.0] < 0} {
-        variant t1lib description {Add PostScript Type 1 font support with t1lib} {
-            depends_lib-append      port:t1lib
-            configure.args-append   --with-t1lib=${prefix}
+            configure.args-append   --with-freetype-dir=${prefix} \
+                                    --with-jpeg-dir=${prefix} \
+                                    --with-png-dir=${prefix} \
+                                    --with-zlib-dir=${prefix}
+
+            if {[vercmp ${branch} 7.0] >= 0} {
+                configure.args-append --with-webp-dir=${prefix}
+            }
+        } else {
+            depends_build-append    port:pkgconfig
+
+            configure.args-append   --with-freetype \
+                                    --with-jpeg \
+                                    --with-webp
+        }
+
+        if {[vercmp ${branch} 7.0] < 0} {
+            variant t1lib description {Add PostScript Type 1 font support with t1lib} {
+                depends_lib-append      port:t1lib
+                configure.args-append   --with-t1lib=${prefix}
+            }
         }
     }
-}
 
 subport ${php}-gettext {
     switch -- ${version} {

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -195,162 +195,160 @@ if {[regexp "^${php}" ${subport}]} {
         dist_subdir         php${major}
     }
 
-if {[is_sapi_subport]} {
+    if {[is_sapi_subport]} {
 
-    depends_build       port:pkgconfig
+        depends_build       port:pkgconfig
 
-    if {${subport} ne ${php}} {
-        depends_lib     port:${php}
-    }
+        if {${subport} ne ${php}} {
+            depends_lib     port:${php}
+        }
 
-    depends_lib-append  path:bin/gsed:gsed \
-                        port:libiconv \
-                        port:libxml2 \
-                        port:bzip2 \
-                        port:mhash \
-                        port:zlib
+        depends_lib-append  path:bin/gsed:gsed \
+                            port:libiconv \
+                            port:libxml2 \
+                            port:bzip2 \
+                            port:mhash \
+                            port:zlib
 
-    if {[vercmp ${branch} 7.3] < 0} {
-        depends_lib-append  port:pcre
-    } else {
-        depends_lib-append  port:pcre2
-    }
+        if {[vercmp ${branch} 7.3] < 0} {
+            depends_lib-append  port:pcre
+        } else {
+            depends_lib-append  port:pcre2
+        }
 
-    # Use -p1 to accommodate the Suhosin patch
-    patch.pre_args      -p1
-    patchfiles-append   patch-${php}-scripts-php-config.in.diff
+        # Use -p1 to accommodate the Suhosin patch
+        patch.pre_args      -p1
+        patchfiles-append   patch-${php}-scripts-php-config.in.diff
 
-    if {[vercmp ${branch} 7.4] >= 0} {
-        patchfiles-append \
-                        patch-${php}-bison-re2c-version.diff
-    }
-    if {[vercmp ${branch} 5.3] <= 0} {
-        patchfiles-append \
-                        patch-${php}-configure.diff
-    }
-    if {[vercmp ${branch} 5.2] <= 0} {
-        patchfiles-append \
-                        patch-${php}-libxml-2.9.diff \
-                        patch-${php}-pcre-8.30.diff
-    }
+        if {[vercmp ${branch} 7.4] >= 0} {
+            patchfiles-append \
+                            patch-${php}-bison-re2c-version.diff
+        }
+        if {[vercmp ${branch} 5.3] <= 0} {
+            patchfiles-append \
+                            patch-${php}-configure.diff
+        }
+        if {[vercmp ${branch} 5.2] <= 0} {
+            patchfiles-append \
+                            patch-${php}-libxml-2.9.diff \
+                            patch-${php}-pcre-8.30.diff
+        }
 
-    # https://trac.macports.org/ticket/31590
-    # Tested all subports (except oracle) and they built with clang-425.  The reported failure was with Xcode 4.2.
-    # Xcode 4.3 may work, but leaving it blacklisted due to lack of testing
-    compiler.blacklist  {clang < 400}
+        # https://trac.macports.org/ticket/31590
+        # Tested all subports (except oracle) and they built with clang-425.  The reported failure was with Xcode 4.2.
+        # Xcode 4.3 may work, but leaving it blacklisted due to lack of testing
+        compiler.blacklist  {clang < 400}
 
-    set phpinidir       ${prefix}/etc/${php}
-    set extraphpinidir  ${prefix}/var/db/${php}
+        set phpinidir       ${prefix}/etc/${php}
+        set extraphpinidir  ${prefix}/var/db/${php}
 
-    configure.args      --mandir=${prefix}/share/man \
-                        --infodir=${prefix}/share/info \
-                        --program-suffix=[php.suffix_from_branch ${branch}] \
-                        --includedir=${prefix}/include/${php} \
-                        --libdir=${prefix}/lib/${php} \
-                        --with-config-file-path=${phpinidir} \
-                        --with-config-file-scan-dir=${extraphpinidir} \
-                        --disable-all \
-                        --enable-bcmath \
-                        --enable-ctype \
-                        --enable-dom \
-                        --enable-filter \
-                        --enable-json \
-                        --enable-pdo \
-                        --enable-session \
-                        --enable-simplexml \
-                        --enable-tokenizer \
-                        --enable-xml \
-                        --enable-xmlreader \
-                        --enable-xmlwriter \
-                        --with-bz2=${prefix} \
-                        --with-mhash=${prefix} \
-                        --with-zlib=${prefix} \
-                        --disable-cgi \
-                        --disable-cli
+        configure.args      --mandir=${prefix}/share/man \
+                            --infodir=${prefix}/share/info \
+                            --program-suffix=[php.suffix_from_branch ${branch}] \
+                            --includedir=${prefix}/include/${php} \
+                            --libdir=${prefix}/lib/${php} \
+                            --with-config-file-path=${phpinidir} \
+                            --with-config-file-scan-dir=${extraphpinidir} \
+                            --disable-all \
+                            --enable-bcmath \
+                            --enable-ctype \
+                            --enable-dom \
+                            --enable-filter \
+                            --enable-json \
+                            --enable-pdo \
+                            --enable-session \
+                            --enable-simplexml \
+                            --enable-tokenizer \
+                            --enable-xml \
+                            --enable-xmlreader \
+                            --enable-xmlwriter \
+                            --with-bz2=${prefix} \
+                            --with-mhash=${prefix} \
+                            --with-zlib=${prefix} \
+                            --disable-cgi \
+                            --disable-cli
 
-    if {[vercmp ${branch} 7.4] < 0} {
-        configure.args-append   --enable-hash \
-                                --enable-libxml \
-                                --with-libxml-dir=${prefix} \
-                                --with-pcre-regex=${prefix} \
-                                --without-pear
-    } else {
-        configure.args-append   --with-libxml \
-                                --with-external-pcre=${prefix}
-    }
+        if {[vercmp ${branch} 7.4] < 0} {
+            configure.args-append   --enable-hash \
+                                    --enable-libxml \
+                                    --with-libxml-dir=${prefix} \
+                                    --with-pcre-regex=${prefix} \
+                                    --without-pear
+        } else {
+            configure.args-append   --with-libxml \
+                                    --with-external-pcre=${prefix}
+        }
 
-    # Ensure we don't regenerate the parsers even if flex/re2c/bison are installed.
-    configure.env       LEX=true \
-                        RE2C=true \
-                        YACC=true
+        # Ensure we don't regenerate the parsers even if flex/re2c/bison are installed.
+        configure.env       LEX=true \
+                            RE2C=true \
+                            YACC=true
 
-    if {[vercmp ${branch} 5.3] >= 0} {
-        configure.args-append \
-                        --enable-fileinfo \
-                        --enable-phar \
-                        --disable-fpm
+        if {[vercmp ${branch} 5.3] >= 0} {
+            configure.args-append \
+                            --enable-fileinfo \
+                            --enable-phar \
+                            --disable-fpm
 
-        # ${php}-mysql +mysqlnd needs mysqlnd support compiled into the SAPI
-        configure.env-append \
-                        PHP_MYSQLND_ENABLED=yes
-    }
+            # ${php}-mysql +mysqlnd needs mysqlnd support compiled into the SAPI
+            configure.env-append \
+                            PHP_MYSQLND_ENABLED=yes
+        }
 
-    if {[vercmp ${branch} 5.4] == 0} {
-        # https://bugs.php.net/bug.php?id=68114
-        configure.args-append ac_cv_decimal_fp_supported=no
-    }
+        if {[vercmp ${branch} 5.4] == 0} {
+            # https://bugs.php.net/bug.php?id=68114
+            configure.args-append ac_cv_decimal_fp_supported=no
+        }
 
-    configure.universal_args-delete --disable-dependency-tracking
+        configure.universal_args-delete --disable-dependency-tracking
 
-    test.run            yes
+        test.run            yes
 
-    destroot.destdir    INSTALL_ROOT=${destroot}
+        destroot.destdir    INSTALL_ROOT=${destroot}
 
-    variant debug description {Enable debug support (useful to analyze a PHP-related core dump)} {
-        configure.args-append   --enable-debug
-    }
+        variant debug description {Enable debug support (useful to analyze a PHP-related core dump)} {
+            configure.args-append   --enable-debug
+        }
 
-    if {[vercmp ${branch} 5.3] <= 0} {
-        variant suhosin description {Add Suhosin patch} {
-            pre-fetch {
-                if {${os.platform} eq "darwin" && ${os.major} < 9} {
-                    ui_error "The suhosin variant requires Mac OS X 10.5 or greater."
-                    return -code error "incompatible Mac OS X version"
+        if {[vercmp ${branch} 5.3] <= 0} {
+            variant suhosin description {Add Suhosin patch} {
+                pre-fetch {
+                    if {${os.platform} eq "darwin" && ${os.major} < 9} {
+                        ui_error "The suhosin variant requires Mac OS X 10.5 or greater."
+                        return -code error "incompatible Mac OS X version"
+                    }
+                    if {!${suhosin_available}} {
+                        ui_error "There is no suhosin patch for PHP ${version} yet.\
+                                  Please check back later."
+                    }
+                    if {![file exists ${extraphpinidir}/suhosin.ini]} {
+                        ui_msg "You may also be interested in the suhosin\
+                                extension, a related but different piece of\
+                                software. See the ${php}-suhosin port."
+                    }
+                    if {!${suhosin_available}} {
+                        return -code error "unavailable variant"
+                    }
                 }
-                if {!${suhosin_available}} {
-                    ui_error "There is no suhosin patch for PHP ${version} yet.\
-                              Please check back later."
-                }
-                if {![file exists ${extraphpinidir}/suhosin.ini]} {
-                    ui_msg "You may also be interested in the suhosin\
-                            extension, a related but different piece of\
-                            software. See the ${php}-suhosin port."
-                }
-                if {!${suhosin_available}} {
-                    return -code error "unavailable variant"
-                }
-            }
-            patch_sites-append          http://download.suhosin.org/
-            if {${suhosin_available}} {
-                if {[vercmp ${branch} 5.3] >= 0} {
-                    patchfiles-append   patch-${php}-suhosin-before.diff
-                }
-                patchfiles-append       ${suhosin_patch}
-                if {[vercmp ${branch} 5.3] >= 0} {
-                    patchfiles-append   patch-${php}-suhosin-after.diff
+                patch_sites-append          http://download.suhosin.org/
+                if {${suhosin_available}} {
+                    if {[vercmp ${branch} 5.3] >= 0} {
+                        patchfiles-append   patch-${php}-suhosin-before.diff
+                    }
+                    patchfiles-append       ${suhosin_patch}
+                    if {[vercmp ${branch} 5.3] >= 0} {
+                        patchfiles-append   patch-${php}-suhosin-after.diff
+                    }
                 }
             }
         }
+
+        if {${subport} ne ${php}} {
+            notes-append "
+    If this is your first install, you need to enable ${subport} in your web server.
+            "
+        }
     }
-
-    if {${subport} ne ${php}} {
-        notes-append "
-If this is your first install, you need to enable ${subport} in your web server.
-        "
-    }
-
-}
-
 }
 
 ### CLI SAPI ###

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -1175,62 +1175,62 @@ ${phpinidir}/php-fpm.conf.default.
         }
     }
 
-if {[vercmp ${branch} 7.2] < 0} {
-    # mcrypt was evicted from PHP core in version 7.2; php72-mcrypt and later
-    # subports are found in the separate php-mcrypt Portfile.
-    subport ${php}-mcrypt {
-        switch -- ${version} {
-            5.2.17              {revision 0}
-            5.3.29              {revision 0}
-            5.4.45              {revision 0}
-            5.5.38              {revision 0}
-            5.6.40              {revision 0}
-            7.0.33              {revision 0}
-            7.1.33              {revision 0}
+    if {[vercmp ${branch} 7.2] < 0} {
+        # mcrypt was evicted from PHP core in version 7.2; php72-mcrypt and later
+        # subports are found in the separate php-mcrypt Portfile.
+        subport ${php}-mcrypt {
+            switch -- ${version} {
+                5.2.17              {revision 0}
+                5.3.29              {revision 0}
+                5.4.45              {revision 0}
+                5.5.38              {revision 0}
+                5.6.40              {revision 0}
+                7.0.33              {revision 0}
+                7.1.33              {revision 0}
+            }
+
+            categories-append       security
+
+            description             a PHP interface to the mcrypt library, which offers \
+                                    a wide variety of algorithms
+
+            long_description        ${description}
+
+            depends_lib-append      port:libmcrypt
+
+            # The mcrypt extension may be using libtool unnecessarily; monitor
+            # https://bugs.php.net/bug.php?id=54500
+            depends_lib-append      port:libtool
+
+            configure.args-append   --with-mcrypt=${prefix}
         }
-
-        categories-append       security
-
-        description             a PHP interface to the mcrypt library, which offers \
-                                a wide variety of algorithms
-
-        long_description        ${description}
-
-        depends_lib-append      port:libmcrypt
-
-        # The mcrypt extension may be using libtool unnecessarily; monitor
-        # https://bugs.php.net/bug.php?id=54500
-        depends_lib-append      port:libtool
-
-        configure.args-append   --with-mcrypt=${prefix}
     }
-}
 
-if {[vercmp ${branch} 7] < 0} {
-    subport ${php}-mssql {
-        switch -- ${version} {
-            5.2.17              {revision 0}
-            5.3.29              {revision 0}
-            5.4.45              {revision 0}
-            5.5.38              {revision 0}
-            5.6.40              {revision 0}
+    if {[vercmp ${branch} 7] < 0} {
+        subport ${php}-mssql {
+            switch -- ${version} {
+                5.2.17              {revision 0}
+                5.3.29              {revision 0}
+                5.4.45              {revision 0}
+                5.5.38              {revision 0}
+                5.6.40              {revision 0}
+            }
+
+            php.extensions          mssql pdo_dblib
+
+            categories-append       databases
+
+            description             a PHP interface to MSSQL using FreeTDS, including \
+                                    the mssql and pdo_dblib extensions
+
+            long_description        ${description}
+
+            depends_lib-append      port:freetds
+
+            configure.args-append   --with-mssql=${prefix} \
+                                    --with-pdo-dblib=${prefix}
         }
-
-        php.extensions          mssql pdo_dblib
-
-        categories-append       databases
-
-        description             a PHP interface to MSSQL using FreeTDS, including \
-                                the mssql and pdo_dblib extensions
-
-        long_description        ${description}
-
-        depends_lib-append      port:freetds
-
-        configure.args-append   --with-mssql=${prefix} \
-                                --with-pdo-dblib=${prefix}
     }
-}
 
 subport ${php}-mysql {
     switch -- ${version} {

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -189,11 +189,11 @@ set php                 php[php.suffix_from_branch ${branch}]
 
 if {[regexp "^${php}" ${subport}]} {
 
-if {[vercmp ${major} 5] > 0} {
-    dist_subdir         ${php}
-} else {
-    dist_subdir         php${major}
-}
+    if {[vercmp ${major} 5] > 0} {
+        dist_subdir         ${php}
+    } else {
+        dist_subdir         php${major}
+    }
 
 if {[is_sapi_subport]} {
 
@@ -311,37 +311,42 @@ if {[is_sapi_subport]} {
     }
 
     if {[vercmp ${branch} 5.3] <= 0} {
-    variant suhosin description {Add Suhosin patch} {
-        pre-fetch {
-            if {${os.platform} eq "darwin" && ${os.major} < 9} {
-                ui_error "The suhosin variant requires Mac OS X 10.5 or greater."
-                return -code error "incompatible Mac OS X version"
+        variant suhosin description {Add Suhosin patch} {
+            pre-fetch {
+                if {${os.platform} eq "darwin" && ${os.major} < 9} {
+                    ui_error "The suhosin variant requires Mac OS X 10.5 or greater."
+                    return -code error "incompatible Mac OS X version"
+                }
+                if {!${suhosin_available}} {
+                    ui_error "There is no suhosin patch for PHP ${version} yet.\
+                              Please check back later."
+                }
+                if {![file exists ${extraphpinidir}/suhosin.ini]} {
+                    ui_msg "You may also be interested in the suhosin\
+                            extension, a related but different piece of\
+                            software. See the ${php}-suhosin port."
+                }
+                if {!${suhosin_available}} {
+                    return -code error "unavailable variant"
+                }
             }
-            if {!${suhosin_available}} {
-                ui_error "There is no suhosin patch for PHP ${version} yet. Please check back later."
-            }
-            if {![file exists ${extraphpinidir}/suhosin.ini]} {
-                ui_msg "You may also be interested in the suhosin extension, a related but different piece of software. See the ${php}-suhosin port."
-            }
-            if {!${suhosin_available}} {
-                return -code error "unavailable variant"
+            patch_sites-append          http://download.suhosin.org/
+            if {${suhosin_available}} {
+                if {[vercmp ${branch} 5.3] >= 0} {
+                    patchfiles-append   patch-${php}-suhosin-before.diff
+                }
+                patchfiles-append       ${suhosin_patch}
+                if {[vercmp ${branch} 5.3] >= 0} {
+                    patchfiles-append   patch-${php}-suhosin-after.diff
+                }
             }
         }
-        patch_sites-append          http://download.suhosin.org/
-        if {${suhosin_available}} {
-            if {[vercmp ${branch} 5.3] >= 0} {
-                patchfiles-append   patch-${php}-suhosin-before.diff
-            }
-            patchfiles-append       ${suhosin_patch}
-            if {[vercmp ${branch} 5.3] >= 0} {
-                patchfiles-append   patch-${php}-suhosin-after.diff
-            }
-        }
-    }
     }
 
     if {${subport} ne ${php}} {
-        notes-append "If this is your first install, you need to enable ${subport} in your web server."
+        notes-append "
+If this is your first install, you need to enable ${subport} in your web server.
+        "
     }
 
 }

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -351,153 +351,159 @@ If this is your first install, you need to enable ${subport} in your web server.
         }
     }
 
-### CLI SAPI ###
 
-subport ${php} {
-    PortGroup               muniversal 1.0
-    PortGroup               select 1.0
+    ### CLI SAPI ###
 
-    switch -- ${version} {
-        5.2.17              {revision 15}
-        5.3.29              {revision 6}
-        5.4.45              {revision 5}
-        5.5.38              {revision 6}
-        5.6.40              {revision 4}
-        7.0.33              {revision 3}
-        7.1.33              {revision 1}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
-    }
+    subport ${php} {
+        PortGroup               muniversal 1.0
+        PortGroup               select 1.0
 
-    depends_run             port:php_select
-
-    select.group            php
-    select.file             ${filespath}/${subport}
-
-    if {[vercmp ${branch} 5.3] == 0} {
-        patchfiles-append   patch-${php}-C++11.diff
-    }
-
-    if {[vercmp ${branch} 5.5] >= 0 && [vercmp ${branch} 7.0] < 0} {
-        patchfiles-append   patch-${php}-Zend-EX_TMP_VAR.diff
-    }
-
-    if {[vercmp ${branch} 5.3] >= 0 && [vercmp ${branch} 7.2] < 0} {
-        patchfiles-append   patch-${php}-icu-61.diff
-    }
-
-    post-patch {
-        # Ensure the build date is the same for all universal archs.
-        reinplace "s|^PHP_BUILD_DATE=.*$|PHP_BUILD_DATE=[clock format [clock seconds] -format {%Y-%m-%d}]|g" ${worksrcpath}/configure
-    }
-
-    configure.args-replace  --disable-cli --enable-cli
-
-    destroot.target         install-cli install-build install-headers install-programs
-
-    destroot.keepdirs       ${destroot}${extraphpinidir}
-
-    post-destroot {
-        # Copy the default php.ini files.
-        xinstall -m 755 -d ${destroot}${phpinidir}
-        if {[vercmp ${branch} 5.3] >= 0} {
-            xinstall -m 644 -W ${worksrcpath} \
-                php.ini-development \
-                php.ini-production \
-                ${destroot}${phpinidir}
-        } else {
-            xinstall -m 644 -W ${worksrcpath} \
-                php.ini-dist \
-                php.ini-recommended \
-                ${destroot}${phpinidir}
+        switch -- ${version} {
+            5.2.17              {revision 15}
+            5.3.29              {revision 6}
+            5.4.45              {revision 5}
+            5.5.38              {revision 6}
+            5.6.40              {revision 4}
+            7.0.33              {revision 3}
+            7.1.33              {revision 1}
+            7.2.34              {revision 0}
+            7.3.23              {revision 0}
+            7.4.11              {revision 0}
         }
 
-        if {[vercmp ${branch} 5.3] >= 0} {
-            # Copy mysqlnd headers.
-            xinstall -d ${destroot}${prefix}/include/${php}/php/ext/mysqlnd
-            xinstall -m 644 {*}[glob ${worksrcpath}/ext/mysqlnd/*.h] ${destroot}${prefix}/include/${php}/php/ext/mysqlnd
-        }
-    }
+        depends_run             port:php_select
 
-    # Include the readline extension https://www.php.net/readline directly in
-    # the PHP CLI SAPI because until PHP 6 the interactive mode "php -a" won't
-    # work with a separately built readline extension.
-    # https://bugs.php.net/bug.php?id=53878
-    # Users might prefer readline over libedit because only readline supports
-    # readline_list_history() (https://www.php.net/readline-list-history).
-    # On the other hand we want libedit to be the default because its license
-    # is compatible with PHP's which means PHP can be distributable.
-    variant libedit conflicts readline description {Build readline extension using libedit library} {
-        depends_lib-append      port:libedit port:ncurses
-        if {[vercmp ${branch} 7.4] < 0} {
-            configure.args-append   --with-libedit=${prefix}
-        } else {
-            configure.args-append   --with-libedit
-        }
-    }
-    variant readline conflicts libedit description {Build readline extension using readline library} {
-        depends_lib-append      port:ncurses port:readline
-        configure.args-append   --with-readline=${prefix}
-    }
-    if {![variant_isset readline]} {
-        default_variants +libedit
-    }
+        select.group            php
+        select.file             ${filespath}/${subport}
 
-    if {[vercmp ${branch} ${php.oldest_supported_branch}] < 0} {
-        notes-append "
-PHP ${branch} has reached end-of-life. Please upgrade to PHP ${php.oldest_supported_branch} or newer. The newest stable version is ${php.latest_stable_branch}.
+        if {[vercmp ${branch} 5.3] == 0} {
+            patchfiles-append   patch-${php}-C++11.diff
+        }
+
+        if {[vercmp ${branch} 5.5] >= 0 && [vercmp ${branch} 7.0] < 0} {
+            patchfiles-append   patch-${php}-Zend-EX_TMP_VAR.diff
+        }
+
+        if {[vercmp ${branch} 5.3] >= 0 && [vercmp ${branch} 7.2] < 0} {
+            patchfiles-append   patch-${php}-icu-61.diff
+        }
+
+        post-patch {
+            # Ensure the build date is the same for all universal archs.
+            reinplace "s|^PHP_BUILD_DATE=.*$|PHP_BUILD_DATE=[clock format [clock seconds] -format {%Y-%m-%d}]|g" ${worksrcpath}/configure
+        }
+
+        configure.args-replace  --disable-cli --enable-cli
+
+        destroot.target         install-cli install-build install-headers install-programs
+
+        destroot.keepdirs       ${destroot}${extraphpinidir}
+
+        post-destroot {
+            # Copy the default php.ini files.
+            xinstall -m 755 -d ${destroot}${phpinidir}
+            if {[vercmp ${branch} 5.3] >= 0} {
+                xinstall -m 644 -W ${worksrcpath} \
+                    php.ini-development \
+                    php.ini-production \
+                    ${destroot}${phpinidir}
+            } else {
+                xinstall -m 644 -W ${worksrcpath} \
+                    php.ini-dist \
+                    php.ini-recommended \
+                    ${destroot}${phpinidir}
+            }
+
+            if {[vercmp ${branch} 5.3] >= 0} {
+                # Copy mysqlnd headers.
+                xinstall -d ${destroot}${prefix}/include/${php}/php/ext/mysqlnd
+                xinstall -m 644 {*}[glob ${worksrcpath}/ext/mysqlnd/*.h] \
+                    ${destroot}${prefix}/include/${php}/php/ext/mysqlnd
+            }
+        }
+
+        # Include the readline extension https://www.php.net/readline directly in
+        # the PHP CLI SAPI because until PHP 6 the interactive mode "php -a" won't
+        # work with a separately built readline extension.
+        # https://bugs.php.net/bug.php?id=53878
+        # Users might prefer readline over libedit because only readline supports
+        # readline_list_history() (https://www.php.net/readline-list-history).
+        # On the other hand we want libedit to be the default because its license
+        # is compatible with PHP's which means PHP can be distributable.
+        variant libedit     conflicts readline \
+                            description {Build readline extension using libedit library} {
+            depends_lib-append      port:libedit port:ncurses
+            if {[vercmp ${branch} 7.4] < 0} {
+                configure.args-append   --with-libedit=${prefix}
+            } else {
+                configure.args-append   --with-libedit
+            }
+        }
+        variant readline    conflicts libedit \
+                            description {Build readline extension using readline library} {
+            depends_lib-append      port:ncurses port:readline
+            configure.args-append   --with-readline=${prefix}
+        }
+        if {![variant_isset readline]} {
+            default_variants +libedit
+        }
+
+        if {[vercmp ${branch} ${php.oldest_supported_branch}] < 0} {
+            notes-append "
+PHP ${branch} has reached end-of-life. Please upgrade to PHP\
+${php.oldest_supported_branch} or newer. The newest stable version\
+is ${php.latest_stable_branch}.
 
 To learn how to update your code, please read the following guide:
 
     https://www.php.net/manual/en/migration[php.suffix_from_branch ${php.latest_stable_branch}].php
+            "
+        }
 
-
-"
-    }
-
-    if {[vercmp ${branch} ${php.latest_stable_branch}] > 0} {
-        notes-append "${php} @${version} is a development preview—do not use it in production!\n\n\n"
-    }
-
-    if {![file exists ${phpinidir}/php.ini]} {
-        if {[vercmp ${branch} 5.3] >= 0} {
+        if {[vercmp ${branch} ${php.latest_stable_branch}] > 0} {
             notes-append "
+${php} @${version} is a development preview—do not use it in production!\n\n\n
+            "
+        }
+
+        if {![file exists ${phpinidir}/php.ini]} {
+            if {[vercmp ${branch} 5.3] >= 0} {
+                notes-append "
 To customize ${php}, copy\
 ${phpinidir}/php.ini-development (if this is a development server) or\
 ${phpinidir}/php.ini-production (if this is a production server) to\
 ${phpinidir}/php.ini and then make changes.
-"
-        } else {
-            notes-append "
+                "
+            } else {
+                notes-append "
 To customize ${php}, copy ${phpinidir}/php.ini-recommended to\
 ${phpinidir}/php.ini and then make changes.
-"
-        }
-    } else {
-        if {[vercmp ${branch} 5.3] >= 0} {
-            notes-append "
+                "
+            }
+        } else {
+            if {[vercmp ${branch} 5.3] >= 0} {
+                notes-append "
 You may need to update your php.ini for any changes that have been made\
 in this version of ${php}. Compare ${phpinidir}/php.ini with\
 ${phpinidir}/php.ini-development (if this is a development server) or\
 ${phpinidir}/php.ini-production (if this is a production server).
-"
-        } else {
-            notes-append "
+                "
+            } else {
+                notes-append "
 You may need to update your php.ini for any changes that have been made\
 in this version of ${php}. Compare ${phpinidir}/php.ini with\
 ${phpinidir}/php.ini-recommended.
-"
+                "
+            }
+        }
+
+        # Enable livecheck for all supported PHP branches and the development branch.
+        if {[vercmp ${branch} ${php.oldest_supported_branch}] >= 0} {
+            livecheck.type      regex
+            default livecheck.url   ${homepage}/downloads.php
+            default livecheck.regex {[quotemeta /php-([quotemeta ${branch}](?:\\.\[0-9.\]+)*)\\.tar]}
         }
     }
-
-    # Enable livecheck for all supported PHP branches and the development branch.
-    if {[vercmp ${branch} ${php.oldest_supported_branch}] >= 0} {
-        livecheck.type      regex
-        default livecheck.url   ${homepage}/downloads.php
-        default livecheck.regex {[quotemeta /php-([quotemeta ${branch}](?:\\.\[0-9.\]+)*)\\.tar]}
-    }
-}
 
 ### Apache 2 handler SAPI ###
 

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -808,61 +808,61 @@ ${phpinidir}/php-fpm.conf.default.
         }
     }
 
-subport ${php}-exif {
-    switch -- ${version} {
-        5.2.17              {revision 0}
-        5.3.29              {revision 0}
-        5.4.45              {revision 0}
-        5.5.38              {revision 0}
-        5.6.40              {revision 0}
-        7.0.33              {revision 0}
-        7.1.33              {revision 0}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
+    subport ${php}-exif {
+        switch -- ${version} {
+            5.2.17              {revision 0}
+            5.3.29              {revision 0}
+            5.4.45              {revision 0}
+            5.5.38              {revision 0}
+            5.6.40              {revision 0}
+            7.0.33              {revision 0}
+            7.1.33              {revision 0}
+            7.2.34              {revision 0}
+            7.3.23              {revision 0}
+            7.4.11              {revision 0}
+        }
+
+        categories-append       graphics
+
+        description             a PHP interface to the EXIF image metadata functions
+
+        long_description        ${description}
     }
 
-    categories-append       graphics
+    subport ${php}-ftp {
+        switch -- ${version} {
+            5.2.17              {revision 2}
+            5.3.29              {revision 2}
+            5.4.45              {revision 2}
+            5.5.38              {revision 2}
+            5.6.40              {revision 2}
+            7.0.33              {revision 1}
+            7.1.33              {revision 0}
+            7.2.34              {revision 0}
+            7.3.23              {revision 0}
+            7.4.11              {revision 0}
+        }
 
-    description             a PHP interface to the EXIF image metadata functions
+        categories-append       net
 
-    long_description        ${description}
-}
+        description             a PHP extension for accessing file servers using the \
+                                File Transfer Protocol
 
-subport ${php}-ftp {
-    switch -- ${version} {
-        5.2.17              {revision 2}
-        5.3.29              {revision 2}
-        5.4.45              {revision 2}
-        5.5.38              {revision 2}
-        5.6.40              {revision 2}
-        7.0.33              {revision 1}
-        7.1.33              {revision 0}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
+        long_description        ${description}
+
+        depends_lib-append      path:lib/libssl.dylib:openssl
+
+        if {[vercmp ${branch} 7.4] >= 0} {
+            depends_build-append \
+                                port:pkgconfig
+        }
+
+        if {[vercmp ${branch} 7.0] < 0} {
+            patchfiles-append   patch-${php}-ext-ftp-ftp_ssl_connect.diff
+        }
+
+        configure.args-append   --with-openssl-dir=${prefix}
     }
-
-    categories-append       net
-
-    description             a PHP extension for accessing file servers using the \
-                            File Transfer Protocol
-
-    long_description        ${description}
-
-    depends_lib-append      path:lib/libssl.dylib:openssl
-
-    if {[vercmp ${branch} 7.4] >= 0} {
-        depends_build-append \
-                            port:pkgconfig
-    }
-
-    if {[vercmp ${branch} 7.0] < 0} {
-        patchfiles-append   patch-${php}-ext-ftp-ftp_ssl_connect.diff
-    }
-
-    configure.args-append   --with-openssl-dir=${prefix}
-}
 
 subport ${php}-gd {
     switch -- ${version} {

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -1396,104 +1396,104 @@ For percona, use ${prefix}/var/run/percona/mysqld.sock
         }
     }
 
-subport ${php}-odbc {
-    switch -- ${version} {
-        5.2.17              {revision 0}
-        5.3.29              {revision 0}
-        5.4.45              {revision 0}
-        5.5.38              {revision 0}
-        5.6.40              {revision 0}
-        7.0.33              {revision 0}
-        7.1.33              {revision 0}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
-    }
-
-    php.extensions          odbc pdo_odbc
-
-    categories-append       databases
-
-    description             a PHP interface for accessing databases via Open \
-                            DataBase Connectivity (ODBC)
-
-    long_description        ${description}
-
-    if {[vercmp ${branch} 5.3] >= 0} {
-    variant iodbc conflicts unixodbc description {Use iODBC} {
-        depends_lib-append      port:libiodbc
-
-        patchfiles-append       patch-${php}-iODBC.diff
-
-        configure.args-append   --with-pdo-odbc=iODBC,${prefix}
-        if {[vercmp ${branch} 7.4] < 0} {
-            configure.args-append   --with-iODBC=${prefix}
-        } else {
-            depends_build-append    port:pkgconfig
-
-            configure.args-append   --with-iODBC
-        }
-    }
-
-    variant unixodbc conflicts iodbc description {Use unixODBC} {}
-
-    if {![variant_isset iodbc] && ![variant_isset unixodbc]} {
-        default_variants +unixodbc
-    }
-    }
-
-    if {[variant_isset unixodbc] || [vercmp ${branch} 5.3] < 0} {
-        depends_lib-append      port:unixODBC
-
-        patchfiles-append       patch-${php}-unixODBC.diff
-
-        configure.args-append   --with-pdo-odbc=unixODBC,${prefix}
-        if {[vercmp ${branch} 7.4] < 0} {
-            configure.args-append   --with-unixODBC=${prefix}
-        } else {
-            depends_build-append    port:pkgconfig
-
-            configure.args-append   --with-unixODBC
-        }
-    }
-}
-
-if {[vercmp ${branch} 5.5] >= 0} {
-    subport ${php}-opcache {
+    subport ${php}-odbc {
         switch -- ${version} {
-            5.5.38              {revision 1}
-            5.6.40              {revision 1}
-            7.0.33              {revision 1}
-            7.1.33              {revision 1}
+            5.2.17              {revision 0}
+            5.3.29              {revision 0}
+            5.4.45              {revision 0}
+            5.5.38              {revision 0}
+            5.6.40              {revision 0}
+            7.0.33              {revision 0}
+            7.1.33              {revision 0}
             7.2.34              {revision 0}
             7.3.23              {revision 0}
             7.4.11              {revision 0}
         }
 
-        php.extensions.zend opcache
+        php.extensions          odbc pdo_odbc
 
-        description         OPcache improves PHP performance by storing precompiled \
-                            script bytecode in shared memory, thereby removing the \
-                            need for PHP to load and parse scripts on each request.
+        categories-append       databases
 
-        long_description    ${description}
+        description             a PHP interface for accessing databases via Open \
+                                DataBase Connectivity (ODBC)
 
-        configure.args-append   --enable-opcache
+        long_description        ${description}
 
-        # file based opcode cache was added in 7.0 (3abde432)
-        if {[vercmp ${branch} 7.0] >= 0} {
-            configure.args-append   --enable-opcache-file
+        if {[vercmp ${branch} 5.3] >= 0} {
+        variant iodbc conflicts unixodbc description {Use iODBC} {
+            depends_lib-append      port:libiodbc
+
+            patchfiles-append       patch-${php}-iODBC.diff
+
+            configure.args-append   --with-pdo-odbc=iODBC,${prefix}
+            if {[vercmp ${branch} 7.4] < 0} {
+                configure.args-append   --with-iODBC=${prefix}
+            } else {
+                depends_build-append    port:pkgconfig
+
+                configure.args-append   --with-iODBC
+            }
         }
 
-        post-destroot {
-            set docdir ${destroot}${prefix}/share/doc/${subport}
-            xinstall -d ${docdir}
+        variant unixodbc conflicts iodbc description {Use unixODBC} {}
+
+        if {![variant_isset iodbc] && ![variant_isset unixodbc]} {
+            default_variants +unixodbc
+        }
+        }
+
+        if {[variant_isset unixodbc] || [vercmp ${branch} 5.3] < 0} {
+            depends_lib-append      port:unixODBC
+
+            patchfiles-append       patch-${php}-unixODBC.diff
+
+            configure.args-append   --with-pdo-odbc=unixODBC,${prefix}
             if {[vercmp ${branch} 7.4] < 0} {
-                xinstall -W ${destroot.dir} -m 644 README ${docdir}
+                configure.args-append   --with-unixODBC=${prefix}
+            } else {
+                depends_build-append    port:pkgconfig
+
+                configure.args-append   --with-unixODBC
             }
         }
     }
-}
+
+    if {[vercmp ${branch} 5.5] >= 0} {
+        subport ${php}-opcache {
+            switch -- ${version} {
+                5.5.38              {revision 1}
+                5.6.40              {revision 1}
+                7.0.33              {revision 1}
+                7.1.33              {revision 1}
+                7.2.34              {revision 0}
+                7.3.23              {revision 0}
+                7.4.11              {revision 0}
+            }
+
+            php.extensions.zend opcache
+
+            description         OPcache improves PHP performance by storing precompiled \
+                                script bytecode in shared memory, thereby removing the \
+                                need for PHP to load and parse scripts on each request.
+
+            long_description    ${description}
+
+            configure.args-append   --enable-opcache
+
+            # file based opcode cache was added in 7.0 (3abde432)
+            if {[vercmp ${branch} 7.0] >= 0} {
+                configure.args-append   --enable-opcache-file
+            }
+
+            post-destroot {
+                set docdir ${destroot}${prefix}/share/doc/${subport}
+                xinstall -d ${docdir}
+                if {[vercmp ${branch} 7.4] < 0} {
+                    xinstall -W ${destroot.dir} -m 644 README ${docdir}
+                }
+            }
+        }
+    }
 
 subport ${php}-openssl {
     switch -- ${version} {

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -1639,126 +1639,126 @@ a web server environment.
                                 not accessible through other means
     }
 
-subport ${php}-postgresql {
-    switch -- ${version} {
-        5.2.17              {revision 0}
-        5.3.29              {revision 0}
-        5.4.45              {revision 0}
-        5.5.38              {revision 0}
-        5.6.40              {revision 0}
-        7.0.33              {revision 0}
-        7.1.33              {revision 0}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
+    subport ${php}-postgresql {
+        switch -- ${version} {
+            5.2.17              {revision 0}
+            5.3.29              {revision 0}
+            5.4.45              {revision 0}
+            5.5.38              {revision 0}
+            5.6.40              {revision 0}
+            7.0.33              {revision 0}
+            7.1.33              {revision 0}
+            7.2.34              {revision 0}
+            7.3.23              {revision 0}
+            7.4.11              {revision 0}
+        }
+
+        php.extensions          pgsql pdo_pgsql
+
+        categories-append       databases
+
+        homepage                https://www.php.net/pgsql
+
+        description             a PHP interface to PostgreSQL, including \
+                                the pgsql and pdo_pgsql extensions
+
+        long_description        ${description}
+
+        variant postgresql82 conflicts postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 8.2 libraries} {
+            depends_lib-append      port:postgresql82
+
+            configure.args-append   --with-pgsql=${prefix}/lib/postgresql82/bin \
+                                    --with-pdo-pgsql=${prefix}/lib/postgresql82/bin
+        }
+
+        variant postgresql83 conflicts postgresql82 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 8.3 libraries} {
+            depends_lib-append      port:postgresql83
+
+            configure.args-append   --with-pgsql=${prefix}/lib/postgresql83/bin \
+                                    --with-pdo-pgsql=${prefix}/lib/postgresql83/bin
+        }
+
+        variant postgresql84 conflicts postgresql82 postgresql83 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 8.4 libraries} {
+            depends_lib-append      port:postgresql84
+
+            configure.args-append   --with-pgsql=${prefix}/lib/postgresql84/bin \
+                                    --with-pdo-pgsql=${prefix}/lib/postgresql84/bin
+        }
+
+        variant postgresql90 conflicts postgresql82 postgresql83 postgresql84 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 9.0 libraries} {
+            depends_lib-append      port:postgresql90
+
+            configure.args-append   --with-pgsql=${prefix}/lib/postgresql90/bin \
+                                    --with-pdo-pgsql=${prefix}/lib/postgresql90/bin
+        }
+
+        variant postgresql91 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 9.1 libraries} {
+            depends_lib-append      port:postgresql91
+
+            configure.args-append   --with-pgsql=${prefix}/lib/postgresql91/bin \
+                                    --with-pdo-pgsql=${prefix}/lib/postgresql91/bin
+        }
+
+        variant postgresql92 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 9.2 libraries} {
+            depends_lib-append      port:postgresql92
+
+            configure.args-append   --with-pgsql=${prefix}/lib/postgresql92/bin \
+                                    --with-pdo-pgsql=${prefix}/lib/postgresql92/bin
+        }
+
+        variant postgresql93 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 9.3 libraries} {
+            depends_lib-append      port:postgresql93
+
+            configure.args-append   --with-pgsql=${prefix}/lib/postgresql93/bin \
+                                    --with-pdo-pgsql=${prefix}/lib/postgresql93/bin
+        }
+
+        variant postgresql94 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 9.4 libraries} {
+            depends_lib-append      port:postgresql94
+
+            configure.args-append   --with-pgsql=${prefix}/lib/postgresql94/bin \
+                                    --with-pdo-pgsql=${prefix}/lib/postgresql94/bin
+        }
+
+        variant postgresql95 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 9.5 libraries} {
+            depends_lib-append      port:postgresql95
+
+            configure.args-append   --with-pgsql=${prefix}/lib/postgresql95/bin \
+                                    --with-pdo-pgsql=${prefix}/lib/postgresql95/bin
+        }
+
+        variant postgresql96 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 9.6 libraries} {
+            depends_lib-append      port:postgresql96
+
+            configure.args-append   --with-pgsql=${prefix}/lib/postgresql96/bin \
+                                    --with-pdo-pgsql=${prefix}/lib/postgresql96/bin
+        }
+
+        variant postgresql10 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql11 postgresql12 description {Use PostgreSQL 10 libraries} {
+            depends_lib-append      port:postgresql10
+
+            configure.args-append   --with-pgsql=${prefix}/lib/postgresql10/bin \
+                                    --with-pdo-pgsql=${prefix}/lib/postgresql10/bin
+        }
+
+        variant postgresql11 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql12 description {Use PostgreSQL 11 libraries} {
+            depends_lib-append      port:postgresql11
+
+            configure.args-append   --with-pgsql=${prefix}/lib/postgresql11/bin \
+                                    --with-pdo-pgsql=${prefix}/lib/postgresql11/bin
+        }
+
+        variant postgresql12 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 description {Use PostgreSQL 12 libraries} {
+            depends_lib-append      port:postgresql12
+
+            configure.args-append   --with-pgsql=${prefix}/lib/postgresql12/bin \
+                                    --with-pdo-pgsql=${prefix}/lib/postgresql12/bin
+        }
+
+        if {![variant_isset postgresql82] && ![variant_isset postgresql83] && ![variant_isset postgresql84] && ![variant_isset postgresql90] && ![variant_isset postgresql91] && ![variant_isset postgresql92] && ![variant_isset postgresql93] && ![variant_isset postgresql94] && ![variant_isset postgresql95] && ![variant_isset postgresql96] && ![variant_isset postgresql10] && ![variant_isset postgresql11] && ![variant_isset postgresql12]} {
+            default_variants +postgresql12
+        }
     }
-
-    php.extensions          pgsql pdo_pgsql
-
-    categories-append       databases
-
-    homepage                https://www.php.net/pgsql
-
-    description             a PHP interface to PostgreSQL, including \
-                            the pgsql and pdo_pgsql extensions
-
-    long_description        ${description}
-
-    variant postgresql82 conflicts postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 8.2 libraries} {
-        depends_lib-append      port:postgresql82
-
-        configure.args-append   --with-pgsql=${prefix}/lib/postgresql82/bin \
-                                --with-pdo-pgsql=${prefix}/lib/postgresql82/bin
-    }
-
-    variant postgresql83 conflicts postgresql82 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 8.3 libraries} {
-        depends_lib-append      port:postgresql83
-
-        configure.args-append   --with-pgsql=${prefix}/lib/postgresql83/bin \
-                                --with-pdo-pgsql=${prefix}/lib/postgresql83/bin
-    }
-
-    variant postgresql84 conflicts postgresql82 postgresql83 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 8.4 libraries} {
-        depends_lib-append      port:postgresql84
-
-        configure.args-append   --with-pgsql=${prefix}/lib/postgresql84/bin \
-                                --with-pdo-pgsql=${prefix}/lib/postgresql84/bin
-    }
-
-    variant postgresql90 conflicts postgresql82 postgresql83 postgresql84 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 9.0 libraries} {
-        depends_lib-append      port:postgresql90
-
-        configure.args-append   --with-pgsql=${prefix}/lib/postgresql90/bin \
-                                --with-pdo-pgsql=${prefix}/lib/postgresql90/bin
-    }
-
-    variant postgresql91 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 9.1 libraries} {
-        depends_lib-append      port:postgresql91
-
-        configure.args-append   --with-pgsql=${prefix}/lib/postgresql91/bin \
-                                --with-pdo-pgsql=${prefix}/lib/postgresql91/bin
-    }
-
-    variant postgresql92 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 9.2 libraries} {
-        depends_lib-append      port:postgresql92
-
-        configure.args-append   --with-pgsql=${prefix}/lib/postgresql92/bin \
-                                --with-pdo-pgsql=${prefix}/lib/postgresql92/bin
-    }
-
-    variant postgresql93 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 9.3 libraries} {
-        depends_lib-append      port:postgresql93
-
-        configure.args-append   --with-pgsql=${prefix}/lib/postgresql93/bin \
-                                --with-pdo-pgsql=${prefix}/lib/postgresql93/bin
-    }
-
-    variant postgresql94 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 9.4 libraries} {
-        depends_lib-append      port:postgresql94
-
-        configure.args-append   --with-pgsql=${prefix}/lib/postgresql94/bin \
-                                --with-pdo-pgsql=${prefix}/lib/postgresql94/bin
-    }
-
-    variant postgresql95 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql96 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 9.5 libraries} {
-        depends_lib-append      port:postgresql95
-
-        configure.args-append   --with-pgsql=${prefix}/lib/postgresql95/bin \
-                                --with-pdo-pgsql=${prefix}/lib/postgresql95/bin
-    }
-
-    variant postgresql96 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql10 postgresql11 postgresql12 description {Use PostgreSQL 9.6 libraries} {
-        depends_lib-append      port:postgresql96
-
-        configure.args-append   --with-pgsql=${prefix}/lib/postgresql96/bin \
-                                --with-pdo-pgsql=${prefix}/lib/postgresql96/bin
-    }
-
-    variant postgresql10 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql11 postgresql12 description {Use PostgreSQL 10 libraries} {
-        depends_lib-append      port:postgresql10
-
-        configure.args-append   --with-pgsql=${prefix}/lib/postgresql10/bin \
-                                --with-pdo-pgsql=${prefix}/lib/postgresql10/bin
-    }
-
-    variant postgresql11 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql12 description {Use PostgreSQL 11 libraries} {
-        depends_lib-append      port:postgresql11
-
-        configure.args-append   --with-pgsql=${prefix}/lib/postgresql11/bin \
-                                --with-pdo-pgsql=${prefix}/lib/postgresql11/bin
-    }
-
-    variant postgresql12 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 description {Use PostgreSQL 12 libraries} {
-        depends_lib-append      port:postgresql12
-
-        configure.args-append   --with-pgsql=${prefix}/lib/postgresql12/bin \
-                                --with-pdo-pgsql=${prefix}/lib/postgresql12/bin
-    }
-
-    if {![variant_isset postgresql82] && ![variant_isset postgresql83] && ![variant_isset postgresql84] && ![variant_isset postgresql90] && ![variant_isset postgresql91] && ![variant_isset postgresql92] && ![variant_isset postgresql93] && ![variant_isset postgresql94] && ![variant_isset postgresql95] && ![variant_isset postgresql96] && ![variant_isset postgresql10] && ![variant_isset postgresql11] && ![variant_isset postgresql12]} {
-        default_variants +postgresql12
-    }
-}
 
 subport ${php}-pspell {
     switch -- ${version} {

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -599,70 +599,70 @@ subport ${php}-cgi {
 ### FPM SAPI ###
 
 if {[vercmp ${branch} 5.3] >= 0} {
-subport ${php}-fpm {
-    switch -- ${version} {
-        5.3.29              {revision 1}
-        5.4.45              {revision 1}
-        5.5.38              {revision 1}
-        5.6.40              {revision 1}
-        7.0.33              {revision 1}
-        7.1.33              {revision 1}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
-    }
+    subport ${php}-fpm {
+        switch -- ${version} {
+            5.3.29              {revision 1}
+            5.4.45              {revision 1}
+            5.5.38              {revision 1}
+            5.6.40              {revision 1}
+            7.0.33              {revision 1}
+            7.1.33              {revision 1}
+            7.2.34              {revision 0}
+            7.3.23              {revision 0}
+            7.4.11              {revision 0}
+        }
 
-    description             ${php} FPM SAPI
+        description             ${php} FPM SAPI
 
-    long_description        ${description}
+        long_description        ${description}
 
-    homepage                https://www.php.net/install.fpm
+        homepage                https://www.php.net/install.fpm
 
-    set fpmuser             nobody
-    set fpmgroup            nobody
+        set fpmuser             nobody
+        set fpmgroup            nobody
 
-    patchfiles-append       patch-${php}-sapi-fpm-php-fpm.conf.in.diff
+        patchfiles-append       patch-${php}-sapi-fpm-php-fpm.conf.in.diff
 
-    post-patch {
-        reinplace "s|@PHP@|${php}|g" ${worksrcpath}/sapi/fpm/php-fpm.conf.in
-    }
+        post-patch {
+            reinplace "s|@PHP@|${php}|g" ${worksrcpath}/sapi/fpm/php-fpm.conf.in
+        }
 
-    configure.args-replace  --disable-fpm --enable-fpm
-    configure.args-append   --datadir=${prefix}/share/examples/${php} \
-                            --sysconfdir=${phpinidir} \
-                            --with-fpm-user=${fpmuser} \
-                            --with-fpm-group=${fpmgroup}
+        configure.args-replace  --disable-fpm --enable-fpm
+        configure.args-append   --datadir=${prefix}/share/examples/${php} \
+                                --sysconfdir=${phpinidir} \
+                                --with-fpm-user=${fpmuser} \
+                                --with-fpm-group=${fpmgroup}
 
-    build.target            fpm
+        build.target            fpm
 
-    destroot.target         install-fpm
+        destroot.target         install-fpm
 
-    destroot.keepdirs       ${destroot}${prefix}/var/log/${php} \
-                            ${destroot}${prefix}/var/run/${php}
+        destroot.keepdirs       ${destroot}${prefix}/var/log/${php} \
+                                ${destroot}${prefix}/var/run/${php}
 
-    post-destroot {
-        xinstall -d -o ${fpmuser} -g ${fpmgroup} ${destroot}${prefix}/var/log/${php} ${destroot}${prefix}/var/run/${php}
-    }
+        post-destroot {
+            xinstall -d -o ${fpmuser} -g ${fpmgroup} ${destroot}${prefix}/var/log/${php} ${destroot}${prefix}/var/run/${php}
+        }
 
-    startupitem.create      yes
-    startupitem.executable  ${prefix}/sbin/php-fpm[php.suffix_from_branch ${branch}]
+        startupitem.create      yes
+        startupitem.executable  ${prefix}/sbin/php-fpm[php.suffix_from_branch ${branch}]
 
-    if {![file exists ${phpinidir}/php-fpm.conf]} {
-        notes-append "
+        if {![file exists ${phpinidir}/php-fpm.conf]} {
+            notes-append "
 
 To use ${subport}, copy\
 ${phpinidir}/php-fpm.conf.default to\
 ${phpinidir}/php-fpm.conf and make changes if desired.
-"
-    } else {
-        notes-append "
+            "
+        } else {
+            notes-append "
 
 You may need to update your php-fpm.conf for any changes that have been made\
 in this version of ${subport}. Compare ${phpinidir}/php-fpm.conf with\
 ${phpinidir}/php-fpm.conf.default.
-"
+            "
+        }
     }
-}
 }
 
 ### Bundled extensions ###
@@ -752,48 +752,48 @@ subport ${php}-dba {
 }
 
 if {[vercmp ${branch} 5.3] >= 0} {
-subport ${php}-enchant {
-    switch -- ${version} {
-        5.3.29              {revision 0}
-        5.4.45              {revision 0}
-        5.5.38              {revision 0}
-        5.6.40              {revision 0}
-        7.0.33              {revision 0}
-        7.1.33              {revision 0}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
-    }
+    subport ${php}-enchant {
+        switch -- ${version} {
+            5.3.29              {revision 0}
+            5.4.45              {revision 0}
+            5.5.38              {revision 0}
+            5.6.40              {revision 0}
+            7.0.33              {revision 0}
+            7.1.33              {revision 0}
+            7.2.34              {revision 0}
+            7.3.23              {revision 0}
+            7.4.11              {revision 0}
+        }
 
-    categories-append       textproc devel
+        categories-append       textproc devel
 
-    description             a PHP interface to enchant
+        description             a PHP interface to enchant
 
-    long_description        ${name} is ${description}, a common API for many spell libraries.
+        long_description        ${name} is ${description}, a common API for many spell libraries.
 
-    depends_lib-append      port:enchant
+        depends_lib-append      port:enchant
 
-    if {[vercmp ${branch} 7.4] < 0} {
-        configure.args-append   --with-enchant=${prefix}
-    } else {
-        depends_build-append    port:pkgconfig
+        if {[vercmp ${branch} 7.4] < 0} {
+            configure.args-append   --with-enchant=${prefix}
+        } else {
+            depends_build-append    port:pkgconfig
 
-        configure.args-append   --with-enchant
-    }
+            configure.args-append   --with-enchant
+        }
 
-    post-destroot {
-        set docdir ${prefix}/share/doc/${subport}
-        xinstall -d ${destroot}${docdir}
-        xinstall -m 644 -W ${destroot.dir} CREDITS ${destroot}${docdir}
+        post-destroot {
+            set docdir ${prefix}/share/doc/${subport}
+            xinstall -d ${destroot}${docdir}
+            xinstall -m 644 -W ${destroot.dir} CREDITS ${destroot}${docdir}
 
-        if {[vercmp ${branch} 7.3] < 0} {
-        set examplesdir ${prefix}/share/examples/${subport}
-        xinstall -d ${destroot}${examplesdir}
-        xinstall -m 644 ${destroot.dir}/docs/examples/example1.php \
-            ${destroot}${examplesdir}
+            if {[vercmp ${branch} 7.3] < 0} {
+            set examplesdir ${prefix}/share/examples/${subport}
+            xinstall -d ${destroot}${examplesdir}
+            xinstall -m 644 ${destroot.dir}/docs/examples/example1.php \
+                ${destroot}${examplesdir}
+            }
         }
     }
-}
 }
 
 subport ${php}-exif {
@@ -907,10 +907,10 @@ subport ${php}-gd {
     }
 
     if {[vercmp ${branch} 7.0] < 0} {
-    variant t1lib description {Add PostScript Type 1 font support with t1lib} {
-        depends_lib-append      port:t1lib
-        configure.args-append   --with-t1lib=${prefix}
-    }
+        variant t1lib description {Add PostScript Type 1 font support with t1lib} {
+            depends_lib-append      port:t1lib
+            configure.args-append   --with-t1lib=${prefix}
+        }
     }
 }
 
@@ -1035,46 +1035,46 @@ subport ${php}-imap {
 }
 
 if {[vercmp ${branch} 5.3] >= 0} {
-subport ${php}-intl {
-    switch -- ${version} {
-        5.3.29              {revision 5}
-        5.4.45              {revision 3}
-        5.5.38              {revision 3}
-        5.6.40              {revision 2}
-        7.0.33              {revision 2}
-        7.1.33              {revision 1}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
-    }
+    subport ${php}-intl {
+        switch -- ${version} {
+            5.3.29              {revision 5}
+            5.4.45              {revision 3}
+            5.5.38              {revision 3}
+            5.6.40              {revision 2}
+            7.0.33              {revision 2}
+            7.1.33              {revision 1}
+            7.2.34              {revision 0}
+            7.3.23              {revision 0}
+            7.4.11              {revision 0}
+        }
 
-    categories-append       devel
+        categories-append       devel
 
-    description             internationalization extension for PHP
+        description             internationalization extension for PHP
 
-    long_description        Internationalization extension implements ICU \
-                            library functionality in PHP.
+        long_description        Internationalization extension implements ICU \
+                                library functionality in PHP.
 
-    depends_build-append    port:pkgconfig
+        depends_build-append    port:pkgconfig
 
-    depends_lib-append      port:icu
+        depends_lib-append      port:icu
 
-    if {[vercmp ${branch} 7.1] < 0} {
-        patchfiles-append   patch-${php}-ext-intl-config.m4.diff
-    }
+        if {[vercmp ${branch} 7.1] < 0} {
+            patchfiles-append   patch-${php}-ext-intl-config.m4.diff
+        }
 
-    # required for ICU
-    compiler.cxx_standard   2011
+        # required for ICU
+        compiler.cxx_standard   2011
 
-    platform darwin 11 {
-        if {[vercmp ${branch} 7.1] >= 0 && [vercmp ${branch} 7.4] < 0} {
-            # Need to investigate how this was fixed for php 7.4 and
-            # possibly backport the fix.
-            # https://bugs.php.net/bug.php?id=76826
-            known_fail          yes
+        platform darwin 11 {
+            if {[vercmp ${branch} 7.1] >= 0 && [vercmp ${branch} 7.4] < 0} {
+                # Need to investigate how this was fixed for php 7.4 and
+                # possibly backport the fix.
+                # https://bugs.php.net/bug.php?id=76826
+                known_fail          yes
+            }
         }
     }
-}
 }
 
 subport ${php}-ipc {
@@ -1164,60 +1164,60 @@ subport ${php}-mbstring {
 }
 
 if {[vercmp ${branch} 7.2] < 0} {
-# mcrypt was evicted from PHP core in version 7.2; php72-mcrypt and later
-# subports are found in the separate php-mcrypt Portfile.
-subport ${php}-mcrypt {
-    switch -- ${version} {
-        5.2.17              {revision 0}
-        5.3.29              {revision 0}
-        5.4.45              {revision 0}
-        5.5.38              {revision 0}
-        5.6.40              {revision 0}
-        7.0.33              {revision 0}
-        7.1.33              {revision 0}
+    # mcrypt was evicted from PHP core in version 7.2; php72-mcrypt and later
+    # subports are found in the separate php-mcrypt Portfile.
+    subport ${php}-mcrypt {
+        switch -- ${version} {
+            5.2.17              {revision 0}
+            5.3.29              {revision 0}
+            5.4.45              {revision 0}
+            5.5.38              {revision 0}
+            5.6.40              {revision 0}
+            7.0.33              {revision 0}
+            7.1.33              {revision 0}
+        }
+
+        categories-append       security
+
+        description             a PHP interface to the mcrypt library, which offers \
+                                a wide variety of algorithms
+
+        long_description        ${description}
+
+        depends_lib-append      port:libmcrypt
+
+        # The mcrypt extension may be using libtool unnecessarily; monitor
+        # https://bugs.php.net/bug.php?id=54500
+        depends_lib-append      port:libtool
+
+        configure.args-append   --with-mcrypt=${prefix}
     }
-
-    categories-append       security
-
-    description             a PHP interface to the mcrypt library, which offers \
-                            a wide variety of algorithms
-
-    long_description        ${description}
-
-    depends_lib-append      port:libmcrypt
-
-    # The mcrypt extension may be using libtool unnecessarily; monitor
-    # https://bugs.php.net/bug.php?id=54500
-    depends_lib-append      port:libtool
-
-    configure.args-append   --with-mcrypt=${prefix}
-}
 }
 
 if {[vercmp ${branch} 7] < 0} {
-subport ${php}-mssql {
-    switch -- ${version} {
-        5.2.17              {revision 0}
-        5.3.29              {revision 0}
-        5.4.45              {revision 0}
-        5.5.38              {revision 0}
-        5.6.40              {revision 0}
+    subport ${php}-mssql {
+        switch -- ${version} {
+            5.2.17              {revision 0}
+            5.3.29              {revision 0}
+            5.4.45              {revision 0}
+            5.5.38              {revision 0}
+            5.6.40              {revision 0}
+        }
+
+        php.extensions          mssql pdo_dblib
+
+        categories-append       databases
+
+        description             a PHP interface to MSSQL using FreeTDS, including \
+                                the mssql and pdo_dblib extensions
+
+        long_description        ${description}
+
+        depends_lib-append      port:freetds
+
+        configure.args-append   --with-mssql=${prefix} \
+                                --with-pdo-dblib=${prefix}
     }
-
-    php.extensions          mssql pdo_dblib
-
-    categories-append       databases
-
-    description             a PHP interface to MSSQL using FreeTDS, including \
-                            the mssql and pdo_dblib extensions
-
-    long_description        ${description}
-
-    depends_lib-append      port:freetds
-
-    configure.args-append   --with-mssql=${prefix} \
-                            --with-pdo-dblib=${prefix}
-}
 }
 
 subport ${php}-mysql {
@@ -1254,15 +1254,16 @@ subport ${php}-mysql {
     configure.args-append   --with-zlib-dir=${prefix}
 
     if {[vercmp ${branch} 5.3] >= 0} {
-    variant mysqlnd conflicts mysql4 mysql5 mysql51 mysql55 mysql56 mariadb percona description {Use MySQL Native Driver} {
-        configure.args-append   --with-mysql=mysqlnd \
-                                --with-mysqli=mysqlnd \
-                                --with-pdo-mysql=mysqlnd
+        variant mysqlnd conflicts mysql4 mysql5 mysql51 mysql55 mysql56 mariadb percona \
+                        description {Use MySQL Native Driver} {
+            configure.args-append   --with-mysql=mysqlnd \
+                                    --with-mysqli=mysqlnd \
+                                    --with-pdo-mysql=mysqlnd
 
-        configure.cppflags-append   -I${worksrcpath}
+            configure.cppflags-append   -I${worksrcpath}
 
-        set phpini ${prefix}/etc/${php}/php.ini
-        notes "
+            set phpini ${prefix}/etc/${php}/php.ini
+            notes "
 To use mysqlnd with a local MySQL server, edit ${phpini} and set\
 mysql.default_socket, mysqli.default_socket and pdo_mysql.default_socket\
 to the path to your MySQL server's socket file.
@@ -1273,8 +1274,8 @@ For mysql55, use ${prefix}/var/run/mysql55/mysqld.sock
 For mysql56, use ${prefix}/var/run/mysql56/mysqld.sock
 For mariadb, use ${prefix}/var/run/mariadb/mysqld.sock
 For percona, use ${prefix}/var/run/percona/mysqld.sock
-"
-    }
+            "
+        }
     }
 
     variant mysql4 conflicts mysqlnd mysql5 mysql51 mysql55 mysql56 mariadb percona description {Use MySQL 4 libraries} {
@@ -1851,80 +1852,80 @@ subport ${php}-sockets {
 }
 
 if {[vercmp ${branch} 7.2] >= 0} {
-subport ${php}-sodium {
-    switch -- ${version} {
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
+    subport ${php}-sodium {
+        switch -- ${version} {
+            7.2.34              {revision 0}
+            7.3.23              {revision 0}
+            7.4.11              {revision 0}
+        }
+
+        php.extensions          sodium
+
+        categories-append       security
+
+        description             a PHP interface to libsodium, a modern and \
+                                easy-to-use crypto library
+
+        long_description        ${description}
+
+        depends_lib-append      port:libsodium
+
+        if {[vercmp ${branch} 7.4] < 0} {
+            configure.args-append   --with-sodium=${prefix}
+        } else {
+            depends_build-append    port:pkgconfig
+
+            configure.args-append   --with-sodium
+        }
     }
-
-    php.extensions          sodium
-
-    categories-append       security
-
-    description             a PHP interface to libsodium, a modern and \
-                            easy-to-use crypto library
-
-    long_description        ${description}
-
-    depends_lib-append      port:libsodium
-
-    if {[vercmp ${branch} 7.4] < 0} {
-        configure.args-append   --with-sodium=${prefix}
-    } else {
-        depends_build-append    port:pkgconfig
-
-        configure.args-append   --with-sodium
-    }
-}
 }
 
 if {[vercmp ${branch} 5.3] >= 0} {
-subport ${php}-sqlite {
-    switch -- ${version} {
-        5.3.29              {revision 0}
-        5.4.45              {revision 0}
-        5.5.38              {revision 0}
-        5.6.40              {revision 0}
-        7.0.33              {revision 0}
-        7.1.33              {revision 0}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
+    subport ${php}-sqlite {
+        switch -- ${version} {
+            5.3.29              {revision 0}
+            5.4.45              {revision 0}
+            5.5.38              {revision 0}
+            5.6.40              {revision 0}
+            7.0.33              {revision 0}
+            7.1.33              {revision 0}
+            7.2.34              {revision 0}
+            7.3.23              {revision 0}
+            7.4.11              {revision 0}
+        }
+
+        php.extensions          sqlite sqlite3 pdo_sqlite
+
+        categories-append       databases
+
+        description             a PHP interface to SQLite, including the sqlite, sqlite3 \
+                                and pdo_sqlite extensions
+
+        if {[vercmp ${branch} 5.4] >= 0} {
+            php.extensions-delete sqlite
+            description-delete "sqlite,"
+        }
+
+        long_description        ${description}
+
+        depends_lib-append      port:sqlite3
+
+        post-extract {
+            move ${worksrcpath}/ext/sqlite3/config0.m4 ${worksrcpath}/ext/sqlite3/config.m4
+        }
+
+        configure.args-append   --enable-sqlite-utf8
+
+        if {[vercmp ${branch} 7.4] < 0} {
+            configure.args-append   --with-sqlite3=${prefix} \
+                                    --with-pdo-sqlite=${prefix}
+        } else {
+            depends_build-append    port:pkgconfig
+
+            configure.args-append   --with-sqlite3 \
+                                    --with-pdo-sqlite
+        }
     }
-
-    php.extensions          sqlite sqlite3 pdo_sqlite
-
-    categories-append       databases
-
-    description             a PHP interface to SQLite, including the sqlite, sqlite3 \
-                            and pdo_sqlite extensions
-
-    if {[vercmp ${branch} 5.4] >= 0} {
-        php.extensions-delete sqlite
-        description-delete "sqlite,"
-    }
-
-    long_description        ${description}
-
-    depends_lib-append      port:sqlite3
-
-    post-extract {
-        move ${worksrcpath}/ext/sqlite3/config0.m4 ${worksrcpath}/ext/sqlite3/config.m4
-    }
-
-    configure.args-append   --enable-sqlite-utf8
-
-    if {[vercmp ${branch} 7.4] < 0} {
-        configure.args-append   --with-sqlite3=${prefix} \
-                                --with-pdo-sqlite=${prefix}
-    } else {
-        depends_build-append    port:pkgconfig
-
-        configure.args-append   --with-sqlite3 \
-                                --with-pdo-sqlite
-    }
-}
 }
 
 subport ${php}-tidy {
@@ -1958,32 +1959,32 @@ subport ${php}-tidy {
 }
 
 if {[vercmp ${branch} 7.4] < 0} {
-# wddx was evicted from PHP core in version 7.4
-subport ${php}-wddx {
-    switch -- ${version} {
-        5.2.17              {revision 0}
-        5.3.29              {revision 0}
-        5.4.45              {revision 0}
-        5.5.38              {revision 0}
-        5.6.40              {revision 0}
-        7.0.33              {revision 0}
-        7.1.33              {revision 0}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
+    # wddx was evicted from PHP core in version 7.4
+    subport ${php}-wddx {
+        switch -- ${version} {
+            5.2.17              {revision 0}
+            5.3.29              {revision 0}
+            5.4.45              {revision 0}
+            5.5.38              {revision 0}
+            5.6.40              {revision 0}
+            7.0.33              {revision 0}
+            7.1.33              {revision 0}
+            7.2.34              {revision 0}
+            7.3.23              {revision 0}
+        }
+
+        categories-append       textproc
+
+        description             a PHP interface to Web Distributed Data Exchange
+
+        long_description        ${description}
+
+        depends_build-append    port:expat \
+                                port:libxml2
+
+        configure.args-append   --with-libexpat-dir=${prefix} \
+                                --with-libxml-dir=${prefix}
     }
-
-    categories-append       textproc
-
-    description             a PHP interface to Web Distributed Data Exchange
-
-    long_description        ${description}
-
-    depends_build-append    port:expat \
-                            port:libxml2
-
-    configure.args-append   --with-libexpat-dir=${prefix} \
-                            --with-libxml-dir=${prefix}
-}
 }
 
 subport ${php}-xmlrpc {

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -677,91 +677,91 @@ ${phpinidir}/php-fpm.conf.default.
     }
 
 
-### Bundled extensions ###
+    ### Bundled extensions ###
 
-subport ${php}-calendar {
-    switch -- ${version} {
-        5.2.17              {revision 0}
-        5.3.29              {revision 0}
-        5.4.45              {revision 0}
-        5.5.38              {revision 0}
-        5.6.40              {revision 0}
-        7.0.33              {revision 0}
-        7.1.33              {revision 0}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
+    subport ${php}-calendar {
+        switch -- ${version} {
+            5.2.17              {revision 0}
+            5.3.29              {revision 0}
+            5.4.45              {revision 0}
+            5.5.38              {revision 0}
+            5.6.40              {revision 0}
+            7.0.33              {revision 0}
+            7.1.33              {revision 0}
+            7.2.34              {revision 0}
+            7.3.23              {revision 0}
+            7.4.11              {revision 0}
+        }
+
+        description             a PHP extension for converting between different \
+                                calendar formats
+
+        long_description        ${description}
     }
 
-    description             a PHP extension for converting between different \
-                            calendar formats
+    subport ${php}-curl {
+        switch -- ${version} {
+            5.2.17              {revision 0}
+            5.3.29              {revision 0}
+            5.4.45              {revision 0}
+            5.5.38              {revision 0}
+            5.6.40              {revision 0}
+            7.0.33              {revision 0}
+            7.1.33              {revision 0}
+            7.2.34              {revision 0}
+            7.3.23              {revision 0}
+            7.4.11              {revision 0}
+        }
 
-    long_description        ${description}
-}
+        categories-append       net www
 
-subport ${php}-curl {
-    switch -- ${version} {
-        5.2.17              {revision 0}
-        5.3.29              {revision 0}
-        5.4.45              {revision 0}
-        5.5.38              {revision 0}
-        5.6.40              {revision 0}
-        7.0.33              {revision 0}
-        7.1.33              {revision 0}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
+        description             a PHP interface to the curl library, which lets you \
+                                download files from servers with a variety of protocols
+
+        long_description        ${description}
+
+        depends_lib-append      port:curl
+
+        if {[vercmp ${branch} 7.4] < 0} {
+            configure.args-append   --with-curl=${prefix}
+        } else {
+            depends_build-append    port:pkgconfig
+
+            configure.args-append   --with-curl
+        }
     }
 
-    categories-append       net www
+    subport ${php}-dba {
+        switch -- ${version} {
+            5.2.17              {revision 0}
+            5.3.29              {revision 0}
+            5.4.45              {revision 0}
+            5.5.38              {revision 0}
+            5.6.40              {revision 0}
+            7.0.33              {revision 0}
+            7.1.33              {revision 0}
+            7.2.34              {revision 0}
+            7.3.23              {revision 0}
+            7.4.11              {revision 0}
+        }
 
-    description             a PHP interface to the curl library, which lets you \
-                            download files from servers with a variety of protocols
+        categories-append       databases
 
-    long_description        ${description}
+        description             a PHP interface for accessing DBM databases such as \
+                                BerkeleyDB
 
-    depends_lib-append      port:curl
+        long_description        ${description}
 
-    if {[vercmp ${branch} 7.4] < 0} {
-        configure.args-append   --with-curl=${prefix}
-    } else {
-        depends_build-append    port:pkgconfig
+        variant gdbm conflicts qdbm description {Add GDBM support} {
+            depends_lib-append      port:gdbm
+            configure.args-append   --with-gdbm=${prefix}
+        }
 
-        configure.args-append   --with-curl
+        variant qdbm conflicts gdbm description {Add QDBM support} {
+            depends_lib-append      port:qdbm
+            configure.args-append   --with-qdbm=${prefix}
+        }
     }
-}
-
-subport ${php}-dba {
-    switch -- ${version} {
-        5.2.17              {revision 0}
-        5.3.29              {revision 0}
-        5.4.45              {revision 0}
-        5.5.38              {revision 0}
-        5.6.40              {revision 0}
-        7.0.33              {revision 0}
-        7.1.33              {revision 0}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
-    }
-
-    categories-append       databases
-
-    description             a PHP interface for accessing DBM databases such as \
-                            BerkeleyDB
-
-    long_description        ${description}
-
-    variant gdbm conflicts qdbm description {Add GDBM support} {
-        depends_lib-append      port:gdbm
-        configure.args-append   --with-gdbm=${prefix}
-    }
-
-    variant qdbm conflicts gdbm description {Add QDBM support} {
-        depends_lib-append      port:qdbm
-        configure.args-append   --with-qdbm=${prefix}
-    }
-}
 
 if {[vercmp ${branch} 5.3] >= 0} {
     subport ${php}-enchant {

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -181,6 +181,7 @@ set php.oldest_supported_branch 7.2
 # Iterate through branches in reverse order, so that the list of subports in
 # "port info" will show newer versions before older versions.
 set i [llength ${php.branches}]
+
 while {[incr i -1] >= 0} {
 
     set branch              [lindex ${php.branches} ${i}]
@@ -188,15 +189,9 @@ while {[incr i -1] >= 0} {
     set php                 php[php.suffix_from_branch ${branch}]
 
     if {[regexp "^${php}" ${subport}]} {
-
-        if {[vercmp ${major} 5] > 0} {
-            dist_subdir         ${php}
-        } else {
-            dist_subdir         php${major}
-        }
+        dist_subdir [expr {[vercmp ${major} 5] > 0 ? "${php}" : "php${major}"}]
 
         if {[is_sapi_subport]} {
-
             depends_build       port:pkgconfig
 
             if {${subport} ne ${php}} {
@@ -204,9 +199,9 @@ while {[incr i -1] >= 0} {
             }
 
             depends_lib-append  path:bin/gsed:gsed \
+                                port:bzip2 \
                                 port:libiconv \
                                 port:libxml2 \
-                                port:bzip2 \
                                 port:mhash \
                                 port:zlib
 
@@ -446,6 +441,7 @@ in your web server.
             depends_lib-append      port:ncurses port:readline
             configure.args-append   --with-readline=${prefix}
         }
+
         if {![variant_isset readline]} {
             default_variants +libedit
         }
@@ -591,6 +587,7 @@ To enable ${subport}, run:
         homepage                https://www.php.net/install.unix.commandline
 
         configure.args-delete   --disable-cgi
+
         if {[vercmp ${branch} 5.3] >= 0} {
             configure.args-append --enable-cgi
         } else {
@@ -950,7 +947,6 @@ ${phpinidir}/php-fpm.conf.default.
         long_description        ${description}
 
         depends_lib-append      port:gettext
-
         configure.args-append   --with-gettext=${prefix}
     }
 
@@ -1007,7 +1003,6 @@ ${phpinidir}/php-fpm.conf.default.
         long_description        ${description}
 
         depends_lib-append      port:libiconv
-
         configure.args-append   --with-iconv=${prefix}
     }
 
@@ -1065,12 +1060,10 @@ ${phpinidir}/php-fpm.conf.default.
             categories-append       devel
 
             description             internationalization extension for PHP
-
             long_description        Internationalization extension implements ICU \
                                     library functionality in PHP.
 
             depends_build-append    port:pkgconfig
-
             depends_lib-append      port:icu
 
             if {[vercmp ${branch} 7.1] < 0} {
@@ -1129,7 +1122,6 @@ ${phpinidir}/php-fpm.conf.default.
         categories-append       databases
 
         description             a PHP interface to LDAP
-
         long_description        ${subport} is ${description}, the Lightweight Directory \
                                 Access Protocol, which is used to access Directory \
                                 Servers.
@@ -1171,7 +1163,6 @@ ${phpinidir}/php-fpm.conf.default.
 
         if {[vercmp ${branch} 7.4] >= 0} {
             depends_build-append    port:pkgconfig
-
             depends_lib-append      port:oniguruma6
         }
     }
@@ -1263,7 +1254,6 @@ ${phpinidir}/php-fpm.conf.default.
         long_description        ${description}
 
         depends_lib-append      port:zlib
-
         configure.args-append   --with-zlib-dir=${prefix}
 
         if {[vercmp ${branch} 5.3] >= 0} {
@@ -1430,26 +1420,26 @@ For percona, use ${prefix}/var/run/percona/mysqld.sock
         long_description        ${description}
 
         if {[vercmp ${branch} 5.3] >= 0} {
-        variant iodbc conflicts unixodbc description {Use iODBC} {
-            depends_lib-append      port:libiodbc
+            variant iodbc conflicts unixodbc description {Use iODBC} {
+                depends_lib-append      port:libiodbc
 
-            patchfiles-append       patch-${php}-iODBC.diff
+                patchfiles-append       patch-${php}-iODBC.diff
 
-            configure.args-append   --with-pdo-odbc=iODBC,${prefix}
-            if {[vercmp ${branch} 7.4] < 0} {
-                configure.args-append   --with-iODBC=${prefix}
-            } else {
-                depends_build-append    port:pkgconfig
+                configure.args-append   --with-pdo-odbc=iODBC,${prefix}
+                if {[vercmp ${branch} 7.4] < 0} {
+                    configure.args-append   --with-iODBC=${prefix}
+                } else {
+                    depends_build-append    port:pkgconfig
 
-                configure.args-append   --with-iODBC
+                    configure.args-append   --with-iODBC
+                }
             }
-        }
 
-        variant unixodbc conflicts iodbc description {Use unixODBC} {}
+            variant unixodbc conflicts iodbc description {Use unixODBC} {}
 
-        if {![variant_isset iodbc] && ![variant_isset unixodbc]} {
-            default_variants +unixodbc
-        }
+            if {![variant_isset iodbc] && ![variant_isset unixodbc]} {
+                default_variants +unixodbc
+            }
         }
 
         if {[variant_isset unixodbc] || [vercmp ${branch} 5.3] < 0} {
@@ -1591,9 +1581,8 @@ For percona, use ${prefix}/var/run/percona/mysqld.sock
         set lib_dir             ${prefix}/lib/oracle
         pre-configure {
             regexp {\.dylib\.(.+)$} [glob -directory ${lib_dir} libclntsh.dylib.*] -> library_version
-            configure.args-append \
-                                --with-oci8=instantclient,${lib_dir} \
-                                --with-pdo-oci=instantclient,${lib_dir},${library_version}
+            configure.args-append   --with-oci8=instantclient,${lib_dir} \
+                                    --with-pdo-oci=instantclient,${lib_dir},${library_version}
         }
     }
 
@@ -1643,10 +1632,9 @@ used within a web server environment.
         categories-append       sysutils
 
         description             a PHP interface to additional POSIX functions
-
         long_description        a PHP interface to those functions defined in the \
                                 IEEE 1003.1 (POSIX.1) standards document which are \
-                                not accessible through other means
+                                not accessible through other means.
     }
 
     subport ${php}-postgresql {
@@ -1778,7 +1766,6 @@ used within a web server environment.
         long_description        ${description}
 
         depends_lib-append      port:aspell
-
         configure.args-append   --with-pspell=${prefix}
     }
 
@@ -1804,7 +1791,6 @@ used within a web server environment.
         long_description        ${description}
 
         depends_lib-append      port:net-snmp
-
         configure.args-append   --with-snmp=${prefix}
     }
 

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -163,7 +163,7 @@ switch ${subport_branch} {
         #
         # php-8.0.0: release is set to Nov 26, 2020
         epoch           0
-        version         8.0.0beta3
+        version         8.0.0rc1
         homepage        https://qa.php.net/
         master_sites    https://downloads.php.net/~carusogabriel/
         use_xz          yes
@@ -219,10 +219,12 @@ while {[incr i -1] >= 0} {
                 patchfiles-append \
                                 patch-${php}-bison-re2c-version.diff
             }
+
             if {[vercmp ${branch} 5.3] <= 0} {
                 patchfiles-append \
                                 patch-${php}-configure.diff
             }
+
             if {[vercmp ${branch} 5.2] <= 0} {
                 patchfiles-append \
                                 patch-${php}-libxml-2.9.diff \
@@ -523,8 +525,7 @@ ${phpinidir}/php.ini-recommended.
         }
 
         description             ${php} Apache 2 Handler SAPI
-
-        long_description        ${description}
+        long_description        {*}${description}.
 
         homepage                https://www.php.net/install.unix.apache2
 
@@ -581,8 +582,7 @@ To enable ${subport}, run:
         }
 
         description             ${php} CGI SAPI
-
-        long_description        ${description}
+        long_description        {*}${description}.
 
         homepage                https://www.php.net/install.unix.commandline
 
@@ -624,8 +624,7 @@ To enable ${subport}, run:
             }
 
             description             ${php} FPM SAPI
-
-            long_description        ${description}
+            long_description        {*}${description}.
 
             homepage                https://www.php.net/install.fpm
 
@@ -694,8 +693,7 @@ ${phpinidir}/php-fpm.conf.default.
 
         description             a PHP extension for converting between different \
                                 calendar formats
-
-        long_description        ${description}
+        long_description        {*}${description}.
     }
 
     subport ${php}-curl {
@@ -716,8 +714,7 @@ ${phpinidir}/php-fpm.conf.default.
 
         description             a PHP interface to the curl library, which lets you \
                                 download files from servers with a variety of protocols
-
-        long_description        ${description}
+        long_description        {*}${description}.
 
         depends_lib-append      port:curl
 
@@ -748,8 +745,7 @@ ${phpinidir}/php-fpm.conf.default.
 
         description             a PHP interface for accessing DBM databases such as \
                                 BerkeleyDB
-
-        long_description        ${description}
+        long_description        {*}${description}.
 
         variant gdbm conflicts qdbm description {Add GDBM support} {
             depends_lib-append      port:gdbm
@@ -779,7 +775,7 @@ ${phpinidir}/php-fpm.conf.default.
             categories-append       textproc devel
 
             description             a PHP interface to enchant
-            long_description        ${name} is ${description}, a common API for many \
+            long_description        ${name} is {*}${description}, a common API for many \
                                     spell libraries.
 
             depends_lib-append      port:enchant
@@ -824,8 +820,7 @@ ${phpinidir}/php-fpm.conf.default.
         categories-append       graphics
 
         description             a PHP interface to the EXIF image metadata functions
-
-        long_description        ${description}
+        long_description        {*}${description}.
     }
 
     subport ${php}-ftp {
@@ -846,8 +841,7 @@ ${phpinidir}/php-fpm.conf.default.
 
         description             a PHP extension for accessing file servers using the \
                                 File Transfer Protocol
-
-        long_description        ${description}
+        long_description        {*}${description}.
 
         depends_lib-append      path:lib/libssl.dylib:openssl
 
@@ -880,8 +874,7 @@ ${phpinidir}/php-fpm.conf.default.
         categories-append       graphics
 
         description             a PHP interface to the gd library
-
-        long_description        ${description}
+        long_description        {*}${description}.
 
         depends_lib-append      port:freetype \
                                 port:jpeg \
@@ -943,8 +936,7 @@ ${phpinidir}/php-fpm.conf.default.
 
         description             a PHP interface to the gettext natural language \
                                 support functions
-
-        long_description        ${description}
+        long_description        {*}${description}.
 
         depends_lib-append      port:gettext
         configure.args-append   --with-gettext=${prefix}
@@ -969,8 +961,7 @@ ${phpinidir}/php-fpm.conf.default.
         description             a PHP interface to GMP, the GNU multiprocessing \
                                 library through which you can work with \
                                 arbitrary-length integers
-
-        long_description        ${description}
+        long_description        {*}${description}.
 
         depends_lib-append      port:gmp
 
@@ -999,8 +990,7 @@ ${phpinidir}/php-fpm.conf.default.
 
         description             a PHP interface to the libiconv character encoding \
                                 conversion functions
-
-        long_description        ${description}
+        long_description        {*}${description}.
 
         depends_lib-append      port:libiconv
         configure.args-append   --with-iconv=${prefix}
@@ -1023,8 +1013,7 @@ ${phpinidir}/php-fpm.conf.default.
         categories-append       mail
 
         description             a PHP interface to the IMAP protocol
-
-        long_description        ${description}
+        long_description        {*}${description}.
 
         depends_build-append    port:cclient
 
@@ -1122,7 +1111,7 @@ ${phpinidir}/php-fpm.conf.default.
         categories-append       databases
 
         description             a PHP interface to LDAP
-        long_description        ${subport} is ${description}, the Lightweight Directory \
+        long_description        ${subport} is {*}${description}, the Lightweight Directory \
                                 Access Protocol, which is used to access Directory \
                                 Servers.
 
@@ -1158,8 +1147,7 @@ ${phpinidir}/php-fpm.conf.default.
 
         description             a PHP extension for manipulating strings in multibyte \
                                 encodings
-
-        long_description        ${description}
+        long_description        {*}${description}.
 
         if {[vercmp ${branch} 7.4] >= 0} {
             depends_build-append    port:pkgconfig
@@ -1185,8 +1173,7 @@ ${phpinidir}/php-fpm.conf.default.
 
             description             a PHP interface to the mcrypt library, which offers \
                                     a wide variety of algorithms
-
-            long_description        ${description}
+            long_description        {*}${description}.
 
             depends_lib-append      port:libmcrypt
 
@@ -1214,8 +1201,7 @@ ${phpinidir}/php-fpm.conf.default.
 
             description             a PHP interface to MSSQL using FreeTDS, including \
                                     the mssql and pdo_dblib extensions
-
-            long_description        ${description}
+            long_description        {*}${description}.
 
             depends_lib-append      port:freetds
 
@@ -1246,12 +1232,13 @@ ${phpinidir}/php-fpm.conf.default.
         categories-append       databases
 
         description             a PHP interface to MySQL databases, including the
+
         if {[vercmp ${branch} 7] < 0} {
             description-append  mysql,
         }
-        description-append      mysqli and pdo_mysql extensions
 
-        long_description        ${description}
+        description-append      mysqli and pdo_mysql extensions
+        long_description        {*}${description}.
 
         depends_lib-append      port:zlib
         configure.args-append   --with-zlib-dir=${prefix}
@@ -1416,8 +1403,7 @@ For percona, use ${prefix}/var/run/percona/mysqld.sock
 
         description             a PHP interface for accessing databases via Open \
                                 DataBase Connectivity (ODBC)
-
-        long_description        ${description}
+        long_description        {*}${description}.
 
         if {[vercmp ${branch} 5.3] >= 0} {
             variant iodbc conflicts unixodbc description {Use iODBC} {
@@ -1472,11 +1458,10 @@ For percona, use ${prefix}/var/run/percona/mysqld.sock
 
             php.extensions.zend opcache
 
-            description         OPcache improves PHP performance by storing precompiled \
-                                script bytecode in shared memory, thereby removing the \
-                                need for PHP to load and parse scripts on each request.
-
-            long_description    ${description}
+            description             OPcache improves PHP performance by storing precompiled \
+                                    script bytecode in shared memory, thereby removing the \
+                                    need for PHP to load and parse scripts on each request.
+            long_description        {*}${description}.
 
             configure.args-append   --enable-opcache
 
@@ -1514,8 +1499,7 @@ For percona, use ${prefix}/var/run/percona/mysqld.sock
         description             a PHP interface to OpenSSL signature-generation \
                                 and -verification and data-encryption and \
                                 -decryption functions
-
-        long_description        ${description}
+        long_description        {*}${description}.
 
         depends_lib-append      port:kerberos5 \
                                 port:libcomerr \
@@ -1569,8 +1553,7 @@ For percona, use ${prefix}/var/run/percona/mysqld.sock
 
         description             a PHP interface to Oracle, including the oci8 and \
                                 pdo_oci extensions
-
-        long_description        ${description}
+        long_description        {*}${description}.
 
         depends_lib-append      port:oracle-instantclient
 
@@ -1605,8 +1588,7 @@ For percona, use ${prefix}/var/run/percona/mysqld.sock
         description             a PHP interface to Unix-style process creation, \
                                 program execution, signal handling and process \
                                 termination functions
-
-        long_description        ${description}
+        long_description        {*}${description}.
 
         notes "
 ${subport} should not be enabled within a web server environment.\
@@ -1659,6 +1641,7 @@ used within a web server environment.
 
         description             a PHP interface to PostgreSQL, including \
                                 the pgsql and pdo_pgsql extensions
+        long_description        {*}${description}.
 
         variant postgresql82    conflicts postgresql83 postgresql84 postgresql90 postgresql91 \
                                 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 \
@@ -1762,8 +1745,7 @@ used within a web server environment.
 
         description             a PHP interface to the aspell library, which lets you \
                                 check spelling and offer spelling suggestions
-
-        long_description        ${description}
+        long_description        {*}${description}.
 
         depends_lib-append      port:aspell
         configure.args-append   --with-pspell=${prefix}
@@ -1787,8 +1769,7 @@ used within a web server environment.
 
         description             a PHP interface to the Simple Network Management \
                                 Protocol (SNMP)
-
-        long_description        ${description}
+        long_description        {*}${description}.
 
         depends_lib-append      port:net-snmp
         configure.args-append   --with-snmp=${prefix}
@@ -1811,8 +1792,7 @@ used within a web server environment.
         categories-append       net
 
         description             a PHP extension for writing SOAP clients and servers
-
-        long_description        ${description}
+        long_description        {*}${description}.
 
         depends_lib-append      port:libxml2
 
@@ -1841,8 +1821,7 @@ used within a web server environment.
 
         description             a PHP interface to BSD socket communication \
                                 functions
-
-        long_description        ${description}
+        long_description        {*}${description}.
     }
 
     if {[vercmp ${branch} 7.2] >= 0} {
@@ -1859,8 +1838,7 @@ used within a web server environment.
 
             description             a PHP interface to libsodium, a modern and \
                                     easy-to-use crypto library
-
-            long_description        ${description}
+            long_description        {*}${description}.
 
             depends_lib-append      port:libsodium
 
@@ -1894,13 +1872,12 @@ used within a web server environment.
 
             description             a PHP interface to SQLite, including the sqlite, sqlite3 \
                                     and pdo_sqlite extensions
+            long_description        {*}${description}.
 
             if {[vercmp ${branch} 5.4] >= 0} {
                 php.extensions-delete sqlite
                 description-delete "sqlite,"
             }
-
-            long_description        ${description}
 
             depends_lib-append      port:sqlite3
 
@@ -1940,8 +1917,7 @@ used within a web server environment.
 
         description             a PHP interface to tidy, the HTML cleaning and \
                                 repair utility
-
-        long_description        ${description}
+        long_description        {*}${description}.
 
         depends_lib-append      port:tidy
 
@@ -1970,8 +1946,7 @@ used within a web server environment.
             categories-append       textproc
 
             description             a PHP interface to Web Distributed Data Exchange
-
-            long_description        ${description}
+            long_description        {*}${description}.
 
             depends_build-append    port:expat \
                                     port:libxml2
@@ -1998,8 +1973,7 @@ used within a web server environment.
         categories-append       textproc
 
         description             a PHP extension for writing XML-RPC clients and servers
-
-        long_description        ${description}
+        long_description        {*}${description}.
 
         depends_build-append    port:libiconv \
                                 port:libxml2
@@ -2040,8 +2014,7 @@ used within a web server environment.
 
         description             a PHP interface to libxslt, which implements the XSL \
                                 standard and lets you perform XSL transformations
-
-        long_description        ${description}
+        long_description        {*}${description}.
 
         depends_lib-append      port:libxslt
 

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -763,50 +763,50 @@ ${phpinidir}/php-fpm.conf.default.
         }
     }
 
-if {[vercmp ${branch} 5.3] >= 0} {
-    subport ${php}-enchant {
-        switch -- ${version} {
-            5.3.29              {revision 0}
-            5.4.45              {revision 0}
-            5.5.38              {revision 0}
-            5.6.40              {revision 0}
-            7.0.33              {revision 0}
-            7.1.33              {revision 0}
-            7.2.34              {revision 0}
-            7.3.23              {revision 0}
-            7.4.11              {revision 0}
-        }
+    if {[vercmp ${branch} 5.3] >= 0} {
+        subport ${php}-enchant {
+            switch -- ${version} {
+                5.3.29              {revision 0}
+                5.4.45              {revision 0}
+                5.5.38              {revision 0}
+                5.6.40              {revision 0}
+                7.0.33              {revision 0}
+                7.1.33              {revision 0}
+                7.2.34              {revision 0}
+                7.3.23              {revision 0}
+                7.4.11              {revision 0}
+            }
 
-        categories-append       textproc devel
+            categories-append       textproc devel
 
-        description             a PHP interface to enchant
+            description             a PHP interface to enchant
 
-        long_description        ${name} is ${description}, a common API for many spell libraries.
+            long_description        ${name} is ${description}, a common API for many spell libraries.
 
-        depends_lib-append      port:enchant
+            depends_lib-append      port:enchant
 
-        if {[vercmp ${branch} 7.4] < 0} {
-            configure.args-append   --with-enchant=${prefix}
-        } else {
-            depends_build-append    port:pkgconfig
+            if {[vercmp ${branch} 7.4] < 0} {
+                configure.args-append   --with-enchant=${prefix}
+            } else {
+                depends_build-append    port:pkgconfig
 
-            configure.args-append   --with-enchant
-        }
+                configure.args-append   --with-enchant
+            }
 
-        post-destroot {
-            set docdir ${prefix}/share/doc/${subport}
-            xinstall -d ${destroot}${docdir}
-            xinstall -m 644 -W ${destroot.dir} CREDITS ${destroot}${docdir}
+            post-destroot {
+                set docdir ${prefix}/share/doc/${subport}
+                xinstall -d ${destroot}${docdir}
+                xinstall -m 644 -W ${destroot.dir} CREDITS ${destroot}${docdir}
 
-            if {[vercmp ${branch} 7.3] < 0} {
-            set examplesdir ${prefix}/share/examples/${subport}
-            xinstall -d ${destroot}${examplesdir}
-            xinstall -m 644 ${destroot.dir}/docs/examples/example1.php \
-                ${destroot}${examplesdir}
+                if {[vercmp ${branch} 7.3] < 0} {
+                set examplesdir ${prefix}/share/examples/${subport}
+                xinstall -d ${destroot}${examplesdir}
+                xinstall -m 644 ${destroot.dir}/docs/examples/example1.php \
+                    ${destroot}${examplesdir}
+                }
             }
         }
     }
-}
 
 subport ${php}-exif {
     switch -- ${version} {

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -505,65 +505,66 @@ ${phpinidir}/php.ini-recommended.
         }
     }
 
-### Apache 2 handler SAPI ###
 
-subport ${php}-apache2handler {
-    PortGroup               active_variants 1.1
+    ### Apache 2 handler SAPI ###
 
-    switch -- ${version} {
-        5.2.17              {revision 3}
-        5.3.29              {revision 3}
-        5.4.45              {revision 3}
-        5.5.38              {revision 3}
-        5.6.40              {revision 1}
-        7.0.33              {revision 1}
-        7.1.33              {revision 1}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
-    }
+    subport ${php}-apache2handler {
+        PortGroup               active_variants 1.1
 
-    description             ${php} Apache 2 Handler SAPI
+        switch -- ${version} {
+            5.2.17              {revision 3}
+            5.3.29              {revision 3}
+            5.4.45              {revision 3}
+            5.5.38              {revision 3}
+            5.6.40              {revision 1}
+            7.0.33              {revision 1}
+            7.1.33              {revision 1}
+            7.2.34              {revision 0}
+            7.3.23              {revision 0}
+            7.4.11              {revision 0}
+        }
 
-    long_description        ${description}
+        description             ${php} Apache 2 Handler SAPI
 
-    homepage                https://www.php.net/install.unix.apache2
+        long_description        ${description}
 
-    depends_lib-append      port:apache2
+        homepage                https://www.php.net/install.unix.apache2
 
-    require_active_variants apache2 preforkmpm
+        depends_lib-append      port:apache2
 
-    set apxs ${prefix}/bin/apxs
-    set confdir ${prefix}/etc/apache2
-    set moduledir ${prefix}/lib/apache2/modules
+        require_active_variants apache2 preforkmpm
 
-    configure.args-append   --with-apxs2=${apxs}
+        set apxs ${prefix}/bin/apxs
+        set confdir ${prefix}/etc/apache2
+        set moduledir ${prefix}/lib/apache2/modules
 
-    build.target            libs/libphp${major}.bundle
+        configure.args-append   --with-apxs2=${apxs}
 
-    if {[vercmp ${branch} 5.3] < 0} {
-        # PHP earlier than 5.3 is not compatible with Apache 2.4 or later, and
-        # earlier versions of Apache were removed from MacPorts. Might be able
-        # to backport Apache 2.4 support, perhaps using a patch from this bug
-        # report: https://bugs.php.net/bug.php?id=62267
-        known_fail          yes
-    }
+        build.target            libs/libphp${major}.bundle
 
-    destroot {
-        xinstall -m 755 -d ${destroot}${moduledir} ${destroot}${confdir}/extra
-        xinstall -m 644 ${worksrcpath}/libs/libphp${major}.so ${destroot}${moduledir}/mod_${php}.so
-        xinstall -m 644 ${filespath}/mod_php.conf.in ${destroot}${confdir}/extra/mod_${php}.conf
-        reinplace s/@MAJOR@/${major}/g ${destroot}${confdir}/extra/mod_${php}.conf
-    }
+        if {[vercmp ${branch} 5.3] < 0} {
+            # PHP earlier than 5.3 is not compatible with Apache 2.4 or later, and
+            # earlier versions of Apache were removed from MacPorts. Might be able
+            # to backport Apache 2.4 support, perhaps using a patch from this bug
+            # report: https://bugs.php.net/bug.php?id=62267
+            known_fail          yes
+        }
 
-    notes-append "
+        destroot {
+            xinstall -m 755 -d ${destroot}${moduledir} ${destroot}${confdir}/extra
+            xinstall -m 644 ${worksrcpath}/libs/libphp${major}.so ${destroot}${moduledir}/mod_${php}.so
+            xinstall -m 644 ${filespath}/mod_php.conf.in ${destroot}${confdir}/extra/mod_${php}.conf
+            reinplace s/@MAJOR@/${major}/g ${destroot}${confdir}/extra/mod_${php}.conf
+        }
 
+        notes-append "
 To enable ${subport}, run:
 
     cd ${moduledir}
     sudo ${apxs} -a -e -n php${major} mod_${php}.so
-"
-}
+        "
+    }
+
 
 ### CGI SAPI ###
 

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -1232,50 +1232,50 @@ ${phpinidir}/php-fpm.conf.default.
         }
     }
 
-subport ${php}-mysql {
-    switch -- ${version} {
-        5.2.17              {revision 0}
-        5.3.29              {revision 0}
-        5.4.45              {revision 0}
-        5.5.38              {revision 0}
-        5.6.40              {revision 0}
-        7.0.33              {revision 0}
-        7.1.33              {revision 0}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
-    }
+    subport ${php}-mysql {
+        switch -- ${version} {
+            5.2.17              {revision 0}
+            5.3.29              {revision 0}
+            5.4.45              {revision 0}
+            5.5.38              {revision 0}
+            5.6.40              {revision 0}
+            7.0.33              {revision 0}
+            7.1.33              {revision 0}
+            7.2.34              {revision 0}
+            7.3.23              {revision 0}
+            7.4.11              {revision 0}
+        }
 
-    php.extensions          mysqli pdo_mysql
-    if {[vercmp ${branch} 7] < 0} {
-        php.extensions-prepend mysql
-    }
+        php.extensions          mysqli pdo_mysql
+        if {[vercmp ${branch} 7] < 0} {
+            php.extensions-prepend mysql
+        }
 
-    categories-append       databases
+        categories-append       databases
 
-    description             a PHP interface to MySQL databases, including the
-    if {[vercmp ${branch} 7] < 0} {
-        description-append  mysql,
-    }
-    description-append      mysqli and pdo_mysql extensions
+        description             a PHP interface to MySQL databases, including the
+        if {[vercmp ${branch} 7] < 0} {
+            description-append  mysql,
+        }
+        description-append      mysqli and pdo_mysql extensions
 
-    long_description        ${description}
+        long_description        ${description}
 
-    depends_lib-append      port:zlib
+        depends_lib-append      port:zlib
 
-    configure.args-append   --with-zlib-dir=${prefix}
+        configure.args-append   --with-zlib-dir=${prefix}
 
-    if {[vercmp ${branch} 5.3] >= 0} {
-        variant mysqlnd conflicts mysql4 mysql5 mysql51 mysql55 mysql56 mariadb percona \
-                        description {Use MySQL Native Driver} {
-            configure.args-append   --with-mysql=mysqlnd \
-                                    --with-mysqli=mysqlnd \
-                                    --with-pdo-mysql=mysqlnd
+        if {[vercmp ${branch} 5.3] >= 0} {
+            variant mysqlnd conflicts mysql4 mysql5 mysql51 mysql55 mysql56 mariadb percona \
+                            description {Use MySQL Native Driver} {
+                configure.args-append   --with-mysql=mysqlnd \
+                                        --with-mysqli=mysqlnd \
+                                        --with-pdo-mysql=mysqlnd
 
-            configure.cppflags-append   -I${worksrcpath}
+                configure.cppflags-append   -I${worksrcpath}
 
-            set phpini ${prefix}/etc/${php}/php.ini
-            notes "
+                set phpini ${prefix}/etc/${php}/php.ini
+                notes "
 To use mysqlnd with a local MySQL server, edit ${phpini} and set\
 mysql.default_socket, mysqli.default_socket and pdo_mysql.default_socket\
 to the path to your MySQL server's socket file.
@@ -1286,115 +1286,115 @@ For mysql55, use ${prefix}/var/run/mysql55/mysqld.sock
 For mysql56, use ${prefix}/var/run/mysql56/mysqld.sock
 For mariadb, use ${prefix}/var/run/mariadb/mysqld.sock
 For percona, use ${prefix}/var/run/percona/mysqld.sock
-            "
-        }
-    }
-
-    variant mysql4 conflicts mysqlnd mysql5 mysql51 mysql55 mysql56 mariadb percona description {Use MySQL 4 libraries} {
-        depends_lib-append      port:mysql4
-
-        configure.args-append   --with-mysql=${prefix} \
-                                --with-pdo-mysql=${prefix}
-    }
-
-    variant mysql5 conflicts mysqlnd mysql4 mysql51 mysql55 mysql56 mariadb percona description {Use MySQL 5 libraries} {
-        depends_lib-append      path:bin/mysql_config5:mysql5
-
-        post-extract {
-            file mkdir ${workpath}/mysql5
-            file link -symbolic ${workpath}/mysql5/lib ${prefix}/lib/mysql5
-            file link -symbolic ${workpath}/mysql5/include ${prefix}/include/mysql5
+                "
+            }
         }
 
-        configure.args-append   --with-mysql=${workpath}/mysql5 \
-                                --with-mysqli=${prefix}/bin/mysql_config5 \
-                                --with-pdo-mysql=${prefix}/bin/mysql_config5 \
-                                --with-mysql-sock=${prefix}/var/run/mysql5/mysqld.sock
-    }
+        variant mysql4 conflicts mysqlnd mysql5 mysql51 mysql55 mysql56 mariadb percona description {Use MySQL 4 libraries} {
+            depends_lib-append      port:mysql4
 
-    variant mysql51 conflicts mysqlnd mysql4 mysql5 mysql55 mysql56 mariadb percona description {Use MySQL 5.1 libraries} {
-        depends_lib-append      port:mysql51
-
-        post-extract {
-            file mkdir ${workpath}/mysql51
-            file link -symbolic ${workpath}/mysql51/lib ${prefix}/lib/mysql51
-            file link -symbolic ${workpath}/mysql51/include ${prefix}/include/mysql51
+            configure.args-append   --with-mysql=${prefix} \
+                                    --with-pdo-mysql=${prefix}
         }
 
-        configure.args-append   --with-mysql=${workpath}/mysql51 \
-                                --with-mysqli=${prefix}/lib/mysql51/bin/mysql_config \
-                                --with-pdo-mysql=${prefix}/lib/mysql51/bin/mysql_config \
-                                --with-mysql-sock=${prefix}/var/run/mysql51/mysqld.sock
-    }
+        variant mysql5 conflicts mysqlnd mysql4 mysql51 mysql55 mysql56 mariadb percona description {Use MySQL 5 libraries} {
+            depends_lib-append      path:bin/mysql_config5:mysql5
 
-    variant mysql55 conflicts mysqlnd mysql4 mysql5 mysql51 mysql56 mariadb percona description {Use MySQL 5.5 libraries} {
-        depends_lib-append      port:mysql55
+            post-extract {
+                file mkdir ${workpath}/mysql5
+                file link -symbolic ${workpath}/mysql5/lib ${prefix}/lib/mysql5
+                file link -symbolic ${workpath}/mysql5/include ${prefix}/include/mysql5
+            }
 
-        post-extract {
-            file mkdir ${workpath}/mysql55
-            file link -symbolic ${workpath}/mysql55/lib ${prefix}/lib/mysql55
-            file link -symbolic ${workpath}/mysql55/include ${prefix}/include/mysql55
+            configure.args-append   --with-mysql=${workpath}/mysql5 \
+                                    --with-mysqli=${prefix}/bin/mysql_config5 \
+                                    --with-pdo-mysql=${prefix}/bin/mysql_config5 \
+                                    --with-mysql-sock=${prefix}/var/run/mysql5/mysqld.sock
         }
 
-        configure.args-append   --with-mysql=${workpath}/mysql55 \
-                                --with-mysqli=${prefix}/lib/mysql55/bin/mysql_config \
-                                --with-pdo-mysql=${prefix}/lib/mysql55/bin/mysql_config \
-                                --with-mysql-sock=${prefix}/var/run/mysql55/mysqld.sock
-    }
+        variant mysql51 conflicts mysqlnd mysql4 mysql5 mysql55 mysql56 mariadb percona description {Use MySQL 5.1 libraries} {
+            depends_lib-append      port:mysql51
 
-    variant mysql56 conflicts mysqlnd mysql4 mysql5 mysql51 mysql55 mariadb percona description {Use MySQL 5.6 libraries} {
-        depends_lib-append      port:mysql56
+            post-extract {
+                file mkdir ${workpath}/mysql51
+                file link -symbolic ${workpath}/mysql51/lib ${prefix}/lib/mysql51
+                file link -symbolic ${workpath}/mysql51/include ${prefix}/include/mysql51
+            }
 
-        post-extract {
-            file mkdir ${workpath}/mysql56
-            file link -symbolic ${workpath}/mysql56/lib ${prefix}/lib/mysql56
-            file link -symbolic ${workpath}/mysql56/include ${prefix}/include/mysql56
+            configure.args-append   --with-mysql=${workpath}/mysql51 \
+                                    --with-mysqli=${prefix}/lib/mysql51/bin/mysql_config \
+                                    --with-pdo-mysql=${prefix}/lib/mysql51/bin/mysql_config \
+                                    --with-mysql-sock=${prefix}/var/run/mysql51/mysqld.sock
         }
 
-        configure.args-append   --with-mysql=${workpath}/mysql56 \
-                                --with-mysqli=${prefix}/lib/mysql56/bin/mysql_config \
-                                --with-pdo-mysql=${prefix}/lib/mysql56/bin/mysql_config \
-                                --with-mysql-sock=${prefix}/var/run/mysql56/mysqld.sock
-    }
+        variant mysql55 conflicts mysqlnd mysql4 mysql5 mysql51 mysql56 mariadb percona description {Use MySQL 5.5 libraries} {
+            depends_lib-append      port:mysql55
 
-    variant mariadb conflicts mysqlnd mysql4 mysql5 mysql51 mysql55 mysql56 percona description {Use MariaDB libraries} {
-        depends_lib-append      port:mariadb
+            post-extract {
+                file mkdir ${workpath}/mysql55
+                file link -symbolic ${workpath}/mysql55/lib ${prefix}/lib/mysql55
+                file link -symbolic ${workpath}/mysql55/include ${prefix}/include/mysql55
+            }
 
-        post-extract {
-            file mkdir ${workpath}/mariadb
-            file link -symbolic ${workpath}/mariadb/lib ${prefix}/lib/mariadb
-            file link -symbolic ${workpath}/mariadb/include ${prefix}/include/mariadb
+            configure.args-append   --with-mysql=${workpath}/mysql55 \
+                                    --with-mysqli=${prefix}/lib/mysql55/bin/mysql_config \
+                                    --with-pdo-mysql=${prefix}/lib/mysql55/bin/mysql_config \
+                                    --with-mysql-sock=${prefix}/var/run/mysql55/mysqld.sock
         }
 
-        configure.args-append   --with-mysql=${workpath}/mariadb \
-                                --with-mysqli=${prefix}/lib/mariadb/bin/mysql_config \
-                                --with-pdo-mysql=${prefix}/lib/mariadb/bin/mysql_config \
-                                --with-mysql-sock=${prefix}/var/run/mariadb/mysqld.sock
-    }
+        variant mysql56 conflicts mysqlnd mysql4 mysql5 mysql51 mysql55 mariadb percona description {Use MySQL 5.6 libraries} {
+            depends_lib-append      port:mysql56
 
-    variant percona conflicts mysqlnd mysql4 mysql5 mysql51 mysql55 mysql56 mariadb description {Use Percona libraries} {
-        depends_lib-append      port:percona
+            post-extract {
+                file mkdir ${workpath}/mysql56
+                file link -symbolic ${workpath}/mysql56/lib ${prefix}/lib/mysql56
+                file link -symbolic ${workpath}/mysql56/include ${prefix}/include/mysql56
+            }
 
-        post-extract {
-            file mkdir ${workpath}/percona
-            file link -symbolic ${workpath}/percona/lib ${prefix}/lib/percona
-            file link -symbolic ${workpath}/percona/include ${prefix}/include/percona
+            configure.args-append   --with-mysql=${workpath}/mysql56 \
+                                    --with-mysqli=${prefix}/lib/mysql56/bin/mysql_config \
+                                    --with-pdo-mysql=${prefix}/lib/mysql56/bin/mysql_config \
+                                    --with-mysql-sock=${prefix}/var/run/mysql56/mysqld.sock
         }
 
-        configure.args-append   --with-mysql=${workpath}/percona \
-                                --with-mysqli=${prefix}/lib/percona/bin/mysql_config \
-                                --with-pdo-mysql=${prefix}/lib/percona/bin/mysql_config \
-                                --with-mysql-sock=${prefix}/var/run/percona/mysqld.sock
-    }
+        variant mariadb conflicts mysqlnd mysql4 mysql5 mysql51 mysql55 mysql56 percona description {Use MariaDB libraries} {
+            depends_lib-append      port:mariadb
 
-    if {![variant_isset mysql4] && ![variant_isset mysql5] && ![variant_isset mysql51] && ![variant_isset mysql55] && ![variant_isset mysql56] && ![variant_isset mariadb] && ![variant_isset percona]} {
-        if {[vercmp ${branch} 5.3] >= 0} {
-            default_variants +mysqlnd
-        } else {
-            default_variants +mariadb
+            post-extract {
+                file mkdir ${workpath}/mariadb
+                file link -symbolic ${workpath}/mariadb/lib ${prefix}/lib/mariadb
+                file link -symbolic ${workpath}/mariadb/include ${prefix}/include/mariadb
+            }
+
+            configure.args-append   --with-mysql=${workpath}/mariadb \
+                                    --with-mysqli=${prefix}/lib/mariadb/bin/mysql_config \
+                                    --with-pdo-mysql=${prefix}/lib/mariadb/bin/mysql_config \
+                                    --with-mysql-sock=${prefix}/var/run/mariadb/mysqld.sock
+        }
+
+        variant percona conflicts mysqlnd mysql4 mysql5 mysql51 mysql55 mysql56 mariadb description {Use Percona libraries} {
+            depends_lib-append      port:percona
+
+            post-extract {
+                file mkdir ${workpath}/percona
+                file link -symbolic ${workpath}/percona/lib ${prefix}/lib/percona
+                file link -symbolic ${workpath}/percona/include ${prefix}/include/percona
+            }
+
+            configure.args-append   --with-mysql=${workpath}/percona \
+                                    --with-mysqli=${prefix}/lib/percona/bin/mysql_config \
+                                    --with-pdo-mysql=${prefix}/lib/percona/bin/mysql_config \
+                                    --with-mysql-sock=${prefix}/var/run/percona/mysqld.sock
+        }
+
+        if {![variant_isset mysql4] && ![variant_isset mysql5] && ![variant_isset mysql51] && ![variant_isset mysql55] && ![variant_isset mysql56] && ![variant_isset mariadb] && ![variant_isset percona]} {
+            if {[vercmp ${branch} 5.3] >= 0} {
+                default_variants +mysqlnd
+            } else {
+                default_variants +mariadb
+            }
         }
     }
-}
 
 subport ${php}-odbc {
     switch -- ${version} {

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -1009,85 +1009,85 @@ ${phpinidir}/php-fpm.conf.default.
         configure.args-append   --with-iconv=${prefix}
     }
 
-subport ${php}-imap {
-    switch -- ${version} {
-        5.2.17              {revision 0}
-        5.3.29              {revision 0}
-        5.4.45              {revision 0}
-        5.5.38              {revision 0}
-        5.6.40              {revision 0}
-        7.0.33              {revision 0}
-        7.1.33              {revision 0}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
-    }
-
-    categories-append       mail
-
-    description             a PHP interface to the IMAP protocol
-
-    long_description        ${description}
-
-    depends_build-append    port:cclient
-
-    depends_lib-append      port:kerberos5 \
-                            port:libcomerr
-
-    configure.args-append   --with-imap=${prefix} \
-                            --with-imap-ssl=${prefix} \
-                            --with-kerberos=${prefix}
-
-    if {[vercmp ${branch} 7.4] >= 0} {
-        depends_build-append    port:pkgconfig
-
-        # https://bugs.php.net/bug.php?id=79112
-        configure.env-append    PHP_OPENSSL=yes
-    }
-}
-
-if {[vercmp ${branch} 5.3] >= 0} {
-    subport ${php}-intl {
+    subport ${php}-imap {
         switch -- ${version} {
-            5.3.29              {revision 5}
-            5.4.45              {revision 3}
-            5.5.38              {revision 3}
-            5.6.40              {revision 2}
-            7.0.33              {revision 2}
-            7.1.33              {revision 1}
+            5.2.17              {revision 0}
+            5.3.29              {revision 0}
+            5.4.45              {revision 0}
+            5.5.38              {revision 0}
+            5.6.40              {revision 0}
+            7.0.33              {revision 0}
+            7.1.33              {revision 0}
             7.2.34              {revision 0}
             7.3.23              {revision 0}
             7.4.11              {revision 0}
         }
 
-        categories-append       devel
+        categories-append       mail
 
-        description             internationalization extension for PHP
+        description             a PHP interface to the IMAP protocol
 
-        long_description        Internationalization extension implements ICU \
-                                library functionality in PHP.
+        long_description        ${description}
 
-        depends_build-append    port:pkgconfig
+        depends_build-append    port:cclient
 
-        depends_lib-append      port:icu
+        depends_lib-append      port:kerberos5 \
+                                port:libcomerr
 
-        if {[vercmp ${branch} 7.1] < 0} {
-            patchfiles-append   patch-${php}-ext-intl-config.m4.diff
+        configure.args-append   --with-imap=${prefix} \
+                                --with-imap-ssl=${prefix} \
+                                --with-kerberos=${prefix}
+
+        if {[vercmp ${branch} 7.4] >= 0} {
+            depends_build-append    port:pkgconfig
+
+            # https://bugs.php.net/bug.php?id=79112
+            configure.env-append    PHP_OPENSSL=yes
         }
+    }
 
-        # required for ICU
-        compiler.cxx_standard   2011
+    if {[vercmp ${branch} 5.3] >= 0} {
+        subport ${php}-intl {
+            switch -- ${version} {
+                5.3.29              {revision 5}
+                5.4.45              {revision 3}
+                5.5.38              {revision 3}
+                5.6.40              {revision 2}
+                7.0.33              {revision 2}
+                7.1.33              {revision 1}
+                7.2.34              {revision 0}
+                7.3.23              {revision 0}
+                7.4.11              {revision 0}
+            }
 
-        platform darwin 11 {
-            if {[vercmp ${branch} 7.1] >= 0 && [vercmp ${branch} 7.4] < 0} {
-                # Need to investigate how this was fixed for php 7.4 and
-                # possibly backport the fix.
-                # https://bugs.php.net/bug.php?id=76826
-                known_fail          yes
+            categories-append       devel
+
+            description             internationalization extension for PHP
+
+            long_description        Internationalization extension implements ICU \
+                                    library functionality in PHP.
+
+            depends_build-append    port:pkgconfig
+
+            depends_lib-append      port:icu
+
+            if {[vercmp ${branch} 7.1] < 0} {
+                patchfiles-append   patch-${php}-ext-intl-config.m4.diff
+            }
+
+            # required for ICU
+            compiler.cxx_standard   2011
+
+            platform darwin 11 {
+                if {[vercmp ${branch} 7.1] >= 0 && [vercmp ${branch} 7.4] < 0} {
+                    # Need to investigate how this was fixed for php 7.4 and
+                    # possibly backport the fix.
+                    # https://bugs.php.net/bug.php?id=76826
+                    known_fail          yes
+                }
             }
         }
     }
-}
 
 subport ${php}-ipc {
     switch -- ${version} {

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -566,114 +566,116 @@ To enable ${subport}, run:
     }
 
 
-### CGI SAPI ###
+    ### CGI SAPI ###
 
-subport ${php}-cgi {
-    switch -- ${version} {
-        5.2.17              {revision 0}
-        5.3.29              {revision 0}
-        5.4.45              {revision 0}
-        5.5.38              {revision 0}
-        5.6.40              {revision 0}
-        7.0.33              {revision 0}
-        7.1.33              {revision 0}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
-    }
-
-    description             ${php} CGI SAPI
-
-    long_description        ${description}
-
-    homepage                https://www.php.net/install.unix.commandline
-
-    configure.args-delete   --disable-cgi
-    if {[vercmp ${branch} 5.3] >= 0} {
-        configure.args-append --enable-cgi
-    } else {
-        configure.args-append --enable-fastcgi --enable-force-cgi-redirect
-    }
-
-    if {[vercmp ${branch} 5.4] >= 0} {
-        build.target        cgi
-        destroot.target     install-cgi
-    } else {
-        destroot {
-            xinstall ${worksrcpath}/sapi/cgi/php-cgi ${destroot}${prefix}/bin/php-cgi[php.suffix_from_branch ${branch}]
-        }
-    }
-
-}
-
-### FPM SAPI ###
-
-if {[vercmp ${branch} 5.3] >= 0} {
-    subport ${php}-fpm {
+    subport ${php}-cgi {
         switch -- ${version} {
-            5.3.29              {revision 1}
-            5.4.45              {revision 1}
-            5.5.38              {revision 1}
-            5.6.40              {revision 1}
-            7.0.33              {revision 1}
-            7.1.33              {revision 1}
+            5.2.17              {revision 0}
+            5.3.29              {revision 0}
+            5.4.45              {revision 0}
+            5.5.38              {revision 0}
+            5.6.40              {revision 0}
+            7.0.33              {revision 0}
+            7.1.33              {revision 0}
             7.2.34              {revision 0}
             7.3.23              {revision 0}
             7.4.11              {revision 0}
         }
 
-        description             ${php} FPM SAPI
+        description             ${php} CGI SAPI
 
         long_description        ${description}
 
-        homepage                https://www.php.net/install.fpm
+        homepage                https://www.php.net/install.unix.commandline
 
-        set fpmuser             nobody
-        set fpmgroup            nobody
-
-        patchfiles-append       patch-${php}-sapi-fpm-php-fpm.conf.in.diff
-
-        post-patch {
-            reinplace "s|@PHP@|${php}|g" ${worksrcpath}/sapi/fpm/php-fpm.conf.in
+        configure.args-delete   --disable-cgi
+        if {[vercmp ${branch} 5.3] >= 0} {
+            configure.args-append --enable-cgi
+        } else {
+            configure.args-append --enable-fastcgi --enable-force-cgi-redirect
         }
 
-        configure.args-replace  --disable-fpm --enable-fpm
-        configure.args-append   --datadir=${prefix}/share/examples/${php} \
-                                --sysconfdir=${phpinidir} \
-                                --with-fpm-user=${fpmuser} \
-                                --with-fpm-group=${fpmgroup}
-
-        build.target            fpm
-
-        destroot.target         install-fpm
-
-        destroot.keepdirs       ${destroot}${prefix}/var/log/${php} \
-                                ${destroot}${prefix}/var/run/${php}
-
-        post-destroot {
-            xinstall -d -o ${fpmuser} -g ${fpmgroup} ${destroot}${prefix}/var/log/${php} ${destroot}${prefix}/var/run/${php}
+        if {[vercmp ${branch} 5.4] >= 0} {
+            build.target        cgi
+            destroot.target     install-cgi
+        } else {
+            destroot {
+                xinstall ${worksrcpath}/sapi/cgi/php-cgi \
+                    ${destroot}${prefix}/bin/php-cgi[php.suffix_from_branch ${branch}]
+            }
         }
 
-        startupitem.create      yes
-        startupitem.executable  ${prefix}/sbin/php-fpm[php.suffix_from_branch ${branch}]
+    }
 
-        if {![file exists ${phpinidir}/php-fpm.conf]} {
-            notes-append "
 
+    ### FPM SAPI ###
+
+    if {[vercmp ${branch} 5.3] >= 0} {
+        subport ${php}-fpm {
+            switch -- ${version} {
+                5.3.29              {revision 1}
+                5.4.45              {revision 1}
+                5.5.38              {revision 1}
+                5.6.40              {revision 1}
+                7.0.33              {revision 1}
+                7.1.33              {revision 1}
+                7.2.34              {revision 0}
+                7.3.23              {revision 0}
+                7.4.11              {revision 0}
+            }
+
+            description             ${php} FPM SAPI
+
+            long_description        ${description}
+
+            homepage                https://www.php.net/install.fpm
+
+            set fpmuser             nobody
+            set fpmgroup            nobody
+
+            patchfiles-append       patch-${php}-sapi-fpm-php-fpm.conf.in.diff
+
+            post-patch {
+                reinplace "s|@PHP@|${php}|g" ${worksrcpath}/sapi/fpm/php-fpm.conf.in
+            }
+
+            configure.args-replace  --disable-fpm --enable-fpm
+            configure.args-append   --datadir=${prefix}/share/examples/${php} \
+                                    --sysconfdir=${phpinidir} \
+                                    --with-fpm-user=${fpmuser} \
+                                    --with-fpm-group=${fpmgroup}
+
+            build.target            fpm
+
+            destroot.target         install-fpm
+
+            destroot.keepdirs       ${destroot}${prefix}/var/log/${php} \
+                                    ${destroot}${prefix}/var/run/${php}
+
+            post-destroot {
+                xinstall -d -o ${fpmuser} -g ${fpmgroup} \
+                    ${destroot}${prefix}/var/log/${php} ${destroot}${prefix}/var/run/${php}
+            }
+
+            startupitem.create      yes
+            startupitem.executable  ${prefix}/sbin/php-fpm[php.suffix_from_branch ${branch}]
+
+            if {![file exists ${phpinidir}/php-fpm.conf]} {
+                notes-append "
 To use ${subport}, copy\
 ${phpinidir}/php-fpm.conf.default to\
 ${phpinidir}/php-fpm.conf and make changes if desired.
-            "
-        } else {
-            notes-append "
-
+                "
+            } else {
+                notes-append "
 You may need to update your php-fpm.conf for any changes that have been made\
 in this version of ${subport}. Compare ${phpinidir}/php-fpm.conf with\
 ${phpinidir}/php-fpm.conf.default.
-            "
+                "
+            }
         }
     }
-}
+
 
 ### Bundled extensions ###
 

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -1863,40 +1863,88 @@ a web server environment.
         long_description        ${description}
     }
 
-if {[vercmp ${branch} 7.2] >= 0} {
-    subport ${php}-sodium {
-        switch -- ${version} {
-            7.2.34              {revision 0}
-            7.3.23              {revision 0}
-            7.4.11              {revision 0}
-        }
+    if {[vercmp ${branch} 7.2] >= 0} {
+        subport ${php}-sodium {
+            switch -- ${version} {
+                7.2.34              {revision 0}
+                7.3.23              {revision 0}
+                7.4.11              {revision 0}
+            }
 
-        php.extensions          sodium
+            php.extensions          sodium
 
-        categories-append       security
+            categories-append       security
 
-        description             a PHP interface to libsodium, a modern and \
-                                easy-to-use crypto library
+            description             a PHP interface to libsodium, a modern and \
+                                    easy-to-use crypto library
 
-        long_description        ${description}
+            long_description        ${description}
 
-        depends_lib-append      port:libsodium
+            depends_lib-append      port:libsodium
 
-        if {[vercmp ${branch} 7.4] < 0} {
-            configure.args-append   --with-sodium=${prefix}
-        } else {
-            depends_build-append    port:pkgconfig
+            if {[vercmp ${branch} 7.4] < 0} {
+                configure.args-append   --with-sodium=${prefix}
+            } else {
+                depends_build-append    port:pkgconfig
 
-            configure.args-append   --with-sodium
+                configure.args-append   --with-sodium
+            }
         }
     }
-}
 
-if {[vercmp ${branch} 5.3] >= 0} {
-    subport ${php}-sqlite {
+    if {[vercmp ${branch} 5.3] >= 0} {
+        subport ${php}-sqlite {
+            switch -- ${version} {
+                5.3.29              {revision 0}
+                5.4.45              {revision 0}
+                5.5.38              {revision 0}
+                5.6.40              {revision 0}
+                7.0.33              {revision 0}
+                7.1.33              {revision 0}
+                7.2.34              {revision 0}
+                7.3.23              {revision 0}
+                7.4.11              {revision 0}
+            }
+
+            php.extensions          sqlite sqlite3 pdo_sqlite
+
+            categories-append       databases
+
+            description             a PHP interface to SQLite, including the sqlite, sqlite3 \
+                                    and pdo_sqlite extensions
+
+            if {[vercmp ${branch} 5.4] >= 0} {
+                php.extensions-delete sqlite
+                description-delete "sqlite,"
+            }
+
+            long_description        ${description}
+
+            depends_lib-append      port:sqlite3
+
+            post-extract {
+                move ${worksrcpath}/ext/sqlite3/config0.m4 ${worksrcpath}/ext/sqlite3/config.m4
+            }
+
+            configure.args-append   --enable-sqlite-utf8
+
+            if {[vercmp ${branch} 7.4] < 0} {
+                configure.args-append   --with-sqlite3=${prefix} \
+                                        --with-pdo-sqlite=${prefix}
+            } else {
+                depends_build-append    port:pkgconfig
+
+                configure.args-append   --with-sqlite3 \
+                                        --with-pdo-sqlite
+            }
+        }
+    }
+
+    subport ${php}-tidy {
         switch -- ${version} {
-            5.3.29              {revision 0}
-            5.4.45              {revision 0}
+            5.2.17              {revision 2}
+            5.3.29              {revision 2}
+            5.4.45              {revision 1}
             5.5.38              {revision 0}
             5.6.40              {revision 0}
             7.0.33              {revision 0}
@@ -1906,69 +1954,21 @@ if {[vercmp ${branch} 5.3] >= 0} {
             7.4.11              {revision 0}
         }
 
-        php.extensions          sqlite sqlite3 pdo_sqlite
+        categories-append       www
 
-        categories-append       databases
-
-        description             a PHP interface to SQLite, including the sqlite, sqlite3 \
-                                and pdo_sqlite extensions
-
-        if {[vercmp ${branch} 5.4] >= 0} {
-            php.extensions-delete sqlite
-            description-delete "sqlite,"
-        }
+        description             a PHP interface to tidy, the HTML cleaning and \
+                                repair utility
 
         long_description        ${description}
 
-        depends_lib-append      port:sqlite3
+        depends_lib-append      port:tidy
 
-        post-extract {
-            move ${worksrcpath}/ext/sqlite3/config0.m4 ${worksrcpath}/ext/sqlite3/config.m4
+        if {[vercmp ${branch} 7.0] <= 0} {
+            patchfiles-append   patch-${php}-ext-tidy-tidy.c.diff
         }
 
-        configure.args-append   --enable-sqlite-utf8
-
-        if {[vercmp ${branch} 7.4] < 0} {
-            configure.args-append   --with-sqlite3=${prefix} \
-                                    --with-pdo-sqlite=${prefix}
-        } else {
-            depends_build-append    port:pkgconfig
-
-            configure.args-append   --with-sqlite3 \
-                                    --with-pdo-sqlite
-        }
+        configure.args-append   --with-tidy=${prefix}
     }
-}
-
-subport ${php}-tidy {
-    switch -- ${version} {
-        5.2.17              {revision 2}
-        5.3.29              {revision 2}
-        5.4.45              {revision 1}
-        5.5.38              {revision 0}
-        5.6.40              {revision 0}
-        7.0.33              {revision 0}
-        7.1.33              {revision 0}
-        7.2.34              {revision 0}
-        7.3.23              {revision 0}
-        7.4.11              {revision 0}
-    }
-
-    categories-append       www
-
-    description             a PHP interface to tidy, the HTML cleaning and \
-                            repair utility
-
-    long_description        ${description}
-
-    depends_lib-append      port:tidy
-
-    if {[vercmp ${branch} 7.0] <= 0} {
-        patchfiles-append   patch-${php}-ext-tidy-tidy.c.diff
-    }
-
-    configure.args-append   --with-tidy=${prefix}
-}
 
 if {[vercmp ${branch} 7.4] < 0} {
     # wddx was evicted from PHP core in version 7.4


### PR DESCRIPTION
#### Description

###### commit 1

php: whitespace and cleanup

  - Clean up the whitespace
  - Make sure the intendation is correct throughout
    the file

###### commit 2

php: fix postgresql variants

  - Reformat the variants for better readability
  - Cut long lines to < 100, etc

###### commit 3

php-apache2handler: req mpms_shared_all instead of preforkmpm

  - req mpms_shared_all instead of preforkmpm
  - apache2: add +mpms_shared_all to default_variants

---

When installing the php-apache2handler it requires the preforkmpm to
be installed, which prevents the use of the other variant on the server
due to conflicts. That was what the mpms_shared_all variant was added
for, to be able to use all different mpms on the same apache2 install -
to be able to set up and run different virtualhosts with different mpms
&/or php versions.

So, it's better to require mpms_shared_all, and then add to the notes
they need to run the php-apache2handler in a preforkmpm mode.

###### Type(s)

- [x] enhancement

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install php74-postgresql +postgresql95`?

###### Notes

This is a PR I've wanted to do for some time now. And after the update yesterday I thought it was a good opportunity to do it now when I already had it open. It's quite a lot, but it's also a 2000+ lines file. _(also see the trac ticket)_

First commit is really a mess to look at in the diff, since it's moving part/blocks all around beacause of the change of intendetion. And it looks a lot more than it really is. It's easier to just look at the files side-by-side to follow along. Perhaps using GUI like Meld could be better - to spot the whitespace changes, etc.

2'nd commit I'm really pleased with, and I've made a test install to make sure it worked (`php74-postgresql +postgresql95`).

3'rd one is a small change I personally need to be able to upgrade/change my custom server to MP. It doesn't change anything, just makes it more flexible to use (see commit msg)

Hopefully it'll be a bit easier to both read and manage the file now. 🤞