### PR TITLE
k9s: update to 0.21.9

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.21.7 v
+go.setup            github.com/derailed/k9s 0.21.9 v
 homepage            https://k9scli.io
 
 categories          sysutils devel
@@ -20,9 +20,9 @@ platforms           darwin
 supported_archs     x86_64
 license             Apache-2
 
-checksums           rmd160  f049bf298a5b4b8049f3989416a9021aae046b2c \
-                    sha256  576418b30b175861022e27e970f40698d5bf4bf8f013592fb50fc1975aecf237 \
-                    size    6082738
+checksums           rmd160  5ffc8298aa109bb58f484ee34eb20a0ed17139a4 \
+                    sha256  e6014a36a3d60943f3f5cde0a5c4bef109f8cd776c58d5def8435a506e03ba2c \
+                    size    6084100
 
 # Reproduce the "build" target from the upstream Makefile
 set go_ldflags      "-w -X ${go.package}/cmd.version=${version} \


### PR DESCRIPTION
#### Description

Update to k9s 0.21.9.

###### Tested on

macOS 10.15.6 19G2021
Xcode 11.7 11E801a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?