### PR TITLE
usd: new port

### DIFF
--- a/graphics/usd/Portfile
+++ b/graphics/usd/Portfile
@@ -1,0 +1,221 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           compiler_blacklist_versions 1.0
+PortGroup           cmake 1.1
+PortGroup           active_variants 1.1
+
+github.setup        PixarAnimationStudios USD 19.11 v
+github.tarball_from archive
+name                usd
+categories          graphics
+platforms           darwin
+license             Apache-2
+maintainers         @jasonliu--
+homepage            http://www.openusd.org
+description         universal scene description
+long_description    Universal Scene Description (USD) is a software \
+                    library, developed by Pixar Animation Studios, \
+                    that provides a system for authoring, reading, and \
+                    streaming time-sampled scene description for \
+                    interchange between computer graphics \
+                    applications. It organizes data into hierarchical \
+                    namespaces of primitives and their properties. \
+                    This provides a set of schemas upon which common \
+                    3-D computer graphics concepts such as geometry, \
+                    shading, models, and assets can be organized and \
+                    manipulated.
+
+checksums           rmd160  26c4c38b45e9254395b5e673a15ed95fb9465a44 \
+                    sha256  84f3bb123f7950b277aace096d678c8876737add0ed0b6ccb77cabb4f32dbcb0 \
+                    size    37563211
+
+set py_ver          2.7
+set py_ver_nodot    [string map {. {}} ${py_ver}]
+
+depends_lib-append  port:boost \
+                    port:tbb
+
+compiler.cxx_standard 2011
+# USD fails to compile for Clang older than 8.1.0
+# (Note: Clang 8.1.0 == clang-802 in Xcode)
+compiler.blacklist-append {clang < 802}
+
+# This patch adds modifications that allow Blender to use USD. The patch
+# file 'patch-add-blender-mods.diff' was extracted from the file in
+# Blender's source code named
+# 'build_files/build_environment/patches/usd.diff'. (No further
+# modifications to the patch itself were needed, since Blender 2.83 was
+# written to be compatible with USD version 19.11.) These modifications
+# essentially add a hook for Blender to use, and shouldn't otherwise
+# affect the functioning of USD.
+patchfiles-append   patch-add-blender-mods.diff
+
+# By default, USD places plugins in a ${prefix}/plugin directory. This
+# patch changes it so that the plugins get placed in a location that
+# conforms with MacPorts' mtree layout: ${prefix}/share/usd/plugins
+patchfiles-append   patch-plugins-output-paths.diff
+
+post-patch {
+    # USD puts its CMake package config files in the wrong place
+    reinplace {s|cmake/||} ${worksrcpath}/pxr/pxrConfig.cmake.in
+    reinplace -E "s|\(set.PXR_INCLUDE_DIRS \).*|\\1\"${prefix}/include\")|" \
+        ${worksrcpath}/pxr/pxrConfig.cmake.in
+    foreach re [list \
+        {s|(PROJECT_BINARY_DIR.*)(pxrConfig)|\1lib/cmake/usd/\2|} \
+        {/DESTINATION.*CMAKE_INSTALL_PREFIX/s|(DESTINATION ")(.*)"|\1\2/lib/cmake/usd"|} \
+        {/DESTINATION.*cmake/s|(DESTINATION ")cmake|\1lib/cmake/usd|} \
+    ] {
+        reinplace -E $re ${worksrcpath}/pxr/CMakeLists.txt
+    }
+}
+
+# Turn off all of USD's default build options. We will allow users to
+# directly control these options using port variants.
+configure.args      -DPXR_BUILD_TESTS=OFF \
+                    -DPXR_BUILD_IMAGING=OFF \
+                    -DPXR_BUILD_USD_IMAGING=OFF \
+                    -DPXR_BUILD_USDVIEW=OFF \
+                    -DPXR_ENABLE_GL_SUPPORT=OFF \
+                    -DPXR_ENABLE_PYTHON_SUPPORT=OFF \
+                    -DPXR_ENABLE_HDF5_SUPPORT=OFF \
+                    -DPXR_ENABLE_PTEX_SUPPORT=OFF
+
+############################# Variants ##############################
+
+variant docs description {Build documentation} {
+    depends_build-append    port:doxygen \
+                            path:bin/dot:graphviz
+
+    post-patch {
+        reinplace {s|docs|share/doc/usd|g} ${worksrcpath}/CMakeLists.txt
+        reinplace {/installPath = os/s|docs|share/doc/usd|} \
+            ${worksrcpath}/cmake/macros/generateDocs.py
+        reinplace {/os.mkdir.installPath/s/mkdir/makedirs/} \
+            ${worksrcpath}/cmake/macros/generateDocs.py
+        reinplace {/PROJECT_NAME.*=/s/$/"Universal Scene Description"/} \
+            ${worksrcpath}/pxr/usd/lib/usd/Doxyfile.in
+        reinplace "/PROJECT_NUMBER.*=/s/$/${version}/" \
+            ${worksrcpath}/pxr/usd/lib/usd/Doxyfile.in
+    }
+
+    configure.args-append   -DPXR_BUILD_DOCUMENTATION=ON
+}
+
+variant tests description {Build unit tests} {
+    patchfiles-append       patch-tests-output-paths.diff
+    configure.args-replace  -DPXR_BUILD_TESTS=OFF \
+                            -DPXR_BUILD_TESTS=ON
+}
+
+variant imaging description {Build imaging components} {
+    depends_lib-append      port:openexr \
+                            port:opensubdiv
+    configure.args-replace  -DPXR_BUILD_IMAGING=OFF \
+                            -DPXR_BUILD_IMAGING=ON
+}
+
+variant usd_imaging requires imaging \
+    description {Build USD imaging components} \
+{
+    configure.args-replace  -DPXR_USD_IMAGING=OFF \
+                            -DPXR_USD_IMAGING=ON
+}
+
+variant opengl description {Enable OpenGL-based components} {
+    if {[variant_isset imaging]} {
+        depends_lib-append  port:glew
+    }
+    configure.args-replace  -DPXR_ENABLE_GL_SUPPORT=OFF \
+                            -DPXR_ENABLE_GL_SUPPORT=ON
+}
+
+variant python description {Enable Python-based components} {
+    require_active_variants boost python${py_ver_nodot}
+    depends_lib-append      port:python${py_ver_nodot} \
+                            port:py${py_ver_nodot}-jinja2
+
+    post-patch {
+        # According to 'cmake --help-module FindBoost': "Note that Boost
+        # Python components require a Python version suffix (Boost 1.67
+        # and later), e.g. 'python36' or 'python27' for the versions
+        # built against Python 3.6 and 2.7, respectively."
+        reinplace -E "/--Boost/,/--Jinja2/s/\(python\)/\\1${py_ver_nodot}/" \
+            ${worksrcpath}/cmake/defaults/Packages.cmake
+    }
+
+    configure.args-replace  -DPXR_ENABLE_PYTHON_SUPPORT=OFF \
+                            -DPXR_ENABLE_PYTHON_SUPPORT=ON
+}
+
+variant viewer \
+    requires usd_imaging python opengl \
+    description {Build USD viewer} \
+{
+    depends_lib-append      port:py${py_ver_nodot}-pyside \
+                            port:py${py_ver_nodot}-opengl
+    configure.args-replace  -DPXR_BUILD_USDVIEW=OFF \
+                            -DPXR_BUILD_USDVIEW=ON
+}
+
+variant ptex description {Enable Ptex support} {
+    depends_lib-append      port:ptex
+    configure.args-replace  -DPXR_ENABLE_PTEX_SUPPORT=OFF \
+                            -DPXR_ENABLE_PTEX_SUPPORT=ON
+}
+
+variant monolithic \
+    description {Build the USD libraries as a single archive library, instead of modular individual libraries} \
+{
+    configure.args-append   -DPXR_BUILD_MONOLITHIC=ON
+}
+
+### Imaging Plugins
+
+variant oiio description {Build OpenImageIO plugin} {
+    depends_lib-append      port:openimageio
+    configure.args-append   -DPXR_BUILD_OPENIMAGEIO_PLUGIN=ON
+}
+
+variant ocio description {Build OpenColorIO plugin} {
+    depends_lib-append      port:opencolorio
+    configure.args-append   -DPXR_BUILD_OPENCOLORIO_PLUGIN=ON
+}
+
+variant alembic description {Build the Alembic plugin for USD} {
+    depends_lib-append      port:alembic
+    configure.args-append   -DPXR_BUILD_ALEMBIC_PLUGIN=ON
+}
+
+variant hdf5 requires alembic \
+    description {Enable HDF5 support in the Alembic plugin} \
+{
+    require_active_variants alembic hdf5
+    configure.args-replace  -DPXR_ENABLE_HDF5_SUPPORT=OFF \
+                            -DPXR_ENABLE_HDF5_SUPPORT_ON
+}
+
+variant materialx description {Build MaterialX plugin} {
+    depends_lib-append      port:materialx
+
+    post-patch {
+        foreach re [list \
+            "/find_package.MaterialX/i\\
+\\    set(CMAKE_MODULE_PATH_ORIG \${CMAKE_MODULE_PATH})\\
+\\    list(PREPEND CMAKE_MODULE_PATH \"\${CMAKE_SOURCE_DIR}/cmake/modules\")\\
+" \
+            "/find_package.MaterialX/a\\
+\\    set(CMAKE_MODULE_PATH \${CMAKE_MODULE_PATH_ORIG})\\
+" \
+        ] {
+            reinplace $re ${worksrcpath}/cmake/defaults/Packages.cmake
+        }
+        reinplace -E {s|(stdlib_defs.mtlx)|share/MaterialX/libraries/stdlib/\1|} \
+            ${worksrcpath}/cmake/modules/FindMaterialX.cmake
+    }
+
+    configure.args-append   -DPXR_BUILD_MATERIALX_PLUGIN=ON
+}
+
+default_variants    +docs +tests +ptex +oiio +ocio +alembic

--- a/graphics/usd/files/patch-add-blender-mods.diff
+++ b/graphics/usd/files/patch-add-blender-mods.diff
@@ -1,0 +1,68 @@
+--- pxr/base/lib/plug/initConfig.cpp.orig	2019-10-24 22:39:53.000000000 +0200
++++ pxr/base/lib/plug/initConfig.cpp		2019-12-11 11:00:37.643323127 +0100
+@@ -69,8 +69,38 @@
+ 
+ ARCH_CONSTRUCTOR(Plug_InitConfig, 2, void)
+ {
++    /* The contents of this constructor have been moved to usd_initialise_plugin_path(...) */
++}
++
++}; // end of anonymous namespace
++
++/**
++ * The contents of this function used to be in the static constructor Plug_InitConfig.
++ * This static constructor made it impossible for Blender to pass a path to the USD
++ * library at runtime, as the constructor would run before Blender's main() function.
++ *
++ * This function is wrapped in a C function of the same name (defined below),
++ * so that it can be called from Blender's main() function.
++ *
++ * The datafiles_usd_path path is used to point to the USD plugin path when Blender
++ * has been installed. The fallback_usd_path path should point to the build-time
++ * location of the USD plugin files so that Blender can be run on a development machine
++ * without requiring an installation step.
++ */
++void
++usd_initialise_plugin_path(const char *datafiles_usd_path)
++{
+     std::vector<std::string> result;
+ 
++    // Add Blender-specific paths. They MUST end in a slash, or symlinks will not be treated as directory.
++    if (datafiles_usd_path != NULL && datafiles_usd_path[0] != '\0') {
++        std::string datafiles_usd_path_str(datafiles_usd_path);
++        if (datafiles_usd_path_str.back() != '/') {
++            datafiles_usd_path_str += "/";
++        }
++        result.push_back(datafiles_usd_path_str);
++    }
++
+     // Determine the absolute path to the Plug shared library.
+     // Any relative paths specified in the plugin search path will be
+     // anchored to this directory, to allow for relocatability.
+@@ -94,9 +124,24 @@
+     _AppendPathList(&result, installLocation, sharedLibPath);
+ #endif // PXR_INSTALL_LOCATION
+ 
+-    Plug_SetPaths(result);
+-}
++    if (!TfGetenv("PXR_PATH_DEBUG").empty()) {
++        printf("USD Plugin paths: (%zu in total):\n", result.size());
++        for(const std::string &path : result) {
++            printf("    %s\n", path.c_str());
++        }
++    }
+ 
++    Plug_SetPaths(result);
+ }
+ 
+ PXR_NAMESPACE_CLOSE_SCOPE
++
++/* Workaround to make it possible to pass a path at runtime to USD. */
++extern "C" {
++void
++usd_initialise_plugin_path(
++    const char *datafiles_usd_path)
++{
++    PXR_NS::usd_initialise_plugin_path(datafiles_usd_path);
++}
++}

