### PR TITLE
zimg: attempt to fix build on macOS 10.11

### DIFF
--- a/graphics/zimg/Portfile
+++ b/graphics/zimg/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        sekrit-twc zimg 3.0.1 release-
 revision            0
@@ -31,6 +32,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 
 compiler.cxx_standard           2011
 compiler.thread_local_storage   yes
+
+# https://trac.macports.org/ticket/61230
+compiler.blacklist-append {clang < 802}
 
 use_autoreconf      yes
 autoreconf.cmd      ./autogen.sh


### PR DESCRIPTION
See: https://trac.macports.org/ticket/61230

#### Description
Build is known to succeed on macOS 10.10 and earlier using MacPorts' clang 9.


<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Untested. Would be interested in knowing whether Travis CI Xcode 8.3 build succeeds, or if minimum Xcode clang version needs to be raised; builds with 8.3 also succeeded for a past PR (#8127) with version 2.9.3.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
