### PR TITLE
py-boto3: update to 1.15.9

### DIFF
--- a/python/py-boto3/Portfile
+++ b/python/py-boto3/Portfile
@@ -4,7 +4,9 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-boto3
-version             1.11.9
+version             1.15.9
+revision            0
+
 platforms           darwin
 supported_archs     noarch
 license             Apache-2
@@ -18,19 +20,17 @@ long_description    Boto3 is the Amazon Web Services (AWS) Software \
 
 homepage            https://github.com/boto/boto3
 
-checksums           rmd160  b0396b6352c17a3ff53fe5b087fd003493c2f68f \
-                    sha256  05f7ae180813fbf11cb7397b43b6bd29463abdc246bee58127836f1a8f6a9a2f \
-                    size    98335
+checksums           rmd160  4d88f2ae027c6eeec1a5947244fb51237d8da681 \
+                    sha256  02f5f7a2b1349760b030c34f90a9cb4600bf8fe3cbc76b801d122bc4cecf3a7f \
+                    size    97133
 
 python.versions     27 35 36 37 38
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-                        port:py${python.version}-setuptools
-    depends_run-append \
-                        port:py${python.version}-botocore \
-                        port:py${python.version}-jmespath \
-                        port:py${python.version}-s3transfer
+    depends_build-append    port:py${python.version}-setuptools
+    depends_run-append      port:py${python.version}-botocore \
+                            port:py${python.version}-jmespath \
+                            port:py${python.version}-s3transfer
 
-    livecheck.type      none
+    livecheck.type          none
 }


### PR DESCRIPTION
#### Description

py-boto3: update to 1.15.9

  - Closes: https://trac.macports.org/ticket/60862

###### Type(s)

- [x] update

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?