### PR TITLE
croc: don't fetch dependencies in build phase

### DIFF
--- a/net/croc/Portfile
+++ b/net/croc/Portfile
@@ -25,9 +25,176 @@ long_description    croc is a tool that allows any two computers to simply \
                     through compression and multiplexing (speedups 1.5x to \
                     4x), and supports IPv6.
 
-checksums           rmd160  09d8ca226837226126d137f13cb332feb0921104 \
-                    sha256  e1bcf0e3978a7579dca30dea5ba059cd6e95c5d11318b91f5347a68f1ec8be55 \
-                    size    497506
+checksums           ${distname}${extract.suffix} \
+                        rmd160  09d8ca226837226126d137f13cb332feb0921104 \
+                        sha256  e1bcf0e3978a7579dca30dea5ba059cd6e95c5d11318b91f5347a68f1ec8be55 \
+                        size    497506
+
+go.vendors          github.com/russross/blackfriday \
+                        lock    v2.0.1 \
+                        rmd160  99cb49faff9bf24b8637dcdb3602c27c115810f3 \
+                        sha256  4078d2cd3b1c6952133b214e4eaca95f3b31a01f87a03adabd7712e7d5f20f60 \
+                        size    79665 \
+                    github.com/schollz/progressbar \
+                        lock    v3.5.1 \
+                        rmd160  b16b93386f1824a6c252fbc4c14a934e20c43fb9 \
+                        sha256  179bb433ec138fe437861bbb39b6ff344dc7f555585192151d6a39f73c22cc57 \
+                        size    601579 \
+                    github.com/stretchr/testify \
+                        lock    v1.4.0 \
+                        rmd160  86bd663e13ea7266334c47689074df16252db5ff \
+                        sha256  8ed95078bfd318ea477da509e6b16e6cf8d0d1b6b8d93b1f6097c6ba2a6df788 \
+                        size    110114 \
+                    gopkg.in/tylerstillwater/is.v1 \
+                        lock    v1.1.2 \
+                        rmd160  ed9715be3638589de2fa615f79ad63f43c266ac2 \
+                        sha256  d6f6a6585a62fa8789e4b8ef15d2a1b0f1e0b163ab2859564195c64074661377 \
+                        size    5595 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.12 \
+                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
+                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
+                        size    4549 \
+                    github.com/shurcooL/sanitized_anchor_name \
+                        lock    v1.0.0 \
+                        rmd160  c7e5322dba53e10db1711d65c146af5649b0c7c8 \
+                        sha256  ed9418de8c92acfbbd8608745855ebfc67fa686c0a0a5245cf8eece8f540baa9 \
+                        size    2144 \
+                    gopkg.in/check.v1 \
+                        lock    41f04d3bba15 \
+                        rmd160  1e5543a8e6a3159296ee63e28cbde9931a04f6b3 \
+                        sha256  c41575a73d10809f89b05ef9e783f2d53facdc6573697770d30efb05a9d2dc28 \
+                        size    31612 \
+                    github.com/OneOfOne/xxhash \
+                        lock    v1.2.5 \
+                        rmd160  3c96a52c71fdb92be0a3d8218e87715ff7917ac9 \
+                        sha256  73a661bc7a6d5bc8f0340faaa668725238453c83478bd39a10ef7cab934d10b0 \
+                        size    14120 \
+                    github.com/cespare/xxhash \
+                        lock    v1.1.0 \
+                        rmd160  881eb63e94fa02d315ee4b023a35832a3d67d672 \
+                        sha256  509b8d4670440aa84dc4e902ed5ca2f9109bf65af830a062da91d23a007fe2e0 \
+                        size    8208 \
+                    github.com/fatih/color \
+                        lock    v1.9.0 \
+                        rmd160  1d8418b4f1b3cb597f680b93aaa08afcc9651be4 \
+                        sha256  577c8e778833fec90d76918f138cee9f7765435757b7c92a669e5b34933e0b4f \
+                        size    1231337 \
+                    gopkg.in/yaml.v2 \
+                        lock    v2.2.7 \
+                        rmd160  8a2eb51b49235820619e4703f557b266d5941645 \
+                        sha256  15d29283f38f1213445158c16dad11f84ab72aa0256af555c2392492315760ba \
+                        size    72665 \
+                    github.com/schollz/pake \
+                        lock    v2.0.4 \
+                        rmd160  030139aa446855a55e63ee9aa0f1e8d4f6984d88 \
+                        sha256  5baf710caff43e252c0d7fe064bb241f0731ea6e9c7aa4a3130260bcb97014fe \
+                        size    6330 \
+                    github.com/schollz/peerdiscovery \
+                        lock    v1.6.0 \
+                        rmd160  94119d7ba822abd071847f318496a6e0dcbe0b0e \
+                        sha256  f995af1d8f86aaf12229be04e9092a0b70c36752fd7ea0802cfd473aee7a4fa2 \
+                        size    9002 \
+                    golang.org/x/text \
+                        lock    v0.3.3 \
+                        rmd160  babfa547ba9a9dab7fe08fa5543f1d8e7ae00301 \
+                        sha256  1c4a8c12295d484e0360d8e010ebc4b8a9a05aa2a07c10c3d3e5b17aa063f0db \
+                        size    7745597 \
+                    github.com/kalafut/imohash \
+                        lock    v1.0.0 \
+                        rmd160  a2f278945a0c7cca1d4f7acd40eae32394d13da2 \
+                        sha256  7b0577dbbe38104667a0479e5b1e60b5dd975237de159973e4454b4a9674808f \
+                        size    7216 \
+                    github.com/mitchellh/colorstring \
+                        lock    d06e56a500db \
+                        rmd160  79e1fb92818b77a56b274c3bb7880891af3f7829 \
+                        sha256  0a3c9097c65cf50b9dfe8150adf2f096f9e62b36200759459969d3b9ee3a20fe \
+                        size    4679 \
+                    github.com/tscholl2/siec \
+                        lock    8da93652b094 \
+                        rmd160  6bee962eef761b43725336fadf9264363006c1be \
+                        sha256  a5706dacc202e6f6309256870b492d46b24f5c4982b6009559dad27c9ebde963 \
+                        size    63770 \
+                    github.com/kr/text \
+                        lock    v0.1.0 \
+                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
+                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
+                        size    8691 \
+                    github.com/mattn/go-colorable \
+                        lock    v0.1.7 \
+                        rmd160  47f774c77efaa0bbcd982cb65bed426d047780ba \
+                        sha256  68de4e31d97da97efc400096c599ea37c6cf1cb91501004f05a1017f4653f926 \
+                        size    9570 \
+                    github.com/mattn/go-runewidth \
+                        lock    v0.0.9 \
+                        rmd160  412c0e508e55f4fe437be0f71d7d22eca2b4366f \
+                        sha256  4f0f4a22257ccecfb6beae88052d850380ecc0e806d6bcc92d3656ebcac3b638 \
+                        size    16716 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/schollz/mnemonicode \
+                        lock    v1.0.1 \
+                        rmd160  3b589e8d02190611df0a94aa681ddfe4a52f9fe3 \
+                        sha256  9b85aa29d9fabce2cad5bb8f382a4668bf70111edd7bc0ee3353a1d9ded5fda5 \
+                        size    18202 \
+                    github.com/cpuguy83/go-md2man \
+                        lock    v2.0.0 \
+                        rmd160  85f342c341fa928e9ec874490c277bdabf1c39c6 \
+                        sha256  2f3f8bc701df4890a5a4baf0b632ad3290be1e0aaf572b2e58fd57df93efc306 \
+                        size    52040 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/denisbrodbeck/machineid \
+                        lock    v1.0.1 \
+                        rmd160  c782c29a666ff8e4ad93945389ca9c395754c2c4 \
+                        sha256  98e4169e90ef7e087d47c2620f94aba71f2087f41f64d85509570c2161e85101 \
+                        size    27812 \
+                    golang.org/x/sys \
+                        lock    dbad9cb7cb7a \
+                        rmd160  478b86bf6a19906d83bd35002c280afe4e349a31 \
+                        sha256  650ae628ea45ad5a556c7532f4a3046f2ca8cc00b8046b0d77ce5248ea7a370b \
+                        size    1063016 \
+                    github.com/schollz/spinner \
+                        lock    6bbc5f7804f9 \
+                        rmd160  c24a101bd8cc5b2c208eee94cf965ddaafca3d17 \
+                        sha256  b5855a5cca53095a6b52df372b196d79f51478c9cffb4e466380460870ffb545 \
+                        size    12931 \
+                    github.com/urfave/cli \
+                        lock    v2.2.0 \
+                        rmd160  4a6ffb4a39be12c9239c971e0faa5118206066ad \
+                        sha256  b7bfbd0ff7fdedb839dec9b56d026fc6bcc4db534e3bb9fce3a9da6604945818 \
+                        size    3404076 \
+                    golang.org/x/crypto \
+                        lock    5c72a883971a \
+                        rmd160  090821b28d0329a087b91a964a53937f3ce0047a \
+                        sha256  a82c522eb9ec32fd6d5511793d1325495caf63371fffc5ac82f1fea63e99664a \
+                        size    1732437 \
+                    golang.org/x/net \
+                        lock    62affa334b73 \
+                        rmd160  250b28a64f34025db998066fbfaa84d28f33efa1 \
+                        sha256  e79476f4b54675d1a9be1be7e17b38c332d2d4d7e102f8de2eff3468869052b3 \
+                        size    1179180 \
+                    github.com/kr/pretty \
+                        lock    v0.1.0 \
+                        rmd160  9aa7a5aad4c48840eecfd0f80186d1fb5ded0fd6 \
+                        sha256  f6c3f89667c63e5b7f1fc6ee2c06b6a6bfdce88f3a965ccd395b64c6f95c9a47 \
+                        size    8553 \
+                    github.com/schollz/logger \
+                        lock    v1.2.0 \
+                        rmd160  5e42136bfd828eda92d96938d6f584c0fc8c5320 \
+                        sha256  6bd512b07cb2ab477bdad31d15cbcf453b2432b9983ccb22266de37b79ec43de \
+                        size    3252 \
+                    github.com/spaolacci/murmur3 \
+                        lock    v1.1.0 \
+                        rmd160  53215abb0d59b6c64e926e90fb33da1906a1a525 \
+                        sha256  54d6a3300600dd2f5e444f6d19fe1f91e1174329cdfff1d50dae837689214a68 \
+                        size    7396
 
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer


### PR DESCRIPTION
#### Description

Per https://trac.macports.org/ticket/61192 this is one of the golang ports that automatically downloads its dependencies at build time.

To fix it, I used `go2port`, but when doing so ran into these tricky points:

1. There is a dependency on `gopkg.in/tylerb/is.v1`. `gopkg.in` is a service that redirects to GitHub, and on GitHub the user `tylerb` was renamed to `tylerstillwater`. This causes the cleanup in the post-fetch phase to fail (I believe this is an issue with the github-1.0 portgroup, not something specific to golang-1.0). Changing the name of the dep to `gopkg.in/tylerstillwater/is.v1` fixed it.
2. Simply pasting the generated `go.vendors` block is not enough; you also have to give the main distfile a filename. Until you do so, the checksum phase will fail in a way that makes it look like issue (2) above.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->