### PR TITLE
ntpsec: update to 1.2.0

### DIFF
--- a/sysutils/ntpsec/Portfile
+++ b/sysutils/ntpsec/Portfile
@@ -5,7 +5,7 @@ PortGroup           waf 1.0
 PortGroup           python 1.0
 
 name                ntpsec
-version             1.1.9
+version             1.2.0
 revision            0
 categories          sysutils net
 maintainers         {fwright.net:fw @fhgwright} openmaintainer
@@ -19,19 +19,22 @@ homepage            https://www.ntpsec.org/
 conflicts           ntp openntpd
 
 master_sites        ftp://ftp.ntpsec.org/pub/releases/
-checksums           rmd160  ff7d8c93a18d9020b327b843dc121c3f53fbce26 \
-                    sha256  0acade979a807a047c2a8fd7f497235d9d6a5d0d54726e5d27505506d6ec00cc \
-                    size    2606066
+checksums           rmd160  c9b30c514feca77d9c65ea7bea9f0e22ca80a767 \
+                    sha256  6a7c7561a750519fe3441cbbaf1f684b379b97b655da4bf9cf0dd2052a4a02c8 \
+                    size    2625968
 
 # To avoid breaking any code that uses our Python package, keep the Python
 # version at 2.7 until we add variants for Python versions.  The upstream
 # code itself works with 2.6, 2.7, and 3.3+.
 python.versions     27
 
-# Note that the upstream --python option doesn't work correctly, so waf
+# Note that the upstream --python option may not work correctly, so waf
 # must be run with the target Python version.  The waf PortGroup doesn't
 # currently allow selecting its Python version, but since it's hard-coded
 # for 2.7, we can ignore this for now.
+
+# Also note that the new ffi-based Python client library doesn't work properly
+# on the Mac, so we use the old extension-based version.
 
 depends_build-append    port:bison port:pkgconfig
 # NOTE: doesn't work with libressl
@@ -40,22 +43,17 @@ depends_lib-append      port:openssl \
 
 patchfiles          patch-PreHighSierra.diff
 
-post-destroot {
-    foreach f {ntpdig ntpkeygen ntploggps ntplogtemp ntpmon ntpq ntpsnmpd ntpsweep ntptrace ntpviz ntpwait} {
-        # Some programs may not exist, e.g. ntploggps w/o gpsd
-        if {[file exists ${destroot}${prefix}/bin/$f]} {
-            reinplace "s,^#!/usr/bin/env python,#!${python.bin}," ${destroot}${prefix}/bin/$f
-        }
-    }
-}
-
 use_configure       yes
 configure.post_args-delete --nocache
 configure.args      --alltests \
                     --define=CONFIG_FILE=${prefix}/etc/ntp.conf \
                     --disable-manpage \
+                    --python=${python.bin} \
+                    --enable-pylib=ext \
                     --pythondir=${python.pkgd} \
                     --pythonarchdir=${python.pkgd}
+# Make sure we use waf, not setup.py for build
+build.cmd           ${waf.python} ./waf
 destroot.cmd        ${build.cmd}
 
 default_variants    +doc
@@ -97,7 +95,11 @@ post-activate {
     }
 }
 
-notes "The default access restrictions have changed; this may affect ntpq."
+notes "See \"man 8 ntpd\" for documentation; \"man ntpd\" may reflect Apple's."
+notes-append "To replace Apple's ntpd,\
+             disable \"Set date and time automatically\"\
+             in the Date & Time Preferences."
+notes-append "Configuration is in ${prefix}/etc/ntp.conf."
 
 startupitem.create      yes
 startupitem.netchange   yes

--- a/sysutils/ntpsec/files/ntp.conf
+++ b/sysutils/ntpsec/files/ntp.conf
@@ -1,9 +1,8 @@
 # Limit network machines to time queries only
-restrict -4 default kod limited nomodify nopeer noquery
-restrict -6 default kod limited nomodify nopeer noquery
+restrict default kod limited nomodify nopeer noquery
 
 # localhost is unrestricted
