### PR TITLE
hey: new port

### DIFF
--- a/www/hey/Portfile
+++ b/www/hey/Portfile
@@ -1,0 +1,54 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/rakyll/hey 0.1.4 v
+revision            0
+
+categories          www net
+license             Apache-2
+platforms           darwin
+
+description         hey is a tiny program that sends some load to a web \
+                    application.
+
+long_description    {*}${description} HTTP load generator, ApacheBench (ab) \
+                    replacement, formerly known as rakyll/boom. Supports \
+                    HTTP\/2.
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+build.env-append    GO111MODULE=off \
+                    GOPROXY=off
+
+build.cmd           make
+build.target        release
+
+post-extract {
+    # Only build macOS: delete commands to build Windows & Linux.
+    reinplace "/windows/ d" ${worksrcpath}/Makefile
+    reinplace "/linux/ d" ${worksrcpath}/Makefile
+}
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/bin/${name}_darwin_amd64 \
+        ${destroot}${prefix}/bin/${name}
+}
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  86ef41b57b866c5b16dd7bb23b472683ebaa9045 \
+                        sha256  95b2055ddcd271bec36e6484cc5c59f122127bbce2bac961d13e248e255e5a74 \
+                        size    446406
+
+go.vendors          golang.org/x/net \
+                        lock    04a2e542c03f \
+                        rmd160  35f22500a015a0a902277c6000c3c1df4229c19e \
+                        sha256  944580a778b971086507c0b03959edb71f14c6c78d160151c5d33f608532a0a2 \
+                        size    967180 \
+                    golang.org/x/text \
+                        lock    v0.3.0 \
+                        rmd160  81061ce2006da3d6f7a8ef8dae237d65305513d3 \
+                        sha256  6243d5bbd9d8550bc44cb58a0d70180f7a3f6767299b490015107b4d27c604ae \
+                        size    6102563


### PR DESCRIPTION
#### Description

New port for the [hey HTTP load generator](https://github.com/rakyll/hey)

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.6 19G2021
Xcode 12.0.1 12A7300

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
