### PR TITLE
python39-devel: attempt to fix 10.7 build

### DIFF
--- a/lang/python39-devel/Portfile
+++ b/lang/python39-devel/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem 1.0
 PortGroup select 1.0
+PortGroup compiler_blacklist_versions 1.0
 
 name                python39-devel
 
@@ -51,6 +52,10 @@ depends_run         port:python_select \
 
 # blacklist llvm-gcc-4.2 compiler known to produce bad code
 compiler.blacklist-append *llvm-gcc-4.2
+
+# Need __builtin_bswap16()
+# https://bugs.python.org/issue41617
+compiler.blacklist-append {clang < 500}
 
 # ensurepip arg may be removed later, now conflicts with pip and setuptools
 # packages


### PR DESCRIPTION
#### Description
There is a known build failure on [macOS 10.7 + Xcode 4.6.3](https://build.macports.org/builders/ports-10.7_x86_64-builder/builds/30925/steps/install-port/logs/stdio):
```
In file included from Objects/unicodeobject.c:4890:
In file included from Objects/stringlib/codecs.h:7:
./Include/internal/pycore_byteswap.h:38:12: error: use of unknown builtin '__builtin_bswap16' [-Wimplicit-function-declaration]
    return __builtin_bswap16(word);
           ^
```
The maintainer (@jmroot) already raised this issue upstream, but it hasn't been properly fixed: https://bugs.python.org/issue41617
Maybe MacPorts should move on to seeing if the port builds with a newer compiler, or if it needs more work. (Final 3.9.0 release is expected 2020-10-05.)
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Untested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
