### PR TITLE
rust: Update to version 1.47.0

### DIFF
--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 
 name                rust
-version             1.46.0
-revision            1
+version             1.47.0
+revision            0
 categories          lang devel
 platforms           darwin
 supported_archs     x86_64
@@ -27,9 +27,9 @@ long_description    Rust is a curly-brace, block-structured expression \
 homepage            https://www.rust-lang.org/
 
 # Get from src/stage0.txt
-set ruststd_version 1.45.2
-set rustc_version   1.45.2
-set cargo_version   0.46.0
+set ruststd_version 1.46.0
+set rustc_version   1.46.0
+set cargo_version   0.47.0
 set llvm_version    9.0
 
 # can use cmake or cmake-devel; default to cmake.
@@ -50,23 +50,23 @@ distfiles-append    rust-std-${ruststd_version}-${build_arch}-apple-${os.platfor
                     cargo-${cargo_version}-${build_arch}-apple-${os.platform}${extract.suffix}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  be052e3ebefd880f1738dca8f96dc946359dfd53 \
-                    sha256  2d6a3b7196db474ba3f37b8f5d50a1ecedff00738d7846840605b42bfc922728 \
-                    size    149449054  
+                    rmd160  2fee85c5e52046982a51eff62f64e123f798ed56 \
+                    sha256  3185df064c4747f2c8b9bb8c4468edd58ff4ad6d07880c879ac1b173b768d81d \
+                    size    151861620 \
 
 checksums-append \
                     rust-std-${ruststd_version}-x86_64-apple-${os.platform}${extract.suffix} \
-                    rmd160  b769e20421103ebb675394c46007db22410b120a \
-                    sha256  2a6e3b89f7f68d3b38bc1c255e20fa801b0159e2f81c588deb5734f7765f4799 \
-                    size    22623191 \
+                    rmd160  bd8d58fca200428b03603d770beeee8bf94e5de6 \
+                    sha256  8c897982bc38c9528b448fe551f089fee7716e692dece98052f4459ccc6e591c \
+                    size    22888748 \
                     rustc-${rustc_version}-x86_64-apple-${os.platform}${extract.suffix} \
-                    rmd160  64373db4741f3798c3b62c1b7b808a7b1a86a8a4 \
-                    sha256  84cc63d2213a05a5007290199d9043092e3bab6f19b8b03ec56d875e2c31cf59 \
-                    size    71529658 \
+                    rmd160  1503424f7cfeee88d6b7133ed5db689fb786bd34 \
+                    sha256  f690b375df7b1399e5baa69b64932e3e4a3f2b651e5ef2ebc85509bee777a9d9 \
+                    size    73665558 \
                     cargo-${cargo_version}-x86_64-apple-${os.platform}${extract.suffix} \
-                    rmd160  5d924c398124e8b70d0c3e1693d08367947a723a \
-                    sha256  a81306558ba470de6d2245982717402ce4517850d9032433e5f14a4785a55eae \
-                    size    5673993
+                    rmd160  123269f99aba6a0def22e77603ada120947023a9 \
+                    sha256  6e8f3319069dd14e1ef756906fa0ef3799816f1aba439bdeea9d18681c353ad6 \
+                    size    5685128
 
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
     known_fail yes


### PR DESCRIPTION
[WIP] rust: Update to version 1.47.0

#### Description

This doesn't build on my local machine. Not sure why.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.0.1 12A7300

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
