### PR TITLE
vigra: Default to python38 to match boost

### DIFF
--- a/graphics/vigra/Portfile
+++ b/graphics/vigra/Portfile
@@ -149,8 +149,8 @@ variant python38 conflicts python27 python35 python36 python37 description "Also
 }
 
 if {![variant_isset python27] && ![variant_isset python35] && ![variant_isset python36] && ![variant_isset python37] && ![variant_isset python38]} {
-	#default for boost is python37
-    default_variants +python37
+    # default for boost is python38
+    default_variants +python38
 }
 
 if {![variant_isset python27] && ![variant_isset python35] && ![variant_isset python36] && ![variant_isset python37] && ![variant_isset python38]} {


### PR DESCRIPTION
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix
