### PR TITLE
newreleases: don't fetch dependencies in build phase

### DIFF
--- a/devel/newreleases/Portfile
+++ b/devel/newreleases/Portfile
@@ -11,10 +11,6 @@ description         A command line client for managing NewReleases \
 
 long_description    {*}${description}
 
-checksums           rmd160  ca8056e7e9cad27605f79741b0f6a3ac1030ca2c \
-                    sha256  655caf72c513038dbf2c52e80d06c4fba5da6bf7aa9f3abb5ee517cedf9d0586 \
-                    size    40383
-
 categories          devel
 license             BSD
 installs_libs       no
@@ -24,6 +20,198 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 
 build.pre_args      -v -o ./nr
 build.args          ./${name}
+
+build.env-append    GOPROXY=off \
+                    GO111MODULE=off
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  ca8056e7e9cad27605f79741b0f6a3ac1030ca2c \
+                        sha256  655caf72c513038dbf2c52e80d06c4fba5da6bf7aa9f3abb5ee517cedf9d0586 \
+                        size    40383
+
+go.package          newreleases.io/cmd
+
+go.vendors          github.com/smartystreets/goconvey \
+                        lock    v1.6.4 \
+                        rmd160  a3dfad6131b94d809efad84d30ce45828c6da756 \
+                        sha256  a03963296bb6d031934a651c1e637e8ab2ce9604ce6a16c158ff551e44e7ba79 \
+                        size    1478824 \
+                    golang.org/x/sys \
+                        lock    c5567b49c5d0 \
+                        rmd160  676a5a926cac1bd8968e69e2abe86b074186ae3f \
+                        sha256  7de0c9c26535368a714a4a19cc8b0d90e428bf9c537f4ccb0b836769d6ef8111 \
+                        size    1446917 \
+                    github.com/jtolio/gls \
+                        lock    v4.20.0 \
+                        rmd160  8e721b1aa6de0606caa5a2a038ddd53a0d05d7b4 \
+                        sha256  6f98dcae4c326cbfb0400e6a01604511e544957ea88494e979ace881e2058cbb \
+                        size    7308 \
+                    github.com/mattn/go-runewidth \
+                        lock    v0.0.7 \
+                        rmd160  82319630034da9c2a7d73cefed068cced7e538d6 \
+                        sha256  33984861cc1c3404174f5a79db9834333dab0ddf3567f2c33cd1ed5e1869493a \
+                        size    16090 \
+                    github.com/mitchellh/mapstructure \
+                        lock    v1.1.2 \
+                        rmd160  a4e01781ea5bb0c987e18e8e450c8f1023d5a857 \
+                        sha256  9c1076f5a8e923d028cb65c36143f3b1478cbaa4420e2e8f332719edc2fc4f71 \
+                        size    20992 \
+                    github.com/pelletier/go-toml \
+                        lock    v1.2.0 \
+                        rmd160  8d91b6485f373ccaa894abcb3bd53839e55b9057 \
+                        sha256  0a9503f2b53444e0c3ea960d18febe14d472c16279844f231994c5ccb81dbdff \
+                        size    57515 \
+                    github.com/jaytaylor/html2text \
+                        lock    3577fbdbcff7 \
+                        rmd160  06143c2f1b361d2ec099d367cd4af94a001a5ff7 \
+                        sha256  6c47427d7e7c3d7597c3ff5b3080a6471d6b90566807003d62ad1ad5c4f9fd73 \
+                        size    15365 \
+                    github.com/BurntSushi/toml \
+                        lock    v0.3.1 \
+                        rmd160  fb9650e2d16525153645e5547626f242f3800149 \
+                        sha256  8cc9e5dc68e247554227973d0b4e023b27bbd9ba5a26e4fb40f44743afcb35f1 \
+                        size    42087 \
+                    github.com/magiconair/properties \
+                        lock    v1.8.1 \
+                        rmd160  c9768d4c6f488f56d9451cfe00898b00fa185e5a \
+                        sha256  ba7ce8c50bdc43c67c5fd97e741ae49c9279c0d42b8e79f978e6e0cd814fec7c \
+                        size    29730 \
+                    github.com/spf13/jwalterweatherman \
+                        lock    v1.0.0 \
+                        rmd160  364fd0d61e94bd3651b5506d61f0e9652d6e33a3 \
+                        sha256  e70eb4dbab0603ad35c32bf89cefd595b2d6d56d66695866bfad2350db939404 \
+                        size    6405 \
+                    github.com/spf13/viper \
+                        lock    v1.7.1 \
+                        rmd160  55d2cf11056c0d6642c4886077a24e295ab2b74b \
+                        sha256  ed5b5c0083fdf44c8a79c2e4cd9b31f428ccf01174ca0f8fc8f15270e2552fd5 \
+                        size    82650 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.3 \
+                        rmd160  32abdd77a987af95ce5b647846bfdbb2d8db91a0 \
+                        sha256  046b6b81e3925ffe60e2213e9a239303ff98a51e76764590b807b591fedf2d1e \
+                        size    46029 \
+                    github.com/stretchr/testify \
+                        lock    v1.3.0 \
+                        rmd160  80582370443047a1d7020211865d85d54c036eea \
+                        sha256  ac782171992e3af1c8ac8384cbf4a39706ec5f9e3c6eed57a246e02dce571762 \
+                        size    102899 \
+                    github.com/subosito/gotenv \
+                        lock    v1.2.0 \
+                        rmd160  359083733ab5db2a09169c8d6d070b03463aef60 \
+                        sha256  01fc25c8959371d006a0460132b72710ac120d5400fceebbc1d321d2e9bcd4a0 \
+                        size    7375 \
+                    gopkg.in/yaml.v2 \
+                        lock    v2.2.4 \
+                        rmd160  e7d6084770eadd1aea75e3e6ad70962436c22989 \
+                        sha256  14dda753969aacb4366477ac95e2b371e1ee940e7e76bfffdec737a55dbd27e0 \
+                        size    72218 \
+                    github.com/gopherjs/gopherjs \
+                        lock    0766667cb4d1 \
+                        rmd160  fe92e39110b5c188dcce98abb3b9aa1b64d68f94 \
+                        sha256  abe56698d0855027a1f6030a44924895d781b19526aa8f9b3ef49ed4199f7c57 \
+                        size    217261 \
+                    github.com/kr/pretty \
+                        lock    v0.1.0 \
+                        rmd160  9aa7a5aad4c48840eecfd0f80186d1fb5ded0fd6 \
+                        sha256  f6c3f89667c63e5b7f1fc6ee2c06b6a6bfdce88f3a965ccd395b64c6f95c9a47 \
+                        size    8553 \
+                    github.com/kr/text \
+                        lock    v0.1.0 \
+                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
+                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
+                        size    8691 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/smartystreets/assertions \
+                        lock    b2de0cb4f26d \
+                        rmd160  32d7082172ea8c4a03119f3ffb803f8aad9744ce \
+                        sha256  469875871db96f87e62f76f0bfc4b3b0b9e4761c2a14d4ce12f246797a7c342c \
+                        size    52177 \
+                    github.com/ssor/bom \
+                        lock    6386211fdfcf \
+                        rmd160  93d18bd4b1376d90faa46b0d8d8578d0958c8d5b \
+                        sha256  61996b134ab2fdca75bfee9cbcbb89110fb21223a07959e292936f8b6f008a57 \
+                        size    1802 \
+                    gopkg.in/check.v1 \
+                        lock    788fd7840127 \
+                        rmd160  b63165c8909a27edc15dda210df66a1b49efb49e \
+                        sha256  7e5547c6471cc48da89a7c87f965b20ca5311f43fc4d883ca62f9fccf7551630 \
+                        size    31597 \
+                    gopkg.in/ini.v1 \
+                        lock    v1.51.0 \
+                        rmd160  fb3d5484b20da6eee5d89fcf693f9fb94e834d5d \
+                        sha256  f7760de2e1e32ed627a3526d3aedafd2c979a40208fdf871fff032e4cb969d98 \
+                        size    43548 \
+                    github.com/fsnotify/fsnotify \
+                        lock    v1.4.7 \
+                        rmd160  24712e412814020224e2779186e634610e2f6926 \
+                        sha256  bc839ee158ad34b81c1f11c3b9e3bcbabfba3297f61d165599880c400b8171dc \
+                        size    31147 \
+                    github.com/inconshreveable/mousetrap \
+                        lock    v1.0.0 \
+                        rmd160  5c617a09f1432fc543672a0e0c1e13d3752030c2 \
+                        sha256  0e6bae2849f13d12fe361ecac087728e4e97f3482f4cec44f6e7a2c53bb9cd0c \
+                        size    2291 \
+                    github.com/spf13/cast \
+                        lock    v1.3.0 \
+                        rmd160  26b82e9734f643bc70be8c73742d4a4f514b6dd2 \
+                        sha256  f2913fc10731a578c016701bd10e6a267c299b94e69d8362d258ce8482d14faf \
+                        size    11086 \
+                    golang.org/x/crypto \
+                        lock    123391ffb6de \
+                        rmd160  4afdc76f139facd878c228d85dee3698de13f793 \
+                        sha256  1b8f464f2d4faca0ac6ac7eac18b2b1118c1ac9ff8f6b7ffc976fb0ebedc520f \
+                        size    1732579 \
+                    github.com/hashicorp/hcl \
+                        lock    v1.0.0 \
+                        rmd160  ad8d0b523bb708fd6ae77df8bb414c103a75aa92 \
+                        sha256  4fc0e87ac9d3d6cd042f044df2db2703bed569051fb8c179d505edeb4433e96e \
+                        size    70636 \
+                    github.com/olekukonko/tablewriter \
+                        lock    v0.0.4 \
+                        rmd160  750bec232562820a4f3ba47cd2864f4c84e7a767 \
+                        sha256  890daf262aee371899075912bab0b3107313bea32846cf796bca83ef9a1dccf5 \
+                        size    19267 \
+                    github.com/spf13/afero \
+                        lock    v1.1.2 \
+                        rmd160  dc2ff3aa582c3dc782e3c062e35b65564bfc44e5 \
+                        sha256  08dca858dce5a4336ca385028ff38e0fa6a9f064f5c874fdabe2096a34b6fc91 \
+                        size    45324 \
+                    github.com/spf13/cobra \
+                        lock    v1.0.0 \
+                        rmd160  73602c4d37ad508ba8b35812c793e1df3eda7bb9 \
+                        sha256  6cdf3f445559b8f41f5288366a4c26e8d1b1601dac6924af091a49f1f6b11396 \
+                        size    128931 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    golang.org/x/net \
+                        lock    3b0461eec859 \
+                        rmd160  24dae39afb612a8977e6f4a91596c64d15dd3664 \
+                        sha256  15f077bb408fb71b22e4015312be5fab7010576e824fdbfdfdb697b611621197 \
+                        size    1099249 \
+                    golang.org/x/text \
+                        lock    v0.3.2 \
+                        rmd160  3b9523084f6a8b2e6a6987e49c56f05e22ad69eb \
+                        sha256  d624899dfd390d9d4a77e5c8e5abd8c45f0b6163e0dc7176aee39f25c5f1bed0 \
+                        size    7168458 \
+                    github.com/newreleasesio/client-go \
+                        lock    v1.6.0 \
+                        rmd160  5bf38f8f0f25ec4647fddec6bbcec870ef10d15f \
+                        sha256  d87374616de65779899809f58f29193d892c9c007809935bd109acb426d2638d \
+                        size    15431
+
+post-extract {
+    file mkdir ${gopath}/src/jaytaylor.com
+    move ${gopath}/src/github.com/jaytaylor/html2text ${gopath}/src/jaytaylor.com/html2text
+    move ${gopath}/src/github.com/newreleasesio/client-go ${gopath}/src/newreleases.io/newreleases
+}
 
 destroot {
     xinstall -m 755 ${worksrcpath}/nr ${destroot}${prefix}/bin/${name}


### PR DESCRIPTION
#### Description

Per https://trac.macports.org/ticket/61192 this is one of the golang ports that automatically downloads its dependencies at build time.

To fix it, I used `go2port`, but when doing so ran into these tricky points:

- The main program is developed under a custom package name, so I had to set `go.package`
- Two of the dependencies use custom domains; luckily both redirect to GitHub, so I was able to refer to the GitHub project in `go.vendors` and then fix up the GOPATH in post-extract. I can imagine handling this better in the golang-1.0 portgroup by adding a `package` keyword (or conversely something like `redirects_to`) to the keywords understood by `go.vendors`.
- One of the dependencies' GitHub authors was renamed

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->