### PR TITLE
py-Pillow: move xcb to x11 variant

### DIFF
--- a/python/py-Pillow/Portfile
+++ b/python/py-Pillow/Portfile
@@ -1,12 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           active_variants 1.1
 PortGroup           python 1.0
 
 name                py-Pillow
 version             7.2.0
-revision            1
+revision            2
 categories-append   devel
 platforms           darwin
 license             BSD
@@ -36,6 +35,8 @@ if {${name} ne ${subport}} {
                             size    37673162
     }
 
+    build.target        build_ext
+
     depends_build-append \
                         port:py${python.version}-setuptools
     depends_lib-append  port:py${python.version}-tkinter \
@@ -54,20 +55,13 @@ if {${name} ne ${subport}} {
         reinplace "s|@prefix@|${prefix}|g" ${worksrcpath}/setup.py
     }
 
-    # When built against a Tk using X11, Pillow will pick up some
-    # extra libraries, such libxcb. Tk's quartz variant doesn't depend
-    # on these libraries, so we add matching variants here.
-    variant x11 conflicts quartz {
-    }
+    if {${python.version} >= 36} {
+        build.args-append   --disable-xcb
 
-    variant quartz conflicts x11 {
-        require_active_variants tk quartz x11
-    }
-
-    if {![catch {set result [active_variants tk quartz x11]}] && $result} {
-        default_variants +quartz
-    } else {
-        default_variants +x11
+        variant x11 {
+            build.args-delete      --disable-xcb
+            depends_lib-append     port:xorg-libxcb
+        }
     }
 
     livecheck.type      none


### PR DESCRIPTION
#### Description

Extract the `xcb` support to a variant. This variant isn't enabled by default, as I assume this isn't a particularly important feature. This partially reverts commit 28ee6c22297ac0a80d3a9147ea92e35eb79fa7fe, done in #8444, as requested by @ryandesign:

> This has nothing to do with what Tk is built against. Pillow always uses xcb directly if present when building.
> 
> ```
> % port installed py37-Pillow
> The following ports are currently installed:
>   py37-Pillow @7.2.0_1+quartz (active)
> % otool -L /opt/local/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/PIL/_imaging.cpython-37m-darwin.so
> /opt/local/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/PIL/_imaging.cpython-37m-darwin.so:
> 	/opt/local/lib/libjpeg.9.dylib (compatibility version 14.0.0, current version 14.0.0)
> 	/opt/local/lib/libopenjp2.7.dylib (compatibility version 7.0.0, current version 2.3.1)
> 	/opt/local/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
> 	/opt/local/lib/libtiff.5.dylib (compatibility version 11.0.0, current version 11.0.0)
> 	/opt/local/lib/libxcb.1.dylib (compatibility version 3.0.0, current version 3.0.0)
> 	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.100.1)
> ```
> 
> Please revert this change and either add a variant that actually controls the use of xcb, or disable use of xcb all the time, or always add an xcb dependency.

Tested by doing a build without trace mode and `libxorg-xcb` installed, and verifying that the binaries don't refer to `libxcb`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
