### PR TITLE
py-entrypoints: add python 3.9

### DIFF
--- a/python/py-entrypoints/Portfile
+++ b/python/py-entrypoints/Portfile
@@ -6,22 +6,20 @@ PortGroup           python 1.0
 name                py-entrypoints
 version             0.3
 revision            0
+
 categories-append   devel
 platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 maintainers         {stromnov @stromnov} openmaintainer
 
 description         Discover and load entry points from installed packages.
-long_description    ${description}
+long_description    {*}${description}
 
 homepage            https://github.com/takluyver/entrypoints
-master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
-
-distname            ${python.rootname}-${version}
 
 checksums           rmd160  368a6f43ee97280b824a597947ea3a276f4125f5 \
                     sha256  c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \


### PR DESCRIPTION
#### Description

py-entrypoints: add python 3.9

###### Type(s)

- [x] update

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?