### PR TITLE
zmq22, zmq3: fix build

### DIFF
--- a/devel/zmq/Portfile
+++ b/devel/zmq/Portfile
@@ -64,6 +64,9 @@ subport zmq3 {
     depends_build-append port:automake port:autoconf
 
     configure.args-append --disable-silent-rules
+
+    # https://trac.macports.org/ticket/60771
+    patchfiles-append patch-zmq3-src_select.cpp.diff
 }
 
 # Legacy subport (as a dependency for p5-zeromq)
@@ -81,6 +84,9 @@ subport zmq22 {
     depends_build-append port:automake port:autoconf
 
     configure.args-append --disable-silent-rules
+
+    # https://trac.macports.org/ticket/60771
+    patchfiles-append patch-zmq22-src_select.cpp.diff
 }
 
 subport zmq-devel {

--- a/devel/zmq/files/patch-zmq22-src_select.cpp.diff
+++ b/devel/zmq/files/patch-zmq22-src_select.cpp.diff
@@ -1,0 +1,17 @@
+Upstream-Status: Backport [https://github.com/zeromq/libzmq/pull/1181]
+
+--- src/select.cpp.orig
++++ src/select.cpp
+@@ -158,8 +158,12 @@
+         memcpy (&exceptfds, &source_set_err, sizeof source_set_err);
+ 
+         //  Wait for events.
++#ifdef ZMQ_HAVE_OSX
++        struct timeval tv = {(long) (timeout / 1000), timeout % 1000 * 1000};
++#else
+         struct timeval tv = {(long) (timeout / 1000),
+             (long) (timeout % 1000 * 1000)};
++#endif
+         int rc = select (maxfd + 1, &readfds, &writefds, &exceptfds,
+             timeout ? &tv : NULL);
+ 

--- a/devel/zmq/files/patch-zmq3-src_select.cpp.diff
+++ b/devel/zmq/files/patch-zmq3-src_select.cpp.diff
@@ -1,0 +1,17 @@
+Upstream-Status: Backport [https://github.com/zeromq/libzmq/pull/1181]
+
+--- src/select.cpp.orig
++++ src/select.cpp
+@@ -159,8 +159,12 @@
+         memcpy (&exceptfds, &source_set_err, sizeof source_set_err);
+ 
+         //  Wait for events.
++#ifdef ZMQ_HAVE_OSX
++        struct timeval tv = {(long) (timeout / 1000), timeout % 1000 * 1000};
++#else
+         struct timeval tv = {(long) (timeout / 1000),
+             (long) (timeout % 1000 * 1000)};
++#endif
+ #ifdef ZMQ_HAVE_WINDOWS
+         int rc = select (0, &readfds, &writefds, &exceptfds,
+             timeout ? &tv : NULL);


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/60771

#### Description
Adapted from https://github.com/zeromq/libzmq/pull/1181

Revision not incremented, as the implementations should behave identically (the existing code casts from `int` to `long` and then back to `int`; the patched code keeps the expression as `int`).
<!-- Note: it is best to make pull requests from a branch rather than from master -->



###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6
Xcode 12 beta 5 command line tools
(Only the build phase has been tested)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
```
--->  Verifying Portfile for zmq22
Error: Line 87 repeats inclusion of PortGroup cmake
Warning: missing recommended checksum type: size
--->  1 errors and 1 warnings found.
--->  Verifying Portfile for zmq3
Error: Line 87 repeats inclusion of PortGroup cmake
Warning: missing recommended checksum type: size
--->  1 errors and 1 warnings found.
```
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with <tt>sudo port -vst <s>install</s> build</tt>?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
