### PR TITLE
gnome-sudoku: use compiler.cxx_standard 2011

### DIFF
--- a/gnome/gnome-sudoku/Portfile
+++ b/gnome/gnome-sudoku/Portfile
@@ -3,8 +3,7 @@
 PortSystem          1.0
 
 # as of version 3.21.4 requires C++11 to build
-
-PortGroup           cxx11 1.1
+compiler.cxx_standard 2011
 
 name                gnome-sudoku
 version             3.26.0


### PR DESCRIPTION
…instead of deprecated `cxx11 1.1` portgroup

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
