### PR TITLE
hostage: use compiler.thread_local_storage yes

### DIFF
--- a/sysutils/hostage/Portfile
+++ b/sysutils/hostage/Portfile
@@ -28,11 +28,8 @@ checksums           rmd160  db27d6f09d8e5d5b3db8075655ee0007b8fb02d0 \
 
 compiler.cxx_standard \
                     2011
-# build fails with "error: thread-local storage is not supported for the current target"
-# setting "compiler.thread_local_storage yes" does not work, so for now just use blacklisting
-# See: https://lists.macports.org/pipermail/macports-dev/2019-November/041503.html
-compiler.blacklist-append \
-                    {clang < 800}
+compiler.thread_local_storage \
+                    yes
 
 cmake.module_path   ${prefix}/lib/cmake/antlr4
 


### PR DESCRIPTION
macports/macports-base#161 included in 2.6.3 release

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
