### PR TITLE
Clojure: update to 1.10.1.561 & take maintainership of the port

### DIFF
--- a/lang/clojure/Portfile
+++ b/lang/clojure/Portfile
@@ -7,7 +7,7 @@ epoch               20110929
 version             1.10.0.411
 license             EPL-1
 categories          lang java
-maintainers         nomaintainer
+maintainers         {gmail.com:jtrtik @jtrtik} openmaintainer
 description         The Clojure programming language
 long_description    Clojure is a dynamic programming language for the JVM. \
                     It is interactive, yet compiled, with a robust \

--- a/lang/clojure/Portfile
+++ b/lang/clojure/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                clojure
 epoch               20110929
-version             1.10.0.411
+version             1.10.1.561
 license             EPL-1
 categories          lang java
 maintainers         {gmail.com:jtrtik @jtrtik} openmaintainer
@@ -20,9 +20,9 @@ supported_archs     noarch
 master_sites        https://download.clojure.org/install/
 distname            clojure-tools-${version}
 worksrcdir          clojure-tools
-checksums           rmd160  59821f4c153046dd4c42474f690f4bc4e2536b67 \
-                    sha256  f0836d56a32f8c76e20d75d442e04ef5c29b023e69d284baaf0ff298b8b17001 \
-                    size    19732792
+checksums           rmd160  a571a313ee9c7488a92b4434e458916676456269 \
+                    sha256  46c193d09f8fce9c0e5e530c2463586cec9717593cdee2f57199d278ed104e2d \
+                    size    17482082
 use_configure       no
 build               {}
 


### PR DESCRIPTION
#### Description
updated to latest stable version

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.7 19H2
Xcode 12.0.1 12A7300

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
