### PR TITLE
staticcheck: don't fetch dependencies in build phase

### DIFF
--- a/devel/staticcheck/Portfile
+++ b/devel/staticcheck/Portfile
@@ -25,10 +25,6 @@ long_description    Staticcheck is a state of the art linter for the Go \
                     working with Go code, including linters and static \
                     analysis.
 
-checksums           rmd160  146de260c6d6105c0e92620d2b9a2027cd134c4a \
-                    sha256  e99f2cf2325700863e9b76770fd1df0b683e7329005ed74ada9b7560f30286d2 \
-                    size    406284
-
 categories          devel
 license             MIT
 
@@ -37,8 +33,72 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 
 installs_libs       no
 
+go.package          honnef.co/go/tools
+
 build.env-append    CGO_ENABLED=0 \
-                    GO111MODULE=on
+                    GOPROXY=off \
+                    GO111MODULE=off
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  146de260c6d6105c0e92620d2b9a2027cd134c4a \
+                        sha256  e99f2cf2325700863e9b76770fd1df0b683e7329005ed74ada9b7560f30286d2 \
+                        size    406284
+
+go.vendors          github.com/google/renameio \
+                        lock    v0.1.0 \
+                        rmd160  ba2fe6be9202636dcf17dd2d1c495aceed231cc9 \
+                        sha256  dd166ecfcacfff3e36567edab9ef94affe756932becbf382939c20646f504a83 \
+                        size    9728 \
+                    github.com/kisielk/gotool \
+                        lock    v1.0.0 \
+                        rmd160  1be58c6702fce46d7c8c83a280517e1888d5d786 \
+                        sha256  78e9d0b64c827b2d688e409ad000852b97ec95dece0bf309c6f04bf837ff48df \
+                        size    9428 \
+                    github.com/rogpeppe/go-internal \
+                        lock    v1.3.0 \
+                        rmd160  cbbca3540d75f12d0be922b26e1d65f6a5600bf7 \
+                        sha256  fb9862536c94d70f4a59873e7ea0fa10152caecb4ff38248d4b0c81275689b99 \
+                        size    112992 \
+                    golang.org/x/mod \
+                        lock    4bf6d317e70e \
+                        rmd160  f899ec0d96d37fb1a87f59a9e17da13ea2beb4da \
+                        sha256  45092b2499b6effa88a9d612dd348998624a3b3a27dff0cf498ab68bd1cb1259 \
+                        size    40860 \
+                    golang.org/x/net \
+                        lock    eb5bcb51f2a3 \
+                        rmd160  cb943e35e512e30b1a1ee9a9af23e200de7fc2fd \
+                        sha256  50ba342bcc50da4b4590ee91a6586f9d0aab43907596c2a0995e6f0868353e7a \
+                        size    976956 \
+                    golang.org/x/text \
+                        lock    v0.3.0 \
+                        rmd160  81061ce2006da3d6f7a8ef8dae237d65305513d3 \
+                        sha256  6243d5bbd9d8550bc44cb58a0d70180f7a3f6767299b490015107b4d27c604ae \
+                        size    6102563 \
+                    github.com/BurntSushi/toml \
+                        lock    v0.3.1 \
+                        rmd160  fb9650e2d16525153645e5547626f242f3800149 \
+                        sha256  8cc9e5dc68e247554227973d0b4e023b27bbd9ba5a26e4fb40f44743afcb35f1 \
+                        size    42087 \
+                    golang.org/x/crypto \
+                        lock    cbcb75029529 \
+                        rmd160  b9490cf03299f43f7840b0c526bde4c05b3e3477 \
+                        sha256  0ea576c393354cc3044397e28a801670bcede50978530515ac655576a279ceac \
+                        size    1685042 \
+                    golang.org/x/sync \
+                        lock    112230192c58 \
+                        rmd160  37a8b11def31e2ad355002a8671245962be359f6 \
+                        sha256  951a6df1dadb061510f1c646197dd8f8a7c7842729d02c6a68a86bce66349f79 \
+                        size    16832 \
+                    golang.org/x/sys \
+                        lock    97732733099d \
+                        rmd160  d83b94fd587bc3799316510e1e5cfda7ff2425e8 \
+                        sha256  62c7cd8777af259c0266055a99d3d67c80a77506104a14a9678547c808010f73 \
+                        size    1350306 \
+                    golang.org/x/tools \
+                        lock    6e064ea0cf2d \
+                        rmd160  f67483e487bb95a2931556d9da338a801d7dbf81 \
+                        sha256  c91a90d605a7e064d2322edac4d5ae3893232c6c05b8c248e2eedf63286473ff \
+                        size    2278595
 
 set _build_path     ${worksrcpath}/build
 


### PR DESCRIPTION
#### Description

Per https://trac.macports.org/ticket/61192 this is one of the golang ports that automatically downloads its dependencies at build time.

To fix it, I used `go2port`, but when doing so ran into this tricky point:

The main program is developed under a custom package name, so I had to set `go.package`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->