### PR TITLE
py-urwidtrees: new port

### DIFF
--- a/python/py-urwidtrees/Portfile
+++ b/python/py-urwidtrees/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-urwidtrees
+version             1.0.3
+platforms           darwin
+license             GPL-3
+supported_archs     noarch
+
+maintainers         {@harens gmail.com:harensdeveloper} \
+                    openmaintainer
+
+description         Tree widgets for urwid
+long_description    This is a Widget Container API for the urwid toolkit. \
+                    It uses a MVC approach and allows to build trees of widgets.
+
+homepage            https://github.com/pazz/urwidtrees
+
+checksums           rmd160  c2a4fca7238ec551e2320cf789b74f09e6645403 \
+                    sha256  50b19c06b03a5a73e561757a26d449cfe0c08afabe5c0f3cd4435596bdddaae9 \
+                    size    13844
+
+python.versions     38
+
+if {${name} ne ${subport}} {
+
+    depends_build-append \
+                        port:py${python.version}-setuptools
+
+    depends_lib-append  port:py${python.version}-urwid
+
+    livecheck.type      none
+}


### PR DESCRIPTION
#### Description

In the hopes of updating the [alot](https://ports.macports.org/port/alot/summary) port, I've written a portfile for urwidtrees since this acts as a new dependency.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.6 19G73
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
