### PR TITLE
Disable build-time dependency fetching in golang-1.0 portgroup

### DIFF
--- a/_resources/port1.0/group/golang-1.0.tcl
+++ b/_resources/port1.0/group/golang-1.0.tcl
@@ -148,12 +148,12 @@ default worksrcdir      {gopath/src/${go.package}}
 default build.cmd   {${go.bin} build}
 default build.args      ""
 default build.target    ""
-default build.env   {GOPATH=${gopath} GOARCH=${goarch} GOOS=${goos} CC=${configure.cc}}
+default build.env   {GOPATH=${gopath} GOARCH=${goarch} GOOS=${goos} CC=${configure.cc} GOPROXY=off GO111MODULE=off}
 
 default test.cmd    {${go.bin} test}
 default test.args       ""
 default test.target     ""
-default test.env    {GOPATH=${gopath} GOARCH=${goarch} GOOS=${goos} CC=${configure.cc}}
+default test.env    {GOPATH=${gopath} GOARCH=${goarch} GOOS=${goos} CC=${configure.cc} GOPROXY=off GO111MODULE=off}
 
 # go.vendors name1 ver1 name2 ver2...
 # When a go.sum, Gopkg.lock, glide.lock, etc. is present use go2port to generate values

--- a/databases/octosql/Portfile
+++ b/databases/octosql/Portfile
@@ -31,9 +31,6 @@ long_description    {*}${description} OctoSQL is a SQL query engine which \
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-build.env-append    GO111MODULE=off \
-                    GOPROXY=off
-
 build.pre_args      -ldflags \"-X main.version=${version}\"
 build.args          ./cmd/octosql
 

--- a/devel/copilot/Portfile
+++ b/devel/copilot/Portfile
@@ -37,6 +37,11 @@ build.pre_args      VERSION=${version}
 build.args          release
 use_parallel_build  no
 
+# FIXME: This port currently can't be built without allowing go mod to fetch
+# dependencies during the build phase. See
+# https://trac.macports.org/ticket/61192
+build.env-delete    GOPROXY=off GO111MODULE=off
+
 patch {
     # Remove Windows and Linux builds for the release target
     reinplace -E {/^release:/ s/compile-(linux|windows)[[:space:]]+//g} \

--- a/devel/evans/Portfile
+++ b/devel/evans/Portfile
@@ -498,9 +498,6 @@ go.vendors          github.com/pkg/term \
                         sha256  d14937aa235e66156aab75b2c27085d360d95244214ccfb843cfff771f372317 \
                         size    46167
 
-build.env-append    GOPROXY=off \
-                    GO111MODULE=off
-
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
 }

--- a/devel/gitqlite/Portfile
+++ b/devel/gitqlite/Portfile
@@ -262,8 +262,6 @@ go.vendors          github.com/spf13/afero \
 
 build.cmd           make
 build.target        build
-build.env-append    GO111MODULE=off \
-                    GOPROXY=off
 
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/

--- a/devel/go-migrate/Portfile
+++ b/devel/go-migrate/Portfile
@@ -30,6 +30,11 @@ build.cmd           make
 build.pre_args      VERSION=${version}
 build.args          build-cli
 
+# FIXME: This port currently can't be built without allowing go mod to fetch
+# dependencies during the build phase. See
+# https://trac.macports.org/ticket/61192
+build.env-delete    GOPROXY=off GO111MODULE=off
+
 post-extract {
     # Comment out builds for non-Darwin platforms
     reinplace -E "s/(\s*)(.*GOOS=\[^d\]\[^a\]\[^r\]\[^w\])/\\1#\\2/g" Makefile

--- a/devel/golangci-lint/Portfile
+++ b/devel/golangci-lint/Portfile
@@ -25,6 +25,11 @@ checksums           rmd160  141616b6e6b3efef6ded3a61e55cdc5aacf5ef6d \
 
 build.args          ./cmd/golangci-lint
 
+# FIXME: This port currently can't be built without allowing go mod to fetch
+# dependencies during the build phase. See
+# https://trac.macports.org/ticket/61192
+build.env-delete    GOPROXY=off GO111MODULE=off
+
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}
 }

