### PR TITLE
minizinc: use legacysupport

### DIFF
--- a/devel/minizinc/Portfile
+++ b/devel/minizinc/Portfile
@@ -4,6 +4,10 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
+# Need strndup()
+PortGroup           legacysupport 1.0
+legacysupport.newest_darwin_requires_legacy 10
+
 github.setup        MiniZinc libminizinc 2.5.0
 name                minizinc
 revision            0


### PR DESCRIPTION
#### Description
Build fails on 10.6:
```
/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_devel_minizinc/minizinc/work/libminizinc-2.5.0/lib/file_utils.cpp:375:19: error: use of undeclared identifier 'strndup'
  char* tmpfile = strndup(_name.c_str(), _name.size());
                  ^
/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_devel_minizinc/minizinc/work/libminizinc-2.5.0/lib/file_utils.cpp:413:19: error: use of undeclared identifier 'strndup'
  char* tmpfile = strndup(_name.c_str(), _name.size());
                  ^
```
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
Untested. 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
