### PR TITLE
util-linux: add bash-completion

### DIFF
--- a/devel/util-linux/Portfile
+++ b/devel/util-linux/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           legacysupport 1.0
 
 github.setup        karelzak util-linux 2.36 v
-revision            0
+revision            1
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          devel
 platforms           darwin
@@ -92,6 +92,15 @@ destroot {
         set file [lindex [split ${path} /] 1]
         xinstall -m 755 ${worksrcpath}/${file} ${destroot}${prefix}/bin
         xinstall -m 644 ${worksrcpath}/${path}.1 ${destroot}${prefix}/share/man/man1
+    }
+
+    set bash.d ${prefix}/etc/bash_completion.d
+    xinstall -m 755 -d ${destroot}${bash.d}
+
+    build.target-delete hardlink
+    foreach _target "${build.target}" {
+        xinstall -m 644 ${worksrcpath}/bash-completion/${_target} \
+                        ${destroot}${bash.d}
     }
 
     set docdir ${prefix}/share/doc/${name}


### PR DESCRIPTION
#### Description

util-linux: add bash-completion

The install should include the bash-completion files. I used the build.target, but removed the hardlink - since there was no bash-completion for that one.

###### Type(s)

- [x] enhancement

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?