### PR TITLE
xchm: cleanup compilers

### DIFF
--- a/textproc/xchm/Portfile
+++ b/textproc/xchm/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem          1.0
 PortGroup           app 1.0
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 PortGroup           wxWidgets 1.0
 
@@ -37,9 +36,5 @@ depends_lib-append  port:chmlib \
                     port:${wxWidgets.port}
 
 compiler.cxx_standard   2014
-
-# Remove this once base's compiler selection for C++14 is fixed:
-# https://github.com/macports/macports-base/pull/162
-compiler.blacklist-append {clang < 602}
 
 configure.args      --with-wxdir=${wxWidgets.wxdir}


### PR DESCRIPTION
macports/macports-base#162 included in 2.6.3 release

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
Untested
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
