### PR TITLE
py-igraph: update to 0.8.3

### DIFF
--- a/python/py-igraph/Portfile
+++ b/python/py-igraph/Portfile
@@ -5,12 +5,12 @@ PortGroup           python 1.0
 
 name                py-igraph
 python.rootname     python-igraph
-version             0.8.2
+version             0.8.3
 categories-append   math science
 platforms           darwin
 license             GPL-2+
 
-python.versions     27 35 36 37 38
+python.versions     27 36 37 38
 
 maintainers         {snc @nerdling} {gmail.com:szhorvat @szhorvat} openmaintainer
 
@@ -22,16 +22,15 @@ long_description    Python interface to the igraph library for network analysis 
 
 homepage            https://igraph.org/python/
 
-checksums           rmd160  a6cf4d12f17f6ec2da28460636da81199b2d1a30 \
-                    sha256  4601638d7d22eae7608cdf793efac75e6c039770ec4bd2cecf76378c84ce7d72 \
-                    size    3970354
 					
+checksums           rmd160  1cbaa63f71ba7c81ea66c1ae35f1b94c5763177c \
+                    sha256  e1f27622eddeb2bd5fdcbadb41ef048e884790bb050f9627c086dc609d0f1236 \
+                    size    4059460
 
 if {${name} ne ${subport}} {
     depends_lib-append      port:py${python.version}-texttable \
                             port:gmp \
-                            port:libxml2 \
-                            port:glpk
+                            port:libxml2
 
     depends_build-append    port:py${python.version}-setuptools \
                             port:libtool \
@@ -40,7 +39,26 @@ if {${name} ne ${subport}} {
                             port:bison \
                             port:flex
 
-    build.env-append        IGRAPH_EXTRA_CONFIGURE_ARGS=--with-external-glpk
+    set extra_configure_args { }
+
+    variant external_glpk description {Build with external GLPK} {
+        lappend extra_configure_args    --with-external-glpk
+        depends_lib-append              port:glpk
+    }
+
+    variant external_linalg description {Build with external BLAS, LAPACK, ARPACK} {
+        lappend extra_configure_args    --with-external-blas --with-external-lapack --with-external-arpack
+        depends_lib-append              port:lapack port:arpack
+    }
+
+    default_variants        +external_glpk
+
+    build.env-append        IGRAPH_EXTRA_CONFIGURE_ARGS="[join $extra_configure_args]"
+
+    test.run                yes
+    test.cmd                python${python.branch} -m unittest
+    test.target             
+    test.env                PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
 
     livecheck.type          none
 }


### PR DESCRIPTION
#### Description

 * update to 0.8.3
 * remove Python 3.5 support
 * add variants external_glpk and external_linalg, make external_glpk default
 * enable running tests

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G6032
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

