### PR TITLE
google-cloud-sdk: update to 313.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             312.0.0
+version             313.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  f25819fedcfb719f3f39bd7f394479f7b6ccd679 \
-                    sha256  3b88d422be3834e91b447dee1c8995a31eda706daa764b40b3f91aecba0ebcf6 \
-                    size    85181259
+    checksums       rmd160  759ab34694e14c92bebe92a3b46071003c2c4c5a \
+                    sha256  3ba426131d9b2cdde6b6175a88a4e6c3493f7c14f965b7709f7f0bd84b32e8e9 \
+                    size    85297130
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  9cad07bc7cb9421177ee8a9a98c04c966e190193 \
-                    sha256  809a2bee632bd71db08a2e6916e0cd8eb83117cbcb4dce1296a83aeed38bfbc7 \
-                    size    86194431
+    checksums       rmd160  c807cfd47ea5907b58b292bd6d1e841fee23f16c \
+                    sha256  759a0f5ef118da16d18df34a3f7a237f23465d496b3e5abf493135c2f4b18d8d \
+                    size    86309285
 }
 
 homepage            https://cloud.google.com/sdk/
@@ -35,7 +35,7 @@ master_sites        https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/
 
 worksrcdir          ${name}
 
-python.default_version 27
+python.default_version 38
 
 post-patch {
     reinplace "s|\"disable_updater\": false|\"disable_updater\": true|" ${worksrcpath}/lib/googlecloudsdk/core/config.json


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 313.0.0. Support for [Python 2 was deprecated](https://cloud.google.com/python/docs/python2-sunset/) on September 30, 2020.

###### Tested on

macOS 10.15.7 19H2
Xcode 12.0.1 12A7300

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?