### PR TITLE
qrcp: Update to 0.6.4

### DIFF
--- a/sysutils/qrcp/Portfile
+++ b/sysutils/qrcp/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/claudiodangelis/qrcp 0.6.2
+go.setup            github.com/claudiodangelis/qrcp 0.6.4
 categories          sysutils net
 maintainers         {cal @neverpanic} openmaintainer
 
@@ -13,20 +13,15 @@ description         Transfer files over wifi from your computer to your mobile d
 long_description    ${description}
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  c937dea99555123c4650bf311284eb73b53f55f7 \
-                        sha256  1380c95daa967580e960383271b532492227e3fdaa63c15e167a7a6ef4e37661 \
-                        size    13363085
+                        rmd160  f0bf351af443f2a6669a018fd86afbf9bc2251fc \
+                        sha256  de7f88c3913a961384c7b0f6c25a71761214540e7bbcfd78630944fb2940cea9 \
+                        size    13288298
 
 go.vendors          github.com/asaskevich/govalidator \
                         lock    475eaeb16496 \
                         rmd160  c9563aa50a3bbf323b07a610062a8dd46dede1e2 \
                         sha256  b5b2683d6b0bb1e516dcba00393f10c198496309575d299a4a996a61207e839d \
                         size    57033 \
-                    github.com/chzyer/logex \
-                        lock    v1.1.10 \
-                        rmd160  105d839f798ba0c3e27b3db4e790d9d21a928029 \
-                        sha256  947e61095044d310b0ad92f10ac77c36eaa3c3e2e6181e87428ad10c20930ba3 \
-                        size    4351 \
                     github.com/chzyer/readline \
                         lock    2972be24d48e \
                         rmd160  933f32b684d0af4b8970d964d610918a9f181df6 \
@@ -37,36 +32,26 @@ go.vendors          github.com/asaskevich/govalidator \
                         rmd160  61f83d79b356cde63a27df0f2832ef92fcbc216d \
                         sha256  98d0c7d1dec438459e31886d65190bb45f70c4ed73e35f5ab2f3b8de582ea309 \
                         size    4007 \
+                    github.com/manifoldco/promptui \
+                        lock    v0.7.0 \
+                        rmd160  9dc391ee449f2d9c535ab79b19b2ae54c8340d23 \
+                        sha256  fed2ddd7c8e15bb66c2679dba0b948cda9e752a4aed5149fb1e65fa9c5331445 \
+                        size    26673 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.3 \
+                        rmd160  32abdd77a987af95ce5b647846bfdbb2d8db91a0 \
+                        sha256  046b6b81e3925ffe60e2213e9a239303ff98a51e76764590b807b591fedf2d1e \
+                        size    46029 \
+                    github.com/chzyer/logex \
+                        lock    v1.1.10 \
+                        rmd160  105d839f798ba0c3e27b3db4e790d9d21a928029 \
+                        sha256  947e61095044d310b0ad92f10ac77c36eaa3c3e2e6181e87428ad10c20930ba3 \
+                        size    4351 \
                     github.com/fatih/color \
                         lock    v1.9.0 \
                         rmd160  1d8418b4f1b3cb597f680b93aaa08afcc9651be4 \
                         sha256  577c8e778833fec90d76918f138cee9f7765435757b7c92a669e5b34933e0b4f \
                         size    1231337 \
-                    github.com/glendc/go-external-ip \
-                        lock    139229dcdddd \
-                        rmd160  c0f7a7447c6025c8d2f4c14d9092cd1a4bb155fe \
-                        sha256  9f0bf3945d0ff2e41278137ec7204f7b8a52c84d3eb876e12d4bd6f825cee724 \
-                        size    5659 \
-                    github.com/inconshreveable/mousetrap \
-                        lock    v1.0.0 \
-                        rmd160  5c617a09f1432fc543672a0e0c1e13d3752030c2 \
-                        sha256  0e6bae2849f13d12fe361ecac087728e4e97f3482f4cec44f6e7a2c53bb9cd0c \
-                        size    2291 \
-                    github.com/jhoonb/archivex \
-                        lock    0488e4ce1681 \
-                        rmd160  f3f52a7b98d1623eb37c90e9137e27c3c7c8c461 \
-                        sha256  cde011a4d4ff9312645893d8a0a49f3e0ff3fdea8a33fba6056afb3e23087a8d \
-                        size    5178 \
-                    github.com/juju/ansiterm \
-                        lock    720a0952cc2a \
-                        rmd160  c3c15da3b3d62f7caa467b66f45b251e2e868626 \
-                        sha256  a0efc9542e6fe50c97cdd999685ddda6069ab44754a6b3c87c6b18b21899e05b \
-                        size    15418 \
-                    github.com/kr/pretty \
-                        lock    v0.1.0 \
-                        rmd160  9aa7a5aad4c48840eecfd0f80186d1fb5ded0fd6 \
-                        sha256  f6c3f89667c63e5b7f1fc6ee2c06b6a6bfdce88f3a965ccd395b64c6f95c9a47 \
-                        size    8553 \
                     github.com/kr/text \
                         lock    v0.1.0 \
                         rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
