### PR TITLE
py-pycryptodome: update to 3.9.8

### DIFF
--- a/python/py-pycryptodome/Portfile
+++ b/python/py-pycryptodome/Portfile
@@ -4,11 +4,14 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pycryptodome
-version             3.9.7
+version             3.9.8
+revision            0
+
 license             BSD
 platforms           darwin
 supported_archs     noarch
 maintainers         {@xeron gmail.com:xeron.oskom} openmaintainer
+
 description         Cryptographic library for Python
 long_description    PyCryptodome is a self-contained Python package of \
                     low-level cryptographic primitives. \
@@ -17,11 +20,10 @@ long_description    PyCryptodome is a self-contained Python package of \
 python.versions     27 35 36 37 38
 
 homepage            https://pypi.python.org/pypi/${python.rootname}/
-distname            ${python.rootname}-${version}
 
-checksums           rmd160 a04415452518532e99d44dae2df38f7492431a52 \
-                    sha256 f1add21b6d179179b3c177c33d18a2186a09cc0d3af41ff5ed3f377360b869f2 \
-                    size   15451558
+checksums           rmd160  062e0f20925213f8345681a629563d712770220e \
+                    sha256  0e24171cf01021bc5dc17d6a9d4f33a048f09d62cc3f62541e95ef104588bda4 \
+                    size    15633268
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

py-pycryptodome: update to 3.9.8

  - add livecheck

###### Type(s)

- [x] update

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?