### PR TITLE
libuuid-util-linux: new port

### DIFF
--- a/devel/util-linux/Portfile
+++ b/devel/util-linux/Portfile
@@ -51,6 +51,8 @@ configure.args      --disable-agetty \
                     --disable-eject \
                     --disable-fallocate \
                     --disable-fsck \
+                    --disable-ipcrm \
+                    --disable-ipcs \
                     --disable-kill \
                     --disable-libblkid \
                     --disable-libmount \
@@ -100,4 +102,21 @@ destroot {
                        ${destroot}${docdir}
 }
 
-github.livecheck.regex  {([^"rc]+)}
+github.livecheck.regex  {([^\"rc]+)}
+
+subport libuuid-util-linux {
+    license                 BSD
+    description             Universally unique id library
+    long_description        ${description} from util-linux.
+    conflicts               ossp-uuid libuuid
+    configure.args          --disable-all-programs \
+                            --enable-libuuid \
+                            --disable-bash-completion
+    build.target            libuuid
+    destroot {
+        system -W ${worksrcpath} "make install DESTDIR=${destroot}"
+
+        file delete -force ${destroot}${prefix}/share/locale
+        file delete -force ${destroot}${prefix}/share/man/man5
+    }
+}


### PR DESCRIPTION
#### Description
Build the libuuid that's shipped with util-linux. The name of this package is kind of a mouthful, if there is a more straightforward way to describe it, I'm all ears.

It conflicts with all the other uuid libraries available in MacPorts. I have started some of the work to move them over, but because all of these libraries are going to conflict with each other when that happens, it's best that they all get flipped in one big PR.  So, for now, that can wait.

###### Type(s)
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G6020
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
