### PR TITLE
elvish: new port

### DIFF
--- a/shells/elvish/Portfile
+++ b/shells/elvish/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/elves/elvish 0.14.1 v
+
+homepage            https://elv.sh/
+
+description         Friendly Interactive Shell and Expressive Programming \
+                    Language
+
+long_description    Elvish is a friendly interactive shell and an expressive \
+                    programming language. It runs on Linux, BSDs, macOS and \
+                    Windows.
+
+categories          shells
+license             BSD
+
+checksums           rmd160  8c5927009d2bf9fcca8b274d841d6856aec73bf2 \
+                    sha256  951969e680d9897b0edbbcbc3e1fa535c878aa32ed4efc786afe48cac1489f2e \
+                    size    575782
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+installs_libs       no
+
+build.cmd           make
+build.args          VERSION=${version}
+build.target        get
+
+destroot {
+    xinstall -m 755 ${gopath}/bin/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
New port for the [elvish](https://elv.sh/) shell.

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.7 11E801a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
