### PR TITLE
trivy: new port

### DIFF
--- a/security/trivy/Portfile
+++ b/security/trivy/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/aquasecurity/trivy 0.11.0 v
+
+description         A Simple and Comprehensive Vulnerability Scanner for \
+                    Containers, Suitable for CI
+
+long_description    {*}${description}. Trivy detects vulnerabilities of OS \
+                    packages (Alpine, RHEL, CentOS, etc.) and application \
+                    dependencies (Bundler, Composer, npm, yarn, etc.). Trivy \
+                    is easy to use. Just install the binary and you're ready \
+                    to scan. All you need to do for scanning is to specify a \
+                    target such as an image name of the container.
+
+categories          security sysutils
+license             Apache-2
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  b62fcd70697845ab1712ef7aa13c298fb2a246af \
+                    sha256  db37ca075269f522ec8eedd2e5850044e241cfa08004bf7e236fbf36c7fe1c28 \
+                    size    20613356
+
+build.cmd           make
+build.args          VERSION=${version}
+build.target        build
+
+installs_libs       no
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
New port for the [trivy security scanner](https://github.com/aquasecurity/trivy/)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.7 11E801a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
