### PR TITLE
py-spaCy, py-spaCy-models: Update to 2.3.2

### DIFF
--- a/python/py-blis/Portfile
+++ b/python/py-blis/Portfile
@@ -6,14 +6,13 @@ PortGroup           github                      1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 name                py-blis
+epoch               1
 # Don't upgrade past py-spaCy's highest supported version.
-version             0.7.1
+github.setup        explosion cython-blis 0.4.2 v
 revision            0
-github.setup        explosion cython-blis ${version} v
-
-checksums           rmd160  cf785889d6dd39dc10008fe94b8a89b26e16e0f2 \
-                    sha256  d220efe8e91153b77f6eb67130d5bd1ac4ea20e0d312a82f10a2f32daf9908d4 \
-                    size    3004317
+checksums           rmd160  3e51b8e63d1018e0695c43bf600b0d3d281f5d7e \
+                    sha256  a54606d48cee4d366442b313fbd2286710b2be0c83cdab0b19cd97492590967c \
+                    size    2038082
 
 platforms           darwin
 supported_archs     x86_64

--- a/python/py-blis/Portfile
+++ b/python/py-blis/Portfile
@@ -6,6 +6,7 @@ PortGroup           github                      1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 name                py-blis
+# Don't upgrade past py-spaCy's highest supported version.
 version             0.7.1
 revision            0
 github.setup        explosion cython-blis ${version} v

--- a/python/py-catalogue/Portfile
+++ b/python/py-catalogue/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
+# Don't upgrade past py-spaCy's highest supported version.
 github.setup        explosion catalogue 2.0.0 v
 revision            0
 name                py-${github.project}

--- a/python/py-catalogue/Portfile
+++ b/python/py-catalogue/Portfile
@@ -4,11 +4,15 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
+epoch               1
 # Don't upgrade past py-spaCy's highest supported version.
-github.setup        explosion catalogue 2.0.0 v
+github.setup        explosion catalogue 1.0.0 v
 revision            0
-name                py-${github.project}
+checksums           rmd160  4c9cd255190c1fe4ac4d477732212b00a673df14 \
+                    sha256  172d02f89b5b53fcccace7e8c9a43eb94639489bb08ea709b323a5dcf20e6756 \
+                    size    8417
 
+name                py-${github.project}
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
@@ -29,21 +33,9 @@ long_description    catalogue is a tiny, zero-dependencies library\
                     instead saved the function, you'd have to use\
                     Pickle for serialization, which has many drawbacks.
 
