### PR TITLE
py-roman: update to 3.3

### DIFF
--- a/python/py-roman/Portfile
+++ b/python/py-roman/Portfile
@@ -4,8 +4,9 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-roman
-version             3.2
+version             3.3
 revision            0
+
 categories-append   textproc
 license             PSF-2.1.1
 platforms           darwin
@@ -13,24 +14,21 @@ supported_archs     noarch
 maintainers         {aronnax @lpsinger} openmaintainer
 
 description         Integer to Roman numerals converter
-long_description    ${description}
+long_description    {*}${description}.
 
-homepage            https://pypi.python.org/pypi/${python.rootname}/
-master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}/
-distname            ${python.rootname}-${version}
+homepage            https://github.com/zopefoundation/roman
 
-checksums           rmd160  2e67286345ec1021dd28fac57d18c7fb119180a0 \
-                    sha256  b1aa46b531f896b9d3aa05ede8208d785626be16b02c0df57c971fcb9940ae63 \
-                    size    7156
+checksums           rmd160  793b600babe15e5cc811f9eb9fe2fe931378a180 \
+                    sha256  2c46ac8db827d34e4fa9ccc0577e7f0b0d84f16ffe112351bd4f1ec2eb12d73f \
+                    size    7577
 
 python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-                    port:py${python.version}-setuptools
+    depends_build-append    port:py${python.version}-setuptools
 
-    test.run        yes
-    test.cmd        ${python.bin} setup.py
+    test.run                yes
+    test.cmd                ${python.bin} setup.py
 
-    livecheck.type  none
+    livecheck.type          none
 }


### PR DESCRIPTION
#### Description

py-roman: update to 3.3

  - Closes: https://trac.macports.org/ticket/60864

###### Type(s)

- [x] update

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?