### PR TITLE
py-flake8-polyfill: add python 3.9

### DIFF
--- a/python/py-flake8-polyfill/Portfile
+++ b/python/py-flake8-polyfill/Portfile
@@ -5,6 +5,8 @@ PortGroup           python 1.0
 
 name                py-flake8-polyfill
 version             1.0.2
+revision            0
+
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
@@ -19,15 +21,11 @@ long_description    \
 
 homepage            https://pypi.python.org/pypi/flake8-polyfill
 
-master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
-
-distname            ${python.rootname}-${version}
-
 checksums           rmd160  6436358ca93393d70ada67859184f6564e1ccef7 \
                     sha256  e44b087597f6da52ec6393a709e7108b2905317d0c0b744cdca6208e670d8eda \
                     size    7591
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

py-flake8-polyfill: add python 3.9

###### Type(s)

- [x] update

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?