### PR TITLE
jenkins-cli: don't fetch dependencies in build phase

### DIFF
--- a/devel/jenkins-cli/Portfile
+++ b/devel/jenkins-cli/Portfile
@@ -12,9 +12,486 @@ maintainers         {@harens gmail.com:harensdeveloper} \
 description         Allows you manage your Jenkins as an easy way
 long_description    ${description}
 
-checksums           rmd160 c70df643173312d9333dbed7c792f51c3406ae78 \
-                    sha256 96758bd996b185214ea5e38d036eecaccd24c65d167b2e59514a53a3eeeca88c \
-                    size   179408
+checksums           ${distname}${extract.suffix} \
+                        rmd160  c70df643173312d9333dbed7c792f51c3406ae78 \
+                        sha256  96758bd996b185214ea5e38d036eecaccd24c65d167b2e59514a53a3eeeca88c \
+                        size    179408
+
+go.vendors          github.com/google/go-querystring \
+                        lock    v1.0.0 \
+                        rmd160  48593728f6bf361fa168bdc87737ee30de24f34b \
+                        sha256  0add5428914c2a378cd9e6e120a4b1e84d69df504b983f99a86aea98a52c5a57 \
+                        size    7536 \
+                    github.com/pkg/errors \
+                        lock    v0.9.1 \
+                        rmd160  dc065c655f8a24c6519b58f9d1202eb266ecda40 \
+                        sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
+                        size    13422 \
+                    github.com/xanzy/ssh-agent \
+                        lock    v0.2.1 \
+                        rmd160  356547460413381067ab37d9a8ce904dc91e5d9b \
+                        sha256  0e439b2a0962200a2e7872fb8cfe8f9be6942aa66a89230c805aac3ddc456664 \
+                        size    7623 \
+                    go.uber.org/multierr \
+                        repo    github.com/uber-go/multierr \
+                        lock    v1.5.0 \
+                        rmd160  9834945a806b4eed65cca2479dc9378cd8ad2e41 \
+                        sha256  e091350339162e7ebf1ee9a983fdebc5462e80f679405961c0e9418e34c28635 \
+                        size    12352 \
+                    github.com/smartystreets/goconvey \
+                        lock    v1.6.4 \
+                        rmd160  a3dfad6131b94d809efad84d30ce45828c6da756 \
+                        sha256  a03963296bb6d031934a651c1e637e8ab2ce9604ce6a16c158ff551e44e7ba79 \
+                        size    1478824 \
+                    github.com/spf13/jwalterweatherman \
+                        lock    v1.0.0 \
+                        rmd160  364fd0d61e94bd3651b5506d61f0e9652d6e33a3 \
+                        sha256  e70eb4dbab0603ad35c32bf89cefd595b2d6d56d66695866bfad2350db939404 \
+                        size    6405 \
+                    github.com/src-d/gcfg \
+                        lock    v1.4.0 \
+                        rmd160  9bc031184466bc7f0c704cd98af4556061a0c370 \
+                        sha256  d94bfbb72f6219a5f24688f4b346fe08d1a00e4426d14565d40f32f76c30a77d \
+                        size    28541 \
+                    golang.org/x/lint \
+                        lock    16217165b5de \
+                        rmd160  6ecf457d183d152054cca90b7dff0d2f5dc875b4 \
+                        sha256  36bd7b7dca98c2695b9f19a8e2401a2b4d8f8dabc0282bddde40c1eb5cf27b11 \
+                        size    31434 \
+                    github.com/AlecAivazis/survey \
+                        lock    v2.0.8 \
+                        rmd160  dc7f2e0e7dcbd91f18189c801daf437c2d702621 \
+                        sha256  32ff3d0a8610cfc01fcb6c2c6ae9991dd98c80868d1640593e28e6a2cc16b129 \
+                        size    1504545 \
+                    github.com/gopherjs/gopherjs \
+                        lock    0766667cb4d1 \
+                        rmd160  fe92e39110b5c188dcce98abb3b9aa1b64d68f94 \
+                        sha256  abe56698d0855027a1f6030a44924895d781b19526aa8f9b3ef49ed4199f7c57 \
+                        size    217261 \
+                    github.com/kballard/go-shellquote \
+                        lock    95032a82bc51 \
+                        rmd160  40415cd59ece9fb38b22170feec07f1f48d518a2 \
+                        sha256  41aa42696f96fb2783c5135d71ff1ec5938dfe178b51eb703e509c8ac0e7db4e \
+                        size    4335 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/fsnotify/fsnotify \
+                        lock    45d7d09e39ef4ac08d493309fa031790c15bfe8a \
+                        rmd160  4660b5721da8aea4c890786e49d7cec39c2e04d3 \
+                        sha256  7920cf1e5ccf268962fcff0b501398ed6c28ed75b1e1281fb17b19a8b0e4db5c \
+                        size    31910 \
+                    github.com/hinshun/vt10x \
+                        lock    1954e6464174 \
+                        rmd160  29d948e8755fbc4fd5000745a47d20b27ab7fae4 \
+                        sha256  31abe1530ab54f5e7dd1892d7affcc45cabade93345357aaad61a50daf11eb55 \
+                        size    1231513 \
+                    github.com/phayes/freeport \
+                        lock    95f893ade6f2 \
+                        rmd160  d1fc5421ad2ca6cf03a0838e2b18b5704a32e956 \
+                        sha256  eae7763d5bc66e629379a0c691a5543ccc8b76cf92bd79a4ccf555b023c2512f \
+                        size    3355 \
+                    moul.io/http2curl \
+                        repo    github.com/moul/http2curl \
+                        lock    v1.0.0 \
+                        rmd160  cafc3d03e88528023f021dad78806b8830d615e4 \
+                        sha256  1bbdb944e9880147b3e4d8cad8049659a5382316d399b4e38a5e9ad4ebcbd17e \
+                        size    100154 \
+                    github.com/BurntSushi/toml \
+                        lock    v0.3.1 \
+                        rmd160  fb9650e2d16525153645e5547626f242f3800149 \
+                        sha256  8cc9e5dc68e247554227973d0b4e023b27bbd9ba5a26e4fb40f44743afcb35f1 \
+                        size    42087 \
+                    github.com/flynn/go-shlex \
+                        repo    github.com/flynn-archive/go-shlex \
+                        lock    3f9db97f8568 \
+                        rmd160  ec42eaffe2cf17a46e12c7c2a7d436c0f68ba655 \
+                        sha256  b4205ec400df652238f7ed287c4b77b5f17a17d5793cd5371b7cc5e0f07dfeed \
+                        size    7690 \
+                    github.com/jtolds/gls \
+                        repo    github.com/jtolio/gls \
+                        lock    v4.20.0 \
+                        rmd160  8e721b1aa6de0606caa5a2a038ddd53a0d05d7b4 \
+                        sha256  6f98dcae4c326cbfb0400e6a01604511e544957ea88494e979ace881e2058cbb \
+                        size    7308 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.12 \
+                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
+                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
+                        size    4549 \
+                    gopkg.in/src-d/go-git-fixtures.v3 \
+                        lock    v3.5.0 \
+                        rmd160  cc539a6f1c735df5d31e34ae661a09a3d00b6b70 \
+                        sha256  037c29f438905932553e626423d0d5f28e01730ca6b1f5bcb16bf59087affcb7 \
+                        size    48427284 \
+                    gopkg.in/src-d/go-git.v4 \
+                        lock    v4.13.1 \
+                        rmd160  5fee27daad2048b683389eed98bcc313e380285e \
+                        sha256  7d778311e93226b0cf7e24febf676599e848be4b2caee1016abc20654ffc75d6 \
+                        size    434964 \
+                    gopkg.in/tomb.v1 \
+                        lock    dd632973f1e7 \
+                        rmd160  ae07f5ddbbc6afc772d6dc5273bb72eaba50529a \
+                        sha256  91c562a4e31c89d13e5391143ff653231fc2d80562743db89ce2172ad8f81008 \
+                        size    3636 \
+                    github.com/emirpasic/gods \
+                        lock    v1.12.0 \
+                        rmd160  5633e4a005c1e335bc00708aefebb0f475d30774 \
+                        sha256  c379f9a4fae5a2defdaa314deab1e201228e866a502afa8948117e52cf644ce2 \
+                        size    76836 \
+                    github.com/ghodss/yaml \
+                        lock    v1.0.0 \
+                        rmd160  b5ddb70fac3e20547f19f24002cc32f206242207 \
+                        sha256  d4bd43ce9348fc1b52af3b7de7a8e62a30d5a02d9137319f312cd95380014f6e \
+                        size    11774 \
+                    github.com/spf13/afero \
+                        lock    v1.1.2 \
+                        rmd160  dc2ff3aa582c3dc782e3c062e35b65564bfc44e5 \
+                        sha256  08dca858dce5a4336ca385028ff38e0fa6a9f064f5c874fdabe2096a34b6fc91 \
+                        size    45324 \
+                    golang.org/x/xerrors \
+                        lock    9bdfabe68543 \
+                        rmd160  eee9929ac1c0380402c45b388077c5c505f13311 \
+                        sha256  dc1be1d7efb43643507e87352ae7161883c48cb5116a20a1739ab93ab558bccf \
+                        size    13661 \
+                    rsc.io/quote \
+                        repo    github.com/rsc/quote \
+                        lock    v3.1.0 \
+                        rmd160  2eb9ee140fd7b1caf9c1982db2701ff5e904aefa \
+                        sha256  2888da2b57ac1ada770239fa88e5f39d80111bc66dbb5576b1cfd6098331292c \
+                        size    2394 \
+                    github.com/Pallinder/go-randomdata \
+                        lock    v1.2.0 \
+                        rmd160  9faa3847288c913f00ca6dd8a789f7d983a40b3b \
+                        sha256  f9994e936987b7dfc61a04dc1838b42ea897dad1b213e8c48db403db7be31406 \
+                        size    29580 \
+                    github.com/hpcloud/tail \
+                        lock    v1.0.0 \
+                        rmd160  2c6daf876a9a3ff47d239f3485810799ae9ced66 \
+                        sha256  aa9d7b729c8ee8b00c1a755ade77024e6b3ec4ac88585a39e31882260249f86b \
+                        size    37817 \
+                    github.com/kr/text \
+                        lock    v0.1.0 \
+                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
+                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
+                        size    8691 \
+                    go.uber.org/tools \
+                        repo    github.com/uber-go/tools \
+                        lock    2cfd321de3ee \
+                        rmd160  91e10fb1fc2beb1b47961d90371f2ef637965bdc \
+                        sha256  3fea942774a52de5ffe183ce6a44789999542737a580879487d7739ad94ca034 \
+                        size    11050 \
+                    gopkg.in/yaml.v3 \
+                        lock    9f266ea9e77c \
+                        rmd160  06dca2ede07b2f31c515b4711fbebc1d5359b5e4 \
+                        sha256  e70dd42fb30b7b2d0129c5cdf0e079caaf5602cab24081fdac830ec01204fa59 \
+                        size    86890 \
+                    github.com/golang/mock \
+                        lock    v1.4.3 \
+                        rmd160  f16c5c17875b60c277a642d930cd66294f803c14 \
+                        sha256  0a048a5e22510f2465410d1e0e90dc6abb9fb8d3ef87b367d4228fb81a905273 \
+                        size    55843 \
+                    github.com/kevinburke/ssh_config \
+                        lock    01f96b0aa0cd \
+                        rmd160  c962defaa545cfeafa69e015b409607091fa81ee \
+                        sha256  d1c0dd1bc30b97aa5fbbd5092aa90acb4f456aba9cc4f1843cb6d54f1265aacc \
+                        size    17343 \
+                    github.com/kr/pty \
+                        lock    v1.1.8 \
+                        rmd160  7fc6efad080de4926974713c76d2e74daf254e48 \
+                        sha256  1ea6bd7570dd02351d383c35d2900bca5295a58721afcabbc76b0d9ffbef956c \
+                        size    2120 \
+                    gopkg.in/fsnotify.v1 \
+                        repo    github.com/fsnotify/fsnotify \
+                        lock    v1.4.7 \
+                        rmd160  24712e412814020224e2779186e634610e2f6926 \
+                        sha256  bc839ee158ad34b81c1f11c3b9e3bcbabfba3297f61d165599880c400b8171dc \
+                        size    31147 \
+                    github.com/sergi/go-diff \
+                        lock    v1.0.0 \
+                        rmd160  c5ac5f7253544101282f5477a71560d1fd6c3e58 \
+                        sha256  147eecf13dff7c6715ada19e097d4c3b7d20b169b475861a98e41e27b891d062 \
+                        size    41633 \
+                    golang.org/x/text \
+                        lock    v0.3.2 \
+                        rmd160  3b9523084f6a8b2e6a6987e49c56f05e22ad69eb \
+                        sha256  d624899dfd390d9d4a77e5c8e5abd8c45f0b6163e0dc7176aee39f25c5f1bed0 \
+                        size    7168458 \
+                    gopkg.in/yaml.v2 \
+                        lock    v2.3.0 \
+                        rmd160  2f8fa56d8a413b6288132eeb7f0d7c64d27d877f \
+                        sha256  a8d1a8bc88239d25507456380b47d59ae3683d4a5f4336da4892db1ce026615f \
+                        size    72838 \
+                    github.com/nxadm/tail \
+                        lock    v1.4.4 \
+                        rmd160  33d7373bd1b164159b9032fc8595bb09b25598f6 \
+                        sha256  16d8773e0be69469d3c296ee785bbef433c3442defb68760682cdbcf80ba40ee \
+                        size    1238830 \
+                    github.com/onsi/gomega \
+                        lock    v1.10.1 \
+                        rmd160  fbdb25ab0da7cc358134327f3bf7390aae2a9e7f \
+                        sha256  f5d901f5a7321a7ed7317d1ae305bb27b7c3febc3cede1c887e2d76a8e995da6 \
+                        size    97315 \
+                    github.com/pelletier/go-toml \
+                        lock    v1.2.0 \
+                        rmd160  8d91b6485f373ccaa894abcb3bd53839e55b9057 \
+                        sha256  0a9503f2b53444e0c3ea960d18febe14d472c16279844f231994c5ccb81dbdff \
+                        size    57515 \
+                    github.com/russross/blackfriday \
+                        lock    v2.0.1 \
+                        rmd160  99cb49faff9bf24b8637dcdb3602c27c115810f3 \
+                        sha256  4078d2cd3b1c6952133b214e4eaca95f3b31a01f87a03adabd7712e7d5f20f60 \
+                        size    79665 \
+                    go.uber.org/atomic \
+                        repo    github.com/uber-go/atomic \
+                        lock    v1.6.0 \
+                        rmd160  ebfda750cce72e0ad3c9cdca9600b93816da7937 \
+                        sha256  c96dbf4429ae71c1f30cd56e541bbc56f47b933b989b3fa776f1b1e0c3d162b5 \
+                        size    9687 \
+                    golang.org/x/net \
+                        lock    59133d7f0dd7 \
+                        rmd160  d616bd1708c6146fcebdbe502150ec864010ec3c \
+                        sha256  6307d9083c82e0e4479928b5b410b081a8e82a2f8e4e1310d582784d47d7d6bb \
+                        size    1174645 \
+                    rsc.io/sampler \
+                        repo    github.com/rsc/sampler \
+                        lock    v1.3.0 \
+                        rmd160  1065f86e4e9b409333fa5c7d5ae8fb758d95c405 \
+                        sha256  3bc8813c1560a38a75d7e3567872fb64edd06a3fc17d84cc2290750d5cb6257b \
+                        size    12085 \
+                    github.com/danieljoos/wincred \
+                        lock    v1.0.2 \
+                        rmd160  5c11e9a9456e95206026f046f7cf4155a1242772 \
+                        sha256  32bd65b53b328fa4fa509ed3191f95b1f30bc25bf0e379df2054a0f05a2a3510 \
+                        size    8488 \
+                    github.com/gosuri/uiprogress \
+                        lock    v0.0.1 \
+                        rmd160  6105a29500818c0ae601b63f4effca0e4491d74c \
+                        sha256  36322491583675a83703aa8d53801038e401d053fbd2455b65a7af05e7679c91 \
+                        size    1655288 \
+                    github.com/stretchr/objx \
+                        lock    v0.2.0 \
+                        rmd160  c56e1cd0bf459aa10978a3db9448860f64ff3464 \
+                        sha256  3e5e938cdfe8b8aa24f9b234cdc61b30cffa37ef385c1c07139af3dde803d622 \
+                        size    80014 \
+                    github.com/zalando/go-keyring \
+                        lock    667557018717 \
+                        rmd160  2e812197bdf9e67dd1cf7b35d433ff4257358b99 \
+                        sha256  20c71285d42c7e955806e92ce14b9aeb3d8fdd6eea1c3fc38987360510dc4f66 \
+                        size    9644 \
+                    github.com/mitchellh/go-homedir \
+                        lock    v1.1.0 \
+                        rmd160  44b3985e40e5bbb22d11f8622c340f9ed727ea91 \
+                        sha256  024c8a57316c7fbc0eb23cdbfd57f72a74b51beb83d714034d67ee9aba48100c \
+                        size    3366 \
+                    golang.org/x/tools \
+                        lock    b9c20aec41a5 \
+                        rmd160  1000add3821149cc56bbf8377f8b0c42475ccc5b \
+                        sha256  c94ccb9eca6541875499b8e5b654200722b117fc9ff29f89cad5edbeaa8ba693 \
+                        size    2299263 \
+                    github.com/google/go-github \
+                        lock    v29.0.3 \
+                        rmd160  4f0c5a14a7fb840aad4fb9a2799bacbaa1746e7a \
+                        sha256  5e58f80fff193d0c2046e124a71e6c1e47d7394b831ca02d029d015e157ee2d6 \
+                        size    280503 \
+                    github.com/hashicorp/go-version \
+                        lock    v1.2.1 \
+                        rmd160  0f4bd846a25d1886e0b49389ef64b86942287d26 \
+                        sha256  bf7d66ca91f84f59277141ec22b5f18ba6facaca23d99b36b0c1a08cc0631f4a \
+                        size    13923 \
+                    github.com/inconshreveable/mousetrap \
+                        lock    v1.0.0 \
+                        rmd160  5c617a09f1432fc543672a0e0c1e13d3752030c2 \
+                        sha256  0e6bae2849f13d12fe361ecac087728e4e97f3482f4cec44f6e7a2c53bb9cd0c \
+                        size    2291 \
+                    github.com/magiconair/properties \
+                        lock    v1.8.0 \
+                        rmd160  327cf3e96df60025444491a413aba0145ef448f3 \
+                        sha256  1a51357a88b298284fa48607836e7d05bee5fc58e00c87ba943a8d719d2ece2c \
+                        size    29500 \
+                    github.com/spf13/cast \
+                        lock    v1.3.0 \
+                        rmd160  26b82e9734f643bc70be8c73742d4a4f514b6dd2 \
+                        sha256  f2913fc10731a578c016701bd10e6a267c299b94e69d8362d258ce8482d14faf \
+                        size    11086 \
+                    golang.org/x/crypto \
+                        lock    0ec3e9974c59 \
+                        rmd160  f6b84b267673d7c369504d9d3fd1733adb82702a \
+                        sha256  8a7868bca28251b1db06da1085e9ea4437fc2c51a5bb6c9756d7f465b273265c \
+                        size    1728327 \
+                    github.com/cpuguy83/go-md2man \
+                        lock    v2.0.0 \
+                        rmd160  85f342c341fa928e9ec874490c277bdabf1c39c6 \
+                        sha256  2f3f8bc701df4890a5a4baf0b632ad3290be1e0aaf572b2e58fd57df93efc306 \
+                        size    52040 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/hashicorp/hcl \
+                        lock    v1.0.0 \
+                        rmd160  ad8d0b523bb708fd6ae77df8bb414c103a75aa92 \
+                        sha256  4fc0e87ac9d3d6cd042f044df2db2703bed569051fb8c179d505edeb4433e96e \
+                        size    70636 \
+                    github.com/jbenet/go-context \
+                        lock    d14ea06fba99 \
+                        rmd160  37097898ecea5e875655fde48f48f126e0331246 \
+                        sha256  ce27afd2576a5bc82565c8aa2ef108b1bb3c4dd80ebb4939455cab2495b74a2f \
+                        size    5943 \
+                    github.com/smartystreets/assertions \
+                        lock    b2de0cb4f26d \
+                        rmd160  32d7082172ea8c4a03119f3ffb803f8aad9744ce \
+                        sha256  469875871db96f87e62f76f0bfc4b3b0b9e4761c2a14d4ce12f246797a7c342c \
+                        size    52177 \
+                    github.com/stretchr/testify \
+                        lock    v1.6.1 \
+                        rmd160  7e5b798212a8f15cd58a63985ae0b928eede8e6b \
+                        sha256  44d77d9b5c1dc08fa710eac9bb324898210660458085cdf965b78a39b1010f2a \
+                        size    84248 \
+                    go.uber.org/zap \
+                        repo    github.com/uber-go/zap \
+                        lock    v1.15.0 \
+                        rmd160  94f29dc9f95b6fa944910baff4c2cbf1317340ec \
+                        sha256  fc689f05de92409aa7b385ec680174868f757635515c5ddbfe5af3ae797d7fb5 \
+                        size    128241 \
+                    golang.org/x/sys \
+                        lock    fe76b779f299 \
+                        rmd160  c5d83512cc97d6991a72faf3427ea94e6528089e \
+                        sha256  f3446372dccde31a5c10b00cd8fada6e479413aa0f7ac4911b1362e524e08af3 \
+                        size    1052809 \
+                    github.com/Netflix/go-expect \
+                        lock    c93bf25de8e8 \
+                        rmd160  a4e10dd1f05c584ae80408e373cc5b9e90581dc7 \
+                        sha256  896ec6b1f14446e88345be7dc7a8575957040b5a3729da1698ca88138e085ee2 \
+                        size    14580 \
+                    github.com/creack/pty \
+                        lock    v1.1.7 \
+                        rmd160  06ce51de1e7f9a347eee40c40189c6e0c9a13d13 \
+                        sha256  150b50e6eb2fec8c7e904e54be1aacfbb1df09b5a97ef7b77284fea8ac44fc3c \
+                        size    8168 \
+                    github.com/godbus/dbus \
+                        lock    v4.1.0 \
+                        rmd160  a5f33db9bdab3ed956745965c1f8c27dfe8e8292 \
+                        sha256  4fe3c261fa88573cb48bad97302ca4f81cb93e0858294165ec8c0877efa66c43 \
+                        size    53485 \
+                    github.com/gosuri/uilive \
+                        lock    v0.0.3 \
+                        rmd160  8a2998501e1548327742df5a947a1130bd79038e \
+                        sha256  d48a49181d5de8cec350018489a3a92b35bf398a2a4941bb19ef82e616b28a09 \
+                        size    153518 \
+                    google.golang.org/protobuf \
+                        repo    github.com/protocolbuffers/protobuf-go \
+                        lock    v1.23.0 \
+                        rmd160  b9954ce9dc927216440d55f850073bbf47113143 \
+                        sha256  41a885f3290ce459bcd4251a6df0787ead449c835a718f8f46342cad1dc26b85 \
+                        size    1214926 \
+                    gopkg.in/src-d/go-billy.v4 \
+                        lock    v4.3.2 \
+                        rmd160  2a253d253ea17bfdbd8765f43cc1d5f1da3c79ef \
+                        sha256  d85b42827fdd2cd1cf24163b734f8520ea8915a8df87aae7747c51ed0416f550 \
+                        size    28036 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.5 \
+                        rmd160  2ce81608a38c6f383a35bccd24d64361df5828c9 \
+                        sha256  7f41acdcba65b1fab5b9b633947a139f9915b60f94bdab486cdbe9d90c54f61e \
+                        size    50815 \
+                    honnef.co/go/tools \
+                        repo    github.com/dominikh/go-tools \
+                        lock    v0.0.1-2019.2.3 \
+                        rmd160  28128f9e1a1133fa5b5f7dc699bce51d51eee885 \
+                        sha256  9c4e923b01dec19623427d959de8d3d53a0a761a812eb003934062337ea32233 \
+                        size    367558 \
+                    github.com/alcortesm/tgz \
+                        lock    9c5fe88206d7 \
+                        rmd160  8871d33b125cb1f85571855293f6b9131496aa51 \
+                        sha256  b834470efd98946b981c77fcfcfb6ac181e675a4599b5799257347e7b7ea4d04 \
+                        size    4129 \
+                    github.com/armon/go-socks5 \
+                        lock    e75332964ef5 \
+                        rmd160  22c2f6c6cfb6fc9e445df5d6e3d7d41d96984e02 \
+                        sha256  30b0b6e33f090505354e6f86d4da39d93d9d31221d354f3166b676f4db30a387 \
+                        size    8583 \
+                    github.com/golang/protobuf \
+                        lock    v1.4.2 \
+                        rmd160  fbf4477bc008421fde463d79f7bc54a36de91db2 \
+                        sha256  206d74f8fd066bb178135ee9c092e986f8a1e1104df242e148e99e5a839e4ef2 \
+                        size    171802 \
+                    github.com/shurcooL/sanitized_anchor_name \
+                        lock    v1.0.0 \
+                        rmd160  c7e5322dba53e10db1711d65c146af5649b0c7c8 \
+                        sha256  ed9418de8c92acfbbd8608745855ebfc67fa686c0a0a5245cf8eece8f540baa9 \
+                        size    2144 \
+                    github.com/mgutz/ansi \
+                        lock    9520e82c474b \
+                        rmd160  fea73fc246ac2b229bb91accba053fed2ea63536 \
+                        sha256  75eaed501d7d121ad75c83246fecdc6222dbbbd3fcb4140c8775e219fff440ce \
+                        size    4878 \
+                    github.com/spf13/cobra \
+                        lock    v1.0.0 \
+                        rmd160  73602c4d37ad508ba8b35812c793e1df3eda7bb9 \
+                        sha256  6cdf3f445559b8f41f5288366a4c26e8d1b1601dac6924af091a49f1f6b11396 \
+                        size    128931 \
+                    gopkg.in/warnings.v0 \
+                        lock    v0.1.2 \
+                        rmd160  e0245ded51f41ce8051ae561d1a0b844f4b8f181 \
+                        sha256  547803dff3ec1c7adb69c411e7b3846595c3265d22a8888001661504d23bd4fb \
+                        size    3772 \
+                    github.com/anmitsu/go-shlex \
+                        lock    648efa622239 \
+                        rmd160  2cd39571128de9ea259f8ebafc292db77bfbc33e \
+                        sha256  ce0cf5fc33466e610f1605683f2e2bcb1e8212cece926074095a80f1326ed15f \
+                        size    3862 \
+                    github.com/atotto/clipboard \
+                        lock    v0.1.2 \
+                        rmd160  4a0617ed814da771a9701f36b2be950301e153df \
+                        sha256  d3923f2514644b13032c76bf75fd66ef4e581afd8a86e186a300d1da12f688b3 \
+                        size    4476 \
+                    github.com/chai2010/gettext-go \
+                        lock    bf70f2a70fb1 \
+                        rmd160  2a4c082bd801eae3ab533878ede13c4e277af11f \
+                        sha256  fc785c4e2dfeffc816da440f3a33246d375a3698ede6476c10aaee555f288196 \
+                        size    812528 \
+                    github.com/google/go-cmp \
+                        lock    v0.4.0 \
+                        rmd160  2d73ccb9863b49adb03196aff7c41a7048e646fb \
+                        sha256  e7274fa6cc337c12123a02acc907524b7c3c234af59b2c924664300a57cb3ea0 \
+                        size    81597 \
+                    github.com/onsi/ginkgo \
+                        lock    v1.14.0 \
+                        rmd160  a1ff8b445c4b593fc8c399993c90f8ff423260fa \
+                        sha256  5aec86ace19613b3976cdadf587d42461d47b89b9b02c5dabafa05a86f704fb2 \
+                        size    145828 \
+                    gopkg.in/check.v1 \
+                        lock    788fd7840127 \
+                        rmd160  b63165c8909a27edc15dda210df66a1b49efb49e \
+                        sha256  7e5547c6471cc48da89a7c87f965b20ca5311f43fc4d883ca62f9fccf7551630 \
+                        size    31597 \
+                    github.com/gliderlabs/ssh \
+                        lock    v0.2.2 \
+                        rmd160  1fef7211bf32e04b3daa1f2dcfb5e56afcff6cd1 \
+                        sha256  fab13a77bd8c2ec9e8f441b81515016f2783fa348405676d9952f2ad78412ca2 \
+                        size    21484 \
+                    github.com/kr/pretty \
+                        lock    v0.1.0 \
+                        rmd160  9aa7a5aad4c48840eecfd0f80186d1fb5ded0fd6 \
+                        sha256  f6c3f89667c63e5b7f1fc6ee2c06b6a6bfdce88f3a965ccd395b64c6f95c9a47 \
+                        size    8553 \
+                    github.com/mattn/go-colorable \
+                        lock    v0.1.4 \
+                        rmd160  aeaf016c7ae6cf014233a5a327e4227acf17adea \
+                        sha256  d64a7c2835de356f83a8af8ac9e07ce45d13a5ecb5062efd7f63b85b0b173193 \
+                        size    8987 \
+                    github.com/mitchellh/mapstructure \
+                        lock    v1.1.2 \
+                        rmd160  a4e01781ea5bb0c987e18e8e450c8f1023d5a857 \
+                        sha256  9c1076f5a8e923d028cb65c36143f3b1478cbaa4420e2e8f332719edc2fc4f71 \
+                        size    20992
+
+build.env-append    GOPROXY=off \
+                    GO111MODULE=off
 
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/jcli


