### PR TITLE
glow: don't fetch dependencies in build phase

### DIFF
--- a/textproc/glow/Portfile
+++ b/textproc/glow/Portfile
@@ -16,9 +16,131 @@ categories          textproc
 license             MIT
 installs_libs       no
 
-checksums           rmd160  012dd6ef8a114b1d3e9dbac96fc9efcad84aca77 \
-                    sha256  ed54c4b9a420a993920eadcf09c851bc9fec938bd4f5211d6447addf5f3332ef \
-                    size    494672
+checksums           glow-${version}.tar.gz \
+                        rmd160  012dd6ef8a114b1d3e9dbac96fc9efcad84aca77 \
+                        sha256  ed54c4b9a420a993920eadcf09c851bc9fec938bd4f5211d6447addf5f3332ef \
+                        size    494672
+
+go.vendors          github.com/dlclark/regexp2 \
+                        lock    v1.2.0 \
+                        rmd160  6df6fe44029a4e40275a928ea6dd4d41040172f9 \
+                        sha256  b836f5cbf685a4247e3cc92e243113478bb7a8dba33380e6c1d036a727305c67 \
+                        size    204592 \
+                    golang.org/x/sys \
+                        lock    d0b11bdaac8a \
+                        rmd160  77203a57d29688c77187c209ff21dff6327e80fa \
+                        sha256  587f757e86a33b31d7d8443a08ec8c18f64f7eb30d27aa9c01199cf934d45966 \
+                        size    1243198 \
+                    github.com/alecthomas/repr \
+                        lock    117648cd9897 \
+                        rmd160  1f78bc0844f7ca6ccb93808bb367080e4c3accf8 \
+                        sha256  6715287714f895ceeed848842618084ea0fb4a53f0b904d9c456bea28ea31e16 \
+                        size    4649 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.4 \
+                        rmd160  0a12014fd5fa0abaf40b622ae21db4e754b8b86c \
+                        sha256  9795d007b5616de49307fb12a4d7e5363512ec3f1094a8ec6660ad4da8c03131 \
+                        size    3379 \
+                    github.com/muesli/reflow \
+                        lock    e5efeac4e302 \
+                        rmd160  4ea09e8c7515cc0fe3ca4f9c1daf171e044d69f6 \
+                        sha256  36c4bd4cb2aeab6fa73139f354b3786949f0f1768e7e6ffa97b6c1b7ec305d2e \
+                        size    15099 \
+                    github.com/spf13/cobra \
+                        lock    v0.0.5 \
+                        rmd160  53e9a05596343a23f3a42bb6bf0d1a740591345d \
+                        sha256  9987c8c42db1f7b6e17abb000d23457463bc3f8884c815777f7fbf5e48e6a498 \
+                        size    111150 \
+                    github.com/stretchr/testify \
+                        lock    v1.3.0 \
+                        rmd160  80582370443047a1d7020211865d85d54c036eea \
+                        sha256  ac782171992e3af1c8ac8384cbf4a39706ec5f9e3c6eed57a246e02dce571762 \
+                        size    102899 \
+                    github.com/yuin/goldmark \
+                        lock    v1.1.19 \
+                        rmd160  a5de99fd4a171dae4751866c626e88a155b89716 \
+                        sha256  1b3085da1bc87ebcf780a395159ee0666befe946f7e8cd82bb9d0d0e3656c9bb \
+                        size    213123 \
+                    golang.org/x/net \
+                        lock    c0dbc17a3553 \
+                        rmd160  48b6f5b26ecb95069c725a10502750e6b80f11d3 \
+                        sha256  551a4a9410c9a69eba624dd070b22128422550c1a98306012313be0e77bd023a \
+                        size    1171907 \
+                    github.com/alecthomas/chroma \
+                        lock    v0.7.0 \
+                        rmd160  e3727850dfc66827ccb77ba4cf4074416cb260fd \
+                        sha256  9128651bdbf85932d4c3f9cc16cd71873bc8fdad6046f07984bf7175abe5df3c \
+                        size    8458048 \
+                    github.com/alecthomas/colour \
+                        lock    60882d9e2721 \
+                        rmd160  9f588ca134237b19f19199a088974aefebe3b301 \
+                        sha256  9178279e7dbff10a8325724c84b344dfcf365578d30d3f436db5fb1cba1030d5 \
+                        size    3484 \
+                    github.com/charmbracelet/glamour \
+                        lock    v0.1.0 \
+                        rmd160  f6c3e9ea5f55334012fe281121daa98e5426a753 \
+                        sha256  cd194014036a672ac4d3312f600ab48e2ed7c061574f46faa1135e97de2ce191 \
+                        size    511826 \
+                    github.com/logrusorgru/aurora \
+                        lock    66b7ad493a23 \
+                        rmd160  82d9fb7cd30d443c91c1f5150c730f9bdf5441e6 \
+                        sha256  a53596d33285bbe33ebc1783d167a0d6413d4c6bcb9dcc745e1a4520d2c2e7c5 \
+                        size    133637 \
+                    github.com/lucasb-eyer/go-colorful \
+                        lock    v1.0.3 \
+                        rmd160  0d0a283ba00c871d123c951efea0605a869951aa \
+                        sha256  ecd902ddda5d05cc8a857873bf8b984a5cd2d7b75f1185edcfc2c472707958b3 \
+                        size    430208 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.3 \
+                        rmd160  32abdd77a987af95ce5b647846bfdbb2d8db91a0 \
+                        sha256  046b6b81e3925ffe60e2213e9a239303ff98a51e76764590b807b591fedf2d1e \
+                        size    46029 \
+                    github.com/alecthomas/assert \
+                        lock    405dbfeb8e38 \
+                        rmd160  5d141a90e1e313657b558c19d51c3bdd65b0e5e5 \
+                        sha256  8c445be2c7daa6b680bfbf96823192076bbf9c0f514642687d6487fd95630a5e \
+                        size    71075 \
+                    github.com/danwakefield/fnmatch \
+                        lock    cbb64ac3d964 \
+                        rmd160  19ae7b520847e16b0e8ac23ee5e6c51db3831f46 \
+                        sha256  2b045b8a716e3ca32d2a930781cd421b042d0e861fa3d36a79ed5535b2e5308a \
+                        size    4960 \
+                    github.com/inconshreveable/mousetrap \
+                        lock    v1.0.0 \
+                        rmd160  5c617a09f1432fc543672a0e0c1e13d3752030c2 \
+                        sha256  0e6bae2849f13d12fe361ecac087728e4e97f3482f4cec44f6e7a2c53bb9cd0c \
+                        size    2291 \
+                    github.com/mattn/go-runewidth \
+                        lock    v0.0.7 \
+                        rmd160  82319630034da9c2a7d73cefed068cced7e538d6 \
+                        sha256  33984861cc1c3404174f5a79db9834333dab0ddf3567f2c33cd1ed5e1869493a \
+                        size    16090 \
+                    github.com/microcosm-cc/bluemonday \
+                        lock    v1.0.2 \
+                        rmd160  78bde56f8c676e8a7f3ed07dfcb63731bb958240 \
+                        sha256  298aa8b8eff4c6beda27bf98eeddd4ebfc63ad01a88fa45880abbc0da6424aab \
+                        size    137682 \
+                    github.com/olekukonko/tablewriter \
+                        lock    v0.0.4 \
+                        rmd160  750bec232562820a4f3ba47cd2864f4c84e7a767 \
+                        sha256  890daf262aee371899075912bab0b3107313bea32846cf796bca83ef9a1dccf5 \
+                        size    19267 \
+                    github.com/sergi/go-diff \
+                        lock    v1.0.0 \
+                        rmd160  c5ac5f7253544101282f5477a71560d1fd6c3e58 \
+                        sha256  147eecf13dff7c6715ada19e097d4c3b7d20b169b475861a98e41e27b891d062 \
+                        size    41633
 
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
Per https://trac.macports.org/ticket/61192 this is one of the golang ports that automatically downloads its dependencies at build time.

To fix it, I used `go2port`, but when doing so ran into these tricky points:

1. go2port 20200217 (the current latest) will duplicate some dependencies. This will be fixed shortly.
2. There were some checksum mismatches; surprisingly enough it seemed like GitHub sometimes served truncated tarballs, because deleting and re-downloading fixed it
3. Simply pasting the generated `go.vendors` block is not enough; you also have to give the main distfile a filename. Until you do so, the checksum phase will fail in a way that makes it look like issue (2) above.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->