### PR TITLE
knot: requires macOS 10.11 or later

### DIFF
--- a/net/knot/Portfile
+++ b/net/knot/Portfile
@@ -36,6 +36,14 @@ depends_lib         port:fstrm \
                     port:protobuf-c \
                     port:userspace-rcu
 
+if {${os.platform} eq "darwin" && ${os.major} < 15} {
+    known_fail          yes
+    pre-fetch {
+        ui_error "${name} ${version} requires macOS 10.11 or greater."
+        return -code error "incompatible macOS version"
+    }
+}
+
 configure.args      --disable-silent-rules
 
 startupitem.create      yes


### PR DESCRIPTION
Uses `connectx()`

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
