### PR TITLE
py3[6789]-pandas: attempt to fix build on macOS 10.8

### DIFF
--- a/python/py-pandas/Portfile
+++ b/python/py-pandas/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
+PortGroup           compiler_blacklist_versions 1.0
 
 name                py-pandas
 version             1.1.4
@@ -45,6 +46,9 @@ if {${name} ne ${subport}} {
         checksums           rmd160  cb526595c8b38bd4973a49ebebb61c165421628b \
                             sha256  52da74df8a9c9a103af0a72c9d5fdc8e0183a90884278db7f386b5692a2220a4 \
                             size    12632585
+    } else {
+        # error: use of logical '&&' with constant operand
+        compiler.blacklist-append {clang < 600}
     }
 
     use_parallel_build  no


### PR DESCRIPTION
#### Description

Build failure is currently observed for [`py36-pandas`](https://build.macports.org/builders/ports-10.8_x86_64-builder/builds/25377/steps/install-port/logs/stdio), [`py37-pandas`](https://build.macports.org/builders/ports-10.8_x86_64-builder/builds/25382/steps/install-port/logs/stdio), and [`py38-pandas`](https://build.macports.org/builders/ports-10.8_x86_64-builder/builds/25369/steps/install-port/logs/stdio) on 10.8, involving Cythonized code which MacPorts' clang 9.0 (used on macOS 10.6) and newer Xcode clang do not complain about:

```
pandas/_libs/window/aggregations.cpp:39797:30: error: use of logical '&&' with constant operand [-Werror,-Wconstant-logical-operand]
  if ((CYTHON_USE_TYPE_SLOTS && CYTHON_USE_PYTYPE_LOOKUP) && likely(!__pyx_type___pyx_MemviewEnum.tp_dictoffset && __pyx_type___pyx_MemviewEnum.tp_getattro == PyObject_GenericGetAttr)) {
                             ^  ~~~~~~~~~~~~~~~~~~~~~~~~
pandas/_libs/window/aggregations.cpp:39797:30: note: use '&' for a bitwise operation
  if ((CYTHON_USE_TYPE_SLOTS && CYTHON_USE_PYTYPE_LOOKUP) && likely(!__pyx_type___pyx_MemviewEnum.tp_dictoffset && __pyx_type___pyx_MemviewEnum.tp_getattro == PyObject_GenericGetAttr)) {
                             ^~
                             &
pandas/_libs/window/aggregations.cpp:39797:30: note: remove constant to silence this warning
  if ((CYTHON_USE_TYPE_SLOTS && CYTHON_USE_PYTYPE_LOOKUP) && likely(!__pyx_type___pyx_MemviewEnum.tp_dictoffset && __pyx_type___pyx_MemviewEnum.tp_getattro == PyObject_GenericGetAttr)) {
                            ~^~~~~~~~~~~~~~~~~~~~~~~~~~~
pandas/_libs/window/aggregations.cpp:39814:30: error: use of logical '&&' with constant operand [-Werror,-Wconstant-logical-operand]
  if ((CYTHON_USE_TYPE_SLOTS && CYTHON_USE_PYTYPE_LOOKUP) && likely(!__pyx_type___pyx_memoryview.tp_dictoffset && __pyx_type___pyx_memoryview.tp_getattro == PyObject_GenericGetAttr)) {
                             ^  ~~~~~~~~~~~~~~~~~~~~~~~~
pandas/_libs/window/aggregations.cpp:39814:30: note: use '&' for a bitwise operation
  if ((CYTHON_USE_TYPE_SLOTS && CYTHON_USE_PYTYPE_LOOKUP) && likely(!__pyx_type___pyx_memoryview.tp_dictoffset && __pyx_type___pyx_memoryview.tp_getattro == PyObject_GenericGetAttr)) {
                             ^~
                             &
pandas/_libs/window/aggregations.cpp:39814:30: note: remove constant to silence this warning
  if ((CYTHON_USE_TYPE_SLOTS && CYTHON_USE_PYTYPE_LOOKUP) && likely(!__pyx_type___pyx_memoryview.tp_dictoffset && __pyx_type___pyx_memoryview.tp_getattro == PyObject_GenericGetAttr)) {
                            ~^~~~~~~~~~~~~~~~~~~~~~~~~~~
pandas/_libs/window/aggregations.cpp:39829:30: error: use of logical '&&' with constant operand [-Werror,-Wconstant-logical-operand]
  if ((CYTHON_USE_TYPE_SLOTS && CYTHON_USE_PYTYPE_LOOKUP) && likely(!__pyx_type___pyx_memoryviewslice.tp_dictoffset && __pyx_type___pyx_memoryviewslice.tp_getattro == PyObject_GenericGetAttr)) {
                             ^  ~~~~~~~~~~~~~~~~~~~~~~~~
pandas/_libs/window/aggregations.cpp:39829:30: note: use '&' for a bitwise operation
  if ((CYTHON_USE_TYPE_SLOTS && CYTHON_USE_PYTYPE_LOOKUP) && likely(!__pyx_type___pyx_memoryviewslice.tp_dictoffset && __pyx_type___pyx_memoryviewslice.tp_getattro == PyObject_GenericGetAttr)) {
                             ^~
                             &
pandas/_libs/window/aggregations.cpp:39829:30: note: remove constant to silence this warning
  if ((CYTHON_USE_TYPE_SLOTS && CYTHON_USE_PYTYPE_LOOKUP) && likely(!__pyx_type___pyx_memoryviewslice.tp_dictoffset && __pyx_type___pyx_memoryviewslice.tp_getattro == PyObject_GenericGetAttr)) {
                            ~^~~~~~~~~~~~~~~~~~~~~~~~~~~
```

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
