### PR TITLE
mpfr: bump to 4.1.0

### DIFF
--- a/devel/mpfr/Portfile
+++ b/devel/mpfr/Portfile
@@ -9,14 +9,21 @@ PortGroup           muniversal 1.0
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           xcode_workaround 1.0
 
-name                mpfr
-# The actual version is generated below, after patchfiles is defined.
-set base_version    4.0.2
-revision            1
-categories          devel math
 platforms           darwin
+categories          devel math
+
+name                mpfr
+version             4.1.0
+revision            0
+
+homepage            https://www.mpfr.org/
+master_sites        ${homepage}/${distname}
 license             LGPL-3+
 maintainers         {larryv @larryv} openmaintainer
+
+checksums           rmd160  6958142bcb36021cc03006acd694e5da724e6a0e \
+                    sha256  0c98a3f1732ff6ca4ea690552079da9c597872d30e96ec28414ee23c95558a7f \
+                    size    1525476
 
 description         C library for multiple-precision floating-point \
                     computations
@@ -27,44 +34,31 @@ long_description    MPFR is a portable C library for arbitrary-precision \
                     has a well-defined semantics. It copies the good \
                     ideas from the ANSI/IEEE-754 standard for \
                     fixed-precision floating-point arithmetic.
-homepage            http://www.mpfr.org/
 
-depends_lib         port:gmp
-
-distname            ${name}-${base_version}
-master_sites        http://www.mpfr.org/${distname}
 use_xz              yes
-checksums           ${distname}${extract.suffix} \
-                        rmd160  14fb12027e7be8d4aa84b8cb8d8dc8769c35b899 \
-                        sha256  1d3be708604eae0e42d578ba93b390c2a145f17743a744d8f3f8c2ad5855a38a \
-                        size    1441996
+
+depends_lib-append  port:gmp
 
 # see https://trac.macports.org/ticket/60091
 xcode_workaround.fixed_xcode_version 11.2
-
-# Upstream patch names are not qualified with the base version.
-dist_subdir         ${name}/${base_version}
-
-patch.args          -p1
-patchfiles          {*}[lsearch -all -inline ${checksums} {patch[0-9][0-9]}]
-
-set patch_level [llength ${patchfiles}]
-if {${patch_level} > 0} {
-    version         ${base_version}-p${patch_level}
-} else {
-    version         ${base_version}
-}
 
 # Due to radr://10291355 (llvm.org PR11111), the new tls support enabled in clang with Xcode 4.2
 # miscompiles mpfr. While this was fixed in Xcode 4.2.1, as the ttls support was never used prior to
 # Xcode 4.2, the generic fix is to pass --disable-thread-safe to configure, however this will break
 # any project that requires a thread-safe mpfr library, therefore the Xcode 4.2 compiler is
 # blacklisted here
-compiler.blacklist  {clang == 211.10.1}
+compiler.blacklist-append  {clang == 211.10.1}
+
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    # the OS toolchains on these systems do not support TLS.
+    # macports-clang-N also does not presently build this correctly on these systems
+    # A multithreaded mpfr is possible on these systems by building with a
+    # current gcc version but that involves a cyclical dep at present
+    configure.args-append --disable-thread-safe
+}
 
 test.run            yes
 test.target         check
 
-livecheck.version   ${base_version}
 livecheck.url       http://www.mpfr.org/mpfr-current/
 livecheck.regex     "mpfr-(\\d+(?:\\.\\d+)*)${extract.suffix}"


### PR DESCRIPTION
simplify Portfile to usual
MacPorts standard layout

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.7 11E801a 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

Test suite (Xcode clang on Catalina) looks good:
```
============================================================================
Testsuite summary for MPFR 4.1.0
============================================================================
# TOTAL: 183
# PASS:  180
# SKIP:  3
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
[tversion] MPFR 4.1.0
[tversion] Compiler: 4.2.1 Compatible Apple LLVM 11.0.3 (clang-1103.0.32.62)
[tversion] C standard: __STDC__ = 1, __STDC_VERSION__ = 201112L
[tversion] __GNUC__ = 4, __GNUC_MINOR__ = 2
[tversion] GMP: header 6.2.0, library 6.2.0
[tversion] __GMP_CC = "/usr/bin/clang"
[tversion] __GMP_CFLAGS = "-O2 -pedantic -fomit-frame-pointer -m64 -mtune=core2 -march=core2"
[tversion] WinDLL: __GMP_LIBGMP_DLL = 0, MPFR_WIN_THREAD_SAFE_DLL = undef
[tversion] MPFR_ALLOCA_MAX = 16384
[tversion] TLS = yes, float128 = no, decimal = no, GMP internals = no
[tversion] Shared cache = no
[tversion] intmax_t = yes, printf = yes, IEEE floats = yes
[tversion] gmp_printf: hhd = yes, lld = yes, jd = yes, td = yes, Ld = yes
[tversion] _mulx_u64 = no
[tversion] MPFR tuning parameters from src/x86_64/core2/mparam.h
[tversion] sizeof(long) = 8, sizeof(mpfr_intmax_t) = 8, sizeof(intmax_t) = 8
[tversion] GMP_NUMB_BITS = 64, sizeof(mp_limb_t) = 8
[tversion] Within limb: long = y/y, intmax_t = y/y
[tversion] _MPFR_PREC_FORMAT = 3, sizeof(mpfr_prec_t) = 8
[tversion] _MPFR_EXP_FORMAT = 3, sizeof(mpfr_exp_t) = 8
[tversion] sizeof(mpfr_t) = 32, sizeof(mpfr_ptr) = 8
[tversion] Precision range: [1,9223372036854775551]
[tversion] Max exponent range: [-4611686018427387903,4611686018427387903]
[tversion] Generic ABI code: no
[tversion] Enable formally proven code: no
[tversion] Locale: en_US.UTF-8
```