### PR TITLE
unbound: rm legacysupport

### DIFF
--- a/net/unbound/Portfile
+++ b/net/unbound/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem          1.0
 PortGroup           compiler_blacklist_versions 1.0
-PortGroup           legacysupport 1.1
 
 name                unbound
 version             1.12.0


### PR DESCRIPTION
#### Description

unbound: rm legacysupport
    
Appearently the legacysupport doesn't mix well with the autotools fix.
    
See: 3abb85ca#commitcomment-43257485