### PR TITLE
fargate-cli: new port

### DIFF
--- a/net/fargate-cli/Portfile
+++ b/net/fargate-cli/Portfile
@@ -1,0 +1,118 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/awslabs/fargatecli 0.3.2
+name                fargate-cli
+revision            0
+
+description         CLI for AWS Fargate
+
+long_description    {*}${description}. AWS Fargate is a serverless compute \
+                    engine for containers that works with both Amazon Elastic \
+                    Container Service (ECS) and Amazon Elastic Kubernetes \
+                    Service (EKS).  Fargate makes it easy for you to focus on \
+                    building your applications. Fargate removes the need to \
+                    provision and manage servers, lets you specify and pay \
+                    for resources per application, and improves security \
+                    through application isolation by design.
+
+categories          net sysutils devel
+license             Apache-2
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+build.env-append    GO111MODULE=off \
+                    GOPROXY=off
+
+build.cmd           make
+build.target        build
+
+installs_libs       no
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/bin/fargate ${destroot}${prefix}/bin/
+}
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  4309778c5efbabe174a69fd9950ebbcaf858c688 \
+                        sha256  e91870a6de5b9014553a540e09c519a4c3f1282e63c0db28e8494020fc48bbc2 \
+                        size    155931
+
+go.vendors          github.com/mattn/go-isatty \
+                        lock    v0.0.3 \
+                        rmd160  52fa78fd66eb44112b174b03b1dcbe9648059280 \
+                        sha256  413ea81dd4dadf78a6713ad12c570577351cf8f4f8db617a8d7ec81c3d99ce09 \
+                        size    3369 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.2 \
+                        rmd160  a5807d8fee0fe122aaed185066436d8c640c94eb \
+                        sha256  4e39500bb2285c4b1299f57a8997a6a63a4ecdf5742903572dfcdcb8b74d07fa \
+                        size    44066 \
+                    golang.org/x/time \
+                        lock    6dc17368e09b \
+                        rmd160  6225e0a1ec76296cc4e5948871a711ad553b613d \
+                        sha256  9222637036830aa909988d79e2d00ac08bcda9745189c202bc4bb3f244ae4869 \
+                        size    9537 \
+                    github.com/aws/aws-sdk-go \
+                        lock    v1.12.70 \
+                        rmd160  a11393868ccb53de23150db50b4c5c1d643e9bbe \
+                        sha256  3e48a609cf582fc1f5fc3ec3e2dd587dc54ed322262ba23940713d8ef184bc9e \
+                        size    8521955 \
+                    github.com/golang/mock \
+                        lock    v1.3.1 \
+                        rmd160  a920208b3f0105e962d2faf892585c08343e6669 \
+                        sha256  54149d163cefcd32897c6fefaf85d0d8be3c3ee51f5cc43f0ff3a8d485da729f \
+                        size    48946 \
+                    github.com/kyokomi/emoji \
+                        lock    7e06b236c489 \
+                        rmd160  5408212e97d30402341225244ad15d7a171e9d13 \
+                        sha256  118af1bb9d2b165d1a7559333316818f03070ee21f64c28d0be8067d97973e38 \
+                        size    32553 \
+                    github.com/mattn/go-colorable \
+                        lock    v0.0.9 \
+                        rmd160  7251bb6bf8e5651a52c8e3244d7117918e812f89 \
+                        sha256  22ae6fdf63bccd195bf108013ba477c896a11fffdbb3398487914e32e1db9b2a \
+                        size    7602 \
+                    github.com/spf13/cobra \
+                        lock    v0.0.3 \
+                        rmd160  973651585034d41c5bf5508d949f616c519e08bf \
+                        sha256  ee5e92464c89386c88ca741b5a38d479090e88f01c95f496737e792271d689ba \
+                        size    101548 \
+                    github.com/go-ini/ini \
+                        lock    v1.32.0 \
+                        rmd160  d66b37f15f1e9a276ce3be59f35c668e3b664044 \
+                        sha256  c6cdb0257638cf63640d1ea6fc39acc8c2b7ef595b7f121715af08648fce9aca \
+                        size    42757 \
+                    golang.org/x/crypto \
+                        lock    c2843e01d9a2 \
+                        rmd160  35481af319848c87b8a91b708c1e045831062227 \
+                        sha256  f8e063af716f960d2bc47bac8f0c84e353797f791a955dd52c2a745396e930be \
+                        size    1650814 \
+                    golang.org/x/sys \
+                        lock    d0b11bdaac8a \
+                        rmd160  77203a57d29688c77187c209ff21dff6327e80fa \
+                        sha256  587f757e86a33b31d7d8443a08ec8c18f64f7eb30d27aa9c01199cf934d45966 \
+                        size    1243198 \
+                    golang.org/x/tools \
+                        lock    36563e24a262 \
+                        rmd160  1972dde442d0c984d9f4ac71a1d4e6f652ecb853 \
+                        sha256  e924891fd48d0da4e011f6b3e9f7ddbfc5bdecd6c78539dcc605992ddcc3c4a8 \
+                        size    2085672 \
+                    github.com/hashicorp/golang-lru \
+                        lock    0fb14efe8c47 \
+                        rmd160  9a43340c605b4dcfe2c43c7e30a12af8c9a1fb66 \
+                        sha256  4ce89ae6d42cdd602add460a915136f217f99b43f6f7c8f7eff47f8741d84ac7 \
+                        size    12908 \
+                    github.com/jmespath/go-jmespath \
+                        lock    0b12d6b521d8 \
+                        rmd160  aa4f36e1bf8c505a426927b06340d11525617649 \
+                        sha256  b3a8874808cc8cdbbfc60d9585d0b4181572246654c69fc9ef2e06afa4d83594 \
+                        size    48245 \
+                    github.com/mgutz/ansi \
+                        lock    9520e82c474b \
+                        rmd160  fea73fc246ac2b229bb91accba053fed2ea63536 \
+                        sha256  75eaed501d7d121ad75c83246fecdc6222dbbbd3fcb4140c8775e219fff440ce \
+                        size    4878


### PR DESCRIPTION
#### Description

New port for the [AWS Fargate CLI](https://github.com/awslabs/fargatecli)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.7 11E801a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
