### PR TITLE
ipe: cleanup compilers

### DIFF
--- a/graphics/ipe/Portfile
+++ b/graphics/ipe/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem                                          1.0
-PortGroup               compiler_blacklist_versions 1.0
+PortSystem              1.0
 
 name                    ipe
 version                 7.2.11
@@ -40,9 +39,7 @@ universal_variant       no
 
 patch.pre_args          -p1
 
-# needs a c++14 compatible compiler
 compiler.cxx_standard   2014
-compiler.blacklist-append  {clang < 602}
 
 # Fix missing cstdlib include
 # https://github.com/otfried/ipe-issues/issues/240


### PR DESCRIPTION
macports/macports-base#162 included in 2.6.3 release

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
