### PR TITLE
sleuthkit: requires C++14

### DIFF
--- a/sysutils/sleuthkit/Portfile
+++ b/sysutils/sleuthkit/Portfile
@@ -29,6 +29,8 @@ long_description    The Sleuth Kit (previously known as TASK) is a collection \
     disks. With these tools, you can identify where partitions are located and \
     extract them so that they can be analyzed with file system analysis tools.
 
+compiler.cxx_standard 2014
+
 use_autoconf        yes
 autoconf.cmd        ./bootstrap
 


### PR DESCRIPTION
#### Description

[Build failure observed on macOS 10.9 + Xcode 6.2](https://build.macports.org/builders/ports-10.9_x86_64-builder/builds/126532/steps/install-port/logs/stdio) due to unmet C++14 requirement:
```
checking whether /usr/bin/clang++ supports C++14 features with -std=c++14... no
checking whether /usr/bin/clang++ supports C++14 features with +std=c++14... no
checking whether /usr/bin/clang++ supports C++14 features with -h std=c++14... no
checking whether /usr/bin/clang++ supports C++14 features with -std=c++1y... no
checking whether /usr/bin/clang++ supports C++14 features with +std=c++1y... no
checking whether /usr/bin/clang++ supports C++14 features with -h std=c++1y... no
configure: error: *** A compiler with support for C++14 language features is required.
```
<!-- Note: it is best to make pull requests from a branch rather than from master -->



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
