### PR TITLE
py-tox: update to 3.20.0

### DIFF
--- a/python/py-tox/Portfile
+++ b/python/py-tox/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-tox
-version             3.14.4
+version             3.20.0
 revision            0
 
 categories-append   devel
@@ -19,9 +19,9 @@ long_description    Tox as is a generic virtualenv management and test command l
 
 homepage            https://tox.readthedocs.io/en/latest/
 
-checksums           rmd160  e6245ebf95020c7d9e5ffc645a68d01a929439e7 \
-                    sha256  73e2ade68cd71a2765ee739ecc27c8c92e9b9c09acbad0f2c5307b20214e0d13 \
-                    size    299100
+checksums           rmd160  f7d473ccaa33d766f77458bd67c8d58aa9096478 \
+                    sha256  eb629ddc60e8542fd4a1956b2462e3b8771d49f1ff630cecceacaa0fbfb7605a \
+                    size    307259
 
 python.versions     27 35 36 37 38
 


### PR DESCRIPTION
#### Description

py-tox: update to 3.20.0

  - Closes: https://trac.macports.org/ticket/60858

###### Type(s)

- [x] update

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?