### PR TITLE
shtools: new port

### DIFF
--- a/science/shtools/Portfile
+++ b/science/shtools/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+name                shtools
+revision            0
+
+categories          science math
+platforms           darwin
+license             BSD-3-Clause
+maintainers         {@MarkWieczorek gmail.com:mark.a.wieczorek}
+description         Spherical Harmonic Tools
+long_description    SHTOOLS is a library of Fortran 95 software that can be \
+                    used to perform spherical harmonic transforms, multitaper \
+                    spectral analyses, expansions of functions into Slepian \
+                    bases, and standard operations on global gravitational \
+                    and magnetic field data. Requires linking with FFTW-3 and \
+                    LAPACK compatible libraries.
+homepage            https://shtools.github.io/SHTOOLS/
+
+github.setup        SHTOOLS SHTOOLS 4.7 v
+github.tarball_from   archive
+checksums           sha256  2d6f426dbdeb8e3a16b1cd5ea5dd5db228bdb76f438abebcccd15e43096e8d37 \
+                    rmd160  8b3e95971495e70871f644c9d445515d7d096391\
+                    size    35144701
+
+use_configure       no
+use_parallel_build  no
+
+build.cmd           make
+build.target        fortran
+
+variant openmp description {Add OpenMP support} {
+    build.target-append     fortran-mp
+}
+
+test.run            yes
+test.cmd            make
+test.target         fortran-tests-no-timing
+test.args           PREFIX=${prefix} LAPACK="-framework Accelerate" BLAS=""
+
+destroot.cmd        make
+destroot.target     install
+destroot.args       PREFIX=${prefix}
+
+depends_run         port:fftw-3
+depends_test        port:fftw-3


### PR DESCRIPTION
#### Description

shtools is an archive of Fortran 95 software for performing spherical harmonic transforms and related operations. It is mature software for more than a decade and is an integral component of the python project pyshtools. More information can be found here: https://shtools.github.io/SHTOOLS/

###### Type(s)
submission

###### Tested on
macOS 10.15.6 19G2021
Xcode 11.7 11E801a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
