### PR TITLE
streamlink: new port

### DIFF
--- a/multimedia/streamlink/Portfile
+++ b/multimedia/streamlink/Portfile
@@ -1,0 +1,53 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                streamlink
+version             1.6.0
+revision            0
+
+categories-append   multimedia net
+platforms           darwin
+supported_archs     noarch
+license             {BSD}
+maintainers         nomaintainer
+
+description         a CLI utility which pipes video streams into a video player
+long_description    ${name} is a CLI utility which pipes video streams from various\
+                    services into a video player, such as VLC. The main purpose of\
+                    ${name} is to avoid resource-heavy and unoptimized websites,\
+                    while still allowing the user to enjoy various streamed content.
+
+homepage            https://github.com/streamlink/streamlink/
+
+checksums           rmd160  35f5d40aaff41574a94c98534777e1188014bfae \
+                    sha256  f7857a54ec55e32d6e90ebd770c9d5d1318791d8ecd8270e104a8b1968a308ab \
+                    size    724753
+
+python.versions     38
+
+depends_build-append \
+                    port:py${python.version}-setuptools
+
+depends_lib-append  port:py${python.version}-iso3166 \
+                    port:py${python.version}-iso639 \
+                    port:py${python.version}-isodate \
+                    port:py${python.version}-requests \
+                    port:py${python.version}-pycryptodome \
+                    port:py${python.version}-socks \
+                    port:py${python.version}-websocket-client
+
+variant ffmpeg description "Play streams that are made up of separate audio and video streams" {
+    depends_lib-append  path:bin/ffmpeg:ffmpeg
+}
+
+variant rtmp description "Play RTMP streams" {
+    depends_lib-append  port:rtmpdump
+}
+
+if {![variant_isset ffmpeg]} {
+    default_variants +ffmpeg
+}
+
+livecheck.type      pypi

--- a/multimedia/streamlink/Portfile
+++ b/multimedia/streamlink/Portfile
@@ -10,7 +10,7 @@ revision            0
 categories-append   multimedia net
 platforms           darwin
 supported_archs     noarch
-license             {BSD}
+license             BSD
 maintainers         nomaintainer
 
 description         a CLI utility which pipes video streams into a video player


### PR DESCRIPTION
#### Description

[Streamlink](https://pypi.org/project/streamlink/) is a CLI utility which pipes video streams from various services into a video player, such as VLC.

Closes: https://trac.macports.org/ticket/61232

###### Type(s)

- [x] submission

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

###### Notes

This port needs the 2 deps: `py-iso{639,3166}` (#8533, #8534), so the checks will
initially fail until they've been added.