### PR TITLE
py-commonmark: new port

### DIFF
--- a/python/py-commonmark/Portfile
+++ b/python/py-commonmark/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-commonmark
+version             0.9.1
+platforms           darwin
+license             BSD
+supported_archs     noarch
+
+maintainers         {@harens gmail.com:harensdeveloper} \
+                    openmaintainer
+
+description         Python CommonMark parser
+long_description    commonmark.py is a pure Python port of jgm's commonmark.js, \
+                    a Markdown parser and renderer for the CommonMark specification, \
+                    using only native modules
+
+homepage            https://commonmarkpy.readthedocs.io/en/latest/
+
+checksums           rmd160 87a980080d252986c782720cbb3e834ca4ede9da \
+                    sha256 452f9dc859be7f06631ddcb328b6919c67984aca654e5fefb3914d54691aed60 \
+                    size   95764
+
+python.versions     38
+
+if {${name} ne ${subport}} {
+
+    depends_build-append \
+                        port:py${python.version}-setuptools
+
+    livecheck.type      none
+
+    notes-append "The CLI tool can be used by running cmark-${python.branch}"
+}


### PR DESCRIPTION
#### Description

In the hopes of adding [rich](https://github.com/willmcgugan/rich) to MacPorts (which is now possible thanks to https://github.com/python-poetry/poetry/issues/1975), I wrote a portfile for one of its dependencies.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.6 19G73
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
