### PR TITLE
weechat: use legacysupport

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -4,6 +4,10 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           conflicts_build 1.0
 
+# Need strndup()
+PortGroup           legacysupport 1.0
+legacysupport.newest_darwin_requires_legacy 10
+
 conflicts           weechat-devel
 name                weechat
 version             2.9


### PR DESCRIPTION
#### Description
Build fails on 10.6 which doesn't have `strndup()`:
```
/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_irc_weechat/weechat/work/weechat-2.9/src/plugins/irc/irc-protocol.c:695:36: error: implicitly declaring library function 'strndup' with type 'char *(const char *, unsigned long)' [-Werror,-Wimplicit-function-declaration]
                        str_name = strndup (caps_supported[i],
                                   ^
```
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Untested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
