### PR TITLE
gtk2: Add missing import statement

### DIFF
--- a/gnome/gtk2/Portfile
+++ b/gnome/gtk2/Portfile
@@ -47,8 +47,9 @@ depends_lib         port:atk \
 depends_run         port:shared-mime-info \
                     port:hicolor-icon-theme
 
-patchfiles-append   patch-aliases.diff
-patchfiles-append   patch-gtk-builder-convert.diff
+patchfiles-append   patch-aliases.diff \
+                    patch-gtk-builder-convert.diff \
+                    patch-gtkclipboard-quartz.diff
 
 # autoreconf to deal with stupid issues during install (install: .libs/libferret.lai: No such file or directory)
 use_autoreconf      yes

--- a/gnome/gtk2/files/patch-gtkclipboard-quartz.diff
+++ b/gnome/gtk2/files/patch-gtkclipboard-quartz.diff
@@ -1,0 +1,10 @@
+--- gtk/gtkclipboard-quartz.c.orig	2020-09-13 16:49:12.000000000 +0200
++++ gtk/gtkclipboard-quartz.c	2020-09-13 16:52:05.000000000 +0200
+@@ -33,6 +33,7 @@
+ #include "gtktextbuffer.h"
+ #include "gtkquartz.h"
+ #include "gtkalias.h"
++#include "gdk/quartz/gdkquartz.h"
+ 
+ enum {
+   OWNER_CHANGE,


### PR DESCRIPTION
The statement fixes the error "implicit declaration of function 'gdk_quartz_pasteboard_type_to_atom_libgtk_only' is invalid in C99". This error prevents compilation with the current Xcode12 beta. Note that the patch does not have an "Upstream-Status" header at the time I submit the MR. I might submit the patch upstream at a later time.

Fixes: https://trac.macports.org/ticket/60926

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix
