### PR TITLE
gnss-sdr[-devel]: requires thread_local

### DIFF
--- a/science/gnss-sdr/Portfile
+++ b/science/gnss-sdr/Portfile
@@ -16,6 +16,7 @@ platforms           darwin
 dist_subdir         gnss-sdr
 
 compiler.cxx_standard 2014
+compiler.thread_local_storage yes
 
 if {${subport} eq "gnss-sdr"} {
 


### PR DESCRIPTION
#### Description
Build failure observed on macOS 10.10:
```
In file included from /opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_science_gnss-sdr/gnss-sdr-devel/work/gnss-sdr-4e0391f4947aabc8e83561e46e1b010bc12affae/src/algorithms/libs/geofunctions.cc:22:
In file included from /opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_science_gnss-sdr/gnss-sdr-devel/work/gnss-sdr-4e0391f4947aabc8e83561e46e1b010bc12affae/src/algorithms/libs/geofunctions.h:29:
In file included from /opt/local/include/armadillo:112:
/opt/local/include/armadillo_bits/arma_rng.hpp:27:10: error: thread-local storage is not supported for the current target
  extern thread_local arma_rng_cxx11 arma_rng_cxx11_instance;
         ^
```

Maybe other `armadillo` dependents are affected as well.
<!-- Note: it is best to make pull requests from a branch rather than from master -->



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
