### PR TITLE
akonadi: use compiler.cxx_standard 2011, switch to GitHub repository

### DIFF
--- a/devel/akonadi/Portfile
+++ b/devel/akonadi/Portfile
@@ -2,11 +2,10 @@
 
 PortSystem          1.0
 PortGroup           kde4    1.1
-PortGroup           cxx11   1.1
 
 #Fetch from git repository to follow updates after the end of KDE4 public releases
 fetch.type          git
-git.url             git://anongit.kde.org/akonadi
+git.url             https://github.com/KDE/akonadi.git
 git.branch          c733429f
 
 name                akonadi
@@ -25,6 +24,8 @@ homepage            https://community.kde.org/KDE_PIM/Akonadi
 depends_lib-append  port:soprano \
                     port:boost \
                     port:shared-mime-info
+
+compiler.cxx_standard 2011
 
 post-patch {
     reinplace "s/c++0x/c++11/" ${worksrcpath}/CMakeLists.txt


### PR DESCRIPTION
…instead of deprecated cxx11 1.1 portgroup

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
