### PR TITLE
FileZilla: fix build on macOS 10.13

### DIFF
--- a/www/FileZilla/Portfile
+++ b/www/FileZilla/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           wxWidgets 1.0
+PortGroup           compiler_blacklist_versions 1.0
 
 name                FileZilla
 version             3.50.0
@@ -59,6 +60,9 @@ configure.env       WXRC=${wxWidgets.wxrc}
 
 compiler.cxx_standard   2017
 compiler.thread_local_storage   yes
+
+# https://trac.macports.org/ticket/59805
+compiler.blacklist-append {clang < 1000}
 
 destroot {
     copy ${worksrcpath}/FileZilla.app ${destroot}${applications_dir}


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/59805

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Untested. See if Travis CI macOS 10.13 "Xcode 9.4" build succeeds.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
