### PR TITLE
slang2: add missing include which is needed when compiling against xcode 12

### DIFF
--- a/lang/slang2/Portfile
+++ b/lang/slang2/Portfile
@@ -35,6 +35,8 @@ use_bzip2           yes
 checksums           rmd160  fc023080f021201a99263d686ab4a8b87bbb575a \
                     sha256  9a8257a9a2a55099af858b13338dc8f3a06dd2069f46f0df2c9c3bb84a01d5db
 
+patchfiles          patch-png-module.diff
+
 depends_lib         port:libiconv \
                     port:libpng \
                     port:pcre \

--- a/lang/slang2/files/patch-png-module.diff
+++ b/lang/slang2/files/patch-png-module.diff
@@ -1,0 +1,10 @@
+--- modules/png-module.c.orig	2020-10-14 15:50:41.000000000 -0400
++++ modules/png-module.c	2020-10-14 15:51:25.000000000 -0400
+@@ -24,6 +24,7 @@
+ 
+ #include <stdio.h>
+ #include <errno.h>
++#include <string.h>
+ #include <slang.h>
+ 
+ #include <png.h>


### PR DESCRIPTION
#### Description

When compiling slang2 on xcode 12.2 beta 3 it errors that memset was not defined

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0 beta 9
Xcode 12.2 beta 3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
