### PR TITLE
Azure CI: use correct command line tools

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,8 +10,9 @@ jobs:
       mac-10.15-xcode12:
         imageName: 'macOS-10.15'
         MP_XCODE_APP: '/Applications/Xcode_12.app'
-      mac-10.15:
+      mac-10.15-xcode11.7:
         imageName: 'macOS-10.15'
+        MP_XCODE_APP: '/Applications/Xcode_11.7.app'
       mac-10.14:
         imageName: 'macOS-10.14'
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,6 +29,10 @@ jobs:
           echo "Custom Xcode not specified"
       fi
       echo "Selected Xcode is $(xcode-select --print-path)"
+      echo '/usr/bin/clang --version'
+      /usr/bin/clang --version
+      echo '/Library/Developer/CommandLineTools/usr/bin/clang --version'
+      /Library/Developer/CommandLineTools/usr/bin/clang --version
     displayName: 'Set custom Xcode version'
 
   - script: ./_ci/bootstrap.sh


### PR DESCRIPTION
#### Description
Even though the Azure macOS 10.15 builder uses Xcode 11 by default, it is emitting implicit function declaration errors from Xcode 12 command line tools, so maybe the versions aren't the same but can be manually set. This first commit is merely checking the output of `clang --version`.
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
