### PR TITLE
evans: don't fetch dependencies in build phase

### DIFF
--- a/devel/evans/Portfile
+++ b/devel/evans/Portfile
@@ -21,9 +21,485 @@ categories          devel
 license             MIT
 installs_libs       no
 
-checksums           rmd160  69f027d174220132e2a5be04b292795bea281842 \
-                    sha256  7f5309d86df5971b50e563ab20ba92aaac73aba1161a330da6de615995922c8f \
-                    size    34534181
+checksums           ${distname}${extract.suffix} \
+                        rmd160  69f027d174220132e2a5be04b292795bea281842 \
+                        sha256  7f5309d86df5971b50e563ab20ba92aaac73aba1161a330da6de615995922c8f \
+                        size    34534181
+
+go.vendors          github.com/pkg/term \
+                        lock    aa71e9d9e942 \
+                        rmd160  8329f2d607e0926bb679c2af74f7a5b0ec50aaa8 \
+                        sha256  c820baf08d8f0932f97160e7e62201a9b2e5b1ef79ae4ef6b8d4c32d676df5f4 \
+                        size    9498 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    go.uber.org/atomic \
+                        repo    github.com/uber-go/atomic \
+                        lock    v1.6.0 \
+                        rmd160  ebfda750cce72e0ad3c9cdca9600b93816da7937 \
+                        sha256  c96dbf4429ae71c1f30cd56e541bbc56f47b933b989b3fa776f1b1e0c3d162b5 \
+                        size    9687 \
+                    github.com/golang/glog \
+                        lock    23def4e6c14b \
+                        rmd160  b5bd9166cd1e073a035b5bbd3c4d9febf2c917a7 \
+                        sha256  2826d20759090e909ba0f8771def236ad6433fc3e44bdc28374b309efe3e57cf \
+                        size    19662 \
+                    github.com/ktr0731/grpc-test \
+                        lock    v0.1.7 \
+                        rmd160  a5719daa24907d521a296bacb5d6e64e4afe2075 \
+                        sha256  9df38b0bd3e8a16f996d07f452314ea9d56e81f6034689964a261610dbed6383 \
+                        size    30461 \
+                    github.com/mitchellh/cli \
+                        lock    v1.0.0 \
+                        rmd160  bd20ce8c189e155c11f6c0e961a73b6d0a21d4f6 \
+                        sha256  d7615a51862dd9b61f738f0693fab1ea5e27540689b0016682fb7fd04018b275 \
+                        size    24148 \
+                    github.com/juju/ansiterm \
+                        lock    720a0952cc2a \
+                        rmd160  c3c15da3b3d62f7caa467b66f45b251e2e868626 \
+                        sha256  a0efc9542e6fe50c97cdd999685ddda6069ab44754a6b3c87c6b18b21899e05b \
+                        size    15418 \
+                    github.com/k0kubun/pp \
+                        lock    v3.0.1 \
+                        rmd160  6126ccc12b66fe9c04daf34acff811246dcbc8a9 \
+                        sha256  6b1c8d5bad8129aa7ad7f51647550ac151b96e9545ab891c36ec0b965846225a \
+                        size    9739 \
+                    github.com/manifoldco/promptui \
+                        lock    v0.7.0 \
+                        rmd160  9dc391ee449f2d9c535ab79b19b2ae54c8340d23 \
+                        sha256  fed2ddd7c8e15bb66c2679dba0b948cda9e752a4aed5149fb1e65fa9c5331445 \
+                        size    26673 \
+                    github.com/spf13/cobra \
+                        lock    v0.0.7 \
+                        rmd160  6546e6f17fc6296e776e3600f1b7927faee9018d \
+                        sha256  1d8a194cf6d7a9e5b2bbcc66b6a4b4fc701ba8823dfd4c0db31bc1c4f4f91b86 \
+                        size    117682 \
+                    github.com/client9/misspell \
+                        lock    v0.3.4 \
+                        rmd160  35b385cb5e39e9505eccbca18ffa2799240710be \
+                        sha256  8193021639e3f4f30db19cb469ac7f43d56d2200eb7749fd868a69319f95fcf1 \
+                        size    239605 \
+                    github.com/hashicorp/go-multierror \
+                        lock    v1.1.0 \
+                        rmd160  868d9a6f0732cba1b2dfbb73556b6a194c797c03 \
+                        sha256  9bd88c4f96aa4c4dcca5c0124e48f540c59754586653924b5e4b7de3af0f8c4a \
+                        size    12091 \
+                    github.com/hashicorp/hcl \
+                        lock    v1.0.0 \
+                        rmd160  ad8d0b523bb708fd6ae77df8bb414c103a75aa92 \
+                        sha256  4fc0e87ac9d3d6cd042f044df2db2703bed569051fb8c179d505edeb4433e96e \
+                        size    70636 \
+                    github.com/pkg/errors \
+                        lock    v0.9.1 \
+                        rmd160  dc065c655f8a24c6519b58f9d1202eb266ecda40 \
+                        sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
+                        size    13422 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.5 \
+                        rmd160  2ce81608a38c6f383a35bccd24d64361df5828c9 \
+                        sha256  7f41acdcba65b1fab5b9b633947a139f9915b60f94bdab486cdbe9d90c54f61e \
+                        size    50815 \
+                    github.com/stretchr/testify \
+                        lock    v1.5.1 \
+                        rmd160  db9d43c3c804950ce9650d830f7dea5434ed83c1 \
+                        sha256  e5f566d1c23fb2b987f8a9f139e32866c1eea8c72051da25bbf6880a4f8c541a \
+                        size    78702 \
+                    github.com/bgentry/speakeasy \
+                        lock    v0.1.0 \
+                        rmd160  cf33541f750b2d597bd22bdf9a88205af5ae4505 \
+                        sha256  32fd3ad8f8ba488804b82b3b6c6361f838c63bb93001494d010ca71566fc99d4 \
+                        size    7495 \
+                    github.com/fsnotify/fsnotify \
+                        lock    v1.4.7 \
+                        rmd160  24712e412814020224e2779186e634610e2f6926 \
+                        sha256  bc839ee158ad34b81c1f11c3b9e3bcbabfba3297f61d165599880c400b8171dc \
+                        size    31147 \
+                    github.com/ktr0731/go-prompt \
+                        lock    7894cc3f2925 \
+                        rmd160  3cb750824e696a296c2c259c2882243a657caebc \
+                        sha256  5447fe27f7dd6f6ec92f1539e3dfebd8becc212a153abb804ebf5d2fcfdf13e6 \
+                        size    42183 \
+                    github.com/ktr0731/dept \
+                        lock    v0.1.3 \
+                        rmd160  ea798fb1d42a519b8a41bdf975bc9e9e3aa0f055 \
+                        sha256  6893d5da5046b92e5020c106b780fb8e2fc4199f05adea984691d9be174aa029 \
+                        size    55580 \
+                    github.com/magiconair/properties \
+                        lock    v1.8.1 \
+                        rmd160  c9768d4c6f488f56d9451cfe00898b00fa185e5a \
+                        sha256  ba7ce8c50bdc43c67c5fd97e741ae49c9279c0d42b8e79f978e6e0cd814fec7c \
+                        size    29730 \
+                    github.com/zchee/go-xdgbasedir \
+                        lock    v1.0.3 \
+                        rmd160  7c829c2bbc2759ee431f99586fd229956e64e53d \
+                        sha256  d88a969083eb9468a8c98173416e16d989c4f2f229c73fa3bd24988b2b949af5 \
+                        size    10670 \
+                    golang.org/x/mod \
+                        lock    v0.2.0 \
+                        rmd160  d3e7249fdb5bbf52bae173899cf440a86af34415 \
+                        sha256  8dc23eb611e895afa9bae9ae942e99c95c9b567f7682ae0e66fdc9f4c17c36e5 \
+                        size    91781 \
+                    golang.org/x/sys \
+                        lock    593003d681fa \
+                        rmd160  8428e885dcbfbe6b527494334b57ab5fa90de6b0 \
+                        sha256  70a98c606efdf3d97b58a95418408962ddf875f7f6fa065891b39518e9ef706f \
+                        size    1051113 \
+                    github.com/fatih/color \
+                        lock    v1.9.0 \
+                        rmd160  1d8418b4f1b3cb597f680b93aaa08afcc9651be4 \
+                        sha256  577c8e778833fec90d76918f138cee9f7765435757b7c92a669e5b34933e0b4f \
+                        size    1231337 \
+                    github.com/gogo/protobuf \
+                        lock    v1.3.1 \
+                        rmd160  16be6b4d8879c774e3b9d9fc29d80cf770632f88 \
+                        sha256  393dda8c157457ce1b3d4003f9012b25528c76b1492d7ba52c9bd7b66c901c13 \
+                        size    2038446 \
+                    github.com/google/go-cmp \
+                        lock    v0.5.2 \
+                        rmd160  5021dfa1c1da165c38f7a1a0b78794204233735f \
+                        sha256  6631e46f37f68fde3c411c90e9b9186526903a2123222f08de658547b1caafca \
+                        size    99774 \
+                    google.golang.org/genproto \
+                        repo    github.com/googleapis/go-genproto \
+                        lock    c45acf45369a \
+                        rmd160  87941d4d9ee5a597c77dd9c3a802b71ce77c56be \
+                        sha256  ef3c4ddeae7833bc4dcfe60ded571f0ab23f38f349d5d7d92bdb18a26c8bef02 \
+                        size    7837576 \
+                    github.com/mitchellh/go-homedir \
+                        lock    v1.1.0 \
+                        rmd160  44b3985e40e5bbb22d11f8622c340f9ed727ea91 \
+                        sha256  024c8a57316c7fbc0eb23cdbfd57f72a74b51beb83d714034d67ee9aba48100c \
+                        size    3366 \
+                    github.com/spf13/cast \
+                        lock    v1.3.0 \
+                        rmd160  26b82e9734f643bc70be8c73742d4a4f514b6dd2 \
+                        sha256  f2913fc10731a578c016701bd10e6a267c299b94e69d8362d258ce8482d14faf \
+                        size    11086 \
+                    github.com/spf13/viper \
+                        lock    v1.7.1 \
+                        rmd160  55d2cf11056c0d6642c4886077a24e295ab2b74b \
+                        sha256  ed5b5c0083fdf44c8a79c2e4cd9b31f428ccf01174ca0f8fc8f15270e2552fd5 \
+                        size    82650 \
+                    golang.org/x/sync \
+                        lock    cd5d95a43a6e \
+                        rmd160  8bef422550566dc5e53557a975560a4f0224e509 \
+                        sha256  0b7b3e06ee571c92736ea8f11b6d2d075ca6e75008f16e8653be49c33e2876a3 \
+                        size    16964 \
+                    github.com/alecthomas/units \
+                        lock    2efee857e7cf \
+                        rmd160  b1fc6e021a0e5579179bf8629e4a50221e4aa805 \
+                        sha256  ebe15098493671b52f282853872f23517613ad484b550881bef8eb1a1257b5aa \
+                        size    3454 \
+                    github.com/improbable-eng/grpc-web \
+                        lock    v0.12.0 \
+                        rmd160  5363b024abef286ca665779c0d5216961fa1c316 \
+                        sha256  1394f50fb23c0b262d34f4a51f496b04c02636d1def214c9ec8c9977a9677820 \
+                        size    377849 \
+                    github.com/lunixbochs/vtclean \
+                        lock    v1.0.0 \
+                        rmd160  28eb7432d03d69a0e3484c49341dd876769ebe55 \
+                        sha256  f6cbd000c28785924742401aa071061b71e321490cc9bea1cec77bfd2c40eb84 \
+                        size    4223 \
+                    github.com/ktr0731/go-multierror \
+                        lock    b7773ae21874 \
+                        rmd160  40a6a26a2d2c0a854807a30ad9aa08357e43ab77 \
+                        sha256  1d9efae7377954a8658c4e524d8720bfff7b38b3a7e54d5e7729660f582c906d \
+                        size    17867 \
+                    github.com/ktr0731/grpc-web-go-client \
+                        lock    v0.2.7 \
+                        rmd160  c196e5f797ac67067ee680c7162ac04227ebcda4 \
+                        sha256  6b61d70588f4ea4b6eb40e862cb197cc2ff0bd8133b11a88fd66172eb3318641 \
+                        size    20536 \
+                    github.com/mattn/go-tty \
+                        lock    523744f04859 \
+                        rmd160  08d61e5102d3028d58b040edacc4d9a787560051 \
+                        sha256  5276a3e36b93a316a61cb05c272c44bd55f7d6b3c4af18a02a1f4823d1831620 \
+                        size    6919 \
+                    github.com/posener/complete \
+                        lock    v1.1.1 \
+                        rmd160  216bede86928670381490cb7e9b64e622557c8ee \
+                        sha256  7f8dd29875483fa28199c76a127d52698b4de6d8c1c936657975d885b90a251e \
+                        size    19019 \
+                    github.com/rakyll/statik \
+                        lock    v0.1.7 \
+                        rmd160  9263c6a794ace45c4314bd0c4c6629dda03436ae \
+                        sha256  1441248897eb6351a1647e341d7be8deb8cd42a910496630d757619492987828 \
+                        size    178426 \
+                    github.com/gopherjs/gopherjs \
+                        lock    0766667cb4d1 \
+                        rmd160  fe92e39110b5c188dcce98abb3b9aa1b64d68f94 \
+                        sha256  abe56698d0855027a1f6030a44924895d781b19526aa8f9b3ef49ed4199f7c57 \
+                        size    217261 \
+                    github.com/hashicorp/go-version \
+                        lock    v1.2.1 \
+                        rmd160  0f4bd846a25d1886e0b49389ef64b86942287d26 \
+                        sha256  bf7d66ca91f84f59277141ec22b5f18ba6facaca23d99b36b0c1a08cc0631f4a \
+                        size    13923 \
+                    github.com/kr/text \
+                        lock    v0.1.0 \
+                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
+                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
+                        size    8691 \
+                    golang.org/x/tools \
+                        lock    e1da425f72fd \
+                        rmd160  472ee5e73f58fca0f1e5faf712b6ce796adf131f \
+                        sha256  623123ff14207027f0ab8ede91c7d1fccb0e3fd4e6f3548d39370fea4e6f59bc \
+                        size    2358578 \
+                    gopkg.in/ini.v1 \
+                        lock    v1.51.0 \
+                        rmd160  fb3d5484b20da6eee5d89fcf693f9fb94e834d5d \
+                        sha256  f7760de2e1e32ed627a3526d3aedafd2c979a40208fdf871fff032e4cb969d98 \
+                        size    43548 \
+                    github.com/mitchellh/copystructure \
+                        lock    v1.0.0 \
+                        rmd160  f302c41c8c05f9f254b5c1354e8aa7ba099fc81b \
+                        sha256  5306cd122f11f481baa0b4c17437dd816e9449c8b91d59475c5e1f5b5edc1a9a \
+                        size    8897 \
+                    github.com/mwitkow/go-conntrack \
+                        lock    cc309e4a2223 \
+                        rmd160  6acfbd89102dcdcf910d60e2d561d150bad39e5a \
+                        sha256  58139f6402a7bc7d7dd69edddad87962517536121bfb5693003b49dfaf50ab99 \
+                        size    16886 \
+                    github.com/rs/cors \
+                        lock    v1.7.0 \
+                        rmd160  3c1f6a7888923f7bab923b27d4f2bfd45cfbe4a1 \
+                        sha256  843f0dd8bc44f775b907ab27de9600e0a18e48ac6758ae751fbb09340871e901 \
+                        size    12154 \
+                    github.com/tj/go-spin \
+                        lock    v1.1.0 \
+                        rmd160  958c16803881df875f8d61a18a0b02aa65c4a8be \
+                        sha256  2683507ba280171e1e84e3e74ad8ffc3402ff144744a7ad368fdc86c4edec6c8 \
+                        size    130196 \
+                    golang.org/x/lint \
+                        lock    16217165b5de \
+                        rmd160  6ecf457d183d152054cca90b7dff0d2f5dc875b4 \
+                        sha256  36bd7b7dca98c2695b9f19a8e2401a2b4d8f8dabc0282bddde40c1eb5cf27b11 \
+                        size    31434 \
+                    github.com/jtolds/gls \
+                        repo    github.com/jtolio/gls \
+                        lock    v4.20.0 \
+                        rmd160  8e721b1aa6de0606caa5a2a038ddd53a0d05d7b4 \
+                        sha256  6f98dcae4c326cbfb0400e6a01604511e544957ea88494e979ace881e2058cbb \
+                        size    7308 \
+                    github.com/kr/pretty \
+                        lock    v0.1.0 \
+                        rmd160  9aa7a5aad4c48840eecfd0f80186d1fb5ded0fd6 \
+                        sha256  f6c3f89667c63e5b7f1fc6ee2c06b6a6bfdce88f3a965ccd395b64c6f95c9a47 \
+                        size    8553 \
+                    github.com/mattn/go-pipeline \
+                        lock    32d779b32768 \
+                        rmd160  36763650ec8cf1c05e0a15831d7df6cfa333edcd \
+                        sha256  fc312056a9c8b333ab51d6a212b3d6932cd69407f599610a765ae7161bbfd6d4 \
+                        size    1902 \
+                    gopkg.in/check.v1 \
+                        lock    788fd7840127 \
+                        rmd160  b63165c8909a27edc15dda210df66a1b49efb49e \
+                        sha256  7e5547c6471cc48da89a7c87f965b20ca5311f43fc4d883ca62f9fccf7551630 \
+                        size    31597 \
+                    gopkg.in/yaml.v2 \
+                        lock    v2.3.0 \
+                        rmd160  2f8fa56d8a413b6288132eeb7f0d7c64d27d877f \
+                        sha256  a8d1a8bc88239d25507456380b47d59ae3683d4a5f4336da4892db1ce026615f \
+                        size    72838 \
+                    github.com/jhump/protoreflect \
+                        lock    10815c273d3f \
+                        rmd160  229bdf802aa7f0018ce39d90d69464279d467508 \
+                        sha256  d62581abb5c014714ba94228f206d03033a5cf04aa5eb833399efb5184d195c2 \
+                        size    501942 \
+                    github.com/mitchellh/reflectwalk \
+                        lock    v1.0.0 \
+                        rmd160  c8f3f4a948ebfd3f69f22663f856e7309877ba8d \
+                        sha256  117a3a92d72f36187cd4aa728890538c9637be7d4ba9a8d7a777c51a15ea8015 \
+                        size    6149 \
+                    google.golang.org/grpc \
+                        repo    github.com/grpc/grpc-go \
+                        lock    v1.31.1 \
+                        rmd160  3570ee8699ededcf72d8775daa749233e206eee3 \
+                        sha256  2e8582c9558ffbfb6d33026fe01b36e03784edfa1c05721a51b6d1441d169686 \
+                        size    969930 \
+                    github.com/chzyer/logex \
+                        lock    v1.1.10 \
+                        rmd160  105d839f798ba0c3e27b3db4e790d9d21a928029 \
+                        sha256  947e61095044d310b0ad92f10ac77c36eaa3c3e2e6181e87428ad10c20930ba3 \
+                        size    4351 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/subosito/gotenv \
+                        lock    v1.2.0 \
+                        rmd160  359083733ab5db2a09169c8d6d070b03463aef60 \
+                        sha256  01fc25c8959371d006a0460132b72710ac120d5400fceebbc1d321d2e9bcd4a0 \
+                        size    7375 \
+                    github.com/gorilla/websocket \
+                        lock    v1.4.2 \
+                        rmd160  784f79f05da87fc2f2af618ad4e1eb576d7c16d8 \
+                        sha256  7805b8fc2002f7d1a7acdaa98feee2d6746d9241db0c597e0ee256cf0ff93a0b \
+                        size    54121 \
+                    github.com/inconshreveable/mousetrap \
+                        lock    v1.0.0 \
+                        rmd160  5c617a09f1432fc543672a0e0c1e13d3752030c2 \
+                        sha256  0e6bae2849f13d12fe361ecac087728e4e97f3482f4cec44f6e7a2c53bb9cd0c \
+                        size    2291 \
+                    github.com/ktr0731/go-updater \
+                        lock    v0.1.5 \
+                        rmd160  1fb4dca261939611215c1c3e2410dc7c30c0dae6 \
+                        sha256  1906bb7c536474589548a5be590028bd7d277fb7a78611bbf088e2d6a9f0cd15 \
+                        size    6998 \
+                    github.com/ktr0731/modfile \
+                        lock    v1.11.2 \
+                        rmd160  66b92dada9564cfd40958bb5461e14703c2fcecf \
+                        sha256  7c2a546bb6d1ff4fe16b79c673f0d87616bd8be34bd0ece9b17f1a8afddd0928 \
+                        size    27663 \
+                    golang.org/x/net \
+                        lock    ff2c4b7c35a0 \
+                        rmd160  dc96bfc4c5902f3e5c9dd91a226cfde9253a489b \
+                        sha256  c381cf981910c7a53a0a78d49d2602f3892c83326a1fc22bf096244014c96c1b \
+                        size    1174388 \
+                    github.com/armon/go-radix \
+                        lock    7fddfc383310 \
+                        rmd160  c23e9776d2dccb4d8f516054df8a7c5019a1a2c1 \
+                        sha256  c9e18e6513e111157e3adb7e3f1c6e277c98f289d0ebc2a838975bd0bded053b \
+                        size    5943 \
+                    github.com/chzyer/readline \
+                        lock    2972be24d48e \
+                        rmd160  933f32b684d0af4b8970d964d610918a9f181df6 \
+                        sha256  f5771c6a3d97166a9536f8a45e85e1c40aed9b02089e395d2f4131681cbf692f \
+                        size    36826 \
+                    github.com/google/go-github \
+                        lock    v17.0.0 \
+                        rmd160  2c1917adfc161a2252354d558352180079005d8d \
+                        sha256  c064b8849dcf8e184e1333f8411c7285e0abeb321ffc268b3798f84d6db5f947 \
+                        size    212064 \
+                    golang.org/x/xerrors \
+                        lock    9bdfabe68543 \
+                        rmd160  eee9929ac1c0380402c45b388077c5c505f13311 \
+                        sha256  dc1be1d7efb43643507e87352ae7161883c48cb5116a20a1739ab93ab558bccf \
+                        size    13661 \
+                    github.com/google/go-querystring \
+                        lock    v1.0.0 \
+                        rmd160  48593728f6bf361fa168bdc87737ee30de24f34b \
+                        sha256  0add5428914c2a378cd9e6e120a4b1e84d69df504b983f99a86aea98a52c5a57 \
+                        size    7536 \
+                    github.com/mattn/go-runewidth \
+                        lock    v0.0.8 \
+                        rmd160  b8241c22c38c3f900825d927ee4aeaf5071d9b30 \
+                        sha256  f5bf317ca979ae9aef8e2703d91abde64bf6674e231a531c971d8015e3d3c4ad \
+                        size    16499 \
+                    github.com/smartystreets/assertions \
+                        lock    b2de0cb4f26d \
+                        rmd160  32d7082172ea8c4a03119f3ffb803f8aad9744ce \
+                        sha256  469875871db96f87e62f76f0bfc4b3b0b9e4761c2a14d4ce12f246797a7c342c \
+                        size    52177 \
+                    github.com/ktr0731/go-shellstring \
+                        lock    v0.1.3 \
+                        rmd160  1f4d92001aa2d22c4b2c6987d9e5b3e61639fa8d \
+                        sha256  7475b6f1932b29131b3f4ca0d5be3bf8946e4750519ee668e782f283810ededb \
+                        size    2598 \
+                    github.com/mattn/go-colorable \
+                        lock    v0.1.7 \
+                        rmd160  47f774c77efaa0bbcd982cb65bed426d047780ba \
+                        sha256  68de4e31d97da97efc400096c599ea37c6cf1cb91501004f05a1017f4653f926 \
+                        size    9570 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.12 \
+                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
+                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
+                        size    4549 \
+                    github.com/pelletier/go-toml \
+                        lock    v1.8.0 \
+                        rmd160  c8bcbcf5947fd070203d8c38d1671c58e59bcac2 \
+                        sha256  06b88ba32c649ea82c0f1bd73ae3aa5f0631e2056b728104d862eac3b25e1045 \
+                        size    96323 \
+                    github.com/phayes/freeport \
+                        lock    95f893ade6f2 \
+                        rmd160  d1fc5421ad2ca6cf03a0838e2b18b5704a32e956 \
+                        sha256  eae7763d5bc66e629379a0c691a5543ccc8b76cf92bd79a4ccf555b023c2512f \
+                        size    3355 \
+                    github.com/BurntSushi/toml \
+                        lock    v0.3.1 \
+                        rmd160  fb9650e2d16525153645e5547626f242f3800149 \
+                        sha256  8cc9e5dc68e247554227973d0b4e023b27bbd9ba5a26e4fb40f44743afcb35f1 \
+                        size    42087 \
+                    github.com/desertbit/timer \
+                        lock    c41aec40b27f \
+                        rmd160  461e3d5bbfd404cb18c84c1feb2d969cc5daf07a \
+                        sha256  89b000634427d5034ed97f707385cc046c4f1c5202c4c112e3429127016350dd \
+                        size    5599 \
+                    github.com/inconshreveable/go-update \
+                        lock    8152e7eb6ccf \
+                        rmd160  7c72b8c458c7bba5ff70464714f7a67b04580d80 \
+                        sha256  1d38cb89d0844e5c2475d873234d8def487b2d2cb720dcc34c5ae39df99e496f \
+                        size    27121 \
+                    github.com/smartystreets/goconvey \
+                        lock    v1.6.4 \
+                        rmd160  a3dfad6131b94d809efad84d30ce45828c6da756 \
+                        sha256  a03963296bb6d031934a651c1e637e8ab2ce9604ce6a16c158ff551e44e7ba79 \
+                        size    1478824 \
+                    github.com/spf13/jwalterweatherman \
+                        lock    v1.1.0 \
+                        rmd160  390db06ec6993dd9479d7fbfeaff1144d4fbc6e9 \
+                        sha256  b75cd39c9d41c3f7e147225b3dbcb077d5e7a5688dc441ec15179bb1a4c6b941 \
+                        size    6870 \
+                    github.com/mitchellh/mapstructure \
+                        lock    v1.1.2 \
+                        rmd160  a4e01781ea5bb0c987e18e8e450c8f1023d5a857 \
+                        sha256  9c1076f5a8e923d028cb65c36143f3b1478cbaa4420e2e8f332719edc2fc4f71 \
+                        size    20992 \
+                    golang.org/x/text \
+                        lock    v0.3.2 \
+                        rmd160  3b9523084f6a8b2e6a6987e49c56f05e22ad69eb \
+                        sha256  d624899dfd390d9d4a77e5c8e5abd8c45f0b6163e0dc7176aee39f25c5f1bed0 \
+                        size    7168458 \
+                    google.golang.org/protobuf \
+                        repo    github.com/protocolbuffers/protobuf-go \
+                        lock    v1.23.0 \
+                        rmd160  b9954ce9dc927216440d55f850073bbf47113143 \
+                        sha256  41a885f3290ce459bcd4251a6df0787ead449c835a718f8f46342cad1dc26b85 \
+                        size    1214926 \
+                    github.com/chzyer/test \
+                        lock    a1ea475d72b1 \
+                        rmd160  61f83d79b356cde63a27df0f2832ef92fcbc216d \
+                        sha256  98d0c7d1dec438459e31886d65190bb45f70c4ed73e35f5ab2f3b8de582ea309 \
+                        size    4007 \
+                    github.com/hashicorp/errwrap \
+                        lock    v1.0.0 \
+                        rmd160  d9bf75f667d7bec9b4b11ca34de7ca722495b914 \
+                        sha256  49e80cf52f294ce69fcc8cd26f06b8d8cee2623f6e0012df871b355fb7b17787 \
+                        size    8351 \
+                    github.com/k0kubun/colorstring \
+                        lock    9440f1994b88 \
+                        rmd160  a11723623f8bce0439dfd2bada5be762525d966e \
+                        sha256  a77a5e55d0ad3a44610645aeb044aafb87f4286228b658b114aa0cc07bf75075 \
+                        size    3632 \
+                    go.uber.org/goleak \
+                        repo    github.com/uber-go/goleak \
+                        lock    v0.10.0 \
+                        rmd160  aef0e765d235e23bbe60e8afca927a56ff6dacc0 \
+                        sha256  46b9051a64ae050a540ef78c962f6ed30aa11df3e0f2981bd4da8258243e724b \
+                        size    7951 \
+                    github.com/golang/protobuf \
+                        lock    v1.4.2 \
+                        rmd160  fbf4477bc008421fde463d79f7bc54a36de91db2 \
+                        sha256  206d74f8fd066bb178135ee9c092e986f8a1e1104df242e148e99e5a839e4ef2 \
+                        size    171802 \
+                    github.com/olekukonko/tablewriter \
+                        lock    v0.0.4 \
+                        rmd160  750bec232562820a4f3ba47cd2864f4c84e7a767 \
+                        sha256  890daf262aee371899075912bab0b3107313bea32846cf796bca83ef9a1dccf5 \
+                        size    19267 \
+                    github.com/spf13/afero \
+                        lock    v1.2.2 \
+                        rmd160  14c42845beaf4ea85310555ff541c3fd993c2977 \
+                        sha256  d14937aa235e66156aab75b2c27085d360d95244214ccfb843cfff771f372317 \
+                        size    46167
+
+build.env-append    GOPROXY=off \
+                    GO111MODULE=off
 
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
#### Description

Per https://trac.macports.org/ticket/61192 this is one of the golang ports that automatically downloads its dependencies at build time.

To fix it, I used `go2port`. Unexpected tricky parts:

- `google.golang.org/protobuf` redirects to `go.googlesource.com/protobuf`, but `go.googlesource.com` can't serve stable tarballs so I had to manually switch to the GitHub mirror at `github.com/protocolbuffers/protobuf-go`
- `github.com/jtolds/gls` has been renamed to `github.com/jtolio/gls`; this needed a manual `repo` specification

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->