### PR TITLE
dovecot: apns variant bugfix and compiler error fix

### DIFF
--- a/mail/dovecot/Portfile
+++ b/mail/dovecot/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 
 github.setup        dovecot core 2.3.11.3
 name                dovecot
-revision            0
+revision            1
 epoch               20060722
 set core_version    ${version}
 
@@ -114,6 +114,7 @@ if {${name} eq ${subport}} {
 
     patch.pre_args  -p1
     patchfiles      patch-doc-example-config-conf.d-10-master.conf.diff \
+                    patch-src-lib-ioloop-notify-kqueue-c.diff \
                     patch-src-master-master-settings.c.diff
 
     post-patch {
@@ -189,11 +190,16 @@ if {${name} eq ${subport}} {
         pre-destroot {
             xinstall -m 0750 -d \
                 -o ${default_internal_user} -g ${default_login_user} \
+                ${destroot}${prefix}/etc/${name}-apns \
+                ${destroot}${prefix}/var/db/${name}-apns
+            close [open ${destroot}${prefix}/var/db/${name}-apns/devices a]
+            file attributes \
                 ${destroot}${prefix}/var/db/${name}-apns/devices \
-                ${destroot}${prefix}/etc/${name}-apns
+                -permissions 0750 \
+                -owner ${default_internal_user} -group ${default_login_user}
             destroot.keepdirs-append \
-                ${destroot}${prefix}/var/db/${name}-apns/devices \
-                ${destroot}${prefix}/etc/${name}-apns
+                ${destroot}${prefix}/etc/${name}-apns \
+                ${destroot}${prefix}/var/db/${name}-apns
             xinstall -m 0755 ${filespath}/pushnotify.pl \
                 ${destroot}${prefix}/sbin
             foreach cmd [list \

--- a/mail/dovecot/files/dovecot-core-pushnotify.patch
+++ b/mail/dovecot/files/dovecot-core-pushnotify.patch
@@ -1,7 +1,64 @@
+diff -Naur ./README.md ./README.md
+--- ./README.md	2020-09-18 20:09:11.000000000 -0400
++++ ./README.md	2020-09-18 19:57:02.000000000 -0400
+@@ -1,3 +1,53 @@
++Apple Push Notification Service (APNS) Plugin
++=============================================
++
++This branch of [dovecot/core](https://github.com/dovecot/core)
++includes a plugin for APNS. This is based on
++[matthewpowell/pushnotify](https://github.com/matthewpowell/pushnotify),
++[cullum/freebsd-ports](https://github.com/cullum/freebsd-ports/tree/master/mail),
++and this [post](https://www.c0ffee.net/blog/dovecot-push-notifications/).
++
++APNS use requires these steps:
++
++1. Acquire APNS Mail certificates from a (virtual) macOS
++   High Sierra 10.13 and Server.app version 5.7. Export
++   the certificates from the Keychain into the file
++   com.apple.servermgrd.apns.mail.p12 . **Note**: APNS Mail
++   certificate creation is deprecated on Server.app version 5.8+.
++2. Convert the APNS Mail certificates to PEM files:
++```
++       openssl pkcs12 -in com.apple.servermgrd.apns.mail.p12  \
++           -clcerts -nokeys | sed '/BEGIN CERTIFICATE/,$!d'   \
++       > mail.crt
++       sudo install -m 0644 -o _dovecot -g _dovenull \
++           mail.crt /opt/local/etc/dovecot-apns
++       openssl pkcs12 -in com.apple.servermgrd.apns.mail.p12  \
++           -nodes -nocerts | sed '/BEGIN PRIVATE KEY/,$!d'    \
++       > mail.key
++       sudo install -m 0640 -o _dovecot -g _dovenull \
++           mail.key /opt/local/etc/dovecot-apns
++```
++3. Configure dovecot for APNS:
++```
++   /opt/local/etc/dovecot/conf.d/15-lda.conf:
++   protocol lda { mail_plugins = $mail_plugins push_notify }
++```
++```
++   /opt/local/etc/dovecot/conf.d/90-apns.conf:
++   aps_topic = com.apple.mail.XServer.<UUID>
++```
++   where the certificate's UUID is obtained from the command:
++```
++       openssl x509 -text -noout                            \
++           -in /opt/local/etc/dovecot-apns/mail.crt         \
++       | grep -E -o 'com.apple.mail.XServer.[0-9a-f-]+'
++```
++4. Launch the APNS daemon (macOS):
++```
++       sudo launchctl load -w \
++           /Library/LaunchDaemons/org.macports.dovecot-apns.plist
++```
++
+ Installation
+ ============
+ 
 diff -Naur ./configure.ac ./configure.ac
---- ./configure.ac	2019-07-23 03:14:10.000000000 -0400
-+++ ./configure.ac	2019-10-10 05:40:20.000000000 -0400
-@@ -911,6 +911,7 @@
+--- ./configure.ac	2020-09-18 20:09:11.000000000 -0400
++++ ./configure.ac	2020-09-18 19:57:02.000000000 -0400
+@@ -930,6 +930,7 @@
  src/plugins/notify/Makefile
  src/plugins/notify-status/Makefile
  src/plugins/push-notification/Makefile
@@ -9,9 +66,564 @@ diff -Naur ./configure.ac ./configure.ac
  src/plugins/pop3-migration/Makefile
  src/plugins/quota/Makefile
  src/plugins/quota-clone/Makefile
+diff -Naur ./dovecot-core-pushnotify.patch ./dovecot-core-pushnotify.patch
+--- ./dovecot-core-pushnotify.patch	1969-12-31 19:00:00.000000000 -0500
++++ ./dovecot-core-pushnotify.patch	2020-09-18 19:57:02.000000000 -0400
+@@ -0,0 +1,551 @@
++diff -Naur ./configure.ac ./configure.ac
++--- ./configure.ac	2019-07-23 03:14:10.000000000 -0400
+++++ ./configure.ac	2019-10-10 05:40:20.000000000 -0400
++@@ -911,6 +911,7 @@
++ src/plugins/notify/Makefile
++ src/plugins/notify-status/Makefile
++ src/plugins/push-notification/Makefile
+++src/plugins/push-notify/Makefile
++ src/plugins/pop3-migration/Makefile
++ src/plugins/quota/Makefile
++ src/plugins/quota-clone/Makefile
++diff -Naur ./src/auth/auth-settings.c ./src/auth/auth-settings.c
++--- ./src/auth/auth-settings.c	2019-07-23 03:14:10.000000000 -0400
+++++ ./src/auth/auth-settings.c	2019-10-08 18:37:33.000000000 -0400
++@@ -269,6 +269,8 @@
++ 	DEFLIST(passdbs, "passdb", &auth_passdb_setting_parser_info),
++ 	DEFLIST(userdbs, "userdb", &auth_userdb_setting_parser_info),
++ 
+++	DEF_NOPREFIX(SET_STR, aps_topic),
+++
++ 	DEF_NOPREFIX(SET_STR, base_dir),
++ 	DEF_NOPREFIX(SET_BOOL, verbose_proctitle),
++ 	DEF_NOPREFIX(SET_UINT, first_valid_uid),
++@@ -331,6 +333,8 @@
++ 	.passdbs = ARRAY_INIT,
++ 	.userdbs = ARRAY_INIT,
++ 
+++	.aps_topic = "",
+++
++ 	.base_dir = PKG_RUNDIR,
++ 	.verbose_proctitle = FALSE,
++ 	.first_valid_uid = 500,
++diff -Naur ./src/auth/auth-settings.h ./src/auth/auth-settings.h
++--- ./src/auth/auth-settings.h	2019-07-23 03:14:10.000000000 -0400
+++++ ./src/auth/auth-settings.h	2019-10-08 17:51:20.000000000 -0400
++@@ -82,6 +82,8 @@
++ 	ARRAY(struct auth_passdb_settings *) passdbs;
++ 	ARRAY(struct auth_userdb_settings *) userdbs;
++ 
+++	const char *aps_topic;
+++
++ 	const char *base_dir;
++ 	const char *ssl_client_ca_dir;
++ 	const char *ssl_client_ca_file;
++diff -Naur ./src/imap/Makefile.am ./src/imap/Makefile.am
++--- ./src/imap/Makefile.am	2019-07-23 03:14:10.000000000 -0400
+++++ ./src/imap/Makefile.am	2019-10-08 20:40:24.000000000 -0400
++@@ -64,6 +64,7 @@
++ 	cmd-unselect.c \
++ 	cmd-unsubscribe.c \
++ 	cmd-urlfetch.c \
+++	cmd-x-apple-push-service.c \
++ 	cmd-x-cancel.c \
++ 	cmd-x-state.c
++ 
++diff -Naur ./src/imap/cmd-x-apple-push-service.c ./src/imap/cmd-x-apple-push-service.c
++--- ./src/imap/cmd-x-apple-push-service.c	1969-12-31 19:00:00.000000000 -0500
+++++ ./src/imap/cmd-x-apple-push-service.c	2019-10-10 06:22:12.000000000 -0400
++@@ -0,0 +1,173 @@
+++/*
+++ * Copyright (c) 2010-2011 Apple Inc. All rights reserved.
+++ * 
+++ * Redistribution and use in source and binary forms, with or without  
+++ * modification, are permitted provided that the following conditions  
+++ * are met:
+++ * 
+++ * 1.  Redistributions of source code must retain the above copyright  
+++ * notice, this list of conditions and the following disclaimer.
+++ * 2.  Redistributions in binary form must reproduce the above  
+++ * copyright notice, this list of conditions and the following  
+++ * disclaimer in the documentation and/or other materials provided  
+++ * with the distribution.
+++ * 3.  Neither the name of Apple Inc. ("Apple") nor the names of its  
+++ * contributors may be used to endorse or promote products derived  
+++ * from this software without specific prior written permission.
+++ * 
+++ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND 
+++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,  
+++ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A  
+++ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS  
+++ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,  
+++ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT  
+++ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF 
+++ * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND  
+++ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,  
+++ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  
+++ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF  
+++ * SUCH DAMAGE.
+++ */
+++
+++#include "imap-common.h"
+++#include "imap-id.h"
+++
+++#include "str.h"
+++#include "home-expand.h"
+++#include "mail-user.h"
+++#include "imap-quote.h"
+++
+++#include <stdio.h>
+++#include <fcntl.h>
+++#include <stdlib.h>
+++#include <unistd.h>
+++#include <sys/un.h>
+++#include <sys/stat.h>
+++#include <sys/socket.h>
+++
+++#define	APS_VERSION		"1"
+++
+++typedef struct msg_data_s {
+++	unsigned long msg;
+++	unsigned long pid;
+++
+++	char d1[128];
+++	char d2[512];
+++	char d3[512];
+++	char d4[512];
+++} msg_data_t;
+++
+++/*
+++   tag1 XAPPLEPUSHSERVICE "aps-version" "1"
+++	  "aps-account-id" "E8CD34AD-98D3-4489-A6BB-86B1D082FECE"
+++	  "aps-device-token" "a66216ad1683d48b9933cdcc3b98a833ee1a968143f41ea494187da54715da66"
+++	  "aps-subtopic" "com.apple.mobilemail"
+++*/
+++
+++static void do_notify(const char *username, const char *aps_acct_id,
+++		      const char *aps_dev_token, const char *aps_sub_topic)
+++{
+++	const char *push_notify_path = "@PREFIX@/var/run/dovecot/push_notify";
+++
+++	msg_data_t msg_data;
+++	memset(&msg_data, 0, sizeof(struct msg_data_s));
+++	msg_data.msg = 2;
+++
+++	strncpy(msg_data.d1, username, sizeof(msg_data.d1));
+++	strncpy(msg_data.d2, aps_acct_id, sizeof(msg_data.d2));
+++	strncpy(msg_data.d3, aps_dev_token, sizeof(msg_data.d3));
+++	strncpy(msg_data.d4, aps_sub_topic, sizeof(msg_data.d4));
+++
+++	int soc = socket( AF_UNIX, SOCK_DGRAM, 0 );
+++	if ( soc < 0 ) {
+++		i_warning( "open notify socket failed(%d): %m", soc );
+++		return;
+++	}
+++
+++	struct sockaddr_un sock_addr;
+++	memset( &sock_addr, 0, sizeof(struct sockaddr_un));
+++	sock_addr.sun_family = AF_UNIX;
+++	strncpy( sock_addr.sun_path, push_notify_path, sizeof(sock_addr.sun_path) );
+++	socklen_t sock_len = sizeof(sock_addr.sun_family) + strlen(sock_addr.sun_path) + 1;
+++	int rc = connect(soc, (struct sockaddr *) &sock_addr, sock_len);
+++	if ( rc < 0 ) {
+++		i_warning("connect to notify socket %s failed: %m",
+++			  push_notify_path);
+++		close(soc);
+++		return;
+++	}
+++
+++	rc = send(soc, (void *)&msg_data, sizeof(msg_data), 0);
+++	if ( rc < 0 )
+++		i_warning("send to notify socket %s failed: %m",
+++			  push_notify_path);
+++
+++	close(soc);
+++}
+++
+++static const char *aps_reply_generate (struct client_command_context *cmd,
+++				       const struct imap_arg *args)
+++{
+++	const char *aps_topic = cmd->client->set->aps_topic;
+++	const char *aps_ver=NULL;
+++	const char *aps_acct_id=NULL;
+++	const char *aps_dev_token=NULL;
+++	const char *aps_sub_topic=NULL;
+++	const char *key, *value;
+++
+++	/* must have a topic */
+++	if (aps_topic == NULL || *aps_topic == '\0')
+++		return NULL;
+++
+++	/* scarf off the aps keys/values */
+++	while (imap_arg_get_astring(&args[0], &key) &&
+++	       imap_arg_get_astring(&args[1], &value)) {
+++		if (strcasecmp(key, "aps-version") == 0)
+++			aps_ver = t_strdup(value);
+++		else if (strcasecmp(key, "aps-account-id") == 0)
+++			aps_acct_id = t_strdup(value);
+++		else if (strcasecmp(key, "aps-device-token") == 0)
+++			aps_dev_token = t_strdup(value);
+++		else if (strcasecmp(key, "aps-subtopic") == 0)
+++			aps_sub_topic = t_strdup(value);
+++		else 
+++			return NULL;
+++		args += 2;
+++	}
+++
+++	/* save notification settings */
+++	if ( aps_ver && aps_acct_id && aps_dev_token && aps_sub_topic ) {
+++		/* subscribe to notification node */
+++		do_notify(cmd->client->user->username, aps_acct_id,
+++			  aps_dev_token, aps_sub_topic);
+++
+++		/* generate aps response */
+++		string_t *str = t_str_new(256);
+++		imap_append_quoted( str, "aps-version" );
+++		str_append_c(str, ' ');
+++		imap_append_quoted( str, APS_VERSION );
+++		str_append_c(str, ' ');
+++		imap_append_quoted( str, "aps-topic" );
+++		str_append_c(str, ' ');
+++		imap_append_quoted( str, aps_topic );
+++		return str_c(str);
+++	}
+++	return NULL;
+++}
+++
+++bool cmd_x_apple_push_service(struct client_command_context *cmd)
+++{
+++	const struct imap_arg *args;
+++
+++	if (!client_read_args(cmd, 0, 0, &args))
+++		return FALSE;
+++
+++	const char *reply = aps_reply_generate(cmd, args);
+++	if (reply != NULL)
+++		client_send_line(cmd->client,
+++				 t_strdup_printf("* XAPPLEPUSHSERVICE %s",
+++						 reply));
+++	client_send_tagline(cmd, "OK XAPPLEPUSHSERVICE completed.");
+++
+++	return TRUE;
+++}
++diff -Naur ./src/imap/imap-client.c ./src/imap/imap-client.c
++--- ./src/imap/imap-client.c	2019-07-23 03:14:10.000000000 -0400
+++++ ./src/imap/imap-client.c	2019-10-08 20:42:59.000000000 -0400
++@@ -182,6 +182,8 @@
++ 		   a chance of working */
++ 		client_add_capability(client, "SEARCH=FUZZY");
++ 	}
+++	if (set->aps_topic != NULL && *set->aps_topic)
+++		str_append(client->capability_string, " XAPPLEPUSHSERVICE");
++ 
++ 	mail_set = mail_user_set_get_storage_set(user);
++ 	if (mail_set->mailbox_list_index) {
++diff -Naur ./src/imap/imap-commands.c ./src/imap/imap-commands.c
++--- ./src/imap/imap-commands.c	2019-07-23 03:14:10.000000000 -0400
+++++ ./src/imap/imap-commands.c	2019-10-08 20:15:39.000000000 -0400
++@@ -76,6 +76,7 @@
++ 	{ "UID SORT",		cmd_sort,        COMMAND_FLAG_BREAKS_SEQS },
++ 	{ "UID THREAD",		cmd_thread,      COMMAND_FLAG_BREAKS_SEQS },
++ 	{ "UNSELECT",		cmd_unselect,    COMMAND_FLAG_BREAKS_MAILBOX },
+++	{ "XAPPLEPUSHSERVICE",	cmd_x_apple_push_service,	0},
++ 	{ "X-CANCEL",		cmd_x_cancel,    0 },
++ 	{ "X-STATE",		cmd_x_state,     COMMAND_FLAG_REQUIRES_SYNC },
++ 	{ "XLIST",		cmd_list,        0 },
++diff -Naur ./src/imap/imap-commands.h ./src/imap/imap-commands.h
++--- ./src/imap/imap-commands.h	2019-07-23 03:14:10.000000000 -0400
+++++ ./src/imap/imap-commands.h	2019-10-08 20:16:48.000000000 -0400
++@@ -121,6 +121,7 @@
++ bool cmd_uid_expunge(struct client_command_context *cmd);
++ bool cmd_move(struct client_command_context *cmd);
++ bool cmd_unselect(struct client_command_context *cmd);
+++bool cmd_x_apple_push_service(struct client_command_context *cmd);
++ bool cmd_x_cancel(struct client_command_context *cmd);
++ bool cmd_x_state(struct client_command_context *cmd);
++ 
++diff -Naur ./src/imap/imap-settings.c ./src/imap/imap-settings.c
++--- ./src/imap/imap-settings.c	2019-07-23 03:14:10.000000000 -0400
+++++ ./src/imap/imap-settings.c	2019-10-08 17:57:36.000000000 -0400
++@@ -73,6 +73,7 @@
++ 	DEF(SET_STR, imap_logout_format),
++ 	DEF(SET_STR, imap_id_send),
++ 	DEF(SET_STR, imap_id_log),
+++	DEF(SET_STR, aps_topic),
++ 	DEF(SET_ENUM, imap_fetch_failure),
++ 	DEF(SET_BOOL, imap_metadata),
++ 	DEF(SET_BOOL, imap_literal_minus),
++@@ -101,6 +102,7 @@
++ 		"body_count=%{fetch_body_count} body_bytes=%{fetch_body_bytes}",
++ 	.imap_id_send = "name *",
++ 	.imap_id_log = "",
+++	.aps_topic = "",
++ 	.imap_fetch_failure = "disconnect-immediately:disconnect-after:no-after",
++ 	.imap_metadata = FALSE,
++ 	.imap_literal_minus = FALSE,
++diff -Naur ./src/imap/imap-settings.h ./src/imap/imap-settings.h
++--- ./src/imap/imap-settings.h	2019-07-23 03:14:10.000000000 -0400
+++++ ./src/imap/imap-settings.h	2019-10-08 17:48:14.000000000 -0400
++@@ -31,6 +31,7 @@
++ 	const char *imap_logout_format;
++ 	const char *imap_id_send;
++ 	const char *imap_id_log;
+++	const char *aps_topic;
++ 	const char *imap_fetch_failure;
++ 	bool imap_metadata;
++ 	bool imap_literal_minus;
++diff -Naur ./src/imap-login/imap-login-client.c ./src/imap-login/imap-login-client.c
++--- ./src/imap-login/imap-login-client.c	2019-07-23 03:14:10.000000000 -0400
+++++ ./src/imap-login/imap-login-client.c	2019-10-11 08:28:49.000000000 -0400
++@@ -117,6 +117,8 @@
++ 		str_append(cap_str, " STARTTLS");
++ 	if (is_login_cmd_disabled(client))
++ 		str_append(cap_str, " LOGINDISABLED");
+++	if (*imap_client->set->aps_topic)
+++		str_append(cap_str, " XAPPLEPUSHSERVICE");
++ 
++ 	client_authenticate_get_capabilities(client, cap_str);
++ 	return str_c(cap_str);
++diff -Naur ./src/imap-login/imap-login-settings.c ./src/imap-login/imap-login-settings.c
++--- ./src/imap-login/imap-login-settings.c	2019-07-23 03:14:10.000000000 -0400
+++++ ./src/imap-login/imap-login-settings.c	2019-10-08 18:33:32.000000000 -0400
++@@ -57,6 +57,7 @@
++ 	DEF(SET_STR, imap_capability),
++ 	DEF(SET_STR, imap_id_send),
++ 	DEF(SET_STR, imap_id_log),
+++	DEF(SET_STR, aps_topic),
++ 	DEF(SET_BOOL, imap_literal_minus),
++ 	DEF(SET_BOOL, imap_id_retain),
++ 
++@@ -67,6 +68,7 @@
++ 	.imap_capability = "",
++ 	.imap_id_send = "name *",
++ 	.imap_id_log = "",
+++	.aps_topic = "",
++ 	.imap_literal_minus = FALSE,
++ 	.imap_id_retain = FALSE,
++ };
++diff -Naur ./src/imap-login/imap-login-settings.h ./src/imap-login/imap-login-settings.h
++--- ./src/imap-login/imap-login-settings.h	2019-07-23 03:14:10.000000000 -0400
+++++ ./src/imap-login/imap-login-settings.h	2019-10-08 17:49:33.000000000 -0400
++@@ -5,6 +5,7 @@
++ 	const char *imap_capability;
++ 	const char *imap_id_send;
++ 	const char *imap_id_log;
+++	const char *aps_topic;
++ 	bool imap_literal_minus;
++ 	bool imap_id_retain;
++ };
++diff -Naur ./src/lib-lda/mail-deliver.c ./src/lib-lda/mail-deliver.c
++--- ./src/lib-lda/mail-deliver.c	2019-07-23 03:14:10.000000000 -0400
+++++ ./src/lib-lda/mail-deliver.c	2019-10-11 08:16:28.000000000 -0400
++@@ -31,6 +31,7 @@
++ };
++ 
++ deliver_mail_func_t *deliver_mail = NULL;
+++deliver_hook_func_t *deliver_hook = NULL;
++ 
++ struct mail_deliver_cache {
++ 	bool filled;
++@@ -409,6 +410,9 @@
++ 		}
++ 		mail_deliver_log(ctx, "saved mail to %s", mailbox_name);
++ 		pool_unref(&changes.pool);
+++
+++		if (deliver_hook != NULL)
+++			deliver_hook(ctx, mailbox);
++ 	} else {
++ 		mail_deliver_log(ctx, "save failed to %s: %s", mailbox_name,
++ 			mail_storage_get_last_internal_error(*storage_r, &error));
++@@ -503,6 +507,8 @@
++ 			/* success. message may or may not have been saved. */
++ 			ret = 0;
++ 		}
+++		if (!ret && deliver_hook)
+++			deliver_hook(ctx, ctx->rcpt_default_mailbox);
++ 		mail_duplicate_db_deinit(&ctx->dup_db);
++ 		if (ret < 0 && mail_deliver_is_tempfailed(ctx, *storage_r)) {
++ 			muser->deliver_ctx = NULL;
++diff -Naur ./src/lib-lda/mail-deliver.h ./src/lib-lda/mail-deliver.h
++--- ./src/lib-lda/mail-deliver.h	2019-07-23 03:14:10.000000000 -0400
+++++ ./src/lib-lda/mail-deliver.h	2019-10-08 20:50:00.000000000 -0400
++@@ -82,6 +82,9 @@
++ 				struct mail_storage **storage_r);
++ 
++ extern deliver_mail_func_t *deliver_mail;
+++typedef void deliver_hook_func_t(struct mail_deliver_context *ctx,
+++	const char *mailbox);
+++extern deliver_hook_func_t *deliver_hook;
++ 
++ const struct var_expand_table *
++ mail_deliver_ctx_get_log_var_expand_table(struct mail_deliver_context *ctx,
++diff -Naur ./src/plugins/Makefile.am ./src/plugins/Makefile.am
++--- ./src/plugins/Makefile.am	2019-07-23 03:14:10.000000000 -0400
+++++ ./src/plugins/Makefile.am	2019-10-11 05:56:16.000000000 -0400
++@@ -31,6 +31,7 @@
++ 	notify \
++ 	notify-status \
++ 	push-notification \
+++	push-notify \
++ 	mail-filter \
++ 	mail-log \
++ 	$(MAIL_LUA) \
++diff -Naur ./src/plugins/push-notify/Makefile.am ./src/plugins/push-notify/Makefile.am
++--- ./src/plugins/push-notify/Makefile.am	1969-12-31 19:00:00.000000000 -0500
+++++ ./src/plugins/push-notify/Makefile.am	2019-10-11 08:48:43.000000000 -0400
++@@ -0,0 +1,25 @@
+++AM_CPPFLAGS = \
+++	-I$(top_srcdir)/src/lib \
+++	-I$(top_srcdir)/src/lib-lda \
+++	-I$(top_srcdir)/src/lib-mail \
+++	-I$(top_srcdir)/src/lib-smtp \
+++	-I$(top_srcdir)/src/lib-storage
+++
+++NOPLUGIN_LDFLAGS =
+++lib20_push_notify_plugin_la_LDFLAGS = -module -avoid-version
+++
+++module_LTLIBRARIES = \
+++	lib20_push_notify_plugin.la
+++
+++if DOVECOT_PLUGIN_DEPS
+++notify_deps = ../notify/lib15_notify_plugin.la
+++endif
+++
+++lib20_push_notify_plugin_la_SOURCES = \
+++	push-notify-plugin.c
+++
+++headers = \
+++	push-notify-plugin.h
+++
+++pkginc_libdir = $(pkgincludedir)
+++pkginc_lib_HEADERS = $(headers)
++diff -Naur ./src/plugins/push-notify/push-notify-plugin.c ./src/plugins/push-notify/push-notify-plugin.c
++--- ./src/plugins/push-notify/push-notify-plugin.c	1969-12-31 19:00:00.000000000 -0500
+++++ ./src/plugins/push-notify/push-notify-plugin.c	2019-10-11 09:06:31.000000000 -0400
++@@ -0,0 +1,102 @@
+++/* Copyright (c) 2008-2011 Apple, inc. */
+++
+++#include "lib.h"
+++#include "mail-deliver.h"
+++#include "mail-namespace.h"
+++#include "message-address.h"
+++#include "push-notify-plugin.h"
+++
+++#include <sys/un.h>
+++#include <sys/stat.h>
+++#include <sys/socket.h>
+++#include <sys/unistd.h>
+++
+++const char *push_notify_plugin_version = DOVECOT_ABI_VERSION;
+++
+++static deliver_hook_func_t *next_deliver_mail;
+++struct et_list *_et_list = NULL;
+++
+++struct message_info {
+++	const char	*from;
+++	const char	*subj;
+++};
+++
+++// -----------------------------------------------------------------
+++//	push_notification ()
+++
+++static void
+++push_notification(struct mail_deliver_context *ctx, const char *mailbox)
+++{
+++	int					debug			= 0;
+++	int					notify_sock		= 0;
+++	const char		   *sock_path		= "@PREFIX@/var/run/dovecot/push_notify";
+++	ssize_t				rc				= 0;
+++	socklen_t			sock_len		= 0;
+++	struct sockaddr_un	sock_addr;
+++	struct msg_data_s	msg_data;
+++
+++	if (ctx->rcpt_user->mail_debug) {
+++		debug = 1;
+++		i_info( "push-notify: push notification enabled" );
+++	}
+++
+++	if ( strcasecmp(mailbox, "INBOX") != 0) {
+++		i_info( "push-notify: message saved to mailbox: %s, no notification sent", mailbox );
+++		return;
+++	}
+++
+++	notify_sock = socket( AF_UNIX, SOCK_DGRAM, 0 );
+++	if ( notify_sock < 0 ) {
+++		/* warn that connect failed but do not fail the plugin or message will not get delivered */
+++		i_warning( "push-notify: open socket: \"%s\" failed", sock_path );
+++		return;
+++	}
+++
+++	sock_addr.sun_family = AF_UNIX;
+++	strncpy( sock_addr.sun_path, "@PREFIX@/var/run/dovecot/push_notify", sizeof(sock_addr.sun_path) );
+++	sock_len = sizeof(sock_addr.sun_family) + strlen(sock_addr.sun_path) + 1;
+++	rc = connect(notify_sock, (struct sockaddr *) &sock_addr,  sock_len);
+++	if ( rc < 0 ) {
+++		/* warn that connect failed but do not fail the plugin or message will not get delivered */
+++		i_warning( "push-notify: connect() to socket: \"%s\" failed: %m", sock_path );
+++		return;
+++	}
+++
+++	memset( &msg_data, 0, sizeof( msg_data ) );
+++	msg_data.msg = 3;
+++
+++	/* set user/account id */
+++	if ( ctx->rcpt_user->username != NULL ) {
+++		strncpy( msg_data.d1, ctx->rcpt_user->username, sizeof(msg_data.d1) );
+++		if (debug)
+++			i_info( "push-notify: notify: %s", msg_data.d1 );
+++	}
+++
+++	rc = send(notify_sock, (void *)&msg_data, sizeof(struct msg_data_s), 0);
+++	if ( rc < 0 )
+++		i_warning( "push-notify: send() to socket: \"%s\" failed: %m", sock_path );
+++
+++	if (debug)
+++		i_info("push-notify: data sent: %lu", rc);
+++
+++	close(notify_sock);
+++} // push_notification
+++
+++static void push_notify_deliver(struct mail_deliver_context *ctx,
+++				const char *mailbox)
+++{
+++	push_notification(ctx, mailbox);
+++	if (next_deliver_mail != NULL)
+++		next_deliver_mail(ctx, mailbox);
+++}
+++
+++void push_notify_plugin_init (struct module *module ATTR_UNUSED)
+++{
+++	next_deliver_mail = deliver_hook;
+++	deliver_hook = push_notify_deliver;
+++}
+++
+++void push_notify_plugin_deinit (void)
+++{
+++	deliver_hook = next_deliver_mail;
+++}
++diff -Naur ./src/plugins/push-notify/push-notify-plugin.h ./src/plugins/push-notify/push-notify-plugin.h
++--- ./src/plugins/push-notify/push-notify-plugin.h	1969-12-31 19:00:00.000000000 -0500
+++++ ./src/plugins/push-notify/push-notify-plugin.h	2019-10-08 20:53:46.000000000 -0400
++@@ -0,0 +1,20 @@
+++/* Copyright (c) 2008-2011 Apple, inc. */
+++
+++#ifndef __NOTIFY_PLUGIN_H__
+++#define __NOTIFY_PLUGIN_H__
+++
+++struct module;
+++void push_notify_plugin_init(struct module *module);
+++void push_notify_plugin_deinit(void);
+++
+++typedef struct msg_data_s {
+++	unsigned long msg;
+++	unsigned long pid;
+++
+++	char d1[128];
+++	char d2[512];
+++	char d3[512];
+++	char d4[512];
+++} msg_data_t;
+++
+++#endif
 diff -Naur ./src/auth/auth-settings.c ./src/auth/auth-settings.c
---- ./src/auth/auth-settings.c	2019-07-23 03:14:10.000000000 -0400
-+++ ./src/auth/auth-settings.c	2019-10-08 18:37:33.000000000 -0400
+--- ./src/auth/auth-settings.c	2020-09-18 20:09:11.000000000 -0400
++++ ./src/auth/auth-settings.c	2020-09-18 19:57:02.000000000 -0400
 @@ -269,6 +269,8 @@
  	DEFLIST(passdbs, "passdb", &auth_passdb_setting_parser_info),
  	DEFLIST(userdbs, "userdb", &auth_userdb_setting_parser_info),
@@ -31,8 +643,8 @@ diff -Naur ./src/auth/auth-settings.c ./src/auth/auth-settings.c
  	.verbose_proctitle = FALSE,
  	.first_valid_uid = 500,
 diff -Naur ./src/auth/auth-settings.h ./src/auth/auth-settings.h
---- ./src/auth/auth-settings.h	2019-07-23 03:14:10.000000000 -0400
-+++ ./src/auth/auth-settings.h	2019-10-08 17:51:20.000000000 -0400
+--- ./src/auth/auth-settings.h	2020-09-18 20:09:11.000000000 -0400
++++ ./src/auth/auth-settings.h	2020-09-18 19:57:02.000000000 -0400
 @@ -82,6 +82,8 @@
  	ARRAY(struct auth_passdb_settings *) passdbs;
  	ARRAY(struct auth_userdb_settings *) userdbs;
@@ -43,8 +655,8 @@ diff -Naur ./src/auth/auth-settings.h ./src/auth/auth-settings.h
  	const char *ssl_client_ca_dir;
  	const char *ssl_client_ca_file;
 diff -Naur ./src/imap/Makefile.am ./src/imap/Makefile.am
---- ./src/imap/Makefile.am	2019-07-23 03:14:10.000000000 -0400
-+++ ./src/imap/Makefile.am	2019-10-08 20:40:24.000000000 -0400
+--- ./src/imap/Makefile.am	2020-09-18 20:09:11.000000000 -0400
++++ ./src/imap/Makefile.am	2020-09-18 19:57:02.000000000 -0400
 @@ -64,6 +64,7 @@
  	cmd-unselect.c \
  	cmd-unsubscribe.c \
@@ -55,7 +667,7 @@ diff -Naur ./src/imap/Makefile.am ./src/imap/Makefile.am
  
 diff -Naur ./src/imap/cmd-x-apple-push-service.c ./src/imap/cmd-x-apple-push-service.c
 --- ./src/imap/cmd-x-apple-push-service.c	1969-12-31 19:00:00.000000000 -0500
-+++ ./src/imap/cmd-x-apple-push-service.c	2019-10-10 06:22:12.000000000 -0400
++++ ./src/imap/cmd-x-apple-push-service.c	2020-09-18 19:57:02.000000000 -0400
 @@ -0,0 +1,173 @@
 +/*
 + * Copyright (c) 2010-2011 Apple Inc. All rights reserved.
@@ -231,9 +843,9 @@ diff -Naur ./src/imap/cmd-x-apple-push-service.c ./src/imap/cmd-x-apple-push-ser
 +	return TRUE;
 +}
 diff -Naur ./src/imap/imap-client.c ./src/imap/imap-client.c
---- ./src/imap/imap-client.c	2019-07-23 03:14:10.000000000 -0400
-+++ ./src/imap/imap-client.c	2019-10-08 20:42:59.000000000 -0400
-@@ -182,6 +182,8 @@
+--- ./src/imap/imap-client.c	2020-09-18 20:09:11.000000000 -0400
++++ ./src/imap/imap-client.c	2020-09-18 19:57:02.000000000 -0400
+@@ -181,6 +181,8 @@
  		   a chance of working */
  		client_add_capability(client, "SEARCH=FUZZY");
  	}
@@ -243,8 +855,8 @@ diff -Naur ./src/imap/imap-client.c ./src/imap/imap-client.c
  	mail_set = mail_user_set_get_storage_set(user);
  	if (mail_set->mailbox_list_index) {
 diff -Naur ./src/imap/imap-commands.c ./src/imap/imap-commands.c
---- ./src/imap/imap-commands.c	2019-07-23 03:14:10.000000000 -0400
-+++ ./src/imap/imap-commands.c	2019-10-08 20:15:39.000000000 -0400
+--- ./src/imap/imap-commands.c	2020-09-18 20:09:11.000000000 -0400
++++ ./src/imap/imap-commands.c	2020-09-18 19:57:02.000000000 -0400
 @@ -76,6 +76,7 @@
  	{ "UID SORT",		cmd_sort,        COMMAND_FLAG_BREAKS_SEQS },
  	{ "UID THREAD",		cmd_thread,      COMMAND_FLAG_BREAKS_SEQS },
@@ -254,8 +866,8 @@ diff -Naur ./src/imap/imap-commands.c ./src/imap/imap-commands.c
  	{ "X-STATE",		cmd_x_state,     COMMAND_FLAG_REQUIRES_SYNC },
  	{ "XLIST",		cmd_list,        0 },
 diff -Naur ./src/imap/imap-commands.h ./src/imap/imap-commands.h
---- ./src/imap/imap-commands.h	2019-07-23 03:14:10.000000000 -0400
-+++ ./src/imap/imap-commands.h	2019-10-08 20:16:48.000000000 -0400
+--- ./src/imap/imap-commands.h	2020-09-18 20:09:11.000000000 -0400
++++ ./src/imap/imap-commands.h	2020-09-18 19:57:02.000000000 -0400
 @@ -121,6 +121,7 @@
  bool cmd_uid_expunge(struct client_command_context *cmd);
  bool cmd_move(struct client_command_context *cmd);
@@ -265,8 +877,8 @@ diff -Naur ./src/imap/imap-commands.h ./src/imap/imap-commands.h
  bool cmd_x_state(struct client_command_context *cmd);
  
 diff -Naur ./src/imap/imap-settings.c ./src/imap/imap-settings.c
---- ./src/imap/imap-settings.c	2019-07-23 03:14:10.000000000 -0400
-+++ ./src/imap/imap-settings.c	2019-10-08 17:57:36.000000000 -0400
+--- ./src/imap/imap-settings.c	2020-09-18 20:09:11.000000000 -0400
++++ ./src/imap/imap-settings.c	2020-09-18 19:57:02.000000000 -0400
 @@ -73,6 +73,7 @@
  	DEF(SET_STR, imap_logout_format),
  	DEF(SET_STR, imap_id_send),
@@ -284,8 +896,8 @@ diff -Naur ./src/imap/imap-settings.c ./src/imap/imap-settings.c
  	.imap_metadata = FALSE,
  	.imap_literal_minus = FALSE,
 diff -Naur ./src/imap/imap-settings.h ./src/imap/imap-settings.h
---- ./src/imap/imap-settings.h	2019-07-23 03:14:10.000000000 -0400
-+++ ./src/imap/imap-settings.h	2019-10-08 17:48:14.000000000 -0400
+--- ./src/imap/imap-settings.h	2020-09-18 20:09:11.000000000 -0400
++++ ./src/imap/imap-settings.h	2020-09-18 19:57:02.000000000 -0400
 @@ -31,6 +31,7 @@
  	const char *imap_logout_format;
  	const char *imap_id_send;
@@ -295,8 +907,8 @@ diff -Naur ./src/imap/imap-settings.h ./src/imap/imap-settings.h
  	bool imap_metadata;
  	bool imap_literal_minus;
 diff -Naur ./src/imap-login/imap-login-client.c ./src/imap-login/imap-login-client.c
---- ./src/imap-login/imap-login-client.c	2019-07-23 03:14:10.000000000 -0400
-+++ ./src/imap-login/imap-login-client.c	2019-10-11 08:28:49.000000000 -0400
+--- ./src/imap-login/imap-login-client.c	2020-09-18 20:09:11.000000000 -0400
++++ ./src/imap-login/imap-login-client.c	2020-09-18 19:57:02.000000000 -0400
 @@ -117,6 +117,8 @@
  		str_append(cap_str, " STARTTLS");
  	if (is_login_cmd_disabled(client))
@@ -307,8 +919,8 @@ diff -Naur ./src/imap-login/imap-login-client.c ./src/imap-login/imap-login-clie
  	client_authenticate_get_capabilities(client, cap_str);
  	return str_c(cap_str);
 diff -Naur ./src/imap-login/imap-login-settings.c ./src/imap-login/imap-login-settings.c
---- ./src/imap-login/imap-login-settings.c	2019-07-23 03:14:10.000000000 -0400
-+++ ./src/imap-login/imap-login-settings.c	2019-10-08 18:33:32.000000000 -0400
+--- ./src/imap-login/imap-login-settings.c	2020-09-18 20:09:11.000000000 -0400
++++ ./src/imap-login/imap-login-settings.c	2020-09-18 19:57:02.000000000 -0400
 @@ -57,6 +57,7 @@
  	DEF(SET_STR, imap_capability),
  	DEF(SET_STR, imap_id_send),
@@ -326,8 +938,8 @@ diff -Naur ./src/imap-login/imap-login-settings.c ./src/imap-login/imap-login-se
  	.imap_id_retain = FALSE,
  };
 diff -Naur ./src/imap-login/imap-login-settings.h ./src/imap-login/imap-login-settings.h
---- ./src/imap-login/imap-login-settings.h	2019-07-23 03:14:10.000000000 -0400
-+++ ./src/imap-login/imap-login-settings.h	2019-10-08 17:49:33.000000000 -0400
+--- ./src/imap-login/imap-login-settings.h	2020-09-18 20:09:11.000000000 -0400
++++ ./src/imap-login/imap-login-settings.h	2020-09-18 19:57:02.000000000 -0400
 @@ -5,6 +5,7 @@
  	const char *imap_capability;
  	const char *imap_id_send;
@@ -337,17 +949,17 @@ diff -Naur ./src/imap-login/imap-login-settings.h ./src/imap-login/imap-login-se
  	bool imap_id_retain;
  };
 diff -Naur ./src/lib-lda/mail-deliver.c ./src/lib-lda/mail-deliver.c
---- ./src/lib-lda/mail-deliver.c	2019-07-23 03:14:10.000000000 -0400
-+++ ./src/lib-lda/mail-deliver.c	2019-10-11 08:16:28.000000000 -0400
-@@ -31,6 +31,7 @@
+--- ./src/lib-lda/mail-deliver.c	2020-09-18 20:09:11.000000000 -0400
++++ ./src/lib-lda/mail-deliver.c	2020-09-18 19:57:02.000000000 -0400
+@@ -35,6 +35,7 @@
  };
  
  deliver_mail_func_t *deliver_mail = NULL;
 +deliver_hook_func_t *deliver_hook = NULL;
  
- struct mail_deliver_cache {
- 	bool filled;
-@@ -409,6 +410,9 @@
+ struct mail_deliver_mailbox {
+ 	union mailbox_module_context module_ctx;
+@@ -459,6 +460,9 @@
  		}
  		mail_deliver_log(ctx, "saved mail to %s", mailbox_name);
  		pool_unref(&changes.pool);
@@ -357,19 +969,19 @@ diff -Naur ./src/lib-lda/mail-deliver.c ./src/lib-lda/mail-deliver.c
  	} else {
  		mail_deliver_log(ctx, "save failed to %s: %s", mailbox_name,
  			mail_storage_get_last_internal_error(*storage_r, &error));
-@@ -503,6 +507,8 @@
+@@ -547,6 +551,8 @@
  			/* success. message may or may not have been saved. */
  			ret = 0;
  		}
 +		if (!ret && deliver_hook)
 +			deliver_hook(ctx, ctx->rcpt_default_mailbox);
  		mail_duplicate_db_deinit(&ctx->dup_db);
- 		if (ret < 0 && mail_deliver_is_tempfailed(ctx, *storage_r)) {
- 			muser->deliver_ctx = NULL;
+ 		if (ret < 0 && mail_deliver_is_tempfailed(ctx, *storage_r))
+ 			return -1;
 diff -Naur ./src/lib-lda/mail-deliver.h ./src/lib-lda/mail-deliver.h
---- ./src/lib-lda/mail-deliver.h	2019-07-23 03:14:10.000000000 -0400
-+++ ./src/lib-lda/mail-deliver.h	2019-10-08 20:50:00.000000000 -0400
-@@ -82,6 +82,9 @@
+--- ./src/lib-lda/mail-deliver.h	2020-09-18 20:09:11.000000000 -0400
++++ ./src/lib-lda/mail-deliver.h	2020-09-18 19:57:02.000000000 -0400
+@@ -140,6 +140,9 @@
  				struct mail_storage **storage_r);
  
  extern deliver_mail_func_t *deliver_mail;
@@ -380,8 +992,8 @@ diff -Naur ./src/lib-lda/mail-deliver.h ./src/lib-lda/mail-deliver.h
  const struct var_expand_table *
  mail_deliver_ctx_get_log_var_expand_table(struct mail_deliver_context *ctx,
 diff -Naur ./src/plugins/Makefile.am ./src/plugins/Makefile.am
---- ./src/plugins/Makefile.am	2019-07-23 03:14:10.000000000 -0400
-+++ ./src/plugins/Makefile.am	2019-10-11 05:56:16.000000000 -0400
+--- ./src/plugins/Makefile.am	2020-09-18 20:09:11.000000000 -0400
++++ ./src/plugins/Makefile.am	2020-09-18 19:57:02.000000000 -0400
 @@ -31,6 +31,7 @@
  	notify \
  	notify-status \
@@ -392,7 +1004,7 @@ diff -Naur ./src/plugins/Makefile.am ./src/plugins/Makefile.am
  	$(MAIL_LUA) \
 diff -Naur ./src/plugins/push-notify/Makefile.am ./src/plugins/push-notify/Makefile.am
 --- ./src/plugins/push-notify/Makefile.am	1969-12-31 19:00:00.000000000 -0500
-+++ ./src/plugins/push-notify/Makefile.am	2019-10-11 08:48:43.000000000 -0400
++++ ./src/plugins/push-notify/Makefile.am	2020-09-18 19:57:02.000000000 -0400
 @@ -0,0 +1,25 @@
 +AM_CPPFLAGS = \
 +	-I$(top_srcdir)/src/lib \
@@ -421,7 +1033,7 @@ diff -Naur ./src/plugins/push-notify/Makefile.am ./src/plugins/push-notify/Makef
 +pkginc_lib_HEADERS = $(headers)
 diff -Naur ./src/plugins/push-notify/push-notify-plugin.c ./src/plugins/push-notify/push-notify-plugin.c
 --- ./src/plugins/push-notify/push-notify-plugin.c	1969-12-31 19:00:00.000000000 -0500
-+++ ./src/plugins/push-notify/push-notify-plugin.c	2019-10-11 09:06:31.000000000 -0400
++++ ./src/plugins/push-notify/push-notify-plugin.c	2020-09-18 19:57:02.000000000 -0400
 @@ -0,0 +1,102 @@
 +/* Copyright (c) 2008-2011 Apple, inc. */
 +
@@ -527,7 +1139,7 @@ diff -Naur ./src/plugins/push-notify/push-notify-plugin.c ./src/plugins/push-not
 +}
 diff -Naur ./src/plugins/push-notify/push-notify-plugin.h ./src/plugins/push-notify/push-notify-plugin.h
 --- ./src/plugins/push-notify/push-notify-plugin.h	1969-12-31 19:00:00.000000000 -0500
-+++ ./src/plugins/push-notify/push-notify-plugin.h	2019-10-08 20:53:46.000000000 -0400
++++ ./src/plugins/push-notify/push-notify-plugin.h	2020-09-18 19:57:02.000000000 -0400
 @@ -0,0 +1,20 @@
 +/* Copyright (c) 2008-2011 Apple, inc. */
 +

--- a/mail/dovecot/files/patch-src-lib-ioloop-notify-kqueue-c.diff
+++ b/mail/dovecot/files/patch-src-lib-ioloop-notify-kqueue-c.diff
@@ -1,0 +1,10 @@
+--- ./src/lib/ioloop-notify-kqueue.c	2020-09-18 19:56:38.000000000 -0400
++++ ./src/lib/ioloop-notify-kqueue.c	2020-09-18 20:54:36.000000000 -0400
+@@ -11,6 +11,7 @@
+ 
+ #include "ioloop-private.h"
+ #include "llist.h"
++#include "time-util.h"
+ #include <unistd.h>
+ #include <fcntl.h>
+ #include <sys/types.h>


### PR DESCRIPTION
dovecot: apns variant bugfix and compiler error fix

* apns variant's `devices` must be a file
* Fix compiler error `error: implicit declaration of function 'i_gettimeofday' is invalid in C99`

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
