### PR TITLE
py-cachelib: new port

### DIFF
--- a/python/py-cachelib/Portfile
+++ b/python/py-cachelib/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-cachelib
+version             0.1.1
+platforms           darwin
+license             BSD-3-Clause
+supported_archs     noarch
+
+maintainers         {@harens gmail.com:harensdeveloper} \
+                    openmaintainer
+
+description         A collection of cache libraries in the same API interface
+long_description    ${description}
+
+homepage            https://github.com/pallets/cachelib
+
+checksums           rmd160 853477722db4002358a736f3853a7f98a5d8ff88 \
+                    sha256 47e95a67d68c729cbad63285a790a06f0e0d27d71624c6e44c1ec3456bb4476f \
+                    size   10192
+
+python.versions     38
+
+if {${name} ne ${subport}} {
+
+    depends_build-append \
+                        port:py${python.version}-setuptools
+
+    livecheck.type      none
+}


### PR DESCRIPTION
#### Description

In the hopes of updating the [howdoi](https://ports.macports.org/port/howdoi/summary) port, I've created a portfile for cachelib since it acts a a new dependency.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
