### PR TITLE
cloudmonkey: don't fetch dependencies in build phase

### DIFF
--- a/sysutils/cloudmonkey/Portfile
+++ b/sysutils/cloudmonkey/Portfile
@@ -5,6 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/apache/cloudstack-cloudmonkey 6.1.0
 name                cloudmonkey
+revision            1
 
 categories          sysutils
 license             Apache-2
@@ -19,11 +20,127 @@ long_description    {*}${description} CloudMonkey can be used both as an \
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-# The build process wants to see a git checkout.
-fetch.type          git
+checksums           ${distname}${extract.suffix} \
+                        rmd160  8abc6f8fa06687399c818da28a0bb8fde2c1cc75 \
+                        sha256  5294b35cb844256cc45ee3b93bb295b692bd81c2ce7b7c9dae17a11d922b530c \
+                        size    1371111
+
+go.vendors          gopkg.in/check.v1 \
+                        lock    788fd7840127 \
+                        rmd160  b63165c8909a27edc15dda210df66a1b49efb49e \
+                        sha256  7e5547c6471cc48da89a7c87f965b20ca5311f43fc4d883ca62f9fccf7551630 \
+                        size    31597 \
+                    github.com/chzyer/test \
+                        lock    a1ea475d72b1 \
+                        rmd160  61f83d79b356cde63a27df0f2832ef92fcbc216d \
+                        sha256  98d0c7d1dec438459e31886d65190bb45f70c4ed73e35f5ab2f3b8de582ea309 \
+                        size    4007 \
+                    github.com/jtolds/gls \
+                        repo    github.com/jtolio/gls \
+                        lock    v4.2.1 \
+                        rmd160  aad45261bf9648ef6b8a33b77c101108d44d7144 \
+                        sha256  1391a8a65d69d394662bc7186f80ff706e55e1dd60e0828dba0c4b226ade571f \
+                        size    7298 \
+                    github.com/kr/text \
+                        lock    v0.1.0 \
+                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
+                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
+                        size    8691 \
+                    github.com/mattn/go-colorable \
+                        lock    v0.0.9 \
+                        rmd160  7251bb6bf8e5651a52c8e3244d7117918e812f89 \
+                        sha256  22ae6fdf63bccd195bf108013ba477c896a11fffdbb3398487914e32e1db9b2a \
+                        size    7602 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.4 \
+                        rmd160  0a12014fd5fa0abaf40b622ae21db4e754b8b86c \
+                        sha256  9795d007b5616de49307fb12a4d7e5363512ec3f1094a8ec6660ad4da8c03131 \
+                        size    3379 \
+                    github.com/mattn/go-runewidth \
+                        lock    v0.0.3 \
+                        rmd160  5b1087f86f7a8dd42ef3283422bd8a8328620b77 \
+                        sha256  7c77123cf4b3f419076c06d0ad33daf3da018ecdae2af02e2bd5b4ab0657b7e0 \
+                        size    22972 \
+                    github.com/briandowns/spinner \
+                        lock    195c31b675a7 \
+                        rmd160  05f5ef9fe4a448644796743936b7bd63fd6284d5 \
+                        sha256  30dac8a8ba14008f04288f1298f85d8b70334413f8dadf171f98809415014235 \
+                        size    199917 \
+                    github.com/gofrs/flock \
+                        lock    v0.7.0 \
+                        rmd160  a18c8f5a96e7b7e3aaf574a46cf68ebb085f1fed \
+                        sha256  e21a652f3042352d78a76134290a7436c82b36511b34d180a9fd368fbe4a14bf \
+                        size    7268 \
+                    github.com/smartystreets/assertions \
+                        lock    b2de0cb4f26d \
+                        rmd160  32d7082172ea8c4a03119f3ffb803f8aad9744ce \
+                        sha256  469875871db96f87e62f76f0bfc4b3b0b9e4761c2a14d4ce12f246797a7c342c \
+                        size    52177 \
+                    github.com/chzyer/logex \
+                        lock    v1.1.10 \
+                        rmd160  105d839f798ba0c3e27b3db4e790d9d21a928029 \
+                        sha256  947e61095044d310b0ad92f10ac77c36eaa3c3e2e6181e87428ad10c20930ba3 \
+                        size    4351 \
+                    github.com/kr/pretty \
+                        lock    v0.1.0 \
+                        rmd160  9aa7a5aad4c48840eecfd0f80186d1fb5ded0fd6 \
+                        sha256  f6c3f89667c63e5b7f1fc6ee2c06b6a6bfdce88f3a965ccd395b64c6f95c9a47 \
+                        size    8553 \
+                    github.com/mitchellh/go-homedir \
+                        lock    v1.0.0 \
+                        rmd160  4b719f7cab0e4c79e79e4a9157bfc3a4c14f0ffb \
+                        sha256  e5a7cbabc2c28de8e3a8f3554373432b16b3e46e7e7040ca47eba3eb0efe94b1 \
+                        size    3249 \
+                    golang.org/x/sys \
+                        lock    8e24a49d80f8 \
+                        rmd160  dc87e51b40964c579e99a84a5ceee85dba8393e3 \
+                        sha256  4ee372af229ee67db442c46bd26ad8ff80e0d204638bdb20b23ce49cf0bb6e8a \
+                        size    1102588 \
+                    gopkg.in/ini.v1 \
+                        lock    v1.39.0 \
+                        rmd160  3a4807d54dbba469707b08a3b137a257d0e8cf5f \
+                        sha256  9f0d285fc3427b59d3d33b87593f59d0ae599ddfcb883f65c51d293c6e976409 \
+                        size    34840 \
+                    github.com/chzyer/readline \
+                        lock    2972be24d48e \
+                        rmd160  933f32b684d0af4b8970d964d610918a9f181df6 \
+                        sha256  f5771c6a3d97166a9536f8a45e85e1c40aed9b02089e395d2f4131681cbf692f \
+                        size    36826 \
+                    github.com/fatih/color \
+                        lock    v1.7.0 \
+                        rmd160  8a65cf00de5399f4498b41b0baed82da363f02d5 \
+                        sha256  a553c1229fe10a6b0765cbbb90245bf3383a99ba52b9608052420b40ca30d148 \
+                        size    816675 \
+                    github.com/google/shlex \
+                        lock    6f45313302b9 \
+                        rmd160  b7b4e546946ffff9f4c9458b9726fece4a5f0d62 \
+                        sha256  3559f8ec78e580e4b6ea28a9093f31cdc131c6afea7da653df4129b910f2931f \
+                        size    7244 \
+                    github.com/gopherjs/gopherjs \
+                        lock    0766667cb4d1 \
+                        rmd160  fe92e39110b5c188dcce98abb3b9aa1b64d68f94 \
+                        sha256  abe56698d0855027a1f6030a44924895d781b19526aa8f9b3ef49ed4199f7c57 \
+                        size    217261 \
+                    github.com/olekukonko/tablewriter \
+                        lock    v0.0.1 \
+                        rmd160  2e33eff4633df242952f7fe7333df7f3385d427b \
+                        sha256  e88e38a28e06ff585a011147c5eca07638fe104d74340c9741641ae68607c2d6 \
+                        size    17517 \
+                    github.com/smartystreets/goconvey \
+                        lock    ef6db91d284a \
+                        rmd160  dd436cf4d891f9cbd0b17765c3492981160fb171 \
+                        sha256  8486305d7ace7bb99968cc6155f9b678a7d4d4f0377efb25f2551b707a9d0b96 \
+                        size    1477153
+
+post-extract {
+    reinplace "s|-mod=vendor||g" ${worksrcpath}/Makefile
+}
 
 build.cmd           make
 build.target        all
+build.args          VERSION=${version} GIT_SHA=unknown V=1
+build.env-append    GOPROXY=off \
+                    GO111MODULE=off
 
 installs_libs       no
 


### PR DESCRIPTION
#### Description

Per https://trac.macports.org/ticket/61192 this is one of the golang ports that automatically downloads its dependencies at build time.

To fix it, I used `go2port`. Unexpected tricky parts:

- `github.com/jtolds/gls` has been renamed to `github.com/jtolio/gls`; this needed a manual `repo` specification
- The `go build` invocations in the Makefile specify `-mod=vendor`, but this is incompatible with `GO111MODULE=off` so I removed it

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->