### PR TITLE
libheif: Update to 1.9.1

### DIFF
--- a/multimedia/libheif/Portfile
+++ b/multimedia/libheif/Portfile
@@ -3,8 +3,12 @@
 PortSystem                  1.0
 PortGroup                   github 1.0
 
-github.setup                strukturag libheif 1.6.2 v
+github.setup                strukturag libheif 1.9.1 v
 revision                    0
+checksums                   rmd160  92a6ff1b051c53da86643ef87c4d6c252772306b \
+                            sha256  5f65ca2bd2510eed4e13bdca123131c64067e9dd809213d7aef4dc5e37948bca \
+                            size    1556450
+
 categories                  multimedia
 license                     LGPL-3+
 maintainers                 {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
@@ -13,10 +17,6 @@ long_description            ${name} is ${description}.
 platforms                   darwin
 
 github.tarball_from         releases
-
-checksums                   rmd160  659bf1335b86bf95c58ef022fd654bd268809d96 \
-                            sha256  bb229e855621deb374f61bee95c4642f60c2a2496bded35df3d3c42cc6d8eefc \
-                            size    1515763
 
 depends_build-append        port:pkgconfig
 


### PR DESCRIPTION
#### Description

libheif: Update to 1.9.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14019
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
