### PR TITLE
chezmoi: don't fetch dependencies in build phase

### DIFF
--- a/sysutils/chezmoi/Portfile
+++ b/sysutils/chezmoi/Portfile
@@ -11,10 +11,6 @@ installs_libs       no
 
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
 
-checksums           rmd160  dbc161306926fc3b53f2a9e4ff909820f9b4c72a \
-                    sha256  7be6973a9d66fdce7faaea69ea8d77ac59d7759c06d0cb4d030f3b01198e840b \
-                    size    2249192
-
 homepage            https://chezmoi.io/
 
 description         Manage your dotfiles across multiple machines, securely.
@@ -22,7 +18,469 @@ description         Manage your dotfiles across multiple machines, securely.
 long_description    chezmoi helps you manage your personal configuration \
                     files (dotfiles, like ~/.bashrc) across multiple machines.
 
+checksums           ${distname}${extract.suffix} \
+                        rmd160  dbc161306926fc3b53f2a9e4ff909820f9b4c72a \
+                        sha256  7be6973a9d66fdce7faaea69ea8d77ac59d7759c06d0cb4d030f3b01198e840b \
+                        size    2249192
+
+go.vendors          github.com/bmatcuk/doublestar \
+                        lock    v2.0.1 \
+                        rmd160  1305273e993dfe3cf9563325cf94186b1ba39ad0 \
+                        sha256  370683cb9146b8239ef1c5367b75f26437c001dc6854de027b28bd86559bc918 \
+                        size    10954 \
+                    github.com/go-git/go-billy \
+                        lock    v5.0.0 \
+                        rmd160  f11fe7645d65d1981a0d69e75bb8983ef944e367 \
+                        sha256  22ebd4234d9dc54f926f5b1c30c857c75d5342b25508b3961415210efa77ed44 \
+                        size    27963 \
+                    github.com/jtolds/gls \
+                        repo    github.com/jtolio/gls \
+                        lock    v4.20.0 \
+                        rmd160  8e721b1aa6de0606caa5a2a038ddd53a0d05d7b4 \
+                        sha256  6f98dcae4c326cbfb0400e6a01604511e544957ea88494e979ace881e2058cbb \
+                        size    7308 \
+                    github.com/magiconair/properties \
+                        lock    v1.8.3 \
+                        rmd160  5a45ba4801b7e5b93c04d0edf1e519b5bdf88f3d \
+                        sha256  0c570f7f0fe68cdccfdbe2ab6b505d1c219b94a69904713da71871336e3cd132 \
+                        size    30270 \
+                    github.com/smartystreets/goconvey \
+                        lock    v1.6.4 \
+                        rmd160  a3dfad6131b94d809efad84d30ce45828c6da756 \
+                        sha256  a03963296bb6d031934a651c1e637e8ab2ce9604ce6a16c158ff551e44e7ba79 \
+                        size    1478824 \
+                    github.com/spf13/afero \
+                        lock    v1.4.0 \
+                        rmd160  3a158e428fafbba1358018982e5c9432d62f3c7a \
+                        sha256  a9eac1879e3b4b4f55ba87d8bb67d02c9aa097cb9f6167a9807e55a15ae77419 \
+                        size    58556 \
+                    github.com/Masterminds/sprig \
+                        lock    v3.1.0 \
+                        rmd160  b0f805018cff92f35ff80a0b0aeefc0f1835a1ce \
+                        sha256  ef40524fc52d151989b42f77321674ee88b7c654d8e35f449849ca21b695e885 \
+                        size    49999 \
+                    github.com/google/goterm \
+                        lock    fc88cf888a3f \
+                        rmd160  f9ec53def00acffe1d5fe5976dc0114a02305a73 \
+                        sha256  e3c84437911cb3c3500f4486b1ae9c7dc1e6e020185187203697f4a39401d77a \
+                        size    18304 \
+                    github.com/gorilla/css \
+                        lock    v1.0.0 \
+                        rmd160  a6274905033f83d731f9cd6c1924b80930857f6c \
+                        sha256  665368712e603d7cdd3e4648eef0ed051237f7284c55f6f571c7ee766d6d20de \
+                        size    6447 \
+                    github.com/huandu/xstrings \
+                        lock    v1.3.2 \
+                        rmd160  b92c0e29b345b7f7cbe79e773f9855375e7bcb2c \
+                        sha256  97bda2aeca4ae1b66f4113ce16d5d861c124baf8f38e22064f5dbd0accb04c57 \
+                        size    17916 \
+                    github.com/inconshreveable/mousetrap \
+                        lock    v1.0.0 \
+                        rmd160  5c617a09f1432fc543672a0e0c1e13d3752030c2 \
+                        sha256  0e6bae2849f13d12fe361ecac087728e4e97f3482f4cec44f6e7a2c53bb9cd0c \
+                        size    2291 \
+                    golang.org/x/oauth2 \
+                        lock    5d25da1a8d43 \
+                        rmd160  32d43c197a403ca59ccb604d752a2ee272ef9c1c \
+                        sha256  7d815f226abc979f687c3a2275173a5cf6a07a65af27f4343f58ea21114132dd \
+                        size    59449 \
+                    google.golang.org/appengine \
+                        repo    github.com/golang/appengine \
+                        lock    v1.6.6 \
+                        rmd160  ee3e5a6d2742607fd310e18634c1268156f39ad4 \
+                        sha256  084ba3a248eccd0c7606dc6cff3918326a0adb2e8d30babcbaf6f1c00e1d28f9 \
+                        size    333013 \
+                    github.com/emirpasic/gods \
+                        lock    v1.12.0 \
+                        rmd160  5633e4a005c1e335bc00708aefebb0f475d30774 \
+                        sha256  c379f9a4fae5a2defdaa314deab1e201228e866a502afa8948117e52cf644ce2 \
+                        size    76836 \
+                    github.com/google/go-querystring \
+                        lock    v1.0.0 \
+                        rmd160  48593728f6bf361fa168bdc87737ee30de24f34b \
+                        sha256  0add5428914c2a378cd9e6e120a4b1e84d69df504b983f99a86aea98a52c5a57 \
+                        size    7536 \
+                    github.com/fsnotify/fsnotify \
+                        lock    v1.4.9 \
+                        rmd160  4660b5721da8aea4c890786e49d7cec39c2e04d3 \
+                        sha256  7920cf1e5ccf268962fcff0b501398ed6c28ed75b1e1281fb17b19a8b0e4db5c \
+                        size    31910 \
+                    github.com/twpayne/go-vfs \
+                        lock    v1.7.0 \
+                        rmd160  885e73d010c4e4a860163a05d73fd824dddeaf5a \
+                        sha256  7ace3377aa2da03b01884619ba6192d9cb3451c3c6c6286a901354376ce1b1e7 \
+                        size    16356 \
+                    gopkg.in/yaml.v3 \
+                        lock    9f266ea9e77c \
+                        rmd160  06dca2ede07b2f31c515b4711fbebc1d5359b5e4 \
+                        sha256  e70dd42fb30b7b2d0129c5cdf0e079caaf5602cab24081fdac830ec01204fa59 \
+                        size    86890 \
+                    gopkg.in/yaml.v2 \
+                        lock    v2.3.0 \
+                        rmd160  2f8fa56d8a413b6288132eeb7f0d7c64d27d877f \
+                        sha256  a8d1a8bc88239d25507456380b47d59ae3683d4a5f4336da4892db1ce026615f \
+                        size    72838 \
+                    github.com/spf13/viper \
+                        lock    v1.7.1 \
+                        rmd160  55d2cf11056c0d6642c4886077a24e295ab2b74b \
+                        sha256  ed5b5c0083fdf44c8a79c2e4cd9b31f428ccf01174ca0f8fc8f15270e2552fd5 \
+                        size    82650 \
+                    github.com/mitchellh/copystructure \
+                        lock    v1.0.0 \
+                        rmd160  f302c41c8c05f9f254b5c1354e8aa7ba099fc81b \
+                        sha256  5306cd122f11f481baa0b4c17437dd816e9449c8b91d59475c5e1f5b5edc1a9a \
+                        size    8897 \
+                    github.com/sergi/go-diff \
+                        lock    v1.1.0 \
+                        rmd160  6449feb5884c316206f256e55b81aba3e6a78a9f \
+                        sha256  026d3d6db40ad086954214a7f3f84b66e352d47ce259bb59b7c2b9bd843b9935 \
+                        size    43569 \
+                    github.com/spf13/jwalterweatherman \
+                        lock    v1.1.0 \
+                        rmd160  390db06ec6993dd9479d7fbfeaff1144d4fbc6e9 \
+                        sha256  b75cd39c9d41c3f7e147225b3dbcb077d5e7a5688dc441ec15179bb1a4c6b941 \
+                        size    6870 \
+                    github.com/twpayne/go-shell \
+                        lock    v0.3.0 \
+                        rmd160  d4e82c3a7369d714c08e5e85d9ea246a53c1588e \
+                        sha256  c427898d6f070838109f13d54626d9608ba1231f08119baf145f74bc3248c051 \
+                        size    3776 \
+                    github.com/xanzy/ssh-agent \
+                        lock    v0.2.1 \
+                        rmd160  356547460413381067ab37d9a8ce904dc91e5d9b \
+                        sha256  0e439b2a0962200a2e7872fb8cfe8f9be6942aa66a89230c805aac3ddc456664 \
+                        size    7623 \
+                    golang.org/x/sync \
+                        lock    e225da77a7e6 \
+                        rmd160  25a34f1d1411e854951b783ce407f6b0ba98f459 \
+                        sha256  7313f1f3044d6ed259893247cc47593e4a717430f3b7431af0a3b73c2e20c05b \
+                        size    16285 \
+                    github.com/lucasb-eyer/go-colorful \
+                        lock    v1.0.3 \
+                        rmd160  0d0a283ba00c871d123c951efea0605a869951aa \
+                        sha256  ecd902ddda5d05cc8a857873bf8b984a5cd2d7b75f1185edcfc2c472707958b3 \
+                        size    430208 \
+                    github.com/dlclark/regexp2 \
+                        lock    v1.2.1 \
+                        rmd160  c1508c3f553c2dc7563162bc3fd8a68fe18e51a6 \
+                        sha256  21b6dbfe6889d4154e1aaf3c0a9f30a47d13d70c818dd8d90f943bbeb845f284 \
+                        size    204626 \
+                    github.com/go-git/go-git \
+                        lock    v5.1.0 \
+                        rmd160  4e9eb8e8c9931e7bd9cfc53887d808af0dae86f5 \
+                        sha256  98f322ea0ccb50c4edeb858c5a83222d7c5b9ca12cf3c544fa9bc20fe5e0d39f \
+                        size    451279 \
+                    github.com/niemeyer/pretty \
+                        lock    a10e7caefd8e \
+                        rmd160  46bcfc3db9e3d98acbacd1f96d9483fa360f88b7 \
+                        sha256  97b952a32175ba84349ef352e523bfa15bf3a06e07e44458a908061fbc519b40 \
+                        size    9405 \
+                    github.com/pelletier/go-toml \
+                        lock    v1.8.1 \
+                        rmd160  f217f227783a53335e26133c21989ae17168f5ad \
+                        sha256  6284580cffabb9b00f42a28465760b33d10457172237be89e70c68a2da4695b2 \
+                        size    98857 \
+                    github.com/alecthomas/chroma \
+                        lock    v0.8.0 \
+                        rmd160  b6b788183fb0ab2b448a070ad925a0bdcd046ee2 \
+                        sha256  40e98f2f30210815d78e76d1f64f234123d6b130b33ac5d7b440f92556987093 \
+                        size    623331 \
+                    github.com/muesli/reflow \
+                        lock    v0.1.0 \
+                        rmd160  13053733dc25f1701d054f383406e72e4976d5a0 \
+                        sha256  85df09198af423b2b25e742fec97a4807d5fcc2731a27df2042b86515e64c2d7 \
+                        size    16198 \
+                    github.com/mattn/go-runewidth \
+                        lock    v0.0.9 \
+                        rmd160  412c0e508e55f4fe437be0f71d7d22eca2b4366f \
+                        sha256  4f0f4a22257ccecfb6beae88052d850380ecc0e806d6bcc92d3656ebcac3b638 \
+                        size    16716 \
+                    github.com/chris-ramon/douceur \
+                        lock    v0.2.0 \
+                        rmd160  f76ad3a78a7c9817f210ff559ff08b91c2a91163 \
+                        sha256  c6c3d47d72a7069e7b21b25e2ce69d84cd727301ff4972e875b43cc79f723dbe \
+                        size    20933 \
+                    github.com/hashicorp/hcl \
+                        lock    v1.0.0 \
+                        rmd160  ad8d0b523bb708fd6ae77df8bb414c103a75aa92 \
+                        sha256  4fc0e87ac9d3d6cd042f044df2db2703bed569051fb8c179d505edeb4433e96e \
+                        size    70636 \
+                    github.com/imdario/mergo \
+                        lock    v0.3.11 \
+                        rmd160  8b9ee50b62ecc6c7db250e5f79227c45d30e9099 \
+                        sha256  98e213812b15d8edf13ba17b6011af1ddc7432cd5d3781e2e88c94fcc355c43b \
+                        size    22076 \
+                    github.com/kr/text \
+                        lock    v0.2.0 \
+                        rmd160  48558c7e8ff67d510f83c66883907e95f4783163 \
+                        sha256  2f2e21ac8a9d523e88cbba4039441defc4a66bfaa78811c900a88fcf28729c4c \
+                        size    8702 \
+                    github.com/shurcooL/sanitized_anchor_name \
+                        lock    v1.0.0 \
+                        rmd160  c7e5322dba53e10db1711d65c146af5649b0c7c8 \
+                        sha256  ed9418de8c92acfbbd8608745855ebfc67fa686c0a0a5245cf8eece8f540baa9 \
+                        size    2144 \
+                    github.com/stretchr/testify \
+                        lock    v1.6.1 \
+                        rmd160  7e5b798212a8f15cd58a63985ae0b928eede8e6b \
+                        sha256  44d77d9b5c1dc08fa710eac9bb324898210660458085cdf965b78a39b1010f2a \
+                        size    84248 \
+                    github.com/subosito/gotenv \
+                        lock    v1.2.0 \
+                        rmd160  359083733ab5db2a09169c8d6d070b03463aef60 \
+                        sha256  01fc25c8959371d006a0460132b72710ac120d5400fceebbc1d321d2e9bcd4a0 \
+                        size    7375 \
+                    github.com/Masterminds/goutils \
+                        lock    v1.1.0 \
+                        rmd160  9c73de9ffa7bbf68eb496d9d18f26a206fe5608d \
+                        sha256  d5edbcb0d321e69213764b9db9afea1aee72316b227bc5dbaf0177a726074482 \
+                        size    14608 \
+                    golang.org/x/text \
+                        lock    v0.3.3 \
+                        rmd160  babfa547ba9a9dab7fe08fa5543f1d8e7ae00301 \
+                        sha256  1c4a8c12295d484e0360d8e010ebc4b8a9a05aa2a07c10c3d3e5b17aa063f0db \
+                        size    7745597 \
+                    github.com/google/renameio \
+                        lock    v0.1.0 \
+                        rmd160  ba2fe6be9202636dcf17dd2d1c495aceed231cc9 \
+                        sha256  dd166ecfcacfff3e36567edab9ef94affe756932becbf382939c20646f504a83 \
+                        size    9728 \
+                    github.com/kr/pretty \
+                        lock    v0.1.0 \
+                        rmd160  9aa7a5aad4c48840eecfd0f80186d1fb5ded0fd6 \
+                        sha256  f6c3f89667c63e5b7f1fc6ee2c06b6a6bfdce88f3a965ccd395b64c6f95c9a47 \
+                        size    8553 \
+                    github.com/olekukonko/tablewriter \
+                        lock    v0.0.4 \
+                        rmd160  750bec232562820a4f3ba47cd2864f4c84e7a767 \
+                        sha256  890daf262aee371899075912bab0b3107313bea32846cf796bca83ef9a1dccf5 \
+                        size    19267 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/yuin/goldmark \
+                        lock    v1.2.1 \
+                        rmd160  bfa2a3a3a6f25b7f40c4436e6e479d65e36d68aa \
+                        sha256  25cb7a8140e2488912f3423da2dbe754ef03fc92cd2545048c1897a0bda2d863 \
+                        size    228498 \
+                    golang.org/x/crypto \
+                        lock    5c72a883971a \
+                        rmd160  090821b28d0329a087b91a964a53937f3ce0047a \
+                        sha256  a82c522eb9ec32fd6d5511793d1325495caf63371fffc5ac82f1fea63e99664a \
+                        size    1732437 \
+                    gopkg.in/warnings.v0 \
+                        lock    v0.1.2 \
+                        rmd160  e0245ded51f41ce8051ae561d1a0b844f4b8f181 \
+                        sha256  547803dff3ec1c7adb69c411e7b3846595c3265d22a8888001661504d23bd4fb \
+                        size    3772 \
+                    github.com/BurntSushi/toml \
+                        lock    v0.3.1 \
+                        rmd160  fb9650e2d16525153645e5547626f242f3800149 \
+                        sha256  8cc9e5dc68e247554227973d0b4e023b27bbd9ba5a26e4fb40f44743afcb35f1 \
+                        size    42087 \
+                    github.com/coreos/go-semver \
+                        lock    v0.3.0 \
+                        rmd160  c4586d02e1c2747dbc72aab4bc10e0cc32703b03 \
+                        sha256  1bbfd8b72c657327bc3d347ca26567d3de99452354eb999695f5ecb3db8ec1fa \
+                        size    10670 \
+                    github.com/danwakefield/fnmatch \
+                        lock    cbb64ac3d964 \
+                        rmd160  19ae7b520847e16b0e8ac23ee5e6c51db3831f46 \
+                        sha256  2b045b8a716e3ca32d2a930781cd421b042d0e861fa3d36a79ed5535b2e5308a \
+                        size    4960 \
+                    github.com/go-git/gcfg \
+                        lock    v1.5.0 \
+                        rmd160  06a73e4c1e53089b6db690754fa04807e5c4a2e1 \
+                        sha256  f5d75c45f9c00c769bb9c85d4d90ebed5a93d24d47d615ef4ca052093ab9f692 \
+                        size    28538 \
+                    github.com/google/go-cmp \
+                        lock    v0.5.1 \
+                        rmd160  f557725ca7d868edfc5d70b1d69bd33570ef5c81 \
+                        sha256  e2c3dc6f5e6e07e5034cad315b76919ee7a7dbdf122ff76eeabd2d8b719a3d57 \
+                        size    99629 \
+                    github.com/jbenet/go-context \
+                        lock    d14ea06fba99 \
+                        rmd160  37097898ecea5e875655fde48f48f126e0331246 \
+                        sha256  ce27afd2576a5bc82565c8aa2ef108b1bb3c4dd80ebb4939455cab2495b74a2f \
+                        size    5943 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.5 \
+                        rmd160  2ce81608a38c6f383a35bccd24d64361df5828c9 \
+                        sha256  7f41acdcba65b1fab5b9b633947a139f9915b60f94bdab486cdbe9d90c54f61e \
+                        size    50815 \
+                    go.etcd.io/bbolt \
+                        repo    github.com/etcd-io/bbolt \
+                        lock    v1.3.5 \
+                        rmd160  95dffb4bbbeec637c46a4ddd0ee218fa2fa4c3c8 \
+                        sha256  ca218846d724343915b264d1c246c34eb39e81ed14535931f370c2db838d4d99 \
+                        size    96543 \
+                    github.com/aymerick/douceur \
+                        lock    v0.2.0 \
+                        rmd160  84476f7c75bac3becc1fbdd8afce7fbb56ea97a3 \
+                        sha256  61f436302495e77e790979b25097aaf1e4e0f07bc8173f1d87232d199a7ada28 \
+                        size    20929 \
+                    gopkg.in/ini.v1 \
+                        lock    v1.61.0 \
+                        rmd160  7347de7fb3a4da236f0ac393607f5a793b190098 \
+                        sha256  9849c87e1c3fd3767476e0fcd92fa3ddae59a579ae018b9687713f12cf3b001f \
+                        size    49699 \
+                    golang.org/x/net \
+                        lock    62affa334b73 \
+                        rmd160  250b28a64f34025db998066fbfaa84d28f33efa1 \
+                        sha256  e79476f4b54675d1a9be1be7e17b38c332d2d4d7e102f8de2eff3468869052b3 \
+                        size    1179180 \
+                    github.com/muesli/termenv \
+                        lock    v0.7.2 \
+                        rmd160  a839579991fdf8c52a3f16cc1fabab40c7b2d31c \
+                        sha256  dab79d90c08eb0fd9501864965c312581c65ec4005b265e592230b73d29badb4 \
+                        size    405826 \
+                    github.com/pkg/diff \
+                        lock    5b29258ca4f7 \
+                        rmd160  f64e901711bf8a99a3bd67e64fc4a1db4a4fb083 \
+                        sha256  52a522dc9d3001ff39a69b9e5025e94da6b783e2705ecf9cac960546587d942e \
+                        size    201074 \
+                    github.com/rogpeppe/go-internal \
+                        lock    v1.6.2 \
+                        rmd160  2846fb5b3dc0aa3ebf74166c27b7593b72efd67f \
+                        sha256  3cea19a23e8e335c8fdd80e3fd2273f3bb5d4cbe558cc38971db2476e89b73bd \
+                        size    123232 \
+                    github.com/spf13/cast \
+                        lock    v1.3.1 \
+                        rmd160  d4ab928edfe2ad8aafbc3248287b788c65ec155f \
+                        sha256  a33b9fbe9c9dd9cc2bb54f43bcd9a4b5503666c028448bc1b600d46961ffb604 \
+                        size    11103 \
+                    github.com/alecthomas/repr \
+                        lock    117648cd9897 \
+                        rmd160  1f78bc0844f7ca6ccb93808bb367080e4c3accf8 \
+                        sha256  6715287714f895ceeed848842618084ea0fb4a53f0b904d9c456bea28ea31e16 \
+                        size    4649 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.12 \
+                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
+                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
+                        size    4549 \
+                    golang.org/x/xerrors \
+                        lock    5ec99f83aff1 \
+                        rmd160  6e8267f353e153297f205e4be219236d6ae43880 \
+                        sha256  9a500a49d83a09e7de6c71b215d1c14b81e315d26884530ef327c95ddf1f2d28 \
+                        size    13667 \
+                    github.com/gopherjs/gopherjs \
+                        lock    0766667cb4d1 \
+                        rmd160  fe92e39110b5c188dcce98abb3b9aa1b64d68f94 \
+                        sha256  abe56698d0855027a1f6030a44924895d781b19526aa8f9b3ef49ed4199f7c57 \
+                        size    217261 \
+                    github.com/golang/protobuf \
+                        lock    v1.4.2 \
+                        rmd160  fbf4477bc008421fde463d79f7bc54a36de91db2 \
+                        sha256  206d74f8fd066bb178135ee9c092e986f8a1e1104df242e148e99e5a839e4ef2 \
+                        size    171802 \
+                    gopkg.in/errgo.v2 \
+                        lock    v2.1.0 \
+                        rmd160  6629a8436aacbbf5e42c0211d591941bfd8ce34d \
+                        sha256  c14c14eba0928e6dfa4f89449bdbe2b6feafc76116b60bdc1b51956abf55c6bf \
+                        size    9938 \
+                    github.com/alecthomas/colour \
+                        lock    60882d9e2721 \
+                        rmd160  9f588ca134237b19f19199a088974aefebe3b301 \
+                        sha256  9178279e7dbff10a8325724c84b344dfcf365578d30d3f436db5fb1cba1030d5 \
+                        size    3484 \
+                    github.com/alecthomas/assert \
+                        lock    405dbfeb8e38 \
+                        rmd160  5d141a90e1e313657b558c19d51c3bdd65b0e5e5 \
+                        sha256  8c445be2c7daa6b680bfbf96823192076bbf9c0f514642687d6487fd95630a5e \
+                        size    71075 \
+                    github.com/charmbracelet/glamour \
+                        lock    v0.2.0 \
+                        rmd160  1205d9655edcde0bf22c9d41f2df22c641c26aac \
+                        sha256  d62259992d3f8b6fc8632f8745b4118b5bc83a117081607c7b02907c8dc2935f \
+                        size    511666 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/google/go-github \
+                        lock    v32.1.0 \
+                        rmd160  2c7249a24c62103a98bd2d28d08536bef2e4ce0e \
+                        sha256  6f8cf86c668f111decb7288ec5f0dc302bce435e1f39ea5c3bf510707b83f9ce \
+                        size    336971 \
+                    github.com/microcosm-cc/bluemonday \
+                        lock    v1.0.4 \
+                        rmd160  b3765357163b9f2774c3f7ba41b4a53c138bb47f \
+                        sha256  7b9f925d02be6c5ebb05c03188ccfa65818200440f4420a794842072ad69191c \
+                        size    160307 \
+                    github.com/mitchellh/go-homedir \
+                        lock    v1.1.0 \
+                        rmd160  44b3985e40e5bbb22d11f8622c340f9ed727ea91 \
+                        sha256  024c8a57316c7fbc0eb23cdbfd57f72a74b51beb83d714034d67ee9aba48100c \
+                        size    3366 \
+                    github.com/mitchellh/reflectwalk \
+                        lock    v1.0.1 \
+                        rmd160  34a6df5e29ac807529773632fc45dc95b616a02b \
+                        sha256  14787431b47b9b32893f244a5884ce18dce5e3d9612f6b8190393cb071cf2f75 \
+                        size    6454 \
+                    github.com/Masterminds/semver \
+                        lock    v3.1.0 \
+                        rmd160  9566932607417056e0a966ca7c18c0f9515ab532 \
+                        sha256  c50b0ed060252fbd721310c9dde17dc865e2e58c62306009e9d5101932c8c9b9 \
+                        size    24485 \
+                    google.golang.org/protobuf \
+                        repo    github.com/protocolbuffers/protobuf-go \
+                        lock    v1.25.0 \
+                        rmd160  ca1a78077118747c660917e50c4273d69b0f04ea \
+                        sha256  5bc3eb5d7160ab9ae45255d6b718c1cf9e9ed80c244b7527bced50370ae18620 \
+                        size    1259096 \
+                    gopkg.in/check.v1 \
+                        lock    8fa46927fb4f \
+                        rmd160  c84f37dc900224c5e9e6e16ed5acc0d625583bc1 \
+                        sha256  c41439b343f3fc3c0b6f943b4aae642f10f19451e945c23dfb324c9c8f87d0b7 \
+                        size    31616 \
+                    github.com/spf13/cobra \
+                        lock    v1.0.0 \
+                        rmd160  73602c4d37ad508ba8b35812c793e1df3eda7bb9 \
+                        sha256  6cdf3f445559b8f41f5288366a4c26e8d1b1601dac6924af091a49f1f6b11396 \
+                        size    128931 \
+                    github.com/kevinburke/ssh_config \
+                        lock    01f96b0aa0cd \
+                        rmd160  c962defaa545cfeafa69e015b409607091fa81ee \
+                        sha256  d1c0dd1bc30b97aa5fbbd5092aa90acb4f456aba9cc4f1843cb6d54f1265aacc \
+                        size    17343 \
+                    github.com/mitchellh/mapstructure \
+                        lock    v1.3.3 \
+                        rmd160  3421ebe013dbd552d810778403645c4c2c33be78 \
+                        sha256  4b425977dde91b0d39ef9a12c20362f837f93d84e3e20f3f4a9d0fe561bfd34e \
+                        size    26065 \
+                    github.com/smartystreets/assertions \
+                        lock    b2de0cb4f26d \
+                        rmd160  32d7082172ea8c4a03119f3ffb803f8aad9744ce \
+                        sha256  469875871db96f87e62f76f0bfc4b3b0b9e4761c2a14d4ce12f246797a7c342c \
+                        size    52177 \
+                    github.com/twpayne/go-vfsafero \
+                        lock    v1.0.0 \
+                        rmd160  bd382e7d21e87af609b41b3396e623c5561f8225 \
+                        sha256  fe08ace5655e47ba1da6f1546716d1dd18dc2e94b9adab43b26c43edc2cb04a1 \
+                        size    2552 \
+                    github.com/twpayne/go-xdg \
+                        lock    v3.1.0 \
+                        rmd160  169454ec66c7f8de3a48c75216b25c368363cadb \
+                        sha256  7849ee4b206a4417e12cba346d7502bb4276b880a1505215b43ab0e28fb31d2c \
+                        size    4782 \
+                    golang.org/x/sys \
+                        lock    af09f7315aff \
+                        rmd160  2e2294bcbcefb80f8ad5a51d474a18f08f8ffcdb \
+                        sha256  9ee36a2c435fda5e5b9d80c764d9972d5110a232418ec1f4f0fb9e5307e0cd51 \
+                        size    1063406 \
+                    github.com/google/uuid \
+                        lock    v1.1.2 \
+                        rmd160  2ace514f2f004e26bb7c968c851cff14ea67b975 \
+                        sha256  106d573bd1a01ebf7a5171a962b4b1f9d368bc9fb43b1e03bd7622950d3b27ae \
+                        size    13884
+
 build.args          -ldflags \"-X main.version=${version} -X main.builtBy=macports\"