-restrict -4 127.0.0.1
-restrict -6 ::1
+restrict 127.0.0.1
+restrict ::1
 
 server time.apple.com

--- a/sysutils/ntpsec/files/patch-PreHighSierra.diff
+++ b/sysutils/ntpsec/files/patch-PreHighSierra.diff
@@ -1,5 +1,5 @@
---- ./attic/backwards.c.orig	2020-05-23 20:00:19.000000000 -0700
-+++ ./attic/backwards.c	2020-05-27 19:21:30.000000000 -0700
+--- ./attic/backwards.c.orig	2020-10-05 21:16:52.000000000 -0700
++++ ./attic/backwards.c	2020-10-08 17:43:39.000000000 -0700
 @@ -7,6 +7,8 @@
  #include <stdlib.h>
  #include <time.h>
@@ -9,8 +9,8 @@
  #define UNUSED_ARG(arg)         ((void)(arg))
  
  static void ts_print(struct timespec *ts0, struct timespec *ts1);
---- ./attic/clocks.c.orig	2020-05-23 20:00:19.000000000 -0700
-+++ ./attic/clocks.c	2020-05-27 19:21:30.000000000 -0700
+--- ./attic/clocks.c.orig	2020-10-05 21:16:52.000000000 -0700
++++ ./attic/clocks.c	2020-10-08 17:43:39.000000000 -0700
 @@ -5,6 +5,8 @@
  #include <stdio.h>
  #include <time.h>
