### PR TITLE
poppler: add boost variant

### DIFF
--- a/graphics/poppler/Portfile
+++ b/graphics/poppler/Portfile
@@ -8,8 +8,10 @@ PortGroup           cmake 1.1
 PortGroup           legacysupport 1.0
 
 name                poppler
-conflicts           xpdf-tools
 version             20.10.0
+revision            1
+
+conflicts           xpdf-tools
 license             GPL-2+
 maintainers         {devans @dbevans} openmaintainer
 categories          graphics
@@ -17,7 +19,7 @@ platforms           darwin
 homepage            https://poppler.freedesktop.org/
 
 description         Poppler is a PDF rendering library based on the xpdf-3.0 code base.
-long_description    ${description}
+long_description    {*}${description}
 
 master_sites        ${homepage} \
                     gentoo
@@ -61,6 +63,8 @@ compiler.cxx_standard 2014
 configure.cxxflags-append -std=c++14
 compiler.blacklist-append {clang < 800.0.38}
 
+patchfiles-append   patch-check-boost.diff
+
 # https://bugs.freedesktop.org/show_bug.cgi?id=106417
 patchfiles-append   patch-bug106417.diff
 
@@ -75,7 +79,15 @@ configure.args-append \
                     -DBUILD_QT5_TESTS=OFF \
                     -DBUILD_QT6_TESTS=OFF \
                     -DBUILD_CPP_TESTS=OFF \
-                    -DWITH_NSS3=ON
+                    -DWITH_NSS3=ON \
+                    -DUSE_BOOST_HEADERS=OFF
+
+variant boost description "Use Boost when building the Splash graphics backend" {
+    depends_build-append    port:boost
+
+    configure.args-replace  -DUSE_BOOST_HEADERS=OFF \
+                            -DUSE_BOOST_HEADERS=ON
+}
 
 subport poppler-qt5 {
     PortGroup qt5 1.0

--- a/graphics/poppler/files/patch-check-boost.diff
+++ b/graphics/poppler/files/patch-check-boost.diff
@@ -1,0 +1,11 @@
+--- CMakeLists.txt.orig	2020-10-01 21:44:58.000000000 +0200
++++ CMakeLists.txt	2020-10-08 14:15:20.000000000 +0200
+@@ -291,7 +291,7 @@
+   include_directories(SYSTEM ${LCMS2_INCLUDE_DIR})
+ endif()
+ 
+-if(ENABLE_SPLASH)
++if(ENABLE_SPLASH AND USE_BOOST_HEADERS)
+   find_package(Boost 1.58.0)
+   if(Boost_FOUND)
+     include_directories(SYSTEM ${Boost_INCLUDE_DIRS})


### PR DESCRIPTION
#### Description

Poppler should consistently either use or not use Boost. Making a
variant solves that.

  - Add patch-check-boost.diff
  - Add variant and depends_build for boost.
  - Closes: https://trac.macports.org/ticket/61290

###### Type(s)

- [x] bugfix

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?