+build.env-append    GOPROXY=off \
+                    GO111MODULE=off
 
 set cm_doc_dir      ${prefix}/share/doc/${name}
 


### PR DESCRIPTION
#### Description

Per https://trac.macports.org/ticket/61192 this is one of the golang ports that automatically downloads its dependencies at build time.

To fix it, I used `go2port`. Unexpected tricky parts:

- `google.golang.org/protobuf` redirects to `go.googlesource.com/protobuf`, but `go.googlesource.com` can't serve stable tarballs so I had to manually switch to the GitHub mirror at `github.com/protocolbuffers/protobuf-go`
- `github.com/jtolds/gls` has been renamed to `github.com/jtolio/gls`; this needed a manual `repo` specification
- Dependencies include both `gopkg.in/yaml.v3` and `gopkg.in/yaml.v2`. These extract to paths under `${workdir}` that differ only in their trailing hashes, and this makes moving to the GOPATH by the `${author}-${project}-*` glob fail.

    It just so happens that `gopkg.in/yaml.v2` is locked to a tag (`v2.3.0`) while `gopkg.in/yaml.v3` is locked to hash (`9f266ea9e77c`). For packages locked to a hash, the golang-1.0 portgroup moves by the `*-${short_sha1}` glob, so it can succeed *if* `gopkg.in/yaml.v3` is attempted first.

    The default order output by `go2port` had `gopkg.in/yaml.v2` first, so I manually moved it below `gopkg.in/yaml.v3` and it worked.

    Yes, this is kind of ridiculous.

    Another workaround could have been to manually resolve the tag `v2.3.0` to the hash it represents, and lock to that. This would work in the case where both packages are locked to tags.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->