### PR TITLE
golang-1.0: handle dependencies from salsa.debian.org

### DIFF
--- a/_resources/port1.0/group/golang-1.0.tcl
+++ b/_resources/port1.0/group/golang-1.0.tcl
@@ -227,6 +227,10 @@ proc handle_set_go_vendors {vendors_str} {
                         set distfile ${vproject}-${vversion}.tar.gz
                         set master_site https://gitlab.com/${vauthor}/${vproject}/-/archive/${vversion}
                     }
+                    salsa.debian.org {
+                        set distfile ${vproject}-${vversion}.tar.gz
+                        set master_site https://salsa.debian.org/${vauthor}/${vproject}/-/archive/${vversion}
+                    }
                     default {
                         ui_error "go.vendors can't handle dependencies from ${vdomain}"
                         error "unsupported dependency domain"

--- a/_resources/port1.0/group/golang-1.0.tcl
+++ b/_resources/port1.0/group/golang-1.0.tcl
@@ -227,9 +227,10 @@ proc handle_set_go_vendors {vendors_str} {
                         set distfile ${vproject}-${vversion}.tar.gz
                         set master_site https://gitlab.com/${vauthor}/${vproject}/-/archive/${vversion}
                     }
+                    gitlab.com -
                     salsa.debian.org {
                         set distfile ${vproject}-${vversion}.tar.gz
-                        set master_site https://salsa.debian.org/${vauthor}/${vproject}/-/archive/${vversion}
+                        set master_site https://${vdomain}/${vauthor}/${vproject}/-/archive/${vversion}
                     }
                     default {
                         ui_error "go.vendors can't handle dependencies from ${vdomain}"


### PR DESCRIPTION
#### Description

Whilst making a Portfile for [wormhole-william](https://github.com/psanford/wormhole-william) I ran into this issue:

`Error: go.vendors can't handle dependencies from salsa.debian.org`

This should fix that. salsa.debian.org is a gitlab instance so the url structure should be the same.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
