### PR TITLE
Bear: upgrade to 2.4.4

### DIFF
--- a/devel/Bear/Portfile
+++ b/devel/Bear/Portfile
@@ -4,10 +4,10 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 
-github.setup        rizsotto Bear 2.4.3 v
-checksums           rmd160  11c019394629f6eb5a95cfaf275464078b0435d1 \
-                    sha256  3b77a18c32e33963c3c1e262f9d0cd821cf991112a1508618f1870a4d79323f9 \
-                    size    49961
+github.setup        rizsotto Bear 2.4.4
+checksums           rmd160  9a1ce3fd173b1d9a905844cef69f7a57c3b55464 \
+                    sha256  e9cb11c75c0cb621650ebfe0d84929286b144d4e6ab5aa4a996f24efd3fd9474 \
+                    size    50384
 
 maintainers         {cal @neverpanic} openmaintainer
 license             GPL-3+
@@ -28,8 +28,3 @@ post-patch {
     reinplace "s|/usr/bin/env @BEAR_PYTHON_EXECUTABLE@|${prefix}/bin/python3.8|g" \
         ${worksrcpath}/bear/bear.py
 }
-
-notes "
-Use bear with port gmake on OS X 10.11 or above, see
-https://github.com/rizsotto/Bear/issues/152.
-"


### PR DESCRIPTION
#### Description

Note was removed due to [this fix](https://github.com/rizsotto/Bear/pull/290)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15
Xcode 11

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
