### PR TITLE
poppler: use compiler.thread_local_storage yes

### DIFF
--- a/graphics/poppler/Portfile
+++ b/graphics/poppler/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           conflicts_build 1.0
 PortGroup           gobject_introspection 1.0
 PortGroup           cmake 1.1
@@ -58,10 +57,9 @@ configure.cppflags-delete -I${prefix}/include
 configure.ldflags-append -liconv
 gobject_introspection yes
 
-# C++14, thread_local
 compiler.cxx_standard 2014
 configure.cxxflags-append -std=c++14
-compiler.blacklist-append {clang < 800.0.38}
+compiler.thread_local_storage yes
 
 patchfiles-append   patch-check-boost.diff
 


### PR DESCRIPTION
macports/macports-base#161 included in 2.6.3 release

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
