### PR TITLE
igraph: update to 0.8.3

### DIFF
--- a/math/igraph/Portfile
+++ b/math/igraph/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        igraph igraph 0.8.2
+github.setup        igraph igraph 0.8.3
 github.tarball_from releases
 
 categories          math science devel
@@ -18,19 +18,24 @@ platforms           darwin
 depends_lib         port:gmp \
                     port:libxml2
 
-checksums           rmd160  4471b3b8110ddefe85e164920ff3bbc4e7e81f83 \
-                    sha256  718a471e7b8cbf02e3e8006153b7be6a22f85bb804283763a0016280e8a60e95 \
-                    size    3625308
+checksums           rmd160  e000e51d3fe0457b746541d84b7f32e5cf4e8bf6 \
+                    sha256  cc935826d3725a9d95f1b0cc46e3c08c554b29cdd6943f0286d965898120b3f1 \
+                    size    3636192
 
 test.run            yes
 test.target         check
 
-# igraph 0.8.1 embeds GLPK 4.45. Currently GLPK is at version 4.65.
+# igraph 0.8.3 embeds GLPK 4.45. Currently GLPK is at version 4.65.
 # Some igraph functions perform better with this new GLPK version.
 
 variant external_glpk description {Build with external GLPK} {
     configure.args-append   --with-external-glpk
     depends_lib-append      port:glpk
+}
+
+variant external_linalg description {Build with external BLAS, LAPACK, ARPACK} {
+    configure.args-append   --with-external-blas --with-external-lapack --with-external-arpack
+    depends_lib-append      port:lapack port:arpack
 }
 
 default_variants    +external_glpk


### PR DESCRIPTION
#### Description

 * update to version 0.8.3
 * add variant external_linalg

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G6032
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
