### PR TITLE
gh: update to 1.1.0

### DIFF
--- a/devel/gh/Portfile
+++ b/devel/gh/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 
-github.setup        cli cli 1.0.0 v
+github.setup        cli cli 1.1.0 v
 revision            0
 name                gh
 categories          devel
@@ -25,9 +25,9 @@ homepage            https://cli.github.com/
 github.tarball_from releases
 distname            gh_${version}_macOS_amd64
 
-checksums           rmd160  c98362099ee3f6cf9d93a139b1dcf7a8d68346ee \
-                    sha256  5d646ebabacf80f365df8c26b493e8aff309642e85b8fc901200fd0302410b4c \
-                    size    5881067
+checksums           rmd160  b46872588b0444babf92a0e0ce5ef53ec9c516e5 \
+                    sha256  4d625455a07a4a6adf0e92183338979084829f28bda0f9593405a53da9d0e251 \
+                    size    5958663
 
 use_configure       no
 installs_libs       no


### PR DESCRIPTION
#### Description

Update the devel/gh from 1.0.0 to 1.1.0 ... nice and simple!

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0 20A5384c
Xcode 12.2 12B5025f

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