--- a/devel/gopls/Portfile
+++ b/devel/gopls/Portfile
@@ -91,7 +91,6 @@ post-extract {
     move ${gopath}/src/github.com/dominikh/go-tools ${gopath}/src/honnef.co/go/tools
 }
 
-build.env-append    GO111MODULE=off
 build.dir           ${worksrcpath}/${name}
 
 destroot {

--- a/devel/gore/Portfile
+++ b/devel/gore/Portfile
@@ -21,9 +21,6 @@ long_description    gore is a Go REPL featuring line editing with history, \
                     multi-line input, package importing with completion, \
                     auto-importing (gore -autoimport) and more.
 
-build.env-append    GO111MODULE=off \
-                    GOPROXY=off
-
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
 }

--- a/devel/grpcurl/Portfile
+++ b/devel/grpcurl/Portfile
@@ -32,6 +32,11 @@ build.pre_args      -ldflags \"-X 'main.version=${version}'\"
 build.args          ./cmd/grpcurl
 installs_libs       no
 
+# FIXME: This port currently can't be built without allowing go mod to fetch
+# dependencies during the build phase. See
+# https://trac.macports.org/ticket/61192
+build.env-delete    GOPROXY=off GO111MODULE=off
+
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
 }

--- a/devel/jenkins-cli/Portfile
+++ b/devel/jenkins-cli/Portfile
@@ -490,9 +490,6 @@ go.vendors          github.com/google/go-querystring \
                         sha256  9c1076f5a8e923d028cb65c36143f3b1478cbaa4420e2e8f332719edc2fc4f71 \
                         size    20992
 
-build.env-append    GOPROXY=off \
-                    GO111MODULE=off
-
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/jcli
 }

--- a/devel/kustomize/Portfile
+++ b/devel/kustomize/Portfile
@@ -37,6 +37,11 @@ build.args          -ldflags \" \
                         -X sigs.k8s.io/kustomize/api/provenance.buildDate=unknown \
                     \"
 
+# FIXME: This port currently can't be built without allowing go mod to fetch
+# dependencies during the build phase. See
+# https://trac.macports.org/ticket/61192
+build.env-delete    GOPROXY=off GO111MODULE=off
+
 destroot {
     xinstall -m 0755 ${build.dir}/${name} ${destroot}${prefix}/bin/
 }

--- a/devel/lazygit/Portfile
+++ b/devel/lazygit/Portfile
@@ -17,10 +17,6 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 
 set build_date      [exec date +%FT%T%z]
 
-# Disable downloading any dependencies from the Internet
-build.env-append    GO111MODULE=off \
-                    GOPROXY=off
-
 # lazygit's dependencies are already vendored in the source code
 build.args          -ldflags \
                       '-X main.date=${build_date} \

--- a/devel/newreleases/Portfile
+++ b/devel/newreleases/Portfile
@@ -21,9 +21,6 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 build.pre_args      -v -o ./nr
 build.args          ./${name}
 
-build.env-append    GOPROXY=off \
-                    GO111MODULE=off
-
 checksums           ${distname}${extract.suffix} \
                         rmd160  ca8056e7e9cad27605f79741b0f6a3ac1030ca2c \
                         sha256  655caf72c513038dbf2c52e80d06c4fba5da6bf7aa9f3abb5ee517cedf9d0586 \

--- a/devel/qri/Portfile
+++ b/devel/qri/Portfile
@@ -30,6 +30,11 @@ checksums           rmd160  eec70d924b38a157526998bc92c9463f6f713163 \
 build.cmd           make
 build.target        build
 
