### PR TITLE
libpagemaker: cleanup compilers

### DIFF
--- a/graphics/libpagemaker/Portfile
+++ b/graphics/libpagemaker/Portfile
@@ -2,9 +2,6 @@
 
 PortSystem          1.0
 
-# requires support for C++11
-PortGroup           cxx11 1.1
-PortGroup           compiler_blacklist_versions 1.0
 
 name                libpagemaker
 version             0.0.4
@@ -31,8 +28,7 @@ depends_build       port:pkgconfig
 depends_lib         port:librevenge \
                     port:boost
 
-# blacklist compilers with known problems on older systems
-compiler.blacklist-append  *gcc-3.* *gcc-4.* {clang < 300}
+compiler.cxx_standard 2011
 
 configure.args      --disable-werror \
                     --disable-silent-rules \


### PR DESCRIPTION
Use `compiler.cxx_standard 2011` instead of deprecated `cxx11 1.1` portgroup

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