@@ -77,11 +62,36 @@ go.vendors          github.com/asaskevich/govalidator \
                         rmd160  a378a8e18f9fc0f242d5d25bfe8f3a321f2cfd25 \
                         sha256  7dcc634f0e50b918bddfdd88f7cfa99e35e885c1e53cf61854e8f638a3a90727 \
                         size    4185 \
-                    github.com/manifoldco/promptui \
-                        lock    v0.7.0 \
-                        rmd160  9dc391ee449f2d9c535ab79b19b2ae54c8340d23 \
-                        sha256  fed2ddd7c8e15bb66c2679dba0b948cda9e752a4aed5149fb1e65fa9c5331445 \
-                        size    26673 \
+                    github.com/inconshreveable/mousetrap \
+                        lock    v1.0.0 \
+                        rmd160  5c617a09f1432fc543672a0e0c1e13d3752030c2 \
+                        sha256  0e6bae2849f13d12fe361ecac087728e4e97f3482f4cec44f6e7a2c53bb9cd0c \
+                        size    2291 \
+                    github.com/jhoonb/archivex \
+                        lock    0488e4ce1681 \
+                        rmd160  f3f52a7b98d1623eb37c90e9137e27c3c7c8c461 \
+                        sha256  cde011a4d4ff9312645893d8a0a49f3e0ff3fdea8a33fba6056afb3e23087a8d \
+                        size    5178 \
+                    github.com/spf13/cobra \
+                        lock    v1.0.0 \
+                        rmd160  73602c4d37ad508ba8b35812c793e1df3eda7bb9 \
+                        sha256  6cdf3f445559b8f41f5288366a4c26e8d1b1601dac6924af091a49f1f6b11396 \
+                        size    128931 \
+                    github.com/glendc/go-external-ip \
+                        lock    139229dcdddd \
+                        rmd160  c0f7a7447c6025c8d2f4c14d9092cd1a4bb155fe \
+                        sha256  9f0bf3945d0ff2e41278137ec7204f7b8a52c84d3eb876e12d4bd6f825cee724 \
+                        size    5659 \
+                    github.com/juju/ansiterm \
+                        lock    720a0952cc2a \
+                        rmd160  c3c15da3b3d62f7caa467b66f45b251e2e868626 \
+                        sha256  a0efc9542e6fe50c97cdd999685ddda6069ab44754a6b3c87c6b18b21899e05b \
+                        size    15418 \
+                    github.com/kr/pretty \
+                        lock    v0.1.0 \
+                        rmd160  9aa7a5aad4c48840eecfd0f80186d1fb5ded0fd6 \
+                        sha256  f6c3f89667c63e5b7f1fc6ee2c06b6a6bfdce88f3a965ccd395b64c6f95c9a47 \
+                        size    8553 \
                     github.com/mattn/go-colorable \
                         lock    v0.1.6 \
                         rmd160  3c6531ff68909aacc83a16f92149722803b465a7 \
@@ -102,16 +112,6 @@ go.vendors          github.com/asaskevich/govalidator \
                         rmd160  30a042f8d9e6d8a3d4f44bfb8107d53dd440a9be \
                         sha256  14df66c360abe69e729592ce94654a86492595adcfaf485f655aaa9ada90222d \
                         size    36086 \
-                    github.com/spf13/cobra \
-                        lock    v1.0.0 \
-                        rmd160  73602c4d37ad508ba8b35812c793e1df3eda7bb9 \
-                        sha256  6cdf3f445559b8f41f5288366a4c26e8d1b1601dac6924af091a49f1f6b11396 \
-                        size    128931 \
-                    github.com/spf13/pflag \
-                        lock    v1.0.3 \
-                        rmd160  32abdd77a987af95ce5b647846bfdbb2d8db91a0 \
-                        sha256  046b6b81e3925ffe60e2213e9a239303ff98a51e76764590b807b591fedf2d1e \
-                        size    46029 \
                     golang.org/x/sys \
                         lock    d5e6a3e2c0ae \
                         rmd160  013d8fa0f0a54aab5bcb8bc874d85f1566182189 \


### PR DESCRIPTION
#### Description

qrcp: Update to 0.6.4

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G6020
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
