### PR TITLE
krew: don't fetch dependencies in build phase

### DIFF
--- a/sysutils/krew/Portfile
+++ b/sysutils/krew/Portfile
@@ -15,15 +15,180 @@ long_description    Krew is the package manager for kubectl plugins. Krew \
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  9c4ff523835bc45bea76d99cbf6651da945a57fb \
-                    sha256  9514d20d543bac30722826f31d434710e4bb6fa0adc18a32a14d5bf1ae6ca965 \
-                    size    544522
-
 categories          sysutils
 license             Apache-2
 installs_libs       no
 
-build.target        sigs.k8s.io/krew/cmd/krew
+go.package          sigs.k8s.io/krew
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  9c4ff523835bc45bea76d99cbf6651da945a57fb \
+                        sha256  9514d20d543bac30722826f31d434710e4bb6fa0adc18a32a14d5bf1ae6ca965 \
+                        size    544522
+
+go.vendors          github.com/kr/pretty \
+                        lock    v0.1.0 \
+                        rmd160  9aa7a5aad4c48840eecfd0f80186d1fb5ded0fd6 \
+                        sha256  f6c3f89667c63e5b7f1fc6ee2c06b6a6bfdce88f3a965ccd395b64c6f95c9a47 \
+                        size    8553 \
+                    golang.org/x/net \
+                        lock    da137c7871d7 \
+                        rmd160  9dda4740e2457dbe51377f26adc3a89b1fbc8b86 \
+                        sha256  be2b974da567e28d799019b7a9ac1e39ee11f707690e9fc7f73e537fd9289a29 \
+                        size    1099247 \
+                    gopkg.in/inf.v0 \
+                        lock    v0.9.1 \
+                        rmd160  ffe5850db548c2f54472facadcd35d2d2d33a74c \
+                        sha256  5aa9ba7d33226f4833d55ee9e30e21a601e14961d793007e3aaa2ac6aab500c0 \
+                        size    13076 \
+                    github.com/google/go-cmp \
+                        lock    v0.3.0 \
+                        rmd160  023b52ba78fcaa734cfa0f54111e6ee8aba4777b \
+                        sha256  0672ceb4418adc04c39047892ec8f6322165c099ac3755c491ff722c47897cae \
+                        size    76135 \
+                    github.com/inconshreveable/mousetrap \
+                        lock    v1.0.0 \
+                        rmd160  5c617a09f1432fc543672a0e0c1e13d3752030c2 \
+                        sha256  0e6bae2849f13d12fe361ecac087728e4e97f3482f4cec44f6e7a2c53bb9cd0c \
+                        size    2291 \
+                    github.com/json-iterator/go \
+                        lock    v1.1.6 \
+                        rmd160  b3f24238e04a4efcea339dd63ebc1c55cf979175 \
+                        sha256  3cf56f400a74afa08c567631e440507ed48dd0533dc5339c9bfb166e28417d0c \
+                        size    76800 \
+                    github.com/pkg/errors \
+                        lock    v0.8.0 \
+                        rmd160  762fc7077449a4f2467de5398bd50501ea2d7be4 \
+                        sha256  3bb85e407ab7aaf2b1e3f23b7242ded175345000b55642dc286c481e8d32d970 \
+                        size    11350 \
+                    github.com/spf13/cobra \
+                        lock    v0.0.3 \
+                        rmd160  973651585034d41c5bf5508d949f616c519e08bf \
+                        sha256  ee5e92464c89386c88ca741b5a38d479090e88f01c95f496737e792271d689ba \
+                        size    101548 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.8 \
+                        rmd160  99d8cbd0920e6e1343f0f7ad2816c52d1dba4754 \
+                        sha256  7ec31b1b9ee5834c9a861e3ef1faeef1ecd972935fa259a8780b07d0f4a78965 \
+                        size    3571 \
+                    github.com/ghodss/yaml \
+                        lock    73d445a93680 \
+                        rmd160  a863573216a3f164365c6139795088142f22af5f \
+                        sha256  d4862207d33456688a54d374fee04f87a438919cda8aeb07e0cb16c90630ba07 \
+                        size    11682 \
+                    github.com/stretchr/testify \
+                        lock    v1.3.0 \
+                        rmd160  80582370443047a1d7020211865d85d54c036eea \
+                        sha256  ac782171992e3af1c8ac8384cbf4a39706ec5f9e3c6eed57a246e02dce571762 \
+                        size    102899 \
+                    k8s.io/apimachinery \
+                        repo    github.com/kubernetes/apimachinery \
+                        lock    0bb8574e0887 \
+                        rmd160  8fbdb1fe58fffaecc1ec728788b214d6c8f6278e \
+                        sha256  e56bb31a3d2d59b6aee0d145851fa32a58bf00462e4240ae200f1a41ec65fbb4 \
+                        size    491177 \
+                    k8s.io/client-go \
+                        repo    github.com/kubernetes/client-go \
+                        lock    v7.0.0 \
+                        rmd160  b8a5be5c0629f578a1ceef8892bc7669dd37f836 \
+                        sha256  0b63a072ae97671c76632d1dcec036288b75124b81d597322410edca35bfdc1b \
+                        size    487442 \
+                    github.com/gogo/protobuf \
+                        lock    v1.2.1 \
+                        rmd160  494337d5b5a44ef41ab2d8af5273c33e37e5f3ff \
+                        sha256  aada5eeede08e90c3ec1141a4913d344cfa17fa14d37db17b7a87137c83c8644 \
+                        size    2017659 \
+                    golang.org/x/text \
+                        lock    v0.3.2 \
+                        rmd160  3b9523084f6a8b2e6a6987e49c56f05e22ad69eb \
+                        sha256  d624899dfd390d9d4a77e5c8e5abd8c45f0b6163e0dc7176aee39f25c5f1bed0 \
+                        size    7168458 \
+                    gopkg.in/yaml.v2 \
+                        lock    v2.2.2 \
+                        rmd160  03aea7b7e847179b29044d5a928b9f8a889fe87b \
+                        sha256  da1e31b7beb9a6907947caa794134bdc2501d1a3474568b61cc2562a398d3d87 \
+                        size    70676 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.3 \
+                        rmd160  32abdd77a987af95ce5b647846bfdbb2d8db91a0 \
+                        sha256  046b6b81e3925ffe60e2213e9a239303ff98a51e76764590b807b591fedf2d1e \
+                        size    46029 \
+                    gopkg.in/check.v1 \
+                        lock    788fd7840127 \
+                        rmd160  b63165c8909a27edc15dda210df66a1b49efb49e \
+                        sha256  7e5547c6471cc48da89a7c87f965b20ca5311f43fc4d883ca62f9fccf7551630 \
+                        size    31597 \
+                    k8s.io/klog \
+                        repo    github.com/kubernetes/klog \
+                        lock    v1.0.0 \
+                        rmd160  a457d7f7f400435d503926bce96ca6da7cb1497e \
+                        sha256  eb1d86ad5496b027b6a42c733c52c1f8f37d0d323910b3eb8fcb06c602cea1de \
+                        size    32378 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/fatih/color \
+                        lock    v1.7.0 \
+                        rmd160  8a65cf00de5399f4498b41b0baed82da363f02d5 \
+                        sha256  a553c1229fe10a6b0765cbbb90245bf3383a99ba52b9608052420b40ca30d148 \
+                        size    816675 \
+                    github.com/google/gofuzz \
+                        lock    v1.0.0 \
+                        rmd160  7c3be51c8a9e481ef490ed549e1772268e6db868 \
+                        sha256  1e015fe823762482aad860f4f8f1fdb5c13ebe7ec21c1718e6115abe78960cfd \
+                        size    13205 \
+                    github.com/kr/text \
+                        lock    v0.1.0 \
+                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
+                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
+                        size    8691 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    sigs.k8s.io/yaml \
+                        repo    github.com/kubernetes-sigs/yaml \
+                        lock    v1.1.0 \
+                        rmd160  63330fda26d3fd3f647451bce6db93e93752ffaf \
+                        sha256  143f8101199ff36a2724a9aceef7b14689a812436ced01e63d969b3bebc2f37b \
+                        size    14903 \
+                    github.com/kylelemons/godebug \
+                        lock    v1.1.0 \
+                        rmd160  917ada648e70d2e339b8ff36d2f86882d0d2efa1 \
+                        sha256  6151c487936ab72cffbf804626228083c9b3abfc908a2bb41b1160e1e5780aaf \
+                        size    17641 \
+                    github.com/modern-go/concurrent \
+                        lock    bacd9c7ef1dd \
+                        rmd160  b039328d6fd40b97513dea8bf5b00adfdd53f14b \
+                        sha256  2f3333805bef60544e64ac9a734522205b513f5c461ba19f3d557510bb205afb \
+                        size    7533 \
+                    github.com/modern-go/reflect2 \
+                        lock    v1.0.1 \
+                        rmd160  5cdaa26d1ee453e37f3a26635aac40397e2f28fa \
+                        sha256  5bcbe1f4c0fa1d853c066a4e6f58eaa5d31ac370c97a3c87e99a6ffecf7b5a65 \
+                        size    14407 \
+                    github.com/sahilm/fuzzy \
+                        lock    v0.0.5 \
+                        rmd160  dcbd479663e7d0960d950e63fb3142954a5751b5 \
+                        sha256  ddd629fb8622eeef169d3918d5f2d742a34d66dd14ecc73567271e771608b875 \
+                        size    3352758 \
+                    golang.org/x/sys \
+                        lock    fae7ac547cb7 \
+                        rmd160  fcfc69599fbaac8ecd6f861df4c227677441335a \
+                        sha256  67f86b8d419d79b55e7fd41437c83cb5bc1e656cf9bb57e3a638324d9c6f8ee7 \
+                        size    1455014 \
+                    github.com/mattn/go-colorable \
+                        lock    v0.1.2 \
+                        rmd160  0f6c884afe23b7bf5846e52ac1dacd99bb845d23 \
+                        sha256  9306da860f1ba95ba0a375b0c47299414698a33cacf37bbf0b09d183f3b81db3 \
+                        size    8525
+
+build.target        ./cmd/krew
+build.env-append    GO111MODULE=off \
+                    GOPROXY=off
 
 destroot {
     xinstall -m 755 ${worksrcpath}/krew ${destroot}${prefix}/bin/


### PR DESCRIPTION
#### Description

Per https://trac.macports.org/ticket/61192 this is one of the golang ports that automatically downloads its dependencies at build time.

To fix it, I used `go2port`. Unexpected tricky parts:

- The project considers itself to be a different package than its host, so it needed a `go.package` statement

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->