@@ -20,19 +20,30 @@
  struct table {
    const int type;
    const char* name;
---- ./attic/digest-timing.c.orig	2020-05-23 20:00:19.000000000 -0700
-+++ ./attic/digest-timing.c	2020-05-27 19:21:30.000000000 -0700
-@@ -34,6 +34,8 @@
- #include <openssl/rand.h>
- #include <openssl/objects.h>
+--- ./attic/cmac-timing.c.orig	2020-10-05 21:16:52.000000000 -0700
++++ ./attic/cmac-timing.c	2020-10-08 17:43:39.000000000 -0700
+@@ -35,6 +35,8 @@
+ #include <openssl/params.h> 
+ #endif
+ 
++#include "ntp_machine.h"	/* For clock_gettime fallback */
++
+ #define UNUSED_ARG(arg)         ((void)(arg))
+ 
+ 
+--- ./attic/digest-timing.c.orig	2020-10-05 21:16:52.000000000 -0700
++++ ./attic/digest-timing.c	2020-10-08 17:43:39.000000000 -0700
+@@ -33,6 +33,8 @@
+ #include <openssl/ssl.h>
+ #endif
  
 +#include "ntp_machine.h"	/* For clock_gettime fallback */
 +
  #define UNUSED_ARG(arg)         ((void)(arg))
  
  #ifndef EVP_MD_CTX_reset
---- ./attic/random.c.orig	2020-05-23 20:00:19.000000000 -0700
-+++ ./attic/random.c	2020-05-27 19:21:30.000000000 -0700
+--- ./attic/random.c.orig	2020-10-05 21:16:52.000000000 -0700
++++ ./attic/random.c	2020-10-08 17:43:39.000000000 -0700
 @@ -10,6 +10,8 @@
  #include <openssl/opensslv.h>    /* for OPENSSL_VERSION_NUMBER */
  #include <openssl/rand.h>
@@ -42,8 +53,8 @@
  #define BATCHSIZE 1000000
  #define BILLION 1000000000
  #define HISTSIZE 2500
---- ./include/ntp_machine.h.orig	2020-05-23 20:00:19.000000000 -0700
-+++ ./include/ntp_machine.h	2020-05-27 19:21:30.000000000 -0700
+--- ./include/ntp_machine.h.orig	2020-10-05 21:16:52.000000000 -0700
++++ ./include/ntp_machine.h	2020-10-08 17:43:39.000000000 -0700
 @@ -13,14 +13,145 @@
  
  #ifndef CLOCK_REALTIME
@@ -196,8 +207,8 @@
  
  int ntp_set_tod (struct timespec *tvs);
  
---- ./include/ntp_stdlib.h.orig	2020-05-23 20:00:19.000000000 -0700
-+++ ./include/ntp_stdlib.h	2020-05-27 19:21:30.000000000 -0700
+--- ./include/ntp_stdlib.h.orig	2020-10-05 21:16:52.000000000 -0700
++++ ./include/ntp_stdlib.h	2020-10-08 17:43:39.000000000 -0700
 @@ -95,7 +95,9 @@ extern	const char * eventstr	(int);
  extern	const char * ceventstr	(int);
  extern	const char * res_match_flags(unsigned short);
@@ -208,8 +219,8 @@
  extern	char *	statustoa	(int, int);
  extern	const char * socktoa	(const sockaddr_u *);
  extern	const char * socktoa_r	(const sockaddr_u *sock, char *buf, size_t buflen);
---- ./include/ntp_syscall.h.orig	2020-05-23 20:00:19.000000000 -0700
-+++ ./include/ntp_syscall.h	2020-05-27 19:21:30.000000000 -0700
+--- ./include/ntp_syscall.h.orig	2020-10-05 21:16:52.000000000 -0700
++++ ./include/ntp_syscall.h	2020-10-08 17:43:39.000000000 -0700
 @@ -9,9 +9,11 @@
  #ifndef GUARD_NTP_SYSCALL_H
  #define GUARD_NTP_SYSCALL_H
@@ -222,8 +233,8 @@
  
  /*
   * The units of the maxerror and esterror fields vary by platform.  If
---- ./libntp/clockwork.c.orig	2020-05-23 20:00:19.000000000 -0700
-+++ ./libntp/clockwork.c	2020-05-27 19:21:30.000000000 -0700
+--- ./libntp/clockwork.c.orig	2020-10-05 21:16:52.000000000 -0700
++++ ./libntp/clockwork.c	2020-10-08 17:43:39.000000000 -0700
 @@ -5,8 +5,10 @@
  #include "config.h"
  
@@ -237,8 +248,8 @@
  
  #include "ntp.h"
  #include "ntp_machine.h"
---- ./libntp/statestr.c.orig	2020-05-23 20:00:19.000000000 -0700
-+++ ./libntp/statestr.c	2020-05-27 19:21:30.000000000 -0700
+--- ./libntp/statestr.c.orig	2020-10-05 21:16:52.000000000 -0700
++++ ./libntp/statestr.c	2020-10-08 17:43:39.000000000 -0700
 @@ -12,7 +12,9 @@
  #include "lib_strbuf.h"
  #include "ntp_refclock.h"
@@ -339,23 +350,9 @@
  
  /*
   * statustoa - return a descriptive string for a peer status
---- ./ntpclients/ntpviz.py.orig	2020-05-23 20:00:19.000000000 -0700
-+++ ./ntpclients/ntpviz.py	2020-05-27 19:21:30.000000000 -0700
-@@ -1612,7 +1612,10 @@ Python by ESR, concept and gnuplot code 
-         if 2 < args.debug_level:
-             sys.stderr.write("ntpviz: INFO: now running at nice: %s\n" % nice)
- 
--    for fontpath in ("/usr/share/fonts/liberation",
-+    for fontpath in ("@PREFIX@/share/fonts/liberation",
-+                     "@PREFIX@/share/fonts/liberation-fonts",
-+                     "@PREFIX@/share/fonts/truetype/liberation",
-+                     "/usr/share/fonts/liberation",
-                      "/usr/share/fonts/liberation-fonts",
-                      "/usr/share/fonts/truetype/liberation"):
- 
---- ./ntpd/ntp_control.c.orig	2020-05-23 20:00:19.000000000 -0700
-+++ ./ntpd/ntp_control.c	2020-05-27 19:21:30.000000000 -0700
-@@ -1366,6 +1366,7 @@ ctl_putsys(
+--- ./ntpd/ntp_control.c.orig	2020-10-05 21:16:52.000000000 -0700
++++ ./ntpd/ntp_control.c	2020-10-08 17:43:39.000000000 -0700
+@@ -1368,6 +1368,7 @@ ctl_putsys(
  	char str[256];
  	double dtemp;
  	const char *ss;
@@ -363,7 +360,7 @@
  	static struct timex ntx;
  	static unsigned long ntp_adjtime_time;
  
-@@ -1381,6 +1382,7 @@ ctl_putsys(
+@@ -1383,6 +1384,7 @@ ctl_putsys(
  		else
                      ntp_adjtime_time = current_time;
  	}
@@ -371,7 +368,7 @@
  
  	switch (varid) {
  
-@@ -1780,50 +1782,93 @@ ctl_putsys(
+@@ -1782,50 +1784,93 @@ ctl_putsys(
  		break;
  
  		/*
@@ -477,8 +474,8 @@
  		break;
  
  	case CS_K_PPS_FREQ:
---- ./ntpd/ntp_loopfilter.c.orig	2020-05-23 20:00:19.000000000 -0700
-+++ ./ntpd/ntp_loopfilter.c	2020-05-27 19:21:30.000000000 -0700
+--- ./ntpd/ntp_loopfilter.c.orig	2020-10-05 21:16:52.000000000 -0700
++++ ./ntpd/ntp_loopfilter.c	2020-10-08 17:43:39.000000000 -0700
 @@ -23,8 +23,10 @@
  
  #define NTP_MAXFREQ	500e-6
@@ -516,7 +513,7 @@
  
  /*
   * Clock state machine variables
-@@ -172,10 +178,19 @@ static int sys_hufflen;		/* huff-n'-puff
+@@ -172,10 +178,13 @@ static int sys_hufflen;		/* huff-n'-puff
  static int sys_huffptr;		/* huff-n'-puff filter pointer */
  static double sys_mindly;	/* huff-n'-puff filter min delay */
  
@@ -524,19 +521,13 @@
  /* Emacs cc-mode goes nuts if we split the next line... */
  #define MOD_BITS (MOD_OFFSET | MOD_MAXERROR | MOD_ESTERROR | \
      MOD_STATUS | MOD_TIMECONST)
