### PR TITLE
emacs-devel: fix build for 10.9 and earlier

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -90,6 +90,10 @@ if {$subport eq $name || $subport eq "emacs-app"} {
 }
 
 if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
+    # Need openat()
+    PortGroup       legacysupport 1.0
+    legacysupport.newest_darwin_requires_legacy 13
+
     epoch           1
     version         20200811
     revision        2


### PR DESCRIPTION
#### Description
Build fails on [10.9](https://build.macports.org/builders/ports-10.9_x86_64-builder/builds/126743/steps/install-port/logs/stdio) and earlier which do not have `openat()` (but which legacysupport can provide):
```
sysdep.c:2469:16: warning: implicit declaration of function 'openat' is invalid in C99 [-Wimplicit-function-declaration]
  while ((fd = openat (dirfd, file, oflags, mode)) < 0 && errno == EINTR)
               ^
…
Undefined symbols for architecture x86_64:
  "_openat", referenced from:
      _emacs_openat in sysdep.o
     (maybe you meant: _openat_proc_name, _openat_save_fail , _openat_restore_fail , _emacs_openat )
ld: symbol(s) not found for architecture x86_64
```
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
```
--->  Verifying Portfile for emacs-devel
Warning: Variant x11 overrides global description
--->  0 errors and 1 warnings found.
```

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
