### PR TITLE
py-fortranformat: Update to 0.2.5; add py38

### DIFF
--- a/python/py-fortranformat/Portfile
+++ b/python/py-fortranformat/Portfile
@@ -1,9 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 PortSystem          1.0
 PortGroup           python 1.0
-PortGroup           bitbucket 1.0
+PortGroup           github 1.0
 
-bitbucket.setup     brendanarnold py-fortranformat 0.2.3
+github.setup        simright py-fortranformat 7de5aa505ee26f2457d25e6546d6814273cd5815
+version             0.2.5
+revision            0
+checksums           rmd160  90ca2363b1b4adf8dd15c3f160219ce53b6cbd5c \
+                    sha256  e72b09b9d9d88804651aa9acc59d40dd7a7eb035a289990cc61e16f51a8838e3 \
+                    size    14117179
+
 categories-append   science print
 platforms           darwin
 supported_archs     noarch
@@ -14,13 +20,9 @@ long_description    Generates text from a Python list of variables or will \
     read a line of text into Python variables according to the FORTRAN format \
     statement passed.
 
-checksums           md5 d78c5a320fedcbdf21f823cd18e28ac0 \
-                    rmd160 212edf59a6da06b8127322f30806e6559353ea79 \
-                    sha256 ec76c1c7bc07972aa98e01ff2303bb0aefe77306be8ff2723bc40b7c7775292c
-python.versions     27 35 36 37
+python.versions     27 35 36 37 38
 
-bitbucket.tarball_from downloads
-distname            fortranformat-${version}
+github.tarball_from archive
 
 if {${name} ne ${subport}} {
     depends_build-append port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

py-fortranformat: Update to 0.2.5; add py38

Closes: https://trac.macports.org/ticket/61238

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14019
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [X] tried a full install with `sudo port -vst install`?