-+#ifdef SIGSYS
-+static void pll_trap (int);	/* configuration trap */
-+static struct sigaction sigsys;	/* current sigaction status */
-+static struct sigaction newsigsys; /* new sigaction status */
-+static sigjmp_buf env;		/* environment var. for pll_trap() */
-+#endif /* SIGSYS */
 +#endif /* HAVE_KERNEL_PLL */
  
 +#ifdef HAVE_KERNEL_PLL
  static void
  sync_status(const char *what, int ostatus, int nstatus) {
  	/* only used in non-lockclock case */
-@@ -199,6 +214,7 @@ static char *file_name(void) {
+@@ -199,6 +208,7 @@ static char *file_name(void) {
  	}
  	return this_file;
  }
@@ -544,7 +535,7 @@
  
  /*
   * init_loopfilter - initialize loop filter data
-@@ -213,6 +229,7 @@ init_loopfilter(void) {
+@@ -213,6 +223,7 @@ init_loopfilter(void) {
  	freq_cnt = (int)clock_minstep;
  }
  
@@ -552,7 +543,7 @@
  /*
   * ntp_adjtime_error_handler - process errors from ntp_adjtime
   */
-@@ -411,6 +428,7 @@ or, from ntp_adjtime():
+@@ -411,6 +422,7 @@ or, from ntp_adjtime():
  	}
  	return;
  }
@@ -560,7 +551,7 @@
  
  /*
   * local_clock - the NTP logical clock loop filter.
-@@ -444,7 +462,9 @@ local_clock(
+@@ -444,7 +456,9 @@ local_clock(
  
  	int	rval;		/* return code */
  	int	osys_poll;	/* old system poll */
