### PR TITLE
keystore-explorer: fix build issue, prevent jdk bundling

### DIFF
--- a/security/keystore-explorer/Portfile
+++ b/security/keystore-explorer/Portfile
@@ -4,7 +4,9 @@ PortSystem              1.0
 PortGroup               java 1.0
 PortGroup               github 1.0
 
-github.setup            lhaeger keystore-explorer 5.4.4 macports-
+github.setup            lhaeger keystore-explorer 5.4.4_1 macports-
+version                 5.4.4
+revision                0
 
 categories              security
 platforms               darwin
@@ -29,12 +31,12 @@ long_description        ${description} with the following features: \
 
 homepage                https://keystore-explorer.org/
 
-checksums               rmd160  b415bf88ff780e665792f90d58d54d15b713f2b8 \
-                        sha256  4fdbe6c2af4bf24b7ebab4410bcdb25c220b1094bfdc0c816d51461cd8a75077 \
-                        size    8231162
+checksums               rmd160  17cc046dbdf5646dfd280ab02decd3953398a2b8 \
+                        sha256  c539067c94c47280e666fac6255e3f15d0b00a110920ebd3e77e631b41b608fe \
+                        size    8231142
 
 java.version            1.8+
-java.fallback           openjdk8
+java.fallback           openjdk15
 
 use_configure           no
 

--- a/security/keystore-explorer/Portfile
+++ b/security/keystore-explorer/Portfile
@@ -36,7 +36,7 @@ checksums               rmd160  17cc046dbdf5646dfd280ab02decd3953398a2b8 \
                         size    8231142
 
 java.version            1.8+
-java.fallback           openjdk15
+java.fallback           openjdk8
 
 use_configure           no
 

--- a/security/keystore-explorer/Portfile
+++ b/security/keystore-explorer/Portfile
@@ -6,7 +6,7 @@ PortGroup               github 1.0
 
 github.setup            lhaeger keystore-explorer 5.4.4_1 macports-
 version                 5.4.4
-revision                0
+revision                1
 
 categories              security
 platforms               darwin


### PR DESCRIPTION
###### Tested on

macOS 10.15.7 19H2
Xcode 12.0.1 12A7300

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?