### PR TITLE
pdf2djvu: enable tests and OpenMP

### DIFF
--- a/graphics/pdf2djvu/Portfile
+++ b/graphics/pdf2djvu/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        jwilk pdf2djvu 0.9.17.1
-revision            2
+revision            3
 categories          graphics textproc
 platforms           darwin
 license             GPL-2
@@ -38,16 +38,14 @@ patchfiles          patch-i18n.hh.diff \
 
 compiler.cxx_standard  2011
 
-#Openmp is anyway not detected with llvm-gcc or clang, and breaks compilation with
-#gcc42 on SL (ticket #38184)
-
 # explicitly configure to build with system libuuid, overriding pkg-config
 # this prevents linking with ossp-uuid if it is installed
 configure.env-append \
                     LIBUUID_CFLAGS=-I/usr/include/uuid/uuid.h \
                     LIBUUID_LIBS=
 
-configure.args-append   --disable-openmp
+compiler.openmp_version 2.5
+configure.args-append   --enable-openmp
 
 configure.universal_args-delete \
                     --disable-dependency-tracking
@@ -60,3 +58,8 @@ post-destroot {
    xinstall -m 644 -W ${worksrcpath}/doc ${name}.1 \
       ${destroot}${prefix}/share/man/man1
 }
+
+test.run            yes
+depends_test-append port:python27 \
+                    port:py27-nose
+test.args           PYTHON=${prefix}/bin/python2.7


### PR DESCRIPTION
#### Description
Given the availability of `compiler.openmp_version` to select an OpenMP-capable compiler and any dependencies (see https://trac.macports.org/wiki/CompilerSelection#GettingtheRightCompilerinthePortfile), it should now be fine to enable OpenMP.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7
MacPorts clang 9.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
No new test failures compared to without OpenMP.
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
Observed expected speedup when run with `-j2`.
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
