### PR TITLE
kb: new port

### DIFF
--- a/office/kb/Portfile
+++ b/office/kb/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           python 1.0
+
+github.setup        gnebbia kb 0.1.1 v
+revision            0
+
+platforms           darwin
+license             GPL-3
+categories          office python
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+description         A minimalist knowledge base manager
+
+long_description    kb is a text-oriented minimalist command line knowledge \
+                    base manager. kb can be considered a quick note \
+                    collection and access tool oriented toward software \
+                    developers, penetration testers, hackers, students or \
+                    whoever has to collect and organize notes in a clean way. \
+                    Although kb is mainly targeted on text-based note \
+                    collection, it supports non-text files as well (e.g., \
+                    images, pdf, videos and others).
+
+checksums           rmd160  0cd1684411814235df0c277e50d017d08b14189c \
+                    sha256  1c245f12400acc153d9b2c40527bdfa4a06f623945cb6b258a1967a587d368e4 \
+                    size    14342881
+
+python.default_version  38
+
+depends_build-append    port:py${python.version}-setuptools
+
+depends_lib-append      port:py${python.version}-attr \
+                        port:py${python.version}-attrs \
+                        port:py${python.version}-colored \
+                        port:py${python.version}-toml


### PR DESCRIPTION
#### Description

New port for [kb](https://github.com/gnebbia/kb)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.7 11E801a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
