### PR TITLE
gpsd: Add python39 variant.

### DIFF
--- a/net/gpsd/Portfile
+++ b/net/gpsd/Portfile
@@ -35,7 +35,7 @@ livecheck.regex         "${name}-(\\d+(?:\\.\\d+)*)${extract.suffix}"
 # GPSD requires Python 2.6, 2.7, or 3.2+; don't use 2.6, 3.2, 3.3, or 3.4,
 # since we're weaning MP off of them.
 
-set pythons_suffixes {27 35 36 37 38}
+set pythons_suffixes {27 35 36 37 38 39}
 
 set pythons_ports {}
 foreach s ${pythons_suffixes} {


### PR DESCRIPTION
TESTED:
Tested (including building the usual set of variant combinations and
running the tests) on 10.5 PPC, 10.5-10.6 i386, and 10.5-10.15 x86_64.
Skipped xgps variant on 10.5 PPC and 10.5-10.6 i386 due to gtk3
breakage.  This port is known not to build on 10.4.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14033, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G6032, x86_64, Xcode 11.3.1 11C505
macOS 10.15.6 19G2021, x86_64, Xcode 12.0.1 12A7300

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
