### PR TITLE
py-iso3166: new port

### DIFF
--- a/python/py-iso3166/Portfile
+++ b/python/py-iso3166/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim: fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-iso3166
+version             1.0.1
+revision            0
+
+platforms           darwin
+license             MIT
+supported_archs     noarch
+maintainers         nomaintainer
+
+description         Self-contained ISO 3166-1 country definitions
+long_description    {*}${description}. ISO 3166-1 defines two-letter, three-letter,\
+                    and three-digit country codes. python-iso3166 is a self-contained\
+                    module that converts between these codes and the corresponding\
+                    country name.
+
+homepage            http://github.com/deactivated/python-iso3166
+
+checksums           rmd160  039173f3a626294db4537dbf387e1c81c2d89b29 \
+                    sha256  b1e58dbcf50fbb2c9c418ec7a6057f0cdb30b8f822ac852f72e71ba769dae8c5 \
+                    size    10052
+
+python.versions     38
+
+if {$subport ne $name} {
+    depends_build-append    port:py${python.version}-setuptools
+
+    livecheck.type      none
+}
+
+livecheck.type      pypi


### PR DESCRIPTION
#### Description

Self-contained ISO 3166-1 country definitions

###### Type(s)

- [x] submission

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

###### Notes

This port is a dep for `streamlink`