### PR TITLE
websocketpp: use compiler.cxx_standard 2011

### DIFF
--- a/net/websocketpp/Portfile
+++ b/net/websocketpp/Portfile
@@ -3,7 +3,6 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
-PortGroup           cxx11 1.1
 
 github.setup        zaphoyd websocketpp 0.8.2
 revision            0
@@ -21,6 +20,8 @@ long_description    WebSocket++ is a header only C++ library that implements \
 checksums           rmd160  1d30eb0b71632fe5d4a790f8d6245063f112fbef \
                     sha256  8b1773ea2832751071ac19d2708314d68316dd3916434c7dc0dd58cef14d51cd \
                     size    701341
+
+compiler.cxx_standard 2011
 
 depends_lib-append  port:asio \
                     path:lib/libssl.dylib:openssl \


### PR DESCRIPTION
…instead of deprecated `cxx11 1.1` portgroup

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
