### PR TITLE
pulseaudio: Fix build error for Xcode 12 CLT

### DIFF
--- a/audio/pulseaudio/Portfile
+++ b/audio/pulseaudio/Portfile
@@ -77,6 +77,9 @@ patchfiles          patch-man-Makefile.am.diff \
                     patch-src_modules_macosx_module_coreaudio_device.c-respect-PA_NAME_MAX.diff \
                     patch-src_daemon_default.pa.in-skip-consolekit-and-systemdlogin.diff
 
+# https://trac.macports.org/ticket/61107
+patchfiles-append   patch-src_modules_macosx_module_coreaudio_device.c-import-util-h.diff
+
 # reconfigure using upstream autogen.sh for intltool 0.51 compatibility
 post-patch {
     xinstall -m 755 ${filespath}/autogen.sh ${worksrcpath}

--- a/audio/pulseaudio/files/patch-src_modules_macosx_module_coreaudio_device.c-import-util-h.diff
+++ b/audio/pulseaudio/files/patch-src_modules_macosx_module_coreaudio_device.c-import-util-h.diff
@@ -1,0 +1,11 @@
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/merge_requests/365]
+--- src/modules/macosx/module-coreaudio-device.c.orig	2020-09-10 19:42:18.000000000 +0200
++++ src/modules/macosx/module-coreaudio-device.c	2020-09-10 19:46:35.000000000 +0200
+@@ -27,6 +27,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <pulse/util.h>
+ #include <pulse/xmalloc.h>
+ 
+ #include <pulsecore/sink.h>


### PR DESCRIPTION
This commit adds a patch which addresses an upstream bug, i.e. the missing import of util.h, which causes a compilation failure with Xcode 12 command line tools.

Fixes https://trac.macports.org/ticket/61107

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix
