### PR TITLE
ansifilter: use the right compiler

### DIFF
--- a/textproc/ansifilter/Portfile
+++ b/textproc/ansifilter/Portfile
@@ -29,7 +29,7 @@ use_configure   no
 compiler.cxx_standard  2011
 
 build.args-append \
-                CC="${configure.cxx}" \
+                CXX="${configure.cxx}" \
                 EXTRA_CXXFLAGS="${configure.cxxflags} -std=c++11" \
                 EXTRA_LDFLAGS="${configure.ldflags} -stdlib=${configure.cxx_stdlib}"
 


### PR DESCRIPTION
#### Description
As of ansifilter 2.17 the `CXX` variable is used instead of `CC`: https://gitlab.com/saalen/ansifilter/-/commit/16ca2840d46c06513c6a4c0c88d7442c26c279a3

Build failures are observed on 10.6 where the port tries to build using `g++`: https://build.macports.org/builders/ports-10.6_i386-builder/builds/18338/steps/install-port/logs/stdio

```
g++ -c -Wall -O2 -DNDEBUG -std=c++11 -fPIC -D_FILE_OFFSET_BITS=64  -Os -stdlib=libc++ -std=c++11 arg_parser.cpp -o arg_parser.o
g++ -c -Wall -O2 -DNDEBUG -std=c++11 -fPIC -D_FILE_OFFSET_BITS=64  -Os -stdlib=libc++ -std=c++11 stringtools.cpp -o stringtools.o
g++ -c -Wall -O2 -DNDEBUG -std=c++11 -fPIC -D_FILE_OFFSET_BITS=64  -Os -stdlib=libc++ -std=c++11 cmdlineoptions.cpp -o cmdlineoptions.o
g++ -c -Wall -O2 -DNDEBUG -std=c++11 -fPIC -D_FILE_OFFSET_BITS=64  -Os -stdlib=libc++ -std=c++11 main.cpp -o main.o
cc1plus: error: unrecognized command line option "-std=c++11"
cc1plus: error: unrecognized command line option "-std=c++11"cc1plus: error: unrecognized command line option "-std=c++11"cc1plus: error: unrecognized command line option "-stdlib=libc++"

cc1plus: error: unrecognized command line option "-std=c++11"cc1plus: error: unrecognized command line option "-std=c++11"
cc1plus: error: unrecognized command line option "-stdlib=libc++"

cc1plus: error: unrecognized command line option "-std=c++11"cc1plus: error: unrecognized command line option "-stdlib=libc++"


cc1plus: error: unrecognized command line option "-std=c++11"
cc1plus: error: unrecognized command line option "-stdlib=libc++"
cc1plus: error: unrecognized command line option "-std=c++11"
```
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk -v ORS=' ' '{print $NF}')"
-->
Untested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
