### PR TITLE
gr-osmosdr: +docs variant requires six

### DIFF
--- a/science/gr-osmosdr/Portfile
+++ b/science/gr-osmosdr/Portfile
@@ -139,6 +139,11 @@ variant docs description "Install ${name} documentation" {
         port:doxygen \
         path:bin/dot:graphviz
 
+    if {${subport} eq "gr-osmosdr"} {
+        depends_build-append \
+            port:py${active_python_version_no_dot}-six
+    }
+
     configure.args-delete \
         -DDOXYGEN_DOT_EXECUTABLE= \
         -DDOXYGEN_EXECUTABLE=


### PR DESCRIPTION
See: https://trac.macports.org/ticket/61106#comment:7

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
Untested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
