### PR TITLE
ruby23-25: Fix build on 10.4, 10.5

### DIFF
--- a/lang/ruby23/Portfile
+++ b/lang/ruby23/Portfile
@@ -20,7 +20,7 @@ long_description    Ruby is the interpreted scripting language for quick \
                     and easy object-oriented programming. It has many \
                     features to process text files and to do system \
                     management tasks (as in Perl). It is simple, \
-                    straight-forward, extensible, and portable.
+                    straightforward, extensible, and portable.
 
 homepage            http://www.ruby-lang.org/
 license             {Ruby BSD}
@@ -51,6 +51,8 @@ select.file         ${filespath}/ruby23
 
 # ext/openssl/ossl.h: <openssl/asn1_mac.h> was deprecated (#58123)
 patchfiles          patch-ext_openssl_ossl.h.diff
+# Fix build on 10.4 i386
+patchfiles-append   patch-tiger.diff
 
 configure.args      --enable-shared \
                     --disable-install-doc \

--- a/lang/ruby23/files/patch-tiger.diff
+++ b/lang/ruby23/files/patch-tiger.diff
@@ -1,0 +1,22 @@
+--- ./signal.c.orig	2015-11-23 16:17:11.000000000 -0800
++++ ./signal.c	2020-08-27 15:24:31.000000000 -0700
+@@ -760,7 +760,7 @@ NORETURN(void ruby_thread_stack_overflow
+ # elif !(defined(HAVE_UCONTEXT_H) && (defined __i386__ || defined __x86_64__ || defined __amd64__))
+ # elif defined __linux__
+ #   define USE_UCONTEXT_REG 1
+-# elif defined __APPLE__
++# elif defined(__APPLE__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1050
+ #   define USE_UCONTEXT_REG 1
+ # elif defined __FreeBSD__
+ #   define USE_UCONTEXT_REG 1
+--- ./vm_dump.c.orig	2018-03-18 07:27:12.000000000 -0700
++++ ./vm_dump.c	2020-08-27 15:24:31.000000000 -0700
+@@ -919,7 +919,7 @@ rb_dump_machine_register(const ucontext_
+ 	dump_machine_register(SS);
+ #   endif
+     }
+-# elif defined __APPLE__
++# elif defined(__APPLE__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1050
+     {
+ 	const mcontext_t mctx = ctx->uc_mcontext;
+ #   if defined __x86_64__

--- a/lang/ruby24/Portfile
+++ b/lang/ruby24/Portfile
@@ -16,7 +16,7 @@ long_description    Ruby is the interpreted scripting language for quick \
                     and easy object-oriented programming. It has many \
                     features to process text files and to do system \
                     management tasks (as in Perl). It is simple, \
-                    straight-forward, extensible, and portable.
+                    straightforward, extensible, and portable.
 
 homepage            http://www.ruby-lang.org/
 license             {Ruby BSD}
@@ -32,6 +32,10 @@ dist_subdir         ruby24
 #     /opt/local/lib/libruby.2.4.3.dylib:
 #     /opt/local/lib/libruby.2.4.dylib
 patchfiles          patch-configure.diff
+# Fix build on 10.4 i386
+patchfiles-append   patch-tiger.diff
+# Fix build on < 10.6
+patchfiles-append   patch-osversions.diff
 
 checksums           md5 b10a7d2fcaf218c98edbaf57efc36e58 \
                     rmd160 0249650b9da5f11b52533827af5db809e1fa6277 \

--- a/lang/ruby24/files/patch-osversions.diff
+++ b/lang/ruby24/files/patch-osversions.diff
@@ -1,0 +1,32 @@
+--- ./dln.c.orig	2020-03-31 04:42:18.000000000 -0700
++++ ./dln.c	2020-08-29 16:46:40.000000000 -0700
+@@ -1334,8 +1334,7 @@ dln_load(const char *file)
+ 	    if (ex && ex != ruby_xmalloc) {
+ 
+ #   if defined __APPLE__ && \
+-    defined(MAC_OS_X_VERSION_MIN_REQUIRED) && \
+-    (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_11)
++    __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 101100
+ 		/* dlclose() segfaults */
+ 		rb_fatal("%s - %s", incompatible, file);
+ #   else
+--- ./error.c.orig	2020-03-31 04:42:18.000000000 -0700
++++ ./error.c	2020-08-29 16:48:42.000000000 -0700
+@@ -379,7 +379,7 @@ preface_dump(FILE *out)
+ 	"-- Crash Report log information "
+ 	"--------------------------------------------\n"
+ 	"   See Crash Report log file under the one of following:\n"
+-# if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_6
++# if MAC_OS_X_VERSION_MIN_REQUIRED < 1060
+ 	"     * ~/Library/Logs/CrashReporter\n"
+ 	"     * /Library/Logs/CrashReporter\n"
+ # endif
+@@ -404,7 +404,7 @@ postscript_dump(FILE *out)
+ 	"[IMPORTANT]"
+ 	/*" ------------------------------------------------"*/
+ 	"\n""Don't forget to include the Crash Report log file under\n"
+-# if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_6
++# if MAC_OS_X_VERSION_MIN_REQUIRED < 1060
+ 	"CrashReporter or "
+ # endif
+ 	"DiagnosticReports directory in bug reports.\n"

--- a/lang/ruby24/files/patch-tiger.diff
+++ b/lang/ruby24/files/patch-tiger.diff
@@ -1,0 +1,22 @@
+--- signal.c.orig	2020-03-31 04:42:18.000000000 -0700
++++ signal.c	2020-08-26 19:07:37.000000000 -0700
+@@ -767,7 +767,7 @@ NORETURN(void ruby_thread_stack_overflow
+ # elif !(defined(HAVE_UCONTEXT_H) && (defined __i386__ || defined __x86_64__ || defined __amd64__))
+ # elif defined __linux__
+ #   define USE_UCONTEXT_REG 1
+-# elif defined __APPLE__
++# elif defined(__APPLE__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1050
+ #   define USE_UCONTEXT_REG 1
+ # elif defined __FreeBSD__
+ #   define USE_UCONTEXT_REG 1
+--- vm_dump.c.orig	2020-03-31 04:42:18.000000000 -0700
++++ vm_dump.c	2020-08-27 14:31:29.000000000 -0700
+@@ -911,7 +911,7 @@ rb_dump_machine_register(const ucontext_
+ 	dump_machine_register(SS);
+ #   endif
+     }
+-# elif defined __APPLE__
++# elif defined(__APPLE__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1050
+     {
+ 	const mcontext_t mctx = ctx->uc_mcontext;
+ #   if defined __x86_64__

--- a/lang/ruby25/Portfile
+++ b/lang/ruby25/Portfile
@@ -16,7 +16,7 @@ long_description    Ruby is the interpreted scripting language for quick \
                     and easy object-oriented programming. It has many \
                     features to process text files and to do system \
                     management tasks (as in Perl). It is simple, \
-                    straight-forward, extensible, and portable.
+                    straightforward, extensible, and portable.
 
 homepage            http://www.ruby-lang.org/
 license             {Ruby BSD}
@@ -51,6 +51,11 @@ if {${os.major} < 10} {
 
 select.group        ruby
 select.file         ${filespath}/ruby25
+
+# Fix build on 10.4 i386
+patchfiles          patch-tiger.diff
+# Fix build on < 10.6
+patchfiles-append   patch-osversions.diff
 
 configure.args      --enable-shared \
                     --enable-install-static-library \

--- a/lang/ruby25/files/patch-osversions.diff
+++ b/lang/ruby25/files/patch-osversions.diff
@@ -1,0 +1,32 @@
+--- ./dln.c.orig	2020-03-31 05:15:56.000000000 -0700
++++ ./dln.c	2020-08-29 18:03:26.000000000 -0700
+@@ -1333,8 +1333,7 @@ dln_load(const char *file)
+ 	    if (ex && ex != ruby_xmalloc) {
+ 
+ #   if defined __APPLE__ && \
+-    defined(MAC_OS_X_VERSION_MIN_REQUIRED) && \
+-    (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_11)
++    __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 101100
+ 		/* dlclose() segfaults */
+ 		rb_fatal("%s - %s", incompatible, file);
+ #   else
+--- ./error.c.orig	2020-03-31 05:15:56.000000000 -0700
++++ ./error.c	2020-08-29 18:03:26.000000000 -0700
+@@ -458,7 +458,7 @@ preface_dump(FILE *out)
+ 	"-- Crash Report log information "
+ 	"--------------------------------------------\n"
+ 	"   See Crash Report log file under the one of following:\n"
+-# if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_6
++# if MAC_OS_X_VERSION_MIN_REQUIRED < 1060
+ 	"     * ~/Library/Logs/CrashReporter\n"
+ 	"     * /Library/Logs/CrashReporter\n"
+ # endif
+@@ -483,7 +483,7 @@ postscript_dump(FILE *out)
+ 	"[IMPORTANT]"
+ 	/*" ------------------------------------------------"*/
+ 	"\n""Don't forget to include the Crash Report log file under\n"
+-# if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_6
++# if MAC_OS_X_VERSION_MIN_REQUIRED < 1060
+ 	"CrashReporter or "
+ # endif
+ 	"DiagnosticReports directory in bug reports.\n"

--- a/lang/ruby25/files/patch-tiger.diff
+++ b/lang/ruby25/files/patch-tiger.diff
@@ -1,0 +1,22 @@
+--- ./signal.c.orig	2020-03-31 05:15:56.000000000 -0700
++++ ./signal.c	2020-08-27 15:31:23.000000000 -0700
+@@ -765,7 +765,7 @@ NORETURN(void rb_ec_stack_overflow(rb_ex
+ # elif !(defined(HAVE_UCONTEXT_H) && (defined __i386__ || defined __x86_64__ || defined __amd64__))
+ # elif defined __linux__
+ #   define USE_UCONTEXT_REG 1
+-# elif defined __APPLE__
++# elif defined(__APPLE__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1050
+ #   define USE_UCONTEXT_REG 1
+ # elif defined __FreeBSD__
+ #   define USE_UCONTEXT_REG 1
+--- ./vm_dump.c.orig	2020-03-31 05:15:56.000000000 -0700
++++ ./vm_dump.c	2020-08-27 15:31:23.000000000 -0700
+@@ -898,7 +898,7 @@ rb_dump_machine_register(const ucontext_
+ 	dump_machine_register(SS);
+ #   endif
+     }
+-# elif defined __APPLE__
++# elif defined(__APPLE__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1050
+     {
+ 	const mcontext_t mctx = ctx->uc_mcontext;
+ #   if defined __x86_64__


### PR DESCRIPTION
#### Description
See the individual commit messages for more details.

The changes here also apply to ruby22, ruby26, and ruby27, but ruby26 and ruby27 have additional unresolved issues, and ruby22 has a late-breaking issue with Xcode 12.

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14033, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G6032, x86_64, Xcode 11.3.1 11C505
macOS 10.15.6 19G2021, x86_64, Xcode 12.0.1 12A7300

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [N/A] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
