### PR TITLE
duplicity: fix build error

### DIFF
--- a/sysutils/duplicity/Portfile
+++ b/sysutils/duplicity/Portfile
@@ -7,6 +7,7 @@ name                duplicity
 categories          sysutils
 
 version             0.8.15
+revision            1
 
 set stable_series   [join [lrange [split ${version} .] 0 1] .]-series
 platforms           darwin
@@ -45,7 +46,7 @@ post-destroot {
         ${destroot}${prefix}/share/man/man1/
 }
 
-depends_build-append    port:py${python.version}-setuptools \
+depends_build-append    port:py${python.version}-setuptools_scm \
                         port:py${python.version}-rbtools \
                         port:py${python.version}-nose \
                         port:py${python.version}-pip


### PR DESCRIPTION
#### Description

duplicity: fix build error
    
  - Use setuptools_scm
  - Closes: https://trac.macports.org/ticket/61180

###### Type(s)

- [x] update
- [x] bugfix

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?