### PR TITLE
commitizen: new port

### DIFF
--- a/devel/commitizen/Portfile
+++ b/devel/commitizen/Portfile
@@ -1,0 +1,45 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                commitizen
+version             2.4.1
+categories-prepend  devel
+platforms           darwin
+license             MIT
+supported_archs     noarch
+
+python.default_version \
+                    38
+
+maintainers         {@harens gmail.com:harensdeveloper} \
+                    openmaintainer
+
+description         Create committing rules for projects, auto bump versions, \
+                    and auto changelog generation
+long_description    Commitizen is a tool designed for teams. Its main purpose is to \
+                    define a standard way of committing rules and communicating it. \
+                    The reasoning behind it is that it is easier to read, and enforces \
+                    writing descriptive commits.
+
+homepage            https://commitizen-tools.github.io/commitizen/
+
+checksums           rmd160  b786915e3ad0b54118f0790b53bf81ef842fc055 \
+                    sha256  469c571b993f451772fdbb5be9ff5520d99981530d2d7f6717524ccaafa17bd2 \
+                    size    28698
+
+depends_build-append \
+    port:py${python.version}-setuptools
+
+depends_lib-append \
+    port:py${python.version}-colorama \
+    port:py${python.version}-decli \
+    port:py${python.version}-jinja2 \
+    port:py${python.version}-packaging \
+    port:py${python.version}-questionary \
+    port:py${python.version}-termcolor \
+    port:py${python.version}-tomlkit \
+    port:py${python.version}-yaml
+
+livecheck.type      pypi


### PR DESCRIPTION
#### Description

Closes https://github.com/commitizen-tools/commitizen/issues/260

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.6 19G73
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->