### PR TITLE
uni: don't fetch dependencies in build phase

### DIFF
--- a/textproc/uni/Portfile
+++ b/textproc/uni/Portfile
@@ -11,16 +11,28 @@ installs_libs       no
 
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
 
-checksums           rmd160  61331f93c959c543e3406c39330e04fbe525d70e \
-                    sha256  0090f70b2bdbe7135c79737a851d4bedb1d227c94731edda3f24770f078beb6f \
-                    size    412661
-
 description         uni queries the Unicode database from the commandline.
 long_description    Query the Unicode database from the commandline, with \
                     good support for emojis. Includes full support for \
                     Unicode 12.1 (May 2019) with full Emoji support (a \
                     surprisingly large amount of emoji pickers don't deal \
                     with emoji sequences very well).
+
+build.env-append    GOPROXY=off \
+                    GO111MODULE=off
+
+go.package          arp242.net/uni
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  61331f93c959c543e3406c39330e04fbe525d70e \
+                        sha256  0090f70b2bdbe7135c79737a851d4bedb1d227c94731edda3f24770f078beb6f \
+                        size    412661
+
+go.vendors          golang.org/x/sys \
+                        lock    bd437916bb0e \
+                        rmd160  8d2ebe3e90c6d80ff0447065c2d6e729bf0feba4 \
+                        sha256  eb31eb19d67029db9ef002650bc92b7ba4f6f1ae0baaf3e9613ae443c33640f4 \
+                        size    1516081
 
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
#### Description

Per https://trac.macports.org/ticket/61192 this is one of the golang ports that automatically downloads its dependencies at build time.

To fix it, I used `go2port`, but when doing so ran into this tricky point:

The main program is developed under a custom package name, so I had to set `go.package`.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->