### PR TITLE
octosql: new port

### DIFF
--- a/databases/octosql/Portfile
+++ b/databases/octosql/Portfile
@@ -1,0 +1,356 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/cube2222/octosql 0.3.0 v
+revision            0
+
+categories          databases textproc
+license             MIT
+
+description         OctoSQL is a query tool that allows you to join, analyse \
+                    and transform data from multiple databases and file \
+                    formats using SQL.
+
+long_description    {*}${description} OctoSQL is a SQL query engine which \
+                    allows you to write standard SQL queries on data stored \
+                    in multiple SQL databases, NoSQL databases, streaming \
+                    sources and files in various formats trying to push down \
+                    as much of the work as possible to the source databases, \
+                    not transferring unnecessary data.  OctoSQL does that by \
+                    creating an internal representation of your query and \
+                    later translating parts of it into the query languages or \
+                    APIs of the source databases. Whenever a datasource \
+                    doesn't support a given operation, OctoSQL will execute \
+                    it in memory, so you don't have to worry about the \
+                    specifics of the underlying datasources. OctoSQL supports \
+                    JSON, CSV, Excel, Parquet, PostgreSQL, MySQL, Redis & \
+                    Kafka.
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+build.env-append    GO111MODULE=off \
+                    GOPROXY=off
+
+build.pre_args      -ldflags \"-X main.version=${version}\"
+build.args          ./cmd/octosql
+
+patchfiles          patch-main-version.diff
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  4b100effba187a7407e52a28f1fcdaac47631eee \
+                        sha256  b42c84ff33a1ddb75876554862cd29d9c912e447b8c71b714c868165325aad19 \
+                        size    5001991
+
+go.vendors          github.com/DataDog/zstd \
+                        lock    v1.4.1 \
+                        rmd160  86c75e5feafd8e615a7eea3b97680c0543a95380 \
+                        sha256  f62a03934f91b063545ce33c40526d33d52fb07dbfbced5dd5b531295b37af4c \
+                        size    498943 \
+                    github.com/onsi/gomega \
+                        lock    v1.5.0 \
+                        rmd160  076054cb1f017ae8c9c5dae0d07f0aed91c2a2a4 \
+                        sha256  8953014a048d54efb08954fa36adabfcd1a663ee5b4ebbb57f442095aa403d41 \
+                        size    88670 \
+                    github.com/stretchr/testify \
+                        lock    v1.4.0 \
+                        rmd160  86bd663e13ea7266334c47689074df16252db5ff \
+                        sha256  8ed95078bfd318ea477da509e6b16e6cf8d0d1b6b8d93b1f6097c6ba2a6df788 \
+                        size    110114 \
+                    github.com/go-tomb/tomb \
+                        lock    dd632973f1e7 \
+                        rmd160  ae07f5ddbbc6afc772d6dc5273bb72eaba50529a \
+                        sha256  91c562a4e31c89d13e5391143ff653231fc2d80562743db89ce2172ad8f81008 \
+                        size    3636 \
+                    github.com/oklog/ulid \
+                        lock    v1.3.1 \
+                        rmd160  6f20287010f0162383e398ab047ce7f5d5fc14e2 \
+                        sha256  7db718d8cbd1be538cddf10cb83cfc7f8c861da35cbe0ca88dd4a173b6cc1ecc \
+                        size    55584 \
+                    github.com/russross/blackfriday \
+                        lock    v1.5.2 \
+                        rmd160  cae679bcc1d73f3b7436b5393e690282799daa31 \
+                        sha256  40b449aee4a4c32edc35254e4df6d4da09448427661e2659806645196f2794c4 \
+                        size    75814 \
+                    github.com/bradleyjkemp/memmap \
+                        lock    71460d4a94035dd9536f3cbec655d060d3e0dd74 \
+                        rmd160  18edab84cb5a1028bf906b422e36a9f1b510edda \
+                        sha256  ba11e36ee6f9b9965fa5c85ac32f39242d338c21d4aaf6cf8e26f48b4d333bca \
+                        size    10191 \
+                    github.com/dustin/go-humanize \
+                        lock    v1.0.0 \
+                        rmd160  e8641035159ea3e8839ee086f01f966443956303 \
+                        sha256  e45e3181c07b3e2dad8e1317e91a5bbbee4845067e3e3879a585a5254bc6a334 \
+                        size    17273 \
+                    github.com/inconshreveable/mousetrap \
+                        lock    v1.0.0 \
+                        rmd160  5c617a09f1432fc543672a0e0c1e13d3752030c2 \
+                        sha256  0e6bae2849f13d12fe361ecac087728e4e97f3482f4cec44f6e7a2c53bb9cd0c \
+                        size    2291 \
+                    github.com/kostya-sh/parquet-go \
+                        lock    06b7130dc45c \
+                        rmd160  c896f85384ec3804df436fca5e80372be7f1ba13 \
+                        sha256  a7b7d73e5f320b3971f653ecdb50797a88199148f597c3f6dd9bcf68d0d5185b \
+                        size    128574 \
+                    github.com/magiconair/properties \
+                        lock    v1.8.0 \
+                        rmd160  327cf3e96df60025444491a413aba0145ef448f3 \
+                        sha256  1a51357a88b298284fa48607836e7d05bee5fc58e00c87ba943a8d719d2ece2c \
+                        size    29500 \
+                    github.com/mitchellh/hashstructure \
+                        lock    v1.0.0 \
+                        rmd160  257eda01ff9bac3360ca257e7dec53a75aeff896 \
+                        sha256  ea42735e765ec7343dfec8c983efc8efb04a1b071aaad4b1effbc773175d084b \
+                        size    6510 \
+                    github.com/segmentio/kafka-go \
+                        lock    v0.3.5 \
+                        rmd160  f44fbef0351ecee2ea416516b4fcf4c5f3ace14d \
+                        sha256  e9e0ae117d0f869631aadff4cfe2b9cd87231dbefdb4acfbbae17dcd29d68daa \
+                        size    132322 \
+                    github.com/fsnotify/fsnotify \
+                        lock    v1.4.7 \
+                        rmd160  24712e412814020224e2779186e634610e2f6926 \
+                        sha256  bc839ee158ad34b81c1f11c3b9e3bcbabfba3297f61d165599880c400b8171dc \
+                        size    31147 \
+                    github.com/go-chi/chi \
+                        lock    v4.0.3 \
+                        rmd160  ae0af58240a90654aa28c1f2b3daf24642bf877c \
+                        sha256  a629a65018a5c21397cc2d4d06d912aa4f6fd3e459014ae21518e057128bb759 \
+                        size    70915 \
+                    github.com/go-check/check \
+                        lock    41f04d3bba15 \
+                        rmd160  1e5543a8e6a3159296ee63e28cbde9931a04f6b3 \
+                        sha256  c41575a73d10809f89b05ef9e783f2d53facdc6573697770d30efb05a9d2dc28 \
+                        size    31612 \
+                    github.com/dgraph-io/badger \
+                        lock    v2.0.3 \
+                        rmd160  fa3b561afae5c30f56812b5dd105857ca47f1400 \
+                        sha256  39507b49d5f0bc50c10dcdc4234a8c4226dbffeb773ede26dcf20f39b87c5f2b \
+                        size    332700 \
+                    github.com/eapache/go-xerial-snappy \
+                        lock    776d5712da21 \
+                        rmd160  7cc49279b09bdcb6e4849a28fa79d0134e768f22 \
+                        sha256  6f94ed42b3b402e4a56f905e9c0de8f702a5750b01d888b5a8d06edf67230c39 \
+                        size    7883 \
+                    github.com/go-sql-driver/mysql \
+                        lock    v1.4.1 \
+                        rmd160  af397829cc55209ef80b4b77a1757a3e6217f71c \
+                        sha256  b435e19a170c3cb355cacfb3368f7c4d4afb2eef4bee95fc6ce39e331a988b8e \
+                        size    83542 \
+                    github.com/olekukonko/tablewriter \
+                        lock    v0.0.1 \
+                        rmd160  2e33eff4633df242952f7fe7333df7f3385d427b \
+                        sha256  e88e38a28e06ff585a011147c5eca07638fe104d74340c9741641ae68607c2d6 \
+                        size    17517 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.3 \
+                        rmd160  32abdd77a987af95ce5b647846bfdbb2d8db91a0 \
+                        sha256  046b6b81e3925ffe60e2213e9a239303ff98a51e76764590b807b591fedf2d1e \
+                        size    46029 \
+                    gopkg.in/yaml.v2 \
+                        repo    github.com/go-yaml/yaml \
+                        lock    v2.2.2 \
+                        rmd160  03aea7b7e847179b29044d5a928b9f8a889fe87b \
+                        sha256  da1e31b7beb9a6907947caa794134bdc2501d1a3474568b61cc2562a398d3d87 \
+                        size    70676 \
+                    github.com/spf13/cast \
+                        lock    v1.3.0 \
+                        rmd160  26b82e9734f643bc70be8c73742d4a4f514b6dd2 \
+                        sha256  f2913fc10731a578c016701bd10e6a267c299b94e69d8362d258ce8482d14faf \
+                        size    11086 \
+                    github.com/bradleyjkemp/cupaloy \
+                        lock    v2.3.0 \
+                        rmd160  5fa620c5af16461b6c656e6c302e4c6c900b85aa \
+                        sha256  7541f609bd4a1f66e7152c08be86886d6ef2468d3c9d780d28692382fbe9e831 \
+                        size    274606 \
+                    github.com/go-redis/redis \
+                        lock    v6.15.2 \
+                        rmd160  94db84e2abcf73e8a34bde872fac3262641e61f3 \
+                        sha256  e42ac6fb694d5cf2752ba07c07cc9e8156d1d443276c460a27e3bc1ec2f71fd1 \
+                        size    89484 \
+                    github.com/kr/pretty \
+                        lock    v0.1.0 \
+                        rmd160  9aa7a5aad4c48840eecfd0f80186d1fb5ded0fd6 \
+                        sha256  f6c3f89667c63e5b7f1fc6ee2c06b6a6bfdce88f3a965ccd395b64c6f95c9a47 \
+                        size    8553 \
+                    github.com/lib/pq \
+                        lock    v1.0.0 \
+                        rmd160  f402fa787270acb206c46b40e66c832303603b57 \
+                        sha256  a9e678ebe7837d12a84057db4c8ad6ab0f9f177d99c7057fc493383ae26f1987 \
+                        size    91448 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.12 \
+                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
+                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
+                        size    4549 \
+                    github.com/pierrec/lz4 \
+                        lock    v2.0.5 \
+                        rmd160  911cc0021dd75a5a5141e8093f3cd5655181436c \
+                        sha256  7a864d3e377f2e2901be5d0e8ea4e4a7290b549a27e4ca8bd649e56db149a68b \
+                        size    3555274 \
+                    github.com/OneOfOne/xxhash \
+                        lock    v1.2.2 \
+                        rmd160  35e2c7b623c069fc08aec00990ca5c82ad831a22 \
+                        sha256  e6a73b9f6acc9b361ea77edcb6f29103e96ac0c623c6d2882909698180e54694 \
+                        size    13444 \
+                    github.com/golang/snappy \
+                        lock    v0.0.1 \
+                        rmd160  a10055b1a93ad290e600742c23156dbd55afe046 \
+                        sha256  5ca0dcca007398f298a6386af5d4696faba962b6a625e3aa3961d212078722b8 \
+                        size    62627 \
+                    github.com/xdg/scram \
+                        lock    7eeb5667e42c \
+                        rmd160  6e27513475f29ca2ebc5ae811d4ed8edc13190c8 \
+                        sha256  016791a8f1e79400bbae701918599126d4d69e0d6d0dc864066c1a4cc88d4dfb \
+                        size    16176 \
+                    github.com/mitchellh/go-homedir \
+                        lock    v1.1.0 \
+                        rmd160  44b3985e40e5bbb22d11f8622c340f9ed727ea91 \
+                        sha256  024c8a57316c7fbc0eb23cdbfd57f72a74b51beb83d714034d67ee9aba48100c \
+                        size    3366 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/dgryski/go-farm \
+                        lock    6a90982ecee2 \
+                        rmd160  a9f7f2372bd4bce849b55eef441e43b9a09330b0 \
+                        sha256  e90d46f1d9f70d28d20e4791aad8c2dbe7900d65bf42140018c443b3480eef72 \
+                        size    26795 \
+                    github.com/pelletier/go-toml \
+                        lock    v1.2.0 \
+                        rmd160  8d91b6485f373ccaa894abcb3bd53839e55b9057 \
+                        sha256  0a9503f2b53444e0c3ea960d18febe14d472c16279844f231994c5ccb81dbdff \
+                        size    57515 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/spf13/afero \
+                        lock    v1.1.2 \
+                        rmd160  dc2ff3aa582c3dc782e3c062e35b65564bfc44e5 \
+                        sha256  08dca858dce5a4336ca385028ff38e0fa6a9f064f5c874fdabe2096a34b6fc91 \
+                        size    45324 \
+                    github.com/awalterschulze/gographviz \
+                        lock    fa59802746ab \
+                        rmd160  6d2376c4ff15286dd7b9eae19550a651d9ff3ae3 \
+                        sha256  13a18db3a2264cd8e5d12507768d2dff3600fbf3405a966e718b63d00945fc3a \
+                        size    170210 \
+                    github.com/bradleyjkemp/memviz \
+                        lock    v0.2.2 \
+                        rmd160  e7234386f0a138a5f72a764b6a06d67dbe69ebe1 \
+                        sha256  69613a54ae08038777b25a7bfc26437c697ae4343fc30dacbb1134e55bd0fc53 \
+                        size    10196 \
+                    github.com/cespare/xxhash \
+                        lock    v1.1.0 \
+                        rmd160  881eb63e94fa02d315ee4b023a35832a3d67d672 \
+                        sha256  509b8d4670440aa84dc4e902ed5ca2f9109bf65af830a062da91d23a007fe2e0 \
+                        size    8208 \
+                    github.com/360EntSecGroup-Skylar/excelize \
+                        lock    v1.4.1 \
+                        rmd160  d2fecc29066906ab3257d8c49812c562f85e14aa \
+                        sha256  c7085c968d368d6322902cd536f9007628587e47f8f19867e537a292eb7ab71a \
+                        size    375638 \
+                    github.com/onsi/ginkgo \
+                        lock    v1.8.0 \
+                        rmd160  7589d251126b1b94dede698aa1958675042791e5 \
+                        sha256  06b1919c83bda9d107e59bf74f951220f690eb734547c2f367837ddf122cfb78 \
+                        size    133407 \
+                    github.com/twmb/murmur3 \
+                        lock    v1.1.3 \
+                        rmd160  7d859d6d1e9bee77070108df3940b52dc9636ff8 \
+                        sha256  8d979a62c146330ca1c988672c67fecf704a33229dc292538d656b10d6f94646 \
+                        size    12708 \
+                    github.com/golang/protobuf \
+                        lock    v1.3.1 \
+                        rmd160  801150957b99de8eef10cb8d5ea2a08b240f2cb5 \
+                        sha256  a53c2c8c5c02311d2fa3bc6656614e20f9e5568b87c9f07702f083457e69f7d2 \
+                        size    310935 \
+                    github.com/hashicorp/hcl \
+                        lock    v1.0.0 \
+                        rmd160  ad8d0b523bb708fd6ae77df8bb414c103a75aa92 \
+                        sha256  4fc0e87ac9d3d6cd042f044df2db2703bed569051fb8c179d505edeb4433e96e \
+                        size    70636 \
+                    github.com/spf13/cobra \
+                        lock    v0.0.5 \
+                        rmd160  53e9a05596343a23f3a42bb6bf0d1a740591345d \
+                        sha256  9987c8c42db1f7b6e17abb000d23457463bc3f8884c815777f7fbf5e48e6a498 \
+                        size    111150 \
+                    github.com/gosuri/uilive \
+                        lock    v0.0.4 \
+                        rmd160  0e4c93664ab9e5d0f0da1e5fa6c7cc2171922388 \
+                        sha256  bc7c21cc891a3de1dc9e5c43e8dd8c4bd5da6ceb17888be041c80dd52078abd2 \
+                        size    153284 \
+                    github.com/dgraph-io/ristretto \
+                        lock    8f368f2f2ab3 \
+                        rmd160  f99c7fbe446e02237d2c373cb6c9047ed624a526 \
+                        sha256  96eb4b33abfe0194bb1f813cdb7c4961ab583f8ea47560555071bf1ffc525d99 \
+                        size    39675 \
+                    github.com/hpcloud/tail \
+                        lock    v1.0.0 \
+                        rmd160  2c6daf876a9a3ff47d239f3485810799ae9ced66 \
+                        sha256  aa9d7b729c8ee8b00c1a755ade77024e6b3ec4ac88585a39e31882260249f86b \
+                        size    37817 \
+                    golang.org/x/text \
+                        lock    v0.3.0 \
+                        rmd160  81061ce2006da3d6f7a8ef8dae237d65305513d3 \
+                        sha256  6243d5bbd9d8550bc44cb58a0d70180f7a3f6767299b490015107b4d27c604ae \
+                        size    6102563 \
+                    github.com/BurntSushi/toml \
+                        lock    v0.3.1 \
+                        rmd160  fb9650e2d16525153645e5547626f242f3800149 \
+                        sha256  8cc9e5dc68e247554227973d0b4e023b27bbd9ba5a26e4fb40f44743afcb35f1 \
+                        size    42087 \
+                    github.com/mattn/go-runewidth \
+                        lock    v0.0.4 \
+                        rmd160  20081e360b3a667d21a7990197740bbaf51ec259 \
+                        sha256  d3b074c23e9cebd7fe786eb4fcdb5f659a8afa7629e3ec9a142f4288067bf39b \
+                        size    19840 \
+                    github.com/mitchellh/mapstructure \
+                        lock    v1.1.2 \
+                        rmd160  a4e01781ea5bb0c987e18e8e450c8f1023d5a857 \
+                        sha256  9c1076f5a8e923d028cb65c36143f3b1478cbaa4420e2e8f332719edc2fc4f71 \
+                        size    20992 \
+                    github.com/mohae/deepcopy \
+                        lock    c48cc78d4826 \
+                        rmd160  fc86fa598a05041fd926c16aeabc2ddfdf3768d9 \
+                        sha256  304235d66e943c2ae5a3b165c30df0fd711b03e2c611e71141be7d85fbec94f5 \
+                        size    9603 \
+                    github.com/spf13/jwalterweatherman \
+                        lock    v1.0.0 \
+                        rmd160  364fd0d61e94bd3651b5506d61f0e9652d6e33a3 \
+                        sha256  e70eb4dbab0603ad35c32bf89cefd595b2d6d56d66695866bfad2350db939404 \
+                        size    6405 \
+                    github.com/xdg-go/stringprep \
+                        lock    v1.0.0 \
+                        rmd160  46a0ead1c0752432b012b124a0677faff4e44480 \
+                        sha256  5237929428fdf9cbc55f601d5c6506862a45971584e8d6a0127c2afa4bfaf620 \
+                        size    28588 \
+                    github.com/kr/text \
+                        lock    v0.1.0 \
+                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
+                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
+                        size    8691 \
+                    github.com/pkg/errors \
+                        lock    v0.8.1 \
+                        rmd160  a33afa0fbe2e76b7a621d25bdb4bf0b964b18bb5 \
+                        sha256  1ec95b0705f5ac6ea502266b4e6bf177041b7832148a4bf090686243b0f9aa59 \
+                        size    11018 \
+                    golang.org/x/net \
+                        lock    3b0461eec859 \
+                        rmd160  24dae39afb612a8977e6f4a91596c64d15dd3664 \
+                        sha256  15f077bb408fb71b22e4015312be5fab7010576e824fdbfdfdb697b611621197 \
+                        size    1099249 \
+                    golang.org/x/sys \
+                        lock    a893ed3 \
+                        rmd160  08c03135dfdd7d1fc2f164bfe17356b46cba1fd4 \
+                        sha256  5afd3d099e412503bb4de541a42a347baba66b34b5866bc90bb92cee1f7f9de3 \
+                        size    1067242

--- a/databases/octosql/files/patch-main-version.diff
+++ b/databases/octosql/files/patch-main-version.diff
@@ -1,0 +1,16 @@
+--- cmd/octosql/main.go	2020-10-08 03:50:17.000000000 -0400
++++ cmd/octosql/main.go	2020-10-08 03:51:08.000000000 -0400
+@@ -222,9 +222,12 @@
+ 	info, ok := debug.ReadBuildInfo()
+ 	if ok {
+ 		version = info.Main.Version
+-	} else {
++	}
++
++	if version == "" {
+ 		version = "unknown"
+ 	}
++
+ 	rootCmd.SetVersionTemplate(fmt.Sprintf("OctoSQL Version: %s\n", version))
+ 	rootCmd.Version = version
+ 


### PR DESCRIPTION
#### Description

New port for [octosql](https://github.com/cube2222/octosql)

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.0.1 12A7300

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