### PR DESCRIPTION
#### Description

Per https://trac.macports.org/ticket/61192 this is one of the golang ports that automatically downloads its dependencies at build time.

To fix it, I used `go2port`. There were some unexpected difficulties:

- The port depends on both `gopkg.in/src-d/go-git.v4` and `gopkg.in/src-d/go-git-fixtures.v3`. After extraction, the sources must be moved to the GOPATH, but the glob used to do that (`${author}-${project}-*`) will match both of these packages and fail if `gopkg.in/src-d/go-git.v4` is attempted first. I moved it after `gopkg.in/src-d/go-git-fixtures.v3` to solve this issue.
- `github.com/flynn/go-shlex`, `github.com/jtolds/gls`, and `gopkg.in/fsnotify.v1` have been renamed on GitHub in ways that required manually specifying the `repo` keyword
- `google.golang.org/protobuf` is hosted at `go.googlesource.com` but the latter cannot serve stable tarballs, so I manually resolved it to the mirror `github.com/protocolbuffers/protobuf-go`
- `github.com/fsnotify/fsnotify` and `gopkg.in/fsnotify.v1` resolve to the same repo but are locked to different versions. Since they use different package names, this is actually OK, but we have the globbing problem again described above. This time we can't solve it by reordering, so I locked `github.com/fsnotify/fsnotify` (because it's first in the list) to the git SHA1 equivalent of the tag (`v1.4.9` → [45d7d09e39ef4ac08d493309fa031790c15bfe8a](https://github.com/fsnotify/fsnotify/releases/tag/v1.4.9)), which allows using the glob `*-${sha1}`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->