### PR TITLE
py-fusepy: add py39

### DIFF
--- a/python/py-fusepy/Portfile
+++ b/python/py-fusepy/Portfile
@@ -8,9 +8,9 @@ version             3.0.1
 revision            0
 
 categories-append   devel
-platforms           darwin
 license             ISC
 maintainers         nomaintainer
+platforms           darwin
 
 description         a simple interface to FUSE and MacFUSE
 long_description    ${python.rootname} is a Python module that provides\
@@ -23,7 +23,7 @@ checksums           rmd160  4a95b1f2278454929f5f037c0c6fee557b8d2293 \
                     sha256  72ff783ec2f43de3ab394e3f7457605bf04c8cf288a2f4068b4cde141d4ee6bd \
                     size    11519
 
-python.versions     38
+python.versions     38 39
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

py-fusepy: add py39

  - Add python v 3.9
  - This was part of another PR.
    See: #8689

###### Type(s)

- [x] update

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?