### PR TITLE
skaffold: update to 1.15.0

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 1.14.0 v
+github.setup        GoogleContainerTools skaffold 1.15.0 v
 revision            0
 
 categories          devel
@@ -23,9 +23,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  d90811be8faff8a51196af10c0c43ef139f024df \
-                    sha256  25e3099f6c444483729808bc3ac5f35d6fc40ad1a648020c3c591de972ac8611 \
-                    size    27385576
+checksums           rmd160  339c0d0c33499bb971034633239048febcb49b4f \
+                    sha256  d16c91191d4d0ac0d8eb29f9fb02462b948faffefcf0d5b91fd6491a3157d8c2 \
+                    size    27144792
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 1.15.0.

###### Tested on

macOS 10.15.7 19H2
Xcode 12.0.1 12A7300

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?