### PR TITLE
py-torchvision: drop deprecated cxx11 1.1 pg

### DIFF
--- a/python/py-torchvision/Portfile
+++ b/python/py-torchvision/Portfile
@@ -3,7 +3,6 @@
 PortSystem                            1.0
 PortGroup           python            1.0
 PortGroup           github            1.0
-PortGroup           cxx11             1.1
 
 name                py-torchvision
 version             0.6.0


### PR DESCRIPTION
#### Description
Already uses `compiler.cxx_standard 2011`
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
