### PR TITLE
eksctl: attempt to fix destroot on 10.9 and earlier

### DIFF
--- a/sysutils/eksctl/Portfile
+++ b/sysutils/eksctl/Portfile
@@ -2,6 +2,10 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
+# Need fdopendir()
+PortGroup           legacysupport 1.0
+legacysupport.newest_darwin_requires_legacy 13
+
 maintainers         {@szczad gmail.com:szczad} openmaintainer
 
 github.setup        weaveworks eksctl 0.26.0


### PR DESCRIPTION
#### Description
Destroot fails on [10.9](https://build.macports.org/builders/ports-10.9_x86_64-builder/builds/126251/steps/install-port/logs/stdio) and earlier:
```
Error: Failed to destroot eksctl: dyld: Symbol not found: _fdopendir$INODE64
  Referenced from: /opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_sysutils_eksctl/eksctl/work/destroot/opt/local/bin/eksctl
  Expected in: flat namespace
```
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
