### PR TITLE
Use Python 3.9 for Mercurial, related ports and their dependents

### DIFF
--- a/devel/dbus-python/Portfile
+++ b/devel/dbus-python/Portfile
@@ -5,7 +5,7 @@ PortSystem      1.0
 name            dbus-python
 version         1.2.16
 
-set python_versions {27 35 36 37 38}
+set python_versions {27 35 36 37 38 39}
 
 # this default version should stay synchronized with python_get_default_version
 #    in the python PortGroup

--- a/devel/qscintilla/Portfile
+++ b/devel/qscintilla/Portfile
@@ -115,7 +115,7 @@ foreach qt_major {4 5} {
         }
     }
 
-    set python_versions {27 35 36 37 38}
+    set python_versions {27 35 36 37 38 39}
 
     foreach pver ${python_versions} {
         subport py${pver}-${name}-qt${qt_major} {

--- a/python/py-brotli/Portfile
+++ b/python/py-brotli/Portfile
@@ -27,7 +27,7 @@ checksums           rmd160  3e2402d137fd75f898007d3730773b32025a4857 \
                     sha256  b56a4371636e063ad3695f7c53aed5c18fc2303034564534981e7d6a11b75138 \
                     size    487046
 
-python.versions     27 36 37 38
+python.versions     27 36 37 38 39
 
 if {$subport ne $name} {
     depends_build-append port:py${python.version}-setuptools

--- a/python/py-dulwich/Portfile
+++ b/python/py-dulwich/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  4b778d690150aeec82f14e5ac27f2a0e87f3ef49 \
                     sha256  e6b02df20a6b1db54c3c6d63d4360679f27d4b26bdc16a2404fd85fc9575f81b \
                     size    379311
 
-python.versions     27 38
+python.versions     27 38 39
 
 if {${name} ne ${subport}} {
     # 0.20 dropped support for Python 2.7

--- a/python/py-iniparse/Portfile
+++ b/python/py-iniparse/Portfile
@@ -18,7 +18,7 @@ use.
 checksums           rmd160  9f111a446f0e4ecce1573b14e3018312aa8017ec \
                     sha256  932e5239d526e7acb504017bb707be67019ac428a6932368e6851691093aa842
 
-python.versions 27 38
+python.versions 27 38 39
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-mercurial_extension_utils/Portfile
+++ b/python/py-mercurial_extension_utils/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  e1ff7af4305f77856a9df35ced0d898028ce83ae \
                     sha256  e864519f7070cc2d03f937d0c0f6e3240c981b7b3d162f7b746b2fe420601e74 \
                     size    22071
 
-python.versions     27 37 38
+python.versions     27 37 38 39
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-mercurial_keyring/Portfile
+++ b/python/py-mercurial_keyring/Portfile
@@ -26,7 +26,7 @@ checksums           rmd160  281bcd19171ab0e3832087161046d6d023c1a04d \
                     sha256  2d17b3eeef284b026e927232e97dd82db6b0630896bf2ca432023379580d5310 \
                     size    19273
 
-python.versions     27 37 38
+python.versions     27 37 38 39
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-pyqt4/Portfile
+++ b/python/py-pyqt4/Portfile
@@ -24,7 +24,7 @@ set patch       [lindex [split ${version} .] 2]
 
 # pre-declare provided subports
 
-python.versions 27 35 36 37 38
+python.versions 27 35 36 37 38 39
 python.default_version 27
 
 foreach py_ver ${python.versions} {

--- a/python/py-pyqt5/Portfile
+++ b/python/py-pyqt5/Portfile
@@ -34,7 +34,7 @@ if {[vercmp ${qt5.version} 5.11] < 0} {
                         size    3264559
 }
 
-python.versions 27 35 36 37 38
+python.versions 27 35 36 37 38 39
 subport "${name}-common" {}
 
 foreach py_ver ${python.versions} {

--- a/python/py-sip/Portfile
+++ b/python/py-sip/Portfile
@@ -54,7 +54,7 @@ epoch               1
 # SIP 4.16.[1-7] provides SIP API 11.1.
 # SIP 4.15.5 provided SIP API 11.0.
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 python.default_version 27
 
 if {${name} ne ${subport}} {


### PR DESCRIPTION
#### Description

This switches the Mercurial port to using Python 3.9. Although Mercurial and most of its dependents don't affect all _that_ many ports, this does not apply to TortoiseHg, which uses PyQt and an awful lot of other ports. Hence this PR.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
