### PR TITLE
scw: don't fetch dependencies in build phase

### DIFF
--- a/net/scw/Portfile
+++ b/net/scw/Portfile
@@ -18,11 +18,170 @@ description         Command Line Interface for Scaleway
 long_description    Scaleway CLI is a tool to help you pilot your Scaleway \
                     infrastructure directly from your terminal.
 
-checksums           rmd160  0eb6264e82b9e6118c80f3ec046d40830e986c5d \
-                    sha256  510e5ec1394999d0bb8261203ada7c199a4978278bb357d45047606d217a1a2f \
-                    size    1566580
+checksums           ${distname}${extract.suffix} \
+                        rmd160  0eb6264e82b9e6118c80f3ec046d40830e986c5d \
+                        sha256  510e5ec1394999d0bb8261203ada7c199a4978278bb357d45047606d217a1a2f \
+                        size    1566580
 
-build.args          ./cmd/scw
+go.vendors          github.com/pkg/errors \
+                        lock    v0.9.1 \
+                        rmd160  dc065c655f8a24c6519b58f9d1202eb266ecda40 \
+                        sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
+                        size    13422 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/alecthomas/repr \
+                        lock    d37bc2a10ba1 \
+                        rmd160  a3e51751bc31cc300b0da1c35fd526f7fcdd1752 \
+                        sha256  9e8ad80685c890d934808f95b2d0c236029f52babb7f7823f42980d23a44e9e5 \
+                        size    4959 \
+                    github.com/containerd/console \
+                        lock    v1.0.0 \
+                        rmd160  94245dee1cb873eb1612bdc4d10660b5b35210c1 \
+                        sha256  833937734cb691a1f980616f21334f9d180d1a9f93f712699ae7686719fc8925 \
+                        size    1399741 \
+                    github.com/dustin/go-humanize \
+                        lock    v1.0.0 \
+                        rmd160  e8641035159ea3e8839ee086f01f966443956303 \
+                        sha256  e45e3181c07b3e2dad8e1317e91a5bbbee4845067e3e3879a585a5254bc6a334 \
+                        size    17273 \
+                    github.com/chzyer/readline \
+                        lock    2972be24d48e \
+                        rmd160  933f32b684d0af4b8970d964d610918a9f181df6 \
+                        sha256  f5771c6a3d97166a9536f8a45e85e1c40aed9b02089e395d2f4131681cbf692f \
+                        size    36826 \
+                    github.com/gorilla/websocket \
+                        lock    v1.4.2 \
+                        rmd160  784f79f05da87fc2f2af618ad4e1eb576d7c16d8 \
+                        sha256  7805b8fc2002f7d1a7acdaa98feee2d6746d9241db0c597e0ee256cf0ff93a0b \
+                        size    54121 \
+                    github.com/certifi/gocertifi \
+                        lock    a6d78f326758 \
+                        rmd160  cb92e303a4332b4aee850301e352e8e6a5013569 \
+                        sha256  fa1f24da822f3b2ed53bf5cda3e2edebb797a8c758388ab475ce441a1fb87f6a \
+                        size    154193 \
+                    golang.org/x/sys \
+                        lock    bd437916bb0e \
+                        rmd160  8d2ebe3e90c6d80ff0447065c2d6e729bf0feba4 \
+                        sha256  eb31eb19d67029db9ef002650bc92b7ba4f6f1ae0baaf3e9613ae443c33640f4 \
+                        size    1516081 \
+                    github.com/chzyer/logex \
+                        lock    v1.1.10 \
+                        rmd160  105d839f798ba0c3e27b3db4e790d9d21a928029 \
+                        sha256  947e61095044d310b0ad92f10ac77c36eaa3c3e2e6181e87428ad10c20930ba3 \
+                        size    4351 \
+                    github.com/spf13/cobra \
+                        lock    v0.0.5 \
+                        rmd160  53e9a05596343a23f3a42bb6bf0d1a740591345d \
+                        sha256  9987c8c42db1f7b6e17abb000d23457463bc3f8884c815777f7fbf5e48e6a498 \
+                        size    111150 \
+                    github.com/scaleway/scaleway-sdk-go \
+                        lock    c51118fe6906 \
+                        rmd160  b812a37535a6cc9d808ad46c36e539504b8d234e \
+                        sha256  4a2511915e723cfe130bedd6ced3234849e5b4ea56bdefb465aad3a550de0cc1 \
+                        size    393006 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.5 \
+                        rmd160  2ce81608a38c6f383a35bccd24d64361df5828c9 \
+                        sha256  7f41acdcba65b1fab5b9b633947a139f9915b60f94bdab486cdbe9d90c54f61e \
+                        size    50815 \
+                    gopkg.in/yaml.v2 \
+                        lock    v2.2.7 \
+                        rmd160  8a2eb51b49235820619e4703f557b266d5941645 \
+                        sha256  15d29283f38f1213445158c16dad11f84ab72aa0256af555c2392492315760ba \
+                        size    72665 \
+                    github.com/dnaeon/go-vcr \
+                        lock    v1.0.1 \
+                        rmd160  83e0e2c778041b5d0c573a5f2db8bd6dcee822a2 \
+                        sha256  56e09ff00fc6103a8cb089974f812a6ef80d7aa93f999410c9e50821e1e6ae19 \
+                        size    87875 \
+                    github.com/getsentry/raven-go \
+                        lock    v0.2.0 \
+                        rmd160  c564a8e9061642f60d401b6ab5b26961feec3212 \
+                        sha256  690d7813db5510d0dc739335dc950519c6664cc47ce49029e9c817f4a0c896c1 \
+                        size    19245 \
+                    github.com/kr/pretty \
+                        lock    v0.1.0 \
+                        rmd160  9aa7a5aad4c48840eecfd0f80186d1fb5ded0fd6 \
+                        sha256  f6c3f89667c63e5b7f1fc6ee2c06b6a6bfdce88f3a965ccd395b64c6f95c9a47 \
+                        size    8553 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/fatih/color \
+                        lock    v1.9.0 \
+                        rmd160  1d8418b4f1b3cb597f680b93aaa08afcc9651be4 \
+                        sha256  577c8e778833fec90d76918f138cee9f7765435757b7c92a669e5b34933e0b4f \
+                        size    1231337 \
+                    github.com/sergi/go-diff \
+                        lock    v1.0.0 \
+                        rmd160  c5ac5f7253544101282f5477a71560d1fd6c3e58 \
+                        sha256  147eecf13dff7c6715ada19e097d4c3b7d20b169b475861a98e41e27b891d062 \
+                        size    41633 \
+                    github.com/kr/text \
+                        lock    v0.1.0 \
+                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
+                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
+                        size    8691 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.11 \
+                        rmd160  e7d2dadfe4bff4cd5a5dfece75632e31af6fad44 \
+                        sha256  a8aac03b74f35ec077c589a8ac186b215f14536bb5e262b320ef7ece85bdcab5 \
+                        size    4399 \
+                    github.com/alecthomas/colour \
+                        lock    60882d9e2721 \
+                        rmd160  9f588ca134237b19f19199a088974aefebe3b301 \
+                        sha256  9178279e7dbff10a8325724c84b344dfcf365578d30d3f436db5fb1cba1030d5 \
+                        size    3484 \
+                    github.com/chzyer/test \
+                        lock    a1ea475d72b1 \
+                        rmd160  61f83d79b356cde63a27df0f2832ef92fcbc216d \
+                        sha256  98d0c7d1dec438459e31886d65190bb45f70c4ed73e35f5ab2f3b8de582ea309 \
+                        size    4007 \
+                    github.com/inconshreveable/mousetrap \
+                        lock    v1.0.0 \
+                        rmd160  5c617a09f1432fc543672a0e0c1e13d3752030c2 \
+                        sha256  0e6bae2849f13d12fe361ecac087728e4e97f3482f4cec44f6e7a2c53bb9cd0c \
+                        size    2291 \
+                    github.com/stretchr/testify \
+                        lock    v1.4.0 \
+                        rmd160  86bd663e13ea7266334c47689074df16252db5ff \
+                        sha256  8ed95078bfd318ea477da509e6b16e6cf8d0d1b6b8d93b1f6097c6ba2a6df788 \
+                        size    110114 \
+                    golang.org/x/crypto \
+                        lock    60c769a6c586 \
+                        rmd160  12da398fd949a16a947abf184fd65e360621b048 \
+                        sha256  25e72c53b0ff22f80b201fc1ec4d6d277fb3b409fc6ed2fb7cc6203bf2f3fd6b \
+                        size    1693061 \
+                    gopkg.in/check.v1 \
+                        lock    788fd7840127 \
+                        rmd160  b63165c8909a27edc15dda210df66a1b49efb49e \
+                        sha256  7e5547c6471cc48da89a7c87f965b20ca5311f43fc4d883ca62f9fccf7551630 \
+                        size    31597 \
+                    github.com/alecthomas/assert \
+                        lock    405dbfeb8e38 \
+                        rmd160  5d141a90e1e313657b558c19d51c3bdd65b0e5e5 \
+                        sha256  8c445be2c7daa6b680bfbf96823192076bbf9c0f514642687d6487fd95630a5e \
+                        size    71075 \
+                    github.com/hashicorp/go-version \
+                        lock    v1.2.0 \
+                        rmd160  4e05420a3160fff330d734de9060dd590fdfb2db \
+                        sha256  aa7d6e4b1b2c7baa447561c3b141780048f9f2fcca8873c9b212792819093470 \
+                        size    13099 \
+                    github.com/mattn/go-colorable \
+                        lock    v0.1.4 \
+                        rmd160  aeaf016c7ae6cf014233a5a327e4227acf17adea \
+                        sha256  d64a7c2835de356f83a8af8ac9e07ce45d13a5ecb5062efd7f63b85b0b173193 \
+                        size    8987
+
+build.target        ./cmd/scw
+build.env-append    GO111MODULE=off \
+                    GOPROXY=off
 
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}


### PR DESCRIPTION
#### Description

Per https://trac.macports.org/ticket/61192 this is one of the golang ports that automatically downloads its dependencies at build time.

To fix it, I used `go2port`. There were no unexpected difficulties.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->