### PR TITLE
tsduck: Disable silent rules

### DIFF
--- a/multimedia/tsduck/Portfile
+++ b/multimedia/tsduck/Portfile
@@ -26,6 +26,8 @@ depends_build-append port:gsed
 
 depends_lib-append  port:curl
 
+patchfiles          disable-silent-rules.patch
+
 # clock_gettime
 legacysupport.newest_darwin_requires_legacy 15
 

--- a/multimedia/tsduck/files/disable-silent-rules.patch
+++ b/multimedia/tsduck/files/disable-silent-rules.patch
@@ -1,0 +1,92 @@
+Disable silent rules.
+--- Makefile.common.orig	2020-08-27 15:21:35.000000000 -0500
++++ Makefile.common	2020-09-21 00:59:38.000000000 -0500
+@@ -971,32 +971,25 @@
+ 
+ # Compilation rules
+ $(OBJDIR)/%.o: %.c
+-	@echo '  [CC] $<'; \
+ 	mkdir -p $(OBJDIR); \
+ 	$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<
+ $(OBJDIR)/%.o: %.cpp
+-	@echo '  [CXX] $<'; \
+ 	mkdir -p $(OBJDIR); \
+ 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c -o $@ $<
+ (%): %
+-	@echo '  [AR] $<'; \
+ 	$(ARLOCK) $(AR) $(ARFLAGS) $@ $<
+ $(BINDIR)/%: $(OBJDIR)/%.o
+-	@echo '  [LD] $@'; \
+ 	$(CC) $(LDFLAGS) $^ $(LDLIBS) -o $@
+ $(BINDIR)/%.so: $(OBJDIR)/%.o
+-	@echo '  [CC] $@'; \
+ 	$(CC) $(CFLAGS) $(SOFLAGS) $(LDFLAGS) $^ $(LDLIBS) -shared -o $@
+ 
+ # Object files dependencies (.dep files, included by makefiles)
+ $(OBJDIR)/%.dep: %.c
+-	@echo '  [DEP] $<'; \
+ 	mkdir -p $(OBJDIR); \
+ 	$(CC) -MM $(CPPFLAGS) $(CFLAGS_INCLUDES) $(CFLAGS_STANDARD) $(CFLAGS_NO_WARNINGS) $< >$@ && \
+ 	$(SED) -i 's,\($*\)\.o[ :]*,$(OBJDIR)/\1.o $@ : ,g' $@ || \
+ 	rm -f $@
+ $(OBJDIR)/%.dep: %.cpp
+-	@echo '  [DEP] $<'; \
+ 	mkdir -p $(OBJDIR); \
+ 	$(CC) -MM $(CPPFLAGS) $(CXXFLAGS_INCLUDES) $(CXXFLAGS_STANDARD) $(CXXFLAGS_NO_WARNINGS) $< >$@ && \
+ 	$(SED) -i 's,\($*\)\.o[ :]*,$(OBJDIR)/\1.o $@ : ,g' $@ || \
+@@ -1017,14 +1010,12 @@
+ # Cleanup utilities
+ .PHONY: clean distclean
+ clean:
+-	@echo '  [CLEAN] $(CURDIR)'; \
+ 	rm -rf $(EXTRA_CLEAN) *~ \
+ 	    *.o *.ko *.a *.gcov *.dep tmp *.tmp *.out *.log *.tlog core core.* vgcore.* *.stackdump \
+ 	    $(OBJDIR)/*.o $(OBJDIR)/*.ko $(OBJDIR)/*.a $(OBJDIR)/*.dep $(OBJDIR)/*.tmp $(OBJDIR)/*.out \
+ 	    $(OBJDIR)/*.log $(OBJDIR)/*.tlog $(OBJDIR)/core $(OBJDIR)/core.* $(OBJDIR)/vgcore.*
+ 	+@$(RECURSE)
+ distclean: clean
+-	@echo '  [DISTCLEAN] $(CURDIR)'; \
+ 	rm -rf $(EXTRA_DISTCLEAN) [Dd]ebug* [Rr]elease* ipch *.exe *.so .kdbgrc.* *.t2d \
+ 	    .vs *.ncb *.suo *.idb *.sdf *.opensdf *.vcproj.*.user \
+ 	    *.vcxproj.user *.dll.embed.manifest.dll *.dll.embed.manifest.ilk \
+--- src/libtsduck/Makefile.orig	2020-08-27 15:21:35.000000000 -0500
++++ src/libtsduck/Makefile	2020-09-21 00:59:16.000000000 -0500
+@@ -74,7 +74,6 @@
+ .PHONY: headers
+ headers: $(GEN_HEADERS)
+ $(GEN_HEADERS): $(BUILD_PROJ_FILES) $(SRCROOT)/HEADER.txt $(SRC_HEADERS)
+-	@echo '  [REBUILD] $@'; \
+ 	$(BUILD_PROJ_FILES) $@
+ 
+ # These header files are regenerated and, normally, make should know that they must be
+@@ -106,7 +105,6 @@
+ .PHONY: configs
+ configs: $(addprefix $(BINDIR)/,$(notdir $(CONFIG_FILES)))
+ $(BINDIR)/%: dtv/%
+-	@echo '  [COPY] $<'; \
+ 	mkdir -p $(BINDIR); \
+ 	cp $< $@
+ 
+@@ -122,11 +120,9 @@
+ libs: $(STATIC_LIBTSDUCK) $(SHARED_LIBTSDUCK)
+ 
+ $(STATIC_LIBTSDUCK): $(OBJS)
+-	@echo '  [AR] $@'; $(AR) $(ARFLAGS) $@ $^
++	$(AR) $(ARFLAGS) $@ $^
+ 
+ $(SHARED_LIBTSDUCK): $(filter-out $(OBJDIR)/tsStaticReferencesDVB.o,$(OBJS))
+-	@echo '  [DTAPI] $(if $(DTAPI_OBJECT),using $(DTAPI_OBJECT),no DTAPI available)'; \
+-	echo '  [CC] $@'; \
+ 	$(CC) $(CFLAGS) $(SOFLAGS) $^ $(LDLIBS) -shared -o $@
+ 
+ # Installing the shared library in same directory as executables.
+--- src/utest/Makefile.orig	2020-08-27 15:21:35.000000000 -0500
++++ src/utest/Makefile	2020-09-21 00:58:18.000000000 -0500
+@@ -46,7 +46,6 @@
+ 
+ # 2) Using static library. Skipt plugin tests since they use the shared object.
+ $(BINDIR)/utest_static: $(subst $(OBJDIR)/utestPluginRepository.o,,$(OBJS)) $(STATIC_LIBTSDUCK)
+-	@echo '  [LD] $@'; \
+ 	$(CC) $(LDFLAGS) $^ $(LDLIBS) -o $@
+ 
+ .PHONY: test


### PR DESCRIPTION
#### Description

Disable silent rules, so that we can see the actual compile commands being used.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14019
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] tried a full install with `sudo port -vst install`?
