### PR TITLE
mpd: update to version 0.22.2

### DIFF
--- a/audio/mpd/Portfile
+++ b/audio/mpd/Portfile
@@ -2,16 +2,12 @@
 
 PortSystem          1.0
 PortGroup           compiler_blacklist_versions 1.0
+PortGroup           meson 1.0
 PortGroup           legacysupport 1.0
 
 name                mpd
 
-# note - versions 0.21.x and beyond require meson, and will require considerable
-# rearrangement of the Portfile to support setting options in variants
-# also, the audio output system changes to requiring 10.8+
-
-version             0.20.23
-revision            1
+version             0.22.4
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          audio
 maintainers         nomaintainer
@@ -28,12 +24,16 @@ master_sites        https://www.musicpd.org/download/${name}/${branch}/
 license             GPL-2+ LGPL-2.1
 use_xz              yes
 
-checksums           rmd160  c288933cd369d606e8fdfe49515c67cadc3da56e \
-                    sha256  503e5f9f237290f568ff7956ab2f9aed563594bf749f19b8fe994fb21434afea \
-                    size    806784
+checksums           rmd160  75d2eff87d9f5d292b882c67acc30cff02b7bdf5 \
+                    sha256  891ea993a539246fa8f670346e5aa6c8cc85ce4be739ff12261712b0b3149dd0 \
+                    size    729264
 
-depends_build \
-    port:pkgconfig
+set python_branch   3.8
+set python_version  [string map {. {}} ${python_branch}]
+
+depends_build-append \
+    port:pkgconfig \
+    port:py${python_version}-sphinx
 
 # this port only uses boost headers during build
 # and does not link with any boost libraries
@@ -42,75 +42,231 @@ depends_build-append \
     port:boost
 
 depends_lib \
-    port:audiofile \
-    port:curl \
-    port:faad2 \
-    port:flac \
     path:lib/pkgconfig/glib-2.0.pc:glib2 \
-    port:icu \
-    port:libcdio-paranoia \
     port:libcue \
-    port:libiconv \
-    port:libid3tag \
-    port:libogg \
-    port:libvorbis \
-    port:zlib \
-    port:libao
+    port:libao \
+    port:zlib
 
-# requires C++14
-compiler.cxx_standard 2014
-compiler.blacklist-append {clang < 700.0.72}
-
-#   revise Main.cxx with patch in future version 0.19.12 to allow compilation without inotify
 configure.args \
-    --mandir=${prefix}/share/man \
-    --disable-ffmpeg \
-    --disable-jack \
-    --enable-ao \
-    --disable-mpc
-
-# build fails against fluidsynth @2.0.3
-configure.args-append \
-    --disable-fluidsynth
+    --mandir ${prefix}/share/man \
+    -Ddocumentation=enabled \
+    -Dlibmpdclient=disabled \
+    -Dwebdav=disabled \
+    -Dcue=true \
+    -Dcdio_paranoia=disabled \
+    -Dcurl=disabled \
+    -Dmms=disabled \
+    -Dnfs=disabled \
+    -Dsmbclient=disabled \
+    -Dqobuz=disabled \
+    -Dsoundcloud=disabled \
+    -Dtidal=disabled \
+    -Did3tag=disabled \
+    -Dchromaprint=disabled \
+    -Dadplug=disabled \
+    -Daudiofile=disabled \
+    -Dfaad=disabled \
+    -Dffmpeg=disabled \
+    -Dflac=disabled \
+    -Dfluidsynth=disabled \
+    -Dgme=disabled \
+    -Dmad=disabled \
+    -Dmikmod=disabled \
+    -Dmodplug=disabled \
+    -Dmpcdec=disabled \
+    -Dmpg123=disabled \
+    -Dopus=disabled \
+    -Dsidplay=disabled \
+    -Dsndfile=disabled \
+    -Dtremor=disabled \
+    -Dvorbis=disabled \
+    -Dwavpack=disabled \
+    -Dwildmidi=disabled \
+    -Dvorbisenc=disabled \
+    -Dlame=disabled \
+    -Dtwolame=disabled \
+    -Dshine=disabled \
+    -Dwave_encoder=true \
+    -Dlibsamplerate=disabled \
+    -Dsoxr=disabled \
+    -Dalsa=disabled \
+    -Dao=enabled \
+    -Dfifo=true \
+    -Dhttpd=true \
+    -Djack=disabled \
+    -Dopenal=disabled \
+    -Doss=disabled \
+    -Dpipe=true \
+    -Dpulse=disabled \
+    -Drecorder=false \
+    -Dshout=disabled \
+    -Dsndio=disabled \
+    -Dsolaris_output=disabled \
+    -Ddbus=disabled \
+    -Dexpat=disabled \
+    -Dicu=disabled \
+    -Diconv=disabled \
+    -Dpcre=disabled \
+    -Dsqlite=disabled \
+    -Dyajl=disabled \
+    -Dzeroconf=auto \
+    -Dzlib=enabled \
+    -Dupnp=disabled
 
 configure.cflags-append -I${prefix}/include
 
-variant mpcdec description {Support for musepack via libmpcdec} {
-    depends_lib-append  port:libmpcdec
-    configure.args-delete --disable-mpc
-}
-variant ffmpeg description {Support for myriad formats via ffmpeg} {
-    depends_lib-append	path:lib/libavcodec.dylib:ffmpeg
-    configure.args-delete --disable-ffmpeg
-}
-variant mod description {Support for several formats of tracker/sequencer files via libmikmod} {
-    depends_lib-append    port:libmikmod
-    configure.args-append --enable-mod
-}
-variant modplug description {Support for several formats of tracker/sequencer files via libmodplug} {
-    depends_lib-append    port:libmodplug
-    configure.args-append --enable-modplug
-}
-variant mpg123 conflicts mad description {Use mpg123 rather than mad as mp3 deconding library} {
-    depends_lib-append    port:mpg123
-    configure.args-append --enable-mpg123 --disable-mad
-}
-variant mad conflicts mpg123 description (Use mad rather than mpg123 as mp3 decoding library} {
-    depends_lib-append      port:libmad
-    configure.args-append   --enable-mad --disable-mpg123
-}
-if {![variant_isset mpg123]} {
-    default_variants    +mad
+variant faad description {Support for AAC format via faad2} {
+    depends_lib-append port:faad2
+    configure.args-replace -Dfaad=disabled -Dfaad=enabled
 }
 
-# requires support for C++14.
-compiler.cxx_standard   2014
+variant ffmpeg description {Support for myriad formats (including ALAC) via FFmpeg} {
+    depends_lib-append path:lib/libavcodec.dylib:ffmpeg
+    configure.args-replace -Dffmpeg=disabled -Dffmpeg=enabled
+}
+
+variant flac description {Support for FLAC format} {
+    depends_lib-append port:flac
+    configure.args-replace -Dflac=disabled -Dflac=enabled
+}
+
+variant pcre description {Support for regular expressions via pcre2} {
+    depends_lib-append port:pcre2
+    configure.args-replace -Dpcre=disabled -Dpcre=enabled
+}
+
+variant stickers description {Support for stickers database} {
+    depends_lib-append port:sqlite3
+    configure.args-replace -Dsqlite=disabled -Dsqlite=enabled
+}
+
+variant ogg description {Support for Ogg Vorbis (encoding/decoding)} {
+    depends_lib-append port:libogg port:libvorbis
+    configure.args-replace -Dvorbis=disabled -Dvorbis=enabled
+    configure.args-replace -Dvorbisenc=disabled -Dvorbisenc=enabled
+}
+
+variant libmpdclient description {Support for libmpdclient proxy database} {
+    depends_lib-append port:libmpdclient
+    configure.args-replace -Dlibmpdclient=disabled -Dlibmpdclient=enabled
+}
+
+variant lame description {Support for MP3 encoding via lame} {
+    depends_lib-append port:lame
+    configure.args-replace -Dlame=disabled -Dlame=enabled
+}
+
+variant twolame description {Support for MP3 encoding via twolame} {
+    depends_lib-append port:twolame
+    configure.args-replace -Dtwolame=disabled -Dtwolame=enabled
+}
+
+variant CD description {Support for CD-ROM access via libcdio-paranoia} {
+    depends_lib-append port:libcdio-paranoia
+    configure.args-replace -Dcdio_paranoia=disabled -Dcdio_paranoia=enabled
+}
+
+variant mpcdec description {Support for Musepack via libmpcdec} {
+    depends_lib-append port:libmpcdec
+    configure.args-replace --Dmpcdec=disabled Dmpcdec=enabled
+}
+
+variant mod description {Support for several formats of tracker/sequencer files via libmikmod} {
+    depends_lib-append port:libmikmod
+    configure.args-append -Dmikmod=enabled
+}
+
+variant modplug description {Support for several formats of tracker/sequencer files via libmodplug} {
+    depends_lib-append port:libmodplug
+    configure.args-append -Dmodplug=enabled
+}
+
+variant fluidsynth description {Support for FluidSynth MIDI} {
+    depends_lib-append port:fluidsynth
+    configure.args-append -Dfluidsynth=enabled
+}
+
+variant opus description {Support for Opus format} {
+    depends_lib-append port:libopus
+    configure.args-append -Dopus=enabled
+}
+
+variant wavpack description {Support for WavPack format} {
+    depends_lib-append port:wavpack
+    configure.args-replace -Dwavpack=disabled -Dwavpack=enabled
+}
+
+variant jack description {Support for JACK output} {
+    depends_lib-append port:jack
+    configure.args-replace -Djack=disabled -Djack=enabled
+}
+
+variant shout description {Support for ShoutCast or IceCast streaming via libshout2} {
+    depends_lib-append port:libshout2
+    configure.args-replace -Dshout=disabled -Dshout=enabled
+}
+
+variant sidplay description {Support for C64 SID support via SIDPLAY} {
+    depends_lib-append port:SIDPLAY
+    configure.args-replace -Dsidplay=disabled -Dsidplay=enabled
+}
+
+variant chromaprint description {Support for ChromaPrint / AcoustID via chromaprint} {
+    depends_lib-append port:chromaprint
+    configure.args-replace -Dchromaprint=disabled -Dchromaprint=enabled
+}
+
+variant mpg123 conflicts mad description {Use mpg123 rather than mad as mp3 deconding library} {
+    depends_lib-append port:mpg123
+    configure.args-replace -D-mpg123=disabled -Dmad=enabled
+}
+
+variant mad conflicts mpg123 description {Use mad rather than mpg123 as mp3 decoding library} {
+    depends_lib-append port:libmad
+    configure.args-replace -Dmad=disabled -Dmad=enabled
+}
+
+variant webdav description {Support WebDAV storage} {
+    depends_lib-append port:curl port:expat
+    configure.args-replace -Dcurl=disabled -Dcurl=enabled
+    configure.args-replace -Dexpat=disabled -Dexpat=enabled
+    configure.args-replace -Dwebdav=disabled -Dwebdav=enabled
+}
+
+variant upnp description {Support UPnP database} {
+    depends_lib-append port:libupnp
+    configure.args-replace -Dupnp=disabled -Dupnp=enabled
+}
+
+variant curl description {Support HTTP client using CURL} {
+    depends_lib-append port:curl
+    configure.args-replace -Dcurl=disabled -Dcurl=enabled
+}
+
+variant mms description {Support MMS input via libmms} {
+    depends_lib-append port:libmms
+    configure.args-replace -Dmms=disabled -Dmms=enabled
+}
+
+variant avahi description {Support zeroconf via avahi} {
+    depends_lib-append port:avahi
+    configure.args-replace -Dzeroconf=auto -Dzeroconf=avahi
+}
+
+configure.env-append \
+    PATH=${frameworks_dir}/Python.framework/Versions/${python_branch}/bin:$env(PATH)
+build.env-append    {*}${configure.env}
+destroot.env-append {*}${configure.env}
+
+# requires support for C++17.
+compiler.cxx_standard   2017
 
 if {${os.platform} eq "darwin" && ${os.major} > 8} {
     set mpduser       _mpd
 } else {
     set mpduser       mpd
 }
+
 # Create new user for mpd:
 add_users ${mpduser} group=${mpduser} realname=Music\ Player\ Daemon
 
@@ -139,6 +295,8 @@ post-activate {
         copy ${prefix}/etc/mpd.conf.default ${prefix}/etc/mpd.conf
     }
 }
+
+default_variants    +mad +flac +faad +pcre
 
 notes "A basic configuration file has been created for you.
 To add music to mpd's database, create symbolic links in


### PR DESCRIPTION
#### Description

I've fumbled my way through updating MPD to 0.21.25.

**n.b.** 0.20.x -> 0.21.x changed the build system to meson.

I'm not really familiar with all this, so `port lint` reports errors in variants.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.6 11E708 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? *fails*
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
