### PR TITLE
netgen: fix build on macOS 10.13 and earlier

### DIFF
--- a/math/netgen/Portfile
+++ b/math/netgen/Portfile
@@ -5,6 +5,7 @@ PortGroup               compilers 1.0
 PortGroup               github    1.0
 PortGroup               cmake     1.1
 PortGroup               active_variants 1.1
+PortGroup               compiler_blacklist_versions 1.0
 
 github.setup            NGSolve netgen 6.2.2004 v
 revision                1
@@ -25,7 +26,11 @@ checksums               rmd160  93f0fe02505d76ad77cc3b9be2624a329f2078c8 \
                         sha256  0b15e66e57551e25e8eecaf02751d78cb8182bc3c7d59ae2d01711b05c59e8a9 \
                         size    3245293
 
-compiler.cxx_standard   2011
+compiler.cxx_standard   2017
+
+# https://trac.macports.org/ticket/60760
+compiler.blacklist-append {clang < 1000}
+
 compilers.choose        cc cxx
 compilers.setup
 


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/60760

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Untested. See if Travis CI builds for 10.13 and earlier succeed.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
