### PR TITLE
terragrunt: update to 0.24.4

### DIFF
--- a/sysutils/terragrunt/Portfile
+++ b/sysutils/terragrunt/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           golang 1.0
 
 name                terragrunt
-version             0.23.4
-revision            1
+version             0.24.4
+revision            0
 
 categories          sysutils
 platforms           darwin linux
@@ -18,9 +18,9 @@ long_description    ${description} that provides extra tools for working with mu
 go.setup            github.com/gruntwork-io/terragrunt ${version} v
 homepage            https://terragrunt.gruntwork.io
 
-checksums           rmd160  f072990cea4a0d0d2a814e32ab233ec64a93825e \
-                    sha256  3b4ddc07684eba41e1d3ad8b33464e8e9aeea6d2adb29aab6799a00f48988a52 \
-                    size    1963542
+checksums           rmd160  5c23e704d7192b4de32c824663598a3466729b7f \
+                    sha256  cc9c56fcbd299f59055b92f1f6258c9ea1610609c1d29a3ca5d32ac93577e335 \
+                    size    2029411
 
 patchfiles          patch-options.go.diff
 


### PR DESCRIPTION
#### Description

Update terragrunt version.

###### Tested on
macOS 10.14.6 18G6020
Xcode 11.2.1 11B500 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
