### PR TITLE
to-f90: new port

### DIFF
--- a/devel/to-f90/Portfile
+++ b/devel/to-f90/Portfile
@@ -1,0 +1,56 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+PortGroup       compilers 1.0
+
+name            to-f90
+version         1999-03-08
+revision        0
+categories      devel
+platforms       darwin
+license         public-domain
+maintainers     {@kamischi web.de:karl-michael.schindler} openmaintainer
+homepage        http://cd.textfiles.com/simtel/simtel0101/simtel/fortran/
+master_sites    ${homepage}
+distname        to_f90
+dist_subdir     ${name}/${version}
+use_zip         yes
+extract.mkdir   yes
+description     Fortran 77 to Fortran 90 converter
+
+long_description \
+A Fortran 90 program for converting fixed-format Fortran 77 code to \
+Fortran 90 free-format.  Other changes replace old Fortran constructs \
+with more modern ones. \
+\n \
+\nThe conversions made include: \
+\n1. Standard format (column 7-72) converted to free-format. \
+\n2. DO loops and IF blocks indented. \
+\n3. Most labels are removed from loops and replaced with END DO, CYCLE, \
+   EXIT, and DO-loop constructs where appropriate. \
+\n4. 3-way arithmetic IFs converted to IF .. THEN .. ELSE constructs. \
+\n5. TYPE and INTENT declarations inserted for all subroutine and \
+   function arguments. \
+\n6. Computed GOTOs converted to SELECT CASE constructs. \
+\n7. Embedded blanks are removed from numerical constants. They are \
+   illegal in free format.
+
+checksums   rmd160 d9b9526d16bc4a53f5f9e849711dc1c362f8ea09 \
+            sha256 8b8336c138bc00ac0b2b9d1cecfdb00271a2ee72403dd432c2563845675165d5 \
+            size   17687
+
+compilers.choose    f90
+compilers.setup     require_fortran
+use_configure       no
+
+build {
+    system -W ${worksrcpath} "${configure.f90} -fdiagnostics-color=auto -o to_f90 TO_F90.F90"
+}
+
+destroot {
+    xinstall -m 755 -W ${worksrcpath} to_f90     ${destroot}${prefix}/bin
+    xinstall -d                                  ${destroot}${prefix}/share/doc/to-f90
+    xinstall -m 644 -W ${worksrcpath} README.TXT ${destroot}${prefix}/share/doc/to-f90/README.TXT
+}
+
+livecheck.type  none


### PR DESCRIPTION
New port for to-f90, a Fortran 77 to Fortran 90 converter.

#### Description

a Fortran 77 to Fortran 90 converter

###### Type(s)

- [x] submission
- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15
Xcode 12.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
