### PR TITLE
update to pdftk-java: add symbolic link to pdftk

### DIFF
--- a/textproc/pdftk-java/Portfile
+++ b/textproc/pdftk-java/Portfile
@@ -36,7 +36,6 @@ post-configure {
     file mkdir ${worksrcpath}/lib
     ln -s ${prefix}/share/java/bcprov/bcprov.jar ${worksrcpath}/lib/
     ln -s ${prefix}/share/java/commons-lang3.jar ${worksrcpath}/lib/
-    ln -s ${prefix}/bin/pdftk-java ${prefix}/bin/pdftk
 }
 
 build.cmd           ant
@@ -49,4 +48,6 @@ destroot {
 
     xinstall -m 0755 ${filespath}/pdftk-java.in ${destroot}${prefix}/bin/${name}
     reinplace "s|@PREFIX@|${prefix}|g" ${destroot}${prefix}/bin/${name}
+
+    ln -s ${name} ${destroot}${prefix}/bin/pdftk
 }

--- a/textproc/pdftk-java/Portfile
+++ b/textproc/pdftk-java/Portfile
@@ -17,6 +17,7 @@ maintainers         nomaintainer
 license             GPL-2+
 platforms           darwin
 description         A port of pdftk into java
+conflicts           pdftk
 long_description    ${description}
 supported_archs     noarch
 
@@ -35,6 +36,7 @@ post-configure {
     file mkdir ${worksrcpath}/lib
     ln -s ${prefix}/share/java/bcprov/bcprov.jar ${worksrcpath}/lib/
     ln -s ${prefix}/share/java/commons-lang3.jar ${worksrcpath}/lib/
+    ln -s ${prefix}/bin/pdftk-java ${prefix}/bin/pdftk
 }
 
 build.cmd           ant

--- a/textproc/pdftk-java/Portfile
+++ b/textproc/pdftk-java/Portfile
@@ -6,7 +6,7 @@ PortGroup           gitlab 1.0
 PortGroup           java 1.0
 
 gitlab.setup        pdftk-java pdftk 3.1.1 v
-revision            1
+revision            2
 checksums           rmd160  ce4f3851b0d3dd46997bb719bdb7019e4a9f7ed8 \
                     sha256  7da20b5172fcbcda8c14e312cd6d40efa3abd4909d62de52403e1d2b418712fd \
                     size    1172831

--- a/textproc/pdftk/Portfile
+++ b/textproc/pdftk/Portfile
@@ -34,6 +34,8 @@ long_description \
     Uncompress and Re-Compress Page Streams \
     Repair Corrupted PDF (Where Possible)
 
+conflicts               pdftk-java
+
 checksums               rmd160  4d9e75abc4a966041bd0be7b1db13bb73819d2ae \
                         sha256  118f6a25fd3acaafb58824dce6f97cdc07e56050e666b90e4c4ef426ea37b8c1 \
                         size    2239008


### PR DESCRIPTION

#### Description

Allow invoking pdftk-java by calling just pdftk for better user experience and in order to keep existing scripts running. For this to work, pdftk and pdftk-java must be marked as conflicting.

Fix https://trac.macports.org/ticket/61323

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.7 19H2
Xcode 12.0.1 12A7300

###### Verification  -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

