### PR TITLE
py-scikit-image: restrict py-tifffile dependency, pin to 1.16.2 for py36

### DIFF
--- a/python/py-scikit-image/Portfile
+++ b/python/py-scikit-image/Portfile
@@ -44,6 +44,8 @@ if {${name} ne ${subport}} {
         depends_run-append  port:py${python.version}-dask \
                             port:py${python.version}-toolz \
                             port:py${python.version}-cloudpickle
+    } else {
+        depends_run-append  port:py${python.version}-tifffile
     }
 
     depends_build-append \
@@ -57,8 +59,7 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-networkx \
                         port:py${python.version}-Pillow \
                         port:py${python.version}-imageio \
-                        port:py${python.version}-pywavelets \
-                        port:py${python.version}-tifffile
+                        port:py${python.version}-pywavelets
 
     livecheck.type      none
 }

--- a/python/py-scikit-image/Portfile
+++ b/python/py-scikit-image/Portfile
@@ -44,6 +44,14 @@ if {${name} ne ${subport}} {
         depends_run-append  port:py${python.version}-dask \
                             port:py${python.version}-toolz \
                             port:py${python.version}-cloudpickle
+    } elseif {${python.version} == 36} {
+        version             0.16.2
+        revision            0
+        epoch               1
+        distname            ${python.rootname}-${version}
+        checksums           rmd160  4315f53c8b32c3dffe58bf054a458cf9e21379c9 \
+                            sha256  dd7fbd32da74d4e9967dc15845f731f16e7966cee61f5dc0e12e2abb1305068c \
+                            size    28945695
     } else {
         depends_run-append  port:py${python.version}-tifffile
     }


### PR DESCRIPTION
#### Description
No `py36-tifffile` port currently available; `py-tifffile` is only needed for scikit-image 0.17.x.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
Separated for clarity.
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
