### PR TITLE
Update port Nheko

### DIFF
--- a/devel/olm/Portfile
+++ b/devel/olm/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 
 name                olm
-version             3.1.4
+version             3.1.5
 categories          devel security
 platforms           darwin
 maintainers         {@scarface-one disroot.org:scarface} openmaintainer
@@ -18,13 +18,8 @@ homepage            https://gitlab.matrix.org/matrix-org/olm/
 
 master_sites        https://gitlab.matrix.org/matrix-org/olm/-/archive/${version}
 
-checksums           rmd160  04922bc2e9571698cbfb6c8f11be33e764e46dcf \
-                    sha256  1ca9926ce71d778fb7352d1ee77513194db8c7f49c0d69d38ac49ec3bafcea38 \
-                    size    521495
-
-variant static description {Make static library} {
-	configure.args-append \
-		-DBUILD_SHARED_LIBS=NO
-}
+checksums           rmd160  27b4c40d42bc81977fd432bf5be05c2bc09e23f8 \
+                    sha256  92ac1eccacbff620a1bc1a168ba204893d83bcb72646e456990ebe2480638696 \
+                    size    522692
 
 compiler.cxx_standard 2011

--- a/devel/tweeny/Portfile
+++ b/devel/tweeny/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 
-github.setup        mobius3 tweeny 2
+github.setup        mobius3 tweeny 3.1.1 v
 categories          devel graphics
 platforms           darwin
 license             MIT
@@ -15,8 +15,8 @@ long_description    Tweeny is an inbetweening library designed \
                     games and other beautiful interactive software
 homepage            http://mobius3.github.io/tweeny
 
-checksums           rmd160  02f4073c1398a1cf907cafb14bceb03eeb6f28e2 \
-                    sha256  c564511eb9cbcddbfbe4152dfb0bb307ceb53a9acbe48628f152cec7603c1b50 \
-                    size    1281212
+checksums           rmd160  8c6800efce87972e20678c346be875e7c20035ca \
+                    sha256  ea2a8eac4f2507b8cddcaa7d734ed9fbaf3ec21cd18c981c46be2ff9b8ac95b0 \
+                    size    49673
 
 depends_lib-append  port:libsdl2

--- a/net/matrix-structs/Portfile
+++ b/net/matrix-structs/Portfile
@@ -1,23 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
-PortGroup           cmake 1.1
+PortGroup           obsolete 1.0
+# Remove after 2021-09-28
 
-github.setup        mujx matrix-structs 8de04af
+name                matrix-client
+replaced_by         mtxclient
 version             2018-07-14
+revision            1
 categories          net devel
-platforms           darwin
-license             public-domain
-maintainers         {@scarface-one disroot.org:scarface} openmaintainer
-description         structs for the matrix library
-long_description    Collection of structs used in the Matrix protocol \
-                    with built in serialization/deserialization to/from \
-                    json.
-
-checksums           rmd160  a8cb9bf9e3da1ebfad3d77198015f0fda16a80d7 \
-                    sha256  894f15d0a83a4970c5783e099bde296187ae0f0a3ca752a5a9cecef323e8878c \
-                    size    412111
-
-compiler.cxx_standard \
-                    2011
+homepage            https://github.com/Nheko-Reborn/mtxclient

--- a/net/mtxclient/Portfile
+++ b/net/mtxclient/Portfile
@@ -3,10 +3,10 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
+PortGroup           compiler_blacklist_versions 1.0
 
-github.setup        mujx mtxclient 2f519d2
-version             2018-07-14
-revision            1
+github.setup        Nheko-Reborn mtxclient 0.3.1 v
+epoch               1
 categories          net chat devel
 platforms           darwin
 license             GPL-3
@@ -14,12 +14,16 @@ maintainers         {@scarface-one disroot.org:scarface} openmaintainer
 description         Client API for Matrix
 long_description    Client API library for the Matrix protocol, built on top of Boost.Asio.
 
