### PR TITLE
libffi: fix darwin powerpc build

### DIFF
--- a/devel/libffi/Portfile
+++ b/devel/libffi/Portfile
@@ -25,6 +25,8 @@ checksums           rmd160  2cd43b66d792f1bad76df2e19a8411beacfcb8e0 \
                     sha256  72fba7922703ddfa7a028d513ac15a85c8d54c8d67f55fa5a4802885dc652056 \
                     size    1305466
 
+patchfiles          patch-libffi-darwin-powerpc-no-go-closures.diff
+
 # Don't use macports gcc or clang toolchains to build this due to dependency cycles
 compiler.blacklist-append macports-*
 
@@ -51,5 +53,9 @@ array set merger_host {
 lappend merger_dont_diff \
     ${prefix}/include/ffi.h \
     ${prefix}/include/ffitarget.h
+
+depends_test-append port:expect port:dejagnu
+test.run            yes
+test.target         check
 
 github.livecheck.regex {(\d+(?:\.\d+)+)}

--- a/devel/libffi/files/patch-libffi-darwin-powerpc-no-go-closures.diff
+++ b/devel/libffi/files/patch-libffi-darwin-powerpc-no-go-closures.diff
@@ -1,0 +1,84 @@
+diff --git src/powerpc/ffi_darwin.c src/powerpc/ffi_darwin.c
+index 61a18c4..64bb94d 100644
+--- src/powerpc/ffi_darwin.c
++++ src/powerpc/ffi_darwin.c
+@@ -33,7 +33,10 @@
+ #include <stdlib.h>
+ 
+ extern void ffi_closure_ASM (void);
++
++#if defined (FFI_GO_CLOSURES)
+ extern void ffi_go_closure_ASM (void);
++#endif
+ 
+ enum {
+   /* The assembly depends on these exact flags.  
+@@ -909,8 +912,10 @@ ffi_prep_cif_machdep (ffi_cif *cif)
+ extern void ffi_call_AIX(extended_cif *, long, unsigned, unsigned *,
+ 			 void (*fn)(void), void (*fn2)(void));
+ 
++#if defined (FFI_GO_CLOSURES)
+ extern void ffi_call_go_AIX(extended_cif *, long, unsigned, unsigned *,
+ 			    void (*fn)(void), void (*fn2)(void), void *closure);
++#endif
+ 
+ extern void ffi_call_DARWIN(extended_cif *, long, unsigned, unsigned *,
+ 			    void (*fn)(void), void (*fn2)(void), ffi_type*);
+@@ -950,6 +955,7 @@ ffi_call (ffi_cif *cif, void (*fn)(void), void *rvalue, void **avalue)
+     }
+ }
+ 
++#if defined (FFI_GO_CLOSURES)
+ void
+ ffi_call_go (ffi_cif *cif, void (*fn) (void), void *rvalue, void **avalue,
+ 	     void *closure)
+@@ -981,6 +987,7 @@ ffi_call_go (ffi_cif *cif, void (*fn) (void), void *rvalue, void **avalue,
+       break;
+     }
+ }
++#endif
+ 
+ static void flush_icache(char *);
+ static void flush_range(char *, int);
+@@ -1110,6 +1117,7 @@ ffi_prep_closure_loc (ffi_closure* closure,
+   return FFI_OK;
+ }
+ 
++#if defined (FFI_GO_CLOSURES)
+ ffi_status
+ ffi_prep_go_closure (ffi_go_closure* closure,
+ 		     ffi_cif* cif,
+@@ -1133,6 +1141,7 @@ ffi_prep_go_closure (ffi_go_closure* closure,
+     }
+   return FFI_OK;
+ }
++#endif
+ 
+ static void
+ flush_icache(char *addr)
+@@ -1168,9 +1177,11 @@ ffi_type *
+ ffi_closure_helper_DARWIN (ffi_closure *, void *,
+ 			   unsigned long *, ffi_dblfl *);
+ 
++#if defined (FFI_GO_CLOSURES)
+ ffi_type *
+ ffi_go_closure_helper_DARWIN (ffi_go_closure*, void *,
+ 			      unsigned long *, ffi_dblfl *);
++#endif
+ 
+ /* Basically the trampoline invokes ffi_closure_ASM, and on
+    entry, r11 holds the address of the closure.
+@@ -1430,6 +1441,7 @@ ffi_closure_helper_DARWIN (ffi_closure *closure, void *rvalue,
+ 				    closure->user_data, rvalue, pgr, pfr);
+ }
+ 
++#if defined (FFI_GO_CLOSURES)
+ ffi_type *
+ ffi_go_closure_helper_DARWIN (ffi_go_closure *closure, void *rvalue,
+ 			      unsigned long *pgr, ffi_dblfl *pfr)
+@@ -1437,4 +1449,4 @@ ffi_go_closure_helper_DARWIN (ffi_go_closure *closure, void *rvalue,
+   return ffi_closure_helper_common (closure->cif, closure->fun,
+ 				    closure, rvalue, pgr, pfr);
+ }
+-
++#endif


### PR DESCRIPTION
disable go closures as they are not supported
on darwin powerpc at present

enable tests

closes: https://trac.macports.org/ticket/61153

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.5.8 PowerPC
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->


To actually run the tests presently requires a newer compiler than gcc-4.2 due to some unrecognized warning flags that gcc-4.2 doesn't support. I ran them with gcc7 from MacPorts.

A few tests fail; I doubt upstream has ever run the testsuite on darwin powerpc. 

clearly this should be looked at upstream as well.