### PR TITLE
iozone: update to 3.490

### DIFF
--- a/benchmarks/iozone/Portfile
+++ b/benchmarks/iozone/Portfile
@@ -3,7 +3,7 @@
 PortSystem       1.0
 
 name             iozone
-version          3.488
+version          3.490
 categories       benchmarks
 platforms        darwin
 license          Restrictive/Distributable GPL-2+
@@ -20,8 +20,9 @@ homepage         http://www.iozone.org/
 
 master_sites     ${homepage}src/current/
 distname         ${name}[string map {. _} ${version}]
-checksums        rmd160 e234f6da29bf99bb2917f9adf7c432f7515a3865 \
-                 sha256 960265163d93f15f7ad352f726d4837c5dd794fff357c743fdb56cbcf4abca04
+checksums        rmd160 32fade5209cbb14494841f2f0ce5377a9b4e9dd8 \
+                 sha256 5eadb4235ae2a956911204c50ebf2d8d8d59ddcd4a2841a1baf42f3145ad4fed \
+                 size   4136960
 
 extract.suffix   .tar
 extract.cmd      cat


### PR DESCRIPTION
#### Description

iozone: update to 3.490

###### Type(s)

- [x] update

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?