### PR TITLE
blender: requires Xcode 8.2 or later

### DIFF
--- a/graphics/blender/Portfile
+++ b/graphics/blender/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.1
+PortGroup           xcodeversion 1.0
 
 name                blender
 version             2.83.0
@@ -28,6 +29,15 @@ use_xz              yes
 checksums           rmd160  227b412d69c2e3db4de05f8a3cfbc762934dcb31 \
                     sha256  14e2bc85e076b12ae94438ff3c1dd417eba642840ed32d7c979724a93aa93f1f \
                     size    38515064
+
+minimum_xcodeversions-append {15 8.2 16 8.2}
+if {${os.platform} eq "darwin" && ${os.major} < 15} {
+    known_fail      yes
+    pre-fetch {
+        ui_error "${name} @${version} requires Mac OS X 10.11 or later."
+        return -code error "incompatible Mac OS X version"
+    }
+}
 
 compiler.cxx_standard 2011
 # We need to blacklist Xcode Clang/LLVM, because Blender needs to


### PR DESCRIPTION
#### Description
Configuration failure observed on 10.10 and earlier:
```
-- Detected OS X 10.10 and Xcode 6.2 at /Applications/Xcode.app
CMake Error at build_files/cmake/platform/platform_apple_xcode.cmake:74 (message):
  Only Xcode version 8.2 and newer is supported
```

See https://trac.macports.org/wiki/XcodeVersionInfo: only macOS 10.11 and later can run Xcode version 8.2 or later.

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
