### PR TITLE
unbound: add variant nghhtp2 (DoH)

### DIFF
--- a/net/unbound/Portfile
+++ b/net/unbound/Portfile
@@ -2,9 +2,12 @@
 
 PortSystem          1.0
 PortGroup           compiler_blacklist_versions 1.0
+PortGroup           legacysupport 1.1
 
 name                unbound
 version             1.12.0
+revision            1
+
 categories          net
 license             BSD
 maintainers         {snc @nerdling} openmaintainer
@@ -59,6 +62,11 @@ variant dnstap description {Enable dnstap support (a binary log format for DNS s
     depends_lib-append      port:protobuf-c
     configure.args-append   --enable-dnstap \
                             --with-protobuf-c=${prefix}
+}
+
+variant nghttp2 description {Build with libnghttp2 (required when setting up ${name} with DoH)} {
+    depends_lib-append      port:nghttp2
+    configure.args-append   --with-libnghttp2=${prefix}
 }
 
 test.run            yes


### PR DESCRIPTION
#### Description

unbound: add variant nghhtp2 (DoH)

New in 1.12.0 is DoH. To use it, nghttp2 is needed.

  - add variant: +nghhtp2
  - add depends_lib: nghhtp2


[Unbound’s DNS-over-HTTPS implementation](https://medium.com/nlnetlabs/dns-over-https-in-unbound-c7a407e8480#6685)

> “We decided to use the amazing nghttp2 library to handle the HTTP/2 framing layer. …”

###### Type(s)

- [x] update

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

###### Notes

If you think the patch: https://trac.macports.org/ticket/61314#comment:4 is ok with you, if not as a tmp fix for that - I can add it here as well.

