### PR TITLE
notmuch: Add build deps; use the right C++ stdlib

### DIFF
--- a/mail/notmuch/Portfile
+++ b/mail/notmuch/Portfile
@@ -58,6 +58,10 @@ configure.args      --with-docs \
 
 configure.python    ${prefix}/bin/python${python_branch}
 
+if {[string match *clang* ${configure.cxx}]} {
+    configure.ldflags-append -stdlib=${configure.cxx_stdlib}
+}
+
 # Add path to sphinx-build
 configure.env-append \
                     PATH=${frameworks_dir}/Python.framework/Versions/${python_branch}/bin:$env(PATH) \

--- a/mail/notmuch/Portfile
+++ b/mail/notmuch/Portfile
@@ -6,6 +6,8 @@ PortGroup           conflicts_build             1.0
 
 name                notmuch
 version             0.31
+revision            1
+
 categories          mail
 platforms           darwin
 license             GPL-3+
@@ -24,16 +26,22 @@ checksums           rmd160  fb81323f925597cd6dbcb7bc555138d4ed492e40 \
                     sha256  571fa0e1539c86612b1f2b2c80a398e08ecfef52e27ef7e48cf8e3b84fa18394 \
                     size    713144
 
-depends_build       port:pkgconfig \
-                    port:python38 \
-                    port:py38-cffi \
-                    port:py38-sphinx \
-                    port:py38-sphinxcontrib-applehelp \
-                    port:py38-sphinxcontrib-devhelp \
-                    port:py38-sphinxcontrib-htmlhelp \
-                    port:py38-sphinxcontrib-jsmath \
-                    port:py38-sphinxcontrib-qthelp \
-                    port:py38-sphinxcontrib-serializinghtml
+set python_branch   3.8
+set python_version  [string map {. {}} ${python_branch}]
+
+depends_build       port:bash-completion \
+                    port:doxygen \
+                    port:pkgconfig \
+                    port:python${python_version} \
+                    port:py${python_version}-cffi \
+                    port:py${python_version}-sphinx \
+                    port:py${python_version}-sphinxcontrib-applehelp \
+                    port:py${python_version}-sphinxcontrib-devhelp \
+                    port:py${python_version}-sphinxcontrib-htmlhelp \
+                    port:py${python_version}-sphinxcontrib-jsmath \
+                    port:py${python_version}-sphinxcontrib-qthelp \
+                    port:py${python_version}-sphinxcontrib-serializinghtml \
+                    port:texinfo
 
 depends_lib         port:gmime3 \
                     port:gpgme \
@@ -44,14 +52,15 @@ depends_lib         port:gmime3 \
 conflicts_build     ${name} xcbuild
 
 configure.args      --with-docs \
+                    --without-desktop \
                     --without-emacs \
                     --without-ruby
 
-configure.python    ${prefix}/bin/python3.7
+configure.python    ${prefix}/bin/python${python_branch}
 
 # Add path to sphinx-build
 configure.env-append \
-                    PATH=${frameworks_dir}/Python.framework/Versions/3.7/bin:$env(PATH) \
+                    PATH=${frameworks_dir}/Python.framework/Versions/${python_branch}/bin:$env(PATH) \
                     TMPDIR=/tmp
 build.env-append    {*}${configure.env}
 destroot.env-append {*}${configure.env}

--- a/mail/notmuch/Portfile
+++ b/mail/notmuch/Portfile
@@ -49,6 +49,8 @@ depends_lib         port:gmime3 \
                     port:xapian-core \
                     port:zlib
 
+patchfiles          realpath.patch
+
 conflicts_build     ${name} xcbuild
 
 configure.args      --with-docs \

--- a/mail/notmuch/files/realpath.patch
+++ b/mail/notmuch/files/realpath.patch
@@ -1,0 +1,13 @@
+Replace $(realpath emacs) with $(cd emacs && pwd -P)
+https://git.notmuchmail.org/git?p=notmuch;a=commit;h=b042a59cdf8be7ad215268eee32d4cc114d312bb
+--- configure.orig
++++ configure
+@@ -1536,7 +1536,7 @@ EOF
+     if [ $WITH_PYTHON_DOCS = "1" ]; then
+         echo "tags.add('WITH_PYTHON')"
+     fi
+-    printf "rsti_dir = '%s'\n" $(realpath emacs)
++    printf "rsti_dir = '%s'\n" "$(cd emacs && pwd -P)"
+ } > sphinx.config
+ 
+ # Finally, after everything configured, inform the user how to continue.


### PR DESCRIPTION
#### Description

**Add optional build deps**

notmuch looks for bash-completion, doxygen, realpath, texinfo at configure time, building and installing extra files if they're present, so add those deps.

Closes: https://trac.macports.org/ticket/61310

Fix python version. This ensures that sphinx is available to the build, which causes the manpages to be built and installed. So that the python version of the deps and the python version used by the build can't get out of sync again, define a python version variable that's used everywhere.

Disable installation of desktop file. The desktop file would have been installed opportunistically if the desktop-file-utils port was active.

Since the installed files change, increase revision.

**Link with the right C++ standard library**

Might fix build on Mac OS X 10.6-10.8.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14019
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
