### PR TITLE
ompl: cleanup compilers

### DIFF
--- a/science/ompl/Portfile
+++ b/science/ompl/Portfile
@@ -3,7 +3,6 @@
 PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           active_variants 1.1
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 
 categories          science
@@ -23,10 +22,6 @@ depends_build-append port:pkgconfig
 depends_lib-append  port:boost port:ode port:flann port:triangle port:eigen3
 
 compiler.cxx_standard   2014
-# Fix MacPorts base selection of C++14-compatible compilers. Remove once
-# https://github.com/macports/macports-base/pull/162 is released.
-compiler.blacklist-append {clang < 602}
-
 configure.args-append   -DOMPL_BUILD_DEMOS=OFF \
                         -DOMPL_BUILD_TESTS=OFF \
                         -DCMAKE_DISABLE_FIND_PACKAGE_spot=ON


### PR DESCRIPTION
macports/macports-base#162 included in 2.6.3 release

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
Untested
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
