### PR TITLE
p5-class-load-xs: drop noarch

### DIFF
--- a/perl/p5-class-load-xs/Portfile
+++ b/perl/p5-class-load-xs/Portfile
@@ -5,12 +5,11 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28 5.30
 perl5.setup         Class-Load-XS 0.10
+revision            1
 
 platforms           darwin
 maintainers         nomaintainer
 license             Artistic-2
-
-supported_archs     noarch
 
 description         XS implementation of parts of Class::Load
 


### PR DESCRIPTION
Port installs architecture-specific library built from XS code

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
