### PR TITLE
qt5-qtwebkit: work around bison related build failure

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -1455,6 +1455,11 @@ foreach {module module_info} [array get modules] {
                 # avoid: Project ERROR: Could not find feature mirclient.
                 patchfiles-append patch-qtwebkit_fix_mirclient_test.diff
 
+                # work around https://trac.macports.org/ticket/60975
+                patchfiles-append patch-webkit_XPathGrammar.y.diff
+                patchfiles-append patch-webkit_makegrammar.pl.diff
+
+
                 # qtwebkit uses
                 #    glx
                 #    libXcomposite

--- a/aqua/qt5/files/patch-webkit_XPathGrammar.y.diff
+++ b/aqua/qt5/files/patch-webkit_XPathGrammar.y.diff
@@ -1,0 +1,10 @@
+--- Source/WebCore/xml/XPathGrammar.y.orig	2017-06-16 14:46:36.000000000 +0200
++++ Source/WebCore/xml/XPathGrammar.y	2020-09-18 23:36:10.000000000 +0200
+@@ -53,6 +53,7 @@
+ 
+ %pure_parser
+ %parse-param { WebCore::XPath::Parser* parser }
++%define api.header.include { "XPathGrammar.h" }
+ 
+ %union
+ {

--- a/aqua/qt5/files/patch-webkit_makegrammar.pl.diff
+++ b/aqua/qt5/files/patch-webkit_makegrammar.pl.diff
@@ -1,0 +1,29 @@
+--- Source/WebCore/css/makegrammar.pl.orig	2017-06-16 14:46:36.000000000 +0200
++++ Source/WebCore/css/makegrammar.pl	2020-09-18 22:59:10.000000000 +0200
+@@ -73,23 +73,7 @@
+ }
+ 
+ my $fileBase = File::Spec->join($outputDir, $filename);
+-system("$bison -d -p $symbolsPrefix $grammarFilePath -o $fileBase.cpp");
+-
+-open HEADER, ">$fileBase.h" or die;
+-print HEADER << "EOF";
+-#ifndef CSSGRAMMAR_H
+-#define CSSGRAMMAR_H
+-EOF
+-
+-open HPP, "<$fileBase.cpp.h" or open HPP, "<$fileBase.hpp" or die;
+-while (<HPP>) {
+-    print HEADER;
+-}
+-close HPP;
+-
+-print HEADER "#endif\n";
+-close HEADER;
+-
+-unlink("$fileBase.cpp.h");
+-unlink("$fileBase.hpp");
++my @bisonCommand = ($bison, "--defines=$fileBase.h", "-p", $symbolsPrefix, $grammarFilePath, "-o", "$fileBase.cpp");
++push @bisonCommand, "--no-lines" if $^O eq "MSWin32"; # Work around bug in bison >= 3.0 on Windows where it puts backslashes into #line directives.
++system(@bisonCommand) == 0 or die;
+ 


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/60975

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G6020
Xcode 11.3.1 11C504 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