@@ -570,7 +561,7 @@
  	double	mu;		/* interval since last update */
  	double	clock_frequency; /* clock frequency */
  	double	dtemp, etemp;	/* double temps */
-@@ -701,6 +721,7 @@ local_clock(
+@@ -701,6 +715,7 @@ local_clock(
  		}
  	}
  
@@ -578,7 +569,7 @@
  	/*
  	 * This code segment works when clock adjustments are made using
  	 * precision time kernel support and the ntp_adjtime() system
-@@ -817,6 +838,7 @@ local_clock(
+@@ -817,6 +832,7 @@ local_clock(
  		}
  #endif /* STA_NANO */
  	}
@@ -586,7 +577,7 @@
  
  	/*
  	 * Clamp the frequency within the tolerance range and calculate
-@@ -928,8 +950,10 @@ adj_host_clock(
+@@ -928,8 +944,10 @@ adj_host_clock(
  	} else if (freq_cnt > 0) {
  		offset_adj = clock_offset / (CLOCK_PLL * ULOGTOD(1));
  		freq_cnt--;
@@ -597,7 +588,7 @@
  	} else {
  		offset_adj = clock_offset / (CLOCK_PLL * ULOGTOD(clkstate.sys_poll));
  	}
-@@ -940,9 +964,11 @@ adj_host_clock(
+@@ -940,9 +958,11 @@ adj_host_clock(
  	 * set_freq().  Otherwise it is a component of the adj_systime()
  	 * offset.
  	 */
@@ -609,7 +600,7 @@
  		freq_adj = loop_data.drift_comp;
  
  	/* Bound absolute value of total adjustment to NTP_MAXFREQ. */
