### PR TITLE
php-apache2handler,apache2: add enable-mpms-shared=all as default

### DIFF
--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -499,8 +499,6 @@ ${phpinidir}/php.ini-recommended.
 ### Apache 2 handler SAPI ###
 
 subport ${php}-apache2handler {
-    PortGroup               active_variants 1.1
-
     switch -- ${version} {
         5.2.17              {revision 3}
         5.3.29              {revision 3}
@@ -521,8 +519,6 @@ subport ${php}-apache2handler {
     homepage                https://www.php.net/install.unix.apache2
     
     depends_lib-append      port:apache2
-    
-    require_active_variants apache2 preforkmpm
     
     set apxs ${prefix}/bin/apxs
     set confdir ${prefix}/etc/apache2
@@ -553,6 +549,8 @@ To enable ${subport}, run:
 
     cd ${moduledir}
     sudo ${apxs} -a -e -n php${major} mod_${php}.so
+
+To run ${subport} you need to use the prefork MPM.
 "
 }
 

--- a/www/apache2/Portfile
+++ b/www/apache2/Portfile
@@ -5,7 +5,7 @@ PortGroup           apache2 1.0
 
 name                apache2
 version             2.4.46
-revision            0
+revision            1
 checksums           rmd160  8e5365222be2b53bed955f6f658fc4b6cc6c60a2 \
                     sha256  740eddf6e1c641992b22359cabc66e6325868c3c5e2e3f98faf349b61ecf41ea \
                     size    7187805
@@ -76,6 +76,7 @@ configure.args     --with-apr=${prefix}/bin/apr-1-config \
                    --with-pcre=${prefix} \
                    --with-z=${prefix} \
                    --enable-mods-shared=all \
+                   --enable-mpms-shared=all \
                    --enable-authn-alias=shared \
                    --enable-ssl \
                    --with-ssl=${prefix} \
@@ -192,10 +193,6 @@ variant brotli description {Build brotli module} {
 variant http2 description {Enable HTTP/2 support} {
     depends_lib-append      port:nghttp2
     configure.args-append   --enable-http2
-}
-
-variant mpms_shared_all description {Build all MPM's as DSO for dynamic loading} {
-    configure.args-append   --enable-mpms-shared=all
 }
 
 variant preforkmpm conflicts workermpm eventmpm description {Use prefork MPM} {


### PR DESCRIPTION
php-apache2handler, apache2: add enable-mpms-shared=all as default arg

  - php-apache2handler: remove req of preforkmpm and PG,
    since it's built by default.
  - Add not about usage.
  - apache2: add enable-mpms-shared=all as default arg, and remove
    variant.

When installing the php-apache2handler it requires the preforkmpm to
be installed, which prevents the use of the other variant on the server
due to conflicts. That was what the mpms_shared_all variant was added
for, to be able to use all different mpms on the same apache2 install -
to be able to set up and run different virtualhosts with different mpms
&/or php versions.

So, it's better to require mpms_shared_all, and then add to the notes
they need to run the php-apache2handler in a preforkmpm mode.

---

_Additionally, one _could_ consider to remove all the preforkmpm/workermpm/eventmpm variants (like I wrote [here](https://github.com/macports/macports-ports/pull/8374#discussion_r486514635)). `enable-mpms-shared=all` will default to prefork anyway._

###### Type(s)

- [x] enhancement

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

###### Notes

This was the 3'rd commit in #8374, which I'm about to break up into smaller changes. Thought it would be better to keep this one in a separate PR instead.