--- a/graphics/usd/files/patch-plugins-output-paths.diff
+++ b/graphics/usd/files/patch-plugins-output-paths.diff
@@ -1,0 +1,44 @@
+--- cmake/macros/Private.cmake.orig	2019-10-24 16:39:53.000000000 -0400
++++ cmake/macros/Private.cmake	2020-10-07 21:57:22.000000000 -0400
+@@ -92,7 +92,7 @@
+     _get_resources_dir_name(PLUG_INFO_RESOURCE_PATH)
+     set(PLUG_INFO_ROOT "..")
+     set(PLUG_INFO_PLUGIN_NAME "pxr.${libTarget}")
+-    set(PLUG_INFO_LIBRARY_PATH "${pluginToLibraryPath}")
++    set(PLUG_INFO_LIBRARY_PATH "")
+ 
+     configure_file(
+         ${plugInfoPath}
+@@ -1139,10 +1139,10 @@
+     _get_install_dir("include/${PXR_PREFIX}/${NAME}" headerInstallPrefix)
+     _get_install_dir("lib" libInstallPrefix)
+     if(isPlugin)
+-        _get_install_dir("plugin" pluginInstallPrefix)
++        _get_install_dir("share/usd/plugins" pluginInstallPrefix)
+         if(NOT PXR_INSTALL_SUBDIR)
+             # XXX -- Why this difference?
+-            _get_install_dir("plugin/usd" pluginInstallPrefix)
++            _get_install_dir("share/usd/plugins" pluginInstallPrefix)
+         endif()
+         if(NOT isObject)
+             # A plugin embedded in the monolithic library is found in
+@@ -1233,7 +1233,7 @@
+             MFB_ALT_PACKAGE_NAME=${PXR_PACKAGE}
+             MFB_PACKAGE_MODULE=${pythonModuleName}
+             PXR_BUILD_LOCATION=usd
+-            PXR_PLUGIN_BUILD_LOCATION=../plugin/usd
++            PXR_PLUGIN_BUILD_LOCATION=../share/usd/plugins
+             ${pxrInstallLocation}
+             ${pythonModulesEnabled}
+             ${apiPrivate}
+--- cmake/macros/Public.cmake.orig	2020-10-01 10:37:22.000000000 -0400
++++ cmake/macros/Public.cmake	2020-10-03 18:11:35.000000000 -0400
+@@ -766,7 +766,7 @@
+          "${plugInfoContents}")
+     install(
+         FILES "${CMAKE_CURRENT_BINARY_DIR}/usd_plugInfo.json"
+-        DESTINATION plugin/usd
++        DESTINATION share/usd/plugins
+         RENAME "plugInfo.json"
+     )
+ endfunction() # pxr_setup_plugins

