### PR TITLE
vdt: use compiler.cxx_standard 2011

### DIFF
--- a/math/vdt/Portfile
+++ b/math/vdt/Portfile
@@ -4,7 +4,6 @@ PortSystem          1.0
 
 PortGroup           cmake 1.0
 PortGroup           github 1.0
-PortGroup           cxx11 1.1
 
 #github.setup        dpiparo vdt 0.4.1 v
 github.setup        cjones051073 vdt b376d0f9e8cc97689d89f7f8c40c3a4644f48679
@@ -26,3 +25,5 @@ description         A collection of fast and inline implementations of mathemati
 long_description    ${name} provides ${description}.
 
 platforms           darwin
+
+compiler.cxx_standard 2011


### PR DESCRIPTION
…instead of deprecated cxx11 1.1 portgroup

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
