### PR TITLE
go: update to 1.15.2

### DIFF
--- a/lang/go/Portfile
+++ b/lang/go/Portfile
@@ -8,7 +8,7 @@ legacysupport.newest_darwin_requires_legacy 13
 
 name                go
 epoch               2
-version             1.15.1
+version             1.15.2
 categories          lang
 platforms           darwin freebsd linux
 license             BSD
@@ -31,9 +31,9 @@ master_sites        https://storage.googleapis.com/golang/
 distfiles           ${name}${version}.src.tar.gz
 worksrcdir          ${name}
 
-checksums           rmd160  5e258cdbf8ae266669f16aadfc040ddabb903d4c \
-                    sha256  d3743752a421881b5cc007c76b4b68becc3ad053e61275567edab1c99e154d30 \
-                    size    23009031
+checksums           rmd160  b2d84ecbdbbfdc4e345f55c389bb21c3200d1fa2 \
+                    sha256  28bf9d0bcde251011caae230a4a05d917b172ea203f2a62f2c2f9533589d4b4d \
+                    size    23012667
 
 depends_build       port:go-1.4
 


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.7 11E801a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