-@@ -1031,6 +1057,7 @@ set_freq(
+@@ -1031,6 +1051,7 @@ set_freq(
  
  	loop_data.drift_comp = freq;
  	loop_desc = "ntpd";
@@ -617,7 +608,7 @@
  	if (clock_ctl.pll_control) {
  		int ntp_adj_ret;
  		ZERO(ntv);
-@@ -1043,10 +1070,12 @@ set_freq(
+@@ -1043,10 +1064,12 @@ set_freq(
  		    ntp_adjtime_error_handler(__func__, &ntv, ntp_adj_ret, errno, false, false, __LINE__ - 1);
  		}
  	}
@@ -630,7 +621,7 @@
  static void
  start_kern_loop(void)
  {
-@@ -1082,8 +1111,10 @@ start_kern_loop(void)
+@@ -1082,8 +1105,10 @@ start_kern_loop(void)
  	  	    "kernel time sync enabled");
  	}
  }
@@ -641,7 +632,7 @@
  static void
  stop_kern_loop(void)
  {
-@@ -1091,6 +1122,7 @@ stop_kern_loop(void)
+@@ -1091,6 +1116,7 @@ stop_kern_loop(void)
  		report_event(EVNT_KERN, NULL,
  		    "kernel time sync disabled");
  }
@@ -649,7 +640,7 @@
  
  
  /*
-@@ -1103,11 +1135,15 @@ select_loop(
+@@ -1103,11 +1129,15 @@ select_loop(
  {
  	if (clock_ctl.kern_enable == use_kern_loop)
  		return;
@@ -665,7 +656,7 @@
  	/*
  	 * If this loop selection change occurs after initial startup,
  	 * call set_freq() to switch the frequency compensation to or
-@@ -1163,10 +1199,12 @@ loop_config(
+@@ -1163,10 +1193,12 @@ loop_config(
  	 * variables. Otherwise, continue leaving no harm behind.
  	 */
  	case LOOP_DRIFTINIT:
@@ -678,7 +669,7 @@
  
  		/*
  		 * Initialize frequency if given; otherwise, begin frequency
-@@ -1185,11 +1223,14 @@ loop_config(
+@@ -1185,11 +1217,14 @@ loop_config(
  			rstclock(EVNT_FSET, 0);
  		else
  			rstclock(EVNT_NSET, 0);
@@ -693,7 +684,7 @@
  		if (!loop_data.lockclock && (clock_ctl.pll_control && clock_ctl.kern_enable)) {
  			memset((char *)&ntv, 0, sizeof(ntv));
  			ntv.modes = MOD_STATUS;
-@@ -1199,6 +1240,7 @@ loop_config(
+@@ -1199,6 +1234,7 @@ loop_config(
  				pll_status,
  				ntv.status);
  		   }
@@ -701,34 +692,13 @@
  #endif
  		break;
  
-@@ -1280,3 +1322,25 @@ loop_config(
+@@ -1279,4 +1315,3 @@ loop_config(
+ 		    "CONFIG: loop_config: unsupported option %d", item);
  	}
  }
- 
-+
-+#if defined(HAVE_KERNEL_PLL) && defined(SIGSYS)
-+/*
-+ * _trap - trap processor for undefined syscalls
-+ *
-+ * This nugget is called by the kernel when the SYS_ntp_adjtime()
-+ * syscall bombs because the silly thing has not been implemented in
-+ * the kernel. In this case the phase-lock loop is emulated by
-+ * the stock adjtime() syscall and a lot of indelicate abuse.
-+ *
-+ * FIXME:  Doing this check in real time is crazy.
-+ */
-+static void
-+pll_trap(
-+	int arg
-+	)
-+{
-+	UNUSED_ARG(arg);
-+	clock_ctl.pll_control = false;
-+	siglongjmp(env, 1);
-+}
-+#endif /* HAVE_KERNEL_PLL && SIGSYS */
---- ./ntpd/ntp_timer.c.orig	2020-05-23 20:00:19.000000000 -0700
-+++ ./ntpd/ntp_timer.c	2020-05-27 19:21:30.000000000 -0700
+-
+--- ./ntpd/ntp_timer.c.orig	2020-10-05 21:16:52.000000000 -0700
++++ ./ntpd/ntp_timer.c	2020-10-08 17:43:39.000000000 -0700
 @@ -13,7 +13,9 @@
  #include <signal.h>
  #include <unistd.h>
@@ -751,8 +721,8 @@
  #ifdef ENABLE_LEAP_SMEAR
  	leap_smear.enabled = (leap_smear_intv != 0);
  #endif
---- ./ntpd/refclock_local.c.orig	2020-05-23 20:00:19.000000000 -0700
-+++ ./ntpd/refclock_local.c	2020-05-27 19:21:30.000000000 -0700
+--- ./ntpd/refclock_local.c.orig	2020-10-05 21:16:52.000000000 -0700
++++ ./ntpd/refclock_local.c	2020-10-08 17:43:39.000000000 -0700
 @@ -158,6 +158,7 @@ local_poll(
  	 * If another process is disciplining the system clock, we set
  	 * the leap bits and quality indicators from the kernel.
@@ -775,8 +745,8 @@
  	pp->lastref = pp->lastrec;
  	refclock_receive(peer);
  }
---- ./ntpfrob/precision.c.orig	2020-05-23 20:00:19.000000000 -0700
-+++ ./ntpfrob/precision.c	2020-05-27 19:21:30.000000000 -0700
+--- ./ntpfrob/precision.c.orig	2020-10-05 21:16:52.000000000 -0700
++++ ./ntpfrob/precision.c	2020-10-08 17:43:39.000000000 -0700
 @@ -11,6 +11,7 @@
  #include "ntp_types.h"
  #include "ntp_calendar.h"
@@ -785,8 +755,8 @@
  
  #define	DEFAULT_SYS_PRECISION	-99
  
---- ./tests/libntp/statestr.c.orig	2020-05-23 20:00:19.000000000 -0700
-+++ ./tests/libntp/statestr.c	2020-05-27 19:21:30.000000000 -0700
+--- ./tests/libntp/statestr.c.orig	2020-10-05 21:16:52.000000000 -0700
++++ ./tests/libntp/statestr.c	2020-10-08 17:43:39.000000000 -0700
 @@ -4,7 +4,9 @@
  #include "unity.h"
  #include "unity_fixture.h"
@@ -807,9 +777,9 @@
  }
  
  // statustoa
