### PR TITLE
ngttp2: update git.setup, + py39

### DIFF
--- a/www/nghttp2/Portfile
+++ b/www/nghttp2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           legacysupport 1.0
 
-github.setup        tatsuhiro-t nghttp2 1.41.0 v
+github.setup        nghttp2 nghttp2 1.41.0 v
 revision            1
 categories          www
 platforms           darwin
@@ -12,7 +12,9 @@ maintainers         {mps @Schamschula} openmaintainer
 license             MIT
 
 description         An implementation of HTTP/2 in C.
-long_description    ${description}
+long_description    {*}${description}
+
+homepage            https://${name}.org
 
 github.tarball_from releases
 use_xz              yes
@@ -79,7 +81,7 @@ subport nghttp2-tools {
     }
 }
 
-set pyversions {27 36 37 38}
+set pyversions {27 36 37 38 39}
 
 foreach pyversion ${pyversions} {
     subport py${pyversion}-${name} {


### PR DESCRIPTION
#### Description

ngttp2: update git.setup, + py39

  - tatsuhiro-t/nghttp2 redirects to nghttp2/nghttp2
  - use real homepage: https://nghttp2.org
  - add p39-nghttp2 subport

###### Type(s)

- [x] update

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?