### PR TITLE
weechat: update to 2.9, cleanup Portfile

### DIFF
--- a/irc/weechat-devel/Portfile
+++ b/irc/weechat-devel/Portfile
@@ -1,0 +1,12 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           obsolete 1.0
+
+name                weechat-devel
+replaced_by         weechat
+version             2.5-dev-20190424
+revision            1
+categories          irc
+
+# remove after 2021-09-30

--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -1,39 +1,19 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.0
+PortGroup           cmake 1.1
 PortGroup           conflicts_build 1.0
-PortGroup           github 1.0
 
+conflicts           weechat-devel
 name                weechat
+version             2.9
+revision            0
+checksums           rmd160  392af28dcbff7b9546b1d4040c7f3e13486fe968 \
+                    sha256  eab406c385c3a10d0107ddc3aac6596ae8c59af99e9158c6d769e90ec9adfa0e \
+                    size    2206584
 
-if {${name} eq ${subport}} {
-    conflicts       weechat-devel
-    name            weechat
-    version         2.7.1
-    revision        0
-    checksums       rmd160  9d2e5eca3d2579bb1f027fb548ce1da6a88adb47 \
-                    sha256  42ed46277401c64ff2be84a7691c2cbdc24638764f899fa2bdb1d2f364209f29 \
-                    size    3184887
-
-    master_sites    https://weechat.org/files/src/
-    use_bzip2       yes
-}
-
-subport weechat-devel {
-    conflicts       weechat
-    name            weechat-devel
-    version         2.5-dev-20190424
-    revision        0
-    checksums       rmd160  ef1b9219d799507e783f84aab90b163546184139 \
-                    sha256  00ca8188a67175e158fafa356a528731ed6520ae8b629627791653f1b204af1b \
-                    size    2952987
-
-    master_sites    https://weechat.org/files/src/devel/
-    use_bzip2       yes
-    distname        ${name}-20190424
-    worksrcdir      ${name}
-}
+master_sites        https://weechat.org/files/src/
+use_xz              yes
 
 homepage            https://weechat.org/
 license             GPL-3
@@ -51,8 +31,7 @@ long_description    \
     \n - and much more!
 
 categories          irc
-maintainers         {gmail.com:starkhalo @harciga} \
-                    openmaintainer
+maintainers         {isi.edu:calvin @cardi} openmaintainer
 platforms           darwin
 
 depends_build-append \
@@ -70,10 +49,6 @@ depends_lib-append  \
 
 license_noconflict  asciidoctor
 
-cmake.out_of_source yes
-
-conflicts_build v8
-
 configure.args-append \
                     -DENABLE_GNUTLS=OFF \
                     -DENABLE_LUA=OFF \
@@ -90,15 +65,25 @@ configure.args-append \
 
 variant python requires python27 description {Compatibility variant, requires +python27} {}
 
-variant python27 description "Bindings for python 2.7 plugins" conflicts python36 {
+variant python27 description "Bindings for python 2.7 plugins" conflicts python36 python37 python38 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
     configure.args-replace  -DENABLE_PYTHON2=OFF -DENABLE_PYTHON2=ON
     depends_lib-append      port:python27
 }
 
-variant python36 description "Bindings for python 3.6 plugins" conflicts python27 {
+variant python36 description "Bindings for python 3.6 plugins" conflicts python27 python37 python38 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
     depends_lib-append      port:python36
+}
+
+variant python37 description "Bindings for python 3.7 plugins" conflicts python27 python36 python38 {
+    configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
+    depends_lib-append      port:python37
+}
+
+variant python38 description "Bindings for python 3.8 plugins" conflicts python27 python36 python37 {
+    configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
+    depends_lib-append      port:python38
 }
 
 post-patch {
@@ -106,9 +91,12 @@ post-patch {
 
     if {[variant_isset python27]} {
         reinplace -E "s|PYTHON python2|PYTHON python-2.7|g" ${patchfile}
-    }
-    if {[variant_isset python36]} {
+    } elseif {[variant_isset python36]} {
         reinplace -E "s|PYTHON python3|PYTHON python-3.6|g" ${patchfile}
+    } elseif {[variant_isset python37]} {
+        reinplace -E "s|PYTHON python3|PYTHON python-3.7|g" ${patchfile}
+    } elseif {[variant_isset python38]} {
+        reinplace -E "s|PYTHON python3|PYTHON python-3.8|g" ${patchfile}
     }
 }
 


### PR DESCRIPTION
## Description
* remove subport for weechat-devel, which is perpetually outdated as they are nightly builds
* update to cmake 1.1 portgroup
* remove unused github portgroup
* switch to using xz decompression
* remove cmake.out_of_source as default is yes
* add variants for python37, python38

###### Tested on
macOS 10.14.6 18G6020
Xcode 11.3.1 11C504

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

