### PR TITLE
python39: fix build on older systems

### DIFF
--- a/lang/python39/Portfile
+++ b/lang/python39/Portfile
@@ -35,6 +35,12 @@ patchfiles          patch-setup.py.diff \
                     patch-configure-xcode4bug.diff \
                     builtin_bswap16.diff
 
+if {${os.platform} eq "darwin" && ${os.major} < 10} {
+    # work around no copyfile and/or pthread_threadid_np on older systems
+    patchfiles-append  patch-no-copyfile-on-Tiger.diff \
+                       patch-threadid-older-systems.diff
+}
+
 depends_build       port:pkgconfig
 depends_lib         port:bzip2 \
                     port:expat \

--- a/lang/python39/files/patch-no-copyfile-on-Tiger.diff
+++ b/lang/python39/files/patch-no-copyfile-on-Tiger.diff
@@ -1,0 +1,78 @@
+posix.copyfile does not exist on Tiger. 
+
+Python 3.8's posix._fcopyfile implementation unconditionally uses <copyfile.h>, 
+which only exists on Leopard ane newer. This patch removes posix._fcopyfile 
+on Tiger - this is okay because the rest of the stdlib uses posix._fcopyfile 
+only conditionally after checking that the function exists 
+(non-Apple systems don't have posix._fcopyfile either).
+
+
+thanks to @dgelessus
+https://github.com/macports/macports-ports/pull/5987
+
+
+diff --git Lib/test/test_shutil.py Lib/test/test_shutil.py
+index e56b337..fdc53e3 100644
+--- Lib/test/test_shutil.py
++++ Lib/test/test_shutil.py
+@@ -2451,7 +2451,7 @@ class TestZeroCopySendfile(_ZeroCopyFileTest, unittest.TestCase):
+             shutil._USE_CP_SENDFILE = True
+ 
+ 
+-@unittest.skipIf(not MACOS, 'macOS only')
++@unittest.skipIf(not MACOS or not hasattr(posix, "_fcopyfile"), 'macOS with posix._fcopyfile only')
+ class TestZeroCopyMACOS(_ZeroCopyFileTest, unittest.TestCase):
+     PATCHPOINT = "posix._fcopyfile"
+ 
+diff --git Modules/clinic/posixmodule.c.h Modules/clinic/posixmodule.c.h
+index 41baa45..3965876 100644
+--- Modules/clinic/posixmodule.c.h
++++ Modules/clinic/posixmodule.c.h
+@@ -5505,7 +5505,7 @@ exit:
+ 
+ #endif /* defined(HAVE_SENDFILE) && !defined(__APPLE__) && !(defined(__FreeBSD__) || defined(__DragonFly__)) */
+ 
+-#if defined(__APPLE__)
++#if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED >= 1050
+ 
+ PyDoc_STRVAR(os__fcopyfile__doc__,
+ "_fcopyfile($module, in_fd, out_fd, flags, /)\n"
+diff --git Modules/posixmodule.c Modules/posixmodule.c
+index 01e8bcb..ff7fb30 100644
+--- Modules/posixmodule.c
++++ Modules/posixmodule.c
+@@ -8,6 +8,7 @@
+    test macro, e.g. '_MSC_VER'. */
+ 
+ #ifdef __APPLE__
++#include <AvailabilityMacros.h>
+    /*
+     * Step 1 of support for weak-linking a number of symbols existing on
+     * OSX 10.4 and later, see the comment in the #ifdef __APPLE__ block
+@@ -109,7 +110,7 @@ corresponding Unix manual entries for more information on calls.");
+ #  include <sys/sendfile.h>
+ #endif
+ 
+-#if defined(__APPLE__)
++#if defined(__APPLE__) && MAC_OS_X_VERSION_MAX_ALLOWED >= 1050
+ #  include <copyfile.h>
+ #endif
+ 
+@@ -9484,7 +9485,7 @@ done:
+ #endif /* HAVE_SENDFILE */
+ 
+ 
+-#if defined(__APPLE__)
++#if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED >= 1050
+ /*[clinic input]
+ os._fcopyfile
+ 
+@@ -14671,7 +14672,7 @@ all_ins(PyObject *m)
+ #endif
+ #endif
+ 
+-#if defined(__APPLE__)
++#if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED >= 1050
+     if (PyModule_AddIntConstant(m, "_COPYFILE_DATA", COPYFILE_DATA)) return -1;
+ #endif
+ 

--- a/lang/python39/files/patch-threadid-older-systems.diff
+++ b/lang/python39/files/patch-threadid-older-systems.diff
@@ -1,0 +1,22 @@
+diff --git Python/thread_pthread.h Python/thread_pthread.h
+index e6910b3..ff9bb1f 100644
+--- Python/thread_pthread.h
++++ Python/thread_pthread.h
+@@ -331,7 +331,17 @@ PyThread_get_thread_native_id(void)
+         PyThread_init_thread();
+ #ifdef __APPLE__
+     uint64_t native_id;
++#if MAC_OS_X_VERSION_MAX_ALLOWED < 1060
++    native_id = pthread_mach_thread_np(pthread_self());
++#elif MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++    if (&pthread_threadid_np != NULL) {
++        (void) pthread_threadid_np(NULL, &native_id);
++    } else {
++        native_id = pthread_mach_thread_np(pthread_self());
++    }
++#else
+     (void) pthread_threadid_np(NULL, &native_id);
++#endif
+ #elif defined(__linux__)
+     pid_t native_id;
+     native_id = syscall(SYS_gettid);


### PR DESCRIPTION
identical fix to python38
closes https://trac.macports.org/ticket/61289

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.4 Intel, PPC
macOS 10.5 PPC

Xcode various

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
