### PR TITLE
pspp: fix build on 10.6 and earlier

### DIFF
--- a/math/pspp/Portfile
+++ b/math/pspp/Portfile
@@ -43,6 +43,12 @@ depends_lib-append  path:lib/pkgconfig/cairo.pc:cairo \
 depends_build-append    port:pkgconfig \
                         port:texinfo
 
+# Need Python 2.7 or later for building, which only 10.7 and later already have
+if {${os.platform} eq "darwin" && ${os.major} <= 10} {
+    depends_build-append    port:python27
+    configure.python        ${prefix}/bin/python2.7
+}
+
 post-extract {
     if {[variant_isset gui]} {
         copy ${filespath}/PSPP ${worksrcpath}


### PR DESCRIPTION
#### Description

[Build currently fails on 10.6](https://build.macports.org/builders/ports-10.6_x86_64-builder/builds/34077/steps/install-port/logs/stdio) which only has Python 2.6 (which doesn't support dict comprehensions):
```
  File "src/output/spv/binary-parser-generator", line 288
    { '%s_%s' % (case_name, k) : v for k, v in choices.items() })
                   File "src/output/spv/binary-parser-generator", line   288
    { '%s_%s' % (case_name, k) : v for k, v in choices.items() })
                                         ^
    SyntaxError :       invalid syntax 
  ^
SyntaxError: invalid syntax
  File "src/output/spv/binary-parser-generator", line 288
    { '%s_%s' % (case_name, k) : v for k, v in choices.items() })
                                     ^
SyntaxError: invalid syntax
  File "src/output/spv/binary-parser-generator", line 288
    { '%s_%s' % (case_name, k) : v for k, v in choices.items() })
                                     ^
SyntaxError: invalid syntax
```

Alternatively, Python 3.x can be used, and/or set for all macOS versions, as done in `pspp-devel`.

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
