### PR TITLE
free42: bump 2.5.20

### DIFF
--- a/emulators/free42/Portfile
+++ b/emulators/free42/Portfile
@@ -5,7 +5,7 @@ PortSystem              1.0
 PortGroup               xcode 1.0
 
 name                    free42
-version                 2.5.16
+version                 2.5.20
 platforms               darwin
 categories              emulators
 license                 GPL-2
@@ -24,9 +24,9 @@ master_sites            http://thomasokken.com/free42/upstream:upstream
 distname                ${name}-macports-${version}
 distfiles               ${distname}.tgz:upstream
 checksums               ${distname}.tgz \
-						rmd160  d16395190703ac4ec31a67cf1407d81bb7ea7c9f \
-                        sha256  8a841ffda6ffc3a8ca5743ed7ca32db56a3b161b2115226a9b8ffc5e4060f01b \
-                        size    8936889
+						rmd160  c05ef21ccab532d87370ff194926df165fb8e3a8 \
+						sha256  453484ad370bbd6b0fc536a3d6b52039d6208d72f16a0dac85ca5e6daaa02139 \
+						size    8938185
 
 extract.only            ${distname}.tgz
 patchfiles              patch-Free42.xcodeproj.diff

--- a/emulators/free42/files/patch-Free42.xcodeproj.diff
+++ b/emulators/free42/files/patch-Free42.xcodeproj.diff
@@ -1,36 +1,18 @@
---- a/mac/Free42.xcodeproj/project.pbxproj.orig	2019-01-21 13:31:34.342110776 -0200
-+++ b/mac/Free42.xcodeproj/project.pbxproj	2019-01-21 13:32:12.737315024 -0200
-@@ -510,7 +510,7 @@
- 				ALWAYS_SEARCH_USER_PATHS = NO;
+--- a/mac/Free42.xcodeproj/project.pbxproj.orig	2020-09-29 12:45:11.832664011 +0200
++++ b/mac/Free42.xcodeproj/project.pbxproj	2020-09-29 12:46:21.584105799 +0200
+@@ -584,7 +584,7 @@
  				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
  				CLANG_CXX_LIBRARY = "libc++";
--				CODE_SIGN_IDENTITY = "Mac Developer";
-+				CODE_SIGN_IDENTITY = "";
- 				COMBINE_HIDPI_IMAGES = YES;
- 				COPY_PHASE_STRIP = NO;
- 				DEVELOPMENT_TEAM = F4D88K2P5W;
-@@ -540,7 +540,7 @@
- 				ALWAYS_SEARCH_USER_PATHS = NO;
- 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
- 				CLANG_CXX_LIBRARY = "libc++";
+ 				CODE_SIGN_ENTITLEMENTS = "Free42Release Binary.entitlements";
 -				CODE_SIGN_IDENTITY = "Mac Developer";
 +				CODE_SIGN_IDENTITY = "";
  				COMBINE_HIDPI_IMAGES = YES;
  				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
  				DEVELOPMENT_TEAM = F4D88K2P5W;
-@@ -644,7 +644,7 @@
- 				ALWAYS_SEARCH_USER_PATHS = NO;
+@@ -741,7 +741,7 @@
  				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
  				CLANG_CXX_LIBRARY = "libc++";
--				CODE_SIGN_IDENTITY = "Mac Developer";
-+				CODE_SIGN_IDENTITY = "";
- 				COMBINE_HIDPI_IMAGES = YES;
- 				COPY_PHASE_STRIP = NO;
- 				DEVELOPMENT_TEAM = F4D88K2P5W;
-@@ -699,7 +699,7 @@
- 				ALWAYS_SEARCH_USER_PATHS = NO;
- 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
- 				CLANG_CXX_LIBRARY = "libc++";
+ 				CODE_SIGN_ENTITLEMENTS = "Free42Release Decimal.entitlements";
 -				CODE_SIGN_IDENTITY = "Mac Developer";
 +				CODE_SIGN_IDENTITY = "";
  				COMBINE_HIDPI_IMAGES = YES;


### PR DESCRIPTION
* Update version
* Update patchfile

Just a version bump. The port is openmaintainer and I have been the maintainer long ago.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6
Xcode 12.0.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->