### PR TITLE
ruby22: fix implicitly defined function

### DIFF
--- a/lang/ruby22/Portfile
+++ b/lang/ruby22/Portfile
@@ -52,6 +52,8 @@ select.file         ${filespath}/ruby22
 # ext/openssl/ossl.h: <openssl/asn1_mac.h> was deprecated (#58123)
 patchfiles          patch-ext_openssl_ossl.h.diff
 
+patchfiles-append   patch-internal.h.diff
+
 configure.args      --enable-shared \
                     --disable-install-doc \
                     --mandir="${prefix}/share/man" \

--- a/lang/ruby22/files/patch-internal.h.diff
+++ b/lang/ruby22/files/patch-internal.h.diff
@@ -1,0 +1,12 @@
+Fix implicit declaration of rb_str_change_terminator_length()
+Upstream-Status: Backport (from Ruby 2.3+)
+--- internal.h.orig
++++ internal.h
+@@ -988,6 +988,7 @@ VALUE rb_id_quote_unprintable(ID);
+ #define QUOTE(str) rb_str_quote_unprintable(str)
+ #define QUOTE_ID(id) rb_id_quote_unprintable(id)
+ void rb_str_fill_terminator(VALUE str, const int termlen);
++void rb_str_change_terminator_length(VALUE str, const int oldtermlen, const int termlen);
+ VALUE rb_str_locktmp_ensure(VALUE str, VALUE (*func)(VALUE), VALUE arg);
+ #ifdef RUBY_ENCODING_H
+ VALUE rb_external_str_with_enc(VALUE str, rb_encoding *eenc);


### PR DESCRIPTION
#### Description
https://github.com/macports/macports-ports/pull/8550#issue-493690109 metioned:
> ruby22 has a late-breaking issue with Xcode 12

The [most recent build for 10.15 (Xcode 11.x)](https://build.macports.org/builders/ports-10.15_x86_64-builder/builds/37775/steps/install-port/logs/stdio) contains a related warning:
```
compiling encoding.c
encoding.c:825:2: warning: implicit declaration of function 'rb_str_change_terminator_length' is invalid in C99 [-Wimplicit-function-declaration]
        rb_str_change_terminator_length(obj, oldtermlen, termlen);
        ^
1 warning generated.
``` 

TODO: disable silent rules for these ports.
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Only the patch phase has been tested. [Port health](https://ports.macports.org/port/ruby22/builds) indicates no known build failures. See if the Azure CI macOS 10.15 + Xcode 12 build succeeds.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
```
--->  Verifying Portfile for ruby22
Warning: missing recommended checksum type: size
--->  0 errors and 1 warnings found.
```
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
