### PR TITLE
py-cchardet: drop noarch, workaround GCC error

### DIFF
--- a/python/py-cchardet/Portfile
+++ b/python/py-cchardet/Portfile
@@ -7,17 +7,16 @@ set realname        cchardet
 
 name                py-${realname}
 version             2.1.6
+revision            1
 categories-append   devel textproc
 license             MIT
 platforms           darwin
-supported_archs     noarch
 maintainers         {toby @tobypeterson} openmaintainer
 description         cChardet is high speed universal character encoding detector.
 long_description    ${description}
 
 homepage            https://github.com/PyYoshi/cChardet
 master_sites        pypi:[string index ${realname} 0]/${realname}
-distname            ${realname}-${version}
 
 checksums           rmd160  514768dad210d6c657d5a107b37003469b7e1863 \
                     sha256  b76afb2059ad69eab576949980a17413c1e9e5a5624abf9e43542d8853f146b3 \
@@ -28,11 +27,16 @@ python.versions     27 35 36 37 38 39
 if {${name} ne ${subport}} {
     if {${python.version} == 27} {
         version     2.1.5
-        revision    0
+        revision    1
         checksums   rmd160  c30f3589db681127984288dd8ad8b348e7719e31 \
                     sha256  240efe3f255f916769458343840b9c6403cf3192720bc5129792cbcb88bf72fb \
                     size    653280
+    } else {
+        # Workaround for https://trac.macports.org/ticket/61299
+        compiler.blacklist-append *gcc*
     }
+
+    distname        ${realname}-${version}
 
     depends_build-append \
                     port:py${python.version}-setuptools


### PR DESCRIPTION
Port installs architecture-specific shared library built from Cythonized code.

Avoid `unrecognized command line option "-Wno-unused-result"` error
See: https://trac.macports.org/ticket/61299

`py27-cchardet`: fix `distname`
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
Untested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
