### PR TITLE
autojump: Update to 22.5.3

### DIFF
--- a/sysutils/autojump/Portfile
+++ b/sysutils/autojump/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        wting autojump 22.5.1 release-v
+github.setup        wting autojump 22.5.3 release-v
 categories          sysutils
 platforms           darwin
 maintainers         nomaintainer
@@ -14,8 +14,9 @@ description         a cd command that learns
 
 long_description    ${name} is ${description}.
 
-checksums           rmd160  5d030385017b4b3df8ccc2deb144dac9822a680b \
-                    sha256  79f38db0a6bb83c54352bd9d6a886b113e75c6adb13fa18c563e85d04c7ace99
+checksums           rmd160  3d4feaf96158b76cb94a14049c1a81108b2bb4f4 \
+                    sha256  00e86809cef2529d77ff8ed88fa59910024411e9e6594ddb042ae1e0eda5aaae \
+                    size    55445
 
 depends_run         port:python27
 


### PR DESCRIPTION
bumps the version of autojump
