### PR TITLE
.github: remove macos-10.14 target

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-10.14, macos-10.15]
+        os: [macos-10.15]
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
#### Description
The 10.14 target is running 10.15 anyway. Example:
https://github.com/macports/macports-ports/runs/1153828353?check_suite_focus=true#step:1:4
Also see annotation: https://github.com/macports/macports-ports/actions/runs/268377692
```
The macOS virtual environment has been updated to Catalina (v10.15). Please update your workflow and change the line 'runs-on: macOS-10.14' to 'runs-on: macOS-latest'
```

(Azure CI still has 10.14 available: https://paste.z0k.xyz/29130ada2458)

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
