### PR TITLE
py-robotframework-seleniumlibrary: needs setuptools

### DIFF
--- a/python/py-robotframework-seleniumlibrary/Portfile
+++ b/python/py-robotframework-seleniumlibrary/Portfile
@@ -32,6 +32,7 @@ set worksrcdir      ${internal_name}-${version}
 
 
 if {${name} ne ${subport}} {
+    depends_build-append port:py${python.version}-setuptools
     depends_lib-append  port:py${python.version}-robotframework
 }
 


### PR DESCRIPTION
#### Description
Build will fail if py-setuptools isn't already installed ([example](https://build.macports.org/builders/ports-10.15_x86_64-builder/builds/38572/steps/install-port/logs/stdio)):
```
Traceback (most recent call last):
  File "setup.py", line 5, in <module>
    from setuptools import setup, find_packages
ModuleNotFoundError: No module named 'setuptools'
```

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Untested. Please check CI build results.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
