### PR TITLE
sentencepiece: use compiler.thread_local_storage yes

### DIFF
--- a/textproc/sentencepiece/Portfile
+++ b/textproc/sentencepiece/Portfile
@@ -3,7 +3,6 @@
 PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
-PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        google sentencepiece 0.1.84 v
 revision            0
@@ -33,10 +32,6 @@ checksums           rmd160  91bc4a0a23d9a4daf98abbb9ec83aed2241fdc42 \
                     size    11828855
 
 compiler.cxx_standard 2011
-
-# build fails with "error: thread-local storage is not supported for the current target"
-# setting "compiler.thread_local_storage yes" does not work, so for now just use blacklisting
-# See: https://lists.macports.org/pipermail/macports-dev/2019-November/041503.html
-compiler.blacklist-append {clang < 800}
+compiler.thread_local_storage yes
 
 depends_lib-append  port:gperftools


### PR DESCRIPTION
macports/macports-base#161 included in 2.6.3 release

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
