### PR TITLE
mole: don't fetch dependencies in build phase

### DIFF
--- a/net/mole/Portfile
+++ b/net/mole/Portfile
@@ -19,10 +19,120 @@ patchfiles          patch-Makefile.diff
 build.cmd           make
 build.args          version=${version}
 build.target        bin
+build.env-append    GOPROXY=off \
+                    GO111MODULE=off
 
-checksums           rmd160  f3c6d6cdd01f9455f61ef96dce919ae951f53fc5 \
-                    sha256  96c0424df523483d99b3180c35855e599922e55ea6bc987a9a5b813c7c5d9815 \
-                    size    54349
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  f3c6d6cdd01f9455f61ef96dce919ae951f53fc5 \
+                        sha256  96c0424df523483d99b3180c35855e599922e55ea6bc987a9a5b813c7c5d9815 \
+                        size    54349
+
+go.vendors          github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/gofrs/uuid \
+                        lock    v3.2.0 \
+                        rmd160  a7e56ffb6b4c8ca6ee828647a6f65a5cad26b141 \
+                        sha256  f7401d47d2310e392b151fe91a5972ff4a63204af4fa9cbb75bdcee0b3acee7f \
+                        size    17078 \
+                    github.com/hashicorp/hcl \
+                        lock    v1.0.0 \
+                        rmd160  ad8d0b523bb708fd6ae77df8bb414c103a75aa92 \
+                        sha256  4fc0e87ac9d3d6cd042f044df2db2703bed569051fb8c179d505edeb4433e96e \
+                        size    70636 \
+                    github.com/kevinburke/ssh_config \
+                        lock    2e50c441276c \
+                        rmd160  9917d3c659dc661cc1657e1d7b9fee8f59d255ae \
+                        sha256  96ed1affc640bdae6703311ebba2b1bfe0d6b726181549cac60488388c42743d \
+                        size    17171 \
+                    github.com/pelletier/go-buffruneio \
+                        lock    v0.2.0 \
+                        rmd160  07afa602d8661c1e3045afa5620e0a0119436cb9 \
+                        sha256  8e21a1948f4e9c2771b67e911630cdd8328076c079ff0fb9a36ae61dd416bf51 \
+                        size    3032 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/prometheus/common \
+                        lock    v0.10.0 \
+                        rmd160  c765a0bd236702e76fdbd77ae6dddc14a5f8992b \
+                        sha256  e1cc3111ffdc29a02b2c6a62554c53868c400115bb997dbdae99a8e835d49efb \
+                        size    107766 \
+                    github.com/awnumar/memguard \
+                        lock    v0.17.1 \
+                        rmd160  10b15f0f55e66b99bcac1dd15f06c1a74d942d94 \
+                        sha256  80d7165cee2dd37aa2ec36fd9f6ab53dd926b211a3f1bd6825a6dc5669e96e12 \
+                        size    1421220 \
+                    golang.org/x/crypto \
+                        lock    123391ffb6de \
+                        rmd160  4afdc76f139facd878c228d85dee3698de13f793 \
+                        sha256  1b8f464f2d4faca0ac6ac7eac18b2b1118c1ac9ff8f6b7ffc976fb0ebedc520f \
+                        size    1732579 \
+                    golang.org/x/sys \
+                        lock    04f50cda93cb \
+                        rmd160  b350db134c68e70efa43be48b431edeabbb17613 \
+                        sha256  423d4b46a2a228cdec3871c1ba4ea4b5d49d248ef487c7d83ae5bb056b5cf5d3 \
+                        size    1448951 \
+                    gopkg.in/alecthomas/kingpin.v2 \
+                        lock    v2.2.6 \
+                        rmd160  af6db4648ec7638fb5cab49fd9536caa705f5fed \
+                        sha256  31378085783496cff78c7d41479ccd6206c4f4e3892909ef0c2cd39e2de3b039 \
+                        size    44374 \
+                    github.com/stretchr/testify \
+                        lock    v1.3.0 \
+                        rmd160  80582370443047a1d7020211865d85d54c036eea \
+                        sha256  ac782171992e3af1c8ac8384cbf4a39706ec5f9e3c6eed57a246e02dce571762 \
+                        size    102899 \
+                    github.com/sirupsen/logrus \
+                        lock    v1.4.2 \
+                        rmd160  9245d7ebabf259e649892609e598a2284e89e499 \
+                        sha256  c3eaf49a2a03ce42b20b5db84771a7d447465475bf083f289ecee631063e6090 \
+                        size    41379 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.5 \
+                        rmd160  2ce81608a38c6f383a35bccd24d64361df5828c9 \
+                        sha256  7f41acdcba65b1fab5b9b633947a139f9915b60f94bdab486cdbe9d90c54f61e \
+                        size    50815 \
+                    github.com/sevlyar/go-daemon \
+                        lock    v0.1.5 \
+                        rmd160  5ae4481cac8b47e4b46ae6a97c724b73b3a3a46f \
+                        sha256  5a0f7a0267b778cdc93bd741294b57100bd5238fe23edd6fed223f9821294603 \
+                        size    64137 \
+                    github.com/alecthomas/template \
+                        lock    fb15b899a751 \
+                        rmd160  34faebabc9eeabdf4e3efc70015e1f858ad787cf \
+                        sha256  7bdd81cd04955c4251637e7196751a4626ae822382b9cbb33ea53eb5f8ce00e5 \
+                        size    55322 \
+                    github.com/alecthomas/units \
+                        lock    c3de453c63f4 \
+                        rmd160  5008bfe6af9cfe334d62399db00901ea6a6c1814 \
+                        sha256  c6a733d020cca4f93b44c8a22eb68a90fb38916b4818a9bb569c65ed9322b3f2 \
+                        size    3497 \
+                    github.com/spf13/cobra \
+                        lock    v0.0.5 \
+                        rmd160  53e9a05596343a23f3a42bb6bf0d1a740591345d \
+                        sha256  9987c8c42db1f7b6e17abb000d23457463bc3f8884c815777f7fbf5e48e6a498 \
+                        size    111150 \
+                    github.com/BurntSushi/toml \
+                        lock    v0.3.1 \
+                        rmd160  fb9650e2d16525153645e5547626f242f3800149 \
+                        sha256  8cc9e5dc68e247554227973d0b4e023b27bbd9ba5a26e4fb40f44743afcb35f1 \
+                        size    42087 \
+                    github.com/phayes/freeport \
+                        lock    95f893ade6f2 \
+                        rmd160  d1fc5421ad2ca6cf03a0838e2b18b5704a32e956 \
+                        sha256  eae7763d5bc66e629379a0c691a5543ccc8b76cf92bd79a4ccf555b023c2512f \
+                        size    3355 \
+                    github.com/fsnotify/fsnotify \
+                        lock    v1.4.7 \
+                        rmd160  24712e412814020224e2779186e634610e2f6926 \
+                        sha256  bc839ee158ad34b81c1f11c3b9e3bcbabfba3297f61d165599880c400b8171dc \
+                        size    31147
 
 destroot {
     xinstall -m 755 ${worksrcpath}/bin/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
#### Description

Per https://trac.macports.org/ticket/61192 this is one of the golang ports that automatically downloads its dependencies at build time.

To fix it, I used `go2port`. This port went smoothly and had no surprises.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->