### PR TITLE
rocksdb: requires thread_local

### DIFF
--- a/databases/rocksdb/Portfile
+++ b/databases/rocksdb/Portfile
@@ -32,6 +32,7 @@ patchfiles-append   patch-Makefile.diff \
                     patch-9cc25190e.diff
 
 compiler.cxx_standard 2011
+compiler.thread_local_storage yes
 
 use_configure       no
 
@@ -53,3 +54,7 @@ destroot.env-append CC=${configure.cc} \
                     DEBUG_LEVEL=0 \
                     OPT=${configure.optflags} \
                     INSTALL_PATH=${destroot}${prefix}
+
+# Disable silent rules
+build.env-append    V=1
+destroot.env-append V=1


### PR DESCRIPTION
#### Description
Build fails if compiler doesn't support `thread_local`, e.g. Xcode prior to version 8.
<!-- Note: it is best to make pull requests from a branch rather than from master -->



###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
Untested. See if Travis CI "Xcode 7.3" succeeds.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
