### PR TITLE
py-fusepy: new port

### DIFF
--- a/python/py-fusepy/Portfile
+++ b/python/py-fusepy/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-fusepy
+version             3.0.1
+revision            0
+
+categories-append   devel
+platforms           darwin
+license             ISC
+maintainers         nomaintainer
+
+description         a simple interface to FUSE and MacFUSE
+long_description    ${python.rootname} is a Python module that provides\
+                    {*}${description}. It's just one file and is\
+                    implemented using ctypes.
+
+homepage            https://github.com/fusepy/fusepy
+
+checksums           rmd160  4a95b1f2278454929f5f037c0c6fee557b8d2293 \
+                    sha256  72ff783ec2f43de3ab394e3f7457605bf04c8cf288a2f4068b4cde141d4ee6bd \
+                    size    11519
+
+python.versions     38
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools
+    depends_lib-append      port:osxfuse
+
+    livecheck.type          none
+}


### PR DESCRIPTION
#### Description

py-fusepy: new port

  - dependency for py-gitfs

###### Type(s)

- [x] submission

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

###### Notes

This port is a part of the `py-gitfs` submission