### PR TITLE
htop: update to 3.0.2

### DIFF
--- a/sysutils/htop/Portfile
+++ b/sysutils/htop/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        htop-dev htop 3.0.1
+github.setup        htop-dev htop 3.0.2
 revision            0
 epoch               1
 
@@ -17,9 +17,9 @@ long_description    ${name} is {*}${description} systems. It aims to be a better
 
 homepage            https://htop.dev
 
-checksums           rmd160  0423afe59514eaff6dd8343e015f42fc878221d7 \
-                    sha256  3665619e682a83648d34cd0bd5af5f1c58780b812b17061963df0f9bb1768441 \
-                    size    179963
+checksums           rmd160  c4bd777dc6ae096b3f1e18c1b42f09bacfec71a5 \
+                    sha256  ec3a80f8772a3e156bc9d7d4ffca6bff342c04b78c52edff3621b6e83ac37b6a \
+                    size    176174
 
 depends_build       port:autoconf \
                     port:automake \


### PR DESCRIPTION
#### Description
- Update `htop` to 3.0.2: https://groups.io/g/htop/topic/htop_3_0_2_bug_fix_release/76855201

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G6020
Xcode 11.3.1 11C504

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?