### PR TITLE
py35-jupyter_console: pin to 6.1.0

### DIFF
--- a/python/py-jupyter_console/Portfile
+++ b/python/py-jupyter_console/Portfile
@@ -37,6 +37,15 @@ if {${name} ne ${subport}} {
         patchfiles-append   patch-setup.py.diff
     }
 
+    if {${python.version} eq 35} {
+        version             6.1.0
+        revision            1
+        distname            ${python.rootname}-${version}
+        checksums           rmd160  5306d349cb34f745d89cf99644c011555625468e \
+                            sha256  6f6ead433b0534909df789ea64f0a14cdf9b6b2360757756f08182be4b9e431b \
+                            size    28468
+    }
+
     depends_lib-append  port:py${python.version}-ipykernel \
                         port:py${python.version}-ipython \
                         port:py${python.version}-jupyter_client \


### PR DESCRIPTION
6.2.0 dropped support for, and will not build on, Python 3.5.

#### Description

Note that an outdated error message is currently shown when trying to install on Python 3.5 which suggests it is supported rather than unsupported. I have opened an upstream PR: jupyter/jupyter_console#229

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
