### PR TITLE
google-cloud-sdk: update to 313.0.1

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             313.0.0
+version             313.0.1
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  759ab34694e14c92bebe92a3b46071003c2c4c5a \
-                    sha256  3ba426131d9b2cdde6b6175a88a4e6c3493f7c14f965b7709f7f0bd84b32e8e9 \
-                    size    85297130
+    checksums       rmd160  9be37129e526bc912bdad5d740eace7894403521 \
+                    sha256  3c59692cf2a50d2a5f0898089501944fe376df17742538ff28fc905f1045508b \
+                    size    85297178
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  c807cfd47ea5907b58b292bd6d1e841fee23f16c \
-                    sha256  759a0f5ef118da16d18df34a3f7a237f23465d496b3e5abf493135c2f4b18d8d \
-                    size    86309285
+    checksums       rmd160  5e6e71be114d704fbeca43d3cd18c2c4c42f0966 \
+                    sha256  3ec47319f0d58a977630e1df452cd5568d20ad2caabf9c0ae3f096128ed24c5c \
+                    size    86309315
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 313.0.1.

###### Tested on

macOS 10.15.7 19H2
Xcode 12.0.1 12A7300

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?