### PR TITLE
pdfgrep: use compiler.cxx_standard 2011

### DIFF
--- a/textproc/pdfgrep/Portfile
+++ b/textproc/pdfgrep/Portfile
@@ -1,5 +1,4 @@
 PortSystem          1.0
-PortGroup           cxx11 1.1
 
 name                pdfgrep
 version             2.1.1
@@ -19,6 +18,8 @@ master_sites        https://pdfgrep.org/download/
 checksums           rmd160  ef5df881b370e0342f33f9775cb156adb796027d \
                     sha256  2c8155f30fe5d9d8ec4340e48133ed0b241496bbebe29498931f975c67a10c0b \
                     size    196526
+
+compiler.cxx_standard 2011
 
 depends_build       port:pkgconfig
 depends_lib         port:poppler \


### PR DESCRIPTION
…instead of deprecated cxx11 1.1 portgroup

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
