### PR TITLE
duf: new port

### DIFF
--- a/sysutils/duf/Portfile
+++ b/sysutils/duf/Portfile
@@ -1,0 +1,84 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/muesli/duf 0.3.1 v
+categories          sysutils
+license             MIT
+
+description         Disk Usage/Free Utility
+long_description    ${description}
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}
+
+build.env-append    GO111MODULE=off \
+                    GOPROXY=off
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  426f6dc65ffeb1f3661e067568ec33681aba261b \
+                        sha256  0e11b63c16b2bc4b3c158f8f61b976dfe92ccb1acbc258a749725f8d9f5e3359 \
+                        size    124345
+
+go.vendors          github.com/mattn/go-runewidth \
+                        lock    v0.0.9 \
+                        rmd160  412c0e508e55f4fe437be0f71d7d22eca2b4366f \
+                        sha256  4f0f4a22257ccecfb6beae88052d850380ecc0e806d6bcc92d3656ebcac3b638 \
+                        size    16716 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    golang.org/x/crypto \
+                        lock    5c72a883971a \
+                        rmd160  090821b28d0329a087b91a964a53937f3ce0047a \
+                        sha256  a82c522eb9ec32fd6d5511793d1325495caf63371fffc5ac82f1fea63e99664a \
+                        size    1732437 \
+                    golang.org/x/sys \
+                        lock    af09f7315aff \
+                        rmd160  2e2294bcbcefb80f8ad5a51d474a18f08f8ffcdb \
+                        sha256  9ee36a2c435fda5e5b9d80c764d9972d5110a232418ec1f4f0fb9e5307e0cd51 \
+                        size    1063406 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/google/goterm \
+                        lock    fc88cf888a3f \
+                        rmd160  f9ec53def00acffe1d5fe5976dc0114a02305a73 \
+                        sha256  e3c84437911cb3c3500f4486b1ae9c7dc1e6e020185187203697f4a39401d77a \
+                        size    18304 \
+                    github.com/jedib0t/go-pretty \
+                        lock    v6.0.4 \
+                        rmd160  56ac2ad82b0b36747015440a0452861236d8292d \
+                        sha256  d05f525c16f5a709c060ea33cf8eb9859aad9daa5f652684d0945a0506b6ff2b \
+                        size    398726 \
+                    github.com/lucasb-eyer/go-colorful \
+                        lock    v1.0.3 \
+                        rmd160  0d0a283ba00c871d123c951efea0605a869951aa \
+                        sha256  ecd902ddda5d05cc8a857873bf8b984a5cd2d7b75f1185edcfc2c472707958b3 \
+                        size    430208 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.12 \
+                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
+                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
+                        size    4549 \
+                    github.com/muesli/termenv \
+                        lock    v0.7.2 \
+                        rmd160  a839579991fdf8c52a3f16cc1fabab40c7b2d31c \
+                        sha256  dab79d90c08eb0fd9501864965c312581c65ec4005b265e592230b73d29badb4 \
+                        size    405826 \
+                    github.com/stretchr/testify \
+                        lock    v1.2.2 \
+                        rmd160  45703d5a082af570664fb80e99918077596349aa \
+                        sha256  ea0e76528dc47d7d84739cd8a8c7560e3f12d4ff490bdd2641a9990a168e6f2f \
+                        size    101747
+
+


### PR DESCRIPTION
#### Description

New port for [duf](https://github.com/muesli/duf)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 11.7 11E801a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
