### PR TITLE
py-{atomiclong,cached-property,pygit2,raven}: add py39

### DIFF
--- a/python/py-atomiclong/Portfile
+++ b/python/py-atomiclong/Portfile
@@ -8,9 +8,9 @@ version             0.1.1
 revision            0
 
 categories-append   devel
-platforms           darwin
 license             MIT
 maintainers         nomaintainer
+platforms           darwin
 
 description         increment numbers, atomically, in python
 long_description    Sometimes you need to increment some numbers, atomically,\
@@ -26,7 +26,7 @@ checksums           rmd160  aa6ea7bd708b3fcf83a7793f5284060a6ee52db8 \
                     sha256  cb1378c4cd676d6f243641c50e277504abf45f70f1ea76e446efcdbb69624bbe \
                     size    5057
 
-python.versions     38
+python.versions     38 39
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-cached-property/Portfile
+++ b/python/py-cached-property/Portfile
@@ -6,15 +6,15 @@ PortGroup           python 1.0
 name                py-cached-property
 version             1.5.1
 revision            1
-categories-append   devel
 
-platforms           darwin
-supported_archs     noarch
+categories-append   devel
 license             BSD
 maintainers         nomaintainer
+platforms           darwin
+supported_archs     noarch
 
 description         A decorator for caching properties in classes
-long_description    ${description}
+long_description    {*}${description}
 
 homepage            https://github.com/pydanny/cached-property
 
@@ -22,11 +22,10 @@ checksums           rmd160  084bed8505a97d24368726fa96d5732978e69ae6 \
                     sha256  9217a59f14a5682da7c4b8829deadbfc194ac22e9908ccf7c8820234e80a1504 \
                     size    12791
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 if {${subport} ne ${name}} {
-    depends_build-append \
-                    port:py${python.version}-setuptools
+    depends_build-append    port:py${python.version}-setuptools
 
-    livecheck.type  none
+    livecheck.type          none
 }

--- a/python/py-pygit2/Portfile
+++ b/python/py-pygit2/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  a19977b0a5caff654b8e7109211d8dad9ca11bd2 \
                     sha256  9cf6bf39dbecc691d1d5d855d0e5d2d1dacb125ae8155feac1987e944e072199 \
                     size    3016546
 
-python.versions     36 37 38
+python.versions     36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-raven/Portfile
+++ b/python/py-raven/Portfile
@@ -6,17 +6,18 @@ PortGroup           python 1.0
 name                py-raven
 version             6.10.0
 revision            0
+
 categories-append   devel
 platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 maintainers         {stromnov @stromnov} openmaintainer
 
 description         Raven is a client for Sentry
-long_description    ${description}
+long_description    {*}${description}
 
 homepage            https://github.com/getsentry/raven-python
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}


### PR DESCRIPTION
#### Description

py-{atomiclong,cached-property,pygit2,raven}: add py39

  - Add python v 3.9

Since python39 is out, and py-gitfs (#8626) isn't merged yet. Updating
those ports – and py-gitfs can start att 39 instead.

###### Type(s)

- [x] update

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

###### Notes

py-fusepy is moved to a separate PR (see comments below)