### PR TITLE
libsignal-protocol-c: new port

### DIFF
--- a/devel/libsignal-protocol-c/Portfile
+++ b/devel/libsignal-protocol-c/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        signalapp libsignal-protocol-c 2.3.3 v
+revision            0
+checksums           rmd160  26c279a15203f11f92edab1ceb64de1c62339dd5 \
+                    sha256  eb8ef165a22582c00f9c31fdbd435dd787451c495d772302d08fd9afc0de96fb \
+                    size    272197
+
+categories          devel security net
+platforms           darwin
+license             {GPL-3 MPL-2}
+maintainers         {isi.edu:calvin @cardi} openmaintainer
+description         A ratcheting forward secrecy protocol for \
+                    synchronous and asynchronous messaging environments.
+long_description    ${description}
+
+variant tests description {Enable unit tests} {
+    depends_test    port:check \
+                    path:lib/libssl.dylib:openssl
+
+    configure.args-append \
+                    -DBUILD_TESTING=1
+
+    test.run        yes
+}


### PR DESCRIPTION
#### Description

###### Tested on
macOS 10.14.6 18G6020
Xcode 11.3.1 11C504

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
