### PR TITLE
cargo: Update to version 0.47.0

### DIFF
--- a/_resources/port1.0/group/cargo_fetch-1.0.tcl
+++ b/_resources/port1.0/group/cargo_fetch-1.0.tcl
@@ -24,7 +24,7 @@
 #
 # To get a list of these, run in worksrcdir:
 #     cargo update
-#     grep \"checksum Cargo.lock | perl -pe 's/"checksum (\S*) (\S*) \S* = "(\S*)"/cargo.crates $1 $2 $3/'
+#     egrep -e '^(name|version|checksum) = ' Cargo.lock | perl -pe 's/^(?:name|version|checksum) = "(.+)"/$1/'
 #
 # https://github.com/macports/macports-contrib/tree/master/cargo2port/cargo2port.tcl
 #

--- a/devel/cargo/Portfile
+++ b/devel/cargo/Portfile
@@ -7,9 +7,9 @@ name                cargo
 if {${subport} ne "${name}-bootstrap"} {
     PortGroup       github 1.0
 
-    github.setup    rust-lang ${name} 0.46.1
+    github.setup    rust-lang ${name} 0.47.0
 } else {
-    version         0.46.1
+    version         0.47.0
 }
 PortGroup           cargo 1.0
 
@@ -41,9 +41,9 @@ if {${subport} ne "${name}-bootstrap"} {
                     port:rust
 
     checksums       ${distname}${extract.suffix} \
-                    rmd160  64860b02053d07e556e2cd7bd67bfa61d468daf7 \
-                    sha256  48754b91f4670ad0c53114cc2f7a2ed4bd182a5db6edc0fe6d9938b765401cf1 \
-                    size    1270395
+                    rmd160  1f4a5cc81fc79174f465e097b7e0a8145d6a5dd2 \
+                    sha256  ea22dcee2891fb27faa455c7e8bde430ae93fc84eee916d8f2c8c4cbd4b6a08c \
+                    size    1292351
 
     pre-configure {
         # create Cargo.lock
@@ -106,9 +106,9 @@ if {${subport} ne "${name}-bootstrap"} {
 
     checksums-append \
         ${name}-${version}-x86_64-apple-darwin${extract.suffix} \
-                    rmd160  98d7f6b7b28302943635e95bb988e8af77084e96 \
-                    sha256  95ca28cdc73deba5cdf29725a0c03aaf1a46e7e1832702cbf5784ce4673db0fb \
-                    size    5671055
+                    rmd160  123269f99aba6a0def22e77603ada120947023a9 \
+                    sha256  6e8f3319069dd14e1ef756906fa0ef3799816f1aba439bdeea9d18681c353ad6 \
+                    size    5685128
 
     set rust_platform [cargo.rust_platform ${build_arch}]
     distfiles  ${name}-${version}-${rust_platform}${extract.suffix}:stage0
@@ -138,125 +138,128 @@ subport ${name}-stage1 {
 }
 
 if {${subport} ne "${name}-bootstrap"} {
+    # cd ${worksrcpath}
+    # sudo cargo update
+    # egrep -e '^(name|version|checksum) = ' Cargo.lock | perl -pe 's/^(?:name|version|checksum) = "(.+)"/$1/'
     cargo.crates \
-        adler                            0.2.3  ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e \
-        aho-corasick                    0.7.13  043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86 \
-        ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
-        anyhow                          1.0.31  85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f \
-        atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
-        autocfg                          1.0.0  f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d \
-        bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
-        bitmaps                          2.1.0  031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2 \
-        bstr                            0.2.13  31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931 \
-        bytesize                         1.0.1  81a18687293a1546b67c246452202bbbf143d239cb43494cc163da14979082da \
-        cc                              1.0.58  f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518 \
-        cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
-        clap                            2.33.1  bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129 \
-        commoncrypto                     0.2.0  d056a8586ba25a1e4d61cb090900e495952c7886786fc55f909ab2f819b69007 \
-        commoncrypto-sys                 0.2.0  1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2 \
-        core-foundation                  0.7.0  57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171 \
-        core-foundation-sys              0.7.0  b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac \
-        crc32fast                        1.2.0  ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1 \
-        crossbeam-utils                  0.7.2  c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8 \
-        crypto-hash                      0.3.4  8a77162240fd97248d19a564a565eb563a3f592b386e4136fb300909e67dddca \
-        curl                            0.4.30  b0447a642435be046540f042950d874a4907f9fee28c0513a0beb3ba89f91eb7 \
-        curl-sys            0.4.32+curl-7.70.0  834425a2f22fdd621434196965bf99fbfd9eaed96348488e27b7ac40736c560b \
-        env_logger                       0.7.1  44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36 \
-        filetime                        0.2.10  affc17579b132fc2461adf7c575cc6e8b134ebca52c51f5411388965227dc695 \
-        flate2                          1.0.16  68c90b0fc46cf89d227cc78b40e494ff81287a92dd07631e5af0d06fe3cf885e \
-        fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
-        foreign-types                    0.3.2  f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1 \
-        foreign-types-shared             0.1.1  00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b \
-        fwdansi                          1.1.0  08c1f5787fe85505d1f7777268db5103d80a7a374d2316a7ce262e57baf8f208 \
-        getrandom                       0.1.14  7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb \
-        git2                            0.13.6  11e4b2082980e751c4bf4273e9cbb4a02c655729c8ee8a79f66cad03c8f4d31e \
-        git2-curl                       0.14.0  502d532a2d06184beb3bc869d4d90236e60934e3382c921b203fa3c33e212bd7 \
-        glob                             0.3.0  9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574 \
-        globset                          0.4.5  7ad1da430bd7281dde2576f44c84cc3f0f7b475e7202cd503042dff01a8c8120 \
-        hermit-abi                      0.1.15  3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9 \
-        hex                              0.3.2  805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77 \
-        hex                              0.4.2  644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35 \
-        home                             0.5.3  2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654 \
-        humantime                        1.3.0  df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f \
-        humantime                        2.0.1  3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a \
-        idna                             0.2.0  02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9 \
-        ignore                          0.4.16  22dcbf2a4a289528dbef21686354904e1c694ac642610a9bff9e7df730d9ec72 \
-        im-rc                           15.0.0  3ca8957e71f04a205cb162508f9326aea04676c8dfd0711220190d6b83664f3f \
-        itoa                             0.4.6  dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6 \
-        jobserver                       0.1.21  5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2 \
-        lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
-        lazycell                         1.2.1  b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f \
-        libc                            0.2.73  bd7d4bd64732af4bf3a67f367c27df8520ad7e230c5817b8ff485864d80242b9 \
-        libgit2-sys               0.12.7+1.0.0  bcd07968649bcb7b9351ecfde53ca4d27673cccfdf57c84255ec18710f3153e0 \
-        libnghttp2-sys            0.1.4+1.41.0  03624ec6df166e79e139a2310ca213283d6b3c30810c54844f307086d4488df1 \
-        libssh2-sys                     0.2.18  eafa907407504b0e683786d4aba47acf250f114d37357d56608333fd167dd0fc \
-        libz-sys                        1.0.25  2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe \
-        log                             0.4.11  4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b \
-        matches                          0.1.8  7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
-        memchr                           2.3.3  3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400 \
-        miniz_oxide                      0.4.0  be0f75932c1f6cfae3c04000e40114adf955636e19040f9c0a2c380702aa1c7f \
-        miow                             0.3.5  07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e \
-        num_cpus                        1.13.0  05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3 \
-        opener                           0.4.1  13117407ca9d0caf3a0e74f97b490a7e64c0ae3aa90a8b7085544d0c37b6f3ae \
-        openssl                        0.10.30  8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4 \
-        openssl-probe                    0.1.2  77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de \
-        openssl-src            111.10.1+1.1.1g  375f12316ddf0762f7cf1e2890a0a857954b96851b47b5af7fc06940c9e12f83 \
-        openssl-sys                     0.9.58  a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de \
-        percent-encoding                 2.1.0  d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
-        pkg-config                      0.3.18  d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33 \
-        ppv-lite86                       0.2.8  237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea \
-        pretty_env_logger                0.4.0  926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d \
-        proc-macro2                     1.0.19  04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12 \
-        quick-error                      1.2.3  a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0 \
-        quote                            1.0.7  aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37 \
-        rand                             0.7.3  6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
-        rand_chacha                      0.2.2  f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402 \
-        rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
-        rand_hc                          0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
-        rand_xoshiro                     0.4.0  a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004 \
-        redox_syscall                   0.1.57  41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce \
-        regex                            1.3.9  9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6 \
-        regex-syntax                    0.6.18  26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8 \
-        remove_dir_all                   0.5.3  3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7 \
-        rustc-workspace-hack             1.0.0  fc71d2faa173b74b232dedc235e3ee1696581bb132fc116fa3626d6151a1a8fb \
-        rustfix                          0.5.1  f2c50b74badcddeb8f7652fa8323ce440b95286f8e4b64ebfd871c609672704e \
-        ryu                              1.0.5  71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e \
-        same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
-        schannel                        0.1.19  8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75 \
-        semver                          0.10.0  394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190 \
-        semver-parser                    0.7.0  388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
-        serde                          1.0.114  5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3 \
-        serde_derive                   1.0.114  2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e \
-        serde_ignored                    0.1.2  1c2c7d39d14f2f2ea82239de71594782f186fd03501ac81f0ce08e674819ff2f \
-        serde_json                      1.0.56  3433e879a558dde8b5e8feb2a04899cf34fdde1fafb894687e52105fc1162ac3 \
-        shell-escape                     0.1.5  45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f \
-        sized-chunks                     0.6.2  1ec31ceca5644fa6d444cc77548b88b67f46db6f7c71683b0f9336e671830d2f \
-        socket2                         0.3.12  03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918 \
-        strip-ansi-escapes               0.1.0  9d63676e2abafa709460982ddc02a3bb586b6d15a49b75c212e06edd3933acee \
-        strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
-        syn                             1.0.34  936cae2873c940d92e697597c5eee105fb570cd5689c695806f672883653349b \
-        tar                             0.4.29  c8a4c1d0bee3230179544336c15eefb563cf0302955d962e456542323e8c2e8a \
-        tempfile                         3.1.0  7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9 \
-        termcolor                        1.1.0  bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f \
-        textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
-        thread_local                     1.0.1  d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14 \
-        tinyvec                          0.3.3  53953d2d3a5ad81d9f844a32f14ebb121f50b650cd59d0ee2a07cf13c617efed \
-        toml                             0.5.6  ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a \
-        typenum                         1.12.0  373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33 \
-        unicode-bidi                     0.3.4  49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5 \
-        unicode-normalization           0.1.13  6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977 \
-        unicode-width                    0.1.8  9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3 \
-        unicode-xid                      0.2.1  f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564 \
-        url                              2.1.1  829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb \
-        utf8parse                        0.1.1  8772a4ccbb4e89959023bc5b7cb8623a795caa7092d99f3aa9501b9484d4557d \
-        vcpkg                           0.2.10  6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c \
-        vec_map                          0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
-        version_check                    0.9.2  b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed \
-        vte                              0.3.3  4f42f536e22f7fcbb407639765c8fd78707a33109301f834a594758bedd6e8cf \
-        walkdir                          2.3.1  777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d \
-        wasi      0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
-        winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
-        winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
-        winapi-util                      0.1.5  70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
-        winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f
+        adler 0.2.3 ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e \
+        aho-corasick 0.7.13 043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86 \
+        ansi_term 0.11.0 ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
+        anyhow 1.0.33 a1fd36ffbb1fb7c834eac128ea8d0e310c5aeb635548f9d58861e1308d46e71c \
+        atty 0.2.14 d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+        autocfg 1.0.1 cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a \
+        bitflags 1.2.1 cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
+        bitmaps 2.1.0 031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2 \
+        bstr 0.2.13 31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931 \
+        bytesize 1.0.1 81a18687293a1546b67c246452202bbbf143d239cb43494cc163da14979082da \
+        cc 1.0.61 ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d \
+        cfg-if 0.1.10 4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
+        clap 2.33.3 37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002 \
+        commoncrypto 0.2.0 d056a8586ba25a1e4d61cb090900e495952c7886786fc55f909ab2f819b69007 \
+        commoncrypto-sys 0.2.0 1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2 \
+        core-foundation 0.9.1 0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62 \
+        core-foundation-sys 0.8.1 c0af3b5e4601de3837c9332e29e0aae47a0d46ebfa246d12b82f564bac233393 \
+         crc32fast 1.2.0 ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1 \
+        crossbeam-utils 0.7.2 c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8 \
+        crypto-hash 0.3.4 8a77162240fd97248d19a564a565eb563a3f592b386e4136fb300909e67dddca \
+        curl 0.4.33 78baca05127a115136a9898e266988fc49ca7ea2c839f60fc6e1fc9df1599168 \
+        curl-sys 0.4.36+curl-7.71.1 68cad94adeb0c16558429c3c34a607acc9ea58e09a7b66310aabc9788fc5d721 \
+        env_logger 0.7.1 44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36 \
+        filetime 0.2.12 3ed85775dcc68644b5c950ac06a2b23768d3bc9390464151aaf27136998dcf9e \
+        flate2 1.0.18 da80be589a72651dcda34d8b35bcdc9b7254ad06325611074d9cc0fbb19f60ee \
+        fnv 1.0.7 3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
+        foreign-types 0.3.2 f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1 \
+        foreign-types-shared 0.1.1 00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b \
+        fwdansi 1.1.0 08c1f5787fe85505d1f7777268db5103d80a7a374d2316a7ce262e57baf8f208 \
+        getrandom 0.1.15 fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6 \
+        git2 0.13.11 1e094214efbc7fdbbdee952147e493b00e99a4e52817492277e98967ae918165 \
+        git2-curl 0.14.1 883539cb0ea94bab3f8371a98cd8e937bbe9ee7c044499184aa4c17deb643a50 \
+        glob 0.3.0 9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574 \
+        globset 0.4.5 7ad1da430bd7281dde2576f44c84cc3f0f7b475e7202cd503042dff01a8c8120 \
+        hermit-abi 0.1.17 5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8 \
+        hex 0.3.2 805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77 \
+        hex 0.4.2 644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35 \
+        home 0.5.3 2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654 \
+        humantime 1.3.0 df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f \
+        humantime 2.0.1 3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a \
+        idna 0.2.0 02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9 \
+        ignore 0.4.16 22dcbf2a4a289528dbef21686354904e1c694ac642610a9bff9e7df730d9ec72 \
+        im-rc 15.0.0 3ca8957e71f04a205cb162508f9326aea04676c8dfd0711220190d6b83664f3f \
+        itoa 0.4.6 dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6 \
+        jobserver 0.1.21 5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2 \
+        lazy_static 1.4.0 e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+        lazycell 1.3.0 830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55 \
+        libc 0.2.79 2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743 \
+        libgit2-sys 0.12.13+1.0.1 069eea34f76ec15f2822ccf78fe0cdb8c9016764d0a12865278585a74dbdeae5 \
+        libnghttp2-sys 0.1.4+1.41.0 03624ec6df166e79e139a2310ca213283d6b3c30810c54844f307086d4488df1 \
+        libssh2-sys 0.2.19 ca46220853ba1c512fc82826d0834d87b06bcd3c2a42241b7de72f3d2fe17056 \
+        libz-sys 1.1.2 602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655 \
+        log 0.4.11 4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b \
+        matches 0.1.8 7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
+        memchr 2.3.3 3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400 \
+        miniz_oxide 0.4.3 0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d \
+        miow 0.3.5 07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e \
+        num_cpus 1.13.0 05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3 \
+        opener 0.4.1 13117407ca9d0caf3a0e74f97b490a7e64c0ae3aa90a8b7085544d0c37b6f3ae \
+        openssl 0.10.30 8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4 \
+        openssl-probe 0.1.2 77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de \
+        openssl-src 111.12.0+1.1.1h 858a4132194f8570a7ee9eb8629e85b23cbc4565f2d4a162e87556e5956abf61 \
+        openssl-sys 0.9.58 a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de \
+        percent-encoding 2.1.0 d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
+        pkg-config 0.3.18 d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33 \
+        ppv-lite86 0.2.9 c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20 \
+        pretty_env_logger 0.4.0 926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d \
+        proc-macro2 1.0.24 1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71 \
+        quick-error 1.2.3 a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0 \
+        quote 1.0.7 aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37 \
+        rand 0.7.3 6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
+        rand_chacha 0.2.2 f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402 \
+        rand_core 0.5.1 90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
+        rand_hc 0.2.0 ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
+        rand_xoshiro 0.4.0 a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004 \
+        redox_syscall 0.1.57 41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce \
+        regex 1.4.0 36f45b719a674bf4b828ff318906d6c133264c793eff7a41e30074a45b5099e2 \
+        regex-syntax 0.6.19 c17be88d9eaa858870aa5e48cc406c206e4600e983fc4f06bbe5750d93d09761 \
+        remove_dir_all 0.5.3 3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7 \
+        rustc-workspace-hack 1.0.0 fc71d2faa173b74b232dedc235e3ee1696581bb132fc116fa3626d6151a1a8fb \
+        rustfix 0.5.1 f2c50b74badcddeb8f7652fa8323ce440b95286f8e4b64ebfd871c609672704e \
+        ryu 1.0.5 71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e \
+        same-file 1.0.6 93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
+        schannel 0.1.19 8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75 \
+        semver 0.10.0 394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190 \
+        semver-parser 0.7.0 388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
+        serde 1.0.116 96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5 \
+        serde_derive 1.0.116 f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8 \
+        serde_ignored 0.1.2 1c2c7d39d14f2f2ea82239de71594782f186fd03501ac81f0ce08e674819ff2f \
+        serde_json 1.0.58 a230ea9107ca2220eea9d46de97eddcb04cd00e92d13dda78e478dd33fa82bd4 \
+        shell-escape 0.1.5 45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f \
+        sized-chunks 0.6.2 1ec31ceca5644fa6d444cc77548b88b67f46db6f7c71683b0f9336e671830d2f \
+        socket2 0.3.15 b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44 \
+        strip-ansi-escapes 0.1.0 9d63676e2abafa709460982ddc02a3bb586b6d15a49b75c212e06edd3933acee \
+        strsim 0.8.0 8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
+        syn 1.0.44 e03e57e4fcbfe7749842d53e24ccb9aa12b7252dbe5e91d2acad31834c8b8fdd \
+        tar 0.4.30 489997b7557e9a43e192c527face4feacc78bfbe6eed67fd55c4c9e381cba290 \
+        tempfile 3.1.0 7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9 \
+        termcolor 1.1.0 bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f \
+        textwrap 0.11.0 d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
+        thread_local 1.0.1 d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14 \
+        tinyvec 0.3.4 238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117 \
+        toml 0.5.7 75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645 \
+        typenum 1.12.0 373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33 \
+        unicode-bidi 0.3.4 49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5 \
+        unicode-normalization 0.1.13 6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977 \
+        unicode-width 0.1.8 9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3 \
+        unicode-xid 0.2.1 f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564 \
+        url 2.1.1 829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb \
+        utf8parse 0.1.1 8772a4ccbb4e89959023bc5b7cb8623a795caa7092d99f3aa9501b9484d4557d \
+        vcpkg 0.2.10 6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c \
+        vec_map 0.8.2 f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
+        version_check 0.9.2 b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed \
+        vte 0.3.3 4f42f536e22f7fcbb407639765c8fd78707a33109301f834a594758bedd6e8cf \
+        walkdir 2.3.1 777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d \
+        wasi 0.9.0+wasi-snapshot-preview1 cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
+        winapi 0.3.9 5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
+        winapi-i686-pc-windows-gnu 0.4.0 ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+        winapi-util 0.1.5 70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
+        winapi-x86_64-pc-windows-gnu 0.4.0 712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f
 }


### PR DESCRIPTION
[WIP] cargo: Update to version 0.47.0

#### Description

This doesn't build on my local machine. Not sure why.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.0.1 12A7300

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
