### PR TITLE
kustomize: update to 3.8.5

### DIFF
--- a/devel/kustomize/Portfile
+++ b/devel/kustomize/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/kubernetes-sigs/kustomize 3.8.4 kustomize/v
+go.setup            github.com/kubernetes-sigs/kustomize 3.8.5 kustomize/v
 revision            0
 
 categories          devel
@@ -23,9 +23,9 @@ long_description    kustomize lets you customize raw, template-free YAML files f
 
 homepage            https://kustomize.io
 
-checksums           rmd160  46343ca71387a4c5ae31a76fe4df48d58e328a34 \
-                    sha256  24c64a37d9072ee1e552d69bcb96123aaca63bbc68f30f28f29ee2a98f3639d8 \
-                    size    26011215
+checksums           rmd160  ddc3a2b0c580f84f3aee68f433b5d8b36fb101b8 \
+                    sha256  ecbe8a98e4795b956f1def3f93637e941b23977123716ef9873bf8e8d5b04cde \
+                    size    26009191
 
 build.dir           ${worksrcpath}/${name}
 


### PR DESCRIPTION
#### Description

Update to Kustomize 3.8.5.

###### Tested on

macOS 10.15.7 19H2
Xcode 12.0.1 12A7300

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?