### PR TITLE
dbvis: update to 11.0.5

### DIFF
--- a/databases/dbvis/Portfile
+++ b/databases/dbvis/Portfile
@@ -4,7 +4,7 @@ PortSystem                  1.0
 PortGroup                   java 1.0
 
 name                        dbvis
-version                     11.0.4
+version                     11.0.5
 categories                  databases
 platforms                   darwin
 supported_archs             x86_64
@@ -22,9 +22,9 @@ master_sites                ${homepage}/product_download/dbvis-${version}/media/
 distname                    dbvis_macos_[strsed $version g/\\./_/]
 extract.suffix              .tgz
 
-checksums                   rmd160  67ca749c079fc5397de91de6de01c8eea54493a1 \
-                            sha256  ef2f581e2e9b84421e7281c642490cb190ba549d22066f10581acc5fd8b774cd \
-                            size    98976054
+checksums                   rmd160  08adc87726706704dcd353e5b4afb9c5d0ff6a37 \
+                            sha256  8108d290756b1bf58fc82d78644e5d9dbdd8acb41b21a739c1f6a12dc0d3a924 \
+                            size    99040068
 
 java.version                1.8+
 java.fallback               openjdk11
@@ -41,4 +41,4 @@ destroot {
 
 livecheck.type              regex
 livecheck.url               ${homepage}/CheckForUpdate/?dbvisVersion=11.0.0&dbvisEdition=Free&channels=feature&channels=maintenance
-livecheck.regex             "dbvis.com/download/(\[0-9.\]+)"
+livecheck.regex             {dbvis.com/download/([0-9.]+)}

--- a/databases/dbvis/Portfile
+++ b/databases/dbvis/Portfile
@@ -41,4 +41,4 @@ destroot {
 
 livecheck.type              regex
 livecheck.url               ${homepage}/CheckForUpdate/?dbvisVersion=11.0.0&dbvisEdition=Free&channels=feature&channels=maintenance
-livecheck.regex             "www.dbvis.com/download/(\[0-9.\]+)"
+livecheck.regex             "dbvis.com/download/(\[0-9.\]+)"


### PR DESCRIPTION
###### Tested on

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?