### PR TITLE
tomcat-native: update to version 1.2.25

### DIFF
--- a/java/tomcat-native/Portfile
+++ b/java/tomcat-native/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           java 1.0
 
 name                tomcat-native
-version             1.2.24
+version             1.2.25
 categories          java www
 maintainers         {thebishops.org:matt @mattbishop} openmaintainer
 license             Apache-2
@@ -17,9 +17,9 @@ long_description    This port provides access to native apr and other \
 homepage            https://tomcat.apache.org/
 master_sites        apache:tomcat/tomcat-connectors/native/${version}/source/
 
-checksums           rmd160  090f0f467eabd59c83252317f82bcd44185013f4 \
-                    sha256  037f52f9a345e766a7dde8361c55b3b69045928f9a8068a406612b603819e76c \
-                    size    419572
+checksums           rmd160  66a8500ca179059deba46e9a0054be017a512b6b \
+                    sha256  b62f29ebd1f5df25ea33698427d7eb53e3bbde953dfbcc0c9c4c6c13ed23a33b \
+                    size    421399
 
 distname            ${name}-${version}-src
 worksrcdir          ${distname}/native


### PR DESCRIPTION
#### Description

Update to tomcat-native to 1.2.25

###### Tested on

macOS 10.13.6 17G14033
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
