### PR TITLE
mingw-binutils: upgrade to 2.35

### DIFF
--- a/_resources/port1.0/group/crossbinutils-1.0.tcl
+++ b/_resources/port1.0/group/crossbinutils-1.0.tcl
@@ -46,6 +46,11 @@ array set crossbinutils.versions_info {
         sha256  f00b0e8803dc9bab1e2165bd568528135be734df3fabf8d0161828cd56028952 \
         size    21637796
     }}
+    2.35 {xz {
+        rmd160  3825ec98bfd8b00009a616e20976c4296aac69bf \
+        sha256  1b11659fb49e20e18db460d44485f09442c8c56d5df165de9461eb09c8302f85 \
+        size    22042160
+    }}
 }
 
 proc crossbinutils.setup {target version} {

--- a/cross/i686-w64-mingw32-binutils/Portfile
+++ b/cross/i686-w64-mingw32-binutils/Portfile
@@ -7,8 +7,8 @@ PortGroup           crossbinutils 1.0
 set mingw_name      w64-mingw32
 set mingw_arch      i686
 set mingw_target    ${mingw_arch}-${mingw_name}
-crossbinutils.setup ${mingw_target} 2.34
-revision            1
+crossbinutils.setup ${mingw_target} 2.35
+revision            0
 
 maintainers         {mojca @mojca} openmaintainer
 

--- a/cross/x86_64-w64-mingw32-binutils/Portfile
+++ b/cross/x86_64-w64-mingw32-binutils/Portfile
@@ -7,8 +7,8 @@ PortGroup           crossbinutils 1.0
 set mingw_name      w64-mingw32
 set mingw_arch      x86_64
 set mingw_target    ${mingw_arch}-${mingw_name}
-crossbinutils.setup ${mingw_target} 2.34
-revision            1
+crossbinutils.setup ${mingw_target} 2.35
+revision            0
 
 maintainers         {mojca @mojca} openmaintainer
 


### PR DESCRIPTION
Upgraded the following files
- crossbinutils-1.0.tcl
- i686-w64-mingw32-binutils
- x86-64-w64-mingw32-binutils

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.14.6 18G6032
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
