### PR TITLE
R: attempt to fix configure phase on 10.7

### DIFF
--- a/math/R/Portfile
+++ b/math/R/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem 1.0
 PortGroup compilers 1.0
+PortGroup compiler_blacklist_versions 1.0
 PortGroup active_variants 1.1
 
 name                        R
@@ -32,6 +33,9 @@ master_sites                https://cran.rstudio.com/src/base/R-4/ \
 checksums                   rmd160  a323d61573a6fc46a7ce80135348578f0e7b347d \
                             sha256  d3bceab364da0876625e4097808b42512395fdf41292f4915ab1fd257c1bbe75 \
                             size    33191186
+
+# Fails to configure with Xcode clang 4.6.3
+compiler.blacklist-append   {clang < 500}
 
 compilers.choose            fc f77
 compilers.setup             require_fortran


### PR DESCRIPTION
#### Description
Failure to configure is observed on [10.7](https://build.macports.org/builders/ports-10.7_x86_64-builder/builds/30854/steps/install-port/logs/stdio):
```
checking how to get verbose linking output from /usr/bin/clang... configure: WARNING: cannot determine how to obtain linking information from /usr/bin/clang

checking for C libraries of /usr/bin/clang... 
checking for dummy main to link with Fortran libraries... none
checking for Fortran name-mangling scheme... lower case, underscore, no extra underscore
checking whether /opt/local/bin/gfortran-mp-10 appends underscores to external names... yes
checking whether /opt/local/bin/gfortran-mp-10 appends extra underscores to external names... no
checking whether mixed C/Fortran code can be run... configure: WARNING: cannot run mixed C/Fortran code
configure: error: Maybe check LDFLAGS for paths to Fortran libraries?
Command failed:  cd "/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_math_R/R/work/R-4.0.2" && ./configure --prefix=/opt/local/Library/Frameworks --enable-R-framework --enable-memory-profiling --enable-R-shlib --enable-BLAS-shlib --without-tcltk --with-cairo --disable-java --with-included-gettext --disable-openmp --without-blas --without-lapack --with-recommended-packages --with-x --x-include=/opt/local/include/X11 --x-lib=/opt/local/lib 
Exit code: 1
```

Since the port builds successfully on 10.6 which uses MacPorts' clang 9.0, using an alternate compiler may help on 10.7 as well.
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
