### PR TITLE
gnome-system-monitor: cleanup compilers

### DIFF
--- a/gnome/gnome-system-monitor/Portfile
+++ b/gnome/gnome-system-monitor/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 # As of 3.17.90 requires C++11 to build when using gtkmm3 > 3.16.0
-PortGroup           cxx11 1.1
+compiler.cxx_standard 2011
 
 name                gnome-system-monitor
 version             3.24.0
@@ -51,9 +51,6 @@ patchfiles          patch-create-gresource-as-bundle.diff
 post-patch {
     xinstall -m 755 ${filespath}/autogen.sh ${worksrcpath}
 }
-
-# requires a compiler that supports C++11 language features
-compiler.blacklist-append  *gcc-3.* *gcc-4.* {clang < 300}
 
 configure.cmd       ./autogen.sh
 


### PR DESCRIPTION
Use `compiler.cxx_standard 2011` instead of deprecated `cxx11 1.1` portgroup

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
