### PR TITLE
octave-symbolic: remove +python35 variant

### DIFF
--- a/math/octave-symbolic/Portfile
+++ b/math/octave-symbolic/Portfile
@@ -18,42 +18,36 @@ checksums           rmd160  c2f03a1e09bc0e8f05d98b0f522b8d20e422be73 \
 
 supported_archs     noarch
 
-variant python27 description "Use Python 2.7 SymPy" conflicts python35 python36 python37 {
+variant python27 description "Use Python 2.7 SymPy" conflicts python36 python37 {
     # remove after 2021-03-09
     ui_error "Python 2.7 is no longer supported."
     return -code error
 }
 
-variant python35 description "Use Python 3.5 SymPy" conflicts python27 python36 python37 python38 {
-    # remove after October 11, 2020
-    ui_error "Please do not install this variant since it has been replaced by the python37 variant."
-    return -code error
-}
-
-variant python36 description "Use Python 3.6 SymPy" conflicts python27 python35 python37 python38 {
+variant python36 description "Use Python 3.6 SymPy" conflicts python27 python37 python38 {
     depends_lib-append  port:python36 \
         port:py36-sympy
     configure.python    ${prefix}/bin/python3.6
 }
 
-variant python37 description "Use Python 3.7 SymPy" conflicts python27 python35 python36 python38 {
+variant python37 description "Use Python 3.7 SymPy" conflicts python27 python36 python38 {
     depends_lib-append  port:python37 \
         port:py37-sympy
     configure.python    ${prefix}/bin/python3.7
 }
 
-variant python38 description "Use Python 3.8 SymPy" conflicts python27 python35 python36 python37 {
+variant python38 description "Use Python 3.8 SymPy" conflicts python27 python36 python37 {
     depends_lib-append  port:python38 \
         port:py38-sympy
     configure.python    ${prefix}/bin/python3.8
 }
 
-if {![variant_isset python27] && ![variant_isset python35] && ![variant_isset python36] && ![variant_isset python37] && ![variant_isset python38]} {
+if {![variant_isset python27] && ![variant_isset python36] && ![variant_isset python37] && ![variant_isset python38]} {
     default_variants +python37
 }
 
 # make sure a python variant is selected
-if {![variant_isset python27] && ![variant_isset python35] && ![variant_isset python36] && ![variant_isset python37]  && ![variant_isset python38]} {
+if {![variant_isset python27] && ![variant_isset python36] && ![variant_isset python37] && ![variant_isset python38]} {
 
     ui_error "\n\nYou must select one of the python variants.\n"
     return -code error "Invalid variant selection"


### PR DESCRIPTION
Marked for removal in fe5debe088

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
