### PR TITLE
py-fontaine: new port

### DIFF
--- a/python/py-fontaine/Portfile
+++ b/python/py-fontaine/Portfile
@@ -1,0 +1,56 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-fontaine
+version             1.4.0
+revision            0
+
+categories-append   devel print
+license             GPL-3
+maintainers         nomaintainer
+platforms           darwin
+supported_archs     noarch
+
+description         a font analyzing tool
+long_description    [string map {"-" ""} ${name}] analyses fonts for their\
+                    language and character/glyph-set support.
+
+homepage            https://github.com/googlefonts/[string map {"-" ""} ${name}]
+
+set pypi_hash       88c6e98ed1d29c34212f59308139018c0f6d63d8d86659c0bc6a8ad4ad2a
+master_sites        https://files.pythonhosted.org/packages/16/32/${pypi_hash}/
+
+distname            ${python.rootname}-${version}-py2.py3-none-any
+
+checksums           rmd160  64223fe6549cd2cf1ca6240ea7d90000b2c10f43 \
+                    sha256  3c1ab64e7581d90922526cf50f527c38ca4d19a07bca06f618e053cdada2610b \
+                    size    3427730
+
+extract.suffix      .whl
+extract.only
+
+python.versions     38
+
+depends_lib-append  port:fonttools
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-pip
+    depends_lib-append      port:py${python.version}-lxml \
+                            port:py${python.version}-pyicu \
+                            port:py${python.version}-requests \
+                            port:py${python.version}-tabulate
+
+    build {}
+
+    destroot.cmd            pip-${python.branch}
+    destroot.args           --ignore-installed \
+                            --no-cache-dir \
+                            --no-dependencies \
+                            --root ${destroot} \
+                            ${distpath}/${distfiles}
+    destroot.post_args
+
+    livecheck.type          none
+}


### PR DESCRIPTION
#### Description

py-fontaine: new port

 - Closes: https://trac.macports.org/ticket/41433

https://github.com/googlefonts/pyfontaine

###### Type(s)

- [x] submission

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?