### PR TITLE
bfs: use legacysupport

### DIFF
--- a/sysutils/bfs/Portfile
+++ b/sysutils/bfs/Portfile
@@ -3,6 +3,10 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
+# Need openat(), unlinkat(), fdopendir()
+PortGroup           legacysupport 1.0
+legacysupport.newest_darwin_requires_legacy 13
+
 github.setup        tavianator bfs 2.0
 
 categories          sysutils


### PR DESCRIPTION
#### Description
Build fails on macOS 10.9 and earlier:
<!-- Note: it is best to make pull requests from a branch rather than from master -->
```
bftw.c:384:11: warning: implicit declaration of function 'openat' is invalid in C99 [-Wimplicit-function-declaration]
        int fd = openat(at_fd, at_path, flags);
                 ^
bftw.c:417:14: error: use of undeclared identifier 'AT_FDCWD'
        int at_fd = AT_FDCWD;
                    ^
exec.c:268:23: error: use of undeclared identifier 'AT_FDCWD'
        if (ftwbuf->at_fd != AT_FDCWD) {
                             ^
bftw.c:495:13: warning: implicit declaration of function 'fdopendir' is invalid in C99 [-Wimplicit-function-declaration]
        DIR *ret = fdopendir(dfd);
                   ^
bftw.c:495:7: warning: incompatible integer to pointer conversion initializing 'DIR *' with an expression of type 'int' [-Wint-conversion]
        DIR *ret = fdopendir(dfd);
             ^     ~~~~~~~~~~~~~~
color.c:730:12: error: use of undeclared identifier 'AT_FDCWD'
                        at_fd = AT_FDCWD;
                                ^
eval.c:341:11: error: use of undeclared identifier 'AT_REMOVEDIR'
                flag |= AT_REMOVEDIR;
                        ^
eval.c:347:6: warning: implicit declaration of function 'unlinkat' is invalid in C99 [-Wimplicit-function-declaration]
        if (unlinkat(ftwbuf->at_fd, ftwbuf->at_path, flag) != 0) {
            ^
color.c:739:16: error: use of undeclared identifier 'AT_FDCWD'
                if (at_fd == AT_FDCWD && path[0] != '/') {
                             ^
eval.c:410:13: warning: implicit declaration of function 'openat' is invalid in C99 [-Wimplicit-function-declaration]
                int dfd = openat(ftwbuf->at_fd, ftwbuf->at_path, O_RDONLY | O_CLOEXEC | O_DIRECTORY);
                          ^
eval.c:416:14: warning: implicit declaration of function 'fdopendir' is invalid in C99 [-Wimplicit-function-declaration]
                DIR *dir = fdopendir(dfd);
                           ^
eval.c:416:8: warning: incompatible integer to pointer conversion initializing 'DIR *' with an expression of type 'int' [-Wint-conversion]
                DIR *dir = fdopendir(dfd);
                     ^     ~~~~~~~~~~~~~~
bftw.c:1024:18: error: use of undeclared identifier 'AT_FDCWD'
        ftwbuf->at_fd = AT_FDCWD;
                        ^
fsade.c:50:38: error: use of undeclared identifier 'AT_FDCWD'
        if (!proc_works || ftwbuf->at_fd == AT_FDCWD) {
                                            ^
fsade.c:61:18: error: use of undeclared identifier 'AT_FDCWD'
                if (xfaccessat(AT_FDCWD, path, F_OK) != 0) {
                               ^
```

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
Untested
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
