### PR TITLE
pandoc: Update to version 2.10.1

### DIFF
--- a/textproc/pandoc/Portfile
+++ b/textproc/pandoc/Portfile
@@ -4,12 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           haskell_stack 1.0
 
-github.setup        jgm pandoc 2.9.2.1
-revision            1
-checksums           rmd160  593c88a301fdaf5f6da615508e2c29b314f5952c \
-                    sha256  f7530a6f94f32ab24a9776ffe808dfe5659f4bd9be53de4f16cea3cfa134bce8 \
-                    size    12670219
-
+github.setup        jgm pandoc 2.10.1
+revision            0
 categories          textproc haskell
 platforms           darwin
 license             GPL-3
@@ -24,6 +20,10 @@ long_description    \
     LaTeX, ConTeXt, Docbook, OpenDocument, ODT, Word docx, RTF, MediaWiki, \
     Textile, groff man pages, plain text, Emacs Org-Mode, AsciiDoc, EPUB (v2 \
     and v3), FictionBook2, and S5, Slidy and Slideous HTML slide shows.
+
+checksums           rmd160  e5a6e7e6f4b2062d9d0afed78f428a11bdb6d664 \
+                    sha256  06e257fb318670501c88abc83fff1f9484c5f1981b6c855640f170a451dcd6d0 \
+                    size    12709912
 
 test.run            yes
 test.args           --test-arguments='-p markdown'


### PR DESCRIPTION
pandoc: Update to version 2.10.1

* Fixes https://trac.macports.org/ticket/60571

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
