### PR TITLE
avahi: reenable building manpage with xmltoman & grab maintainership

### DIFF
--- a/net/avahi/Portfile
+++ b/net/avahi/Portfile
@@ -6,9 +6,9 @@ PortGroup           github 1.0
 PortGroup           gobject_introspection 1.0
 
 github.setup        lathiat avahi 0.8 v
-revision            0
+revision            1
 categories          net devel
-maintainers         nomaintainer
+maintainers         {@i0ntempest me.com:szf1234} openmaintainer
 license             LGPL-2.1+
 platforms           darwin
 description         Avahi is an Implementation of the DNS Service Discovery and Multicast DNS \
@@ -44,7 +44,9 @@ post-patch {
 }
 
 depends_build       port:pkgconfig \
-                    port:intltool
+                    port:intltool \
+                    port:libxml2 \
+                    port:xmltoman
 
 depends_lib         port:expat \
                     port:gdbm \
@@ -80,7 +82,6 @@ configure.args      --disable-autoipd \
                     --with-distro=darwin \
                     --enable-compat-libdns_sd \
                     --disable-gtk3 \
-                    --disable-xmltoman \
                     --disable-gtk \
                     --disable-tests \
                     --with-avahi-priv-access-group=${avahi_priv_group} \
@@ -142,22 +143,23 @@ variant mono description {Enable Mono support} {
 variant test description {Build tests} {
     configure.args-delete   --disable-tests
     configure.args-append   --enable-tests
-    test.run            yes
-    test.target         check
+    test.run                yes
+    test.target             check
 }
 
 variant gtk description {Build with GTK2} {
     depends_lib-append      port:gtk2 \
                             port:libglade2
     configure.args-replace  --disable-gtk --enable-gtk
-    configure.args-append --disable-manpages
-    post-destroot {delete ${destroot}${prefix}/share/man/man1/*}
 }
 
 variant gtk3 description {Build with GTK3} {
     depends_lib-append      port:gtk3
     configure.args-delete   --disable-gtk3
-    configure.args-append --disable-manpages
+    # Enable manpages that are built with gtk variant but not with gtk3
+    pre-configure {
+        reinplace "s|HAVE_GTK_TRUE|HAVE_GTK2OR3_TRUE|g" ${worksrcpath}/man/Makefile.in
+    }
 }
 
 variant qt4 description {Build with Qt4} {
@@ -168,8 +170,8 @@ variant qt4 description {Build with Qt4} {
 variant qt5 description {Build with Qt5} {
     PortGroup   qt5 1.0
     # This configure script does not use CXXFLAGS variable for Qt5 compile test so I have to do this
-    configure.env-append QT5_CFLAGS=-std=c++11\ -DQT_CORE_LIB\ -F${qt_dir}/lib\ -I${qt_dir}/lib/QtCore.framework/Headers\ -I${qt_dir}/include
-    compiler.cxx_standard 2011
+    configure.env-append    QT5_CFLAGS=-std=c++11\ -DQT_CORE_LIB\ -F${qt_dir}/lib\ -I${qt_dir}/lib/QtCore.framework/Headers\ -I${qt_dir}/include
+    compiler.cxx_standard   2011
     configure.args-delete   --disable-qt5
 }
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
