### PR TITLE
jython: minor improvements

### DIFF
--- a/lang/jython/Portfile
+++ b/lang/jython/Portfile
@@ -18,13 +18,9 @@ long_description    \
     language Python written in 100% Pure Java, and seamlessly integrated with \
     the Java platform. It thus allows you to run Python on any Java platform.
 
-homepage            http://www.jython.org/
+homepage            https://www.jython.org/
 
-# Jython 2.7.1 is only compatible with Java 7/8, and is known to be
-# incompatible with Java 9+ (this will likely be resolved by Jython 2.7.2).
-# Since the Java portgroup doesn't support specifying a maximum Java version
-# but supports specifying an exact version, only use Java 8 for now.
-java.version        1.8
+# LTS Java to install if compatible Java not present
 java.fallback       openjdk8
 
 use_configure       no
@@ -35,7 +31,7 @@ python.default_version 27
 set jython_home     ${prefix}/share/java/${name}
 
 variant installer description {Use installer, rather than building from source} {
-    master_sites    http://search.maven.org/remotecontent?filepath=org/python/jython-installer/${version}
+    master_sites    https://search.maven.org/remotecontent?filepath=org/python/jython-installer/${version}
 
     distfiles       ${name}-installer-${version}.jar
 
@@ -44,6 +40,8 @@ variant installer description {Use installer, rather than building from source} 
                     size    80153928
 
     extract.only
+
+    java.version    1.7+
 
     build.cmd       java
     build.target    -jar ${distpath}/${distfiles}
@@ -67,9 +65,15 @@ if {![variant_isset installer]} {
     PortGroup       github 1.0
     github.setup    jythontools jython ${version} v
 
-    checksums       rmd160  34c48eae181694b590ce500175e452b83fdab2b8 \
-                    sha256  82a05fd72d8f681e99effa5dbfd148740ace444f226a3e479a5f3646f72af645 \
-                    size    46102901
+    checksums       rmd160  13ea84c24ffd0abbcf25a1b168d243ea6e57c86d \
+                    sha256  4938cc7079f48fa64e7558682b9bf9a62ebee16bbce698570007667945d08f60 \
+                    size    46106571
+    # Remove during next update
+    dist_subdir   ${name}/${version}_1
+
+    # Jython built with JDK 9 or later won't run on Java 8
+    # https://github.com/macports/macports-ports/pull/8425#discussion_r488342820
+    java.version    1.8
 
     # Use Ant 1.10.x for Java 8 compatibility
     depends_build-append \


### PR DESCRIPTION
Repair checksums for `-installer`

Relax Java version requirement following 2.7.2 update

Use HTTPS URLs

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6
OpenJDK 11.0.8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
Only for `jython -installer`
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
