### PR TITLE
py-mock: add python 3.9

### DIFF
--- a/python/py-mock/Portfile
+++ b/python/py-mock/Portfile
@@ -14,7 +14,7 @@ license             BSD
 maintainers         {reneeotten @reneeotten} openmaintainer
 
 description         Rolling backport of unittest.mock for all Pythons
-long_description    ${description}
+long_description    {*}${description}.
 
 homepage            https://mock.readthedocs.org/en/latest/
 
@@ -22,7 +22,7 @@ checksums           sha256  dd33eb70232b6118298d516bbcecd26704689c386594f0f3c4f1
                     rmd160  afcf4f5d3956095f6e8616877b39189a69d62cf4 \
                     size    71961
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

py-mock: add python 3.9

###### Type(s)

- [x] update

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?