### PR TITLE
py39-lxml: new port

### DIFF
--- a/python/py-lxml/Portfile
+++ b/python/py-lxml/Portfile
@@ -9,7 +9,7 @@ categories-append   devel
 platforms           darwin
 license             BSD
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 maintainers         {petr @petrrr} openmaintainer
 


### PR DESCRIPTION
Adding version 39 to the list of Python versions in pkg py-lxml
to generate py39-lxml

#### Description

This adds py39-lxml (py-lxml sub-port for Python 3.9)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
