### PR TITLE
py-tensorflow: Bugix: Add portgroup legacysupport

### DIFF
--- a/python/py-tensorflow/Portfile
+++ b/python/py-tensorflow/Portfile
@@ -1,16 +1,17 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem                                         1.0
-PortGroup           python                         1.0
-PortGroup           java                           1.0
-PortGroup           github                         1.0
-PortGroup           compilers                      1.0
-PortGroup           compiler_blacklist_versions    1.0
-PortGroup           xcode_workaround               1.0
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           java 1.0
+PortGroup           github 1.0
+PortGroup           compilers 1.0
+PortGroup           compiler_blacklist_versions 1.0
+PortGroup           legacysupport 1.0
+PortGroup           xcode_workaround 1.0
 
 name                py-tensorflow
 version             2.3.1
-revision            0
+revision            1
 github.setup        tensorflow tensorflow ${version} v
 platforms           darwin
 supported_archs     x86_64
@@ -47,7 +48,7 @@ java.fallback       openjdk11
 # declare no conflict to allow redistribution of binaries.
 license_noconflict  ${java.fallback}
 
-compiler.cxx_standard 2014
+compiler.cxx_standard   2014
 
 # The oldest Xcode version to use default Xcode compiler
 # https://github.com/tensorflow/tensorflow/issues/39262


### PR DESCRIPTION
py-tensorflow: Bugix: Add portgroup legacysupport

Fixes:
* https://trac.macports.org/ticket/60960
* https://github.com/tensorflow/tensorflow/issues/42479

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
