### PR TITLE
p5-unicode-utf8: drop noarch

### DIFF
--- a/perl/p5-unicode-utf8/Portfile
+++ b/perl/p5-unicode-utf8/Portfile
@@ -5,6 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28 5.30
 perl5.setup         Unicode-UTF8 0.62
+revision            1
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
 description         Unicode::UTF8 - Encoding and decoding of UTF-8 encoding form
@@ -18,7 +19,4 @@ checksums           rmd160  e60eb81e170bade35f419e3fdaf124fae6612fb8 \
 if {${perl5.major} != ""} {
     depends_build-append \
                     port:p${perl5.major}-test-fatal
-    
-    supported_archs noarch
 }
-


### PR DESCRIPTION
Port installs architecture-specific library.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
