### PR TITLE
mirror_sites.tcl: remove perl-hackers.net

### DIFF
--- a/_resources/port1.0/fetch/mirror_sites.tcl
+++ b/_resources/port1.0/fetch/mirror_sites.tcl
@@ -76,7 +76,6 @@ set portfetch::mirror_sites::sites(cpan) {
     http://cpan.noris.de/modules/by-module/
     https://cpan.pair.com/modules/by-module/
     http://cpan.panu.it/modules/by-module/
-    http://cpan.perl-hackers.net/modules/by-module/
     http://cpan.perl.pt/modules/by-module/
     http://cpan.pesat.net.id/modules/by-module/
     http://cpan.rinet.ru/modules/by-module/


### PR DESCRIPTION
Mirror is compromised
https://lists.macports.org/pipermail/macports-users/2020-September/048792.html

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
