### PR TITLE
annie: don't fetch dependencies in build phase

### DIFF
--- a/net/annie/Portfile
+++ b/net/annie/Portfile
@@ -11,9 +11,145 @@ maintainers         {l2dy @l2dy} openmaintainer
 description         fast, simple and clean video downloader
 long_description    Annie is a ${description} built with Go.
 
-checksums           rmd160  79e8e586b12e3b28273e3d29d1acab8a24b4c967 \
-                    sha256  1de8bb310907b19cac68591ea85ec6ecae89b303000059feefd7139b7267b8cf \
-                    size    73335
+checksums           ${distname}${extract.suffix} \
+                        rmd160  79e8e586b12e3b28273e3d29d1acab8a24b4c967 \
+                        sha256  1de8bb310907b19cac68591ea85ec6ecae89b303000059feefd7139b7267b8cf \
+                        size    73335
+
+go.vendors          github.com/tidwall/gjson \
+                        lock    v1.3.2 \
+                        rmd160  f54a944fae334aa845b7c200ce5d82d25727bb31 \
+                        sha256  892cd9d5e0d6ea42c2c68d2f10f7077c6b54c714e2fd6cb2931dc557995d45dc \
+                        size    49984 \
+                    golang.org/x/net \
+                        lock    3b0461eec859 \
+                        rmd160  24dae39afb612a8977e6f4a91596c64d15dd3664 \
+                        sha256  15f077bb408fb71b22e4015312be5fab7010576e824fdbfdfdb697b611621197 \
+                        size    1099249 \
+                    gopkg.in/cheggaaa/pb.v1 \
+                        lock    f907f6f5dd81f77c2bbc1cde92e4c5a04720cb11 \
+                        rmd160  67e88c2b3231e120d1a5a59218cd19593db2ece1 \
+                        sha256  75cb4d7ed3e85d8c41ebfc3e495c6f6e203fb417e1081001a0fb7623d90260e1 \
+                        size    11789 \
+                    gopkg.in/yaml.v2 \
+                        lock    v2.2.2 \
+                        rmd160  03aea7b7e847179b29044d5a928b9f8a889fe87b \
+                        sha256  da1e31b7beb9a6907947caa794134bdc2501d1a3474568b61cc2562a398d3d87 \
+                        size    70676 \
+                    gopkg.in/sourcemap.v1 \
+                        lock    v1.0.5 \
+                        rmd160  76b8e83f152fd3165e3fe61af6236b304d013277 \
+                        sha256  c0812e6da42c36fdfe817782c9f62ced1f4735b5e514812032428bae617940cd \
+                        size    5366 \
+                    github.com/andybalholm/cascadia \
+                        lock    v1.0.0 \
+                        rmd160  7e33fd35d1939f2d3cc47038a3de0045189da3d2 \
+                        sha256  f253c09a1bf4a2f7fda93afc244a58e227793862c5669761d61db6c45e6a3270 \
+                        size    13253 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.0 \
+                        rmd160  0303eae19a01f38fe314921fd965e4d09b9ef3ad \
+                        sha256  810a597004388d68bb92d8aa612375419ba1080dd5fc2c66dd41b58f0ba4442c \
+                        size    42348 \
+                    github.com/fatih/color \
+                        lock    v1.7.0 \
+                        rmd160  8a65cf00de5399f4498b41b0baed82da363f02d5 \
+                        sha256  a553c1229fe10a6b0765cbbb90245bf3383a99ba52b9608052420b40ca30d148 \
+                        size    816675 \
+                    github.com/mattn/go-runewidth \
+                        lock    v0.0.6 \
+                        rmd160  48723c7674ed822f62a2066e0af8790a0a902212 \
+                        sha256  03e292faf4dc53cc72326fc453d235c050848fbb89efa93c0b8908981ae5f209 \
+                        size    16027 \
+                    github.com/mihaiav/ytdl \
+                        lock    5f2bf8b4fec0 \
+                        rmd160  c87d0da0b180aeb267fe5a4aaeb7c8b242f15bee \
+                        sha256  3c433adb2a4ba97cf48bab6d8ded9e87c713da88cb46bc50c73b93ab95c35720 \
+                        size    121823 \
+                    github.com/tidwall/pretty \
+                        lock    v1.0.0 \
+                        rmd160  415f4cfbf485d5b5ef0837c8c81f44b6d7f4290c \
+                        sha256  e17d9d3147ea8a3a59d5ba61f1da7db81dc6e1e3c25f79cd003520bd9977ed47 \
+                        size    8825 \
+                    gopkg.in/check.v1 \
+                        lock    20d25e280405 \
+                        rmd160  412aa0d109919182ff84259e9b5bbc9f24d78117 \
+                        sha256  233f8faf427ce6701ac3427f85c28bc6b6ae7cdc97a303a52873c69999223325 \
+                        size    30360 \
+                    github.com/MercuryEngineering/CookieMonster \
+                        lock    1584578b3403 \
+                        rmd160  8e7f403f08c5e17262ae96471e879799a1930399 \
+                        sha256  fb3eea1d65ed795b0f1d0658c71579f47e0267bc6ad1a23d40bc11866eaa04e6 \
+                        size    2561 \
+                    github.com/PuerkitoBio/goquery \
+                        lock    v1.4.1 \
+                        rmd160  b70912635f930c604d1c1db9347a7340591026a2 \
+                        sha256  cdb91ddc24c3388477d072d5bf27aa62dbf6211e11f9c40af0e4173ada89e0a2 \
+                        size    100484 \
+                    github.com/kr/pretty \
+                        lock    v0.1.0 \
+                        rmd160  9aa7a5aad4c48840eecfd0f80186d1fb5ded0fd6 \
+                        sha256  f6c3f89667c63e5b7f1fc6ee2c06b6a6bfdce88f3a965ccd395b64c6f95c9a47 \
+                        size    8553 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.10 \
+                        rmd160  093514b53f1413cac2feb43f96d011191d9137b4 \
+                        sha256  50aee9bfbe31ba1db5a87d11ad8a1315327438b62c54761308d34f6a181ab806 \
+                        size    4473 \
+                    github.com/robertkrimen/otto \
+                        lock    c382bd3c16ff \
+                        rmd160  f7f8b9d5317ce8c9262b12445f73e14b983f149c \
+                        sha256  eca02ef6b28d42d8a0fb9b1f4c861d56b2645d218843bacd67e814ecdc77864a \
+                        size    251825 \
+                    github.com/rs/zerolog \
+                        lock    v1.16.0 \
+                        rmd160  278377370543aeb1a80f6ae347062c764d3ccb04 \
+                        sha256  7fdb5d49e2097db5c20b50e8e8d850d2436ac13624b4df63ecacd62a7ec237d5 \
+                        size    213581 \
+                    golang.org/x/sys \
+                        lock    e8c54fb511f6 \
+                        rmd160  2ae118108d2c1a0c98904246b64bb001d45fe683 \
+                        sha256  147228aadbe6ed748682843f2d73f5d91eba46dc1f281e4c94c1919c747730a1 \
+                        size    1514121 \
+                    github.com/cheggaaa/pb \
+                        lock    v1.0.25 \
+                        rmd160  399661c555dfd09a4436f7e2a3f4e32f6335c22a \
+                        sha256  38615dcd6f5a28658c508ab0fa5e034ad88b3a14ec3c7592d5d660b48523fb6b \
+                        size    11811 \
+                    github.com/kr/text \
+                        lock    v0.1.0 \
+                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
+                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
+                        size    8691 \
+                    github.com/mattn/go-colorable \
+                        lock    v0.0.9 \
+                        rmd160  7251bb6bf8e5651a52c8e3244d7117918e812f89 \
+                        sha256  22ae6fdf63bccd195bf108013ba477c896a11fffdbb3398487914e32e1db9b2a \
+                        size    7602 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/stretchr/testify \
+                        lock    v1.4.0 \
+                        rmd160  86bd663e13ea7266334c47689074df16252db5ff \
+                        sha256  8ed95078bfd318ea477da509e6b16e6cf8d0d1b6b8d93b1f6097c6ba2a6df788 \
+                        size    110114 \
+                    github.com/tidwall/match \
+                        lock    v1.0.1 \
+                        rmd160  4d768df32f352d4461eaf7fc8b9b4da5d72665ba \
+                        sha256  9085c9f3cb6a7bd868535f018d3b69146b3420ddf5e9dbe0d44de843ec50b1f5 \
+                        size    4366
+
+post-extract {
+    # go.mod has a replace directive:
+    file mkdir ${gopath}/src/github.com/rylio
+    ln -s ${gopath}/src/github.com/mihaiav/ytdl ${gopath}/src/github.com/rylio/ytdl
+}
+
+build.env-append    GO111MODULE=off \
+                    GOPROXY=off
 
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin


### PR DESCRIPTION
#### Description

Per https://trac.macports.org/ticket/61192 this is one of the golang ports that automatically downloads its dependencies at build time.

To fix it, I used `go2port`. Unexpected tricky parts:

- The project depends on `gopkg.in/cheggaaa/pb.v1` and `github.com/cheggaaa/pb`, which both resolve to the same GitHub repo. When moving the extracted source to the GOPATH, the `${author}-${project}-*` glob will fail because it finds both of them. I solved this by locking the first listed to the SHA1 that its tag represents ([v1.0.28 → f907f6f5dd81f77c2bbc1cde92e4c5a04720cb11](https://github.com/cheggaaa/pb/releases/tag/v1.0.28)), which lets the portgroup use a `*-${sha1}` glob instead.
- The project's go.sum replaces one of the dependencies with a fork; this is handled with a symlink in the post-extract phase.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->