### PR TITLE
Azure CI: Xcode 12 no longer beta

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,9 +7,9 @@ jobs:
 
   strategy:
     matrix:
-      mac-10.15-xcode12beta:
+      mac-10.15-xcode12:
         imageName: 'macOS-10.15'
-        MP_XCODE_APP: '/Applications/Xcode_12_beta.app'
+        MP_XCODE_APP: '/Applications/Xcode_12.app'
       mac-10.15:
         imageName: 'macOS-10.15'
       mac-10.14:


### PR DESCRIPTION
#### Description
Update to use final release of Xcode 12. (Xcode 11.7 is still the default for now on macOS 10.15. I am aware the Azure CI tasks in MacPorts will likely soon be replaced by equivalent GitHub Actions tasks.)
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
