### PR TITLE
ghostscript: fix build with freetype 2.10.3

### DIFF
--- a/print/ghostscript/Portfile
+++ b/print/ghostscript/Portfile
@@ -38,6 +38,11 @@ patchfiles          patch-base_unix-dll.mak.diff \
 #  https://bugs.ghostscript.com/show_bug.cgi?id=702474
 patchfiles-append    patch-6756b355c238.diff
 
+# Provide FT_CALLBACK_DEF macro removed from
+# <freetype/config/ftconfig.h> in freetype 2.10.3
+# https://trac.macports.org/ticket/61306
+patchfiles-append    patch-base_fapi_ft.c.diff
+
 checksums           ghostpdl-9.52.tar.gz \
                     rmd160  1e719f907c8dc6dd0000bf2c547eee54fd583b9f \
                     sha256  8f6e48325c106ae033bbae3e55e6c0b9ee5c6b57e54f7cd24fb80a716a93b06a \

--- a/print/ghostscript/Portfile
+++ b/print/ghostscript/Portfile
@@ -43,6 +43,9 @@ patchfiles-append    patch-6756b355c238.diff
 # https://trac.macports.org/ticket/61306
 patchfiles-append    patch-base_fapi_ft.c.diff
 
+# Missing stdlib.h for abs()
+patchfiles-append    patch-jpegxr_r_strip.c.diff
+
 checksums           ghostpdl-9.52.tar.gz \
                     rmd160  1e719f907c8dc6dd0000bf2c547eee54fd583b9f \
                     sha256  8f6e48325c106ae033bbae3e55e6c0b9ee5c6b57e54f7cd24fb80a716a93b06a \

--- a/print/ghostscript/files/patch-base_fapi_ft.c.diff
+++ b/print/ghostscript/files/patch-base_fapi_ft.c.diff
@@ -1,0 +1,21 @@
+Provide FT_CALLBACK_DEF macro removed from
+<freetype/config/ftconfig.h> in freetype 2.10.3
+https://trac.macports.org/ticket/61306
+
+--- base/fapi_ft.c.orig
++++ base/fapi_ft.c
+@@ -124,6 +124,14 @@
+ static void
+ delete_inc_int_info(gs_fapi_server * a_server,
+                     FT_IncrementalRec * a_inc_int_info);
++
++#ifndef FT_CALLBACK_DEF
++#ifdef __cplusplus
++#define FT_CALLBACK_DEF( x )  extern "C"  x
++#else
++#define FT_CALLBACK_DEF( x )  static  x
++#endif
++#endif
+ 
+ FT_CALLBACK_DEF(void *)
+ FF_alloc(FT_Memory memory, long size)

--- a/print/ghostscript/files/patch-jpegxr_r_strip.c.diff
+++ b/print/ghostscript/files/patch-jpegxr_r_strip.c.diff
@@ -1,0 +1,29 @@
+From c4e79952b42ebccb669063e053e3d7ce0f88cc22 Mon Sep 17 00:00:00 2001
+From: Chris Liddell <chris.liddell@artifex.com>
+Date: Wed, 16 Sep 2020 17:33:30 +0100
+Subject: [PATCH] Fix compile failure due to missing header.
+
+A user reported (privately) that a pre-release of an upcoming XCode release
+fails to compile due to a missing prototype/declation of abs() in the jpegxr
+code. It's clearly a simple omission, as several files use abs() and do include
+the relevant header.
+
+So adding it here.
+---
+ jpegxr/r_strip.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git jpegxr/r_strip.c.orig jpegxr/r_strip.c
+index 062baf0c5..0c0e2df5a 100644
+--- jpegxr/r_strip.c.orig
++++ jpegxr/r_strip.c
+@@ -46,6 +46,7 @@
+ #endif
+ 
+ # include "jxr_priv.h"
++# include <stdlib.h>
+ # include <limits.h>
+ # include <assert.h>
+ # include <math.h>
+-- 
+2.17.1


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/61306

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7
Xcode 12 command line tools

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
