### PR TITLE
impressive: update to 0.12.1

### DIFF
--- a/python/impressive/Portfile
+++ b/python/impressive/Portfile
@@ -4,8 +4,9 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                impressive
-version             0.12.0
-revision            4
+version             0.12.1
+revision            0
+
 categories-append   graphics
 license             GPL-2
 maintainers         nomaintainer
@@ -13,21 +14,21 @@ platforms           darwin
 supported_archs     noarch
 
 description         Slide presentation tool
-long_description    Impressive is a program that displays presentation slides, but \
-                    unlike OpenOffice.org Impress or other similar applications, \
-                    it does so with style. Smooth alpha-blended slide transitions    \
-                    are provided for the sake of eye candy, but in addition to this, \
-                    Impressive offers some unique tools that are really useful       \
-                    for presentations.
+long_description    Impressive is a program that displays presentation slides,\
+                    but unlike OpenOffice.org Impress or other similar\
+                    applications, it does so with style. Smooth alpha-blended\
+                    slide transitions are provided for the sake of eye candy,\
+                    but in addition to this, Impressive offers some unique\
+                    tools that are really useful for presentations.
 
 homepage            http://impressive.sourceforge.net/
 master_sites        sourceforge:impressive
 
 distname            Impressive-${version}
 
-checksums           rmd160  4d9b016907b504b36836c7e4eb0754b15ba08828 \
-                    sha256  7dc78de333e4a942036ba4bda53358799f493114f2f655b2ab2689b6fdc0587d \
-                    size    209514
+checksums           rmd160  15cd3ec85a8e64b622ded68ecc9ebd31feab6824 \
+                    sha256  74a331f41e39a363b362dcadf861e3a300351d5ad5cfe033b5d47215c886f1e4 \
+                    size    210928
 
 python.default_version 27
 


### PR DESCRIPTION
#### Description

impressive: update to 0.12.1

###### Type(s)

- [x] update

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

###### Notes

While installing the port using the `-vst` options… One port in the dep chain (`libmikmod`) failed to configure. I could install it separately, and it installed the binary version so I could finish this. But, incase the checks in this PR fails, it might come from that.

_I saw there was an update avail for `libmikmod`. Perhaps that helps._