### PR TITLE
up: don't fetch dependencies in build phase

### DIFF
--- a/sysutils/up/Portfile
+++ b/sysutils/up/Portfile
@@ -20,13 +20,53 @@ long_description    The main goal of the Ultimate Plumber is to help \
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  b2da5077d2c5de8c8bccf48a45462e9153fa3865 \
-                    sha256  9f1a61aaeef293694745bf11237bcf8f2866169e038f585f1a477e957bf7a1e2 \
-                    size    157031
-
 categories          sysutils
 license             Apache-2
 installs_libs       no
+
+build.env-append    GOPROXY=off \
+                    GO111MODULE=off
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  b2da5077d2c5de8c8bccf48a45462e9153fa3865 \
+                        sha256  9f1a61aaeef293694745bf11237bcf8f2866169e038f585f1a477e957bf7a1e2 \
+                        size    157031
+
+go.vendors          github.com/gdamore/tcell \
+                        lock    493f3b46b3c2 \
+                        rmd160  413355a4b44741030504846ae10c3af03666df97 \
+                        sha256  493b1693a05ab9790da3dfaa9b2f16037f03636c132cc33cc973974417dc18bd \
+                        size    720193 \
+                    github.com/lucasb-eyer/go-colorful \
+                        lock    231272389856 \
+                        rmd160  e65adf8b253ffe0b479f63dc69af6720efe9d659 \
+                        sha256  14be296c1798eb62daef9a9effb9cdf5619f2ce6933b06dd63618cbde9c7da5b \
+                        size    428450 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.3 \
+                        rmd160  52fa78fd66eb44112b174b03b1dcbe9648059280 \
+                        sha256  413ea81dd4dadf78a6713ad12c570577351cf8f4f8db617a8d7ec81c3d99ce09 \
+                        size    3369 \
+                    github.com/mattn/go-runewidth \
+                        lock    v0.0.2 \
+                        rmd160  7ced16d5d525a5876ced0ab310930ebfd9d16d10 \
+                        sha256  e51a2a2496e9c6f1e139740b535b47a3c18d739b5c948d9dc360086b2d36d169 \
+                        size    22375 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.3 \
+                        rmd160  32abdd77a987af95ce5b647846bfdbb2d8db91a0 \
+                        sha256  046b6b81e3925ffe60e2213e9a239303ff98a51e76764590b807b591fedf2d1e \
+                        size    46029 \
+                    golang.org/x/text \
+                        lock    f21a4dfb5e38 \
+                        rmd160  fecb60b88ea1fdd2ff097059183c1a4d555059a6 \
+                        sha256  ec51c6c0bbc46fc17c603aac5eb887c517f9a75529789517ccc8bd5fd7e03d94 \
+                        size    6102629 \
+                    github.com/gdamore/encoding \
+                        lock    b23993cbb635 \
+                        rmd160  27d40e6a7cd1f6c720eeffa0a6b94a8f3f82e1d4 \
+                        sha256  9400f6380819a37465c79393f25e4039d09138829f79d48c964ba2943134d421 \
+                        size    10645
 
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
#### Description

Per https://trac.macports.org/ticket/61192 this is one of the golang ports that automatically downloads its dependencies at build time.

To fix it, I used `go2port`. The output was usable as-is.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->