### PR TITLE
realpath: Fix version

### DIFF
--- a/sysutils/realpath/Portfile
+++ b/sysutils/realpath/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        user454322 realpath 1.0.1 v
+revision            1
 categories          sysutils
 platforms           darwin
 maintainers         yahoo.com.mx:dev.modprobe
@@ -16,7 +17,10 @@ long_description    realpath uses realpath(3) to resolve the path of the \
                     to stdout.
 
 checksums           rmd160  7526580f51f19891067ad243b4a4c90e9e2c4d69 \
-                    sha256  bf38a149a528486e4c3caa26b8584410b55fdf824f64709ef8b93e75559d797d
+                    sha256  bf38a149a528486e4c3caa26b8584410b55fdf824f64709ef8b93e75559d797d \
+                    size    4591
+
+patchfiles          version.patch
 
 configure.pre_args
 configure.args      -b ${prefix} \

--- a/sysutils/realpath/files/version.patch
+++ b/sysutils/realpath/files/version.patch
@@ -1,0 +1,12 @@
+https://github.com/user454322/realpath/issues/1
+--- realpath.c.orig	2016-04-02 06:24:09.000000000 -0500
++++ realpath.c	2020-10-16 13:21:32.000000000 -0500
+@@ -33,7 +33,7 @@
+ #include <unistd.h>
+ 
+ 
+-#define	VERSION	"1.0.0"
++#define	VERSION	"1.0.1"
+ #define	INVALID_OPTION_ERROR	1
+ #define	REAL_PATH_ERROR	2
+ 


### PR DESCRIPTION
#### Description

Fixes `realpath -v` to report the correct version number.

Closes: https://trac.macports.org/ticket/61330

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14019
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
