### PR TITLE
pdns-recursor: cleanup compilers

### DIFF
--- a/net/pdns-recursor/Portfile
+++ b/net/pdns-recursor/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cxx11 1.1
 
 name                pdns-recursor
 version             4.2.0
@@ -33,9 +32,8 @@ depends_build       port:pkgconfig
 depends_lib         port:boost \
                     path:lib/libssl.dylib:openssl
 
-# thread-local storage support
-compiler.blacklist-append \
-                    {clang < 800}
+compiler.cxx_standard 2011
+compiler.thread_local_storage yes
 
 startupitem.create      yes
 startupitem.executable  ${prefix}/sbin/pdns_recursor


### PR DESCRIPTION
Use `compiler.cxx_standard 2011` instead of deprecated `cxx11 1.1` portgroup

Use `compiler.thread_local_storage yes`
macports/macports-base#161 included in 2.6.3 release

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
Untested
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
