### PR TITLE
drill, ldns-tools: remove obsolete ports

### DIFF
--- a/net/ldns/Portfile
+++ b/net/ldns/Portfile
@@ -3,8 +3,6 @@
 PortSystem          1.0
 
 name                ldns
-subport             ldns-tools {}
-subport             drill {}
 
 version             1.7.1
 revision            0
@@ -18,10 +16,6 @@ if {${subport} eq ${name}} {
     long_description    ldns is a library with the aim of simplifying DNS \
                         programming in C. It is heavily based upon the Net::DNS module from \
                         Perl.
-} else {
-    PortGroup           obsolete 1.0
-    replaced_by         ldns
-    # Remove after 2020-09-09
 }
 
 homepage            https://www.nlnetlabs.nl/projects/ldns/about/


### PR DESCRIPTION
Marked obsolete in 30467d225b one year ago.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
