### PR TITLE
smpeg: fix patch offsets

### DIFF
--- a/multimedia/smpeg/Portfile
+++ b/multimedia/smpeg/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 name                smpeg
 version             0.4.4
 revision            9
+
 categories          multimedia
 # libs are LGPL, executables are GPL
 # the readme says LGPLv2 but the actual source files say "or any later version"
@@ -12,22 +13,29 @@ maintainers         nomaintainer
 platforms           darwin
 
 description         a general purpose MPEG video/audio player/library
-long_description    smpeg is a general purpose MPEG video/audio player and \
-    library programmed by Loki entertainment and others
+long_description    ${name} is {*}${description} programmed by Loki\
+                    entertainment and others.
 
 homepage            https://icculus.org/smpeg/
 master_sites        macports freebsd
 
 checksums           rmd160  d55249ad53417fa0df3d925aed0e83d2204e28b7 \
-                    sha256  1efa7984d0aada0c2954cd0aaef357e9d7871dadd3368dbe742ab5f260523e57
+                    sha256  1efa7984d0aada0c2954cd0aaef357e9d7871dadd3368dbe742ab5f260523e57 \
+                    size    315054
 
 depends_lib         port:libsdl
 
-patchfiles          patch-smpeg.h.diff patch-glmovie-tile.c.diff \
+patchfiles          patch-smpeg.h.diff \
+                    patch-glmovie-tile.c.diff \
                     patch-glmovie.c.diff \
-                    patch-smpeg.m4.diff patch-MPEGaudio.h.diff patch-video.h.diff \
-                    patch-MPEG.cpp.diff patch-smpeg-gtkm4.diff patch-automake-as.diff \
-                    patch-configure-flags.diff patch-Makefile.am.diff
+                    patch-smpeg.m4.diff \
+                    patch-MPEGaudio.h.diff \
+                    patch-video.h.diff \
+                    patch-MPEG.cpp.diff \
+                    patch-smpeg-gtkm4.diff \
+                    patch-automake-as.diff \
+                    patch-configure-flags.diff \
+                    patch-Makefile.am.diff
 
 post-patch {
     file delete ${worksrcpath}/acinclude.m4

--- a/multimedia/smpeg/files/patch-configure-flags.diff
+++ b/multimedia/smpeg/files/patch-configure-flags.diff
@@ -1,6 +1,6 @@
 --- configure.in.orig
 +++ configure.in
-@@ -60,7 +60,7 @@ dnl The alpha architecture needs special
+@@ -62,7 +62,7 @@ dnl The alpha architecture needs special
  case "$target" in
      alpha*-*-linux*)
  	if test x$ac_cv_prog_gcc = xyes; then
@@ -9,7 +9,7 @@
          fi
          ;;
      sparc*-*-solaris*)
-@@ -102,17 +102,17 @@ AC_ARG_ENABLE(debug,
+@@ -104,17 +104,17 @@ AC_ARG_ENABLE(debug,
                , enable_debug=yes)
  if test x$enable_debug != xyes; then
      if test x$ac_cv_prog_gcc = xyes; then
@@ -30,7 +30,7 @@
              fi
              ;;
      esac
-@@ -124,7 +124,7 @@ AM_PATH_SDL($SDL_VERSION,
+@@ -126,7 +126,7 @@ AM_PATH_SDL($SDL_VERSION,
              :,
  	    AC_MSG_ERROR([*** SDL version $SDL_VERSION not found!])
  )
@@ -39,7 +39,7 @@
  LIBS="$LIBS $SDL_LIBS"
  
  dnl See if we need to pass -lm for the math library
-@@ -145,7 +145,7 @@ if test x$enable_mmx = xyes; then
+@@ -147,7 +147,7 @@ if test x$enable_mmx = xyes; then
      AC_MSG_RESULT($use_mmx)
  
      if test x$use_mmx = xyes; then
@@ -48,7 +48,7 @@
      fi
  fi
  
-@@ -162,7 +162,7 @@ if test x$enable_ati = xyes; then
+@@ -164,7 +164,7 @@ if test x$enable_ati = xyes; then
      AC_MSG_RESULT($use_ati)
  
      if test x$use_ati = xyes; then
@@ -57,7 +57,7 @@
      fi
  fi
  
-@@ -171,7 +171,7 @@ AC_ARG_ENABLE(timestamp-sync,
+@@ -173,7 +173,7 @@ AC_ARG_ENABLE(timestamp-sync,
  [  --enable-timestamp-sync  enable system timestamp sync [default=yes]],
                , enable_timestamp_sync=no)
  if test x$enable_timestamp_sync = xyes; then
@@ -66,7 +66,7 @@
  fi
  
  dnl Enable the use of the system thread
-@@ -179,7 +179,7 @@ AC_ARG_ENABLE(threaded-system,
+@@ -181,7 +181,7 @@ AC_ARG_ENABLE(threaded-system,
  [  --enable-threaded-system enable system thread         [default=no]],
                , enable_threaded_system=no)
  if test x$enable_threaded_system = xyes; then
@@ -75,7 +75,7 @@
  fi
  
  dnl Enable threaded audio
-@@ -187,7 +187,7 @@ AC_ARG_ENABLE(threaded-audio,
+@@ -189,7 +189,7 @@ AC_ARG_ENABLE(threaded-audio,
  [  --enable-threaded-audio  enable threaded audio        [default=yes]],
                , enable_threaded_audio=yes)
  if test x$enable_threaded_audio = xyes; then
@@ -84,7 +84,7 @@
  fi
  
  dnl See if we can build the GTk player
-@@ -198,7 +198,7 @@ have_gtk=no
+@@ -200,7 +200,7 @@ have_gtk=no
  if test x$enable_gtk_player = xyes; then
      AM_PATH_GTK(1.2.1, have_gtk=yes)
      if test x$have_gtk = xyes; then
@@ -93,7 +93,7 @@
      fi
      AC_SUBST(GTK_LIBS)
  fi
-@@ -224,7 +224,7 @@ if test x$enable_opengl_player = xyes; t
+@@ -226,7 +226,7 @@ if test x$enable_opengl_player = xyes; t
              AC_PATH_X
              AC_PATH_XTRA
              if test x$have_x = xyes; then
@@ -102,7 +102,7 @@
                  SYS_GL_LIBS="$X_LIBS -lGL -lGLU"
              else
                  SYS_GL_LIBS="-lGL -lGLU"
-@@ -255,17 +255,16 @@ AC_ARG_ENABLE(assertions,
+@@ -257,17 +257,16 @@ AC_ARG_ENABLE(assertions,
  [  --enable-assertions     Enable consistency checks in decoding [default=no]],
                , enable_assertions=no)
  if test x$enable_assertions != xyes; then


### PR DESCRIPTION
#### Description

smpeg: fix patch offsets
    
  - fix patch offsets
  - cleanup the Portfile, like add 'size'

###### Type(s)

- [x] enhancement

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?