### PR TITLE
py-ligo-segments: fix stub port

### DIFF
--- a/python/py-ligo-segments/Portfile
+++ b/python/py-ligo-segments/Portfile
@@ -28,14 +28,14 @@ checksums           rmd160  d559c6f445dff24103dea6a0f0d5466e60f2ae9f \
 python.versions     27 36 37 38
 python.default_version 27
 
-patch {
-    # FIXME: the upstream tarball has the wrong permissions.
-    # See https://git.ligo.org/lscsoft/ligo-segments/-/issues/11
-    system "find '${worksrcpath}' -type d -exec chmod go+rx {} \\;"
-    system "find '${worksrcpath}' -type f -exec chmod go+r {} \\;"
-}
-
 if {${name} ne ${subport}} {
+    patch {
+        # FIXME: the upstream tarball has the wrong permissions.
+        # See https://git.ligo.org/lscsoft/ligo-segments/-/issues/11
+        system "find '${worksrcpath}' -type d -exec chmod go+rx {} \\;"
+        system "find '${worksrcpath}' -type f -exec chmod go+r {} \\;"
+    }
+
     depends_lib-append  port:py${python.version}-six \
                         port:py${python.version}-ligo-common
 


### PR DESCRIPTION
#### Description
Avoid patch error in `py-ligo-segments` stub port by moving custom patch phase to only apply to subports.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
Only patch phase of `py-ligo-segments` is tested.
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~ <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
