### PR TITLE
Fix building MacVim with Xcode12

### DIFF
--- a/editors/MacVim/Portfile
+++ b/editors/MacVim/Portfile
@@ -76,9 +76,10 @@ configure.args      --enable-gui=macvim \
 # Old pre-compiled headers could influence build, #26723
 build.args          XCODEFLAGS="CACHE_ROOT=${workpath}/caches"
 
-# this port does not build with the new xcode build system at present
-if {[vercmp ${xcodeversion} 10.0] >= 0} {
-    build.args    XCODEFLAGS="CACHE_ROOT=${workpath}/caches -UseNewBuildSystem=NO MACOSX_DEPLOYMENT_TARGET=${macosx_deployment_target} ARCHS=${supported_archs}"
+if {[vercmp ${xcodeversion} 12.0] >= 0} {
+    build.args    XCODEFLAGS="CACHE_ROOT=${workpath}/caches -UseNewBuildSystem=NO MACOSX_DEPLOYMENT_TARGET=${macosx_deployment_target} ARCHS=${configure.build_arch}"
+} elseif {[vercmp ${xcodeversion} 10.0] >= 0} {
+    build.args    XCODEFLAGS="CACHE_ROOT=${workpath}/caches -UseNewBuildSystem=NO MACOSX_DEPLOYMENT_TARGET=${macosx_deployment_target}"
 }
 
 destroot {

--- a/editors/MacVim/Portfile
+++ b/editors/MacVim/Portfile
@@ -78,7 +78,7 @@ build.args          XCODEFLAGS="CACHE_ROOT=${workpath}/caches"
 
 # this port does not build with the new xcode build system at present
 if {[vercmp ${xcodeversion} 10.0] >= 0} {
-    build.args    XCODEFLAGS="CACHE_ROOT=${workpath}/caches -UseNewBuildSystem=NO MACOSX_DEPLOYMENT_TARGET=${macosx_deployment_target}"
+    build.args    XCODEFLAGS="CACHE_ROOT=${workpath}/caches -UseNewBuildSystem=NO MACOSX_DEPLOYMENT_TARGET=${macosx_deployment_target} ARCHS=${supported_archs}"
 }
 
 destroot {


### PR DESCRIPTION
#### Description

Fixes build with Xcode 12.0.1 (12A7300) on macOS 10.15.6 (19G2021), which has arm64 architecture enabled by default.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.6 19G2021
Xcode 12.0.1 12A7300 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
