### PR TITLE
zola: new port

### DIFF
--- a/www/zola/Portfile
+++ b/www/zola/Portfile
@@ -1,0 +1,338 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo 1.0
+
+github.setup        getzola zola 0.12.2 v
+revision            0
+categories          www
+platforms           darwin
+license             MIT
+
+homepage            https://www.getzola.org/
+
+description         A fast static site generator in a single binary with \
+                    everything built-in.
+
+long_description    {*}${description} Zola comes as a single executable with \
+                    Sass compilation, syntax highlighting, table of contents \
+                    and many other features that traditionally require \
+                    setting up a dev environment or adding some JavaScript \
+                    libraries to your site. The average site will be \
+                    generated in less than a second, including Sass \
+                    compilation and syntax highlighting.  Zola renders your \
+                    whole site as static sites, making it trivial to handle \
+                    any kind of traffic you will throw at it at no cost \
+                    without having to worry about managing a server or a \
+                    database. Using augmented Markdown, Zola comes with \
+                    shortcodes and internal links to make it easier to write \
+                    your content.
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  c23a2cafb9b812a399de2bff24acbafed749ff5f \
+                    sha256  a6ef54ffc7fef5be5116d7ca214b8a1a38cd0296a82c8326887a722bb8c5f27c \
+                    size    10477522
+
+depends_lib         path:lib/libssl.dylib:openssl
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/${name} ${destroot}${prefix}/bin/
+}
+
+cargo.crates \
+    adler                            0.2.3  ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e \
+    adler32                          1.2.0  aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234 \
+    ahash                            0.3.8  e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217 \
+    aho-corasick                    0.7.13  043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86 \
+    ammonia                          3.1.0  89eac85170f4b3fb3dc5e442c1cfb036cb8eecf9dbbd431a161ffad15d90ea3b \
+    ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
+    assert-json-diff                 1.1.0  4259cbe96513d2f1073027a259fc2ca917feb3026a5a8d984e3628e490255cc0 \
+    atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+    autocfg                          1.0.1  cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a \
+    base64                          0.12.3  3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff \
+    bincode                          1.3.1  f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d \
+    bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
+    block-buffer                     0.7.3  c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b \
+    block-buffer                     0.9.0  4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4 \
+    block-padding                    0.1.5  fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5 \
+    bstr                            0.2.13  31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931 \
+    bumpalo                          3.4.0  2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820 \
+    byte-tools                       0.3.1  e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7 \
+    bytemuck                         1.4.1  41aa2ec95ca3b5c54cf73c91acf06d24f4495d5f1b1c12506ae3483d646177ac \
+    byteorder                        1.3.4  08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de \
+    bytes                           0.4.12  206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c \
+    bytes                            0.5.6  0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38 \
+    cc                              1.0.60  ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c \
+    cedarwood                        0.4.4  963e82c7b94163808ca3a452608d260b64ba5bc7b5653b4af1af59887899f48d \
+    cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
+    chrono                          0.4.18  d021fddb7bd3e734370acfa4a83f34095571d8570c039f1420d77540f68d5772 \
+    chrono-tz                        0.5.3  2554a3155fec064362507487171dcc4edc3df60cb10f3a1fb10ed8094822b120 \
+    clap                            2.33.3  37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002 \
+    color_quant                      1.0.1  0dbbb57365263e881e805dc77d94697c9118fd94d8da011240555aa7b23445bd \
+    colored                          1.9.3  f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59 \
+    cpuid-bool                       0.1.2  8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634 \
+    crc32fast                        1.2.0  ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1 \
+    crossbeam-channel                0.4.4  b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87 \
+    crossbeam-deque                  0.7.3  9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285 \
+    crossbeam-epoch                  0.8.2  058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace \
+    crossbeam-utils                  0.7.2  c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8 \
+    csv                              1.1.3  00affe7f6ab566df61b4be3ce8cf16bc2576bca0963ceb0955e45d514bf9a279 \
+    csv-core                        0.1.10  2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90 \
+    ctrlc                            3.1.6  d0b676fa23f995faf587496dcd1c80fead847ed58d2da52ac1caca9a72790dd2 \
+    deflate                          0.8.6  73770f8e1fe7d64df17ca66ad28994a0a623ea497fa69486e14984e715c5d174 \
+    deunicode                        0.4.3  850878694b7933ca4c9569d30a34b55031b9b139ee1fc7b94a527c4ef960d690 \
+    difference                       2.0.0  524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198 \
+    digest                           0.8.1  f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5 \
+    digest                           0.9.0  d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066 \
+    doc-comment                      0.3.3  fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10 \
+    dtoa                             0.4.6  134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b \
+    either                           1.6.1  e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457 \
+    elasticlunr-rs                   2.3.9  35622eb004c8f0c5e7e2032815f3314a93df0db30a1ce5c94e62c1ecc81e22b9 \
+    encoding                        0.2.33  6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec \
+    encoding-index-japanese   1.20141219.5  04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91 \
+    encoding-index-korean     1.20141219.5  4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81 \
+    encoding-index-simpchinese 1.20141219.5 d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7 \
+    encoding-index-singlebyte 1.20141219.5  3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a \
+    encoding-index-tradchinese 1.20141219.5 fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18 \
+    encoding_index_tests             0.1.4  a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569 \
+    encoding_rs                     0.8.24  a51b8cf747471cb9499b6d59e59b0444f4c90eba8968c4e44874e92b5b64ace2 \
+    extend                           0.1.2  f47da3a72ec598d9c8937a7ebca8962a5c7a1f28444e38c2b33c771ba3f55f05 \
+    fake-simd                        0.1.2  e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed \
+    filetime                        0.2.12  3ed85775dcc68644b5c950ac06a2b23768d3bc9390464151aaf27136998dcf9e \
+    flate2                          1.0.17  766d0e77a2c1502169d4a93ff3b8c15a71fd946cd0126309752104e5f3c46d94 \
+    fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
+    fsevent                          0.4.0  5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6 \
+    fsevent-sys                      2.0.1  f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0 \
+    fuchsia-zircon                   0.3.3  2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
+    fuchsia-zircon-sys               0.3.3  3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
+    futf                             0.1.4  7c9c1ce3fa9336301af935ab852c437817d14cd33690446569392e65170aac3b \
+    futures-channel                  0.3.5  f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5 \
+    futures-core                     0.3.5  59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399 \
+    futures-io                       0.3.5  de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789 \
+    futures-macro                    0.3.5  d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39 \
+    futures-sink                     0.3.5  3f2032893cb734c7a05d85ce0cc8b8c4075278e93b24b66f9de99d6eb0fa8acc \
+    futures-task                     0.3.5  bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626 \
+    futures-util                     0.3.5  8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6 \
+    generic-array                   0.12.3  c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec \
+    generic-array                   0.14.4  501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817 \
+    getrandom                       0.1.15  fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6 \
+    gif                             0.11.1  02efba560f227847cb41463a7395c514d127d4f74fff12ef0137fff1b84b96c4 \
+    glob                             0.3.0  9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574 \
+    globset                          0.4.5  7ad1da430bd7281dde2576f44c84cc3f0f7b475e7202cd503042dff01a8c8120 \
+    globwalk                         0.8.0  178270263374052c40502e9f607134947de75302c1348d1a0e31db67c1691446 \
+    h2                               0.2.6  993f9e0baeed60001cf565546b0d3dbe6a6ad23f2bd31644a133c641eccf6d53 \
+    hashbrown                        0.8.2  e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25 \
+    hashbrown                        0.9.0  00d63df3d41950fb462ed38308eea019113ad1508da725bbedcd0fa5a85ef5f7 \
+    heck                             0.3.1  20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205 \
+    hermit-abi                      0.1.16  4c30f6d0bc6b00693347368a67d41b58f2fb851215ff1da49e90fe2c5c667151 \
+    html5ever                       0.25.1  aafcf38a1a36118242d29b92e1b08ef84e67e4a5ed06e0a80be20e6a32bfed6b \
+    http                             0.2.1  28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9 \
+    http-body                        0.3.1  13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b \
+    httparse                         1.3.4  cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9 \
+    httpdate                         0.3.2  494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47 \
+    humansize                        1.1.0  b6cab2627acfc432780848602f3f558f7e9dd427352224b0d9324025796d2a5e \
+    hyper                           0.13.8  2f3afcfae8af5ad0576a31e768415edb627824129e8e5a29b8bfccb2f234e835 \
+    hyper-rustls                    0.21.0  37743cc83e8ee85eacfce90f2f4102030d9ff0a95244098d781e9bee4a90abb6 \
+    hyper-staticfile                 0.5.3  f059991575d4be26e3946276a4f3ee24bcf17a232449407354045eaf064d3475 \
+    idna                             0.2.0  02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9 \
+    ignore                          0.4.16  22dcbf2a4a289528dbef21686354904e1c694ac642610a9bff9e7df730d9ec72 \
+    image                          0.23.10  985fc06b1304d19c28d5c562ed78ef5316183f2b0053b46763a0b94862373c34 \
+    indexmap                         1.6.0  55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2 \
+    inotify                          0.7.1  4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f \
+    inotify-sys                      0.1.3  e74a1aa87c59aeff6ef2cc2fa62d41bc43f54952f55652656b18a02fd5e356c0 \
+    iovec                            0.1.4  b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e \
+    ipnet                            2.3.0  47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135 \
+    itoa                             0.4.6  dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6 \
+    jieba-rs                         0.5.1  2ca2de723e93727460917d9542f7ae35a74d03d93923f03380a0238d860d137c \
+    jpeg-decoder                    0.1.20  cc797adac5f083b8ff0ca6f6294a999393d76e197c36488e2ef732c4715f6fa3 \
+    js-sys                          0.3.45  ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8 \
+    kernel32-sys                     0.2.2  7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    lazycell                         1.3.0  830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55 \
+    levenshtein_automata             0.1.1  73a004f877f468548d8d0ac4977456a249d8fabbdb8416c36db163dfc8f2e8ca \
+    libc                            0.2.77  f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235 \
+    lindera                          0.3.5  71b867cd68f5fc19a6d8b8361a6aba55ed2485f243044b70da14b6ba5a128c00 \
+    lindera-core                     0.3.3  97b7f132a5d361c1236b28434c632097fb8867ebdf4e4c9ab4f793525bb681ff \
+    lindera-dictionary               0.3.3  78a61a066057d24faab043586633274fa3468c5c54cb8191895659811218a8ec \
+    lindera-fst                      0.1.1  a6098a7ca6679296cd2d227efa232f990552c5278394c845bec8a70ab0284ae0 \
+    lindera-ipadic                   0.3.3  9f12f44c385a6f4c1ff0863a2f0a91ce5f1ff6c2e0e44c69b37051b56fece112 \
+    line-wrap                        0.1.1  f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9 \
+    linked-hash-map                  0.5.3  8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a \
+    log                             0.4.11  4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b \
+    lzw                             0.10.0  7d947cbb889ed21c2a84be6ffbaebf5b4e0f4340638cba0444907e38b56be084 \
+    mac                              0.1.1  c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4 \
+    maplit                           1.0.2  3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d \
+    markup5ever                     0.10.0  aae38d669396ca9b707bfc3db254bc382ddb94f57cc5c235f34623a669a01dab \
+    markup5ever_rcdom                0.1.0  f015da43bcd8d4f144559a3423f4591d69b8ce0652c905374da7205df336ae2b \
+    matches                          0.1.8  7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
+    maybe-uninit                     2.0.0  60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00 \
+    memchr                           2.3.3  3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400 \
+    memoffset                        0.5.6  043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa \
+    mime                            0.3.16  2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d \
+    mime_guess                       2.0.3  2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212 \
+    minify-html                      0.3.8  30f114c59124a0424fff930aecd3c3b991fc9a775bf656ecd9b659975d1b9658 \
+    miniz_oxide                      0.3.7  791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435 \
+    miniz_oxide                      0.4.2  c60c0dfe32c10b43a144bad8fc83538c52f58302c92300ea7ec7bf7b38d5a7b9 \
+    mio                             0.6.22  fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430 \
+    mio-extras                       2.0.6  52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19 \
+    miow                             0.2.1  8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919 \
+    mockito                         0.27.0  3a634720d366bcbce30fb05871a35da229cef101ad0b2ea4e46cf5abf031a273 \
+    net2                            0.2.35  3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853 \
+    new_debug_unreachable            1.0.4  e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54 \
+    nix                             0.17.0  50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363 \
+    notify                          4.0.15  80ae4a7688d1fab81c5bf19c64fc8db920be8d519ce6336ed4e7efe024724dbd \
+    num-integer                     0.1.43  8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b \
+    num-iter                        0.1.41  7a6e6b7c748f995c4c29c5f5ae0248536e04a5739927c74ec0fa564805094b9f \
+    num-rational                     0.3.0  a5b4d7360f362cfb50dde8143501e6940b22f644be75a4cc90b2d81968908138 \
+    num-traits                      0.2.12  ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611 \
+    num_cpus                        1.13.0  05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3 \
+    once_cell                        1.4.1  260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad \
+    onig                             6.1.0  8a155d13862da85473665694f4c05d77fb96598bdceeaf696433c84ea9567e20 \
+    onig_sys                        69.5.1  9bff06597a6b17855040955cae613af000fc0bfc8ad49ea68b9479a74e59292d \
+    opaque-debug                     0.2.3  2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c \
+    opaque-debug                     0.3.0  624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5 \
+    open                             1.4.0  7c283bf0114efea9e42f1a60edea9859e8c47528eae09d01df4b29c1e489cc48 \
+    parse-zoneinfo                   0.3.0  c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41 \
+    percent-encoding                 2.1.0  d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
+    pest                             2.1.3  10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53 \
+    pest_derive                      2.1.0  833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0 \
+    pest_generator                   2.1.3  99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55 \
+    pest_meta                        2.1.3  54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d \
+    phf                              0.8.0  3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12 \
+    phf_codegen                      0.8.0  cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815 \
+    phf_generator                    0.8.0  17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526 \
+    phf_shared                       0.8.0  c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7 \
+    pin-project                     0.4.24  f48fad7cfbff853437be7cf54d7b993af21f53be7f0988cbfe4a51535aa77205 \
+    pin-project-internal            0.4.24  24c6d293bdd3ca5a1697997854c6cf7855e43fb6a0ba1c47af57a5bcafd158ae \
+    pin-project-lite                 0.1.8  71f349a4f0e70676ffb2dbafe16d0c992382d02f0a952e3ddf584fc289dac6b3 \
+    pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
+    pkg-config                      0.3.18  d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33 \
+    plist                            1.0.0  7b336d94e8e4ce29bf15bba393164629764744c567e8ad306cc1fdd0119967fd \
+    png                             0.16.7  dfe7f9f1c730833200b134370e1d5098964231af8450bce9b78ee3ab5278b970 \
+    ppv-lite86                       0.2.9  c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20 \
+    precomputed-hash                 0.1.1  925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c \
+    proc-macro-error                 1.0.4  da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c \
+    proc-macro-error-attr            1.0.4  a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869 \
+    proc-macro-hack                 0.5.18  99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598 \
+    proc-macro-nested                0.1.6  eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a \
+    proc-macro2                     1.0.23  51ef7cd2518ead700af67bf9d1a658d90b6037d77110fd9c0445429d0ba1c6c9 \
+    pulldown-cmark                   0.8.0  ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8 \
+    quote                            1.0.7  aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37 \
+    rand                             0.7.3  6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
+    rand_chacha                      0.2.2  f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402 \
+    rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
+    rand_hc                          0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
+    rand_pcg                         0.2.1  16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429 \
+    rayon                            1.4.0  cfd016f0c045ad38b5251be2c9c0ab806917f82da4d36b2a327e5166adad9270 \
+    rayon-core                       1.8.1  e8c4fec834fb6e6d2dd5eece3c7b432a52f0ba887cf40e595190c4107edc08bf \
+    redox_syscall                   0.1.57  41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce \
+    regex                            1.3.9  9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6 \
+    regex-automata                   0.1.9  ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4 \
+    regex-syntax                     0.4.2  8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e \
+    regex-syntax                    0.6.18  26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8 \
+    relative-path                    1.3.2  65aff7c83039e88c1c0b4bedf8dfa93d6ec84d5fc2945b37c1fa4186f46c5f94 \
+    remove_dir_all                   0.5.3  3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7 \
+    reqwest                         0.10.8  e9eaa17ac5d7b838b7503d118fa16ad88f440498bf9ffe5424e621f93190d61e \
+    ring                           0.16.15  952cd6b98c85bbc30efa1ba5783b8abf12fec8b3287ffa52605b9432313e34e4 \
+    roxmltree                       0.11.0  d5001f134077069d87f77c8b9452b690df2445f7a43f1c7ca4a1af8dd505789d \
+    rust-stemmers                    1.2.0  e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54 \
+    rustls                          0.18.1  5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81 \
+    ryu                              1.0.5  71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e \
+    safemem                          0.3.3  ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072 \
+    same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
+    sass-rs                          0.2.2  cabcf7c6e55053f359911187ac401409aad2dc14338cae972dec266fee486abd \
+    sass-sys                        0.4.21  0df9ac0fd0b8d62a99b9948094dcd56c441e3e10bf49f9b12da40b2183804908 \
+    scoped_threadpool                0.1.9  1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8 \
+    scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
+    sct                              0.6.0  e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c \
+    serde                          1.0.116  96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5 \
+    serde_derive                   1.0.116  f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8 \
+    serde_json                      1.0.57  164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c \
+    serde_urlencoded                 0.6.1  9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97 \
+    sha-1                            0.8.2  f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df \
+    sha2                             0.9.1  2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1 \
+    siphasher                        0.3.3  fa8f3741c7372e75519bd9346068370c9cdaabcc1f9599cbcf2a2719352286b7 \
+    slab                             0.4.2  c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8 \
+    slotmap                          0.4.0  c46a3482db8f247956e464d783693ece164ca056e6e67563ee5505bdb86452cd \
+    slug                             0.1.4  b3bc762e6a4b6c6fcaade73e77f9ebc6991b676f88bb2358bddb56560f073373 \
+    smallvec                         1.4.2  fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252 \
+    socket2                         0.3.15  b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44 \
+    spin                             0.5.2  6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d \
+    string_cache                     0.8.0  2940c75beb4e3bf3a494cef919a747a2cb81e52571e212bfbd185074add7208a \
+    string_cache_codegen             0.5.1  f24c8e5e19d22a726626f1a5e16fe15b132dcf21d10177fa5a45ce7962996b97 \
+    strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
+    strum                           0.18.0  57bd81eb48f4c437cadc685403cad539345bf703d78e63707418431cecd4522b \
+    strum_macros                    0.18.0  87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c \
+    svg_metadata                     0.4.1  5fe5b1fbd62339f055704951dcaf2e757c460b9f6abe17f6de0d2563da821c57 \
+    syn                             1.0.42  9c51d92969d209b54a98397e1b91c8ae82d8c87a7bb87df0b29aa2ad81454228 \
+    syntect                          4.4.0  4e3978df05b5850c839a6b352d3c35ce0478944a4be689be826b53cf75363e88 \
+    tempfile                         3.1.0  7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9 \
+    tendril                          0.4.1  707feda9f2582d5d680d733e38755547a3e8fb471e7ba11452ecfd9ce93a5d3b \
+    tera                             1.5.0  1381c83828bedd5ce4e59473110afa5381ffe523406d9ade4b77c9f7be70ff9a \
+    termcolor                        1.1.0  bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f \
+    textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
+    thread_local                     1.0.1  d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14 \
+    tiff                             0.5.0  3f3b8a87c4da944c3f27e5943289171ac71a6150a79ff6bacfff06d159dfff2f \
+    time                            0.1.44  6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255 \
+    tinyvec                          0.3.4  238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117 \
+    tokio                           0.2.22  5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd \
+    tokio-macros                     0.2.5  f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389 \
+    tokio-rustls                    0.14.1  e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a \
+    tokio-util                       0.3.1  be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499 \
+    toml                             0.5.6  ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a \
+    tower-service                    0.3.0  e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860 \
+    tracing                         0.1.19  6d79ca061b032d6ce30c660fded31189ca0b9922bf483cd70759f13a2d86786c \
+    tracing-core                    0.1.16  5bcf46c1f1f06aeea2d6b81f3c863d0930a596c86ad1920d4e5bad6dd1d7119a \
+    try-lock                         0.2.3  59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642 \
+    typenum                         1.12.0  373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33 \
+    ucd-trie                         0.1.3  56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c \
+    unic-char-property               0.9.0  a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221 \
+    unic-char-range                  0.9.0  0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc \
+    unic-common                      0.9.0  80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc \
+    unic-segment                     0.9.0  e4ed5d26be57f84f176157270c112ef57b86debac9cd21daaabbe56db0f88f23 \
+    unic-ucd-segment                 0.9.0  2079c122a62205b421f499da10f3ee0f7697f012f55b675e002483c73ea34700 \
+    unic-ucd-version                 0.9.0  96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4 \
+    unicase                          2.6.0  50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6 \
+    unicode-bidi                     0.3.4  49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5 \
+    unicode-normalization           0.1.13  6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977 \
+    unicode-segmentation             1.6.0  e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0 \
+    unicode-width                    0.1.8  9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3 \
+    unicode-xid                      0.2.1  f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564 \
+    untrusted                        0.7.1  a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a \
+    url                              2.1.1  829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb \
+    utf-8                            0.7.5  05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7 \
+    utf8-ranges                      1.0.4  b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba \
+    vec_map                          0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
+    version_check                    0.9.2  b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed \
+    void                             1.0.2  6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d \
+    walkdir                          2.3.1  777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d \
+    want                             0.3.0  1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0 \
+    wasi      0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
+    wasi     0.10.0+wasi-snapshot-preview1  1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f \
+    wasm-bindgen                    0.2.68  1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42 \
+    wasm-bindgen-backend            0.2.68  f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68 \
+    wasm-bindgen-futures            0.4.18  b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da \
+    wasm-bindgen-macro              0.2.68  6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038 \
+    wasm-bindgen-macro-support      0.2.68  f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe \
+    wasm-bindgen-shared             0.2.68  1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307 \
+    web-sys                         0.3.45  4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d \
+    webpki                          0.21.3  ab146130f5f790d45f82aeeb09e55a256573373ec64409fc19a6fb82fb1032ae \
+    webpki-roots                    0.19.0  f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739 \
+    weezl                            0.1.0  a3d2f24b6c3aa92fb33279566dbebf1cbe66b03a73f09aa69cf8cf14d2f9feb9 \
+    winapi                           0.2.8  167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
+    winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
+    winapi-build                     0.1.1  2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                      0.1.5  70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    winreg                           0.7.0  0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69 \
+    ws                               0.9.1  c51a2c47b5798ccc774ffb93ff536aec7c4275d722fd9c740c83cdd1af1f2d94 \
+    ws2_32-sys                       0.2.1  d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e \
+    xml-rs                           0.8.3  b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a \
+    xml5ever                        0.16.1  0b1b52e6e8614d4a58b8e70cf51ec0cc21b256ad8206708bcff8139b5bbd6a59 \
+    xmlparser                       0.13.3  114ba2b24d2167ef6d67d7d04c8cc86522b87f490025f39f0303b7db5bf5e3d8 \
+    yaml-rust                        0.4.4  39f0c922f1a334134dc2f7a8b67dc5d25f0735263feec974345ff706bcf20b0d \


### PR DESCRIPTION
#### Description

New port for the [zola static site generator](https://www.getzola.org/)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G2021
Xcode 12.0.1 12A7300

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
