### PR TITLE
gobject-introspection: add patch to fix in-build scanner execution

### DIFF
--- a/gnome/gobject-introspection/Portfile
+++ b/gnome/gobject-introspection/Portfile
@@ -5,7 +5,7 @@ PortGroup           active_variants 1.1
 
 name                gobject-introspection
 version             1.60.2
-revision            1
+revision            2
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          gnome
 platforms           darwin
@@ -36,7 +36,8 @@ depends_lib         path:lib/pkgconfig/cairo.pc:cairo \
 depends_run         bin:glibtool:libtool
 
 patchfiles          no-env-shebang.patch \
-                    patch-fix-rpath-gir-typelib.diff
+                    patch-fix-rpath-gir-typelib.diff \
+                    patch-fix-scanner-in-build-execution.diff
 
 post-patch {
     reinplace "s|libcairo-gobject.2.dylib|${prefix}/lib/libcairo-gobject.2.dylib|g" ${worksrcpath}/configure.ac

--- a/gnome/gobject-introspection/files/patch-fix-scanner-in-build-execution.diff
+++ b/gnome/gobject-introspection/files/patch-fix-scanner-in-build-execution.diff
@@ -1,0 +1,57 @@
+--- giscanner/ccompiler.py.orig
++++ giscanner/ccompiler.py
+@@ -184,7 +184,10 @@
+         if os.name == 'nt':
+             runtime_path_envvar = ['LIB', 'PATH']
+         else:
+-            runtime_path_envvar = ['LD_LIBRARY_PATH', 'DYLD_FALLBACK_LIBRARY_PATH']
++            if sys.platform == "darwin":
++                runtime_path_envvar = ['DYLD_LIBRARY_PATH']
++            else:
++                runtime_path_envvar = ['LD_LIBRARY_PATH']
+             # Search the current directory first
+             # (This flag is not supported nor needed for Visual C++)
+             args.append('-L.')
+--- giscanner/dumper.py.orig
++++ giscanner/dumper.py
+@@ -236,8 +236,20 @@
+ 
+         args.extend(sources)
+ 
+-        pkg_config_libs = pkgconfig.libs(self._packages,
+-                                         msvc_syntax=self._compiler.check_is_msvc())
++        pkg_config_libs, pkg_config_libs_only_L = pkgconfig.libs(
++            self._packages, msvc_syntax=self._compiler.check_is_msvc())
++        this_L = [lib[len('-L'):] for lib in pkg_config_libs_only_L]
++
++        if os.name == 'nt':
++            runtime_path_envvar = ['LIB', 'PATH']
++        else:
++            runtime_path_envvar = ['LIBRARY_PATH']
++        for envvar in runtime_path_envvar:
++            if envvar in os.environ:
++                os.environ[envvar] = \
++                    os.pathsep.join(this_L + [os.environ[envvar]])
++            else:
++                os.environ[envvar] = os.pathsep.join(this_L)
+ 
+         if not self._options.external_library:
+             self._compiler.get_internal_link_flags(args,
+--- giscanner/pkgconfig.py.orig
++++ giscanner/pkgconfig.py
+@@ -52,7 +52,12 @@
+ 
+ def libs(packages, msvc_syntax=False, ignore_errors=True, command=None):
+     flags = ['--msvc-syntax'] if msvc_syntax else []
+-    flags.append('--libs')
++    flags.append('--libs-only-l')
++    flags.append('--libs-only-other')
+     flags.extend(packages)
+-    out = check_output(flags, ignore_errors, command)
+-    return shlex.split(out)
++    out_libs_only_not_L = shlex.split(check_output(flags, ignore_errors, command))
++    flags = ['--msvc-syntax'] if msvc_syntax else []
++    flags.append('--libs-only-L')
++    flags.extend(packages)
++    out_libs_only_L = shlex.split(check_output(flags, ignore_errors, command))
++    return out_libs_only_not_L, out_libs_only_L


### PR DESCRIPTION
Ref: https://trac.macports.org/ticket/58574

Hopefully this PR addresses that ticket's issue, finally. I note "Ref" since I want it referenced, but not necessarily closed. Hopefully closed but only after extensive testing!

#### Description

Various tweaks to the GI-O scanner Python code to provide for in-build execution. Getting this into a PR for everyone to test / verify. The code changes read well to me, and should be macOS-version agnostic.

Note that since we're using an older version of GO-I (pre-meson @ 1.60.2 ; current is 1.66.1), so any fixes here may or not be relevant to current GO-I. If/when we decide to upgrade GO-I, it will involve retesting and possible fixing up the patches we come up with to fix this issue for us ... which makes upgrading that much more challenging!

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0 20A5384c
Xcode 12.2 12B5025f

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
