### PR TITLE
nebula: don't fetch dependencies in build phase

### DIFF
--- a/net/nebula/Portfile
+++ b/net/nebula/Portfile
@@ -22,13 +22,206 @@ long_description    Nebula is a scalable overlay networking tool with a focus \
                     It can be used to connect a small number of computers, \
                     but is also able to connect tens of thousands of computers.
 
-checksums           rmd160  bb94926f060b4a6450723434f3e08486ca031fc7 \
-                    sha256  55985393100e3f1a3bd8e74c145ba1745af4aae5fae021c02cc7ede2fe1f061f \
-                    size    132873
+checksums           ${distname}${extract.suffix} \
+                        rmd160  bb94926f060b4a6450723434f3e08486ca031fc7 \
+                        sha256  55985393100e3f1a3bd8e74c145ba1745af4aae5fae021c02cc7ede2fe1f061f \
+                        size    132873
+
+go.vendors          gopkg.in/yaml.v3 \
+                        lock    9f266ea9e77c \
+                        rmd160  06dca2ede07b2f31c515b4711fbebc1d5359b5e4 \
+                        sha256  e70dd42fb30b7b2d0129c5cdf0e079caaf5602cab24081fdac830ec01204fa59 \
+                        size    86890 \
+                    gopkg.in/yaml.v2 \
+                        lock    v2.2.7 \
+                        rmd160  8a2eb51b49235820619e4703f557b266d5941645 \
+                        sha256  15d29283f38f1213445158c16dad11f84ab72aa0256af555c2392492315760ba \
+                        size    72665 \
+                    gopkg.in/check.v1 \
+                        lock    788fd7840127 \
+                        rmd160  b63165c8909a27edc15dda210df66a1b49efb49e \
+                        sha256  7e5547c6471cc48da89a7c87f965b20ca5311f43fc4d883ca62f9fccf7551630 \
+                        size    31597 \
+                    golang.org/x/sys \
+                        lock    ac6580df4449 \
+                        rmd160  15e879c655f411767a2c648a183b3fb963287c80 \
+                        sha256  c89cc8c29ef2cae42dc8debb6342a7de3d5d86a30f4dbdc1b2b55147dfb142de \
+                        size    1533171 \
+                    golang.org/x/sync \
+                        lock    cd5d95a43a6e \
+                        rmd160  8bef422550566dc5e53557a975560a4f0224e509 \
+                        sha256  0b7b3e06ee571c92736ea8f11b6d2d075ca6e75008f16e8653be49c33e2876a3 \
+                        size    16964 \
+                    golang.org/x/net \
+                        lock    c0dbc17a3553 \
+                        rmd160  48b6f5b26ecb95069c725a10502750e6b80f11d3 \
+                        sha256  551a4a9410c9a69eba624dd070b22128422550c1a98306012313be0e77bd023a \
+                        size    1171907 \
+                    golang.org/x/crypto \
+                        lock    bac4c82f6975 \
+                        rmd160  33b66b399f9890573a6a50f5acad1a2d1658bbaa \
+                        sha256  2d727af130cf127de0ff630f374de5054b67d4cc14bacbcc70ac0f6f2aa5d8f8 \
+                        size    1725219 \
+                    github.com/vishvananda/netns \
+                        lock    0a2b9b5464df \
+                        rmd160  5be871420e4acb8a7d78824d342648b8992c8d35 \
+                        sha256  95632c3b94742b88abf5ca895513569c21699747a9adaa30d0da752c1cf80f86 \
+                        size    8010 \
+                    github.com/vishvananda/netlink \
+                        lock    00009fb8606a \
+                        rmd160  8ba728fd47e91bc88627098801f35731aad2e431 \
+                        sha256  926a814771d4f1afa8d79ecbfe9b1681daacc54f66647d6894d2eacbee234998 \
+                        size    137963 \
+                    github.com/stretchr/testify \
+                        lock    v1.6.1 \
+                        rmd160  7e5b798212a8f15cd58a63985ae0b928eede8e6b \
+                        sha256  44d77d9b5c1dc08fa710eac9bb324898210660458085cdf965b78a39b1010f2a \
+                        size    84248 \
+                    github.com/songgao/water \
+                        lock    fd331bda3f4b \
+                        rmd160  b6ece32740af654d43febfe797082b6c8d41ea07 \
+                        sha256  64799f1dba1ebfef66e8cd1b907e3724d0ee9404666342dd69576754c7278bf3 \
+                        size    17094 \
+                    github.com/sirupsen/logrus \
+                        lock    v1.4.2 \
+                        rmd160  9245d7ebabf259e649892609e598a2284e89e499 \
+                        sha256  c3eaf49a2a03ce42b20b5db84771a7d447465475bf083f289ecee631063e6090 \
+                        size    41379 \
+                    github.com/rcrowley/go-metrics \
+                        lock    cac0b30c2563 \
+                        rmd160  10f565254cbcee6a0288d19fcda77964c6cc9689 \
+                        sha256  bd5e5564f6ef65bd7ac946d97cae11ac1b55071bc58109fdc1053a65d3cef544 \
+                        size    37564 \
+                    github.com/prometheus/procfs \
+                        lock    v0.0.8 \
+                        rmd160  74f5d4323c41843a0370ff97f4188c68dba528c1 \
+                        sha256  90e2fa6ee51f8897bbe408ef8281e9f52a3dd238e3c0fe2931ac419aa110ead5 \
+                        size    126342 \
+                    github.com/prometheus/common \
+                        lock    v0.7.0 \
+                        rmd160  71589422d9f6d26d1d28e631322077e19818e554 \
+                        sha256  95baf93244a8160dffe12d220a06c54bf209f7cf0bf1196c686623f3da570fed \
+                        size    100513 \
+                    github.com/prometheus/client_model \
+                        lock    d1d2010b5bee \
+                        rmd160  040c0e8cfa3963b485cd93e17d8845fdbe17e01a \
+                        sha256  cc2b9d8905a7ec305ddd5a7fcc057d936e5a43dee6740475f025d66ae8ea5b41 \
+                        size    10526 \
+                    github.com/prometheus/client_golang \
+                        lock    v1.2.1 \
+                        rmd160  fba18019de66807a9a4a9381f69eb2e7097a0ad0 \
+                        sha256  0bbb4b4c3e907fbcf9475b5ca957fd165e24fd5378751c121a00ea4e6a4da7ca \
+                        size    142483 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/nbrownus/go-metrics-prometheus \
+                        lock    6e6d5173d99c \
+                        rmd160  6325f976bb6e04ccef66171a5f075216acdde983 \
+                        sha256  349ffd6dedd1b3dad305d9258c612f8c646c0dc70110d34acac715c9268d4f69 \
+                        size    6541 \
+                    github.com/modern-go/reflect2 \
+                        lock    v1.0.1 \
+                        rmd160  5cdaa26d1ee453e37f3a26635aac40397e2f28fa \
+                        sha256  5bcbe1f4c0fa1d853c066a4e6f58eaa5d31ac370c97a3c87e99a6ffecf7b5a65 \
+                        size    14407 \
+                    github.com/modern-go/concurrent \
+                        lock    bacd9c7ef1dd \
+                        rmd160  b039328d6fd40b97513dea8bf5b00adfdd53f14b \
+                        sha256  2f3333805bef60544e64ac9a734522205b513f5c461ba19f3d557510bb205afb \
+                        size    7533 \
+                    github.com/miekg/dns \
+                        lock    v1.1.25 \
+                        rmd160  fed850fe45142a57c770b56b84b9e595d3558ce5 \
+                        sha256  686fc26de84b3e5420c76c0fb19add70594fd79061850baaa974d86a3eb1e163 \
+                        size    179434 \
+                    github.com/matttproud/golang_protobuf_extensions \
+                        lock    v1.0.1 \
+                        rmd160  e28c4169919e72c08ee6520ad2ce16943d18e40c \
+                        sha256  c40d4c38e7dc2a7bae57e3740bb28d463e173d82e4603622d04d01741ff7a083 \
+                        size    37197 \
+                    github.com/kr/text \
+                        lock    v0.1.0 \
+                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
+                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
+                        size    8691 \
+                    github.com/kr/pretty \
+                        lock    v0.1.0 \
+                        rmd160  9aa7a5aad4c48840eecfd0f80186d1fb5ded0fd6 \
+                        sha256  f6c3f89667c63e5b7f1fc6ee2c06b6a6bfdce88f3a965ccd395b64c6f95c9a47 \
+                        size    8553 \
+                    github.com/konsorten/go-windows-terminal-sequences \
+                        lock    v1.0.2 \
+                        rmd160  9b5e034c9a2fbbe2c4a3768d00d6337a8e06ab74 \
+                        sha256  0a29b8c0a24ace07e3280feb5ee7b71ddb965a894ace70d8c77c0a4f330a8dbb \
+                        size    1987 \
+                    github.com/kardianos/service \
+                        lock    v1.0.0 \
+                        rmd160  acbd9b07ce3652384b2bd61694d476c884c29582 \
+                        sha256  45a6ed85a8c19b83f2c2e4035a48cbff9835c3e52ad6aa854bed1eea293ab133 \
+                        size    19396 \
+                    github.com/imdario/mergo \
+                        lock    v0.3.8 \
+                        rmd160  553551b01c1d06739cb0036fb7539dffa3352d56 \
+                        sha256  500ea403f7d92826b97e50a4d30dd9a9bedaa2772b8b9e31c94de8e150725358 \
+                        size    18200 \
+                    github.com/google/go-cmp \
+                        lock    v0.3.1 \
+                        rmd160  66e42f672a5a40561c388b78b3644abd926e7bef \
+                        sha256  86ee7c90714e7eb5c60d1a8a515235daef806df454c767043b593540e958167f \
+                        size    76416 \
+                    github.com/golang/protobuf \
+                        lock    v1.3.2 \
+                        rmd160  c22496279cf6fc64781561cd1b5fef34e0ea61b8 \
+                        sha256  e467fab2ce26db4265fa0695b13d07fe825391023f7a02d5945a0f0b0913abe7 \
+                        size    312331 \
+                    github.com/flynn/noise \
+                        lock    2492fe189ae6 \
+                        rmd160  d97f12933a3495bf2036367c07de2960c6eddd4d \
+                        sha256  a1cd4a08313ef3abf4d66ee7dc1cba3ff5e2eda43872e1980f9fa695c89859c7 \
+                        size    208627 \
+                    github.com/flynn/go-shlex \
+                        lock    3f9db97f8568 \
+                        rmd160  ec42eaffe2cf17a46e12c7c2a7d436c0f68ba655 \
+                        sha256  b4205ec400df652238f7ed287c4b77b5f17a17d5793cd5371b7cc5e0f07dfeed \
+                        size    7690 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/cyberdelia/go-metrics-graphite \
+                        lock    39f87cc3b432 \
+                        rmd160  d4f9888305a6523b25e5aa25991f40ac034279c9 \
+                        sha256  44940317350bdc0d6a7e44b8d7071f581e67ac63fd38b7d08b6a84656faa12c9 \
+                        size    3915 \
+                    github.com/cespare/xxhash \
+                        lock    v2.1.1 \
+                        rmd160  0c0da0840864215209db2afcd2ee92a52ca2d4d1 \
+                        sha256  7416baf9eeefe07e3c50c57826d839cdbba125ea0a6d74af378e865df4f25e00 \
+                        size    9300 \
+                    github.com/beorn7/perks \
+                        lock    v1.0.1 \
+                        rmd160  c6c5c7fd2132f01925c7fccd9d27c9d7a80f2adb \
+                        sha256  78da4421e9f9fa2ee5e3855bdd31cfb04c7e823d9c0ec385cc2c008132d98b96 \
+                        size    10874 \
+                    github.com/armon/go-radix \
+                        lock    v1.0.0 \
+                        rmd160  fbaf4605ffc4654bdd5b8a3b60d7f2b65333d1b3 \
+                        sha256  f9a27dc2a25030e5a6a5334dd82697e0494e5719ec4cfdc59b6ba903f99c9400 \
+                        size    5982 \
+                    github.com/anmitsu/go-shlex \
+                        lock    648efa622239 \
+                        rmd160  2cd39571128de9ea259f8ebafc292db77bfbc33e \
+                        sha256  ce0cf5fc33466e610f1605683f2e2bcb1e8212cece926074095a80f1326ed15f \
+                        size    3862
 
 build.env-append    BUILD_NUMBER="${version}"
 build.cmd           make
 build.target        bin-darwin
+build.post_args     GO111MODULE=off
 
 use_parallel_build  no
 installs_libs       no


### PR DESCRIPTION
#### Description

Per https://trac.macports.org/ticket/61192 this is one of the golang ports that automatically downloads its dependencies at build time.

To fix it, I used `go2port`. Unexpected tricky parts:

- The project's Makefile explicitly enables `GO111MODULE` so I had to explicitly disable it in `build.post_args`

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->