### PR TITLE
H3D ports: h3dutil and h3dapi need std=gnu++11 to build

### DIFF
--- a/graphics/h3dapi/Portfile
+++ b/graphics/h3dapi/Portfile
@@ -65,6 +65,9 @@ if {${subport} eq ${name}} {
     configure.post_args \
                     ${worksrcpath}/build
 
+    compiler.cxx_standard  2011
+    configure.cxxflags-append -std=gnu++11
+
     configure.args  -DGENERATE_H3DAPI_loader_PROJECTS:BOOL=OFF \
                     -DGENERATE_H3DLoad_PROJECTS:BOOL=OFF \
                     -DGENERATE_H3DViewer_PROJECTS:BOOL=OFF

--- a/graphics/h3dutil/Portfile
+++ b/graphics/h3dutil/Portfile
@@ -29,6 +29,9 @@ depends_lib         port:dcmtk \
 
 configure.post_args ${worksrcpath}/build
 
+compiler.cxx_standard  2011
+configure.cxxflags-append -std=gnu++11
+
 livecheck.type      regex
 livecheck.url       [lindex ${master_sites} 0]
 livecheck.regex     ${name}-(\[0-9.\]+)${extract.suffix}


### PR DESCRIPTION
#### Description

Currently, h3dutil and h3dapi fail building. Adding the requirement that they need C++11, and more specifically std=gnu++11, enable them to build (and to upgrade their dependencies like h3dload, h3dviewer).


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.13.6 17G14019
Xcode 9.1 9B55
 and
macOS 10.15.6 19G2021
Xcode 12.0.1 12A7300

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
