### PR TITLE
py-atomiclong: new port

### DIFF
--- a/python/py-atomiclong/Portfile
+++ b/python/py-atomiclong/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-atomiclong
+version             0.1.1
+revision            0
+
+categories-append   devel
+platforms           darwin
+license             MIT
+maintainers         nomaintainer
+
+description         increment numbers, atomically, in python
+long_description    Sometimes you need to increment some numbers, atomically,\
+                    in python. AtomicLong was born out of the need for fast\
+                    thread-safe counters in python. It uses CFFI to bind GCC's\
+                    Atomic Builtins. Its value is a C long which can be\
+                    incremented, decremented, and set atomically. It is\
+                    inspired by Java's java.util.concurrent.atomic.AtomicLong.
+
+homepage            https://github.com/dreid/atomiclong
+
+checksums           rmd160  aa6ea7bd708b3fcf83a7793f5284060a6ee52db8 \
+                    sha256  cb1378c4cd676d6f243641c50e277504abf45f70f1ea76e446efcdbb69624bbe \
+                    size    5057
+
+python.versions     38
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools
+    depends_lib-append      port:py${python.version}-cffi
+
+    livecheck.type          none
+}


### PR DESCRIPTION
#### Description

py-atomiclong: new port

  - dependency for py-gitfs

###### Type(s)

- [x] submission

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

###### Notes

This port is a part of the `py-gitfs` submission