### PR TITLE
py-distorm: drop noarch

### DIFF
--- a/python/py-distorm/Portfile
+++ b/python/py-distorm/Portfile
@@ -5,6 +5,7 @@ PortGroup           github 1.0
 PortGroup           python 1.0
 
 github.setup        gdabah distorm 3.5 v
+revision            1
 set realname        distorm
 name                py-${realname}
 categories-append   devel
@@ -18,8 +19,6 @@ long_description \
     diStorm3 is really a decomposer, which means it takes an instruction \
     and returns a binary structure which describes it rather than static \
     text, which is great for advanced binary code analysis.
-
-supported_archs     noarch
 
 checksums           rmd160  89c26b9d980566330c470a0bb3aa7ef3f38ff10b \
                     sha256  d79110e81295f1bcff7c99563916b7ef273bebb52e9aeefa5cf36e30b237cd9a \


### PR DESCRIPTION
Port installs architecture-specific library

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7
Xcode 12 command line tools
Python 3.8.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~ <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
