### PR TITLE
py-iso639: new port

### DIFF
--- a/python/py-iso639/Portfile
+++ b/python/py-iso639/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim: fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-iso639
+set real_name       iso-639
+version             0.4.5
+revision            0
+
+platforms           darwin
+license             AGPL-3
+supported_archs     noarch
+maintainers         nomaintainer
+
+description         ISO 639 library for Python
+long_description    {*}${description}. This library is aimed to be fully\
+                    compatible with pycountry.languages v1.11 and before.\
+                    In v1.12 they broke their own API and this library will\
+                    not support the new API.
+
+homepage            https://github.com/noumar/iso639
+master_sites        pypi:[string index ${real_name} 0]/${real_name}
+
+distname            ${real_name}-${version}
+
+checksums           rmd160  601a21b5d90320412f8f406f69ce465ad84f8488 \
+                    sha256  dc9cd4b880b898d774c47fe9775167404af8a85dd889d58f9008035109acce49 \
+                    size    167421
+
+python.versions     38
+
+if {$subport ne $name} {
+    depends_build-append    port:py${python.version}-setuptools
+
+    livecheck.type      none
+}
+
+livecheck.type      pypi


### PR DESCRIPTION
#### Description

ISO 639 library for Python

###### Type(s)

- [x] submission

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

###### Notes

This port is a dep for `streamlink`.