### PR TITLE
micro: don't fetch dependencies in build phase

### DIFF
--- a/editors/micro/Portfile
+++ b/editors/micro/Portfile
@@ -26,12 +26,196 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 
 installs_libs       no
 
+checksums           ${distname}${extract.suffix} \
+                        rmd160  8a2ef228de688c9b30f4b161286c3b34b9883bc4 \
+                        sha256  ed21196c1dd642c8e5a15ac938035f1a1613bbdb757b2d7b2f61da497b630d1d \
+                        size    797930
+
+go.vendors          github.com/gdamore/encoding \
+                        lock    v1.0.0 \
+                        rmd160  3ed8916f763a5b51db1bcc8bd3ad06cf3d12ec07 \
+                        sha256  4f470c7308790bea8a526ea26cecbaa22345aad8dc566821cda6175b3d241ee1 \
+                        size    10900 \
+                    github.com/mitchellh/go-homedir \
+                        lock    v1.1.0 \
+                        rmd160  44b3985e40e5bbb22d11f8622c340f9ed727ea91 \
+                        sha256  024c8a57316c7fbc0eb23cdbfd57f72a74b51beb83d714034d67ee9aba48100c \
+                        size    3366 \
+                    github.com/yuin/gopher-lua \
+                        lock    ab39c6098bdb \
+                        rmd160  cb9f019eb9dcae8f8535eea12ddcce50c197758a \
+                        sha256  19afead308e71eef0d2aeb4fd31cdbb6bc19347692577eb5bdb0a4987280afe2 \
+                        size    161554 \
+                    github.com/zyedidia/glob \
+                        lock    dd4023a66dc3 \
+                        rmd160  914cbde5d529052339d07c3ea9bf5ea73ca5ea01 \
+                        sha256  b1786c50ca52b8bc8de12a9e9f41cd79ca30e89e18779e91f3d8bb90ee6ccf1e \
+                        size    2699 \
+                    github.com/zyedidia/json5 \
+                        lock    2da050b1a98d \
+                        rmd160  3441ecaa05d0682d93d0ea8af8c083ac6bf93221 \
+                        sha256  ae4d3e921554eaed2f0867e8e38299f634594bc86be6bc7e1c18f51529a84c81 \
+                        size    40006 \
+                    gopkg.in/sourcemap.v1 \
+                        lock    v1.0.5 \
+                        rmd160  76b8e83f152fd3165e3fe61af6236b304d013277 \
+                        sha256  c0812e6da42c36fdfe817782c9f62ced1f4735b5e514812032428bae617940cd \
+                        size    5366 \
+                    github.com/lucasb-eyer/go-colorful \
+                        lock    v1.0.3 \
+                        rmd160  0d0a283ba00c871d123c951efea0605a869951aa \
+                        sha256  ecd902ddda5d05cc8a857873bf8b984a5cd2d7b75f1185edcfc2c472707958b3 \
+                        size    430208 \
+                    github.com/zyedidia/highlight \
+                        lock    201131ce5cf5 \
+                        rmd160  698b47bc390cd3222fc60e70b16bfbbcf3d184b1 \
+                        sha256  bc6a27987f545a294ab78729bb4dd3144318056f3e1f63829d6ccc5a562ba134 \
+                        size    59767 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/zyedidia/go-shellquote \
+                        lock    eccd813c0655 \
+                        rmd160  ba59aa7090a1103de0757b14ea2afaa975f1f1f0 \
+                        sha256  0757e5fb57ed8f4ed856ceebf34ba885943e3d269edc52c419d13ffa9bb9fd31 \
+                        size    4416 \
+                    layeh.com/gopher-luar \
+                        repo    github.com/layeh/gopher-luar \
+                        lock    v1.0.7 \
+                        rmd160  80880561203f50263d54749060ea29d213cc1560 \
+                        sha256  b7d42e41cfd5786d0f219944681627f556778517bc3254fd19662e31106f327c \
+                        size    24030 \
+                    github.com/blang/semver \
+                        lock    v3.5.1 \
+                        rmd160  f3746971886e0aa556800bfd543d2f4a89a69767 \
+                        sha256  5f5743805f1baf458ddf2dd8f49c553aa1f5c9667feadf357143602489d3587f \
+                        size    14842 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/go-errors/errors \
+                        lock    v1.0.1 \
+                        rmd160  22a0344a550bf59c7efcea8876f8f5c06ba9f7f3 \
+                        sha256  e627783d715b21fa562c87daee06c30cc5889b87c625e6ad2c06c20e13946494 \
+                        size    8650 \
+                    github.com/zyedidia/poller \
+                        lock    v1.0.1 \
+                        rmd160  8995d2e162e03c9619639f9793d48f5c93c57f55 \
+                        sha256  1ed3ef9eafbb0ac8fd3fdd68d38e165f6059fb1399c895849bc3c1685f41d5a2 \
+                        size    15930 \
+                    github.com/zyedidia/pty \
+                        lock    v2.0.0 \
+                        rmd160  aca969aebed28365f90fa10132f673a74758c8a1 \
+                        sha256  513136de481b4094bd69ad6c04cc8dd6205b7f5927524394c3ac7865dcbaf3f3 \
+                        size    5760 \
+                    github.com/zyedidia/terminal \
+                        lock    533c623e2415 \
+                        rmd160  d76a48fc4afd47a7835ef62184bc3aa7acd5186a \
+                        sha256  f41ccb88fb6f6f0e8942b8e6144ba795853e8472ca3d4e8386b84572cf25b462 \
+                        size    12891 \
+                    github.com/dustin/go-humanize \
+                        lock    v1.0.0 \
+                        rmd160  e8641035159ea3e8839ee086f01f966443956303 \
+                        sha256  e45e3181c07b3e2dad8e1317e91a5bbbee4845067e3e3879a585a5254bc6a334 \
+                        size    17273 \
+                    github.com/p-e-w/go-runewidth \
+                        lock    3e1705c5c059 \
+                        rmd160  c4aca518189ab27662005a5498a076ba42622194 \
+                        sha256  0c5166d52222f9d6e871ed46a99b5852d972741d559a112b02d3077b097ed5cb \
+                        size    16803 \
+                    github.com/stretchr/objx \
+                        lock    v0.1.0 \
+                        rmd160  fa58b6a0f55fce44b3d4e246b07574f016a1dabf \
+                        sha256  e80eb3ee16d44676befb5b8044459492f73e6f153ad3f28b13949c9f9cfaf558 \
+                        size    109497 \
+                    github.com/stretchr/testify \
+                        lock    v1.4.0 \
+                        rmd160  86bd663e13ea7266334c47689074df16252db5ff \
+                        sha256  8ed95078bfd318ea477da509e6b16e6cf8d0d1b6b8d93b1f6097c6ba2a6df788 \
+                        size    110114 \
+                    golang.org/x/sys \
+                        lock    33540a1f6037 \
+                        rmd160  c0f935b516176c256e198073c3e99e43b8703bb8 \
+                        sha256  12203e31fcb839217947a1d61f385747f6f7776a2b0340b0d5b6a355e77594a8 \
+                        size    1497790 \
+                    github.com/xo/terminfo \
+                        lock    454e5b68f9e8 \
+                        rmd160  7075c23372949aa3527b66a99dec46aba0f55499 \
+                        sha256  cb84c33b785072301328de2686ce1625aa35c6aa26cd1ea9c3a662ff6bef6e87 \
+                        size    35565 \
+                    github.com/zyedidia/tcell \
+                        lock    v2.0.2 \
+                        rmd160  47ccbbd128982a52cb0dc39356da720283eb2a9b \
+                        sha256  c824850901dfc4b4cbcecfd0756ee83014219a4583d0ceb028cc7b43632c5b93 \
+                        size    131508 \
+                    golang.org/x/text \
+                        lock    v0.3.2 \
+                        rmd160  3b9523084f6a8b2e6a6987e49c56f05e22ad69eb \
+                        sha256  d624899dfd390d9d4a77e5c8e5abd8c45f0b6163e0dc7176aee39f25c5f1bed0 \
+                        size    7168458 \
+                    github.com/kr/text \
+                        lock    v0.1.0 \
+                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
+                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
+                        size    8691 \
+                    gopkg.in/check.v1 \
+                        lock    41f04d3bba15 \
+                        rmd160  1e5543a8e6a3159296ee63e28cbde9931a04f6b3 \
+                        sha256  c41575a73d10809f89b05ef9e783f2d53facdc6573697770d30efb05a9d2dc28 \
+                        size    31612 \
+                    gopkg.in/yaml.v2 \
+                        lock    v2.2.7 \
+                        rmd160  8a2eb51b49235820619e4703f557b266d5941645 \
+                        sha256  15d29283f38f1213445158c16dad11f84ab72aa0256af555c2392492315760ba \
+                        size    72665 \
+                    github.com/kr/pretty \
+                        lock    v0.1.0 \
+                        rmd160  9aa7a5aad4c48840eecfd0f80186d1fb5ded0fd6 \
+                        sha256  f6c3f89667c63e5b7f1fc6ee2c06b6a6bfdce88f3a965ccd395b64c6f95c9a47 \
+                        size    8553 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.11 \
+                        rmd160  e7d2dadfe4bff4cd5a5dfece75632e31af6fad44 \
+                        sha256  a8aac03b74f35ec077c589a8ac186b215f14536bb5e262b320ef7ece85bdcab5 \
+                        size    4399 \
+                    github.com/robertkrimen/otto \
+                        lock    c382bd3c16ff \
+                        rmd160  f7f8b9d5317ce8c9262b12445f73e14b983f149c \
+                        sha256  eca02ef6b28d42d8a0fb9b1f4c861d56b2645d218843bacd67e814ecdc77864a \
+                        size    251825 \
+                    github.com/sergi/go-diff \
+                        lock    v1.1.0 \
+                        rmd160  6449feb5884c316206f256e55b81aba3e6a78a9f \
+                        sha256  026d3d6db40ad086954214a7f3f84b66e352d47ce259bb59b7c2b9bd843b9935 \
+                        size    43569 \
+                    github.com/zyedidia/clipboard \
+                        lock    v1.0.3 \
+                        rmd160  b6b97a1e0761b0f7764f20c2c331a72734257035 \
+                        sha256  382a9b98c3f5dbc437faa73539afcdb820a266c1ba8891ef09cb181eb9986d0a \
+                        size    4881
+
 build.cmd           make
 build.target        build
