### PR TITLE
thrift: actually use patchfiles

### DIFF
--- a/devel/thrift/Portfile
+++ b/devel/thrift/Portfile
@@ -29,7 +29,9 @@ homepage        https://thrift.apache.org/
 master_sites    apache:${name}/${version}
 
 # https://trac.macports.org/ticket/61252
-patchfiles-append   patch-thrift_protocol_decorator.h.diff
+patchfiles-append   patch-thrift_protocol_decorator.h.diff \
+                    patch-thrift_ssl_socket.h.diff \
+                    patch-0d6a2d3.diff
 
 depends_build       port:autoconf \
                     port:automake \


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/61252

#### Description
Further updates to portfile to add patches didn't make it to #8584.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.7
Xcode 12 command line tools

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
