### PR TITLE
mos: new port

### DIFF
--- a/devel/mos/Portfile
+++ b/devel/mos/Portfile
@@ -1,0 +1,52 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+categories          devel
+license             Apache-2.0
+name                mos
+
+set python.versions \
+                    38
+
+depends_lib-append  port:libftdi1 \
+                    port:libftdi0 \
+                    port:libusb \
+                    port:libusb-compat \
+
+depends_build-append \
+                    port:python${python.versions} \
+                    port:py${python.versions}-setuptools \
+                    port:pkgconfig \
+
+maintainers         {@harens gmail.com:harensdeveloper} \
+                    openmaintainer
+description         Mongoose OS command-line tool
+long_description    ${description}. Provides device management \
+                    and firmware building capabilities.
+
+subport ${name}-latest {
+    long_description \
+                    A port of ${name} aimed for development purposes
+}
+
+if {${subport} eq "${name}"} {
+    conflicts       ${name}-latest
+    go.setup        github.com/mongoose-os/mos 2.18.0
+    checksums       rmd160  9ad2092f04bae9e21d26999e38699c5d3ceba7e3 \
+                    sha256  555df9fc6a629f6b79e61245cb4802544193e14528b110c13de015e2098954be \
+                    size    673863
+} else {
+    conflicts       ${name}
+    go.setup        github.com/mongoose-os/mos 93ecd2a813fd936d521f3f5b15f09f6140d850dc
+    checksums       rmd160  11731aece35690c4e28c2de7a6efd7b80042d8f8 \
+                    sha256  ecfd93a7eed2272a8369e573db353646ce0b58299f9e77fa2fd0dfa3e6826090 \
+                    size    672968
+}
+
+build.cmd           make
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

Add mos to MacPorts https://github.com/mongoose-os/mos/issues/37

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
xcode-select version 2373

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
