### PR TITLE
gstreamer010-gst-ffmpeg: patch for orc 0.4.30+

### DIFF
--- a/gnome/gstreamer010-gst-ffmpeg/Portfile
+++ b/gnome/gstreamer010-gst-ffmpeg/Portfile
@@ -10,6 +10,7 @@ PortGroup   compiler_blacklist_versions 1.0
 name                gstreamer010-gst-ffmpeg
 set my_name         gst-ffmpeg
 version             0.10.13
+revision            1
 description         This is gst-ffmpeg, a set of plug-ins for GStreamer.
 long_description     ${description}
 maintainers         nomaintainer
@@ -25,6 +26,7 @@ checksums           rmd160  3e5e3d44302665214cfde8a908b633f8d0f70d31 \
                     sha256  76fca05b08e00134e3cb92fa347507f42cbd48ddb08ed3343a912def187fbb62
 
 patchfiles          patch-gst-libs_ext_libav_configure.diff \
+                    patch-orc-0.4.30-fixes.diff \
                     patch-configure.ac.diff
 
 post-patch {

--- a/gnome/gstreamer010-gst-ffmpeg/files/patch-orc-0.4.30-fixes.diff
+++ b/gnome/gstreamer010-gst-ffmpeg/files/patch-orc-0.4.30-fixes.diff
@@ -1,0 +1,25 @@
+Fix build for orc 0.4.30 and later
+Taken from https://anonhg.netbsd.org/pkgsrc/rev/b7ba46cae228
+
+--- ext/libpostproc/gstpostproc.c.orig	2011-07-12 23:35:27.000000000 +0900
++++ ext/libpostproc/gstpostproc.c	2019-10-14 22:25:15.311639480 +0900
+@@ -299,7 +299,7 @@ change_context (GstPostProc * postproc, 
+     ppflags = (mmx_flags & ORC_TARGET_MMX_MMX ? PP_CPU_CAPS_MMX : 0)
+         | (mmx_flags & ORC_TARGET_MMX_MMXEXT ? PP_CPU_CAPS_MMX2 : 0)
+         | (mmx_flags & ORC_TARGET_MMX_3DNOW ? PP_CPU_CAPS_3DNOW : 0)
+-        | (altivec_flags & ORC_TARGET_ALTIVEC_ALTIVEC ? PP_CPU_CAPS_ALTIVEC :
++        | (altivec_flags & ORC_TARGET_POWERPC_ALTIVEC ? PP_CPU_CAPS_ALTIVEC :
+         0);
+ #else
+     mmx_flags = 0;
+--- ext/libswscale/gstffmpegscale.c.orig	2011-11-02 22:04:05.000000000 +0900
++++ ext/libswscale/gstffmpegscale.c	2019-10-14 22:19:36.351245163 +0900
+@@ -638,7 +638,7 @@ gst_ffmpegscale_set_caps (GstBaseTransfo
+   swsflags = (mmx_flags & ORC_TARGET_MMX_MMX ? SWS_CPU_CAPS_MMX : 0)
+       | (mmx_flags & ORC_TARGET_MMX_MMXEXT ? SWS_CPU_CAPS_MMX2 : 0)
+       | (mmx_flags & ORC_TARGET_MMX_3DNOW ? SWS_CPU_CAPS_3DNOW : 0)
+-      | (altivec_flags & ORC_TARGET_ALTIVEC_ALTIVEC ? SWS_CPU_CAPS_ALTIVEC : 0);
++      | (altivec_flags & ORC_TARGET_POWERPC_ALTIVEC ? SWS_CPU_CAPS_ALTIVEC : 0);
+ #else
+   mmx_flags = 0;
+   altivec_flags = 0;


### PR DESCRIPTION
#### Description
[Build currently fails](https://build.macports.org/builders/ports-10.15_x86_64-builder/builds/36684/steps/install-port/logs/stdio) due to orc being updated to 0.4.30+:

```
libtool: compile:  /usr/bin/clang -DHAVE_CONFIG_H -I. -I../.. -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk -I ../../gst-libs/ext/libav/libswscale -I ../../gst-libs/ext/libav/libavutil -I ../../gst-libs/ext/libav -I ../../gst-libs/ext/libav -Wno-deprecated-declarations -D_REENTRANT -I/opt/local/include/gstreamer-0.10 -I/opt/local/include/glib-2.0 -I/opt/local/lib/glib-2.0/include -I/opt/local/include/libxml2 -D_REENTRANT -I/opt/local/include/gstreamer-0.10 -I/opt/local/include/glib-2.0 -I/opt/local/lib/glib-2.0/include -I/opt/local/include/libxml2 -I../../gst-libs -I../../gst-libs -D_REENTRANT -I/opt/local/include/gstreamer-0.10 -I/opt/local/include/glib-2.0 -I/opt/local/lib/glib-2.0/include -I/opt/local/include/libxml2 -Wall -Wdeclaration-after-statement -Wvla -Wpointer-arith -Wmissing-declarations -Wmissing-prototypes -Wredundant-decls -Wundef -Wwrite-strings -Wformat-nonliteral -Wformat-security -Wold-style-definition -Winit-self -Wmissing-include-dirs -Waddress -Waggregate-return -Wno-multichar -Wnested-externs -I/opt/local/include/orc-0.4 -pipe -Os -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk -arch x86_64 -MT libgstffmpegscale_la-gstffmpegscale.lo -MD -MP -MF .deps/libgstffmpegscale_la-gstffmpegscale.Tpo -c gstffmpegscale.c  -fno-common -DPIC -o .libs/libgstffmpegscale_la-gstffmpegscale.o
gstffmpegscale.c:641:26: error: use of undeclared identifier 'ORC_TARGET_ALTIVEC_ALTIVEC'; did you mean 'ORC_TARGET_POWERPC_ALTIVEC'?
      | (altivec_flags & ORC_TARGET_ALTIVEC_ALTIVEC ? SWS_CPU_CAPS_ALTIVEC : 0);
                         ^~~~~~~~~~~~~~~~~~~~~~~~~~
                         ORC_TARGET_POWERPC_ALTIVEC
/opt/local/include/orc-0.4/orc/orctarget.h:25:3: note: 'ORC_TARGET_POWERPC_ALTIVEC' declared here
  ORC_TARGET_POWERPC_ALTIVEC = (1<<2),
  ^
1 error generated.
```

Rebuilding seems necessary since the replacement constants have different values.

I don't know whether port was able to build prior to the orc update. If more effort is needed to fix the port, then I would propose deleting it instead; an older version of `totem` used to be its only dependent. Newer versions of the upstream project are in the `gstreamer1-gst-libav` port.
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Only the patch phase is tested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
