### PR TITLE
py-pyside2: update to 5.15.2, add Python 3.9 subport

### DIFF
--- a/python/py-pyside2/Portfile
+++ b/python/py-pyside2/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    py-pyside2
-version                 5.15.0
+version                 5.15.2
 categories-append       devel aqua
 platforms               darwin
 maintainers             {pmetzger @pmetzger} {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
@@ -17,11 +17,11 @@ master_sites            https://download.qt.io/official_releases/QtForPython/pys
 distname                pyside-setup-opensource-src-${version}
 use_xz                  yes
 
-checksums               rmd160  6c6756018a4f76fcac5e0f9c00a0cd1564bb1a89 \
-                        sha256  f1cdee53de3b76e22c1117a014a91ed95ac16e4760776f4f12dc38cd5a7b6b68 \
-                        size    3367088
+checksums               rmd160  09c0517e0fe07722e799a32c0248cd7bf8b3a581 \
+                        sha256  b306504b0b8037079a8eab772ee774b9e877a2d84bab2dbefbe4fa6f83941418 \
+                        size    3472624
 
-python.versions         27 36 37 38
+python.versions         27 36 37 38 39
 
 set llvm_version        10
 
@@ -30,6 +30,9 @@ if {${name} ne ${subport}} {
 
     # see https://trac.macports.org/ticket/57517
     qt5.min_version     5.8
+
+    # Needed for generating shiboken2 documentation
+    qt5.depends_build_component sqlite-plugin
 
     depends_build-append \
         path:bin/cmake:cmake \


### PR DESCRIPTION
#### Description

See https://www.qt.io/blog/qtforpython-5.15.1-released

~~**This PR currently does not build**~~ This PR builds with Qt 5.15.2, but did not previously with Qt 5.14.x. pyside2 5.15.1 release added support for `QSocketDescriptor`, which was introduced in Qt 5.15:
```
:info:build make[2]: *** No rule to make target `PySide2/QtCore/PySide2/QtCore/qsocketdescriptor_wrapper.cpp', needed by `PySide2/QtCore/CMakeFiles/QtCore.dir/PySide2/QtCore/qsocketdescriptor_wrapper.cpp.o'.  Stop.
```
Is pyside2 still supposed to work with Qt 5.14 or older? I would like to know whether an attempt should be made to disable new class support, or if `qt5` should be updated to 5.15.x before updating this port.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6
Xcode 12 beta 5 command line tools

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