+build.args          HASH=unknown VERSION=${version}
+build.env-append    GO111MODULE=off \
+                    GOPROXY=off
 
+post-extract {
+    reinplace "s|^HASH =|HASH ?=|" ${worksrcpath}/Makefile
+    reinplace "s|^VERSION =|VERSION ?=|" ${worksrcpath}/Makefile
+    # When building with GO111MODULE=off, the package identifier cannot be
+    # versioned or else it will not be recognized
+    reinplace "s|${go.package}/v2/|${go.package}/|g" ${worksrcpath}/Makefile
 
-# Makefile uses info only available in a git checkout.
-fetch.type          git
+    # go.mod has redirect directives:
+    file mkdir ${gopath}/src/github.com/kballard ${gopath}/src/github.com/mattn
+    ln -s ${gopath}/src/github.com/zyedidia/go-shellquote ${gopath}/src/github.com/kballard/go-shellquote
+    ln -s ${gopath}/src/github.com/p-e-w/go-runewidth ${gopath}/src/github.com/mattn/go-runewidth
+}
 
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
#### Description

Per https://trac.macports.org/ticket/61192 this is one of the golang ports that automatically downloads its dependencies at build time.

To fix it, I used `go2port`. Unexpected tricky parts:

- The project's Makefile assumes it is being run in a git repository; it took some finagling to work around that.
- The project's `go.mod` file uses `redirect` directives to replace some dependencies with others; this needs to be worked around in post-fetch with symlinks

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->