### PR TITLE
py3[678]-terminado: requires setuptools

### DIFF
--- a/python/py-terminado/Portfile
+++ b/python/py-terminado/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-terminado
 version             0.9.1
-revision            0
+revision            1
 categories-append   devel
 platforms           darwin
 license             BSD
@@ -34,6 +34,9 @@ if {${name} ne ${subport}} {
         checksums           rmd160  560debcbd40f868b5cb8aaed91f63abcc507f0ac \
                             sha256  4804a774f802306a7d9af7322193c5390f1da0abb429e082a10ef1d46e6fb2c2 \
                             size    21165
+    } else {
+        depends_build-append \
+                            port:py${python.version}-setuptools
     }
 
     livecheck.type      none


### PR DESCRIPTION
#### Description
Current builds fail:
```
Traceback (most recent call last):
  File "setup.py", line 1, in <module>
    from setuptools import setup, find_packages
ModuleNotFoundError: No module named 'setuptools'
```

setuptools apparently wasn't needed for py-terminado 0.8.3.
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Untested.
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
