### PR TITLE
micronaut: update to 2.1.1

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       java 1.0
 
-github.setup    micronaut-projects micronaut-starter 2.1.0 v
+github.setup    micronaut-projects micronaut-starter 2.1.1 v
 revision        0
 name            micronaut
 categories      java
@@ -53,9 +53,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  0406b5c9ab220430211ba28477e31818412876e9 \
-                sha256  9a35f8184c3acdc5db732e660322645087b423a10870926034f73364f9a2ce40 \
-                size    14729052
+checksums       rmd160  8daefb22074fbb87898155ec989cd6bee025ccd5 \
+                sha256  54df9bdb5ef4d5e79c815e63e205b6ba2d7be4288c3ac585a39643bf173bf120 \
+                size    14742380
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 2.1.1.

###### Tested on

macOS 10.15.7 19H2
Xcode 12.0.1 12A7300

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?