### PR TITLE
py-gitfs: new port

### DIFF
--- a/python/py-fusepy/Portfile
+++ b/python/py-fusepy/Portfile
@@ -2,10 +2,11 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
+PortGroup           fuse 1.0
 
 name                py-fusepy
 version             3.0.1
-revision            0
+revision            1
 
 categories-append   devel
 license             ISC
@@ -27,7 +28,6 @@ python.versions     38 39
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
-    depends_lib-append      port:osxfuse
 
     livecheck.type          none
 }

--- a/python/py-gitfs/Portfile
+++ b/python/py-gitfs/Portfile
@@ -1,0 +1,86 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           python 1.0
+PortGroup           fuse 1.0
+
+name                py-gitfs
+github.setup        presslabs ${python.rootname} 0.5.2
+github.tarball_from archive
+revision            0
+
+categories-append   devel
+platforms           darwin
+supported_archs     noarch
+license             Apache-2
+maintainers         nomaintainer
+
+description         a FUSE file system that fully integrates with git
+long_description    ${python.rootname} is {*}${description}. You can mount a \
+                    remote repository’s branch locally, and any subsequent \
+                    changes made to the files will be automatically committed \
+                    to the remote.
+
+homepage            https://www.presslabs.com/docs/code/${python.rootname}/
+
+checksums           rmd160  965080148fc253fa3b7987b99b920e12f2daa9e7 \
+                    sha256  921e24311e3b8ea3a5448d698a11a747618ee8dd62d5d43a85801de0b111cbf3 \
+                    size    64141
+
+python.versions     39
+
+if {${name} ne ${subport}} {
+    patchfiles      patch-mounter.py.diff \
+                    patch-utils-args.py.diff
+
+    post-patch {
+        reinplace "s|@@PREFIX@@|${prefix}|g" ${worksrcpath}/gitfs/utils/args.py
+    }
+
+    depends_build-append  \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-atomiclong \
+                    port:py${python.version}-cffi \
+                    port:py${python.version}-fusepy \
+                    port:py${python.version}-pycparser \
+                    port:py${python.version}-pygit2 \
+                    port:py${python.version}-raven \
+                    port:py${python.version}-six
+
+    post-activate {
+        # the default tmp folder from gitfs/utils/args.py
+        xinstall -d ${prefix}/var/lib/${python.rootname}
+    }
+
+    notes "
+A simple example of mounting a local “bare” repo:
+
+    \$ cd .test.d/
+    \$ mkdir mnt
+    \$ gitfs file://${user_home}/Repos/test.git/ mnt/\
+-o repo_path=gitclone,fetch_timeout=2,sync_timout=2
+
+Verify with:
+
+    \$ mount | grep osxfuse
+    file://${user_home}/Repos/test.git/ on ${user_home}/.test.d/mnt\
+(osxfuse, nodev, nosuid, synchronous, mounted by ${::env(USER)})
+
+In Finder you'll find the mount, and can unmount it from there as well.
+
+    \$ open -R .
+
+- - -
+
+If you find the documentation to be a bit confusing, there are 2 great videos\
+(talks) about ${python.rootname} you can watch:
+
+  » https://www.youtube.com/watch?v=elA96lMW-gA (~32min)
+  » https://www.youtube.com/watch?v=mdhZpFp5n80 (~27min)
+    "
+
+    livecheck.type  none
+}

--- a/python/py-gitfs/files/patch-mounter.py.diff
+++ b/python/py-gitfs/files/patch-mounter.py.diff
@@ -1,0 +1,15 @@
+See:
+ - https://github.com/libgit2/pygit2/issues/1018#issuecomment-696392171
+ - https://github.com/presslabs/gitfs/issues/323
+
+--- gitfs/mounter.py.orig	2019-10-20 13:00:10.000000000 +0200
++++ gitfs/mounter.py	2020-10-03 14:26:43.000000000 +0200
+@@ -19,7 +19,7 @@
+
+ from fuse import FUSE
+ from pygit2 import Keypair, UserPass
+-from pygit2.remote import RemoteCallbacks
++from pygit2.callbacks import RemoteCallbacks
+
+ from gitfs import __version__
+ from gitfs.utils import Args

--- a/python/py-gitfs/files/patch-utils-args.py.diff
+++ b/python/py-gitfs/files/patch-utils-args.py.diff
@@ -1,0 +1,11 @@
+--- gitfs/utils/args.py.orig	2019-10-20 13:00:10.000000000 +0200
++++ gitfs/utils/args.py	2020-10-03 14:38:43.000000000 +0200
+@@ -182,7 +182,7 @@
+         return "{}@{}".format(args.user, socket.gethostname())
+
+     def get_repo_path(self, args):
+-        return tempfile.mkdtemp(dir="/var/lib/gitfs")
++        return tempfile.mkdtemp(dir="@@PREFIX@@/var/lib/gitfs")
+
+     def get_ssh_key(self, args):
+         return os.environ["HOME"] + "/.ssh/id_rsa"


### PR DESCRIPTION
#### Description

py-gitfs: new port

  - Use github release, since pypi doesn't have the latest version.
  - Closes: https://trac.macports.org/ticket/52249

###### Type(s)

- [x] submission

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

###### Notes

I've tested this with a local repo. The online documentation din't cover the example I got to work, so I added an eaxample in the port notes, + a link to 2 talks, as complement.

#8624 and #8625 is needed for this port, so the checks will initially fail due to the missing dependencies.