### PR TITLE
alan: new port

### DIFF
--- a/lang/alan/Portfile
+++ b/lang/alan/Portfile
@@ -1,0 +1,57 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        alantech alan 0.1.7 v
+revision            0
+
+platforms           darwin
+categories          lang
+
+license             Apache-2 \
+                    AGPL-3
+
+homepage            https://alan-lang.org/
+
+description         The Alan Programming Language
+
+long_description    {*}${description}: The alan compiler and runtime can \
+                    parallelize your code without concurrent or asynchronous \
+                    programming (threads, promises, channels, etc) by only \
+                    allowing iteration and recursion that is guaranteed to \
+                    halt (e.g. no while (true) \{\} loops)
+
+checksums           rmd160  f66acbfb8e35272718d58c8c159d28d234ed8140 \
+                    sha256  c84fd2971bd820bcea659eae6400a50358722f46387510a1fe671c0201739280 \
+                    size    292965
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+depends_build       port:cargo \
+                    port:python27 \
+                    port:rust \
+                    port:yarn
+
+build.env-append    PATH=${workpath}/bin:$env(PATH)
+build.target
+
+use_configure       no
+use_parallel_build  no
+
+post-extract {
+    file mkdir ${workpath}/bin
+    ln -s ${prefix}/bin/python2.7 ${workpath}/bin/python2
+
+    # Replace npm with yarn in the build process
+    reinplace "/npm init/ d" ${worksrcpath}/Makefile
+    reinplace "s|npm run|yarn run|g" compiler/package.json
+}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/avm/target/release/${name} \
+                    ${destroot}${prefix}/bin/
+}
+
+github.livecheck.regex {([0-9.]+)}


### PR DESCRIPTION
#### Description

New port for the [Alan Programming Language](https://alan-lang.org/)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.7 11E801a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
