### PR TITLE
cc65: update to 2.18

### DIFF
--- a/lang/cc65/Portfile
+++ b/lang/cc65/Portfile
@@ -1,53 +1,36 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; truncate-lines: t; indent-tabs-mode: nil; c-basic-offset: 4; -*-
-# vim: set fileencoding=utf-8 tabstop=4 shiftwidth=4 softtabstop=4 noexpandtab filetype=tcl :
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name            cc65
-conflicts       grc
-version         2.18
-categories      lang
-platforms       darwin
-maintainers     nomaintainer
+PortSystem          1.0
+PortGroup           github 1.0
 
-description     6502 C compiler
-long_description \
-                cc65 is a complete cross development package for 65(C)02 \
-                systems, including a powerful macro assembler, a C compiler, \
-                linker, librarian and several other tools.
-license         CC-BY-SA 
+github.setup        cc65 cc65 2.18 V
+conflicts           grc
+categories          lang
+platforms           darwin
+maintainers         nomaintainer
 
-homepage        http://cc65.github.io/cc65
-distfiles       V${version}.tar.gz
+description         6502 C compiler
+long_description    cc65 is a complete cross development package for 65(C)02 \
+                    systems, including a powerful macro assembler, a C compiler, \
+                    linker, librarian and several other tools.
+license             CC-BY-SA 
 
-master_sites    git:https://github.com/cc65/cc65/archive
+homepage            http://cc65.github.io/cc65
 
+github.tarball_from archive
 checksums           rmd160  602e4956e4699103ab66dd654bfa53bce0766a85 \
                     sha256  d14a22fb87c7bcbecd8a83d5362d5d317b19c6ce2433421f2512f28293a6eaab \
                     size    2254374
 
-use_configure   no
+use_configure       no
 
-build.target    bin lib
-build.args      PREFIX=${prefix}
-use_parallel_build no
+build.target        bin lib
+build.args          PREFIX=${prefix}
+use_parallel_build  no
 
-destroot.args   PREFIX=${prefix}
+destroot.args       PREFIX=${prefix}
 
 variant docs description {Install extra documentation} {
-    depends_build-append port:linuxdoc-tools
-    build.target-append doc
-
-	if {! [file exists ${prefix}/bin/perl] } {
-		ui_error "«${prefix}/bin/perl» is missing.
-
-The linuxdoc-tools depends on the perl executable.
-Please create an appropriate symbolic link.
-For example you could try using:
-
-pushd ${prefix}/bin
-sudo ln -s perl5.28 perl
-popd
-"
-		return -code error "missing dependency"
-	}
+    depends_build-append    port:linuxdoc-tools path:bin/perl:perl5
+    build.target-append     doc
 }

--- a/lang/cc65/Portfile
+++ b/lang/cc65/Portfile
@@ -1,8 +1,10 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; truncate-lines: t; indent-tabs-mode: nil; c-basic-offset: 4; -*-
+# vim: set fileencoding=utf-8 tabstop=4 shiftwidth=4 softtabstop=4 noexpandtab filetype=tcl :
 PortSystem 1.0
 
 name            cc65
 conflicts       grc
-version         2.13.3
+version         2.18
 categories      lang
 platforms       darwin
 maintainers     nomaintainer
@@ -12,43 +14,40 @@ long_description \
                 cc65 is a complete cross development package for 65(C)02 \
                 systems, including a powerful macro assembler, a C compiler, \
                 linker, librarian and several other tools.
+license         CC-BY-SA 
 
-# Per http://www.cc65.org/ discontinued support in 2013, moved to github
-# No version tags on github yet
 homepage        http://cc65.github.io/cc65
-distfiles       cc65-sources-${version}.tar.bz2
-use_bzip2       yes
+distfiles       V${version}.tar.gz
 
-master_sites    http://cc65.oldos.net/ \
-                http://bj.spline.de/cc65/ \
-                ftp://ftp.musoftware.de/pub/uz/cc65/ \
-                ftp://ftp.musoftware.de/pub/uz/cc65/old/
+master_sites    git:https://github.com/cc65/cc65/archive
 
-checksums       rmd160  ad728cb61113af4592460bce7d42ca57f6a2fb1a \
-                sha256  a98a1b69d3fa15551fe7d53d5bebfc5f9b2aafb9642ee14b735587a421e00468
+checksums           rmd160  602e4956e4699103ab66dd654bfa53bce0766a85 \
+                    sha256  d14a22fb87c7bcbecd8a83d5362d5d317b19c6ce2433421f2512f28293a6eaab \
+                    size    2254374
 
 use_configure   no
 
-build.target    bins libs
-build.args      -f make/gcc.mak prefix=${prefix}
+build.target    bin lib
+build.args      PREFIX=${prefix}
 use_parallel_build no
 
-destroot.args   -f make/gcc.mak prefix=${destroot}${prefix}
-
-post-patch {
-    foreach file [glob ${worksrcpath}/src/*/make/gcc.mak] {
-        reinplace -E "s|^CC\[\[:space:\]\]*=\[\[:space:\]\]*gcc|CC=${configure.cc}|" $file
-    }
-}
+destroot.args   PREFIX=${prefix}
 
 variant docs description {Install extra documentation} {
     depends_build-append port:linuxdoc-tools
-    build.target-append docs
-    post-destroot {
-        set docdir ${destroot}${prefix}/share/doc/${name}
-        file mkdir "${docdir}/html"
-        foreach file [glob -directory ${docdir} *.htm*] {
-            move ${file} "${docdir}/html"
-        }
-    }
+    build.target-append doc
+
+	if {! [file exists ${prefix}/bin/perl] } {
+		ui_error "«${prefix}/bin/perl» is missing.
+
+The linuxdoc-tools depends on the perl executable.
+Please create an appropriate symbolic link.
+For example you could try using:
+
+pushd ${prefix}/bin
+sudo ln -s perl5.28 perl
+popd
+"
+		return -code error "missing dependency"
+	}
 }

--- a/lang/cc65/Portfile
+++ b/lang/cc65/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           makefile 1.0
 
 github.setup        cc65 cc65 2.18 V
 conflicts           grc


### PR DESCRIPTION
#### Description

* Update version
* Download newest source from github
* Update makefile targets (now spelled singular)
* Remove HTML documentation install (now installs automatically)
* Aborts build if perl symbolic link is missing

Found one ticket requesting this update:

https://trac.macports.org/ticket/59732

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.6
Xcode 12.0

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?