### PR TITLE
py-brotli: Use MacPorts CXXFLAGS

### DIFF
--- a/python/py-brotli/Portfile
+++ b/python/py-brotli/Portfile
@@ -1,12 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
 # keep this in sync with port brotli
 github.setup        google brotli 1.0.9 v
+revision            1
 name                py-brotli
 categories          python archivers
 platforms           darwin
@@ -27,13 +27,12 @@ checksums           rmd160  3e2402d137fd75f898007d3730773b32025a4857 \
                     sha256  b56a4371636e063ad3695f7c53aed5c18fc2303034564534981e7d6a11b75138 \
                     size    487046
 
-# make sure it use libc++
-compiler.blacklist  {clang < 500}
-
 python.versions     27 36 37 38
 
 if {$subport ne $name} {
     depends_build-append port:py${python.version}-setuptools
+
+    patchfiles      CXXFLAGS.patch
 
     test.run yes
 

--- a/python/py-brotli/files/CXXFLAGS.patch
+++ b/python/py-brotli/files/CXXFLAGS.patch
@@ -1,0 +1,27 @@
+Honor MacPorts CXXFLAGS.
+--- setup.py.orig	2020-08-27 09:12:55.000000000 -0500
++++ setup.py	2020-10-05 22:57:09.000000000 -0500
+@@ -79,11 +79,15 @@
+                 cxx_sources.append(source)
+         extra_args = ext.extra_compile_args or []
+ 
++        cxxflags = os.environ['CXXFLAGS'].split()
++
+         objects = []
+         for lang, sources in (('c', c_sources), ('c++', cxx_sources)):
+             if lang == 'c++':
+                 if self.compiler.compiler_type == 'msvc':
+                     extra_args.append('/EHsc')
++                else:
++                    extra_args.extend(cxxflags)
+ 
+             macros = ext.define_macros[:]
+             if platform.system() == 'Darwin':
+@@ -110,6 +114,7 @@
+         if ext.extra_objects:
+             objects.extend(ext.extra_objects)
+         extra_args = ext.extra_link_args or []
++        extra_args.extend(cxxflags)
+         # when using GCC on Windows, we statically link libgcc and libstdc++,
+         # so that we don't need to package extra DLLs
+         if self.compiler.compiler_type == 'mingw32':


### PR DESCRIPTION
#### Description

This ensures that it's using the right C++ standard library. Since it wasn't doing that before for 10.6-10.8, this changes the files on disk on those systems, so the revision is increased.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14019
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] tried a full install with `sudo port -vst install`?
