### PR TITLE
vcsn: use compiler.cxx_standard 2011

### DIFF
--- a/devel/vcsn/Portfile
+++ b/devel/vcsn/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cxx11 1.1
 PortGroup           active_variants 1.1
 
 name                vcsn
@@ -25,6 +24,8 @@ use_xz              yes
 checksums           rmd160  bfa67e399a25473a2c449905c19464f4167dc2cf \
                     sha256  1fe0afa7a52d211143ef0f15632b777d1137706d66a2accb004447c33b53d1c2 \
                     size    14837372
+
+compiler.cxx_standard 2011
 
 # python3.x is required - force dependencies to use it as well
 set python_version  36


### PR DESCRIPTION
…instead of deprecated `cxx11 1.1` portgroup

#### Description


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~ <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
