### PR TITLE
texlive-bin: add patch to fix finding of snprintf and vsnprintf on macOS 11.0

### DIFF
--- a/tex/texlive-bin/Portfile
+++ b/tex/texlive-bin/Portfile
@@ -101,6 +101,9 @@ patchfiles-append  \
 patchfiles-append  patch-libs_luajit_configure.diff \
                    patch-texk_web2c_configure.diff
 
+# fix finding of snprintf and vsnprintf on macOS 11.0
+# https://trac.macports.org/ticket/60963
+patchfiles-append  patch-texk_kpathsea_configure.diff
 
 post-patch {
     reinplace "s|@@TEXMFDIST@@|${texlive_texmfdist}|" ${worksrcpath}/texk/texlive/linked_scripts/Makefile.in

--- a/tex/texlive-bin/files/patch-texk_kpathsea_configure.diff
+++ b/tex/texlive-bin/files/patch-texk_kpathsea_configure.diff
@@ -1,0 +1,18 @@
+--- texk/kpathsea/configure.orig	2020-09-01 11:22:00.000000000 +0100
++++ texk/kpathsea/configure	2020-09-01 11:23:36.000000000 +0100
+@@ -14057,6 +14057,7 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ #include <stdarg.h>
++#include <stdio.h>
+                                                   char buf[16];
+                                                   va_list ap;
+ int
+@@ -14086,6 +14087,7 @@
+ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
++#include <stdio.h>
+ char buf[4] = "abc";
+ int
+ main ()


### PR DESCRIPTION
Will not harm older macOS or other OSs

Closes: https://trac.macports.org/ticket/60963

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 11.0 20A5374i
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
