### PR TITLE
py-brotli: use a newer clang

### DIFF
--- a/python/py-brotli/Portfile
+++ b/python/py-brotli/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
@@ -13,7 +14,7 @@ maintainers         {raimue @raimue} \
                     openmaintainer
 license             MIT
 
-description         Python module for brotli compression format 
+description         Python module for brotli compression format
 
 long_description    \
     Brotli is a generic-purpose lossless compression algorithm that is similar \
@@ -25,6 +26,9 @@ dist_subdir         brotli
 checksums           rmd160  3e2402d137fd75f898007d3730773b32025a4857 \
                     sha256  b56a4371636e063ad3695f7c53aed5c18fc2303034564534981e7d6a11b75138 \
                     size    487046
+
+# make sure it use libc++
+compiler.blacklist  {clang < 500}
 
 python.versions     27 36 37 38
 


### PR DESCRIPTION
#### Description

py-brotli: use a newer clang

Use a newer clang to make sure it use libc++

—

_Just had an endless rev-upgrade loop:_

```
py38-brotli is using libstdc++ (this installation is configured to use libc++)
--->  Found 1 broken port, determining rebuild order
...
```

###### Type(s)

- [x] bugfix

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?