### PR TITLE
yq: don't fetch dependencies in build phase

### DIFF
--- a/textproc/yq/Portfile
+++ b/textproc/yq/Portfile
@@ -19,12 +19,101 @@ long_description    {*}${description}. The aim of the project is to be the jq \
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  0f55282cd034fb9bdd97483a9acdfd9a51a3a72c \
-                    sha256  1171f5d7e6bcb81fc59b51bc39a02f444d003dab9dd9f36cd04bb1c48fc7d20d \
-                    size    729010
-
-build.target        github.com/mikefarah/yq/v3
 installs_libs       no
+
+build.env-append    GOPROXY=off \
+                    GO111MODULE=off
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  0f55282cd034fb9bdd97483a9acdfd9a51a3a72c \
+                        sha256  1171f5d7e6bcb81fc59b51bc39a02f444d003dab9dd9f36cd04bb1c48fc7d20d \
+                        size    729010
+
+go.vendors          gopkg.in/check.v1 \
+                        lock    788fd7840127 \
+                        rmd160  b63165c8909a27edc15dda210df66a1b49efb49e \
+                        sha256  7e5547c6471cc48da89a7c87f965b20ca5311f43fc4d883ca62f9fccf7551630 \
+                        size    31597 \
+                    github.com/fatih/color \
+                        lock    v1.9.0 \
+                        rmd160  1d8418b4f1b3cb597f680b93aaa08afcc9651be4 \
+                        sha256  577c8e778833fec90d76918f138cee9f7765435757b7c92a669e5b34933e0b4f \
+                        size    1231337 \
+                    github.com/kr/text \
+                        lock    v0.1.0 \
+                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
+                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
+                        size    8691 \
+                    github.com/mattn/go-colorable \
+                        lock    v0.1.7 \
+                        rmd160  47f774c77efaa0bbcd982cb65bed426d047780ba \
+                        sha256  68de4e31d97da97efc400096c599ea37c6cf1cb91501004f05a1017f4653f926 \
+                        size    9570 \
+                    golang.org/x/xerrors \
+                        lock    5ec99f83aff1 \
+                        rmd160  6e8267f353e153297f205e4be219236d6ae43880 \
+                        sha256  9a500a49d83a09e7de6c71b215d1c14b81e315d26884530ef327c95ddf1f2d28 \
+                        size    13667 \
+                    github.com/kr/pretty \
+                        lock    v0.1.0 \
+                        rmd160  9aa7a5aad4c48840eecfd0f80186d1fb5ded0fd6 \
+                        sha256  f6c3f89667c63e5b7f1fc6ee2c06b6a6bfdce88f3a965ccd395b64c6f95c9a47 \
+                        size    8553 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.5 \
+                        rmd160  2ce81608a38c6f383a35bccd24d64361df5828c9 \
+                        sha256  7f41acdcba65b1fab5b9b633947a139f9915b60f94bdab486cdbe9d90c54f61e \
+                        size    50815 \
+                    golang.org/x/tools \
+                        lock    11955173bddd \
+                        rmd160  3f018974cbd88912e85ad015d33a5bf3c02cf100 \
+                        sha256  beda28740d4fc61c10f191f7dfb51dcaa6ac5a9c20ec16ab3e1096e987161740 \
+                        size    2651713 \
+                    gopkg.in/op/go-logging.v1 \
+                        lock    b2cb9fa56473 \
+                        rmd160  2621efba2352994d2b3a1541c853511b24884e54 \
+                        sha256  73acfa44b0fe8e3074d173f04ce164e81b6996327d07d0bec0025df0491e4091 \
+                        size    35888 \
+                    github.com/inconshreveable/mousetrap \
+                        lock    v1.0.0 \
+                        rmd160  5c617a09f1432fc543672a0e0c1e13d3752030c2 \
+                        sha256  0e6bae2849f13d12fe361ecac087728e4e97f3482f4cec44f6e7a2c53bb9cd0c \
+                        size    2291 \
+                    github.com/spf13/cobra \
+                        lock    v1.0.0 \
+                        rmd160  73602c4d37ad508ba8b35812c793e1df3eda7bb9 \
+                        sha256  6cdf3f445559b8f41f5288366a4c26e8d1b1601dac6924af091a49f1f6b11396 \
+                        size    128931 \
+                    golang.org/x/sys \
+                        lock    be1d3432aa8f \
+                        rmd160  9ceec947fb65514ea4d6bf867caa7f3640537fc5 \
+                        sha256  1d83b9877a6abdc4a7d76f7f9ccbcdc4797be376679f140c761bc93297f12767 \
+                        size    1059883 \
+                    gopkg.in/yaml.v3 \
+                        lock    eeeca48fe776 \
+                        rmd160  fa7f02bf2d79fd300b4db2107596674b41479412 \
+                        sha256  33580a955d8c31b781de66dbc7a3c9940ab842a39eb3eb92e696a82307f7d570 \
+                        size    88775 \
+                    github.com/goccy/go-yaml \
+                        lock    v1.8.1 \
+                        rmd160  e72bdb3fe54678e8ce77d0438cbde8c06efc639a \
+                        sha256  157a1959b09d11a913c49762ecb711393b5abb15e818713ee49bc6ab6378dcf7 \
+                        size    69212 \
+                    github.com/kylelemons/godebug \
+                        lock    v1.1.0 \
+                        rmd160  917ada648e70d2e339b8ff36d2f86882d0d2efa1 \
+                        sha256  6151c487936ab72cffbf804626228083c9b3abfc908a2bb41b1160e1e5780aaf \
+                        size    17641 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.12 \
+                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
+                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
+                        size    4549 \
+                    github.com/pkg/errors \
+                        lock    v0.9.1 \
+                        rmd160  dc065c655f8a24c6519b58f9d1202eb266ecda40 \
+                        sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
+                        size    13422
 
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
#### Description

Per https://trac.macports.org/ticket/61192 this is one of the golang ports that automatically downloads its dependencies at build time.

To fix it, I used `go2port`, but when doing so ran into this tricky point:

The upstream `go.sum` file is not "clean": it lists unused dependencies, in particular `gopkg.in/yaml.v2` which has been replaced with `gopkg.in/yaml.v3` in the `go.mod` file. This caused confusion fetching distfiles because the golang-1.0 portgroup created colliding tags (fix pending). Even fixing the tags doesn't allow it to work: construction of the GOPATH is very finnicky, and can't accommodate multiple dependencies that are git tarballs that differ only in their hash (I believe this limitation is shared by the github-1.0 portgroup).

Luckily `gopkg.in/yaml.v2` is disused so merely removing it fixed the issue.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->