--- a/graphics/usd/files/patch-tests-output-paths.diff
+++ b/graphics/usd/files/patch-tests-output-paths.diff
@@ -1,0 +1,123 @@
+--- cmake/macros/Public.cmake.orig	2019-10-24 16:39:53.000000000 -0400
++++ cmake/macros/Public.cmake	2020-10-01 10:37:22.000000000 -0400
+@@ -391,7 +391,7 @@
+             RENAME 
+                 __init__.py
+             DESTINATION 
+-                tests/${tm_INSTALL_PREFIX}/lib/python/${MODULE_NAME}
++                share/usd/tests/${tm_INSTALL_PREFIX}/lib/python/${MODULE_NAME}
+         )
+     endif()
+     if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${plugInfoFile}")
+@@ -401,7 +401,7 @@
+             RENAME 
+                 plugInfo.json
+             DESTINATION 
+-                tests/${tm_INSTALL_PREFIX}/lib/python/${MODULE_NAME}
++                share/usd/tests/${tm_INSTALL_PREFIX}/lib/python/${MODULE_NAME}
+         )
+     endif()
+ endfunction() # pxr_create_test_module
+@@ -422,7 +422,7 @@
+         _pxr_target_link_libraries(${LIBRARY_NAME}
+             ${bt_LIBRARIES}
+         )
+-        _get_folder("tests/lib" folder)
++        _get_folder("share/usd/tests/lib" folder)
+         set_target_properties(${LIBRARY_NAME}
+             PROPERTIES 
+                 FOLDER "${folder}"
+@@ -430,7 +430,7 @@
+ 
+         # Find libraries under the install prefix, which has the core USD
+         # libraries.
+-        _pxr_init_rpath(rpath "tests/lib")
++        _pxr_init_rpath(rpath "share/usd/tests/lib")
+         _pxr_add_rpath(rpath "${CMAKE_INSTALL_PREFIX}/lib")
+         _pxr_install_rpath(rpath ${LIBRARY_NAME})
+ 
+@@ -444,14 +444,14 @@
+             set(TEST_PLUG_INFO_ROOT "..")
+             set(LIBRARY_FILE "${CMAKE_SHARED_LIBRARY_PREFIX}${LIBRARY_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}")
+ 
+-            set(testPlugInfoLibDir "tests/${bt_INSTALL_PREFIX}/lib/${LIBRARY_NAME}")
++            set(testPlugInfoLibDir "share/usd/tests/${bt_INSTALL_PREFIX}/lib/${LIBRARY_NAME}")
+             set(testPlugInfoResourceDir "${testPlugInfoLibDir}/${TEST_PLUG_INFO_RESOURCE_PATH}")
+             set(testPlugInfoPath "${CMAKE_BINARY_DIR}/${testPlugInfoResourceDir}/plugInfo.json")
+ 
+             file(RELATIVE_PATH 
+                 TEST_PLUG_INFO_LIBRARY_PATH
+                 "${CMAKE_INSTALL_PREFIX}/${testPlugInfoLibDir}"
+-                "${CMAKE_INSTALL_PREFIX}/tests/lib/${LIBRARY_FILE}")
++                "${CMAKE_INSTALL_PREFIX}/share/usd/tests/lib/${LIBRARY_FILE}")
+ 
+             configure_file("${testPlugInfoSrcPath}" "${testPlugInfoPath}")
+             # XXX -- We shouldn't have to install to run tests.
+@@ -474,9 +474,9 @@
+         # XXX -- We shouldn't have to install to run tests.
+         install(
+             TARGETS ${LIBRARY_NAME}
+-            LIBRARY DESTINATION "tests/lib"
+-            ARCHIVE DESTINATION "tests/lib"
+-            RUNTIME DESTINATION "tests/lib"
++            LIBRARY DESTINATION "share/usd/tests/lib"
++            ARCHIVE DESTINATION "share/usd/tests/lib"
++            RUNTIME DESTINATION "share/usd/tests/lib"
+         )
+     endif()
+ endfunction() # pxr_build_test_shared_lib
+@@ -495,7 +495,7 @@
+ 
+         # Turn PIC ON otherwise ArchGetAddressInfo() on Linux may yield
+         # unexpected results.
+-        _get_folder("tests/bin" folder)
++        _get_folder("share/usd/tests/bin" folder)
+         set_target_properties(${TEST_NAME}
+             PROPERTIES 
+                 FOLDER "${folder}"
+@@ -510,13 +510,13 @@
+ 
+         # Find libraries under the install prefix, which has the core USD
+         # libraries.
+-        _pxr_init_rpath(rpath "tests")
++        _pxr_init_rpath(rpath "share/usd/tests")
+         _pxr_add_rpath(rpath "${CMAKE_INSTALL_PREFIX}/lib")
+         _pxr_install_rpath(rpath ${TEST_NAME})
+ 
+         # XXX -- We shouldn't have to install to run tests.
+         install(TARGETS ${TEST_NAME}
+-            RUNTIME DESTINATION "tests"
++            RUNTIME DESTINATION "share/usd/tests"
+         )
+     endif()
+ endfunction() # pxr_build_test
+@@ -536,7 +536,7 @@
+         # XXX -- We shouldn't have to install to run tests.
+         install(
+             PROGRAMS ${file}
+-            DESTINATION tests
++            DESTINATION share/usd/tests
+             RENAME ${destFile}
+         )
+     endforeach()
+@@ -554,7 +554,7 @@
+         # XXX -- We shouldn't have to install to run tests.
+         install(
+             DIRECTORY ${bt_SRC}/
+-            DESTINATION tests/ctest/${bt_DEST}
++            DESTINATION share/usd/tests/ctest/${bt_DEST}
+         )
+     endif()
+ endfunction() # pxr_install_test_dir
+@@ -625,9 +625,9 @@
+         # assume the testenv has the same name as the test but allow it to be
+         # overridden by specifying TESTENV.
+         if (bt_TESTENV)
+-            set(testenvDir ${CMAKE_INSTALL_PREFIX}/tests/ctest/${bt_TESTENV})
++            set(testenvDir ${CMAKE_INSTALL_PREFIX}/share/usd/tests/ctest/${bt_TESTENV})
+         else()
+-            set(testenvDir ${CMAKE_INSTALL_PREFIX}/tests/ctest/${TEST_NAME})
++            set(testenvDir ${CMAKE_INSTALL_PREFIX}/share/usd/tests/ctest/${TEST_NAME})
+         endif()
+ 
+         set(testWrapperCmd ${testWrapperCmd} --testenv-dir=${testenvDir})


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

[Universal Scene Description (USD)](http://www.openusd.org/) is a software library, developed by Pixar Animation Studios, that provides a system for authoring, reading, and streaming time-sampled scene description for interchange between computer graphics applications.

Note: I have purposely left off `openmaintainer` from the list of maintainers, similar to what I did for my Blender port. This is because the version of USD and the version of Blender that are compatible are intimately linked, and I am still playing "catch-up" with the Blender releases. Once I am able to get the newest version of Blender merged into the ports tree, I plan to add `openmaintainer` to both the Blender port and this port.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->