### PR TITLE
topgrade: remove broken dependency on mas

### DIFF
--- a/sysutils/topgrade/Portfile
+++ b/sysutils/topgrade/Portfile
@@ -25,7 +25,8 @@ checksums           ${distfiles} \
                     size    832350
 
 # include support for AppStore apps
-depends_lib         port:mas
+# disable this until https://github.com/mas-cli/mas/issues/252 has been fixed
+#depends_lib         port:mas
 
 # see https://trac.macports.org/ticket/60150 
 compiler.cpath


### PR DESCRIPTION
#### Description

mas is currently broken and causes topgrade to fail building on macOS < 10.13. 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.7 19H2
Xcode 12.0.1 12A7300

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
