### PR TITLE
lilypond: attempt to fix build on macOS 10.8

### DIFF
--- a/textproc/lilypond/Portfile
+++ b/textproc/lilypond/Portfile
@@ -39,6 +39,8 @@ notes-append "\
     Note that TeX is not needed after installation."
 
 
+compiler.cxx_standard 2011
+
 if {${subport} eq ${name}} {
     version         2.20.0
     revision        4
@@ -48,6 +50,11 @@ if {${subport} eq ${name}} {
                     size    18100533
 
     set livecheck_url "source.html"
+
+    # not needed for lilypond > 2.20.x ?
+    if {[string match *clang* ${configure.cxx}]} {
+        configure.ldflags-append -stdlib=${configure.cxx_stdlib}
+    }
 } else {
     version         2.21.7
     revision        0
@@ -116,8 +123,6 @@ depends_lib-append  path:lib/pkgconfig/pango.pc:pango \
 build.type          gnu
 configure.cmd       autoconf -f && ./configure
 configure.python    ${prefix}/bin/python3.8
-
-compiler.cxx_standard 2011
 
 
 set lilypond.texgyredir \


### PR DESCRIPTION
#### Description
`lilypond` [fails to build on macOS 10.8](https://build.macports.org/builders/ports-10.8_x86_64-builder/builds/27538/steps/install-port/logs/stdio) due to a long list of `Undefined symbols for architecture x86_64: "std::__1::…"` when linking.
This PR applies a workaround used by other ports that encountered similar errors. `lilypond-devel` seems to have a different build process and isn't affected, so maybe this workaround isn't needed for future stable releases.
<!-- Note: it is best to make pull requests from a branch rather than from master -->



###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
Untested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
