### PR TITLE
kcov: use legacysupport portgroup for MAP_ANONYMOUS

### DIFF
--- a/devel/kcov/Portfile
+++ b/devel/kcov/Portfile
@@ -4,6 +4,10 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 
+# Need MAP_ANONYMOUS
+PortGroup           legacysupport 1.0
+legacysupport.newest_darwin_requires_legacy 14
+
 github.setup        SimonKagstrom kcov 38 v
 revision            0
 checksums           rmd160  7bc2dfb463ec46c5ae541894fc522c18a615e9f2 \


### PR DESCRIPTION
#### Description
Should fix build failures observed on 10.7-10.10:
```
In file included from /opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_devel_kcov/kcov/work/kcov-38/src/engines/system-mode-file-format.cc:1:
/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_devel_kcov/kcov/work/kcov-38/src/engines/system-mode-file-format.hh:35:19: error: use of undeclared identifier 'MAP_ANONYMOUS'
                                        MAP_SHARED | MAP_ANONYMOUS, -1, 0);
                                                     ^
1 error generated.
In file included from /opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_devel_kcov/kcov/work/kcov-38/src/engines/system-mode-engine.cc:23:
/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_devel_kcov/kcov/work/kcov-38/src/engines/system-mode-file-format.hh:35:19: error: use of undeclared identifier 'MAP_ANONYMOUS'
                                        MAP_SHARED | MAP_ANONYMOUS, -1, 0);
                                                     ^
1 error generated.
```

(Failures on 10.6 are because `LLDB_LIBRARY` isn't defined.)
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
Untested.
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
