### PR TITLE
keystore-explorer: update to 5.4.4

### DIFF
--- a/security/keystore-explorer/Portfile
+++ b/security/keystore-explorer/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               java 1.0
 PortGroup               github 1.0
 
-github.setup            lhaeger keystore-explorer 5.4.3 macports-
+github.setup            lhaeger keystore-explorer 5.4.4 macports-
 
 categories              security
 platforms               darwin
@@ -27,11 +27,11 @@ long_description        ${description} with the following features: \
                         \n* Sign JAR files \
                         \n* Configure a CA Certs KeyStore for use with KeyStore operations
 
-homepage                http://keystore-explorer.org/
+homepage                https://keystore-explorer.org/
 
-checksums               rmd160  70787aa34b795670c9314c7023af01a1e148c241 \
-                        sha256  3e8aef812c16c01149ecdd286b8cbf5798ac735463bb44e3d7d8a623032769be \
-                        size    8230235
+checksums               rmd160  b415bf88ff780e665792f90d58d54d15b713f2b8 \
+                        sha256  4fdbe6c2af4bf24b7ebab4410bcdb25c220b1094bfdc0c816d51461cd8a75077 \
+                        size    8231162
 
 java.version            1.8+
 java.fallback           openjdk8
@@ -42,9 +42,13 @@ depends_build-append    port:gradle
 
 build.env-append        GRADLE_USER_HOME=${worksrcpath}/kse
 build.cmd               ${prefix}/bin/gradle
-build.args              --no-daemon --console=plain --stacktrace -p ${worksrcpath}/kse
+build.args              --no-daemon -i -p ${worksrcpath}/kse
 build.target            clean appbundler
 
 destroot {
     copy "${worksrcpath}/kse/build/appBundle/KeyStore Explorer.app" ${destroot}${applications_dir}
 }
+
+# run livecheck against upstream
+livecheck.url           https://github.com/kaikramer/keystore-explorer/tags
+livecheck.regex         "archive/v${github.livecheck.regex}.tar.gz"


### PR DESCRIPTION
###### Tested on

macOS 10.15.7 19H2
Xcode 12.0.1 12A7300

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?