-checksums           rmd160  d0d0b96bd45e1eadbe9be40f6cddab32fa79fb7c \
-                    sha256  89bbad38ea3311309c178422db88989dfd3e5722927774823c94a1bbaccd5265 \
-                    size    8380
-
 python.versions     35 36 37 38
 
 if {${name} ne ${subport}} {
-    if {${python.version} == 35} {
-        github.setup    explosion catalogue 1.0.0 v
-        revision        0
-        checksums       rmd160  4c9cd255190c1fe4ac4d477732212b00a673df14 \
-                        sha256  172d02f89b5b53fcccace7e8c9a43eb94639489bb08ea709b323a5dcf20e6756 \
-                        size    8417
-    }
-
     depends_build-append \
                     port:py${python.version}-setuptools
 

--- a/python/py-cymem/Portfile
+++ b/python/py-cymem/Portfile
@@ -30,8 +30,7 @@ python.versions     27 35 36 37 38
 if {${name} ne ${subport}} {
 
     depends_build-append \
-        port:py${python.version}-setuptools \
-        port:py${python.version}-wheel
+        port:py${python.version}-setuptools
 
     depends_lib-append \
         port:py${python.version}-cython
@@ -39,10 +38,7 @@ if {${name} ne ${subport}} {
     depends_test-append \
         port:py${python.version}-pytest
 
-    post-extract {
-        # Fix hard-coded dep ...
-        reinplace "s|0.33.0|0.33.999|g" ${worksrcpath}/setup.py
-    }
+    patchfiles      setup.py.patch
 
     livecheck.type none 
 

--- a/python/py-cymem/Portfile
+++ b/python/py-cymem/Portfile
@@ -5,6 +5,7 @@ PortGroup           python           1.0
 PortGroup           github           1.0
 
 name                py-cymem
+# Don't upgrade past py-spaCy's highest supported version.
 version             2.0.3
 revision            0
 github.setup        explosion cymem ${version} v

--- a/python/py-cymem/files/setup.py.patch
+++ b/python/py-cymem/files/setup.py.patch
@@ -1,0 +1,12 @@
+Remove unnecessary dependency on wheel.
+https://github.com/explosion/cymem/issues/13
+--- setup.py.orig	2019-11-12 08:52:36.000000000 -0600
++++ setup.py	2020-10-06 23:08:58.000000000 -0500
+@@ -121,7 +121,6 @@
+             url=about["__uri__"],
+             license=about["__license__"],
+             ext_modules=ext_modules,
+-            setup_requires=["wheel>=0.32.0,<0.33.0"],
+             classifiers=[
+                 "Environment :: Console",
+                 "Intended Audience :: Developers",

--- a/python/py-murmurhash/Portfile
+++ b/python/py-murmurhash/Portfile
@@ -34,8 +34,7 @@ python.default_version 37
 if {${name} ne ${subport}} {
 
     depends_build-append \
-        port:py${python.version}-setuptools \
-        port:py${python.version}-wheel
+        port:py${python.version}-setuptools
 
     depends_lib-append \
         port:py${python.version}-cython
@@ -43,10 +42,7 @@ if {${name} ne ${subport}} {
     depends_test-append \
         port:py${python.version}-pytest
 
-    post-extract {
-        # Fix hard-coded dep ...
-        reinplace "s|0.33.0|0.33.999|g" ${worksrcpath}/setup.py
-    }
+    patchfiles      setup.py.patch
     
     livecheck.type none
     

--- a/python/py-murmurhash/Portfile
+++ b/python/py-murmurhash/Portfile
@@ -5,6 +5,7 @@ PortGroup           python           1.0
 PortGroup           github           1.0
 
 name                py-murmurhash
+# Don't upgrade past py-spaCy's highest supported version.
 version             1.0.2
 revision            0
 github.setup        explosion murmurhash ${version} v

--- a/python/py-murmurhash/files/setup.py.patch
+++ b/python/py-murmurhash/files/setup.py.patch
@@ -1,0 +1,12 @@
+Remove unnecessary dependency on wheel.
+https://github.com/explosion/murmurhash/issues/12
+--- setup.py.orig	2019-02-18 08:17:50.000000000 -0600
++++ setup.py	2020-10-06 23:11:35.000000000 -0500
+@@ -126,7 +126,6 @@
+             url=about['__uri__'],
+             license=about['__license__'],
+             ext_modules=ext_modules,
+-            setup_requires=['wheel>=0.32.0,<0.33.0'],
+             classifiers=[
+                 'Development Status :: 5 - Production/Stable',
+                 'Environment :: Console',

--- a/python/py-preshed/Portfile
+++ b/python/py-preshed/Portfile
@@ -34,8 +34,7 @@ python.default_version 37
 if {${name} ne ${subport}} {
 
     depends_build-append \
-        port:py${python.version}-setuptools \
-        port:py${python.version}-wheel
+        port:py${python.version}-setuptools
 
     depends_lib-append \
         port:py${python.version}-cython \
@@ -44,11 +43,6 @@ if {${name} ne ${subport}} {
 
     depends_test-append \
         port:py${python.version}-pytest
-
-    post-extract {
-        # Fix hard-coded dep ...
-        reinplace "s|0.33.0|0.33.999|g" ${worksrcpath}/setup.py
-    }
 
     livecheck.type none 
 

--- a/python/py-preshed/Portfile
+++ b/python/py-preshed/Portfile
@@ -5,6 +5,7 @@ PortGroup           python         1.0
 PortGroup           github         1.0
 
 name                py-preshed
+# Don't upgrade past py-spaCy's highest supported version.
 version             3.0.2
 revision            0
 github.setup        explosion preshed ${version} v

--- a/python/py-spaCy-models/Portfile
+++ b/python/py-spaCy-models/Portfile
@@ -4,7 +4,7 @@ PortSystem                         1.0
 PortGroup           python         1.0
 
 name                py-spaCy-models
-version             2.2.4
+version             2.3.2
 revision            0
 
 platforms           darwin
@@ -15,14 +15,12 @@ license             MIT
 maintainers         nomaintainer
 
 description         Models for the spaCy Natural Language Processing (NLP) library
-long_description    ${description}
+long_description    {*}${description}
 
 homepage            https://spacy.io/models
 
-# Support python versions
 python.versions     36 37 38
 
-patchfiles
 distfiles
 build {}
 
@@ -31,9 +29,9 @@ if {${name} ne ${subport}} {
     depends_lib-append \
         port:py${python.version}-spaCy
     
-    destroot.cmd "${python.bin} -m spacy download en"
-    destroot.args " "
-    destroot.pre_args " "
+    destroot.cmd    ${python.bin}
+    destroot.pre_args
+    destroot.args   -m spacy download en
 
 }
 

--- a/python/py-spaCy/Portfile
+++ b/python/py-spaCy/Portfile
@@ -2,18 +2,15 @@
 
 PortSystem                                      1.0
 PortGroup           python                      1.0
-PortGroup           github                      1.0
 PortGroup           mpi                         1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 name                py-spaCy
-version             2.2.4
+version             2.3.2
 revision            0
-github.setup        explosion spaCy ${version} v
-
-checksums           rmd160  e8767e6e38da0396c7f61f31819986524ad08340 \
-                    sha256  817343b98a3ab2673f0645bc62c74d76cb9778c27c79c5d0c22572dadac5744d \
-                    size    4875280
+checksums           rmd160  e4341628128740cc4c5003893eacdbb65ba34f1f \
+                    sha256  818de26e0e383f64ccbe3db185574920de05923d8deac8bbb12113b9e33cee1f \
+                    size    5902578
 
 platforms           darwin
 supported_archs     x86_64
@@ -23,14 +20,11 @@ license             MIT
 maintainers         nomaintainer
 
 description         Industrial-strength Natural Language Processing (NLP) with Python and Cython
-long_description    ${description}
+long_description    {*}${description}
 
 homepage            https://spacy.io
 
-# Exclude anything with non-numbers
-github.livecheck.regex {([0-9.]+)}
-
-# Support python versions
+python.rootname     spacy
 python.versions     36 37 38
 python.default_version 38
 
@@ -39,8 +33,6 @@ if {${name} ne ${subport}} {
 
     compiler.cxx_standard 2014
     compiler.blacklist-append *gcc* {clang < 900} {macports-clang-3.[0-9]} macports-clang-4.0
-
-    set PythonVersionWithDot [join [split ${python.version} ""] "."]
 
     depends_build-append \
         port:cctools \
@@ -53,25 +45,27 @@ if {${name} ne ${subport}} {
         port:py${python.version}-catalogue \
         port:py${python.version}-cython \
         port:py${python.version}-jsonschema \
-        port:py${python.version}-mmh3 \
         port:py${python.version}-murmurhash \
         port:py${python.version}-numpy \
-        port:py${python.version}-pip \
         port:py${python.version}-plac \
         port:py${python.version}-preshed \
         port:py${python.version}-requests \
         port:py${python.version}-srsly \
         port:py${python.version}-thinc \
+        port:py${python.version}-tqdm \
         port:py${python.version}-wasabi  
 
     depends_test-append \
         port:py${python.version}-flake8 \
         port:py${python.version}-mock \
-        port:py${python.version}-pytest \
-        port:py${python.version}-regex
+        port:py${python.version}-pytest
+
+    # spaCy uses pip to download models.
+    depends_run-append \
+        port:py${python.version}-pip
     
     post-patch {
-        reinplace "s|\"cython\"|\"cython-${PythonVersionWithDot}\"|g" ${worksrcpath}/bin/cythonize.py
+        reinplace "s|\"cython\"|\"cython-${python.branch}\"|g" ${worksrcpath}/bin/cythonize.py
         reinplace "s|python|${python.bin}|g" ${worksrcpath}/bin/spacy
         reinplace "s|python \-m|${python.bin} \-m|g" ${worksrcpath}/spacy/cli/validate.py
     }

--- a/python/py-spaCy/Portfile
+++ b/python/py-spaCy/Portfile
@@ -74,8 +74,8 @@ if {${name} ne ${subport}} {
     
     post-extract {
         reinplace "s|\"cython\"|\"cython-${PythonVersionWithDot}\"|g" ${worksrcpath}/bin/cythonize.py
-        reinplace "s|python|${python.bin}|g" bin/spacy
-        reinplace "s|python \-m|${python.bin} \-m|g" spacy/cli/validate.py
+        reinplace "s|python|${python.bin}|g" ${worksrcpath}/bin/spacy
+        reinplace "s|python \-m|${python.bin} \-m|g" ${worksrcpath}/spacy/cli/validate.py
     }
     
     build.cmd    "${python.bin} setup.py build_ext --inplace"

--- a/python/py-spaCy/Portfile
+++ b/python/py-spaCy/Portfile
@@ -34,13 +34,11 @@ github.livecheck.regex {([0-9.]+)}
 python.versions     36 37 38
 python.default_version 38
 
-mpi.setup           -gcc44 -gcc45 -clang33 -clang34 -clang37 -gfortran -g95
-
-# Compiler selection
-compiler.cxx_standard 2014
-compiler.blacklist-append *gcc* {clang < 900} {macports-clang-3.[0-9]} macports-clang-4.0
-
 if {${name} ne ${subport}} {
+    mpi.setup       -gcc44 -gcc45 -clang33 -clang34 -clang37 -gfortran -g95
+
+    compiler.cxx_standard 2014
+    compiler.blacklist-append *gcc* {clang < 900} {macports-clang-3.[0-9]} macports-clang-4.0
 
     set PythonVersionWithDot [join [split ${python.version} ""] "."]
 

--- a/python/py-spaCy/Portfile
+++ b/python/py-spaCy/Portfile
@@ -72,7 +72,7 @@ if {${name} ne ${subport}} {
         port:py${python.version}-pytest \
         port:py${python.version}-regex
     
-    post-extract {
+    post-patch {
         reinplace "s|\"cython\"|\"cython-${PythonVersionWithDot}\"|g" ${worksrcpath}/bin/cythonize.py
         reinplace "s|python|${python.bin}|g" ${worksrcpath}/bin/spacy
         reinplace "s|python \-m|${python.bin} \-m|g" ${worksrcpath}/spacy/cli/validate.py

--- a/python/py-spaCy/Portfile
+++ b/python/py-spaCy/Portfile
@@ -76,7 +76,8 @@ if {${name} ne ${subport}} {
         reinplace "s|python \-m|${python.bin} \-m|g" ${worksrcpath}/spacy/cli/validate.py
     }
     
-    build.cmd    "${python.bin} setup.py build_ext --inplace"
+    build.target-replace build build_ext
+    build.args-append --inplace
 
     livecheck.type none 
 

--- a/python/py-srsly/Portfile
+++ b/python/py-srsly/Portfile
@@ -5,6 +5,7 @@ PortGroup           python           1.0
 PortGroup           github           1.0
 
 name                py-srsly
+# Don't upgrade past py-spaCy's highest supported version.
 version             2.3.0
 revision            0
 github.setup        explosion srsly ${version} v

--- a/python/py-srsly/Portfile
+++ b/python/py-srsly/Portfile
@@ -5,14 +5,13 @@ PortGroup           python           1.0
 PortGroup           github           1.0
 
 name                py-srsly
+epoch               1
 # Don't upgrade past py-spaCy's highest supported version.
-version             2.3.0
+github.setup        explosion srsly 1.0.2 v
 revision            0
-github.setup        explosion srsly ${version} v
-
-checksums           rmd160  77ab4c7b1a928e5ba4b34b22e775f35a6de2b3d5 \
-                    sha256  7bdde31612a21512ddfba8ee63b89b77bb1ff8a7c8b68206c300c8cf56846499 \
-                    size    359416
+checksums           rmd160  2ef0645c3072b55ef85cb3aef280b3800aac1898 \
+                    sha256  180a1456862a5a86b93ed9ab6cd47c5292de481af4c8fb6d48694e411883c8b6 \
+                    size    241824
 
 platforms           darwin
 supported_archs     x86_64
@@ -22,7 +21,7 @@ license             MIT
 maintainers         {jonesc @cjones051073} openmaintainer
 
 description         Modern high-performance serialization utilities for Python
-long_description    ${description}
+long_description    {*}${description}
 
 # Supported python versions
 python.versions     36 37 38
@@ -30,8 +29,7 @@ python.versions     36 37 38
 if {${name} ne ${subport}} {
 
     depends_build-append \
-        port:py${python.version}-setuptools \
-        port:py${python.version}-wheel 
+        port:py${python.version}-setuptools
 
     depends_lib-append \
         port:py${python.version}-cython \

--- a/python/py-thinc/Portfile
+++ b/python/py-thinc/Portfile
@@ -6,6 +6,7 @@ PortGroup           github                      1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 name                py-thinc
+# Don't upgrade past py-spaCy's highest supported version.
 version             7.4.1
 revision            0
 github.setup        explosion thinc ${version} v

--- a/python/py-wasabi/Portfile
+++ b/python/py-wasabi/Portfile
@@ -5,6 +5,7 @@ PortGroup           python           1.0
 PortGroup           github           1.0
 
 name                py-wasabi
+# Don't upgrade past py-spaCy's highest supported version.
 version             0.8.0
 revision            0
 github.setup        ines wasabi ${version} v


### PR DESCRIPTION
#### Description

Updates py-spaCy and py-spaCy-models to 2.3.2 and fixes the build problems by downgrading the dependencies to the last supported versions.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14019
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] tried a full install with `sudo port -vst install`?
