### PR TITLE
certigo: don't fetch dependencies in build phase

### DIFF
--- a/sysutils/certigo/Portfile
+++ b/sysutils/certigo/Portfile
@@ -21,9 +21,134 @@ installs_libs       no
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  dd6ecaef6e7ca89aa072a420ecd05160bb6e832c \
-                    sha256  dc8430ba91d4d716800c15515be3afea5686d11bd1cee8cf8122cae0198b197f \
-                    size    379580
+checksums           ${distname}${extract.suffix} \
+                        rmd160  dd6ecaef6e7ca89aa072a420ecd05160bb6e832c \
+                        sha256  dc8430ba91d4d716800c15515be3afea5686d11bd1cee8cf8122cae0198b197f \
+                        size    379580
+
+go.vendors          github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/fatih/color \
+                        lock    v1.9.0 \
+                        rmd160  1d8418b4f1b3cb597f680b93aaa08afcc9651be4 \
+                        sha256  577c8e778833fec90d76918f138cee9f7765435757b7c92a669e5b34933e0b4f \
+                        size    1231337 \
+                    github.com/google/uuid \
+                        lock    v1.0.0 \
+                        rmd160  f9abf89bceb1da1e3e3ae5a7686e541c64a61c83 \
+                        sha256  a4e3d2b116eb2f6e99cd851a0ae936b081546428271970ddd08ef6490b13e967 \
+                        size    13130 \
+                    github.com/mattn/go-colorable \
+                        lock    v0.1.4 \
+                        rmd160  aeaf016c7ae6cf014233a5a327e4227acf17adea \
+                        sha256  d64a7c2835de356f83a8af8ac9e07ce45d13a5ecb5062efd7f63b85b0b173193 \
+                        size    8987 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.12 \
+                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
+                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
+                        size    4549 \
+                    github.com/Masterminds/goutils \
+                        lock    v1.1.0 \
+                        rmd160  9c73de9ffa7bbf68eb496d9d18f26a206fe5608d \
+                        sha256  d5edbcb0d321e69213764b9db9afea1aee72316b227bc5dbaf0177a726074482 \
+                        size    14608 \
+                    github.com/Masterminds/semver \
+                        lock    v1.4.2 \
+                        rmd160  44cd009860ab2905e17f730d35ba93358f5c81c2 \
+                        sha256  0ff3a26c8c0f77c0538385e3af3636cce2b442fb9e2d149eba77d32375d3fdf0 \
+                        size    15917 \
+                    github.com/alecthomas/units \
+                        lock    2efee857e7cf \
+                        rmd160  b1fc6e021a0e5579179bf8629e4a50221e4aa805 \
+                        sha256  ebe15098493671b52f282853872f23517613ad484b550881bef8eb1a1257b5aa \
+                        size    3454 \
+                    github.com/mitchellh/reflectwalk \
+                        lock    v1.0.0 \
+                        rmd160  c8f3f4a948ebfd3f69f22663f856e7309877ba8d \
+                        sha256  117a3a92d72f36187cd4aa728890538c9637be7d4ba9a8d7a777c51a15ea8015 \
+                        size    6149 \
+                    github.com/mwitkow/go-http-dialer \
+                        lock    378f744fb2b8 \
+                        rmd160  05ea34cd12da7d053b0cf886ea523b8a9e201865 \
+                        sha256  000e7c21d14470f1072f92209c08dd6e2967f0a9846204b7a32f7caf17bb7339 \
+                        size    16066 \
+                    golang.org/x/crypto \
+                        lock    0c41d7ab0a0e \
+                        rmd160  c92d759b52ea9d4e7fe4a277dd417253f9102d3e \
+                        sha256  af979256862df025599703b970348840b64d2d576e55591931a9bc8367a561c9 \
+                        size    1638955 \
+                    gopkg.in/alecthomas/kingpin.v2 \
+                        lock    v2.2.6 \
+                        rmd160  af6db4648ec7638fb5cab49fd9536caa705f5fed \
+                        sha256  31378085783496cff78c7d41479ccd6206c4f4e3892909ef0c2cd39e2de3b039 \
+                        size    44374 \
+                    github.com/huandu/xstrings \
+                        lock    v1.2.0 \
+                        rmd160  92b6b3011932e59dde576edc90b43acb318ba288 \
+                        sha256  ad15de7c79bdbadbcebea0dd4591a300d578c6fc8b676ab287501c84a4d3bce0 \
+                        size    16632 \
+                    github.com/imdario/mergo \
+                        lock    v0.3.6 \
+                        rmd160  6228108363d0f1691ceb0fcc42dec2c84eda3f4d \
+                        sha256  39bd93c3787ef92629b914b392fbd23ef1026edb766caafca5f5aad3c643ee08 \
+                        size    16082 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/mitchellh/copystructure \
+                        lock    v1.0.0 \
+                        rmd160  f302c41c8c05f9f254b5c1354e8aa7ba099fc81b \
+                        sha256  5306cd122f11f481baa0b4c17437dd816e9449c8b91d59475c5e1f5b5edc1a9a \
+                        size    8897 \
+                    gopkg.in/check.v1 \
+                        lock    20d25e280405 \
+                        rmd160  412aa0d109919182ff84259e9b5bbc9f24d78117 \
+                        sha256  233f8faf427ce6701ac3427f85c28bc6b6ae7cdc97a303a52873c69999223325 \
+                        size    30360 \
+                    github.com/stretchr/testify \
+                        lock    v1.5.1 \
+                        rmd160  db9d43c3c804950ce9650d830f7dea5434ed83c1 \
+                        sha256  e5f566d1c23fb2b987f8a9f139e32866c1eea8c72051da25bbf6880a4f8c541a \
+                        size    78702 \
+                    golang.org/x/sys \
+                        lock    b77594299b42 \
+                        rmd160  7e54355c0025dc83f1507b6c03b7a59f8df0040b \
+                        sha256  26cacb991c0f1851edbe364c15e47d93e488f2700fc70be40e41aaeb01a9ebfb \
+                        size    1534714 \
+                    gopkg.in/asn1-ber.v1 \
+                        lock    379148ca0225 \
+                        rmd160  b710011b3de9b2d6262507edd9233d4e6da6176c \
+                        sha256  ff0a36e43eb30929c692c0c6473f7543663d811ae3119c820da95a06de941cdf \
+                        size    12442 \
+                    gopkg.in/yaml.v2 \
+                        lock    v2.2.2 \
+                        rmd160  03aea7b7e847179b29044d5a928b9f8a889fe87b \
+                        sha256  da1e31b7beb9a6907947caa794134bdc2501d1a3474568b61cc2562a398d3d87 \
+                        size    70676 \
+                    github.com/Masterminds/sprig \
+                        lock    v2.22.0 \
+                        rmd160  b26a0d2f2e833afcf8adcbfbb58660ee27e31e1d \
+                        sha256  f170a47590a589c3958e69e298c3bffaa8a815bb0395f308b517c0c83cdbb30e \
+                        size    42058 \
+                    github.com/alecthomas/template \
+                        lock    a0175ee3bccc \
+                        rmd160  ed34ba888ec2b18c8fa2d745ff25dec1ce67d6d4 \
+                        sha256  be0a63f0fece9a590713aa740e64b7cc4e923d57706d3b4f478c1cae0fd135b0 \
+                        size    55257 \
+                    github.com/stretchr/objx \
+                        lock    v0.1.0 \
+                        rmd160  fa58b6a0f55fce44b3d4e246b07574f016a1dabf \
+                        sha256  e80eb3ee16d44676befb5b8044459492f73e6f153ad3f28b13949c9f9cfaf558 \
+                        size    109497
+
+build.env-append    GO111MODULE=off \
+                    GOPROXY=off
 
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
#### Description

Per https://trac.macports.org/ticket/61192 this is one of the golang ports that automatically downloads its dependencies at build time.

To fix it, I used `go2port`. There were no surprises.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->