### PR TITLE
py-cchardet: do not blacklist compilers

### DIFF
--- a/python/py-cchardet/Portfile
+++ b/python/py-cchardet/Portfile
@@ -31,9 +31,6 @@ if {${name} ne ${subport}} {
         checksums   rmd160  c30f3589db681127984288dd8ad8b348e7719e31 \
                     sha256  240efe3f255f916769458343840b9c6403cf3192720bc5129792cbcb88bf72fb \
                     size    653280
-    } else {
-        # Workaround for https://trac.macports.org/ticket/61299
-        compiler.blacklist-append *gcc*
     }
 
     distname        ${realname}-${version}


### PR DESCRIPTION
Removing `noarch` was sufficient
See: https://trac.macports.org/ticket/61299#comment:7

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
