### PR TITLE
py-fann2: drop noarch

### DIFF
--- a/python/py-fann2/Portfile
+++ b/python/py-fann2/Portfile
@@ -5,14 +5,13 @@ PortGroup           github 1.0
 
 github.setup        FutureLinkCorporation fann2 1.2.0
 name                py-fann2
-revision            0
+revision            1
 checksums           rmd160  751e4b4ea2104bbd6500c601bd153e50a2709b27 \
                     sha256  63b2a6dde0b1d7f9a642598b86f223d0880cb87aef09024e19cc829840c1e3f0 \
                     size    65126
 
 categories-append   science
 platforms           darwin
-supported_archs     noarch
 license             LGPL-2
 maintainers         {fusion.gat.com:smithsp @smithsp} openmaintainer
 description         Python bindings for Fast Artificial Neural Networks 2.2.0 (FANN >= 2.2.0).


### PR DESCRIPTION
Port installs architecture-specific shared library.

~~Avoid `unrecognized command line option "-Wno-unused-result"` error
See: https://trac.macports.org/ticket/61299~~

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
Untested

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