+# FIXME: This port currently can't be built without allowing go mod to fetch
+# dependencies during the build phase. See
+# https://trac.macports.org/ticket/61192
+build.env-delete    GOPROXY=off GO111MODULE=off
+
 installs_libs       no
 
 destroot {

--- a/devel/shfmt/Portfile
+++ b/devel/shfmt/Portfile
@@ -126,9 +126,6 @@ go.vendors          github.com/creack/pty \
                         sha256  ff6d5f23da7cfd2d9afaa6f139365cd6d2a52f56ffc4a44e727bc9096c959744 \
                         size    9311
 
-# Disable "module mode" on modular project to get the compiler to look for
-# locally downloaded dependencies
-build.env-append    GO111MODULE=off
 build.pre_args      -ldflags '-X main.version=${version}'
 build.post_args     ${go.package}/cmd/shfmt
 

--- a/devel/staticcheck/Portfile
+++ b/devel/staticcheck/Portfile
@@ -35,9 +35,7 @@ installs_libs       no
 
 go.package          honnef.co/go/tools
 
-build.env-append    CGO_ENABLED=0 \
-                    GOPROXY=off \
-                    GO111MODULE=off
+build.env-append    CGO_ENABLED=0
 
 set _build_path     ${worksrcpath}/build
 
@@ -117,4 +115,3 @@ go.vendors          golang.org/x/xerrors \
                         rmd160  fb9650e2d16525153645e5547626f242f3800149 \
                         sha256  8cc9e5dc68e247554227973d0b4e023b27bbd9ba5a26e4fb40f44743afcb35f1 \
                         size    42087
-

--- a/devel/tektoncd-cli/Portfile
+++ b/devel/tektoncd-cli/Portfile
@@ -38,6 +38,7 @@ patchfiles          patch-Makefile.diff
 # Do not fetch dependencies from the Internet, as tektoncd-cli already vendors
 # its dependencies in its source
 build.env-append    GOPROXY=off
+build.env-delete    GO111MODULE=off
 
 build.cmd           make
 build.pre_args      RELEASE_VERSION=${version}

--- a/devel/tektoncd-cli/Portfile
+++ b/devel/tektoncd-cli/Portfile
@@ -35,9 +35,6 @@ if {${build_arch} eq "x86_64"} {
 
 patchfiles          patch-Makefile.diff
 
-# Do not fetch dependencies from the Internet, as tektoncd-cli already vendors
-# its dependencies in its source
-build.env-append    GOPROXY=off
 build.env-delete    GO111MODULE=off
 
 build.cmd           make

--- a/devel/webify/Portfile
+++ b/devel/webify/Portfile
@@ -30,9 +30,6 @@ go.vendors          github.com/mattn/go-shellwords \
                         sha256  69fa12881cbb765af4777d04832d935c705415648f524065d17ba38da3374377 \
                         size    14429 \
 
-build.env-append    GO111MODULE=off \
-                    GOPROXY=off
-
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
 }

--- a/devel/yaegi/Portfile
+++ b/devel/yaegi/Portfile
@@ -28,9 +28,6 @@ checksums           rmd160  d4d62875436c38304da34064ed1ddbec032e1abe \
                     sha256  f82a9bffcd2384ecf6e80e36b9f49364ef4b4b987ebd597d509eb15b43a9888b \
                     size    1958471
 
-build.env-append    GO111MODULE=off \
-                    GOPROXY=off
-
 build.target        ./cmd/yaegi
 
 github.tarball_from archive

--- a/editors/micro/Portfile
+++ b/editors/micro/Portfile
@@ -29,8 +29,6 @@ installs_libs       no
 build.cmd           make
 build.target        build
 build.args          HASH=unknown VERSION=${version}
-build.env-append    GO111MODULE=off \
-                    GOPROXY=off
 
 post-extract {
     reinplace "s|^HASH =|HASH ?=|" ${worksrcpath}/Makefile
@@ -220,4 +218,3 @@ go.vendors          github.com/kr/text \
                         rmd160  3b9523084f6a8b2e6a6987e49c56f05e22ad69eb \
                         sha256  d624899dfd390d9d4a77e5c8e5abd8c45f0b6163e0dc7176aee39f25c5f1bed0 \
                         size    7168458
-

--- a/net/annie/Portfile
+++ b/net/annie/Portfile
@@ -148,9 +148,6 @@ post-extract {
     ln -s ${gopath}/src/github.com/mihaiav/ytdl ${gopath}/src/github.com/rylio/ytdl
 }
 
-build.env-append    GO111MODULE=off \
-                    GOPROXY=off
-
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin
 

--- a/net/cloudflared/Portfile
+++ b/net/cloudflared/Portfile
@@ -410,8 +410,6 @@ go.vendors          zombiezen.com/go/capnproto2 \
 
 set time [clock format [clock seconds] -format "%Y-%m-%d-%H%M %Z"]
 build.args-append   -ldflags=\"-X 'main.Version=${version}' -X 'main.BuildTime=${time}'\" -o ./cloudflared ./cmd/cloudflared
-build.env-append    GOPROXY=off \
-                    GO111MODULE=off
 
 post-patch {
     reinplace "s|\"/etc/cloudflared\", DefaultUnixConfigLocation|\"/etc/cloudflared\", \"${prefix}/etc/cloudflared\", DefaultUnixConfigLocation|" ${gopath}/src/github.com/cloudflare/cloudflared/cmd/cloudflared/config/configuration.go

--- a/net/croc/Portfile
+++ b/net/croc/Portfile
@@ -29,9 +29,6 @@ long_description    croc is a tool that allows any two computers to simply \
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-build.env-append    GO111MODULE=off \
-                    GOPROXY=off
-
 installs_libs       no
 
 destroot {
@@ -211,4 +208,3 @@ go.vendors          gopkg.in/yaml.v2 \
                         rmd160  3c96a52c71fdb92be0a3d8218e87715ff7917ac9 \
                         sha256  73a661bc7a6d5bc8f0340faaa668725238453c83478bd39a10ef7cab934d10b0 \
                         size    14120
-

--- a/net/ec2-ls-hosts/Portfile
+++ b/net/ec2-ls-hosts/Portfile
@@ -88,9 +88,6 @@ go.vendors          github.com/aws/aws-sdk-go \
                         sha256  da1e31b7beb9a6907947caa794134bdc2501d1a3474568b61cc2562a398d3d87 \
                         size    70676
 
-# Disable "module mode" on modular project to get the compiler to look for
-# locally downloaded dependencies
-build.env-append    GO111MODULE=off
 build.cmd           make
 build.target        build
 build.args-append   VERSION=${version}

--- a/net/fargate-cli/Portfile
+++ b/net/fargate-cli/Portfile
@@ -24,9 +24,6 @@ license             Apache-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-build.env-append    GO111MODULE=off \
-                    GOPROXY=off
-
 build.cmd           make
 build.target        build
 

--- a/net/ipfs/Portfile
+++ b/net/ipfs/Portfile
@@ -22,10 +22,13 @@ long_description    IPFS is a global, versioned, peer-to-peer filesystem. \
                     exchanging git objects. IPFS provides an interface as \
                     simple as the HTTP web, but with permanence built in.
 
-depends_build       port:go
-
 build.cmd           make
 build.target        build
+
+# FIXME: This port currently can't be built without allowing go mod to fetch
+# dependencies during the build phase. See
+# https://trac.macports.org/ticket/61192
+build.env-delete    GOPROXY=off GO111MODULE=off
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/cmd/ipfs/ipfs ${destroot}${prefix}/bin

--- a/net/mole/Portfile
+++ b/net/mole/Portfile
@@ -19,9 +19,6 @@ patchfiles          patch-Makefile.diff
 build.cmd           make
 build.args          version=${version}
 build.target        bin
-build.env-append    GOPROXY=off \
-                    GO111MODULE=off
-
 
 checksums           ${distname}${extract.suffix} \
                         rmd160  f3c6d6cdd01f9455f61ef96dce919ae951f53fc5 \

--- a/net/rclone/Portfile
+++ b/net/rclone/Portfile
@@ -22,6 +22,11 @@ checksums \
 
 platforms           darwin
 
+# FIXME: This port currently can't be built without allowing go mod to fetch
+# dependencies during the build phase. See
+# https://trac.macports.org/ticket/61192
+build.env-delete    GOPROXY=off GO111MODULE=off
+
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
 

--- a/net/syncthing/Portfile
+++ b/net/syncthing/Portfile
@@ -499,14 +499,10 @@ build.cmd           ${go.bin} run build.go
 build.target        install syncthing
 build.pre_args      -version v${version} -no-upgrade
 build.post_args     ${build.target}
-build.env-append    GO111MODULE=off \
-                    GOPROXY=off
 
 test.run            yes
 test.cmd            ${build.cmd}
 test.target         test
-test.env-append     GO111MODULE=off \
-                    GOPROXY=off
 
 destroot {
     xinstall -W ${worksrcpath}/bin syncthing ${destroot}${prefix}/bin

--- a/net/trojan-go/Portfile
+++ b/net/trojan-go/Portfile
@@ -229,7 +229,7 @@ go.vendors          gopkg.in/yaml.v3 \
                         size    1530
 # Notes for updating this port:
 # Replace go.googlesource.com/protobuf with github.com/protocolbuffers/protobuf-go
-# github.com/riobard/go-bloom needs to be manually added, see 
+# github.com/riobard/go-bloom needs to be manually added, see
 # https://github.com/shadowsocks/go-shadowsocks2/blob/master/go.mod with correct version for required bloom version
 # Remember to update git commit hash
 
@@ -239,9 +239,7 @@ post-extract {
     ln -s ${gopath}/src/github.com/v2ray/v2ray-core ${gopath}/src/v2ray.com/core
 }
 
-build.env-append    CGO_ENABLED=0 \
-                    GO111MODULE=off \
-                    GOPROXY=off
+build.env-append    CGO_ENABLED=0
 
 build.post_args     -tags \"full\" -ldflags=\"-s -w -X 'github.com/p4gefau1t/trojan-go/constant.Version=v${version}' -X 'github.com/p4gefau1t/trojan-go/constant.Commit=${git-commit}'\"
 

--- a/net/v2ray/Portfile
+++ b/net/v2ray/Portfile
@@ -127,9 +127,7 @@ go.vendors          google.golang.org/protobuf \
 # Notes for updating this port:
 # Replace go.googlesource.com/protobuf with github.com/protocolbuffers/protobuf-go
 
-build.env-append    CGO_ENABLED=0 \
-                    GO111MODULE=off \
-                    GOPROXY=off
+build.env-append    CGO_ENABLED=0
 build.post_args     -ldflags '-s -w'
 
 build {

--- a/net/vegeta/Portfile
+++ b/net/vegeta/Portfile
@@ -155,9 +155,7 @@ set go_ldflags      "-s -w -extldflags -static \
     -X main.Version=${version} \
     -X main.Commit=unknown \
     -X main.Date=unknown"
-build.env-append    CGO_ENABLED=0 \
-                    GO111MODULE=off \
-                    GOPROXY=off
+build.env-append    CGO_ENABLED=0
 build.args          -ldflags \"${go_ldflags}\" ${go.package}
 
 destroot {

--- a/office/ultralist/Portfile
+++ b/office/ultralist/Portfile
@@ -22,9 +22,6 @@ installs_libs       no
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-build.env-append    GO111MODULE=off \
-                    GOPROXY=off
-
 build.args-append   -o ${workpath}/${name}
 
 destroot {

--- a/security/aws-vault/Portfile
+++ b/security/aws-vault/Portfile
@@ -25,9 +25,6 @@ license             MIT
 platforms           darwin
 installs_libs       no
 
-build.env-append    GO111MODULE=off \
-                    GOPROXY=off
-
 build.cmd           make
 build.pre_args      VERSION=${version}
 build.args          aws-vault-darwin-amd64

--- a/security/trivy/Portfile
+++ b/security/trivy/Portfile
@@ -29,6 +29,11 @@ build.cmd           make
 build.args          VERSION=${version}
 build.target        build
 
+# FIXME: This port currently can't be built without allowing go mod to fetch
+# dependencies during the build phase. See
+# https://trac.macports.org/ticket/61192
+build.env-delete    GOPROXY=off GO111MODULE=off
+
 installs_libs       no
 
 destroot {

--- a/shells/elvish/Portfile
+++ b/shells/elvish/Portfile
@@ -23,9 +23,6 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 
 installs_libs       no
 
-build.env-append    GO111MODULE=off \
-                    GOPROXY=off
-
 build.cmd           make
 build.args          VERSION=${version}
 build.target        get

--- a/sysutils/certigo/Portfile
+++ b/sysutils/certigo/Portfile
@@ -147,9 +147,6 @@ go.vendors          github.com/davecgh/go-spew \
                         sha256  e80eb3ee16d44676befb5b8044459492f73e6f153ad3f28b13949c9f9cfaf558 \
                         size    109497
 
-build.env-append    GO111MODULE=off \
-                    GOPROXY=off
-
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
 }

--- a/sysutils/chezmoi/Portfile
+++ b/sysutils/chezmoi/Portfile
@@ -21,8 +21,6 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 build.args          -ldflags \"-X main.version=${version} -X main.builtBy=macports\"
-build.env-append    GOPROXY=off \
-                    GO111MODULE=off
 
 set cm_doc_dir      ${prefix}/share/doc/${name}
 

--- a/sysutils/cloudmonkey/Portfile
+++ b/sysutils/cloudmonkey/Portfile
@@ -139,8 +139,6 @@ post-extract {
 build.cmd           make
 build.target        all
 build.args          VERSION=${version} GIT_SHA=unknown V=1
-build.env-append    GOPROXY=off \
-                    GO111MODULE=off
 
 installs_libs       no
 

--- a/sysutils/duf/Portfile
+++ b/sysutils/duf/Portfile
@@ -17,9 +17,6 @@ destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
 }
 
-build.env-append    GO111MODULE=off \
-                    GOPROXY=off
-
 build.args-append   -ldflags \"-X 'main.Version=${version}'\"
 
 checksums           ${distname}${extract.suffix} \

--- a/sysutils/fzf/Portfile
+++ b/sysutils/fzf/Portfile
@@ -84,9 +84,6 @@ go.vendors          golang.org/x/net \
                         sha256  03d811c26b803853f4e7971a7efc812765a5aace626fde7fe577d432cdd566f2 \
                         size    2289348
 
-build.env-append    GO111MODULE=off \
-                    GOPROXY=off
-
 destroot {
     # install fzf
     xinstall -d ${destroot}${prefix}/bin

--- a/sysutils/go2port/Portfile
+++ b/sysutils/go2port/Portfile
@@ -80,8 +80,6 @@ go.vendors          github.com/urfave/cli \
                         size    52040
 
 build.args          -ldflags "'-X main.version=${version}'"
-build.env-append    GO111MODULE=off \
-                    GOPROXY=off
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin

--- a/sysutils/gotop/Portfile
+++ b/sysutils/gotop/Portfile
@@ -140,8 +140,6 @@ go.vendors          github.com/davecgh/go-spew \
 
 set time [clock format [clock seconds] -format %Y%m%dT%H%M%S]
 build.args-append   -ldflags=\"-X 'main.Version=v${version}' -X 'main.BuildDate=${time}'\" -o ./gotop ./cmd/gotop
-build.env-append    GOPROXY=off \
-                    GO111MODULE=off
 
 destroot {
     xinstall -m 755 ${worksrcpath}/gotop ${destroot}${prefix}/bin

--- a/sysutils/infracost/Portfile
+++ b/sysutils/infracost/Portfile
@@ -23,11 +23,6 @@ long_description    Infracost shows hourly and monthly cost estimates for a \
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-# Set GO111MODULE=off to force the usage of the dependencies being provided by
-# go.vendors.
-build.env-append    GO111MODULE=off \
-                    GOPROXY=off
-
 build.cmd           make
 build.pre_args      VERSION=${version}
 build.args          darwin

--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -30,6 +30,11 @@ set go_ldflags      "-w -X ${go.package}/cmd.version=${version} \
     -X ${go.package}/cmd.date=unknown"
 build.args          -ldflags \"${go_ldflags}\" ${go.package}
 
+# FIXME: This port currently can't be built without allowing go mod to fetch
+# dependencies during the build phase. See
+# https://trac.macports.org/ticket/61192
+build.env-delete    GOPROXY=off GO111MODULE=off
+
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
 }

--- a/sysutils/krew/Portfile
+++ b/sysutils/krew/Portfile
@@ -187,8 +187,6 @@ go.vendors          github.com/kr/pretty \
                         size    8525
 
 build.target        ./cmd/krew
-build.env-append    GO111MODULE=off \
-                    GOPROXY=off
 
 destroot {
     xinstall -m 755 ${worksrcpath}/krew ${destroot}${prefix}/bin/

--- a/sysutils/kubergrunt/Portfile
+++ b/sysutils/kubergrunt/Portfile
@@ -34,6 +34,11 @@ checksums           rmd160  044a74637610de6df7dd4a4f5f76487a14c43087 \
 build.pre_args      -v -o ${worksrcpath}/${name}
 build.args          ./cmd
 
+# FIXME: This port currently can't be built without allowing go mod to fetch
+# dependencies during the build phase. See
+# https://trac.macports.org/ticket/61192
+build.env-delete    GOPROXY=off GO111MODULE=off
+
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
 }

--- a/sysutils/leaf/Portfile
+++ b/sysutils/leaf/Portfile
@@ -18,9 +18,6 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-build.env-append    GO111MODULE=off \
-                    GOPROXY=off
-
 build.cmd           make
 build.target        build
 

--- a/sysutils/pulumi/Portfile
+++ b/sysutils/pulumi/Portfile
@@ -37,6 +37,11 @@ build.pre_args      VERSION="${github.tag_prefix}${version}"
 # and not the SDKs
 build.args          brew
 
+# FIXME: This port currently can't be built without allowing go mod to fetch
+# dependencies during the build phase. See
+# https://trac.macports.org/ticket/61192
+build.env-delete    GOPROXY=off GO111MODULE=off
+
 destroot {
     xinstall -m 755 {*}[glob ${gopath}/bin/pulumi*] ${destroot}${prefix}/bin/
 }

--- a/sysutils/qrcp/Portfile
+++ b/sysutils/qrcp/Portfile
@@ -128,11 +128,6 @@ go.vendors          gopkg.in/cheggaaa/pb.v1 \
                         sha256  b5b2683d6b0bb1e516dcba00393f10c198496309575d299a4a996a61207e839d \
                         size    57033
 
-# Force-disable module support and disallow network access by setting
-# GOPROXY=off to force go to use the vendored dependencies
-build.env-append    GO111MODULE=off \
-                    GOPROXY=off
-
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
 }

--- a/sysutils/terragrunt/Portfile
+++ b/sysutils/terragrunt/Portfile
@@ -30,6 +30,11 @@ post-patch {
 
 depends_run         port:terraform-0.12
 
+# FIXME: This port currently can't be built without allowing go mod to fetch
+# dependencies during the build phase. See
+# https://trac.macports.org/ticket/61192
+build.env-delete    GOPROXY=off GO111MODULE=off
+
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
 }

--- a/sysutils/up/Portfile
+++ b/sysutils/up/Portfile
@@ -24,9 +24,6 @@ categories          sysutils
 license             Apache-2
 installs_libs       no
 
-build.env-append    GOPROXY=off \
-                    GO111MODULE=off
-
 checksums           ${distname}${extract.suffix} \
                         rmd160  b2da5077d2c5de8c8bccf48a45462e9153fa3865 \
                         sha256  9f1a61aaeef293694745bf11237bcf8f2866169e038f585f1a477e957bf7a1e2 \

--- a/sysutils/wtfutil/Portfile
+++ b/sysutils/wtfutil/Portfile
@@ -27,6 +27,11 @@ set build_date      [exec date +%FT%T%z]
 build.args          -o ${name} -ldflags \
                         '-X main.version=${version} -X main.date=${build_date}'
 
+# FIXME: This port currently can't be built without allowing go mod to fetch
+# dependencies during the build phase. See
+# https://trac.macports.org/ticket/61192
+build.env-delete    GOPROXY=off GO111MODULE=off
+
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}
     xinstall -d -m 0755 ${destroot}${prefix}/share/${name}

--- a/textproc/dashing/Portfile
+++ b/textproc/dashing/Portfile
@@ -60,9 +60,6 @@ go.vendors          github.com/andybalholm/cascadia \
                         sha256  9f355d0eeabdbd1d61fd22a7d0dc687faf1c4f636c5230d4e152d70e4ea2cd63 \
                         size    1173168
 
-# Disable "module mode" on modular project to get the compiler to look for
-# locally downloaded dependencies
-build.env-append    GO111MODULE=off
 build.cmd           make
 build.target        build
 build.args          VERSION=${version}

--- a/textproc/glow/Portfile
+++ b/textproc/glow/Portfile
@@ -16,8 +16,6 @@ categories          textproc
 license             MIT
 installs_libs       no
 
-build.env-append    GO111MODULE=off \
-                    GOPROXY=off
 build.args-append   -ldflags=\"-X 'main.Version=${version}'\"
 
 destroot {
@@ -279,4 +277,3 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  5d141a90e1e313657b558c19d51c3bdd65b0e5e5 \
                         sha256  8c445be2c7daa6b680bfbf96823192076bbf9c0f514642687d6487fd95630a5e \
                         size    71075
-

--- a/textproc/uni/Portfile
+++ b/textproc/uni/Portfile
@@ -18,9 +18,6 @@ long_description    Query the Unicode database from the commandline, with \
                     surprisingly large amount of emoji pickers don't deal \
                     with emoji sequences very well).
 
-build.env-append    GOPROXY=off \
-                    GO111MODULE=off
-
 go.package          arp242.net/uni
 
 checksums           ${distname}${extract.suffix} \

--- a/textproc/yq/Portfile
+++ b/textproc/yq/Portfile
@@ -21,9 +21,6 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 
 installs_libs       no
 
-build.env-append    GOPROXY=off \
-                    GO111MODULE=off
-
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
 }
@@ -123,4 +120,3 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  1d8418b4f1b3cb597f680b93aaa08afcc9651be4 \
                         sha256  577c8e778833fec90d76918f138cee9f7765435757b7c92a669e5b34933e0b4f \
                         size    1231337
-

--- a/www/doctl/Portfile
+++ b/www/doctl/Portfile
@@ -33,8 +33,9 @@ append ld_flags     " ${base_flag}.Patch=${doctl_patch}"
 build.cmd-append    " -ldflags \"${ld_flags}\""
 build.cmd-append    " -o ${name}"
 
-build.env-append    GO111MODULE=on
-build.env-append    CGO_ENABLED=0
+build.env-delete    GO111MODULE=off
+build.env-append    GO111MODULE=on \
+                    CGO_ENABLED=0
 
 build.target        ${worksrcpath}/cmd/${name}/main.go
 

--- a/www/hey/Portfile
+++ b/www/hey/Portfile
@@ -20,9 +20,6 @@ long_description    {*}${description} HTTP load generator, ApacheBench (ab) \
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-build.env-append    GO111MODULE=off \
-                    GOPROXY=off
-
 build.cmd           make
 build.target        release
 

--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -18,6 +18,11 @@ long_description    ${description}
 
 build.env-append    GO111MODULE=on
 
+# FIXME: This port currently can't be built without allowing go mod to fetch
+# dependencies during the build phase. See
+# https://trac.macports.org/ticket/61192
+build.env-delete    GOPROXY=off GO111MODULE=off
+
 destroot {
     xinstall -d ${destroot}${prefix}/bin
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}


### PR DESCRIPTION
#### Description

With the (relatively) new go modules system, go by default will fetch dependencies at build time. This PR disables such dynamic fetching by setting appropriate envars for the build and test phases. Previously this was being done on a port-by-port basis.

There is tooling (go2port) to help generate the appropriate markup to fetch dependencies with the `go.vendors` mechanism in the golang-1.0 portgroup, and this has been used to fix most ports that were downloading at build time (see https://trac.macports.org/ticket/61192). However some of the ports exercise parts of the build system that are harder to support in this fashion, so this PR grandfathers them in to the old behavior of allowing build-time dependency fetching.

I tested the changes in this PR by destrooting every port that uses the golang-1.0 portgroup.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2  
Xcode 12.0.1 12A7300

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
