### PR TITLE
thrift +glib2: fix implicit function declaration

### DIFF
--- a/devel/thrift/Portfile
+++ b/devel/thrift/Portfile
@@ -28,6 +28,9 @@ long_description \
 homepage        https://thrift.apache.org/
 master_sites    apache:${name}/${version}
 
+# https://trac.macports.org/ticket/61252
+patchfiles-append   patch-thrift_protocol_decorator.h.diff
+
 depends_build       port:autoconf \
                     port:automake \
                     port:bison \

--- a/devel/thrift/files/patch-0d6a2d3.diff
+++ b/devel/thrift/files/patch-0d6a2d3.diff
@@ -1,0 +1,69 @@
+From 0d6a2d36ea02839313e63421fb1ba4a9de2604ea Mon Sep 17 00:00:00 2001
+From: zeshuai007 <51382517@qq.com>
+Date: Tue, 24 Mar 2020 18:31:37 +0800
+Subject: [PATCH] THRIFT-4272: warnings in glibc library Client: c_glib Patch:
+ Zezeng Wang
+
+This closes #2067
+---
+ .../thrift/c_glib/transport/thrift_socket.h   | 26 +++++++++++++++++++
+ .../c_glib/transport/thrift_ssl_socket.h      |  9 +++++++
+ 2 files changed, 35 insertions(+)
+
+diff --git a/lib/c_glib/src/thrift/c_glib/transport/thrift_socket.h b/lib/c_glib/src/thrift/c_glib/transport/thrift_socket.h
+index c91f52f186..912929e81f 100644
+--- lib/c_glib/src/thrift/c_glib/transport/thrift_socket.h
++++ lib/c_glib/src/thrift/c_glib/transport/thrift_socket.h
+@@ -68,6 +68,32 @@ struct _ThriftSocketClass
+ /* used by THRIFT_TYPE_SOCKET */
+ GType thrift_socket_get_type (void);
+ 
++/**
++ * Check if the socket is open and ready to send and receive
++ * @param transport
++ * @return true if open
++ */
++gboolean
++thrift_socket_is_open (ThriftTransport *transport);
++
++/**
++ * Open connection if required and set the socket to be ready to send and receive
++ * @param transport
++ * @param error
++ * @return true if operation was correct
++ */
++gboolean
++thrift_socket_open (ThriftTransport *transport, GError **error);
++
++/**
++ * Close connection if required
++ * @param transport
++ * @param error
++ * @return true if operation was correct
++ */
++gboolean
++thrift_socket_close (ThriftTransport *transport, GError **error);
++
+ G_END_DECLS
+ 
+ #endif
+diff --git a/lib/c_glib/src/thrift/c_glib/transport/thrift_ssl_socket.h b/lib/c_glib/src/thrift/c_glib/transport/thrift_ssl_socket.h
+index 0ca465a0f3..dd07c63164 100644
+--- lib/c_glib/src/thrift/c_glib/transport/thrift_ssl_socket.h
++++ lib/c_glib/src/thrift/c_glib/transport/thrift_ssl_socket.h
+@@ -188,6 +188,15 @@ thrift_ssl_socket_is_open (ThriftTransport *transport);
+ gboolean
+ thrift_ssl_socket_open (ThriftTransport *transport, GError **error);
+ 
++/**
++ * Close connection if required
++ * @param transport
++ * @param error
++ * @return true if operation was correct
++ */
++gboolean
++thrift_ssl_socket_close (ThriftTransport *transport, GError **error);
++
+ 
+ /**
+  * @brief Initialization function

--- a/devel/thrift/files/patch-thrift_protocol_decorator.h.diff
+++ b/devel/thrift/files/patch-thrift_protocol_decorator.h.diff
@@ -1,0 +1,16 @@
+Upstream-Status: Pending
+--- lib/c_glib/src/thrift/c_glib/protocol/thrift_protocol_decorator.h.orig
++++ lib/c_glib/src/thrift/c_glib/protocol/thrift_protocol_decorator.h
+@@ -67,6 +67,12 @@
+ /* used by THRIFT_TYPE_PROTOCOL_DECORATOR */
+ GType thrift_protocol_decorator_get_type (void);
+ 
++gint32 thrift_protocol_decorator_write_message_begin (
++           ThriftProtocol *protocol,
++           const gchar *name,
++           const ThriftMessageType message_type,
++           const gint32 seqid, GError **error);
++
+ G_END_DECLS
+ 
+ #endif /* _THRIFT_PROTOCOL_DECORATOR_H */

--- a/devel/thrift/files/patch-thrift_ssl_socket.h.diff
+++ b/devel/thrift/files/patch-thrift_ssl_socket.h.diff
@@ -1,0 +1,13 @@
+Upstream-Status: Pending
+--- lib/c_glib/src/thrift/c_glib/transport/thrift_ssl_socket.h.orig
++++ lib/c_glib/src/thrift/c_glib/transport/thrift_ssl_socket.h
+@@ -213,6 +213,9 @@
+  */
+ void
+ thrift_ssl_socket_finalize_openssl(void);
++
++gboolean
++thrift_ssl_socket_authorize(ThriftTransport * transport, GError **error);
+ 
+ G_END_DECLS
+ #endif


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/61252

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.7
Xcode 12 command line tools

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
(`+glib2` variant; reporter stated that default variants already built fine).
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
