### PR TITLE
nghttp2: cleanup compilers

### DIFF
--- a/www/nghttp2/Portfile
+++ b/www/nghttp2/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 PortGroup           legacysupport 1.0
 
@@ -22,9 +21,6 @@ checksums           rmd160  9d23cd271ac59c4f0c1c4748076d51e356b2fc0b \
                     sha256  abc25b8dc601f5b3fefe084ce50fcbdc63e3385621bee0cbfa7b57f9ec3e67c2 \
                     size    1640712
 
-# nghttp2 requires C++14
-compiler.blacklist-append {clang < 602}
-
 depends_build       port:pkgconfig
 
 # See: https://trac.macports.org/ticket/57960
@@ -35,7 +31,7 @@ patchfiles-append   patch-configure-nopython.diff \
 
 use_autoreconf      yes
 
-compiler.cxx_standard   2011
+compiler.cxx_standard   2014
 
 configure.args      --disable-silent-rules \
                     --disable-threads \


### PR DESCRIPTION
macports/macports-base#162 included in 2.6.3 release

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
Untested
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
