### PR TITLE
pugixml: update to 1.10

### DIFF
--- a/textproc/pugixml/Portfile
+++ b/textproc/pugixml/Portfile
@@ -4,9 +4,8 @@ PortSystem          1.0
 
 PortGroup           github 1.0
 PortGroup           cmake 1.1
-PortGroup           cxx11 1.1
 
-github.setup        zeux pugixml 1.8.1 v
+github.setup        zeux pugixml 1.10 v
 
 categories          textproc
 platforms           darwin
@@ -18,8 +17,11 @@ description         C++ Library for XML processing
 long_description    C++ library for creating and manipulating XML DOMs. Features: \
                     efficient parsing of XML, XPath 1.0 support, full Unicode support.
 
-checksums           sha256  929c4657c207260f8cc28e5b788b7499dffdba60d83d59f55ea33d873d729cd4 \
-                    rmd160  5663e6f5226f0ce12b4c93d16a5b8cda1811ea57
+checksums           sha256  c82eb3d355a048fcea820d34478dcc17afca66ebb6ff8b2af2eee64ef1b4f049 \
+                    rmd160  beb1f81a775a028b030624bb7c46881ce9e92750 \
+                    size    562801
+
+compiler.cxx_standard 2011
 
 configure.args-append -DBUILD_SHARED_LIBS=ON
 configure.args-append -DCMAKE_CXX_FLAGS='-std=c++11'


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/59793

Use `compiler.cxx_standard 2011` instead of deprecated `cxx11 1.1` portgroup

#### Description
See https://github.com/zeux/pugixml/releases
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
macOS 10.15.7
Xcode 12 command line tools

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
