### PR TITLE
omniawrite: new port

### DIFF
--- a/editors/omniawrite/Portfile
+++ b/editors/omniawrite/Portfile
@@ -1,0 +1,66 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        TorstenDittmann OmniaWrite 1.0.4 v
+name                omniawrite
+revision            0
+
+homepage            https://www.omniawrite.com/
+
+description         OmniaWrite is a text editor engineered for creative \
+                    writing.
+
+long_description    OmniaWrite is a next-generation plain text editor \
+                    engineered for creative writing. It is perfect for \
+                    writing novels, lyrics, poems, essays, drafts and \
+                    screenplays. Writing a good story is one of the most \
+                    challenging things in life. But for many it is a dream \
+                    worth pursuing. OmniaWrite doesn't help you create a \
+                    novel out of nothing, but is a faithful companion at \
+                    every step of your projects. Organisation, environment \
+                    for concentrated work, export to all common file formats \
+                    and much more.
+
+categories          editors
+license             Apache-2
+platforms           darwin
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  580317930ef1656283fa1eba34af79658ca27910 \
+                    sha256  326c9888f85b6da1477a46166ba83c2f9f394d33d97e4f0e2a105f24ee3019e5 \
+                    size    6378522
+
+depends_build       port:yarn
+
+use_configure       no
+
+build.env-append    CSC_IDENTITY_AUTO_DISCOVERY=false
+
+post-extract {
+    # Change the electron-builder target to build just the app bundle, and not
+    # the .pkg file.
+    reinplace "s|--macos pkg|--macos dir|g" ${worksrcpath}/package.json
+}
+
+build {
+    # Set up JS dependencies
+    system -W ${worksrcpath} "yarn --frozen-lockfile"
+
+    # Build project
+    system -W ${worksrcpath} "yarn run build"
+    system -W ${worksrcpath} "yarn run svelte-build"
+    system -W ${worksrcpath} "yarn run license"
+
+    # Build electron app
+    system -W ${worksrcpath} "${build.env} yarn run electron-builder"
+}
+
+destroot {
+    copy ${worksrcpath}/dist/mac/OmniaWrite.app ${destroot}${applications_dir}/
+}
+
+github.livecheck.regex {([0-9.]+)}


### PR DESCRIPTION
#### Description

New port for [OmniaWrite](https://www.omniawrite.com/), a text editor for creative writing.

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.7 11E801a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
