### PR TITLE
openexr: cleanup compilers

### DIFF
--- a/graphics/openexr/Portfile
+++ b/graphics/openexr/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
-PortGroup               compiler_blacklist_versions 1.0
 PortGroup               github 1.0
 
 github.setup            openexr openexr 2.3.0 v
@@ -23,11 +22,6 @@ configure.env-append    NM=${prefix}/bin/nm
 configure.env-append    GREP=/usr/bin/grep
 
 compiler.cxx_standard   2014
-
-# please remove when in a later MacPorts version
-# see https://github.com/macports/macports-base/commit/cdfb534f91748d22a627a6336e536915b1a5297d
-compiler.blacklist-append \
-                        {clang < 602}
 
 if {${subport} ne "ilmbase"} {
     depends_build-append \


### PR DESCRIPTION
macports/macports-base#162 included in 2.6.3 release

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
