### PR TITLE
extractpdfmark: use compiler.cxx_standard 2011

### DIFF
--- a/textproc/extractpdfmark/Portfile
+++ b/textproc/extractpdfmark/Portfile
@@ -4,7 +4,6 @@ PortSystem          1.0
 
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
-PortGroup           cxx11 1.1
 
 github.setup        trueroad extractpdfmark 1.1.0 v
 categories          textproc
@@ -26,6 +25,8 @@ github.tarball_from releases
 checksums           rmd160  8d6dd90de6f4f555012bd6edd8ac4e00dfc356fc \
                     sha256  0935045084211fcf68a9faaba2b65c037d0adfd7fa27224d2b6c7ae0fd7964cb \
                     size    308226
+
+compiler.cxx_standard 2011
 
 # build fails on 10.9 10.10 using Apple clang
 compiler.blacklist-append {clang < 800.0.38}


### PR DESCRIPTION
…instead of deprecated `cxx11 1.1` portgroup

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
