### PR TITLE
golang-1.0 portgroup: improve support for dependencies hosted on custom domains

### DIFF
--- a/devel/newreleases/Portfile
+++ b/devel/newreleases/Portfile
@@ -61,7 +61,8 @@ go.vendors          github.com/smartystreets/goconvey \
                         rmd160  8d91b6485f373ccaa894abcb3bd53839e55b9057 \
                         sha256  0a9503f2b53444e0c3ea960d18febe14d472c16279844f231994c5ccb81dbdff \
                         size    57515 \
-                    github.com/jaytaylor/html2text \
+                    jaytaylor.com/html2text \
+                        repo    github.com/jaytaylor/html2text \
                         lock    3577fbdbcff7 \
                         rmd160  06143c2f1b361d2ec099d367cd4af94a001a5ff7 \
                         sha256  6c47427d7e7c3d7597c3ff5b3080a6471d6b90566807003d62ad1ad5c4f9fd73 \
@@ -201,17 +202,12 @@ go.vendors          github.com/smartystreets/goconvey \
                         rmd160  3b9523084f6a8b2e6a6987e49c56f05e22ad69eb \
                         sha256  d624899dfd390d9d4a77e5c8e5abd8c45f0b6163e0dc7176aee39f25c5f1bed0 \
                         size    7168458 \
-                    github.com/newreleasesio/client-go \
+                    newreleases.io/newreleases \
+                        repo    github.com/newreleasesio/client-go \
                         lock    v1.6.0 \
                         rmd160  5bf38f8f0f25ec4647fddec6bbcec870ef10d15f \
                         sha256  d87374616de65779899809f58f29193d892c9c007809935bd109acb426d2638d \
                         size    15431
-
-post-extract {
-    file mkdir ${gopath}/src/jaytaylor.com
-    move ${gopath}/src/github.com/jaytaylor/html2text ${gopath}/src/jaytaylor.com/html2text
-    move ${gopath}/src/github.com/newreleasesio/client-go ${gopath}/src/newreleases.io/newreleases
-}
 
 destroot {
     xinstall -m 755 ${worksrcpath}/nr ${destroot}${prefix}/bin/${name}

--- a/devel/shfmt/Portfile
+++ b/devel/shfmt/Portfile
@@ -119,16 +119,12 @@ go.vendors          github.com/creack/pty \
                         rmd160  03aea7b7e847179b29044d5a928b9f8a889fe87b \
                         sha256  da1e31b7beb9a6907947caa794134bdc2501d1a3474568b61cc2562a398d3d87 \
                         size    70676 \
-                    github.com/mvdan/editorconfig \
+                    mvdan.cc/editorconfig \
+                        repo    github.com/mvdan/editorconfig \
                         lock    e40951bde157 \
                         rmd160  1262f81708a7f5f626fa77318897780a3104373a \
                         sha256  ff6d5f23da7cfd2d9afaa6f139365cd6d2a52f56ffc4a44e727bc9096c959744 \
                         size    9311
-
-post-extract {
-    # Author uses custom host name for his packages
-    move ${gopath}/src/github.com/mvdan/editorconfig ${gopath}/src/mvdan.cc/editorconfig
-}
 
 # Disable "module mode" on modular project to get the compiler to look for
 # locally downloaded dependencies

--- a/sysutils/gotop/Portfile
+++ b/sysutils/gotop/Portfile
@@ -130,17 +130,14 @@ go.vendors          github.com/davecgh/go-spew \
                         rmd160  a99c5ed0fab4285172d060988708e3c818a00fc0 \
                         sha256  8eab5b10ae2b57adc8f03ca852d328e3cf12dfcc6053c9f9e97e12afea60bd7c \
                         size    32822 \
-                    github.com/DHowett/go-plist \
+                    howett.net/plist \
+                        repo    github.com/DHowett/go-plist \
                         lock    3b63eb3a43b5 \
                         rmd160  b65265101166d7b7c29de187d69d7c70caa545e4 \
                         sha256  97f4de0b54212f2e92ac7515754526ec3313cf68b0b2bad4b8b6ed8ea5e81073 \
                         size    52295
 
 
-pre-build {
-    file mkdir ${gopath}/src/howett.net
-    ln -s ${gopath}/src/github.com/DHowett/go-plist ${gopath}/src/howett.net/plist
-}
 set time [clock format [clock seconds] -format %Y%m%dT%H%M%S]
 build.args-append   -ldflags=\"-X 'main.Version=v${version}' -X 'main.BuildDate=${time}'\" -o ./gotop ./cmd/gotop
 build.env-append    GOPROXY=off \


### PR DESCRIPTION
#### Description

Non-trivial golang projects have lots of dependencies, and sometimes those are hosted on custom domains outside of the usual GitHub, Bitbucket, etc.

This PR adds a new `resolves_to` keyword to `go.vendors`: when a dependency is hosted at a custom domain, specify the package name as referenced in the source code as the "main" package, and specify the resolved GitHub, etc., name with `resolves_to`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->