-checksums           rmd160  28330b8f5c028792aaa5a1dbdd3738aea4854e7d \
-                    sha256  760a03fabae4cca250a5a7aa1328e7fb922186b431c1b65530ad083dcb9fda4c \
-                    size    92272
+checksums           rmd160  31722fa1af22f239c68527b4d677b79c06c748ea \
+                    sha256  4742e95097a5ec1be31685398173d9bf248ecc2fef96932bad8fe528de7255a2 \
+                    size    512153
 
 compiler.cxx_standard \
-                    2014
+                    2017
+#Need <variant> header and std::optional::value
+platform darwin 17 {
+    compiler.blacklist-append clang
+}
 
 configure.args-append \
                     -DBUILD_LIB_TESTS=OFF \
@@ -34,9 +38,10 @@ configure.args-append \
 depends_build-append \
                     port:olm \
                     path:lib/libssl.dylib:openssl \
+                    port:nlohmann-json \
                     port:pkgconfig \
-                    port:spdlog0
+                    port:spdlog
 
 depends_lib-append  port:boost \
                     port:libsodium \
-                    port:matrix-structs
+                    port:olm

--- a/net/nheko/Portfile
+++ b/net/nheko/Portfile
@@ -4,29 +4,25 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 PortGroup           qt5 1.0
-PortGroup           cxx11 1.1
 PortGroup           compiler_blacklist_versions 1.0
 
-#NOTE: requires C++14
-
-github.setup        mujx nheko 0.5.2 v
+github.setup        nheko-reborn nheko 0.7.2 v
 categories          net chat
 platforms           darwin
 license             GPL-3
-maintainers         {@scarface-one gmail.com:sireeshkodali1}
+maintainers         {@scarface-one disroot.org:scarface}
 description         A matrix chat client
 long_description    Nheko is a native desktop matrix \
                     chat client. It aims to be more \
                     like a chat app and less like an \
                     IRC client
 
-checksums           rmd160  be32b10c51960a1d27dd4fa410f82e5dd1e98534 \
-                    sha256  d7c189efd04ffa032b46c5eb24cf076ade5ddec3434b937ec9d0de952bb8f79b \
-                    size    4526124
+checksums           rmd160  67e1790fabb3105c6ea19bdf04a2bfd4151b94a0 \
+                    sha256  0b31481df6aadcb040011247ebfcaf2bc4081b0be61edca627216a1d8fdc124d \
+                    size    899673
 
-#C++14 was first fully supported by clang 3.4 aka apple clang 503.0.38
-# But TLS was first implemented by apple clang 800.0.38
-compiler.blacklist-append {clang < 800.0.38}
+compiler.cxx_standard  2014
+compiler.thread_local_storage yes
 
 if {(${os.major} < 16)} {
     pre-fetch {
@@ -37,8 +33,8 @@ if {(${os.major} < 16)} {
 
 configure.cxxflags-append -fno-sized-deallocation
 
-depends_build-append port:lmdbxx \
-                    port:matrix-structs \
+depends_build-append port:cmark \
+                    port:lmdbxx \
                     port:mtxclient \
                     port:olm \
                     port:tweeny
@@ -47,11 +43,13 @@ depends_lib-append  port:boost \
                     port:fontconfig \
                     port:libsodium \
                     port:lmdb \
+                    port:nlohmann-json \
                     port:spdlog
 
 qt5.depends_component qtbase \
                     qtmacextras \
                     qtmultimedia \
+                    qtquickcontrols2 \
                     qtsvg \
                     qttools
 


### PR DESCRIPTION
#### Description

This commit series updates the port Nheko and its dependencies

It changes the port to track Nheko-Reborn, the fork, since the original Nheko is no longer maintained

~The only issue is that `port:mtxclient` now has proper versioning, which conflicts with the versioning from the previous port, I'm not sure how to correctly deal with that~
I've put an epoch for mtxclient, as the library now has proper versioning

Fixes: https://trac.macports.org/ticket/59517

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.4 11E146

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
