### PR TITLE
geant4: use compiler.cxx_standard 2011

### DIFF
--- a/science/geant4/Portfile
+++ b/science/geant4/Portfile
@@ -299,7 +299,8 @@ foreach {geant.version geant.revision geant.datarevision geant.patchlevel geant.
                             patch-cmake-Modules-Geant4BuildProjectConfig.cmake.4102.diff
         }
         if {${geant.version} >= 10.2} {
-            PortGroup       cxx11 1.1
+            compiler.cxx_standard 2011
+            compiler.thread_local_storage yes
         }
         if {${geant.version} == "10.1"} {
             patchfiles      patch-cmake-Modules-Geant4InterfaceOptions.cmake.4101.diff \


### PR DESCRIPTION
…instead of deprecated `cxx11 1.1` portgroup

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
