### PR TITLE
py-scikit-image: build with OpenMP support

### DIFF
--- a/python/py-scikit-image/Portfile
+++ b/python/py-scikit-image/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-scikit-image
 version             0.17.2
-revision            1
+revision            2
 categories-append   science
 platforms           darwin
 license             BSD
@@ -30,10 +30,11 @@ checksums           rmd160  5c990500ca1977a410190238be3785dbfc8f8071 \
                     size    29818001
 
 if {${name} ne ${subport}} {
+    compiler.openmp_version 2.5
 
     if {${python.version} < 36} {
         version             0.14.2
-        revision            1
+        revision            2
         distname            ${python.rootname}-${version}
         checksums           rmd160  2126c9e2d11c46e3cabb73656bc048cc27d2c960 \
                             sha256  1afd0b84eefd77afd1071c5c1c402553d67be2d7db8950b32d6f773f25850c1f \
@@ -46,7 +47,7 @@ if {${name} ne ${subport}} {
                             port:py${python.version}-cloudpickle
     } elseif {${python.version} == 36} {
         version             0.16.2
-        revision            0
+        revision            1
         epoch               1
         distname            ${python.rootname}-${version}
         checksums           rmd160  4315f53c8b32c3dffe58bf054a458cf9e21379c9 \


### PR DESCRIPTION
#### Description
scikit-image currently builds with OpenMP support somewhat opportunistically, i.e. when an OpenMP-capable compiler is used, and `libomp` is present; this PR "forces" building with OpenMP support by ensuring these conditions are met. (I'm not aware if scikit-image has a way of manually specifying whether to build with OpenMP support.)
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6
MacPorts clang 9.0
Python 3.8.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
