### PR TITLE
knot: revision 1 of version 3.0.0

### DIFF
--- a/net/knot/Portfile
+++ b/net/knot/Portfile
@@ -8,7 +8,7 @@ legacysupport.newest_darwin_requires_legacy 15
 
 name                knot
 version             3.0.0
-revision            0
+revision            1
 categories          net
 license             GPL-3+
 maintainers         {mps @Schamschula} openmaintainer
@@ -32,6 +32,7 @@ depends_lib         port:fstrm \
                     port:gnutls \
                     port:libidn \
                     port:lmdb \
+                    port:nghttp2 \
                     port:protobuf-c \
                     port:userspace-rcu
 


### PR DESCRIPTION
###### Description

* add dependecy for kdig (library libnghttp2)

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.6 19G2021
Xcode 11.7 11E801a

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
