### PR TITLE
py-igraph: add python 3.9 and py-texttable: update to 1.6.3

### DIFF
--- a/python/py-igraph/Portfile
+++ b/python/py-igraph/Portfile
@@ -6,11 +6,12 @@ PortGroup           python 1.0
 name                py-igraph
 python.rootname     python-igraph
 version             0.8.3
+revision            1
 categories-append   math science
 platforms           darwin
 license             GPL-2+
 
-python.versions     27 36 37 38
+python.versions     27 36 37 38 39
 
 maintainers         {snc @nerdling} {gmail.com:szhorvat @szhorvat} openmaintainer
 
@@ -39,26 +40,35 @@ if {${name} ne ${subport}} {
                             port:bison \
                             port:flex
 
-    set extra_configure_args { }
-
-    variant external_glpk description {Build with external GLPK} {
-        lappend extra_configure_args    --with-external-glpk
-        depends_lib-append              port:glpk
+    variant external_glpk description {Build with external GLPK} {        
+        depends_lib-append      port:glpk
     }
 
     variant external_linalg description {Build with external BLAS, LAPACK, ARPACK} {
-        lappend extra_configure_args    --with-external-blas --with-external-lapack --with-external-arpack
-        depends_lib-append              port:lapack port:arpack
+        depends_lib-append      port:lapack port:arpack
     }
 
     default_variants        +external_glpk
 
-    build.env-append        IGRAPH_EXTRA_CONFIGURE_ARGS="[join $extra_configure_args]"
+    set extra_configure_args { }
+
+    if {[variant_isset external_glpk]} {
+        lappend extra_configure_args    --with-external-glpk
+    }
+
+    if {[variant_isset external_linalg]} {
+        lappend extra_configure_args    --with-external-blas --with-external-lapack --with-external-arpack
+    }
+
+    build.env-append        IGRAPH_EXTRA_CONFIGURE_ARGS=[join $extra_configure_args]
+
+    pre-test {
+        test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
+    }
 
     test.run                yes
     test.cmd                python${python.branch} -m unittest
     test.target             
-    test.env                PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
 
     livecheck.type          none
 }

--- a/python/py-texttable/Portfile
+++ b/python/py-texttable/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-texttable
-version             1.6.2
+version             1.6.3
 revision            0
 
 categories-append   textproc
@@ -20,11 +20,11 @@ homepage            https://github.com/foutaise/texttable/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  de4b333c22983a30793af5dae97dffeb7512ce57 \
-                    sha256  eff3703781fbc7750125f50e10f001195174f13825a92a45e9403037d539b4f4 \
-                    size    13176
+checksums           rmd160  57fbb611b7f73d9253429d8c18033df8f28008c5 \
+                    sha256  ce0faf21aa77d806bbff22b107cc22cce68dc9438f97a2df32c93e9afa4ce436 \
+                    size    14470
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

 * py-texttable: update to 1.6.3
 * py-texttable: add python 3.9
 * py-igraph: add python 3.9
 * py-igraph: move test.env to pre-test
 * py-igraph: fix variants not passing options to ./configure
 * py-igraph: increase revision to 1

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G6032
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
