### PR TITLE
k9s: update to 0.22.0

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.21.9 v
+go.setup            github.com/derailed/k9s 0.22.0 v
 homepage            https://k9scli.io
 
 categories          sysutils devel
@@ -20,9 +20,9 @@ platforms           darwin
 supported_archs     x86_64
 license             Apache-2
 
-checksums           rmd160  5ffc8298aa109bb58f484ee34eb20a0ed17139a4 \
-                    sha256  e6014a36a3d60943f3f5cde0a5c4bef109f8cd776c58d5def8435a506e03ba2c \
-                    size    6084100
+checksums           rmd160  26632732130d398d9cd334cfeb24ad1a259685ae \
+                    sha256  4b027ffed36a5721347b526c5049a194674adeaab85225aefd017c5860b6861d \
+                    size    6084706
 
 # Reproduce the "build" target from the upstream Makefile
 set go_ldflags      "-w -X ${go.package}/cmd.version=${version} \


### PR DESCRIPTION
#### Description

Update to K9s 0.22.0.

###### Tested on

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?