### PR TITLE
opencv: add variant python39

### DIFF
--- a/graphics/opencv/Portfile
+++ b/graphics/opencv/Portfile
@@ -322,7 +322,7 @@ variant python27 description {Add Python 2.7 bindings.} {
 }
 
 
-set pythonversions {3.5 3.6 3.7 3.8}
+set pythonversions {3.5 3.6 3.7 3.8 3.9}
 foreach pdv ${pythonversions} {
     set pv [join [lrange [split ${pdv} .] 0 1] ""]
     set conflist ""


### PR DESCRIPTION
Adding 3.9 to the list of Python versions, to create a
new variant python39 for Python 3.9 bindings

#### Description

This adds Python 3.9 bindings to the OpenCV 3 package.

**Important:** ~~this change depends on Numpy for Python 3.9 (i.e. py39-numpy), for which I created a [separate pull request](https://github.com/macports/macports-ports/pull/8790) that must be looked at first.~~ (fixed)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
