### PR TITLE
leaf: new port

### DIFF
--- a/sysutils/leaf/Portfile
+++ b/sysutils/leaf/Portfile
@@ -1,0 +1,257 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/vrongmeal/leaf 1.3.0 v
+
+description         General purpose reloader for all projects.
+
+long_description    {*}${description} Command leaf watches for changes in the \
+                    working directory and runs the specified set of commands \
+                    whenever a file updates. A set of filters can be applied \
+                    to the watch and directories can be excluded.
+
+categories          sysutils
+license             MIT
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+build.env-append    GO111MODULE=off \
+                    GOPROXY=off
+
+build.cmd           make
+build.target        build
+
+installs_libs       no
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/build/${name} ${destroot}${prefix}/bin/
+}
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  5f7f5b69aaea63c1e76a6468bae3a9a0fd4530ef \
+                        sha256  f3cc289fdee4e2c96d207f5343181ab31901c61787f5e183b1ae51644f1970e7 \
+                        size    23577
+
+go.vendors          golang.org/x/xerrors \
+                        lock    1b5146add898 \
+                        rmd160  2cc4b800c18d0a62360e39184f2a99b1ebd49a95 \
+                        sha256  6369e59584a604215ed9649649fe273e46295d3fb8d5a811f4028844c861faaa \
+                        size    12201 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.8 \
+                        rmd160  99d8cbd0920e6e1343f0f7ad2816c52d1dba4754 \
+                        sha256  7ec31b1b9ee5834c9a861e3ef1faeef1ecd972935fa259a8780b07d0f4a78965 \
+                        size    3571 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.5 \
+                        rmd160  2ce81608a38c6f383a35bccd24d64361df5828c9 \
+                        sha256  7f41acdcba65b1fab5b9b633947a139f9915b60f94bdab486cdbe9d90c54f61e \
+                        size    50815 \
+                    github.com/hpcloud/tail \
+                        lock    v1.0.0 \
+                        rmd160  2c6daf876a9a3ff47d239f3485810799ae9ced66 \
+                        sha256  aa9d7b729c8ee8b00c1a755ade77024e6b3ec4ac88585a39e31882260249f86b \
+                        size    37817 \
+                    github.com/inconshreveable/mousetrap \
+                        lock    v1.0.0 \
+                        rmd160  5c617a09f1432fc543672a0e0c1e13d3752030c2 \
+                        sha256  0e6bae2849f13d12fe361ecac087728e4e97f3482f4cec44f6e7a2c53bb9cd0c \
+                        size    2291 \
+                    github.com/konsorten/go-windows-terminal-sequences \
+                        lock    v1.0.2 \
+                        rmd160  9b5e034c9a2fbbe2c4a3768d00d6337a8e06ab74 \
+                        sha256  0a29b8c0a24ace07e3280feb5ee7b71ddb965a894ace70d8c77c0a4f330a8dbb \
+                        size    1987 \
+                    github.com/onsi/gomega \
+                        lock    v1.9.0 \
+                        rmd160  82bcf5f0bb56669bc69b395acc205bac6a2e88ea \
+                        sha256  50573d2ae4c54dd98ef4dc88d776897cdf62d44f9679dd0878081b499bfb6b96 \
+                        size    93615 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/spf13/viper \
+                        lock    v1.6.2 \
+                        rmd160  5bc672e3d1f1699a09a7c2b4a5d9238aaa357cb9 \
+                        sha256  0085402fa0cdc98b666c2ddae50a96e01723f51144b563dc541ceadd84468e25 \
+                        size    52006 \
+                    github.com/BurntSushi/toml \
+                        lock    v0.3.1 \
+                        rmd160  fb9650e2d16525153645e5547626f242f3800149 \
+                        sha256  8cc9e5dc68e247554227973d0b4e023b27bbd9ba5a26e4fb40f44743afcb35f1 \
+                        size    42087 \
+                    github.com/hashicorp/hcl \
+                        lock    v1.0.0 \
+                        rmd160  ad8d0b523bb708fd6ae77df8bb414c103a75aa92 \
+                        sha256  4fc0e87ac9d3d6cd042f044df2db2703bed569051fb8c179d505edeb4433e96e \
+                        size    70636 \
+                    golang.org/x/net \
+                        lock    aa69164e4478 \
+                        rmd160  4ab62a1bf4dd59a854f5471c6adb652930287c3c \
+                        sha256  d0f3b6aa3663ba556f78b1fe33a4d6f355d74e3b237da5506302882863481da2 \
+                        size    1100713 \
+                    github.com/x-cray/logrus-prefixed-formatter \
+                        lock    v0.5.2 \
+                        rmd160  f6bc343a984463187fb8081173868417ed5816b6 \
+                        sha256  e12158f4076f615988164b5f958d4fdeaaadda7cc042e33681ee11495301ecdd \
+                        size    6870 \
+                    golang.org/x/crypto \
+                        lock    87dc89f01550 \
+                        rmd160  fe423943cd10a4dbe4bf5956abdcd4feb7fcba71 \
+                        sha256  452b5b4bbf469674ca6b50a856785641c45e3eb6c2ef8675cc618f5ea68dfa88 \
+                        size    1709161 \
+                    github.com/mgutz/ansi \
+                        lock    9520e82c474b \
+                        rmd160  fea73fc246ac2b229bb91accba053fed2ea63536 \
+                        sha256  75eaed501d7d121ad75c83246fecdc6222dbbbd3fcb4140c8775e219fff440ce \
+                        size    4878 \
+                    github.com/mitchellh/mapstructure \
+                        lock    v1.1.2 \
+                        rmd160  a4e01781ea5bb0c987e18e8e450c8f1023d5a857 \
+                        sha256  9c1076f5a8e923d028cb65c36143f3b1478cbaa4420e2e8f332719edc2fc4f71 \
+                        size    20992 \
+                    github.com/smartystreets/assertions \
+                        lock    b2de0cb4f26d \
+                        rmd160  32d7082172ea8c4a03119f3ffb803f8aad9744ce \
+                        sha256  469875871db96f87e62f76f0bfc4b3b0b9e4761c2a14d4ce12f246797a7c342c \
+                        size    52177 \
+                    github.com/spf13/cobra \
+                        lock    v0.0.6 \
+                        rmd160  ae15786490f8d48d0cb17b2c98fa55ef744f1c66 \
+                        sha256  2e38b4a8b346588459c4503410e1575c9966043380be71af9a6a15f27702465c \
+                        size    117326 \
+                    gopkg.in/check.v1 \
+                        lock    41f04d3bba15 \
+                        rmd160  1e5543a8e6a3159296ee63e28cbde9931a04f6b3 \
+                        sha256  c41575a73d10809f89b05ef9e783f2d53facdc6573697770d30efb05a9d2dc28 \
+                        size    31612 \
+                    github.com/golang/protobuf \
+                        lock    v1.3.2 \
+                        rmd160  c22496279cf6fc64781561cd1b5fef34e0ea61b8 \
+                        sha256  e467fab2ce26db4265fa0695b13d07fe825391023f7a02d5945a0f0b0913abe7 \
+                        size    312331 \
+                    github.com/gopherjs/gopherjs \
+                        lock    0766667cb4d1 \
+                        rmd160  fe92e39110b5c188dcce98abb3b9aa1b64d68f94 \
+                        sha256  abe56698d0855027a1f6030a44924895d781b19526aa8f9b3ef49ed4199f7c57 \
+                        size    217261 \
+                    github.com/magiconair/properties \
+                        lock    v1.8.1 \
+                        rmd160  c9768d4c6f488f56d9451cfe00898b00fa185e5a \
+                        sha256  ba7ce8c50bdc43c67c5fd97e741ae49c9279c0d42b8e79f978e6e0cd814fec7c \
+                        size    29730 \
+                    github.com/pelletier/go-toml \
+                        lock    v1.6.0 \
+                        rmd160  8ce449abeefeaab912ce6b6e0479a76fd056fefb \
+                        sha256  63a97d25dfed5f9a3a5d8c9f98a2e3894e556f31b4232483dedda3cd16348b87 \
+                        size    82744 \
+                    golang.org/x/sys \
+                        lock    d5e6a3e2c0ae \
+                        rmd160  013d8fa0f0a54aab5bcb8bc874d85f1566182189 \
+                        sha256  bf780ede9ee43be95fc99f13c99c35f5fcb2702eb501c94fb3085b5c616e8d37 \
+                        size    1539166 \
+                    github.com/kr/pretty \
+                        lock    v0.2.0 \
+                        rmd160  45bbf0be7a3328e33186718ab12cb506c0f5a073 \
+                        sha256  35fb1f8788552fc7df2120bc06dd34e00aa3284d23c250fc1f143eef51d08586 \
+                        size    8762 \
+                    github.com/kr/text \
+                        lock    v0.1.0 \
+                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
+                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
+                        size    8691 \
+                    github.com/sirupsen/logrus \
+                        lock    v1.4.2 \
+                        rmd160  9245d7ebabf259e649892609e598a2284e89e499 \
+                        sha256  c3eaf49a2a03ce42b20b5db84771a7d447465475bf083f289ecee631063e6090 \
+                        size    41379 \
+                    github.com/spf13/afero \
+                        lock    v1.2.2 \
+                        rmd160  14c42845beaf4ea85310555ff541c3fd993c2977 \
+                        sha256  d14937aa235e66156aab75b2c27085d360d95244214ccfb843cfff771f372317 \
+                        size    46167 \
+                    github.com/spf13/jwalterweatherman \
+                        lock    v1.1.0 \
+                        rmd160  390db06ec6993dd9479d7fbfeaff1144d4fbc6e9 \
+                        sha256  b75cd39c9d41c3f7e147225b3dbcb077d5e7a5688dc441ec15179bb1a4c6b941 \
+                        size    6870 \
+                    github.com/fsnotify/fsnotify \
+                        lock    v1.4.7 \
+                        rmd160  24712e412814020224e2779186e634610e2f6926 \
+                        sha256  bc839ee158ad34b81c1f11c3b9e3bcbabfba3297f61d165599880c400b8171dc \
+                        size    31147 \
+                    github.com/kballard/go-shellquote \
+                        lock    95032a82bc51 \
+                        rmd160  40415cd59ece9fb38b22170feec07f1f48d518a2 \
+                        sha256  41aa42696f96fb2783c5135d71ff1ec5938dfe178b51eb703e509c8ac0e7db4e \
+                        size    4335 \
+                    github.com/mattn/go-colorable \
+                        lock    v0.1.4 \
+                        rmd160  aeaf016c7ae6cf014233a5a327e4227acf17adea \
+                        sha256  d64a7c2835de356f83a8af8ac9e07ce45d13a5ecb5062efd7f63b85b0b173193 \
+                        size    8987 \
+                    github.com/onsi/ginkgo \
+                        lock    v1.12.0 \
+                        rmd160  9b958135a345cbf58867dbaa4e520483bfade214 \
+                        sha256  49da9c5b71b76320d2b5640b3fe29fd72fa97e994e5c7a5f06e5c25bce7334c2 \
+                        size    138578 \
+                    github.com/smartystreets/goconvey \
+                        lock    v1.6.4 \
+                        rmd160  a3dfad6131b94d809efad84d30ce45828c6da756 \
+                        sha256  a03963296bb6d031934a651c1e637e8ab2ce9604ce6a16c158ff551e44e7ba79 \
+                        size    1478824 \
+                    github.com/spf13/cast \
+                        lock    v1.3.1 \
+                        rmd160  d4ab928edfe2ad8aafbc3248287b788c65ec155f \
+                        sha256  a33b9fbe9c9dd9cc2bb54f43bcd9a4b5503666c028448bc1b600d46961ffb604 \
+                        size    11103 \
+                    golang.org/x/text \
+                        lock    v0.3.2 \
+                        rmd160  3b9523084f6a8b2e6a6987e49c56f05e22ad69eb \
+                        sha256  d624899dfd390d9d4a77e5c8e5abd8c45f0b6163e0dc7176aee39f25c5f1bed0 \
+                        size    7168458 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/jtolds/gls \
+                        lock    v4.20.0 \
+                        rmd160  31d8656bd6c1426338ceaac9535198244248b254 \
+                        sha256  04069406ca336d355eab62b4ab9e84b820ac968ac1e20bd3777efec2d3843446 \
+                        size    7305 \
+                    gopkg.in/ini.v1 \
+                        lock    v1.52.0 \
+                        rmd160  1854467781d01b8256bfbc9d3a3c96e7df213920 \
+                        sha256  1ff68197815c9fd2ba7cc8ad0fc7eafdbb2a7fbc74532176b1c7303bdcf996a9 \
+                        size    44307 \
+                    gopkg.in/tomb.v1 \
+                        lock    dd632973f1e7 \
+                        rmd160  ae07f5ddbbc6afc772d6dc5273bb72eaba50529a \
+                        sha256  91c562a4e31c89d13e5391143ff653231fc2d80562743db89ce2172ad8f81008 \
+                        size    3636 \
+                    gopkg.in/yaml.v2 \
+                        lock    v2.2.8 \
+                        rmd160  cd9df3ede3e0a28cc30fa7f41f59f20acb91edbf \
+                        sha256  7c8b9e36fac643f1b4a5fc1dc578fb569fc3a1d611c02c3338f4efa84de729fa \
+                        size    72749 \
+                    github.com/subosito/gotenv \
+                        lock    v1.2.0 \
+                        rmd160  359083733ab5db2a09169c8d6d070b03463aef60 \
+                        sha256  01fc25c8959371d006a0460132b72710ac120d5400fceebbc1d321d2e9bcd4a0 \
+                        size    7375 \
+                    github.com/mitchellh/go-homedir \
+                        lock    v1.1.0 \
+                        rmd160  44b3985e40e5bbb22d11f8622c340f9ed727ea91 \
+                        sha256  024c8a57316c7fbc0eb23cdbfd57f72a74b51beb83d714034d67ee9aba48100c \
+                        size    3366 \
+                    github.com/stretchr/testify \
+                        lock    v1.4.0 \
+                        rmd160  86bd663e13ea7266334c47689074df16252db5ff \
+                        sha256  8ed95078bfd318ea477da509e6b16e6cf8d0d1b6b8d93b1f6097c6ba2a6df788 \
+                        size    110114


### PR DESCRIPTION
New port for [leaf](https://github.com/vrongmeal/leaf)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.7 11E801a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
