### PR TITLE
kubeseal: update to 0.12.6

### DIFF
--- a/sysutils/kubeseal/Portfile
+++ b/sysutils/kubeseal/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 name                kubeseal
-github.setup        bitnami-labs sealed-secrets 0.12.5 v
+github.setup        bitnami-labs sealed-secrets 0.12.6 v
 revision            0
 categories          sysutils
 platforms           darwin
@@ -21,9 +21,9 @@ github.tarball_from releases
 distfiles           kubeseal-darwin-amd64
 dist_subdir         ${name}/${version}
 
-checksums           rmd160  436086b254cb2ec8f40d4a8e8321108d52b09d1d \
-                    sha256  238a1d290f80527ead1c521e0bb01d42df6e025fdcd711c5d30a039bc4d6c2fd \
-                    size    34790936
+checksums           rmd160  9c10aa3ac6181feaa4048221689af975b8716d9d \
+                    sha256  2cf77775b0c16f68a498ea537673489a185d441bd1fbf86e86e722433b6612d1 \
+                    size    34836064
 
 use_configure       no
 


### PR DESCRIPTION
#### Description

Update from 0.12.5. to 0.12.6
[Realse note](https://github.com/bitnami-labs/sealed-secrets/blob/master/RELEASE-NOTES.md#v0126)
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.6 19G2021
Xcode 12.0.1 12A7300

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
