### PR TITLE
ghc: Update to version 8.10.2

### DIFF
--- a/lang/ghc/Portfile
+++ b/lang/ghc/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           gpg_verify 1.0
 
 name                ghc
-version             8.10.1
+version             8.10.2
 revision            0
 categories          lang haskell
 maintainers         {ieee.org:s.t.smith @essandess} openmaintainer
@@ -12,19 +12,20 @@ license             BSD
 platforms           darwin
 supported_archs     x86_64
 
-description The Glorious Glasgow Haskell Compilation System
-long_description    \
-        The Glasgow Haskell Compiler is a robust,       \
-        fully-featured, optimising compiler and interactive \
-        environment for Haskell 98, GHC compiles Haskell to \
-        either native code or C.  It implements numerous    \
-        experimental language extensions to Haskell 98,     \
-        for example: concurrency, a foreign language interface, \
-        multi-parameter type classes, scoped type variables,    \
-        existential and universal quantification, unboxed   \
-        types, exceptions, weak pointers, and so on.        \
-        GHC comes with a generational garbage collector,    \
-        and a space and time profiler.
+description         The Glorious Glasgow Haskell Compilation System
+long_description    The Glasgow Haskell Compiler is a robust,\
+                    fully-featured, optimising compiler and\
+                    interactive environment for Haskell 98, GHC\
+                    compiles Haskell to either native code or C.  It\
+                    implements numerous experimental language\
+                    extensions to Haskell 98, for example:\
+                    concurrency, a foreign language interface,\
+                    multi-parameter type classes, scoped type\
+                    variables, existential and universal\
+                    quantification, unboxed types, exceptions, weak\
+                    pointers, and so on.  GHC comes with a\
+                    generational garbage collector, and a space and\
+                    time profiler.
 
 homepage            http://haskell.org/${name}
 
@@ -40,13 +41,13 @@ distfiles           ${distname}-x86_64-apple-darwin${extract.suffix} \
                     ${distname}-testsuite${extract.suffix}
 
 checksums           ${distname}-x86_64-apple-darwin${extract.suffix} \
-                    rmd160  5798ed5082418e20603ea022228a3a1015253848 \
-                    sha256  65b1ca361093de4804a7e40b3e68178e1ef720f84f743641ec8d95e56a45b3a8 \
-                    size    192889416 \
+                    rmd160  eb97c90addf98984fbd07a358b8a03d471199f31 \
+                    sha256  edb772b00c0d7f18bb56ad27765162ee09c508104d40f82128c9114a02f6cfc2 \
+                    size    193710384 \
                     ${distname}-testsuite${extract.suffix} \
-                    rmd160  225d1aba26458102330a730b96ae4500cf00d0bc \
-                    sha256  37cf67b04bcf00ae78914e4612db9d959bc5bd455a27ea5f6461100137c0b800 \
-                    size    2091988
+                    rmd160  55e9ddfa3490463695d8e34e62542abb675aa2c1 \
+                    sha256  3a4aac2f2fba635499bb8c946c19410a37740e5d26c3e6816304b29cfa426a29 \
+                    size    2101788
 
 gpg_verify.use_gpg_verification \
                     yes
@@ -100,9 +101,9 @@ if { [variant_isset "prebuilt"] } {
                     ${distname}-src${extract.suffix}
     checksums-append \
                     ${distname}-src${extract.suffix} \
-                    rmd160  99cd5da02c02364bdfb9b171f14012bea32b843a \
-                    sha256  4e3b07f83a266b3198310f19f71e371ebce97c769b14f0d688f4cbf2a2a1edf5 \
-                    size    19781652
+                    rmd160  370e1f509bcfa913300b218b4397411efc317522 \
+                    sha256  9c573a4621a78723950617c223559bdc325ea6a3409264aedf68f05510b0880b \
+                    size    21880680
 
     depends_build-append \
                     port:alex \
@@ -172,6 +173,7 @@ if { [variant_isset "prebuilt"] } {
         configure.env-append CC=${configure.cc}
         build.env-append     CC=${configure.cc} \
                              CXX=${configure.cxx}
+        # diff -Naur ghc ghc-patched | sed -E -e 's/ghc(-patched)?\//.\//g' > patch-gmp-ghc.mk.diff
         system -W ${srcpath}/${distname} "patch -p0 < ${filespath}/patch-gmp-ghc.mk.diff"
 
         system -W ${srcpath}/${distname} \

--- a/lang/ghc/files/patch-gmp-ghc.mk.diff
+++ b/lang/ghc/files/patch-gmp-ghc.mk.diff
@@ -1,11 +1,12 @@
---- libraries/integer-gmp/gmp/ghc.mk.orig	2019-11-23 13:27:35.000000000 -0700
-+++ libraries/integer-gmp/gmp/ghc.mk	2020-04-25 10:45:20.000000000 -0700
+diff -Naur ./libraries/integer-gmp/gmp/ghc.mk ./libraries/integer-gmp/gmp/ghc.mk
+--- ./libraries/integer-gmp/gmp/ghc.mk	2020-09-22 14:03:12.000000000 -0400
++++ ./libraries/integer-gmp/gmp/ghc.mk	2020-09-22 14:04:35.000000000 -0400
 @@ -130,7 +130,7 @@
  	#       `./configure`, not `HOSTPLATFORM`: the 'host' on which GMP will
  	#       run is the 'target' platform of the compiler we're building.
  	cd libraries/integer-gmp/gmp/gmpbuild; \
 -	    CC=$(CCX) CXX=$(CCX) NM=$(NM) AR=$(AR_STAGE1) ./configure \
 +	    NM=$(NM) AR=$(AR_STAGE1) ./configure \
- 	          --enable-shared=no \
+ 	          --enable-shared=no --with-pic=yes \
  	          --host=$(TARGETPLATFORM) --build=$(BUILDPLATFORM)
  	$(MAKE) -C libraries/integer-gmp/gmp/gmpbuild MAKEFLAGS=


### PR DESCRIPTION
ghc: Update to version 8.10.2

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
