### PR TITLE
py-pycryptodome: drop noarch

### DIFF
--- a/python/py-pycryptodome/Portfile
+++ b/python/py-pycryptodome/Portfile
@@ -5,11 +5,10 @@ PortGroup           python 1.0
 
 name                py-pycryptodome
 version             3.9.8
-revision            0
+revision            1
 
 license             BSD
 platforms           darwin
-supported_archs     noarch
 maintainers         {@xeron gmail.com:xeron.oskom} openmaintainer
 
 description         Cryptographic library for Python


### PR DESCRIPTION
Port installs architecture-specific shared libraries.

~~Avoid `unrecognized command line option "-Wno-unused-result"` error
See: https://trac.macports.org/ticket/61299~~

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
Untested

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
