### PR TITLE
postgresql13: fix reference to psql12

### DIFF
--- a/databases/postgresql13/Portfile
+++ b/databases/postgresql13/Portfile
@@ -93,7 +93,7 @@ livecheck.regex    (13\\.\[.0-9\]+)
 livecheck.url       ${homepage}/ftp/source/
 
 post-destroot {
-    system "cd ${destroot}${prefix}/bin && ln -sf ${libdir}/bin/psql psql12"
+    system "cd ${destroot}${prefix}/bin && ln -sf ${libdir}/bin/psql psql13"
 
     reinplace -E "s#^CFLAGS =#CFLAGS +=#g" \
         ${destroot}${prefix}/lib/${name}/pgxs/src/Makefile.global


### PR DESCRIPTION
#### Description

Fix for https://trac.macports.org/ticket/61285. There's a stray reference to `psql12` in the Portfile.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G3020
Xcode 11.3.1 11C504

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
