### PR TITLE
libstrophe: update to 0.10.0, cleanup Portfile

### DIFF
--- a/net/libstrophe/Portfile
+++ b/net/libstrophe/Portfile
@@ -1,33 +1,36 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem         1.0
-PortGroup github   1.0
+PortSystem          1.0
+PortGroup           github 1.0
 
-github.setup       strophe libstrophe 0.9.1
-revision           1
-categories         net
-platforms          darwin
-maintainers        nomaintainer
-description        A simple, lightweight C library for writing XMPP clients
-homepage           http://strophe.im/libstrophe/
-license            {GPL-3 MIT}
+github.setup        strophe libstrophe 0.10.0
+revision            0
+checksums           rmd160  16c753a73383f1d15706a4c9c6089a0a9f295701 \
+                    sha256  9b83b2f85f43b1196b371a0410e13d68e3bb691858b51df0eca64be1671bcdfd \
+                    size    173180
 
-long_description   libstrophe is a lightweight XMPP client library written in C. \
-                   It has minimal dependencies and is configurable for various \
-                   environments. It runs well on both Linux, Unix, and Windows \
-                   based platforms.
+categories          net
+platforms           darwin
+maintainers         nomaintainer
+description         A simple, lightweight C library for writing XMPP clients
+homepage            https://strophe.im/libstrophe/
+license             {GPL-3 MIT}
 
-checksums          rmd160  ad91c0a0c2eb2726efd854dd696eb086204c608b \
-                   sha256  b15427e9fdac36a72144ffe7bfc4c501e9cf3ccd97ed9afafe575fa10b2e95d7
+long_description    libstrophe is a lightweight XMPP client library written in C. \
+                    It has minimal dependencies and is configurable for various \
+                    environments. It runs well on both Linux, Unix, and Windows \
+                    based platforms.
 
-depends_build      port:m4 \
-                   port:pkgconfig
-depends_lib        port:expat \
-                   path:lib/libssl.dylib:openssl
+depends_build       port:m4 \
+                    port:pkgconfig
 
-use_autoreconf     yes
+depends_lib         port:expat \
+                    path:lib/libssl.dylib:openssl
+
+use_autoreconf      yes
 
 variant libxml description {Use libxml for XML parsing} {
+    depends_lib-delete     port:expat
     depends_lib-append     port:libxml2
     configure.args-append  --with-libxml2
 }


### PR DESCRIPTION
#### Description
* Portfile: fix indentations
* libxml variant: remove expat dependency

###### Tested on
macOS 10.14.6 18G6020
Xcode 11.3.1 11C504

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

