### PR TITLE
grep: attempt to fix build on macOS 10.7

### DIFF
--- a/sysutils/grep/Portfile
+++ b/sysutils/grep/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
+PortGroup       compiler_blacklist_versions 1.0
 
 name            grep
 version         3.5
@@ -22,6 +23,11 @@ use_xz          yes
 checksums       rmd160  45775cbc551ff7ab644569c7fc334598607fe729 \
                 sha256  b82ac77707c2ab945520c8404c9fa9f890f7791a62cf2103cf6238acad87a44a \
                 size    1586396
+
+# error: type name requires a specifier or qualifier
+# error: expected member name or ';' after declaration specifiers
+# error: expected ';' at end of declaration list
+compiler.blacklist {clang < 500}
 
 # Ensure system version of grep is used instead of a possibly broken MacPorts version.
 configure.env   PATH=/usr/bin:$env(PATH)


### PR DESCRIPTION
#### Description
[Various build errors observed on macOS 10.7](https://build.macports.org/builders/ports-10.7_x86_64-builder/builds/31410/steps/install-port/logs/stdio) in die.h as of the 3.5 update. The port builds on 10.6 using MacPorts' clang 9.0, so maybe that will work for 10.7 as well.
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Untested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
