### PR TITLE
osmocore(-devel): add missing libusb dependency

### DIFF
--- a/science/osmocore/Portfile
+++ b/science/osmocore/Portfile
@@ -27,7 +27,7 @@ if {${subport} eq ${name}} {
     checksums rmd160 b225cad23edc006bf26c7d1680aba034dad1cf6a \
               sha256 cc36bfff7ca362b72dc2977e89493cd63597e70e8f999adeaa4de8203d41a9fb \
               size   1287754
-    revision  0
+    revision  1
 
     # fix 'timer_clockgettime.c' to work with OSs that don't provide
     # the function 'clock_gettime' and/or its various options.
@@ -50,7 +50,7 @@ if {${subport} eq ${name}} {
     checksums rmd160 4ef1a67ed3b1ac9004bdbb7e174128a936f6bc4f \
               sha256 9e0d56a53f931c491fb802c3f3d835d43f71bcafac0afe94b5da9f6ed22ac71d \
               size   1288521
-    revision  0
+    revision  1
 
     # fix 'timer_clockgettime.c' to work with OSs that don't provide
     # the function 'clock_gettime' and/or its various options.
@@ -71,6 +71,7 @@ depends_build-append \
     port:pkgconfig
 
 depends_lib-append \
+    path:lib/libusb-1.0.dylib:libusb \
     port:gnutls \
     port:python27 \
     port:talloc


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/60259

~~Fix license (see https://osmocom.org/projects/cellular-infrastructure/wiki/SoftwareLicensing)~~

~~Remove redundant epoch comment (see https://lists.macports.org/pipermail/macports-dev/2020-August/042287.html)~~

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6
Xcode 12 beta 5 command line tools
(`osmocore-devel` untested)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
