### PR TITLE
esmf: use known_fail yes on 10.7 and earlier

### DIFF
--- a/science/esmf/Portfile
+++ b/science/esmf/Portfile
@@ -37,6 +37,7 @@ depends_lib         port:netcdf \
                     port:xercesc3
 
 if {${os.platform} eq "darwin" && ${os.major} < 12} {
+    known_fail      yes
     pre-fetch {
         ui_error "${name} is not supported on Lion or older."
         error "unsupported platform"


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
