### PR TITLE
groovy: update to 3.0.6

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            groovy
-version         3.0.5
+version         3.0.6
 revision        0
 
 categories      lang java
@@ -41,9 +41,9 @@ master_sites    https://dl.bintray.com/${name}/maven/
 distname        apache-${name}-binary-${version}
 use_zip         yes
 
-checksums       rmd160  8d3755a96d6eeb723be458de68a1c50edbd12b27 \
-                sha256  f7ffaed8aa63611bf68bef0db512ab979926c6e8778393fe573c553b9bd39e10 \
-                size    45728943
+checksums       rmd160  b3cf2c24ca93f842f17c24d302fc954b2fef7e85 \
+                sha256  6e0cc2d5b8a7b8585f15816c7d5cae1b09b4003ced0002e79abe7b4b1ebb35f2 \
+                size    43587616
 
 worksrcdir      ${name}-${version}
 


### PR DESCRIPTION
#### Description

Update to Groovy 3.0.6.

###### Tested on

macOS 10.15.7 19H2
Xcode 12.0.1 12A7300

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?