### PR TITLE
armadillo: uses C++11 and thread_local

### DIFF
--- a/science/armadillo/Portfile
+++ b/science/armadillo/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem                      1.0
 PortGroup                       cmake 1.0
-PortGroup                       compiler_blacklist_versions 1.0
 PortGroup                       mpi 1.0
 
 name                            armadillo
@@ -67,8 +66,8 @@ if {[variant_isset gcc44] || [variant_isset gcc45] || [variant_isset gcc46] || \
     configure.cxx_stdlib        libstdc++
 }
 
-# Snow Leopard (and older) will fail to build with the error "Need a newer compiler"
-compiler.blacklist-append       *gcc-3.* *gcc-4.0 *gcc-4.2 {clang <= 211.10.1}
+compiler.cxx_standard           2011
+compiler.thread_local_storage   yes
 
 livecheck.type                  regex
 livecheck.url                   ${homepage}download.html


### PR DESCRIPTION
Cleanup old compiler blacklist

#### Description
Armadillo 10.x requires C++11 and `thread_local` keyword support (see [CMakeLists.txt](https://gitlab.com/conradsnicta/armadillo-code/-/blob/82c6ff64d45973b99c102053ae2c053f7a95014e/CMakeLists.txt#L91)), which is unavailable in Xcode prior to version 8: configuration fails on macOS 10.8-10.10 with `Compiler too old`.  The port builds on macOS 10.6 which uses MacPorts' clang 9.0 instead.
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
Untested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
