### PR TITLE
gopass: new port

### DIFF
--- a/security/gopass/Portfile
+++ b/security/gopass/Portfile
@@ -1,0 +1,370 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/gopasspw/gopass 1.10.1 v
+categories          security
+maintainers         {@sikmir gmail.com:sikmir} openmaintainer
+license             MIT
+
+description         The slightly more awesome Standard Unix Password Manager for Teams
+long_description    {*}${description}
+homepage            https://www.gopass.pw
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  2542e8efd52e32d9c29d668acb55b1e50aa3ab96 \
+                        sha256  43db894eaa2f123269ffdc0178bb93ec5cdae043f78c35cf15a17fa476e07a1e \
+                        size    475938
+
+go.vendors          rsc.io/qr \
+                        repo    github.com/rsc/qr \
+                        lock    v0.2.0 \
+                        rmd160  f642fe01c13937615e5a975e6a1932f8dc25359a \
+                        sha256  1d69d5a13366a84a1484abdec5affd7f5781016469f4b43b1a26f5fa5c93497b \
+                        size    18816 \
+                    gotest.tools \
+                        repo    github.com/gotestyourself/gotest.tools \
+                        lock    v3.0.2 \
+                        rmd160  ccc2d160fcdb27d0e8461506d0c38e27487c8bd7 \
+                        sha256  9b17efa7751a66942c72f54e62716574bc34561bdcdaf8337bea3612e85a7025 \
+                        size    61955 \
+                    gopkg.in/yaml.v3 \
+                        lock    eeeca48fe776 \
+                        rmd160  fa7f02bf2d79fd300b4db2107596674b41479412 \
+                        sha256  33580a955d8c31b781de66dbc7a3c9940ab842a39eb3eb92e696a82307f7d570 \
+                        size    88775 \
+                    gopkg.in/yaml.v2 \
+                        lock    v2.3.0 \
+                        rmd160  2f8fa56d8a413b6288132eeb7f0d7c64d27d877f \
+                        sha256  a8d1a8bc88239d25507456380b47d59ae3683d4a5f4336da4892db1ce026615f \
+                        size    72838 \
+                    gopkg.in/ini.v1 \
+                        lock    v1.57.0 \
+                        rmd160  d9421555b1f9a82bc62fe56b99bd291c040d3d58 \
+                        sha256  044b205ad0bcc0500c3b52e7b2700db1994c9428f1fe4b4b8668195cba6026e1 \
+                        size    48422 \
+                    gopkg.in/check.v1 \
+                        lock    8fa46927fb4f \
+                        rmd160  c84f37dc900224c5e9e6e16ed5acc0d625583bc1 \
+                        sha256  c41439b343f3fc3c0b6f943b4aae642f10f19451e945c23dfb324c9c8f87d0b7 \
+                        size    31616 \
+                    google.golang.org/protobuf \
+                        repo    github.com/protocolbuffers/protobuf-go \
+                        lock    v1.25.0 \
+                        rmd160  ca1a78077118747c660917e50c4273d69b0f04ea \
+                        sha256  5bc3eb5d7160ab9ae45255d6b718c1cf9e9ed80c244b7527bced50370ae18620 \
+                        size    1259096 \
+                    golang.org/x/xerrors \
+                        lock    5ec99f83aff1 \
+                        rmd160  6e8267f353e153297f205e4be219236d6ae43880 \
+                        sha256  9a500a49d83a09e7de6c71b215d1c14b81e315d26884530ef327c95ddf1f2d28 \
+                        size    13667 \
+                    golang.org/x/text \
+                        lock    v0.3.3 \
+                        rmd160  babfa547ba9a9dab7fe08fa5543f1d8e7ae00301 \
+                        sha256  1c4a8c12295d484e0360d8e010ebc4b8a9a05aa2a07c10c3d3e5b17aa063f0db \
+                        size    7745597 \
+                    golang.org/x/sys \
+                        lock    1030fc2bf1d9 \
+                        rmd160  e2ec51a20810f433fb425c722c7c1cdb0cff6b56 \
+                        sha256  bfa31b28391b0be6f37b9a9371405d2fe3920b3fdf5d8f1408d858f25db1829a \
+                        size    1058430 \
+                    golang.org/x/net \
+                        lock    ab3426394381 \
+                        rmd160  e74cee73965d58ff027e1ba0e0131f9630125409 \
+                        sha256  49fe6598268f2cc9b50dea06a00f5c03c71a54d2893ebf9fbfa193486b65cd83 \
+                        size    1177682 \
+                    golang.org/x/crypto \
+                        lock    123391ffb6de \
+                        rmd160  4afdc76f139facd878c228d85dee3698de13f793 \
+                        sha256  1b8f464f2d4faca0ac6ac7eac18b2b1118c1ac9ff8f6b7ffc976fb0ebedc520f \
+                        size    1732579 \
+                    github.com/xrash/smetrics \
+                        lock    89a2a8a1fb0b \
+                        rmd160  350ca8872823c2d934da9a0da957e1d373542d92 \
+                        sha256  565b0a0b533971f54a767d0709b8370e92f4919f0df83552c2d45ef5f13c95ce \
+                        size    1823868 \
+                    github.com/urfave/cli \
+                        lock    v2.2.0 \
+                        rmd160  4a6ffb4a39be12c9239c971e0faa5118206066ad \
+                        sha256  b7bfbd0ff7fdedb839dec9b56d026fc6bcc4db534e3bb9fce3a9da6604945818 \
+                        size    3404076 \
+                    github.com/stretchr/testify \
+                        lock    v1.6.1 \
+                        rmd160  7e5b798212a8f15cd58a63985ae0b928eede8e6b \
+                        sha256  44d77d9b5c1dc08fa710eac9bb324898210660458085cdf965b78a39b1010f2a \
+                        size    84248 \
+                    github.com/smartystreets/goconvey \
+                        lock    v1.6.4 \
+                        rmd160  a3dfad6131b94d809efad84d30ce45828c6da756 \
+                        sha256  a03963296bb6d031934a651c1e637e8ab2ce9604ce6a16c158ff551e44e7ba79 \
+                        size    1478824 \
+                    github.com/smartystreets/assertions \
+                        lock    v1.0.0 \
+                        rmd160  8fedd5565a5283a7708236397595879588dc9787 \
+                        sha256  0d65770741aba0134c82bdc4a8a7192ca2e17b4f0ea6d9785b811a1c97c8c06f \
+                        size    84426 \
+                    github.com/skip2/go-qrcode \
+                        lock    da1b6568686e \
+                        rmd160  bbb9e2167ddfc72dd22da6df324b41792e70a627 \
+                        sha256  28f73bbd2c7f78308c9189c5c8abb2a329b3e02f11dec7a54254c457630ad581 \
+                        size    36689 \
+                    github.com/shurcooL/sanitized_anchor_name \
+                        lock    v1.0.0 \
+                        rmd160  c7e5322dba53e10db1711d65c146af5649b0c7c8 \
+                        sha256  ed9418de8c92acfbbd8608745855ebfc67fa686c0a0a5245cf8eece8f540baa9 \
+                        size    2144 \
+                    github.com/sergi/go-diff \
+                        lock    v1.1.0 \
+                        rmd160  6449feb5884c316206f256e55b81aba3e6a78a9f \
+                        sha256  026d3d6db40ad086954214a7f3f84b66e352d47ce259bb59b7c2b9bd843b9935 \
+                        size    43569 \
+                    github.com/schollz/closestmatch \
+                        lock    1fbe626be92e \
+                        rmd160  0c09dba0d527a6046585125a6fb2a93bc08c635c \
+                        sha256  52174a0c7551cbaeb0253dd9a00506e285877fe2cb464c6c79dcf65ed02f7ec9 \
+                        size    623995 \
+                    github.com/russross/blackfriday \
+                        lock    v2.0.1 \
+                        rmd160  99cb49faff9bf24b8637dcdb3602c27c115810f3 \
+                        sha256  4078d2cd3b1c6952133b214e4eaca95f3b31a01f87a03adabd7712e7d5f20f60 \
+                        size    79665 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/pkg/errors \
+                        lock    v0.9.1 \
+                        rmd160  dc065c655f8a24c6519b58f9d1202eb266ecda40 \
+                        sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
+                        size    13422 \
+                    github.com/niemeyer/pretty \
+                        lock    a10e7caefd8e \
+                        rmd160  46bcfc3db9e3d98acbacd1f96d9483fa360f88b7 \
+                        sha256  97b952a32175ba84349ef352e523bfa15bf3a06e07e44458a908061fbc519b40 \
+                        size    9405 \
+                    github.com/nbutton23/zxcvbn-go \
+                        lock    ae427f1e4c1d \
+                        rmd160  6649ad02c877632f50bd7c713fe98359fa307f71 \
+                        sha256  5cad3f266a9c9882c83c103e38b32179c4a0087dbac9f13a84d09484468a670c \
+                        size    980120 \
+                    github.com/muesli/crunchy \
+                        lock    v0.4.0 \
+                        rmd160  3029073bbcf95a9154c93b01803f3b48d7a3ec7e \
+                        sha256  039c5f45b9d1f7a02562cad503749bce7820d510657f720d2db2ea593093d438 \
+                        size    7791 \
+                    github.com/modern-go/reflect2 \
+                        lock    v1.0.1 \
+                        rmd160  5cdaa26d1ee453e37f3a26635aac40397e2f28fa \
+                        sha256  5bcbe1f4c0fa1d853c066a4e6f58eaa5d31ac370c97a3c87e99a6ffecf7b5a65 \
+                        size    14407 \
+                    github.com/modern-go/concurrent \
+                        lock    bacd9c7ef1dd \
+                        rmd160  b039328d6fd40b97513dea8bf5b00adfdd53f14b \
+                        sha256  2f3333805bef60544e64ac9a734522205b513f5c461ba19f3d557510bb205afb \
+                        size    7533 \
+                    github.com/mitchellh/go-ps \
+                        lock    v1.0.0 \
+                        rmd160  230cfe4a0b10fceb33f1826b75ad5a36de0aa241 \
+                        sha256  8e158a59a9b7e407b27a4cf6100f33648b7c8bffb4ac07bd074f43d4796afa87 \
+                        size    7631 \
+                    github.com/mitchellh/go-homedir \
+                        lock    v1.1.0 \
+                        rmd160  44b3985e40e5bbb22d11f8622c340f9ed727ea91 \
+                        sha256  024c8a57316c7fbc0eb23cdbfd57f72a74b51beb83d714034d67ee9aba48100c \
+                        size    3366 \
+                    github.com/minio/sha256-simd \
+                        lock    v0.1.1 \
+                        rmd160  50654a6c3da3bcc426cb9189299e1d8d76f52a2b \
+                        sha256  ab49163b74a1b89c8ab795eda31cbf65af572fe3f87028cc1234bac2ae45706c \
+                        size    65042 \
+                    github.com/minio/minio-go \
+                        lock    v6.0.57 \
+                        rmd160  d401b7f4def782f30507795ae600515d43b98b2f \
+                        sha256  c677a90c3972340a817eadef6c27904d0bf6f408a6c7e02dc55c9e4e1eb5b079 \
+                        size    220801 \
+                    github.com/minio/md5-simd \
+                        lock    v1.1.0 \
+                        rmd160  7929f1dc43d777a143a826c47948490d8ed121e0 \
+                        sha256  49d89141ce43f38098b264acf3b3d9341d553a1f82816485f1c036e18deb2b58 \
+                        size    99242 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.12 \
+                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
+                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
+                        size    4549 \
+                    github.com/mattn/go-colorable \
+                        lock    v0.1.7 \
+                        rmd160  47f774c77efaa0bbcd982cb65bed426d047780ba \
+                        sha256  68de4e31d97da97efc400096c599ea37c6cf1cb91501004f05a1017f4653f926 \
+                        size    9570 \
+                    github.com/martinhoefling/goxkcdpwgen \
+                        lock    7dc3d102eca3 \
+                        rmd160  f8b32dbe86765d33f5f6e57cc3047f6951bd6957 \
+                        sha256  6a8aa5b817f6bf895b32995360380e8382059965e56aabd1bc997ec36b612ff4 \
+                        size    287962 \
+                    github.com/kr/text \
+                        lock    v0.2.0 \
+                        rmd160  48558c7e8ff67d510f83c66883907e95f4783163 \
+                        sha256  2f2e21ac8a9d523e88cbba4039441defc4a66bfaa78811c900a88fcf28729c4c \
+                        size    8702 \
+                    github.com/klauspost/cpuid \
+                        lock    v1.3.1 \
+                        rmd160  0c161f6a90600c80e908141c2a81130ba703307e \
+                        sha256  8db60afc9f494af07150fff47e676377588d36fb5ee3cc181ec59ff35c238c79 \
+                        size    367163 \
+                    github.com/kballard/go-shellquote \
+                        lock    95032a82bc51 \
+                        rmd160  40415cd59ece9fb38b22170feec07f1f48d518a2 \
+                        sha256  41aa42696f96fb2783c5135d71ff1ec5938dfe178b51eb703e509c8ac0e7db4e \
+                        size    4335 \
+                    github.com/jtolds/gls \
+                        lock    v4.20.0 \
+                        rmd160  31d8656bd6c1426338ceaac9535198244248b254 \
+                        sha256  04069406ca336d355eab62b4ab9e84b820ac968ac1e20bd3777efec2d3843446 \
+                        size    7305 \
+                    github.com/json-iterator/go \
+                        lock    v1.1.10 \
+                        rmd160  963a70cf0a7d056f6b00fb2224687895612a35e2 \
+                        sha256  e82947d6f32c1cf730c796409eabc8051c208c2eafabe793d196d448529a7f0f \
+                        size    83377 \
+                    github.com/jsimonetti/pwscheme \
+                        lock    76804708ecad \
+                        rmd160  88e53d2efe5fafd457fd5a101b6ba9b58353a1bf \
+                        sha256  8c8946c5aa3ad151a1536b92376811d7b3e69bcd98d7fa0640f3dac0156bd079 \
+                        size    3871 \
+                    github.com/hashicorp/golang-lru \
+                        lock    v0.5.4 \
+                        rmd160  833d8d87b84f13bc545ecffff9358a19671d185a \
+                        sha256  c358bb5050adae91e443f59ff70b7c0ad6906fc4abe1b30066bf0c408fdf9b5c \
+                        size    13435 \
+                    github.com/hashicorp/go-multierror \
+                        lock    v1.1.0 \
+                        rmd160  868d9a6f0732cba1b2dfbb73556b6a194c797c03 \
+                        sha256  9bd88c4f96aa4c4dcca5c0124e48f540c59754586653924b5e4b7de3af0f8c4a \
+                        size    12091 \
+                    github.com/hashicorp/errwrap \
+                        lock    v1.0.0 \
+                        rmd160  d9bf75f667d7bec9b4b11ca34de7ca722495b914 \
+                        sha256  49e80cf52f294ce69fcc8cd26f06b8d8cee2623f6e0012df871b355fb7b17787 \
+                        size    8351 \
+                    github.com/gopherjs/gopherjs \
+                        lock    0766667cb4d1 \
+                        rmd160  fe92e39110b5c188dcce98abb3b9aa1b64d68f94 \
+                        sha256  abe56698d0855027a1f6030a44924895d781b19526aa8f9b3ef49ed4199f7c57 \
+                        size    217261 \
+                    github.com/google/go-querystring \
+                        lock    v1.0.0 \
+                        rmd160  48593728f6bf361fa168bdc87737ee30de24f34b \
+                        sha256  0add5428914c2a378cd9e6e120a4b1e84d69df504b983f99a86aea98a52c5a57 \
+                        size    7536 \
+                    github.com/google/go-github \
+                        lock    v17.0.0 \
+                        rmd160  2c1917adfc161a2252354d558352180079005d8d \
+                        sha256  c064b8849dcf8e184e1333f8411c7285e0abeb321ffc268b3798f84d6db5f947 \
+                        size    212064 \
+                    github.com/google/go-cmp \
+                        lock    v0.5.1 \
+                        rmd160  f557725ca7d868edfc5d70b1d69bd33570ef5c81 \
+                        sha256  e2c3dc6f5e6e07e5034cad315b76919ee7a7dbdf122ff76eeabd2d8b719a3d57 \
+                        size    99629 \
+                    github.com/golang/protobuf \
+                        lock    v1.4.2 \
+                        rmd160  fbf4477bc008421fde463d79f7bc54a36de91db2 \
+                        sha256  206d74f8fd066bb178135ee9c092e986f8a1e1104df242e148e99e5a839e4ef2 \
+                        size    171802 \
+                    github.com/gokyle/twofactor \
+                        lock    v1.0.1 \
+                        rmd160  639cb3e1e214c43cd212bbec6faae070a2acbc4c \
+                        sha256  c69fa4f30d2f7a1f8a1781a2bffd4009bd90a69d6a33806b33bdfe73863db258 \
+                        size    22514 \
+                    github.com/godbus/dbus \
+                        lock    8a1682060722 \
+                        rmd160  90cbb8302b7c386e2685633781ec52c8e3f0424f \
+                        sha256  54c06c5988808eca9affe01cabe122e02ba4af5763f29fff1c341dce1424aa21 \
+                        size    62423 \
+                    github.com/fatih/color \
+                        lock    v1.9.0 \
+                        rmd160  1d8418b4f1b3cb597f680b93aaa08afcc9651be4 \
+                        sha256  577c8e778833fec90d76918f138cee9f7765435757b7c92a669e5b34933e0b4f \
+                        size    1231337 \
+                    github.com/dominikschulz/github-releases \
+                        lock    v0.0.3 \
+                        rmd160  eeda323288295e66045e21fe0bf27e151fbd67ea \
+                        sha256  2e134b870e1ba46cf42d2c914013c6a98f0c19f4e30ff071aeb2c48606b3c58c \
+                        size    2162 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/cpuguy83/go-md2man \
+                        lock    v2.0.0 \
+                        rmd160  85f342c341fa928e9ec874490c277bdabf1c39c6 \
+                        sha256  2f3f8bc701df4890a5a4baf0b632ad3290be1e0aaf572b2e58fd57df93efc306 \
+                        size    52040 \
+                    github.com/client9/misspell \
+                        lock    v0.3.4 \
+                        rmd160  35b385cb5e39e9505eccbca18ffa2799240710be \
+                        sha256  8193021639e3f4f30db19cb469ac7f43d56d2200eb7749fd868a69319f95fcf1 \
+                        size    239605 \
+                    github.com/chzyer/test \
+                        lock    a1ea475d72b1 \
+                        rmd160  61f83d79b356cde63a27df0f2832ef92fcbc216d \
+                        sha256  98d0c7d1dec438459e31886d65190bb45f70c4ed73e35f5ab2f3b8de582ea309 \
+                        size    4007 \
+                    github.com/chzyer/readline \
+                        lock    2972be24d48e \
+                        rmd160  933f32b684d0af4b8970d964d610918a9f181df6 \
+                        sha256  f5771c6a3d97166a9536f8a45e85e1c40aed9b02089e395d2f4131681cbf692f \
+                        size    36826 \
+                    github.com/chzyer/logex \
+                        lock    v1.1.10 \
+                        rmd160  105d839f798ba0c3e27b3db4e790d9d21a928029 \
+                        sha256  947e61095044d310b0ad92f10ac77c36eaa3c3e2e6181e87428ad10c20930ba3 \
+                        size    4351 \
+                    github.com/cenkalti/backoff \
+                        lock    v2.2.1 \
+                        rmd160  568461ff9b5b063c18d20a2814ca4a0629b547c1 \
+                        sha256  4f6a3d7d9fdc5e02522faed8e96539476f646ab64983633a92ea1b71e18bca4f \
+                        size    8633 \
+                    github.com/caspr-io/yamlpath \
+                        lock    502e8d113a9b \
+                        rmd160  7b3d05122f821aac68278a797aa205b09312d25a \
+                        sha256  4975c9a92c5f4eb1034e916cdea2aaa96dd912dabc8f7e6379900a1a6e579d58 \
+                        size    6334 \
+                    github.com/blang/semver \
+                        lock    1a9109f8c4a1 \
+                        rmd160  b4ebb77c1acc4a111b6f947b959678d88685b475 \
+                        sha256  db45cea3471269c894f1ad024826047b6175f1b87b0c71ac4b12180608a3e07a \
+                        size    15415 \
+                    github.com/atotto/clipboard \
+                        lock    v0.1.2 \
+                        rmd160  4a0617ed814da771a9701f36b2be950301e153df \
+                        sha256  d3923f2514644b13032c76bf75fd66ef4e581afd8a86e186a300d1da12f688b3 \
+                        size    4476 \
+                    github.com/alecthomas/binary \
+                        lock    fb1b1d9c299c \
+                        rmd160  8757238e059f322ce724d9f18e42ccd2c6de5b55 \
+                        sha256  4c9dcedb409590df9c9c5b3977d423b39ec12a705396a66a4d6cfec0cd8d7399 \
+                        size    4410 \
+                    github.com/BurntSushi/toml \
+                        lock    v0.3.1 \
+                        rmd160  fb9650e2d16525153645e5547626f242f3800149 \
+                        sha256  8cc9e5dc68e247554227973d0b4e023b27bbd9ba5a26e4fb40f44743afcb35f1 \
+                        size    42087 \
+                    filippo.io/age \
+                        repo    github.com/FiloSottile/age \
+                        lock    v1.0.0-beta4 \
+                        rmd160  40729805449116617866c1b16cf4e588f752a3b3 \
+                        sha256  f0525db9eba63f3163ce8374b9e7f1cf4851bb424d3470db0d04646060879790 \
+                        size    36023
+
+set go_ldflags      "-s -w -X main.version=${version}"
+build.args          -ldflags \"${go_ldflags}\"
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description
[gopass](https://github.com/gopasspw/gopass) is a simple but powerful password manager for your terminal.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
