### PR TITLE
infracost: new port

### DIFF
--- a/sysutils/infracost/Portfile
+++ b/sysutils/infracost/Portfile
@@ -1,0 +1,174 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/infracost/infracost 0.5.2 v
+revision            0
+categories          sysutils net
+
+license             Apache-2
+platforms           darwin
+supported_archs     x86_64
+
+homepage            https://www.infracost.io
+
+description         Cloud cost estimates for Terraform in your CLI
+
+long_description    Infracost shows hourly and monthly cost estimates for a \
+                    Terraform project. This helps developers, DevOps et al. \
+                    quickly see the cost breakdown and compare different \
+                    deployment options upfront.
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  c1ce95be89de8bdcb8fda8b10035ebf9e1720e01 \
+                        sha256  97c51c3aef4e93dadb2d4c67fee9f054b4c316ff9b326854c7e6e74d74c8dd79 \
+                        size    162798
+
+go.vendors          github.com/briandowns/spinner \
+                        lock    v1.11.1 \
+                        rmd160  f4c3484dc811bd4d221fc086a43a5aa3aaa34798 \
+                        sha256  cd774ef21175e11a41e635a2f78ab44f54de36f988e3594bd8f94afd4c8d96bd \
+                        size    1309608 \
+                    github.com/cpuguy83/go-md2man \
+                        lock    f79a8a8ca69d \
+                        rmd160  85f342c341fa928e9ec874490c277bdabf1c39c6 \
+                        sha256  2f3f8bc701df4890a5a4baf0b632ad3290be1e0aaf572b2e58fd57df93efc306 \
+                        size    52040 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/fatih/color \
+                        lock    v1.9.0 \
+                        rmd160  1d8418b4f1b3cb597f680b93aaa08afcc9651be4 \
+                        sha256  577c8e778833fec90d76918f138cee9f7765435757b7c92a669e5b34933e0b4f \
+                        size    1231337 \
+                    github.com/google/go-cmp \
+                        lock    v0.5.2 \
+                        rmd160  5021dfa1c1da165c38f7a1a0b78794204233735f \
+                        sha256  6631e46f37f68fde3c411c90e9b9186526903a2123222f08de658547b1caafca \
+                        size    99774 \
+                    github.com/joho/godotenv \
+                        lock    v1.3.0 \
+                        rmd160  d148eaad98aa087f37b2363dde436b3ad4acff5f \
+                        sha256  98dfa588184833217ce9c6521b7e9b179c2033f2b62570458ed5b76cb00eb07c \
+                        size    9946 \
+                    github.com/kelseyhightower/envconfig \
+                        lock    v1.4.0 \
+                        rmd160  3045036fa33fdff530677ae4a989089af841ed40 \
+                        sha256  4d5ba70026d7875624510f14e38c34305192cbe73726beed28e4e4b597388638 \
+                        size    14360 \
+                    github.com/konsorten/go-windows-terminal-sequences \
+                        lock    v1.0.3 \
+                        rmd160  26e90ab69813fa0a56d0dae2738c5289487932bb \
+                        sha256  56dd8452636a977fecbd826fc89a8d00b54a481a5c59e9b47e68a8ae6fc2c175 \
+                        size    1982 \
+                    github.com/mattn/go-colorable \
+                        lock    v0.1.4 \
+                        rmd160  aeaf016c7ae6cf014233a5a327e4227acf17adea \
+                        sha256  d64a7c2835de356f83a8af8ac9e07ce45d13a5ecb5062efd7f63b85b0b173193 \
+                        size    8987 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.11 \
+                        rmd160  e7d2dadfe4bff4cd5a5dfece75632e31af6fad44 \
+                        sha256  a8aac03b74f35ec077c589a8ac186b215f14536bb5e262b320ef7ece85bdcab5 \
+                        size    4399 \
+                    github.com/mattn/go-runewidth \
+                        lock    v0.0.7 \
+                        rmd160  82319630034da9c2a7d73cefed068cced7e538d6 \
+                        sha256  33984861cc1c3404174f5a79db9834333dab0ddf3567f2c33cd1ed5e1869493a \
+                        size    16090 \
+                    github.com/olekukonko/tablewriter \
+                        lock    v0.0.4 \
+                        rmd160  750bec232562820a4f3ba47cd2864f4c84e7a767 \
+                        sha256  890daf262aee371899075912bab0b3107313bea32846cf796bca83ef9a1dccf5 \
+                        size    19267 \
+                    github.com/pkg/errors \
+                        lock    v0.9.1 \
+                        rmd160  dc065c655f8a24c6519b58f9d1202eb266ecda40 \
+                        sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
+                        size    13422 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/russross/blackfriday \
+                        lock    v2.0.1 \
+                        rmd160  99cb49faff9bf24b8637dcdb3602c27c115810f3 \
+                        sha256  4078d2cd3b1c6952133b214e4eaca95f3b31a01f87a03adabd7712e7d5f20f60 \
+                        size    79665 \
+                    github.com/shopspring/decimal \
+                        lock    v1.2.0 \
+                        rmd160  816b30c16e4272887fdb54cdb31edf8d0518cbb6 \
+                        sha256  efa72d6c6d5a261d614ac11ce5db7c2a76d671866300f087f4f4225b4b11f500 \
+                        size    37774 \
+                    github.com/shurcooL/sanitized_anchor_name \
+                        lock    v1.0.0 \
+                        rmd160  c7e5322dba53e10db1711d65c146af5649b0c7c8 \
+                        sha256  ed9418de8c92acfbbd8608745855ebfc67fa686c0a0a5245cf8eece8f540baa9 \
+                        size    2144 \
+                    github.com/sirupsen/logrus \
+                        lock    v1.6.0 \
+                        rmd160  86f47e96e9adaa208f0bc5f7e8b0591e76f2d73c \
+                        sha256  2810c27a2d1927be0a7bd542443af5a0230680a38423d4c0e4906a7ace4d6387 \
+                        size    45760 \
+                    github.com/stretchr/testify \
+                        lock    v1.2.2 \
+                        rmd160  45703d5a082af570664fb80e99918077596349aa \
+                        sha256  ea0e76528dc47d7d84739cd8a8c7560e3f12d4ff490bdd2641a9990a168e6f2f \
+                        size    101747 \
+                    github.com/tidwall/gjson \
+                        lock    v1.6.1 \
+                        rmd160  33dc4dcdf357f9ec3d1eab5e86ad3f3eb0812a9f \
+                        sha256  8b74b82965f89bb3277ad7b20dad85efce60ffa6699bf706b66e1b23ff4db725 \
+                        size    50687 \
+                    github.com/tidwall/match \
+                        lock    v1.0.1 \
+                        rmd160  4d768df32f352d4461eaf7fc8b9b4da5d72665ba \
+                        sha256  9085c9f3cb6a7bd868535f018d3b69146b3420ddf5e9dbe0d44de843ec50b1f5 \
+                        size    4366 \
+                    github.com/tidwall/pretty \
+                        lock    v1.0.2 \
+                        rmd160  e75f75a2785ba3ce3069d368ce85d2bf4c64adb8 \
+                        sha256  6cd1240063683c334310292b75f29e4fc0c71041f3f4797710e838ad7176b066 \
+                        size    8866 \
+                    github.com/urfave/cli \
+                        lock    v2.2.0 \
+                        rmd160  4a6ffb4a39be12c9239c971e0faa5118206066ad \
+                        sha256  b7bfbd0ff7fdedb839dec9b56d026fc6bcc4db534e3bb9fce3a9da6604945818 \
+                        size    3404076 \
+                    golang.org/x/sys \
+                        lock    33540a1f6037 \
+                        rmd160  c0f935b516176c256e198073c3e99e43b8703bb8 \
+                        sha256  12203e31fcb839217947a1d61f385747f6f7776a2b0340b0d5b6a355e77594a8 \
+                        size    1497790 \
+                    golang.org/x/xerrors \
+                        lock    9bdfabe68543 \
+                        rmd160  eee9929ac1c0380402c45b388077c5c505f13311 \
+                        sha256  dc1be1d7efb43643507e87352ae7161883c48cb5116a20a1739ab93ab558bccf \
+                        size    13661
+
+# Set GO111MODULE=off to force the usage of the dependencies being provided by 
+# go.vendors.
+build.env-append    GO111MODULE=off
+
+build.cmd           make
+build.pre_args      VERSION=${version}
+build.args          darwin
+ 
+use_parallel_build  no
+
+post-extract {
+    reinplace "s|CGO_ENABLED=0||g" Makefile
+}
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/build/${name}-darwin-amd64 \
+                     ${destroot}${prefix}/bin/${name}
+}


### PR DESCRIPTION
#### Description

New port for [infracost](https://www.infracost.io)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.7 11E801a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
