### PR TITLE
yara: fix build on macOS 10.6 and earlier

### DIFF
--- a/security/yara/Portfile
+++ b/security/yara/Portfile
@@ -3,6 +3,10 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
+# Need strnlen() and strndup()
+PortGroup               legacysupport 1.0
+legacysupport.newest_darwin_requires_legacy 10
+
 github.setup            VirusTotal yara 4.0.2 v
 revision                0
 


### PR DESCRIPTION
#### Description
Need legacysupport for `strnlen()` and `strndup()`:
```
Undefined symbols for architecture i386:
  "_strnlen", referenced from:
      _parse_elf_header_32_le in libyara.a(elf.o)
      _parse_elf_header_64_le in libyara.a(elf.o)
      _parse_elf_header_32_be in libyara.a(elf.o)
      _parse_elf_header_64_be in libyara.a(elf.o)
      _pe__load in libyara.a(pe.o)
     (maybe you meant: _strnlen_w)
  "_strndup", referenced from:
      _yr_strndup in libyara.a(mem.o)
     (maybe you meant: _yr_strndup)
``` 
<!-- Note: it is best to make pull requests from a branch rather than from master -->



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
