### PR TITLE
add arm64 as a valid architecture for cmake

### DIFF
--- a/devel/cmake/Portfile
+++ b/devel/cmake/Portfile
@@ -10,7 +10,7 @@ PortGroup           legacysupport 1.1
 PortGroup           clang_dependency 1.0
 
 name                cmake
-
+revision            2
 categories          devel
 license             BSD
 installs_libs       no
@@ -163,7 +163,7 @@ if {${subport} eq ${name}} {
     configure.universal_args
 
     # CMake's configure script doesn't recognize `--host`.
-    array set merger_host {i386 {} x86_64 {} ppc {} ppc64 {}}
+    array set merger_host {i386 {} x86_64 {} ppc {} ppc64 {} arm64 {}}
 
     platform darwin 8 {
         configure.ldflags-append -Wl,-framework -Wl,ApplicationServices


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0 beta 9
Xcode 12.2 beta 3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
