### PR TITLE
py-Pillow: add dummy x11 & quartz variants

### DIFF
--- a/python/py-Pillow/Portfile
+++ b/python/py-Pillow/Portfile
@@ -1,10 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           active_variants 1.1
 PortGroup           python 1.0
 
 name                py-Pillow
 version             7.2.0
+revision            1
 categories-append   devel
 platforms           darwin
 license             BSD
@@ -50,6 +52,22 @@ if {${name} ne ${subport}} {
 
     post-patch {
         reinplace "s|@prefix@|${prefix}|g" ${worksrcpath}/setup.py
+    }
+
+    # When built against a Tk using X11, Pillow will pick up some
+    # extra libraries, such libxcb. Tk's quartz variant doesn't depend
+    # on these libraries, so we add matching variants here.
+    variant x11 conflicts quartz {
+    }
+
+    variant quartz conflicts x11 {
+        require_active_variants tk quartz x11
+    }
+
+    if {![catch {set result [active_variants tk quartz x11]}] && $result} {
+        default_variants +quartz
+    } else {
+        default_variants +x11
     }
 
     livecheck.type      none


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

When built against a Tk using X11, Pillow will pick up some extra libraries, such libxcb. Tk's quartz variant doesn't depend on these libraries, so installing both that (from source) and Pillow (from an archive) can lead to a missing dependency, as noticed by rev-upgrade.

The workaround is to add explicit variants for this; we pick which one to use based on Tk's choice.

See: https://trac.macports.org/ticket/53374

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15
Xcode 11

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