---- ./wafhelpers/bin_test.py.orig	2020-05-23 20:00:19.000000000 -0700
-+++ ./wafhelpers/bin_test.py	2020-05-27 19:21:30.000000000 -0700
-@@ -97,6 +97,12 @@ def cmd_bin_test(ctx, config):
+--- ./wafhelpers/bin_test.py.orig	2020-10-05 21:16:52.000000000 -0700
++++ ./wafhelpers/bin_test.py	2020-10-08 17:43:39.000000000 -0700
+@@ -95,6 +95,12 @@ def cmd_bin_test(ctx, config):
      if ctx.env['PYTHON_CURSES']:
          cmd_map_python.update(cmd_map_python_curses)
  
@@ -822,8 +792,8 @@
      for cmd in sorted(cmd_map):
          if not run(cmd, cmd_map[cmd], False):
              fails += 1
---- ./wafhelpers/options.py.orig	2020-05-23 20:00:19.000000000 -0700
-+++ ./wafhelpers/options.py	2020-05-27 19:21:30.000000000 -0700
+--- ./wafhelpers/options.py.orig	2020-10-05 21:16:52.000000000 -0700
++++ ./wafhelpers/options.py	2020-10-08 17:43:39.000000000 -0700
 @@ -21,6 +21,8 @@ def options_cmd(ctx, config):
                     help="Droproot earlier (breaks SHM and NetBSD).")
      grp.add_option('--enable-seccomp', action='store_true',
@@ -833,9 +803,9 @@
      grp.add_option('--disable-mdns-registration', action='store_true',
                     default=False, help="Disable MDNS registration.")
      grp.add_option(
---- ./wscript.orig	2020-05-23 20:00:19.000000000 -0700
-+++ ./wscript	2020-05-27 19:21:30.000000000 -0700
-@@ -544,7 +544,7 @@ int main(int argc, char **argv) {
+--- ./wscript.orig	2020-10-05 21:16:52.000000000 -0700
++++ ./wscript	2020-10-08 17:43:39.000000000 -0700
+@@ -563,7 +563,7 @@ int main(int argc, char **argv) {
      structures = (
          ("struct if_laddrconf", ["sys/types.h", "net/if6.h"], False),
          ("struct if_laddrreq", ["sys/types.h", "net/if6.h"], False),
@@ -844,7 +814,7 @@
          ("struct ntptimeval", ["sys/time.h", "sys/timex.h"], False),
      )
      for (s, h, r) in structures:
-@@ -755,6 +755,21 @@ int main(int argc, char **argv) {
+@@ -774,6 +774,21 @@ int main(int argc, char **argv) {
          ctx.define("ENABLE_FUZZ", 1,
                     comment="Enable fuzzing low bits of time")
  


### PR DESCRIPTION
This includes the patches for compatibility with macOS<10.13,
which can also be seen (more readably) at:

    https://gitlab.com/fhgwright/ntpsec/tree/macports_1_2_0

Fixes a bad side effect of the python PortGroup, which mysteriously
didn't cause trouble before.

The new FFI-based Python client library doesn't currently work
properly on the Mac, so it uses the old extension-based version.

Now specifies the target Python version explicitly, in case the
waf Python version changes.

Removes obsolete shebang rewriting.

Simplifies the default ntp.conf due to code fixes.

Updates the notes to include basic doc and installation info.

TESTED:
Tested (including building the usual set of variant combinations)
on 10.4-10.5 ppc, 10.4-10.6 i386, and 10.6-10.15 x86_64.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14033, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G6032, x86_64, Xcode 11.3.1 11C505
macOS 10.15.6 19G2021, x86_64, Xcode 12.0.1 12A7300

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [N/A] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
