### PR TITLE
ansifilter: update to 2.17

### DIFF
--- a/textproc/ansifilter/Portfile
+++ b/textproc/ansifilter/Portfile
@@ -1,10 +1,9 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
-PortGroup       cxx11 1.1
 
 name            ansifilter
-version         2.16
+version         2.17
 revision        0
 categories      textproc
 maintainers     {evermeet.cx:tessarek @tessus} openmaintainer
@@ -21,11 +20,13 @@ homepage        http://www.andre-simon.de/doku/ansifilter/en/ansifilter.php
 master_sites    http://www.andre-simon.de/zip/
 use_bzip2       yes
 
-checksums       rmd160  c54fc4766da2540a158c3bd5b8d79afe87fff3c3 \
-                sha256  7fcd2fa3520bce2bd3834c299f533cbfb43a29a095c83e8fea372a383dfbbaf2 \
-                size    441932
+checksums       rmd160  deccc97918724720a9450311efd5a45548c8af77 \
+                sha256  5985beb39c960a3cb5b0e70d6a121687043dc8458e5783777ff250303cccc42f \
+                size    436116
 
 use_configure   no
+
+compiler.cxx_standard  2011
 
 build.args-append \
                 CC="${configure.cxx}" \


### PR DESCRIPTION
#### Description

Update ansifilter to 2.17

You can mark this as invalid so that it doesn't count for Hacktoberfest. I opened the PR because the new version has just been released.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G6032
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
