### PR TITLE
xournalpp: submission

### DIFF
--- a/x11/xournalpp/Portfile
+++ b/x11/xournalpp/Portfile
@@ -1,0 +1,56 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+PortGroup        github 1.0
+PortGroup        cmake 1.0
+
+github.setup     xournalpp xournalpp 1.0.18
+categories       x11
+platforms        darwin
+maintainers      nomaintainer
+license          GPL-2
+
+description      A hand note taking software
+
+long_description Xournal++ is a hand note taking software written in C++ \
+                 with the target of flexibility, functionality and speed.
+
+checksums        rmd160  f407a8391a3683d87c15d3762c9ecacc13d4dbf5 \
+                 sha256  13e37aef0bc8178d78301c2405e5e463f70069600512a7b61dedec46cf860844 \
+                 size    14892459
+
+depends_build    port:pkgconfig \
+                 port:gtk-mac-bundler
+
+depends_lib      port:gtk3 \
+                 port:poppler \
+                 port:portaudio \
+                 port:zlib \
+                 port:libzip \
+                 port:libsndfile \
+                 port:adwaita-icon-theme \
+                 port:lua
+
+global appName
+set appName Xournal++.app
+
+post-build {
+     # Do not clutter $HOME/.local
+    reinplace "s|\$1/inst|${prefix}|g;s/make install/#make install/" ${worksrcpath}/mac-setup/build-app.sh
+
+    reinplace "s|<main-binary>\${prefix}/bin/|<main-binary dest=\"\${bundle}/foobar\">${worksrcpath}/src/|;s|<launcher-script></launcher-script >|<!-- <launcher-script></launcher-script > -->|" ${worksrcpath}/mac-setup/xournalpp.bundle
+    system -W ${worksrcpath} "./mac-setup/build-app.sh ${prefix}"
+    reinplace "s/export DYLD_LIBRARY_PATH/#export DYLD_LIBRARY_PATH/" ${worksrcpath}/mac-setup/${appName}/Contents/MacOS/xournalpp
+}
+
+post-destroot {
+    set docdir ${prefix}/share/doc/${subport}
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 644 -W ${worksrcpath} AUTHORS LICENSE CHANGELOG.md README.md ${destroot}${docdir}
+
+    copy ${worksrcpath}/mac-setup/${appName} ${destroot}${applications_dir}
+
+     # Xournal++ is intended to be used through ${appName}, binary in 
+     # $prefix/bin won't work properly
+    file delete ${destroot}/${prefix}/bin/xournalpp
+}

--- a/x11/xournalpp/Portfile
+++ b/x11/xournalpp/Portfile
@@ -1,41 +1,40 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem       1.0
-PortGroup        github 1.0
-PortGroup        cmake 1.0
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.0
 
-github.setup     xournalpp xournalpp 1.0.18
-categories       x11
-platforms        darwin
-maintainers      nomaintainer
-license          GPL-2
+github.setup        xournalpp xournalpp 1.0.18
+categories          x11
+platforms           darwin
+maintainers         nomaintainer
+license             GPL-2
 
-description      A hand note taking software
+description         A hand note taking software
 
-long_description Xournal++ is a hand note taking software written in C++ \
-                 with the target of flexibility, functionality and speed.
+long_description    Xournal++ is a hand note taking software written in C++ \
+                    with the target of flexibility, functionality and speed.
 
-checksums        rmd160  f407a8391a3683d87c15d3762c9ecacc13d4dbf5 \
-                 sha256  13e37aef0bc8178d78301c2405e5e463f70069600512a7b61dedec46cf860844 \
-                 size    14892459
+checksums           rmd160  f407a8391a3683d87c15d3762c9ecacc13d4dbf5 \
+                    sha256  13e37aef0bc8178d78301c2405e5e463f70069600512a7b61dedec46cf860844 \
+                    size    14892459
 
-depends_build    port:pkgconfig \
-                 port:gtk-mac-bundler
+depends_build       port:pkgconfig \
+                    port:gtk-mac-bundler
 
-depends_lib      port:gtk3 \
-                 port:poppler \
-                 port:portaudio \
-                 port:zlib \
-                 port:libzip \
-                 port:libsndfile \
-                 port:adwaita-icon-theme \
-                 port:lua
+depends_lib         port:gtk3 \
+                    port:poppler \
+                    port:portaudio \
+                    port:zlib \
+                    port:libzip \
+                    port:libsndfile \
+                    port:adwaita-icon-theme \
+                    port:lua
 
-global appName
-set appName Xournal++.app
+set appName         Xournal++.app
 
 post-build {
-     # Do not clutter $HOME/.local
+    # Do not clutter $HOME/.local
     reinplace "s|\$1/inst|${prefix}|g;s/make install/#make install/" ${worksrcpath}/mac-setup/build-app.sh
 
     reinplace "s|<main-binary>\${prefix}/bin/|<main-binary dest=\"\${bundle}/foobar\">${worksrcpath}/src/|;s|<launcher-script></launcher-script >|<!-- <launcher-script></launcher-script > -->|" ${worksrcpath}/mac-setup/xournalpp.bundle
@@ -46,11 +45,11 @@ post-build {
 post-destroot {
     set docdir ${prefix}/share/doc/${subport}
     xinstall -d ${destroot}${docdir}
-    xinstall -m 644 -W ${worksrcpath} AUTHORS LICENSE CHANGELOG.md README.md ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} AUTHORS LICENSE CHANGELOG.md README.md ${destroot}${docdir}
 
     copy ${worksrcpath}/mac-setup/${appName} ${destroot}${applications_dir}
 
-     # Xournal++ is intended to be used through ${appName}, binary in 
-     # $prefix/bin won't work properly
-    file delete ${destroot}/${prefix}/bin/xournalpp
+    # Xournal++ is intended to be used through ${appName}, binary in
+    # $prefix/bin won't work properly
+    delete ${destroot}${prefix}/bin/xournalpp
 }


### PR DESCRIPTION
#### Description

Submitting a port for Xournal++ (there is also an existing port for Xournal). This ports builds the bundle Xournal++.app .

###### Type(s)

- [x] enhancement

###### Tested on

macOS 10.15.7 19H2
Xcode 12.0.1 12A7300

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
