### PR TITLE
py-graph-tool: Update dependency to cgal5, remove old Python 35 and 36 versions

### DIFF
--- a/python/py-graph-tool/Portfile
+++ b/python/py-graph-tool/Portfile
@@ -7,7 +7,7 @@ PortGroup           active_variants 1.1
 set realname        graph-tool
 name                py-${realname}
 version             2.33
-revision            0
+revision            1
 epoch               20190711
 categories          python science
 platforms           darwin
@@ -26,7 +26,7 @@ checksums           rmd160  5eecb61bacb6a26d211f9c3c43c2b3641cb9f9bf \
                     size    15153528
 distname            ${realname}-${version}
 
-python.versions     27 35 36 37 38
+python.versions     27 37 38 39
 python.default_version 27
 
 if {${os.major} <= 12 && ${os.platform} eq "darwin"} {
@@ -57,7 +57,7 @@ if {${name} ne ${subport}} {
     depends_build-append port:pkgconfig
     depends_lib-append port:boost \
                        port:cairomm \
-                       port:cgal4 \
+                       port:cgal5 \
                        port:expat \
                        path:bin/dot:graphviz \
                        port:py${python.version}-numpy \


### PR DESCRIPTION
py-graph-tool: Update dependency to cgal5, remove old Python 35 and 36 versions

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.7 11E801a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
