### PR TITLE
openjdk8: add subport openjdk15

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -153,6 +153,14 @@ subport openjdk14-openj9-large-heap {
     set openj9_version 0.21.0
 }
 
+subport openjdk15 {
+    version      15
+    revision     0
+
+    set build    36
+    set major    15
+}
+
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
 platforms        darwin
@@ -461,6 +469,15 @@ if {${subport} eq "openjdk8"} {
                  suitable for running all workloads. \
                  \
                  This version uses non-compressed references and should be used for applications which require heaps that are over ~57 GB.
+} elseif {${subport} eq "openjdk15"} {
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}/
+    distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}_${build}
+
+    checksums    rmd160  86184738b178fc57f8fdd79f2e43e502e1bd1ee2 \
+                 sha256  bd1fc774232e2dfee93056a01f5765bd92ffb19d68dd548c233a82bb5c162be4 \
+                 size    195853361
+
+    worksrcdir   jdk-${version}+${build}
 }
 
 variant Applets \
@@ -505,10 +522,10 @@ by adding the following line to your shell profile:
     export JAVA_HOME=${target}/Contents/Home
 "
 
-if {${subport} eq "openjdk10" || [string match openjdk12* ${subport}] || [string match openjdk13* ${subport}]} {
+if {${subport} eq "openjdk10" || [string match openjdk12* ${subport}] || [string match openjdk13* ${subport}] || [string match openjdk14* ${subport}]} {
     notes-append "
     Warning: Support for OpenJDK ${major} has reached end of life and there will be no more updates.
              Please consider migrating to a supported OpenJDK version.
-             Currently OpenJDK 8, 11 and 14 are supported.
+             Currently OpenJDK 8, 11 and 15 are supported.
     "
 }


### PR DESCRIPTION
#### Description

Add subport `openjdk15` for AdoptOpenJDK 15 with HotSpot VM, mark `openjdk14*` as end of life.

###### Tested on

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?