### PR TITLE
fluent-bit: attempt to fix build on 10.7/10.8

### DIFF
--- a/sysutils/fluent-bit/Portfile
+++ b/sysutils/fluent-bit/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.1
+PortGroup           compiler_blacklist_versions 1.0
 
 # Need clock_gettime()
 PortGroup           legacysupport 1.0
@@ -34,6 +35,9 @@ master_sites        ${homepage}releases/${branch}/
 checksums           rmd160  c4c999be2ef6592733dde6aaade207b3827b8943 \
                     sha256  8af3f998bdf940f2a31a94db1f9a20001f2ad1cc0c0d040b79894c10387c58f0 \
                     size    12759507
+
+# /usr/bin/ranlib: unknown option character `n' in: -no_warning_for_no_symbols
+compiler.blacklist-append {clang < 700}
 
 depends_build-append \
                     port:bison


### PR DESCRIPTION
#### Description

Build still fails on [10.7](https://build.macports.org/builders/ports-10.7_x86_64-builder/builds/30405/steps/install-port/logs/stdio)/[10.8](https://build.macports.org/builders/ports-10.8_x86_64-builder/builds/25355/steps/install-port/logs/stdio):
```
/usr/bin/ranlib: unknown option character `n' in: -no_warning_for_no_symbols
```

An identical error was addressed in `mbedtls` by using a different `ranlib`: see https://trac.macports.org/ticket/60762#comment:3. However I encountered a similar error in `mesos` which was resolved by avoiding Xcode < 7: https://github.com/macports/macports-ports/pull/8346#issuecomment-688358862. The former approach is more precise for only switching out `ranlib` rather than the whole compiler, but I think the latter approach (if it works here) would be easier on portfile maintainers, and both approaches involve installing part or all of a MacPorts-provided compiler.

10.6 has a separate failure which I do not know an obvious fix for.

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
