### PR TITLE
proj7: fix build on 10.8-10.9

### DIFF
--- a/gis/proj7/Portfile
+++ b/gis/proj7/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           compiler_blacklist_versions 1.0
 
 set realname        proj
 name                ${realname}7
@@ -30,6 +31,10 @@ checksums           rmd160  64194fb306bfb9445667a9307d71f0dec36803bb \
                     size    5509592
 
 compiler.cxx_standard 2011
+
+# error: return type 'const nn<[...]>' must match previous return type
+# 'nn<[...]>' when lambda expression has unspecified explicit return type
+compiler.blacklist-append {clang < 602}
 
 depends_build-append \
                     port:pkgconfig


### PR DESCRIPTION
#### Description

Build failure observed on [10.8](https://build.macports.org/builders/ports-10.8_x86_64-builder/builds/24733/steps/install-port/logs/stdio) and [10.9](https://build.macports.org/builders/ports-10.9_x86_64-builder/builds/125908/steps/install-port/logs/stdio):
```
libtool: compile:  /usr/bin/clang++ -std=c++11 -DHAVE_CONFIG_H -I. -DPROJ_LIB=\"/opt/local/lib/proj7/share/proj\" -DMUTEX_pthread -I../include -DTIFF_ENABLED -I/opt/local/include -DCURL_ENABLED -I/opt/local/include -Wall -Wextra -Winit-self -Wunused-parameter -Wformat -Werror=format-security -Wno-format-nonliteral -Wshorten-64-to-32 -Wshadow -Werror=vla -Wnull-dereference -Wextra-semi -Wdocumentation -Wno-documentation-deprecated-sync -Wunused-private-field -Wmissing-declarations -Wnon-virtual-dtor -Weffc++ -Woverloaded-virtual -Wweak-vtables -Wdeprecated -Wabstract-vbase-init -pipe -Os -stdlib=libc++ -arch x86_64 -fvisibility=hidden -DNOMINMAX -MT iso19111/coordinateoperation.lo -MD -MP -MF iso19111/.deps/coordinateoperation.Tpo -c iso19111/coordinateoperation.cpp  -fno-common -DPIC -o iso19111/.libs/coordinateoperation.o
iso19111/coordinateoperation.cpp:13719:9: error: return type 'nn<[...]>' must match previous return type 'const nn<[...]>' when lambda expression has unspecified explicit return type
        return ret;
        ^
…
libtool: compile:  /usr/bin/clang++ -std=c++11 -DHAVE_CONFIG_H -I. -DPROJ_LIB=\"/opt/local/lib/proj7/share/proj\" -DMUTEX_pthread -I../include -DTIFF_ENABLED -I/opt/local/include -DCURL_ENABLED -I/opt/local/include -Wall -Wextra -Winit-self -Wunused-parameter -Wformat -Werror=format-security -Wno-format-nonliteral -Wshorten-64-to-32 -Wshadow -Werror=vla -Wnull-dereference -Wextra-semi -Wdocumentation -Wno-documentation-deprecated-sync -Wunused-private-field -Wmissing-declarations -Wnon-virtual-dtor -Weffc++ -Woverloaded-virtual -Wweak-vtables -Wdeprecated -Wabstract-vbase-init -pipe -Os -stdlib=libc++ -arch x86_64 -fvisibility=hidden -DNOMINMAX -MT iso19111/io.lo -MD -MP -MF iso19111/.deps/io.Tpo -c iso19111/io.cpp  -fno-common -DPIC -o iso19111/.libs/io.o
iso19111/io.cpp:4606:9: error: return type 'const nn<[...]>' must match previous return type 'nn<[...]>' when lambda expression has unspecified explicit return type
        return crs;
        ^
iso19111/io.cpp:6216:33: error: return type 'const nn<[...]>' must match previous return type 'nn<[...]>' when lambda expression has unspecified explicit return type
                                return obj;
                                ^
iso19111/io.cpp:8265:17: error: return type 'nn<[...]>' must match previous return type 'const nn<[...]>' when lambda expression has unspecified explicit return type
                return GeodeticReferenceFrame::create(
                ^
iso19111/io.cpp:8314:25: error: return type 'nn<[...]>' must match previous return type 'const nn<[...]>' when lambda expression has unspecified explicit return type
                        return GeodeticReferenceFrame::create(
                        ^
```
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
