### PR TITLE
mtxclient: include missing header

### DIFF
--- a/net/mtxclient/Portfile
+++ b/net/mtxclient/Portfile
@@ -40,3 +40,7 @@ depends_build-append \
 depends_lib-append  port:boost \
                     port:libsodium \
                     port:matrix-structs
+
+# Can be removed if port is updated to 81d497a (2018-09-06)
+# or later (e.g. v0.2.0, 2018-09-21)
+patchfiles-append   patch-include_mtxclient_http_session.hpp.diff

--- a/net/mtxclient/files/patch-include_mtxclient_http_session.hpp.diff
+++ b/net/mtxclient/files/patch-include_mtxclient_http_session.hpp.diff
@@ -1,0 +1,12 @@
+Upstream-Status: Inappropriate [not needed by later releases]
+--- include/mtxclient/http/session.hpp.orig
++++ include/mtxclient/http/session.hpp
+@@ -7,6 +7,8 @@
+ #include "mtxclient/http/errors.hpp"
+ #include "mtxclient/utils.hpp"
+ 
++#include <iostream>
++
+ namespace mtx {
+ namespace http {
+ 


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/59517

#### Description
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Only the patch phase is tested (dependency `matrix-structs` doesn't build on 10.15, which is what I'm using).

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
