### PR TITLE
seed: need to define BUILDING_GTK__

### DIFF
--- a/gnome/seed/Portfile
+++ b/gnome/seed/Portfile
@@ -63,4 +63,8 @@ configure.cmd       ./autogen.sh
 configure.args      --with-webkit=4.0 \
                     --disable-silent-rules
 
+# https://trac.macports.org/ticket/61246
+configure.cppflags-append \
+                   -DBUILDING_GTK__
+
 livecheck.type      none


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/61246

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Untested. See if the Azure CI builds succeed.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
