### PR TITLE
emacs: Fix typo and clean up configure flags

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -42,7 +42,7 @@ configure.args  --without-ns \
                 --without-gconf \
                 --without-libotf \
                 --without-m17n-flt \
-                --with-gpm \
+                --with-gmp \
                 --with-gnutls \
                 --with-json \
                 --with-xml2 \
@@ -82,7 +82,7 @@ platform darwin {
 
 if {$subport eq $name || $subport eq "emacs-app"} {
     version         27.1
-    revision        1
+    revision        2
 
     checksums       rmd160  9ddfd28ab54c4aee168eeecb783d13599e5b5288 \
                     sha256  ffbfa61dc951b92cf31ebe3efc86c5a9d4411a1222b8a4ae6716cfd0e2a584db \
@@ -92,7 +92,7 @@ if {$subport eq $name || $subport eq "emacs-app"} {
 if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
     epoch           1
     version         20200811
-    revision        1
+    revision        2
 
     fetch.type      git
     git.url         https://github.com/emacs-mirror/emacs.git
@@ -185,15 +185,11 @@ if {$subport eq $name || $subport eq "emacs-devel"} {
 }
 
 if {$subport eq "emacs-app" || $subport eq "emacs-app-devel"} {
+    revision 2
     categories-append   aqua
 
     configure.args-append  --with-ns \
-        --with-gif \
-        --with-jpeg \
         --with-lcms2 \
-        --with-png \
-        --with-tiff \
-        --with-xpm \
         --without-harfbuzz \
         --without-imagemagick \
         --without-rsvg \
@@ -201,12 +197,7 @@ if {$subport eq "emacs-app" || $subport eq "emacs-app-devel"} {
 
     configure.args-delete  --without-ns  --without-x
 
-    depends_lib-append  port:giflib \
-        port:jpeg \
-        port:lcms2 \
-        port:libpng \
-        port:tiff \
-        port:xpm \
+    depends_lib-append  port:lcms2
 
     universal_variant   no
 
@@ -233,12 +224,14 @@ if {$subport eq "emacs-app" || $subport eq "emacs-app-devel"} {
     }
 
     variant imagemagick description {Use ImageMagick} {
-        depends_lib-append  port:ImageMagick
-        configure.args-append --with-imagemagick
+        depends_lib-append     port:ImageMagick
+        configure.args-delete  --without-imagemagick
+        configure.args-append  --with-imagemagick
     }
 
     variant rsvg description {Use librsvg} {
         depends_lib-append     port:librsvg
+        configure.args-delete  --without-rsvg
         configure.args-append  --with-rsvg
     }
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Emacs configure flags unfortunately had both `--with-gpm` and `--with-gmp`, and I meant for `--with-gmp` in my last change. I've also removed a bunch of flags and lib dependencies not required under the NS port.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15
Xcode 11

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
