### PR TITLE
seed: include util.h for openpty()

### DIFF
--- a/gnome/seed/Portfile
+++ b/gnome/seed/Portfile
@@ -52,6 +52,8 @@ depends_lib         port:gettext \
 
 gobject_introspection yes
 
+patchfiles-append   patch-modules-os-seed-os.c.diff
+
 # reconfigure using upstream autogen.sh for intltool 0.51 compatibility
 
 post-patch {

--- a/gnome/seed/files/patch-modules-os-seed-os.c.diff
+++ b/gnome/seed/files/patch-modules-os-seed-os.c.diff
@@ -1,0 +1,12 @@
+Upstream-Status: Pending
+--- modules/os/seed-os.c.orig
++++ modules/os/seed-os.c
+@@ -38,6 +38,8 @@
+ #include <termios.h>
+ #if defined(__FreeBSD__)
+ #include <libutil.h>
++#elif defined(__APPLE__)
++#include <util.h>
+ #endif
+ #include <unistd.h>
+ 


### PR DESCRIPTION
#### Description
Build fails under Xcode 12:
```
libtool: compile:  /usr/bin/clang -arch x86_64 -DHAVE_CONFIG_H -I. -I../.. -I/opt/local/include -DBUILDING_GTK__ -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk -I../../libseed/ -D_REENTRANT -I/opt/local/include/gobject-introspection-1.0 -I/opt/local/include/glib-2.0 -I/opt/local/lib/glib-2.0/include -DG_DISABLE_ASSERT -DG_DISABLE_CHECKS -DG_DISABLE_CAST_CHECKS -pipe -Os -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk -arch x86_64 -Wall -MT libseed_os_la-seed-os.lo -MD -MP -MF .deps/libseed_os_la-seed-os.Tpo -c seed-os.c  -fno-common -DPIC -o .libs/libseed_os_la-seed-os.o
seed-os.c:813:5: error: implicit declaration of function 'openpty' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
    openpty(&master, &slave, NULL, NULL, NULL);
    ^
seed-os.c:813:5: note: did you mean 'openat'?
/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include/sys/fcntl.h:532:9: note: 'openat' declared here
int     openat(int, const char *, int, ...) __DARWIN_NOCANCEL(openat) __OSX_AVAILABLE_STARTING(__MAC_10_10, __IPHONE_8_0);
        ^
1 error generated.
```

I'd like to submit this upstream, but would like to get review from someone more familiar with using macOS platform detection macros.
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Only patch phase is tested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
