### PR TITLE
seqan-apps: replace old seqan-apps port by seqan2-apps

### DIFF
--- a/science/seqan-apps/Portfile
+++ b/science/seqan-apps/Portfile
@@ -5,7 +5,9 @@ PortGroup           cmake 1.1
 
 name                seqan-apps
 version             2.4.0
-revision            2
+revision            3
+replaced_by         seqan2-apps
+
 categories          science
 platforms           darwin
 universal_variant   no
@@ -20,31 +22,12 @@ long_description    SeqAn applications for the analysis of large sets of sequenc
 
 homepage            https://www.seqan.de/applications/
 
-depends_lib-append  port:boost \
-                    port:bzip2 \
-                    port:zlib
-depends_run-append  port:coinor-liblemon
+livecheck.type      none
 
-master_sites        http://packages.seqan.de/seqan-src
-distfiles           seqan-src-${version}${extract.suffix}
-distname            seqan-seqan-v${version}
-
-checksums           rmd160  c843f8c749e6f2d8ff5233f160d9683743dce7c2 \
-                    sha256  d7084d17729214003e84818e0280a16f223c8f1c6a30eeef040c27e0c0047bd7 \
-                    size    109626901
-
-compiler.cxx_standard   2014
-compiler.openmp_version 3.0
-
-configure.args-append   -DSEQAN_BUILD_SYSTEM=SEQAN_RELEASE_APPS
-
-if {${os.platform} eq "darwin" && ${os.major} < 16} {
-    known_fail yes
-    pre-fetch {
-        ui_error "${name} ${version} requires macOS 10.12 or greater."
-        return -code error "Incompatible macOS version."
-    }
+pre-configure {
+    ui_error "Please do not install this port since it has been replaced by 'seqan2-apps'.\
+              Note that the all-in-one application package is not supported any more in seqan3."
+    return -code error
 }
 
-livecheck.url       http://packages.seqan.de/
-livecheck.regex     seqan-src-(\[0-9.\]+)${extract.suffix}
+distfiles

--- a/science/seqan2-apps/Portfile
+++ b/science/seqan2-apps/Portfile
@@ -1,0 +1,49 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+
+name                seqan2-apps
+version             2.4.0
+categories          science
+platforms           darwin
+universal_variant   no
+
+license             BSD LGPL-3 GPL-3
+maintainers         fu-berlin.de:rene.rahn
+
+description         Applications distributed with the SeqAn library
+
+long_description    SeqAn applications for the analysis of large sets of sequences, e.g. \
+                    read mapping, genome comparison, local alignment, data mining.
+
+homepage            https://www.seqan.de/applications/
+
+depends_lib-append  port:boost \
+                    port:bzip2 \
+                    port:zlib
+depends_run-append  port:coinor-liblemon
+
+master_sites        http://packages.seqan.de/seqan-src
+distfiles           seqan-src-${version}${extract.suffix}
+distname            seqan-seqan-v${version}
+
+checksums           rmd160  c843f8c749e6f2d8ff5233f160d9683743dce7c2 \
+                    sha256  d7084d17729214003e84818e0280a16f223c8f1c6a30eeef040c27e0c0047bd7 \
+                    size    109626901
+
+compiler.cxx_standard   2014
+compiler.openmp_version 3.0
+
+configure.args-append   -DSEQAN_BUILD_SYSTEM=SEQAN_RELEASE_APPS
+
+if {${os.platform} eq "darwin" && ${os.major} < 16} {
+    known_fail yes
+    pre-fetch {
+        ui_error "${name} ${version} requires macOS 10.12 or greater."
+        return -code error "Incompatible macOS version."
+    }
+}
+
+livecheck.url       http://packages.seqan.de/
+livecheck.regex     seqan-src-(\[0-9.\]+)${extract.suffix}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
With the current SeqAn version 3 we stopped maintaing all-in-one application packaging.
Accordingly, the users cannot expect that there are updates to this package any more.
To reflect the end of life-cylce for this port we decided to rename it to the respective seqan version 2.
This change also reflects the changes made in:  #8769 and  #8770 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.
Xcode 12.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
