### PR TITLE
qcachegrind: update to 20.08.1, Qt5

### DIFF
--- a/devel/qcachegrind/Portfile
+++ b/devel/qcachegrind/Portfile
@@ -1,39 +1,39 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           qt4 1.0
+PortGroup           qmake5 1.0
+PortGroup           github 1.0
 
+github.setup        KDE kcachegrind 20.08.1 v
 name                qcachegrind
-version             0.7.4
 categories          devel
-platforms           macosx
+platforms           darwin
 maintainers         m4x.org:frederic.devernay
+license             GPL-2
 
 description         Callgrind profile data visualization
 
 long_description    ${description}
 
-homepage            http://kcachegrind.sourceforge.net/
-master_sites        http://kcachegrind.sourceforge.net/
-distname            kcachegrind-${version}
-extract.suffix      .tar.gz
+homepage            https://kcachegrind.github.io/html/Home.html
 
 checksums \
-    rmd160 a7d0ca0677e455720ad876e449cc7a003183d44d \
-    sha256 0bf6efb647d500bf09bbbab617d30a8a2a0a2cbf87fd1f2a1375d774c005b379
-                    
-depends_lib         port:qt4-mac
+    rmd160  af03f33b85957ea81c340c229dc0e08611013062 \
+    sha256  1510710e0d58bf9c87460d53539bb485d8fbfb4adf3ad0a824ae33c97c69ff46 \
+    size    353614
 
-universal_variant   no
+depends_run         port:graphviz
+
+patchfiles          0001-Fix-shell-invocations-for-MacPorts.patch
+patch.args          -p1
+
+post-patch {
+    reinplace -W ${worksrcpath} "s|@@PREFIX@@|${prefix}|g" \
+        qcachegrind/qcgtoplevel.cpp \
+        libviews/callgraphview.cpp
+}
 
 destroot {
     copy ${worksrcpath}/qcachegrind/qcachegrind.app \
          ${destroot}${applications_dir}
 }
-
-configure.cmd       {qmake}
-configure.pre_args  INSTALLBASE="${prefix}"
-
-livecheck.type      sourceforge
-livecheck.name      kcachegrind
-livecheck.regex     "kcachegrind-(\[0-9\](\.\[0-9\]){1,2})"

--- a/devel/qcachegrind/files/0001-Fix-shell-invocations-for-MacPorts.patch
+++ b/devel/qcachegrind/files/0001-Fix-shell-invocations-for-MacPorts.patch
@@ -1,0 +1,42 @@
+From 2e2b1f4241a92d11e99b39b4c514173df3b2dcd4 Mon Sep 17 00:00:00 2001
+From: Aaron Madlon-Kay <aaron@wovn.io>
+Date: Fri, 18 Sep 2020 09:16:48 +0900
+Subject: [PATCH] Fix shell invocations for MacPorts
+
+---
+ libviews/callgraphview.cpp  | 4 ++--
+ qcachegrind/qcgtoplevel.cpp | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/libviews/callgraphview.cpp b/libviews/callgraphview.cpp
+index 2f3c25f..be6d683 100644
+--- a/libviews/callgraphview.cpp
++++ b/libviews/callgraphview.cpp
+@@ -2069,9 +2069,9 @@ void CallGraphView::refresh()
+     QString renderProgram;
+     QStringList renderArgs;
+     if (_layout == GraphOptions::Circular)
+-        renderProgram = QStringLiteral("twopi");
++        renderProgram = QStringLiteral("@@PREFIX@@/bin/twopi");
+     else
+-        renderProgram = QStringLiteral("dot");
++        renderProgram = QStringLiteral("@@PREFIX@@/bin/dot");
+     renderArgs << QStringLiteral("-Tplain");
+ 
+     _unparsedOutput = QString();
+diff --git a/qcachegrind/qcgtoplevel.cpp b/qcachegrind/qcgtoplevel.cpp
+index 5c60ae7..1f61b37 100644
+--- a/qcachegrind/qcgtoplevel.cpp
++++ b/qcachegrind/qcgtoplevel.cpp
+@@ -904,7 +904,7 @@ void QCGTopLevel::exportGraph()
+ 
+ #ifdef Q_OS_UNIX
+     // shell commands only work in UNIX
+-    QString cmd = QStringLiteral("(dot %1 -Tps > %2.ps; xdg-open %3.ps)&")
++    QString cmd = QStringLiteral("(@@PREFIX@@/bin/dot %1 -Tps > %2.ps; open %3.ps)&")
+                   .arg(n).arg(n).arg(n);
+     if (::system(QFile::encodeName( cmd ))<0)
+         qDebug() << "QCGTopLevel::exportGraph: can not run " << cmd;
+-- 
+2.28.0
+


### PR DESCRIPTION
#### Description

Update qcachegrind. The current version is ancient and didn't build for me due to the same issue described [here](https://trac.macports.org/ticket/54183). Rather than patch the existing version, I updated to use the modern codebase.

Also qcachegrind shells out to GraphViz at runtime to generate some graphs; this doesn't work as-is because GUI apps do not inherit the users's shell's `PATH`; I've fixed this as well.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.6 19G2021

Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->