### PR TITLE
carthage: Update to 0.35.0

### DIFF
--- a/devel/carthage/Portfile
+++ b/devel/carthage/Portfile
@@ -5,7 +5,10 @@ PortGroup           github 1.0
 PortGroup           xcodeversion 1.0
 
 use_xcode           yes
-github.setup        Carthage Carthage 0.34.0
+# github.setup        Carthage Carthage 0.35.0
+# a33d3483b3 is the commit immediately after 0.35.0 tag with fix for Xcode 12/Swift 5.3
+github.setup        Carthage Carthage a33d3483b3
+version             0.35.0
 name                carthage
 categories          devel
 platforms           darwin
@@ -24,12 +27,17 @@ use_configure       no
 # everything is built during the prefix_install target
 build               {}
 
-destroot {
-    if { [vercmp ${xcodeversion} "9.0"] < 0 } {
-        ui_error "Xcode 9.0 or greater is needed to build ${name}; only found version ${xcodeversion}."
-        return -code error "incompatible Xcode version"
-    }
+minimum_xcodeversions-append {17 10.0}
 
+if {${os.major} < 17} {
+    known_fail      yes
+    pre-fetch {
+        ui_error "${name} @${version} requires Mac OS X 10.13 or later."
+        return -code error "incompatible Mac OS X version"
+    }
+}
+
+destroot {
     system -W ${worksrcpath} "${build.cmd} prefix_install PREFIX=${destroot}${prefix} CARTHAGE_TEMPORARY_FOLDER=${destroot} SWIFTPM_DISABLE_SANDBOX_SHOULD_BE_FLAGGED=should_be_flagged"
 }
 

--- a/devel/carthage/Portfile
+++ b/devel/carthage/Portfile
@@ -32,8 +32,8 @@ minimum_xcodeversions-append {17 10.0}
 if {${os.major} < 17} {
     known_fail      yes
     pre-fetch {
-        ui_error "${name} @${version} requires Mac OS X 10.13 or later."
-        return -code error "incompatible Mac OS X version"
+        ui_error "${name} @${version} requires macOS 10.13 or later."
+        return -code error "incompatible macOS version"
     }
 }
 


### PR DESCRIPTION
#### Description

Update carthage port as an open maintainer.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.5 19F101
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- - [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? ← no tickets found -->
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
<!-- - [ ] tried existing tests with `sudo port test`? ← no tests exist -->
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
