### PR TITLE
gnome-dictionary: remove pre-activate

### DIFF
--- a/gnome/gnome-dictionary/Portfile
+++ b/gnome/gnome-dictionary/Portfile
@@ -36,21 +36,6 @@ depends_lib         port:desktop-file-utils \
 depends_run         port:adwaita-icon-theme \
                     port:yelp
 
-# if port gnome-utils is installed
-# and gnome-dictionary binary exists
-# and port gnome-dictionary is NOT installed
-# deactivate outdated port gnome-utils
- 
-pre-activate {
-    if {![catch {registry_active gnome-utils}]} {
-        if {[file exists ${prefix}/bin/gnome-dictionary]} {
-            if {[catch {registry_active gnome-dictionary}]} {
-                registry_deactivate_composite gnome-utils "" [list ports_nodepcheck 1]
-            }
-        }
-    }
-}
-
 # port installs desktop application file, and gschemas
 post-activate {
     system "${prefix}/bin/update-desktop-database ${prefix}/share/applications"


### PR DESCRIPTION
Present in fe0a2c6801 when port was added over 6 years ago

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
