### PR TITLE
gotop: don't fetch dependencies in build phase

### DIFF
--- a/sysutils/gotop/Portfile
+++ b/sysutils/gotop/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           golang 1.0
 
 go.setup            github.com/xxxserxxx/gotop 4.0.1 v
-revision            1
+revision            2
 name                gotop
 categories          sysutils
 platforms           darwin
@@ -15,13 +15,136 @@ long_description    gotop is a terminal-based (TUI) system monitor for Linux and
                     The software is inspired by gtop and vtop, but while these 2 utilities \
                     use Node.js, gotop is written in Go.
 
-checksums           rmd160  a8c55fe1d67b251a51b3faaf62d88c6795386230 \
-                    sha256  3eeb147bedc39a42991a68efaf2c3f557813a4c987b75aadf4b8f61a91a453a3 \
-                    size    997924
+checksums           ${distname}${extract.suffix} \
+                        rmd160  a8c55fe1d67b251a51b3faaf62d88c6795386230 \
+                        sha256  3eeb147bedc39a42991a68efaf2c3f557813a4c987b75aadf4b8f61a91a453a3 \
+                        size    997924
+
+go.vendors          github.com/davecgh/go-spew \
+                        lock    v1.1.0 \
+                        rmd160  0303eae19a01f38fe314921fd965e4d09b9ef3ad \
+                        sha256  810a597004388d68bb92d8aa612375419ba1080dd5fc2c66dd41b58f0ba4442c \
+                        size    42348 \
+                    github.com/shibukawa/configdir \
+                        lock    e180dbdc8da0 \
+                        rmd160  7d98ef23d1f5664c935ba332a439f6bf1c11885b \
+                        sha256  232e87909860090ce5a95f2efd7afc72d18fd4dbffa0d464e48ea8cfca4255a4 \
+                        size    3786 \
+                    github.com/valyala/histogram \
+                        lock    v1.0.1 \
+                        rmd160  321ba05a07f3e3f9df07fee44c0ac57688e1b8bb \
+                        sha256  963acfb953318bf94c2aea837be4c6081d0171b5b8cbdea369793fff8d6943c8 \
+                        size    2681 \
+                    github.com/xxxserxxx/opflag \
+                        lock    v1.0.5 \
+                        rmd160  ca196c2cd510fea8b53f030befcf4c0be029cb28 \
+                        sha256  546e8a5919433af7db28a813712b115b1b9615a2ec425e4cd5daedb8943217be \
+                        size    16090 \
+                    golang.org/x/sys \
+                        lock    7e40ca221e25 \
+                        rmd160  d1ff2284d6d4fce48d43b1f6ad4b66565850f166 \
+                        sha256  3a22a640fc46177e07c932f91805f2a10b1723e9c270042ed08c422f8948ff6b \
+                        size    1052457 \
+                    github.com/VictoriaMetrics/metrics \
+                        lock    v1.11.2 \
+                        rmd160  e140dcdfb77fc90df9598b5fd9c3e23ef7f81aea \
+                        sha256  2541165d6b4a520ceeb34f72b18d2468c2a1218b82d2760714069bd24cebffb3 \
+                        size    18871 \
+                    github.com/distatus/battery \
+                        lock    v0.9.0 \
+                        rmd160  c1a642fba629fa9fb498e41c8327936d08040acf \
+                        sha256  3f469ed8c33f385a5d9e86e8e5faad8ea69f1a0148ffb21509e079e6109910ef \
+                        size    13745 \
+                    github.com/kr/text \
+                        lock    v0.1.0 \
+                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
+                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
+                        size    8691 \
+                    github.com/mitchellh/go-wordwrap \
+                        lock    ad45545899c7 \
+                        rmd160  76f2fe70134df2cc85b432cf5259b488cc09c51c \
+                        sha256  6653ada6adf689695d5725c9702f16e955f918f5a649efc3a04405bb52e8c25b \
+                        size    2741 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/shirou/gopsutil \
+                        lock    v2.20.3 \
+                        rmd160  a64a4e2525b4fdbae11f452a03ce91991a58b70b \
+                        sha256  fdd50d6be55ce29d174eb4db963c38a9ec2df2d1808a35473b02dfb3c6d5bb9f \
+                        size    136334 \
+                    github.com/StackExchange/wmi \
+                        lock    cbe66965904d \
+                        rmd160  1c28ff3f595532ab67c85f5232c9228cf97d65d9 \
+                        sha256  01b78146552b0c7d6126b64cdf4f7c40fe1e1e15a9f822d4a1bc6db5df1f48ca \
+                        size    11289 \
+                    github.com/gizak/termui \
+                        lock    v3.1.0 \
+                        rmd160  f1be2950d4a743e6584c28a5e099c1b33efb53dd \
+                        sha256  5e1ae80e56b28bd92d6fad83371235ab3b1761f5023ec80c2cbc90f9de02d461 \
+                        size    185693 \
+                    github.com/kr/pretty \
+                        lock    v0.1.0 \
+                        rmd160  9aa7a5aad4c48840eecfd0f80186d1fb5ded0fd6 \
+                        sha256  f6c3f89667c63e5b7f1fc6ee2c06b6a6bfdce88f3a965ccd395b64c6f95c9a47 \
+                        size    8553 \
+                    github.com/stretchr/testify \
+                        lock    v1.4.0 \
+                        rmd160  86bd663e13ea7266334c47689074df16252db5ff \
+                        sha256  8ed95078bfd318ea477da509e6b16e6cf8d0d1b6b8d93b1f6097c6ba2a6df788 \
+                        size    110114 \
+                    github.com/valyala/fastrand \
+                        lock    v1.0.0 \
+                        rmd160  477e2e028c4d48b3ca7e557ad7f384e4a4268209 \
+                        sha256  10e3522a0d6eae00d6db93677210bb9026d739e9a83796d47b6e487697452d5c \
+                        size    3321 \
+                    gopkg.in/check.v1 \
+                        lock    788fd7840127 \
+                        rmd160  b63165c8909a27edc15dda210df66a1b49efb49e \
+                        sha256  7e5547c6471cc48da89a7c87f965b20ca5311f43fc4d883ca62f9fccf7551630 \
+                        size    31597 \
+                    gopkg.in/yaml.v2 \
+                        lock    v2.2.2 \
+                        rmd160  03aea7b7e847179b29044d5a928b9f8a889fe87b \
+                        sha256  da1e31b7beb9a6907947caa794134bdc2501d1a3474568b61cc2562a398d3d87 \
+                        size    70676 \
+                    github.com/cjbassi/drawille-go \
+                        lock    27dc511fe6fd \
+                        rmd160  4fed2bdea9aced25f2fd81c161e92369580d8df6 \
+                        sha256  ba962168b43d8cf438d4e50c7eab0c68c576b4d8e01f2735bb62ba5887b37792 \
+                        size    1715 \
+                    github.com/go-ole/go-ole \
+                        lock    v1.2.4 \
+                        rmd160  ff816f1835d4311c60fbed68b0d01838c4265bb6 \
+                        sha256  55590e7d9e56e30094fd487a2dcf4926aa4bb82471f21f33131b606a6ce41294 \
+                        size    51683 \
+                    github.com/mattn/go-runewidth \
+                        lock    v0.0.4 \
+                        rmd160  20081e360b3a667d21a7990197740bbaf51ec259 \
+                        sha256  d3b074c23e9cebd7fe786eb4fcdb5f659a8afa7629e3ec9a142f4288067bf39b \
+                        size    19840 \
+                    github.com/nsf/termbox-go \
+                        lock    38ba6e5628f1 \
+                        rmd160  a99c5ed0fab4285172d060988708e3c818a00fc0 \
+                        sha256  8eab5b10ae2b57adc8f03ca852d328e3cf12dfcc6053c9f9e97e12afea60bd7c \
+                        size    32822 \
+                    github.com/DHowett/go-plist \
+                        lock    3b63eb3a43b5 \
+                        rmd160  b65265101166d7b7c29de187d69d7c70caa545e4 \
+                        sha256  97f4de0b54212f2e92ac7515754526ec3313cf68b0b2bad4b8b6ed8ea5e81073 \
+                        size    52295
 
 
+pre-build {
+    file mkdir ${gopath}/src/howett.net
+    ln -s ${gopath}/src/github.com/DHowett/go-plist ${gopath}/src/howett.net/plist
+}
 set time [clock format [clock seconds] -format %Y%m%dT%H%M%S]
 build.args-append   -ldflags=\"-X 'main.Version=v${version}' -X 'main.BuildDate=${time}'\" -o ./gotop ./cmd/gotop
+build.env-append    GOPROXY=off \
+                    GO111MODULE=off
 
 destroot {
     xinstall -m 755 ${worksrcpath}/gotop ${destroot}${prefix}/bin


### PR DESCRIPTION
See https://trac.macports.org/ticket/61192

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
