### PR TITLE
google-cloud-sdk: update to 312.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             311.0.0
+version             312.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  64f9aa5de60814d1e429f6dfa09043f1144efa9a \
-                    sha256  a82e1ab5748de568871dd897a4feb327a575343c472e7ba4a6b79b2e0faacc38 \
-                    size    85068210
+    checksums       rmd160  f25819fedcfb719f3f39bd7f394479f7b6ccd679 \
+                    sha256  3b88d422be3834e91b447dee1c8995a31eda706daa764b40b3f91aecba0ebcf6 \
+                    size    85181259
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  e46809d8006bb6cff98691d91e7cb96e78b32726 \
-                    sha256  c3d5c0a8f8df656b4d94143346441d4b9feeea47f5121713ee394ff3240196ca \
-                    size    86082243
+    checksums       rmd160  9cad07bc7cb9421177ee8a9a98c04c966e190193 \
+                    sha256  809a2bee632bd71db08a2e6916e0cd8eb83117cbcb4dce1296a83aeed38bfbc7 \
+                    size    86194431
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 312.0.0.

###### Tested on

macOS 10.15.7 19H2
Xcode 12.0.1 12A7300

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?