### PR TITLE
antlr4-cpp-runtime: requires thread_local

### DIFF
--- a/lang/antlr4-cpp-runtime/Portfile
+++ b/lang/antlr4-cpp-runtime/Portfile
@@ -3,7 +3,6 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
-PortGroup           cxx11 1.1
 
 github.setup        antlr antlr4 4.8
 name                antlr4-cpp-runtime
@@ -32,6 +31,9 @@ long_description    ANTLR (ANother Tool for Language Recognition) is a \
 checksums           rmd160  6741389766456f4926266c7333d4a554480c5598 \
                     sha256  fe549cd48807144de2c798a1f614ec288984b9932fdf28b7f4f3b26de21199e1 \
                     size    4294177
+
+compiler.cxx_standard 2011
+compiler.thread_local_storage yes
 
 configure.args-append \
                     -DANTLR4_INSTALL=ON


### PR DESCRIPTION
Use `compiler.cxx_standard 2011` instead of deprecated `cxx11 1.1` portgroup

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
