### PR TITLE
openjdk8: add OpenJ9 subports for openjdk15

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -9,11 +9,19 @@ revision         0
 set build        01
 set major        8
 
+checksums        rmd160  c663ab3056c3731c1e780bd3e37fe59321576330 \
+                 sha256  f316b154e8c4a99b95bc3d07add3c9b19609c541a2f297112f274c1abce1efb4 \
+                 size    101998442
+
 subport openjdk8-graalvm {
     version      20.2.0
     revision     0
 
     set major    8
+    
+    checksums    rmd160  0bf3977fec6ad8a12fbdb5b1f0b52453d2fe19d7 \
+                 sha256  a1f524788354cfd2434566f0de972372f4a7743919bae49a9d508f2080385e7b \
+                 size    330118707
 }
 
 subport openjdk8-openj9 {
@@ -23,6 +31,10 @@ subport openjdk8-openj9 {
     set build    01
     set major    8
     set openj9_version 0.21.0
+    
+    checksums    rmd160  060f6aa970f9343ee1f303f62a719e5166f0ac40 \
+                 sha256  963683189fe2ab6d35f00d6ad9562fc7e9790e7e82fe3d1b01e6c80bde910c63 \
+                 size    114361837
 }
 
 subport openjdk8-openj9-large-heap {
@@ -32,6 +44,10 @@ subport openjdk8-openj9-large-heap {
     set build    01
     set major    8
     set openj9_version 0.21.0
+    
+    checksums    rmd160  b869a0877dcb5f294d211a3809eaacda1fbd5213 \
+                 sha256  2b804a0ac732df6076965b76ac32064ba5eeba205f06d2b4bdefc4356b15069d \
+                 size    113721837
 }
 
 subport openjdk10 {
@@ -40,6 +56,10 @@ subport openjdk10 {
     
     set build    13
     set major    10
+    
+    checksums    rmd160  d29498411adc487bf8191adbc4276c72602022cf \
+                 sha256  77ea7675ee29b85aa7df138014790f91047bfdafbc997cb41a1030a0417356d7 \
+                 size    200916897
 }
 
 subport openjdk11 {
@@ -48,6 +68,10 @@ subport openjdk11 {
 
     set build    10
     set major    11
+    
+    checksums    rmd160  678de7cdaaf6fd8f66bae841fcc0a91977562198 \
+                 sha256  4a8dadd58cdc32c7e59978971d56aec610be7ee0ddf0dc1d137bb8b78456499f \
+                 size    185054456
 }
 
 subport openjdk11-graalvm {
@@ -55,6 +79,10 @@ subport openjdk11-graalvm {
     revision     0
 
     set major    11
+    
+    checksums    rmd160  829239c28ecee8be0b8206645d597819684b895b \
+                 sha256  e9df2caace6f90fcfbc623c184ef1bbb053de20eb4cf5b002d708c609340ba7a \
+                 size    422700256
 }
 
 subport openjdk11-openj9 {
@@ -64,6 +92,10 @@ subport openjdk11-openj9 {
     set build    10
     set major    11
     set openj9_version 0.21.0
+    
+    checksums    rmd160  a21fefdde2a624285e10650188198b447cc59506 \
+                 sha256  71df9865d068a2dd1a963636b7e30f4e9188bac73b3935822b76b354f9e30216 \
+                 size    195447520
 }
 
 subport openjdk11-openj9-large-heap {
@@ -73,6 +105,10 @@ subport openjdk11-openj9-large-heap {
     set build    10
     set major    11
     set openj9_version 0.21.0
+    
+    checksums    rmd160  db07b68e990116eae21fcef91c7c1be1b78aa90a \
+                 sha256  c698263cc776f6179a81576a6aefb07fc724c4447cffa40a9055b010aed4231f \
+                 size    194670767
 }
 
 subport openjdk12 {
@@ -81,6 +117,10 @@ subport openjdk12 {
 
     set build    10
     set major    12
+    
+    checksums    rmd160  298235796f231dcd79baa1eccce40b4eb4aba456 \
+                 sha256  9919eee037554d40c7d2f219bbd654f2bf119e16a2f4d284d8dedaf525ee59e6 \
+                 size    198392994
 }
 
 subport openjdk12-openj9 {
@@ -90,6 +130,10 @@ subport openjdk12-openj9 {
     set build    10
     set major    12
     set openj9_version 0.15.1
+    
+    checksums    rmd160  eb8b931dc23ff3adb998e9c880e027e03b11e7cf \
+                 sha256  20d19ec20f65335edbf4db3861421be393d48720d5a389cd76e1c81a8aff8fee \
+                 size    197951754
 }
 
 subport openjdk12-openj9-large-heap {
@@ -99,6 +143,10 @@ subport openjdk12-openj9-large-heap {
     set build    10
     set major    12
     set openj9_version 0.15.1
+    
+    checksums    rmd160  01c7e4723cbee7e8a34e605a369a3986ace9d07a \
+                 sha256  d7c4c75f04f75767e26ffa0083c8a365ec95e8f5ccddcc0005dbd538954064b4 \
+                 size    197960269
 }
 
 subport openjdk13 {
@@ -107,6 +155,10 @@ subport openjdk13 {
 
     set build    8
     set major    13
+    
+    checksums    rmd160  0de593a1b3df57a6a91d9ab3e3d0ee7475bc1e0d \
+                 sha256  0ddb24efdf5aab541898d19b7667b149a1a64a8bd039b708fc58ee0284fa7e07 \
+                 size    198206427
 }
 
 subport openjdk13-openj9 {
@@ -116,6 +168,10 @@ subport openjdk13-openj9 {
     set build    8
     set major    13
     set openj9_version 0.18.0
+    
+    checksums    rmd160  193fc075719f33545f7f9deafebd783b5d7e8df1 \
+                 sha256  dd8d92eec98a3455ec5cd065a0a6672cc1aef280c6a68c507c372ccc1d98fbaa \
+                 size    201152468
 }
 
 subport openjdk13-openj9-large-heap {
@@ -125,6 +181,10 @@ subport openjdk13-openj9-large-heap {
     set build    8
     set major    13
     set openj9_version 0.18.0
+    
+    checksums    rmd160  7e71c9b1bd5aa8365af66803e3b5292b391e710b \
+                 sha256  a9b7cf11ec9c5df29a09336c91dd7e3232f6fae423e10eec60836330efc2c8cc \
+                 size    201151793
 }
 
 subport openjdk14 {
@@ -133,6 +193,10 @@ subport openjdk14 {
 
     set build    12
     set major    14
+    
+    checksums    rmd160  2b6beb756626e8ab72eb85d25701be522e5beb3f \
+                 sha256  09b7e6ab5d5eb4b73813f4caa793a0b616d33794a17988fa6a6b7c972e8f3dd3 \
+                 size    195705010
 }
 
 subport openjdk14-openj9 {
@@ -142,6 +206,10 @@ subport openjdk14-openj9 {
     set build    12
     set major    14
     set openj9_version 0.21.0
+    
+    checksums    rmd160  0ea69114a43e0c4e3e4cb80abf7bcd9bf86c05ca \
+                 sha256  95e6abcc12dde676ccd5ba65ab86f06ddaa22749dde00e31f4c6d3ea95277359 \
+                 size    200090793
 }
 
 subport openjdk14-openj9-large-heap {
@@ -151,6 +219,10 @@ subport openjdk14-openj9-large-heap {
     set build    12
     set major    14
     set openj9_version 0.21.0
+    
+    checksums    rmd160  f77124d360ab493a5f69b3b58e5dd9e8d77c718a \
+                 sha256  178270b6cc2213bad148c32e3bced0fb18aafee1f83be735d729e0261b4958da \
+                 size    200881593
 }
 
 subport openjdk15 {
@@ -159,6 +231,36 @@ subport openjdk15 {
 
     set build    36
     set major    15
+    
+    checksums    rmd160  86184738b178fc57f8fdd79f2e43e502e1bd1ee2 \
+                 sha256  bd1fc774232e2dfee93056a01f5765bd92ffb19d68dd548c233a82bb5c162be4 \
+                 size    195853361
+}
+
+subport openjdk15-openj9 {
+    version      15
+    revision     0
+
+    set build    36
+    set major    15
+    set openj9_version 0.22.0
+    
+    checksums    rmd160  ad9af8552346a43a615d5ed9afa835173740f62a \
+                 sha256  d861a0fc91019a0821f83ef8afa5d86443697bfeff76652950fa264d68a3299d \
+                 size    195023238
+}
+
+subport openjdk15-openj9-large-heap {
+    version      15
+    revision     0
+
+    set build    36
+    set major    15
+    set openj9_version 0.22.0
+    
+    checksums    rmd160  cecfaa2c933286b23d88d56b399c20f799d32dde \
+                 sha256  461d81284f041ad892f94fb4c33f67003284eaed5dce2ce03ad8dd577823954f \
+                 size    195766581
 }
 
 categories       java devel
@@ -166,16 +268,6 @@ maintainers      {breun.nl:nils @breun} openmaintainer
 platforms        darwin
 license          GPL-2
 supported_archs  x86_64
-
-description      Open Java Development Kit ${major} (AdoptOpenJDK) with HotSpot VM
-
-long_description OpenJDK build provided by AdoptOpenJDK, built from a fully \
-                 open-source set of build scripts and infrastructure. \
-                 \
-                 HotSpot is the VM from the OpenJDK community and  the most widely used VM. \
-                 It is suitable for all workloads.
-
-homepage         https://adoptopenjdk.net/
 
 if {${subport} eq "openjdk8"} {
     livecheck.url    https://api.adoptopenjdk.net/v2/info/releases/${subport}?release=latest&openjdk_impl=hotspot
@@ -194,41 +286,18 @@ if {${os.platform} eq "darwin" && ${os.major} < 14} {
 }
 
 if {${subport} eq "openjdk8"} {
+    description  Open Java Development Kit ${major} (AdoptOpenJDK) with HotSpot VM
+    long_description OpenJDK build provided by AdoptOpenJDK, built from a fully \
+                 open-source set of build scripts and infrastructure. \
+                 \
+                 HotSpot is the VM from the OpenJDK community and  the most widely used VM. \
+                 It is suitable for all workloads.
+
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}/
-
-    checksums    rmd160  c663ab3056c3731c1e780bd3e37fe59321576330 \
-                 sha256  f316b154e8c4a99b95bc3d07add3c9b19609c541a2f297112f274c1abce1efb4 \
-                 size    101998442
-
     distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}b${build}
     worksrcdir   jdk${version}-b${build}
-
     configure.cxx_stdlib libstdc++
-} elseif {${subport} eq "openjdk8-graalvm"} {
-    master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/
-    distname     graalvm-ce-java${major}-darwin-amd64-${version}
-    worksrcdir   graalvm-ce-java${major}-${version}
-
-    checksums    rmd160  0bf3977fec6ad8a12fbdb5b1f0b52453d2fe19d7 \
-                 sha256  a1f524788354cfd2434566f0de972372f4a7743919bae49a9d508f2080385e7b \
-                 size    330118707
-
-    description  GraalVM Community Edition based on OpenJDK ${major}
-    long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, \
-                 Ruby, R, JVM-based languages like Java, Scala, Groovy, Kotlin, Clojure, and LLVM-based languages \
-                 such as C and C++.
-
-    homepage     https://www.graalvm.org
 } elseif {${subport} eq "openjdk8-openj9"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
-
-    checksums    rmd160  060f6aa970f9343ee1f303f62a719e5166f0ac40 \
-                 sha256  963683189fe2ab6d35f00d6ad9562fc7e9790e7e82fe3d1b01e6c80bde910c63 \
-                 size    114361837
-
-    distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}b${build}_openj9-${openj9_version}
-    worksrcdir   jdk${version}-b${build}
-
     description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM
     long_description AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully \
                  open-source set of build scripts and infrastructure. \
@@ -236,16 +305,11 @@ if {${subport} eq "openjdk8"} {
                  OpenJ9 is the virtual machine from the Eclipse community. It is an enterprise-grade \
                  VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
                  suitable for running all workloads.
-} elseif {${subport} eq "openjdk8-openj9-large-heap"} {
+
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
-
-    checksums    rmd160  b869a0877dcb5f294d211a3809eaacda1fbd5213 \
-                 sha256  2b804a0ac732df6076965b76ac32064ba5eeba205f06d2b4bdefc4356b15069d \
-                 size    113721837
-
-    distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}b${build}_openj9-${openj9_version}
+    distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}b${build}_openj9-${openj9_version}
     worksrcdir   jdk${version}-b${build}
-
+} elseif {${subport} eq "openjdk8-openj9-large-heap"} {
     description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM for large heap sizes
     long_description AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully \
                  open-source set of build scripts and infrastructure. \
@@ -255,16 +319,11 @@ if {${subport} eq "openjdk8"} {
                  suitable for running all workloads. \
                  \
                  This version uses non-compressed references and should be used for applications which require heaps that are over ~57 GB.
+
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
+    distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}b${build}_openj9-${openj9_version}
+    worksrcdir   jdk${version}-b${build}
 } elseif {${subport} eq "openjdk10"} {
-    master_sites https://download.java.net/java/GA/jdk${major}/${version}/19aef61b38124481863b1413dce1855f/${build}/
-
-    checksums    rmd160  d29498411adc487bf8191adbc4276c72602022cf \
-                 sha256  77ea7675ee29b85aa7df138014790f91047bfdafbc997cb41a1030a0417356d7 \
-                 size    200916897
-
-    distname     openjdk-${version}_osx-x64_bin
-    worksrcdir   jdk-${version}.jdk
-
     description  Oracle OpenJDK ${major} with HotSpot VM
     long_description Production-ready, free and open-source build of the Java \
                  Development Kit, an implementation of the Java Standard \
@@ -273,211 +332,63 @@ if {${subport} eq "openjdk8"} {
                  HotSpot virtual machine, the Java class library and the Java \
                  compiler.
 
-    homepage     https://jdk.java.net/${major}/
-} elseif {${subport} eq "openjdk11"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}/
-
-    checksums    rmd160  678de7cdaaf6fd8f66bae841fcc0a91977562198 \
-                 sha256  4a8dadd58cdc32c7e59978971d56aec610be7ee0ddf0dc1d137bb8b78456499f \
-                 size    185054456
-
-    distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}_${build}
-    worksrcdir   jdk-${version}+${build}
-} elseif {${subport} eq "openjdk11-graalvm"} {
-    master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/
-    distname     graalvm-ce-java${major}-darwin-amd64-${version}
-    worksrcdir   graalvm-ce-java${major}-${version}
-
-    checksums    rmd160  829239c28ecee8be0b8206645d597819684b895b \
-                 sha256  e9df2caace6f90fcfbc623c184ef1bbb053de20eb4cf5b002d708c609340ba7a \
-                 size    422700256
-
+    master_sites https://download.java.net/java/GA/jdk${major}/${version}/19aef61b38124481863b1413dce1855f/${build}/
+    distname     openjdk-${version}_osx-x64_bin
+    worksrcdir   jdk-${version}.jdk
+} elseif [string match *-graalvm ${subport}] {
     description  GraalVM Community Edition based on OpenJDK ${major}
     long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, \
                  Ruby, R, JVM-based languages like Java, Scala, Groovy, Kotlin, Clojure, and LLVM-based languages \
                  such as C and C++.
 
+    master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/
+    distname     graalvm-ce-java${major}-darwin-amd64-${version}
+    worksrcdir   graalvm-ce-java${major}-${version}
+} elseif [string match *-openj9-large-heap ${subport}] {
+    description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM for large heap sizes
+    long_description AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully \
+                 open-source set of build scripts and infrastructure. \
+                 \
+                 OpenJ9 is the virtual machine from the Eclipse community. It is an enterprise-grade \
+                 VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
+                 suitable for running all workloads. \
+                 \
+                 This version uses non-compressed references and should be used for applications which require heaps that are over ~57 GB.
+
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
+    distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
+    worksrcdir   jdk-${version}+${build}
+} elseif [string match *-openj9 ${subport}] {
+    description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM
+    long_description AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully \
+                 open-source set of build scripts and infrastructure. \
+                 \
+                 OpenJ9 is the virtual machine from the Eclipse community. It is an enterprise-grade \
+                 VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
+                 suitable for running all workloads.
+
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
+    distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
+    worksrcdir   jdk-${version}+${build}
+} else {
+    description  Open Java Development Kit ${major} (AdoptOpenJDK) with HotSpot VM
+    long_description OpenJDK build provided by AdoptOpenJDK, built from a fully \
+                 open-source set of build scripts and infrastructure. \
+                 \
+                 HotSpot is the VM from the OpenJDK community and  the most widely used VM. \
+                 It is suitable for all workloads.
+
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}/
+    distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}_${build}
+    worksrcdir   jdk-${version}+${build}
+}
+
+if [string match *-graalvm ${subport}] {
     homepage     https://www.graalvm.org
-} elseif {${subport} eq "openjdk11-openj9"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
-
-    checksums    rmd160  a21fefdde2a624285e10650188198b447cc59506 \
-                 sha256  71df9865d068a2dd1a963636b7e30f4e9188bac73b3935822b76b354f9e30216 \
-                 size    195447520
-
-    distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
-    worksrcdir   jdk-${version}+${build}
-
-    description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM
-    long_description AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully \
-                 open-source set of build scripts and infrastructure. \
-                 \
-                 OpenJ9 is the virtual machine from the Eclipse community. It is an enterprise-grade \
-                 VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
-                 suitable for running all workloads.
-} elseif {${subport} eq "openjdk11-openj9-large-heap"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
-
-    checksums    rmd160  db07b68e990116eae21fcef91c7c1be1b78aa90a \
-                 sha256  c698263cc776f6179a81576a6aefb07fc724c4447cffa40a9055b010aed4231f \
-                 size    194670767
-
-    distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
-    worksrcdir   jdk-${version}+${build}
-
-    description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM for large heap sizes
-    long_description AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully \
-                 open-source set of build scripts and infrastructure. \
-                 \
-                 OpenJ9 is the virtual machine from the Eclipse community. It is an enterprise-grade \
-                 VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
-                 suitable for running all workloads. \
-                 \
-                 This version uses non-compressed references and should be used for applications which require heaps that are over ~57 GB.
-} elseif {${subport} eq "openjdk12"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}/
-    distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}_${build}
-
-    checksums    rmd160  298235796f231dcd79baa1eccce40b4eb4aba456 \
-                 sha256  9919eee037554d40c7d2f219bbd654f2bf119e16a2f4d284d8dedaf525ee59e6 \
-                 size    198392994
-
-    worksrcdir   jdk-${version}+${build}
-} elseif {${subport} eq "openjdk12-openj9"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
-    distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
-
-    checksums    rmd160  eb8b931dc23ff3adb998e9c880e027e03b11e7cf \
-                 sha256  20d19ec20f65335edbf4db3861421be393d48720d5a389cd76e1c81a8aff8fee \
-                 size    197951754
-
-    worksrcdir   jdk-${version}+${build}
-
-    description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM
-    long_description AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully \
-                 open-source set of build scripts and infrastructure. \
-                 \
-                 OpenJ9 is the virtual machine from the Eclipse community. It is an enterprise-grade \
-                 VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
-                 suitable for running all workloads.
-} elseif {${subport} eq "openjdk12-openj9-large-heap"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
-    distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
-
-    checksums    rmd160  01c7e4723cbee7e8a34e605a369a3986ace9d07a \
-                 sha256  d7c4c75f04f75767e26ffa0083c8a365ec95e8f5ccddcc0005dbd538954064b4 \
-                 size    197960269
-
-    worksrcdir   jdk-${version}+${build}
-
-    description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM for large heap sizes
-    long_description AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully \
-                 open-source set of build scripts and infrastructure. \
-                 \
-                 OpenJ9 is the virtual machine from the Eclipse community. It is an enterprise-grade \
-                 VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
-                 suitable for running all workloads. \
-                 \
-                 This version uses non-compressed references and should be used for applications which require heaps that are over ~57 GB.
-} elseif {${subport} eq "openjdk13"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}/
-    distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}_${build}
-
-    checksums    rmd160  0de593a1b3df57a6a91d9ab3e3d0ee7475bc1e0d \
-                 sha256  0ddb24efdf5aab541898d19b7667b149a1a64a8bd039b708fc58ee0284fa7e07 \
-                 size    198206427
-
-    worksrcdir   jdk-${version}+${build}
-} elseif {${subport} eq "openjdk13-openj9"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
-    distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
-
-    checksums    rmd160  193fc075719f33545f7f9deafebd783b5d7e8df1 \
-                 sha256  dd8d92eec98a3455ec5cd065a0a6672cc1aef280c6a68c507c372ccc1d98fbaa \
-                 size    201152468
-
-    worksrcdir   jdk-${version}+${build}
-
-    description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM
-    long_description AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully \
-                 open-source set of build scripts and infrastructure. \
-                 \
-                 OpenJ9 is the virtual machine from the Eclipse community. It is an enterprise-grade \
-                 VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
-                 suitable for running all workloads.
-} elseif {${subport} eq "openjdk13-openj9-large-heap"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
-    distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
-
-    checksums    rmd160  7e71c9b1bd5aa8365af66803e3b5292b391e710b \
-                 sha256  a9b7cf11ec9c5df29a09336c91dd7e3232f6fae423e10eec60836330efc2c8cc \
-                 size    201151793
-
-    worksrcdir   jdk-${version}+${build}
-
-    description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM for large heap sizes
-    long_description AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully \
-                 open-source set of build scripts and infrastructure. \
-                 \
-                 OpenJ9 is the virtual machine from the Eclipse community. It is an enterprise-grade \
-                 VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
-                 suitable for running all workloads. \
-                 \
-                 This version uses non-compressed references and should be used for applications which require heaps that are over ~57 GB.
-} elseif {${subport} eq "openjdk14"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}/
-    distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}_${build}
-
-    checksums    rmd160  2b6beb756626e8ab72eb85d25701be522e5beb3f \
-                 sha256  09b7e6ab5d5eb4b73813f4caa793a0b616d33794a17988fa6a6b7c972e8f3dd3 \
-                 size    195705010
-
-    worksrcdir   jdk-${version}+${build}
-} elseif {${subport} eq "openjdk14-openj9"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
-    distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
-
-    checksums    rmd160  0ea69114a43e0c4e3e4cb80abf7bcd9bf86c05ca \
-                 sha256  95e6abcc12dde676ccd5ba65ab86f06ddaa22749dde00e31f4c6d3ea95277359 \
-                 size    200090793
-
-    worksrcdir   jdk-${version}+${build}
-
-    description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM
-    long_description AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully \
-                 open-source set of build scripts and infrastructure. \
-                 \
-                 OpenJ9 is the virtual machine from the Eclipse community. It is an enterprise-grade \
-                 VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
-                 suitable for running all workloads.
-} elseif {${subport} eq "openjdk14-openj9-large-heap"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
-    distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
-
-    checksums    rmd160  f77124d360ab493a5f69b3b58e5dd9e8d77c718a \
-                 sha256  178270b6cc2213bad148c32e3bced0fb18aafee1f83be735d729e0261b4958da \
-                 size    200881593
-
-    worksrcdir   jdk-${version}+${build}
-
-    description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM for large heap sizes
-    long_description AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully \
-                 open-source set of build scripts and infrastructure. \
-                 \
-                 OpenJ9 is the virtual machine from the Eclipse community. It is an enterprise-grade \
-                 VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
-                 suitable for running all workloads. \
-                 \
-                 This version uses non-compressed references and should be used for applications which require heaps that are over ~57 GB.
-} elseif {${subport} eq "openjdk15"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}/
-    distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}_${build}
-
-    checksums    rmd160  86184738b178fc57f8fdd79f2e43e502e1bd1ee2 \
-                 sha256  bd1fc774232e2dfee93056a01f5765bd92ffb19d68dd548c233a82bb5c162be4 \
-                 size    195853361
-
-    worksrcdir   jdk-${version}+${build}
+} elseif {${subport} eq "openjdk10"} {
+    homepage     https://jdk.java.net/archive/
+} else {
+    homepage     https://adoptopenjdk.net
 }
 
 variant Applets \
@@ -516,7 +427,7 @@ destroot {
 }
 
 notes "
-If you have more than one JDK installed you can make JDK ${major} the default
+If you have more than one JDK installed you can make ${subport} the default
 by adding the following line to your shell profile:
 
     export JAVA_HOME=${target}/Contents/Home


### PR DESCRIPTION
#### Description

Adding subports for AdoptOpenJDK 15 with OpenJ9 VM.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.7 19H2
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?