### PR TITLE
webify: don't fetch dependencies in build phase

### DIFF
--- a/devel/webify/Portfile
+++ b/devel/webify/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           golang 1.0
 
 go.setup            github.com/beefsack/webify 1.5.0 v
+revision            1
 categories          devel
 license             MIT
 
@@ -12,9 +13,25 @@ maintainers         {@harens gmail.com:harensdeveloper} \
 description         Turn shell commands into web services
 long_description    ${description}
 
-checksums           rmd160  d85b1fc41d23f8b7a22bd23aa8efa77bff89980e \
-                    sha256  ca82793a2716d7b315d936e3cd890e423300a3670b299af1b3ead190ec65752d \
-                    size    5648
+checksums           ${distname}${extract.suffix} \
+                        rmd160  d85b1fc41d23f8b7a22bd23aa8efa77bff89980e \
+                        sha256  ca82793a2716d7b315d936e3cd890e423300a3670b299af1b3ead190ec65752d \
+                        size    5648
+
+
+go.vendors          github.com/mattn/go-shellwords \
+                        lock    v1.0.10 \
+                        rmd160  5cd8df0280d795cc159d4be9039b193418375f4c \
+                        sha256  3691f606a48a973e02cb57e1ce724500a29cff5cad229dae24179ee3094561ae \
+                        size    5149 \
+                    github.com/namsral/flag\
+                        lock    v1.7.4-pre \
+                        rmd160  8a8530838b4e890390d265fcabb2f5eb590f9a14 \
+                        sha256  69fa12881cbb765af4777d04832d935c705415648f524065d17ba38da3374377 \
+                        size    14429 \
+
+build.env-append    GO111MODULE=off \
+                    GOPROXY=off
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
#### Description

As a result of https://trac.macports.org/ticket/61192, this was a port that downloaded dependencies at build time.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
