### PR TITLE
py-*: py39 support for 15 packages

### DIFF
--- a/python/py-Pillow/Portfile
+++ b/python/py-Pillow/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 platforms           darwin
 license             BSD
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-altgraph/Portfile
+++ b/python/py-altgraph/Portfile
@@ -25,7 +25,7 @@ checksums           md5 9450020282270749db205038b8c90b55 \
                     rmd160 01f1feb3a846dcc669e5329fc7cb15f41b0a3405 \
                     sha256 1f05a47122542f97028caf78775a095fbe6a2699b5089de8477eb583167d69aa
 
-python.versions     27 33 34 35 36 37 38
+python.versions     27 33 34 35 36 37 38 39
 
 if {$subport ne $name} {
     depends_build   port:py${python.version}-setuptools

--- a/python/py-beaker/Portfile
+++ b/python/py-beaker/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD MIT
 supported_archs     noarch
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-cppy/Portfile
+++ b/python/py-cppy/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  4ff906130cd679a2f5e0781b6f2e3e1fc16b2093 \
                     sha256  4eda6f1952054a270f32dc11df7c5e24b259a09fddf7bfaa5f33df9fb4a29642 \
                     size    11777
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-cycler/Portfile
+++ b/python/py-cycler/Portfile
@@ -17,7 +17,7 @@ checksums           rmd160  cf3cceb56449e99d74920b57c9119ecb30fe5e77 \
                     sha256  5fd8508cb46ec86a4e08b13e946eb7fef16217e76fdb95601ae2c069e3efbbaf \
                     size    21691
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 if {${subport} ne ${name}} {
     depends_build   port:py${python.version}-setuptools

--- a/python/py-gnureadline/Portfile
+++ b/python/py-gnureadline/Portfile
@@ -8,7 +8,7 @@ version             8.0.0
 platforms           darwin
 license             GPL-3+ PSF
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-kiwisolver/Portfile
+++ b/python/py-kiwisolver/Portfile
@@ -26,7 +26,7 @@ checksums           rmd160  50b6a0970a6fd009f789c38d6968e81ba3b4b14e \
                     sha256  c161efde429ffa569d2845373e444ca38d4c1a88b764f03cadd8e63a8d3699ca \
                     size    54260
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
     if {${python.version} in "27 35"} {

--- a/python/py-macholib/Portfile
+++ b/python/py-macholib/Portfile
@@ -26,7 +26,7 @@ checksums           md5 226cf0d4d07162d98c7344f5affd1d6f \
                     rmd160 c5b12071106ed4d5b63d780dd84db0bb047f9fb1 \
                     sha256 0c436bc847e7b1d9bda0560351bf76d7caf930fb585a828d13608839ef42c432
 
-python.versions     27 33 34 35 36 37 38
+python.versions     27 33 34 35 36 37 38 39
 
 if {$subport ne $name} {
     depends_lib     port:py${python.version}-modulegraph

--- a/python/py-mako/Portfile
+++ b/python/py-mako/Portfile
@@ -12,7 +12,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-matplotlib/Portfile
+++ b/python/py-matplotlib/Portfile
@@ -31,7 +31,7 @@ checksums           rmd160  a6b883a64588983ddecdfd7f4ef47077ef06121f \
 
 use_parallel_build  no
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-modulegraph/Portfile
+++ b/python/py-modulegraph/Portfile
@@ -25,7 +25,7 @@ checksums           md5 24d01d62e26d3f42b6a930107c7a87d3 \
                     rmd160 188f5a9030876b894f52eda837fc29e96c12f45b \
                     sha256 11c03dac1368bb9e7f780b58d251a0880c30b5a14816b6f88ec5a6fe1e3e5611
 
-python.versions     27 33 34 35 36 37 38
+python.versions     27 33 34 35 36 37 38 39
 
 if {$subport ne $name} {
     depends_lib     port:py${python.version}-altgraph \

--- a/python/py-olefile/Portfile
+++ b/python/py-olefile/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 maintainers         nomaintainer
 

--- a/python/py-py2app/Portfile
+++ b/python/py-py2app/Portfile
@@ -22,7 +22,7 @@ checksums           md5 80f27c88c07a0e4526c98656bba61703 \
                     rmd160 8e8fc2737cb4efdf230a04483028c212e5e71262 \
                     sha256 0ec29109338cb7c5340457aa6df972904d0d00533e8ab4107b9e00fe1da5d300
 
-python.versions     27 34 35 36 37 38
+python.versions     27 34 35 36 37 38 39
 
 if {$subport ne $name} {
     depends_lib     port:py${python.version}-macholib

--- a/python/py-tornado/Portfile
+++ b/python/py-tornado/Portfile
@@ -10,7 +10,7 @@ categories-append   www
 platforms           darwin
 license             Apache-2
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-tornado5/Portfile
+++ b/python/py-tornado5/Portfile
@@ -11,7 +11,7 @@ categories-append   www
 platforms           darwin
 license             Apache-2
 
-python.versions     37 38
+python.versions     37 38 39
 
 maintainers         nomaintainer
 


### PR DESCRIPTION
#### Description

Adds py39 support for these Python packages:
* altgraph
* beaker
* cppy
* cycler
* gnureadline
* kiwisolver
* macholib
* mako
* matplotlib
* modulegraph
* olefile
* Pillow
* py2app
* tornado
* tornado5

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
