### PR TITLE
check: update to 0.15.2, cleanup Portfile

### DIFF
--- a/devel/check/Portfile
+++ b/devel/check/Portfile
@@ -1,11 +1,18 @@
-PortSystem          1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name                check
-version             0.10.0
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        libcheck check 0.15.2
+revision            0
+checksums           rmd160  56617db11452f9a72a700e45f03b3982bedfc368 \
+                    sha256  272bc05b0db3b25177c5a4fb266fb67dabb4dc5ebba75f73074924b5c03fcaae \
+                    size    306088
+
 categories          devel
 license             LGPL-2.1+
 maintainers         nomaintainer
-homepage            http://check.sf.net/
+homepage            https://libcheck.github.io/check/
 description         C unit testing framework
 long_description    Check is a unit test framework for C. It \
                     features a simple interface for defining unit \
@@ -18,18 +25,12 @@ long_description    Check is a unit test framework for C. It \
                     source code editors and IDEs.
 platforms           darwin
 
-master_sites        sourceforge:check
-
 depends_build       port:autoconf \
                     port:automake \
                     port:libtool \
                     port:pkgconfig
 
-checksums           rmd160  fbd36eff66e010cbea3d2c0c503e4b4d4a91e730 \
-                    sha256  f5f50766aa6f8fe5a2df752666ca01a950add45079aa06416b83765b1cf71052
-
-configure.args      --infodir=${prefix}/share/info \
-                    --mandir=${prefix}/share/man
+use_autoreconf      yes
 
 test.run            yes
 test.target         check


### PR DESCRIPTION
#### Description
* add modeline
* code moved from sourceforge to github
* set use of autoreconf

###### Tested on
macOS 10.14.6 18G6020
Xcode 11.3.1 11C504

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?