### PR TITLE
p5-future-asyncawait: drop noarch

### DIFF
--- a/perl/p5-future-asyncawait/Portfile
+++ b/perl/p5-future-asyncawait/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28 5.30
 perl5.setup         Future-AsyncAwait 0.44 ../../authors/id/P/PE/PEVANS
-revision            0
+revision            1
 license             {Artistic-1 GPL}
 maintainers         {devans @dbevans} openmaintainer
 description         Future::AsyncAwait - deferred subroutine syntax for futures
@@ -26,5 +26,4 @@ if {${perl5.major} != ""} {
                     port:p${perl5.major}-future
 
     perl5.use_module_build
-    supported_archs noarch
 }


### PR DESCRIPTION
Installs architecture-specific library

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
