### PR TITLE
libqalculate: fix build on macOS 10.8-10.11

### DIFF
--- a/math/libqalculate/Portfile
+++ b/math/libqalculate/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        qalculate libqalculate 3.13.0 v
 revision            0
@@ -55,6 +56,9 @@ depends_lib-append \
 # required for ICU
 compiler.cxx_standard 2011
 configure.cxxflags-append -std=c++11
+
+# error: variable length array of non-POD element type 'Number'
+compiler.blacklist-append {clang < 802}
 
 patch {
     reinplace "s|libtoolize|glibtoolize|g" ${worksrcpath}/autogen.sh


### PR DESCRIPTION
#### Description
Build failure observed on [macOS 10.8-10.11](https://ports.macports.org/port/libqalculate/builds):
```
MathStructure-integrate.cc:6580:11: error: variable length array of non-POD element type 'Number'
        Number R1[max_steps], R2[max_steps];
                 ^
MathStructure-integrate.cc:6581:30: error: use of undeclared identifier 'R2'
        Number *Rp = &R1[0], *Rc = &R2[0];
                                    ^
```

Since the port builds on 10.6-10.7, which use MacPorts' clang 9.0, avoiding older Xcode versions on 10.8-10.11 should allow the port to build on those OS versions as well.
<!-- Note: it is best to make pull requests from a branch rather than from master -->



###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Untested. See if Travis CI Xcode 7.3 and 8.3 builds succeed.


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
