### PR TITLE
scid: move compiler.cxx_standard

### DIFF
--- a/games/scid/Portfile
+++ b/games/scid/Portfile
@@ -26,13 +26,14 @@ depends_lib             port:tcl \
 
 patchfiles              patch-Makefile.conf.diff
 
+compiler.cxx_standard   2014
+
 configure.post_args     BINDIR="${prefix}/bin" SHAREDIR="${prefix}/share/${name}" \
                         COMPILE="${configure.cxx}" LINK="${configure.cxx}"
 
 build.args-append       CC=${configure.cc} \
                         CXX=${configure.cxx} \
                         CPP=${configure.cpp}
-compiler.cxx_standard   2014
 
 destroot.target         install_scid
 destroot.target-append  install_engines


### PR DESCRIPTION


#### Description
I had added `compiler.cxx_standard 2014` but didn't make sure it went somewhere before compiler selection variables (`compiler.cc`, `compiler.cxx`, `compiler.cpp`) were being read. As a result there are build failures on [10.9](https://build.macports.org/builders/ports-10.9_x86_64-builder/builds/126871/steps/install-port/logs/stdio) and earlier, because even though MacPorts clang 9 is the selected compiler, the configure script is run with `COMPILE="/usr/bin/clang++" LINK="/usr/bin/clang++"` and `make` is run with `CC=/usr/bin/clang CXX=/usr/bin/clang++ CPP=/usr/bin/cpp `, leading to errors:
```
error: invalid value 'c++14' in '-std=c++14'
```
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
