### PR TITLE
josm: update to 17084

### DIFF
--- a/gis/JOSM/Portfile
+++ b/gis/JOSM/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                JOSM
-version             17013
+version             17084
 categories          gis editors java
 platforms           darwin
 license             GPL-2+
@@ -19,9 +19,9 @@ homepage            https://josm.openstreetmap.de
 master_sites        ${homepage}/download/macosx/
 distname            josm-macosx-${version}
 
-checksums           rmd160  db2fd3388ac9558ed24aad5ae9d6c071072ee942 \
-                    sha256  46eb568bfcbc2395c3be7a1167d56225ebc8bf52cf4596d80350f5ca35ebead7 \
-                    size    14448921
+checksums           rmd160  3eac868c8bbe196efd84e6e57401bf243bbf187b \
+                    sha256  e10ed32bb193fbf086359522828d33354f5d0e8d8d01435834ed4aa835c9a2ed \
+                    size    14529450
 
 extract.mkdir       yes
 


### PR DESCRIPTION
#### Description
[Changelog (2020-10-05: Stable release 17084)](https://josm.openstreetmap.de/wiki/Changelog#stable-release-20.09)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
