### PR TITLE
py-MDAnalysis: update to 1.0.0 + python 38 + patch

### DIFF
--- a/python/py-MDAnalysis/Portfile
+++ b/python/py-MDAnalysis/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-MDAnalysis
-version             0.20.1
+version             1.0.0
 revision            0
 categories-append   science
 platforms           darwin
 license             GPL-2.0+
 
-python.versions     27 36 37
+python.versions     27 36 37 38
 
 maintainers         {gmail.com:giovanni.bussi @GiovanniBussi} openmaintainer
 
@@ -25,9 +25,11 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  036b507f4da17a7f1d960c3ca9dcb0cf04d58c8d \
-                    sha256  d04b71b193b9716d2597ffb9938b93f43487fa535da1bb5c1f2baccf356d7df9 \
-                    size    3655404
+checksums           rmd160  6ac6c5ad4ad83ff1227ec596cf47de76587d4478 \
+                    sha256  f45a024aca45e390ff1c45ca90beb2180b78881be377e2a1aa9cd6c109bcfa81 \
+                    size    19552874
+
+patchfiles          patch-unistd.diff
 
 if {${name} ne ${subport}} {
     # OpenMP is disabled now
@@ -44,6 +46,7 @@ if {${name} ne ${subport}} {
                             port:py${python.version}-networkx \
                             port:py${python.version}-numpy \
                             port:py${python.version}-scipy \
-                            port:py${python.version}-six
+                            port:py${python.version}-six \
+                            port:py${python.version}-tqdm
     livecheck.type          none
 }

--- a/python/py-MDAnalysis/files/patch-unistd.diff
+++ b/python/py-MDAnalysis/files/patch-unistd.diff
@@ -1,0 +1,17 @@
+--- MDAnalysis/analysis/encore/dimensionality_reduction/src/spe.c.orig	2020-09-20 22:03:20.000000000 +0200
++++ MDAnalysis/analysis/encore/dimensionality_reduction/src/spe.c	2020-09-20 22:03:38.000000000 +0200
+@@ -27,12 +27,10 @@
+ #include <time.h>
+ #include <sys/types.h>
+ 
+-#ifdef __unix__
+-    #include <unistd.h>
+-#endif
+-
+ #ifdef _WIN32
+     #include <io.h>
++#else
++    #include <unistd.h>
+ #endif
+ 
+ #define EPSILON 1e-8


### PR DESCRIPTION
#### Description

I updated the package to the stable version 1.0.0 and added python 38 subport.

Unrelated to this, I noticed that (likely due to some change in xcode 12) there was a compilation error. I managed to solve it with the attached patch. I guess che c compiler in xcode 12 does not define `__unix__` anymore. It might be a problem for other ports as well. I will then report it upstream.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 12.0 12A7209 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
