### PR TITLE
google-cloud-sdk: update to 311.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             310.0.0
+version             311.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  c150d27e2de12305eb1a7366cd9b7b70929b3634 \
-                    sha256  59baf2df83a25541dbf4a751af47c4a5421cd8ff7c732589d856f95e60250644 \
-                    size    84780763
+    checksums       rmd160  64f9aa5de60814d1e429f6dfa09043f1144efa9a \
+                    sha256  a82e1ab5748de568871dd897a4feb327a575343c472e7ba4a6b79b2e0faacc38 \
+                    size    85068210
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  a9b23e030c4c8b752e07a52e850ab82da6d7caf1 \
-                    sha256  459418f28ad3521db1162f502269318e59a333842dd324c877e622963a20cdbb \
-                    size    85796134
+    checksums       rmd160  e46809d8006bb6cff98691d91e7cb96e78b32726 \
+                    sha256  c3d5c0a8f8df656b4d94143346441d4b9feeea47f5121713ee394ff3240196ca \
+                    size    86082243
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 311.0.0.

###### Tested on

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?