### PR TITLE
openmotif: Fixes for compilation on macOS11

### DIFF
--- a/x11/openmotif/Portfile
+++ b/x11/openmotif/Portfile
@@ -2,6 +2,7 @@ PortSystem      1.0
 
 name            openmotif
 version         2.3.8
+revision        1
 categories      x11
 license         LGPL
 platforms       darwin
@@ -36,6 +37,9 @@ depends_lib \
 	port:xorg-libXmu \
 	port:xorg-libXp \
 	port:xorg-libXt
+
+patchfiles wcs-functions.patch
+patchfiles-append include-stdlib.patch
 
 # See https://trac.macports.org/ticket/42847
 if {[string match "*clang*" ${configure.compiler}]} {

--- a/x11/openmotif/files/include-stdlib.patch
+++ b/x11/openmotif/files/include-stdlib.patch
@@ -1,0 +1,10 @@
+--- ./demos/unsupported/xmform/xmform.c.orig	2016-03-16 02:10:08.000000000 +0000
++++ ./demos/unsupported/xmform/xmform.c	2020-09-03 10:45:32.000000000 +0100
+@@ -50,6 +50,7 @@
+ xmform*bottomShadowColor:        black
+ ***-------------------------------------------------------------------*/
+ 
++#include <stdlib.h>
+ #include <Xm/Xm.h>
+ #include <Xm/Form.h>
+ #include <Xm/PushB.h>

--- a/x11/openmotif/files/wcs-functions.patch
+++ b/x11/openmotif/files/wcs-functions.patch
@@ -1,0 +1,11 @@
+--- lib/Xm/TextF.c.orig	2017-08-22 01:27:47.000000000 +0100
++++ lib/Xm/TextF.c	2020-09-03 10:19:13.000000000 +0100
+@@ -82,7 +82,7 @@
+ #define FIX_1409
+ 
+ #if (defined(__FreeBSD__) && (__FreeBSD__ < 4)) || \
+-    (defined(__APPLE__) || defined(__NetBSD__) || defined(__OpenBSD__))
++    (defined(__NetBSD__) || defined(__OpenBSD__))
+ /*
+  * Modification by Integrated Computer Solutions, Inc.  May 2000
+  *


### PR DESCRIPTION
#### Description

This pull request fixes compilation on macOS11 (arm64).
- include stdlib.h for calloc
- use the system wcs functions, which are available on all modern versions of macOS

###### Type(s)


- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.0 20A5299w
Xcode 12.0 12A8158a 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
