### PR TITLE
nanogui, nanogui-wjakob: requires OpenGL 3 (macOS 10.7+)

### DIFF
--- a/graphics/nanogui/Portfile
+++ b/graphics/nanogui/Portfile
@@ -75,6 +75,15 @@ configure.cxxflags-append -std=c++11
 
 }
 
+# macOS 10.6 and earlier do not have OpenGL 3 (gl3.h)
+if {${os.platform} eq "darwin" && ${os.major} <= 10} {
+    known_fail      yes
+    pre-fetch {
+        ui_error "${subport} requires OpenGL 3 (available in Mac OS X 10.7 and later)."
+        return -code error "incompatible Mac OS X version"
+    }
+}
+
 depends_lib-append  port:glfw \
                     port:nanovg
 


### PR DESCRIPTION
#### Description
macOS 10.6 and earlier did not ship with OpenGL 3 support, so their SDKs do not have gl3.h:
```
In file included from /opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_graphics_nanogui/nanogui/work/nanogui-21e5cbc880b2e26b28b2a35085a9e6706da1e2a8/include/nanogui/opengl.h:42:
/opt/local/include/GLFW/glfw3.h:116:12: fatal error: 'OpenGL/gl3.h' file not found
  #include <OpenGL/gl3.h>
           ^~~~~~~~~~~~~~
/opt/local/include/GLFW/glfw3.h:116:12: note: did not find header 'gl3.h' in framework 'OpenGL' (loaded from '/System/Library/Frameworks')
```

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
