### PR TITLE
seqan: replace old seqan port by seqan2

### DIFF
--- a/science/seqan/Portfile
+++ b/science/seqan/Portfile
@@ -5,6 +5,10 @@ PortSystem          1.0
 name                seqan
 version             2.4.0
 categories          science
+
+revision            1
+replaced_by         seqan2
+
 platforms           darwin
 supported_archs     noarch
 
@@ -18,29 +22,13 @@ long_description    SeqAn is an open source C++ library of efficient algorithms 
                     focus on biological data.
 
 homepage            https://www.seqan.de
-master_sites        http://packages.seqan.de/${name}-library
 
-use_xz              yes
-distname            ${name}-library-${version}
+livecheck.type      none
 
-checksums           rmd160  b7426de5fb7f7bb7c8ade4055f7afe238a39dd84 \
-                    sha256  dd97b1514ab83acb7d7be911b157979e188e8ca72cc61c430c1e0fd03bcd41a5 \
-                    size    4868868
-
-use_configure       no
-
-set major           [lindex [split ${version} .] 0]
-
-build {}
-
-destroot {
-    file copy ${worksrcpath}/include/seqan ${destroot}${prefix}/include
-    file copy ${worksrcpath}/share/doc/seqan ${destroot}${prefix}/share/doc
-    file copy ${worksrcpath}/share/pkgconfig/${name}-${major}.pc ${destroot}${prefix}/lib/pkgconfig/
-    file mkdir ${destroot}${prefix}/lib/cmake/${name}
-    file copy ${worksrcpath}/share/cmake/seqan/seqan-config.cmake ${destroot}${prefix}/lib/cmake/${name}/
+pre-configure {
+    ui_error "Please do not install this port since it has been replaced by 'seqan2'.\
+              You can also install the new SeqAn version using the port 'seqan3'."
+    return -code error
 }
 
-livecheck.type      regex
-livecheck.url       http://packages.seqan.de/
-livecheck.regex     ${name}-library-(\[0-9.\]+)${extract.suffix}
+distfiles

--- a/science/seqan2/Portfile
+++ b/science/seqan2/Portfile
@@ -1,0 +1,47 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                seqan2
+version             2.4.0
+categories          science
+platforms           darwin
+supported_archs     noarch
+
+license             BSD
+maintainers         fu-berlin.de:rene.rahn
+
+description         SeqAn - The C++ Sequence Analysis Library
+
+long_description    SeqAn is an open source C++ library of efficient algorithms \
+                    and data structures for the analysis of sequences with the \
+                    focus on biological data.
+
+set base_name       [string range ${name} 0 4]
+homepage            https://www.seqan.de
+master_sites        http://packages.seqan.de/${base_name}-library
+
+use_xz              yes
+distname            ${base_name}-library-${version}
+
+checksums           rmd160  b7426de5fb7f7bb7c8ade4055f7afe238a39dd84 \
+                    sha256  dd97b1514ab83acb7d7be911b157979e188e8ca72cc61c430c1e0fd03bcd41a5 \
+                    size    4868868
+
+use_configure       no
+
+set major           [lindex [split ${version} .] 0]
+
+build {}
+
+destroot {
+    file copy ${worksrcpath}/include/seqan ${destroot}${prefix}/include
+    file copy ${worksrcpath}/share/doc/seqan ${destroot}${prefix}/share/doc
+    file copy ${worksrcpath}/share/pkgconfig/${base_name}-${major}.pc ${destroot}${prefix}/lib/pkgconfig/
+    file mkdir ${destroot}${prefix}/lib/cmake/${base_name}
+    file copy ${worksrcpath}/share/cmake/seqan/seqan-config.cmake ${destroot}${prefix}/lib/cmake/${base_name}/
+}
+
+livecheck.type      regex
+livecheck.url       http://packages.seqan.de/
+livecheck.regex     ${base_name}-library-(\[0-9.\]+)${extract.suffix}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
The old port with the name seqan has been replaced by the name seqan2.
This change is necessary to avoid confusion about the most recent seqan version
after seqan3 has been released.
Since both versions can coexists, seqan3 has been distributed via its own port.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.
Xcode 12.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
