### PR TITLE
shtools: new port

### DIFF
--- a/science/shtools/Portfile
+++ b/science/shtools/Portfile
@@ -8,7 +8,7 @@ revision            0
 
 categories          science math
 platforms           darwin
-license             BSD-3-Clause
+license             BSD
 maintainers         {@MarkWieczorek gmail.com:mark.a.wieczorek}
 description         Spherical Harmonic Tools
 long_description    SHTOOLS is a library of Fortran 95 software that can be \
@@ -21,13 +21,12 @@ homepage            https://shtools.github.io/SHTOOLS/
 
 github.setup        SHTOOLS SHTOOLS 4.7.1 v
 github.tarball_from   archive
-checksums           sha256  176610743ddd76ea1fe7b45db3e8613171630b85c3759c9a4b31cde6b5d2ae3d \
-                    rmd160  58959a91c2889488844f6a7e4745090b0c906057 \
-                    size    35165653
+checksums           sha256  6ed2130eed7b741df3b19052b29b3324601403581c7b9afb015e0370e299a2bd \
+                    rmd160  ef9a2ca09e7d9703ebb037e223c9d200f0031e39 \
+                    size    35165654
 
 use_configure       no
 
-build.cmd           make
 build.target        fortran F95="${prefix}/bin/gfortran-mp-10"
 
 variant openmp description {Add OpenMP support} {
@@ -36,14 +35,11 @@ variant openmp description {Add OpenMP support} {
 }
 
 test.run            yes
-test.cmd            make
 test.target         fortran-tests-no-timing
 test.args           PREFIX=${prefix} F95="${prefix}/bin/gfortran-mp-10" LAPACK="-framework Accelerate" BLAS=""
 
-destroot.cmd        make
-destroot.target     install
 destroot.args       PREFIX=${prefix}
 
-depends_build       port:gcc10 port:fftw-3
-depends_test        port:gcc10 port:fftw-3
+depends_build       port:gcc10
+depends_test        port:gcc10
 depends_lib         port:fftw-3

--- a/science/shtools/Portfile
+++ b/science/shtools/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+name                shtools
+revision            0
+
+categories          science math
+platforms           darwin
+license             BSD-3-Clause
+maintainers         {@MarkWieczorek gmail.com:mark.a.wieczorek}
+description         Spherical Harmonic Tools
+long_description    SHTOOLS is a library of Fortran 95 software that can be \
+                    used to perform spherical harmonic transforms, multitaper \
+                    spectral analyses, expansions of functions into Slepian \
+                    bases, and standard operations on global gravitational \
+                    and magnetic field data. Requires linking with FFTW-3 and \
+                    LAPACK compatible libraries.
+homepage            https://shtools.github.io/SHTOOLS/
+
+github.setup        SHTOOLS SHTOOLS 4.7.1 v
+github.tarball_from   archive
+checksums           sha256  176610743ddd76ea1fe7b45db3e8613171630b85c3759c9a4b31cde6b5d2ae3d \
+                    rmd160  58959a91c2889488844f6a7e4745090b0c906057 \
+                    size    35165653
+
+use_configure       no
+
+build.cmd           make
+build.target        fortran F95="${prefix}/bin/gfortran-mp-10"
+
+variant openmp description {Add OpenMP support} {
+    build.target-append     fortran-mp
+}
+
+test.run            yes
+test.cmd            make
+test.target         fortran-tests-no-timing
+test.args           PREFIX=${prefix} F95="${prefix}/bin/gfortran-mp-10" LAPACK="-framework Accelerate" BLAS=""
+
+destroot.cmd        make
+destroot.target     install
+destroot.args       PREFIX=${prefix}
+
+depends_build       port:gcc10 port:fftw-3
+depends_test        port:gcc10 port:fftw-3
+depends_lib         port:fftw-3

--- a/science/shtools/Portfile
+++ b/science/shtools/Portfile
@@ -31,6 +31,7 @@ build.cmd           make
 build.target        fortran F95="${prefix}/bin/gfortran-mp-10"
 
 variant openmp description {Add OpenMP support} {
+    use_parallel_build      no
     build.target-append     fortran-mp
 }
 


### PR DESCRIPTION
#### Description

shtools is an archive of Fortran 95 software for performing spherical harmonic transforms and related operations. It is mature software for more than a decade and is an integral component of the python project pyshtools. More information can be found here: https://shtools.github.io/SHTOOLS/

###### Type(s)
submission (new Portfile)

###### Tested on
macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

