### PR TITLE
quassel: cleanup compilers

### DIFF
--- a/irc/quassel/Portfile
+++ b/irc/quassel/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem      1.0
 PortGroup       cmake 1.1
-PortGroup       compiler_blacklist_versions 1.0
 PortGroup       qt5 1.0
 PortGroup       github 1.0
 
@@ -31,9 +30,6 @@ patchfiles      patch-src_common_types.h
 compiler.cxx_standard \
                 2011
 compiler.thread_local_storage yes
-# Work around thread local compiler selection bug. Remove after
-# https://github.com/macports/macports-base/pull/161 is released.
-compiler.blacklist-append {clang < 800}
 
 configure.args  -DWANT_CORE=OFF \
                 -DWANT_QTCLIENT=OFF \


### PR DESCRIPTION
macports/macports-base#161 included in 2.6.3 release

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
Untested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
