### PR TITLE
fzf: don't fetch dependencies in build phase

### DIFF
--- a/sysutils/fzf/Portfile
+++ b/sysutils/fzf/Portfile
@@ -5,9 +5,6 @@ PortGroup           golang 1.0
 
 go.setup            github.com/junegunn/fzf 0.22.0
 revision            0
-checksums           rmd160  d908079785b3be51944f68df948850362381e0c4 \
-                    sha256  dbe74e4bec942ed762d5c17cf0a39013990c9d8c0c28eabd8a3b9c3e701ebd8a \
-                    size    168520
 
 categories          sysutils
 platforms           darwin
@@ -16,7 +13,79 @@ maintainers         {isi.edu:calvin @cardi} openmaintainer
 description         A command-line fuzzy finder written in Go
 long_description    ${description}
 
-build.env-append    GO111MODULE=on
+checksums           ${distname}${extract.suffix} \
+                        rmd160  d908079785b3be51944f68df948850362381e0c4 \
+                        sha256  dbe74e4bec942ed762d5c17cf0a39013990c9d8c0c28eabd8a3b9c3e701ebd8a \
+                        size    168520
+
+go.vendors          golang.org/x/net \
+                        lock    3b0461eec859 \
+                        rmd160  24dae39afb612a8977e6f4a91596c64d15dd3664 \
+                        sha256  15f077bb408fb71b22e4015312be5fab7010576e824fdbfdfdb697b611621197 \
+                        size    1099249 \
+                    golang.org/x/sys \
+                        lock    d101bd2416d5 \
+                        rmd160  b4fde1971c7da30823f86330c47f3e7ce99c1b0b \
+                        sha256  a25e432daf585f35b4a51fa126d27cdea0e5a8f0d4246c052d82221458ee7120 \
+                        size    1537258 \
+                    golang.org/x/text \
+                        lock    v0.3.2 \
+                        rmd160  3b9523084f6a8b2e6a6987e49c56f05e22ad69eb \
+                        sha256  d624899dfd390d9d4a77e5c8e5abd8c45f0b6163e0dc7176aee39f25c5f1bed0 \
+                        size    7168458 \
+                    github.com/saracen/walker \
+                        lock    324a081bae7e \
+                        rmd160  82ffb595d3c00f061e3b998508e3178583e8a55c \
+                        sha256  3f33300b0aa161cc2d9981e240031557f15b95e21cf82fae0dd8457386bc7db5 \
+                        size    11213 \
+                    github.com/gdamore/tcell \
+                        lock    v1.3.0 \
+                        rmd160  c0f9ed6375d47639b22e60fbaf9a92f1707b9ebe \
+                        sha256  d50806e75494295f22a87ba45262c641eac89c192919832aec536b44d6197a9b \
+                        size    148681 \
+                    github.com/lucasb-eyer/go-colorful \
+                        lock    v1.0.3 \
+                        rmd160  0d0a283ba00c871d123c951efea0605a869951aa \
+                        sha256  ecd902ddda5d05cc8a857873bf8b984a5cd2d7b75f1185edcfc2c472707958b3 \
+                        size    430208 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.12 \
+                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
+                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
+                        size    4549 \
+                    github.com/mattn/go-runewidth \
+                        lock    v0.0.8 \
+                        rmd160  b8241c22c38c3f900825d927ee4aeaf5071d9b30 \
+                        sha256  f5bf317ca979ae9aef8e2703d91abde64bf6674e231a531c971d8015e3d3c4ad \
+                        size    16499 \
+                    github.com/mattn/go-shellwords \
+                        lock    v1.0.9 \
+                        rmd160  5aa935c3dbfcd53edd0bb141853ec372ec21b3f2 \
+                        sha256  90e0e629892eb4b5cb31371bc59c2c86911d12c224960ffb9809c4d03813f9ea \
+                        size    5337 \
+                    golang.org/x/crypto \
+                        lock    69ecbb4d6d5d \
+                        rmd160  9e63b66c11c1b147236d923f7b14ca539b11bb07 \
+                        sha256  1d6695a9acc00b3256047a4045ed8185f79c4a30a0cf4bb034aebe97dba72495 \
+                        size    1719868 \
+                    golang.org/x/sync \
+                        lock    cd5d95a43a6e \
+                        rmd160  8bef422550566dc5e53557a975560a4f0224e509 \
+                        sha256  0b7b3e06ee571c92736ea8f11b6d2d075ca6e75008f16e8653be49c33e2876a3 \
+                        size    16964 \
+                    github.com/gdamore/encoding \
+                        lock    v1.0.0 \
+                        rmd160  3ed8916f763a5b51db1bcc8bd3ad06cf3d12ec07 \
+                        sha256  4f470c7308790bea8a526ea26cecbaa22345aad8dc566821cda6175b3d241ee1 \
+                        size    10900 \
+                    golang.org/x/tools \
+                        lock    4c025a95b26e \
+                        rmd160  141f3496c83502ba6731d9abfdc175d32be6db09 \
+                        sha256  03d811c26b803853f4e7971a7efc812765a5aace626fde7fe577d432cdd566f2 \
+                        size    2289348
+
+build.env-append    GO111MODULE=off \
+                    GOPROXY=off
 
 destroot {
     # install fzf


### PR DESCRIPTION
#### Description

Per https://trac.macports.org/ticket/61192 this is one of the golang ports that automatically downloads its dependencies at build time.

To fix it, I used `go2port`. There were no unexpected difficulties.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->