### PR TITLE
fdupes: Add missing deps and clean up

### DIFF
--- a/sysutils/fdupes/Portfile
+++ b/sysutils/fdupes/Portfile
@@ -1,10 +1,12 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        adrianlopezroche fdupes 2.1.2 v
-
-name                fdupes
 epoch               1
+github.setup        adrianlopezroche fdupes 2.1.2 v
+revision            1
+
 categories          sysutils
 maintainers         {grimreaper @grimreaper}
 license             MIT zlib
@@ -14,17 +16,16 @@ long_description    ${name} identifies and/or deletes duplicate files in specifi
 
 platforms           darwin freebsd
 
-checksums           rmd160  515013b26355c778469defca87a2058b43e11033 \
-                    sha256  3643fd800cce6b6346488fbe825582645a03f72b5d4e5b0640b986b3a62cd16b
+github.tarball_from releases
 
-use_autoreconf      yes
+# Remove with next version update
+dist_subdir         ${name}/${version}_1
 
-variant universal {}
+checksums           rmd160  55e5839c7baf29c06088a3297f9d205c0a6af02c \
+                    sha256  cd5cb53b6d898cf20f19b57b81114a5b263cc1149cd0da3104578b083b2837bd \
+                    size    142266
 
-build.target        ${name}
-build.args          PREFIX=${prefix} \
-                    CC=${configure.cc} \
-                    COMPILER_OPTIONS="${configure.cflags} [get_canonical_archflags cc]"
+depends_build       port:pkgconfig
 
-destroot.args       PREFIX=${prefix} \
-                    MAN_BASE_DIR=${prefix}/share/man
+depends_lib         port:ncurses \
+                    port:pcre2


### PR DESCRIPTION
#### Description

Add missing dependencies that led to build failure.

Use release download to avoid the need to autoreconf.

Remove Portfile detritus left over from pre-autotools versions of fdupes.

Add standard modeline.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14019
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
