### PR TITLE
plplot: add optional +deprecated variant

### DIFF
--- a/science/plplot/Portfile
+++ b/science/plplot/Portfile
@@ -256,6 +256,10 @@ variant lua description {Add support for Lua} {
     configure.args-append   -DENABLE_lua=ON
 }
 
+variant deprecated description {Allow build of deprecated API} {
+    configure.args-append   -DPL_DEPRECATED=ON
+}
+
 variant aquaterm description {Add support for Aquaterm} {
     depends_lib-append      port:aquaterm
     configure.args-delete   -DPLD_aqt=OFF


### PR DESCRIPTION
Allows building of deprecated API for ports that may still need them.

This fixes a build issue for p5-pdl-graphics-plplot which still uses deprecated plshade1.
See discussion on plshade1 vs plshade in the version 5.14.0 release notes, section 2.4,'Implement plStatic2dGrid'
https://sourceforge.net/projects/plplot/files/plplot/5.14.0%20Source/

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.0.1 12A7300


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
