### PR TITLE
libpipeline: Use fetch group and don't manually set --prefix

### DIFF
--- a/devel/libpipeline/Portfile
+++ b/devel/libpipeline/Portfile
@@ -10,7 +10,7 @@ license             GPL-3+
 maintainers         {@ylluminarious orbitalimpact.com:georgedp} openmaintainer
 description         C library for manipulating pipelines of subprocesses.
 homepage            http://libpipeline.nongnu.org
-master_sites        https://download.savannah.nongnu.org/releases/libpipeline/
+master_sites        nongnu
 
 long_description    libpipeline is a C library for manipulating pipelines of \
     subprocesses in a flexible and convenient way. It is available in at least \

--- a/devel/libpipeline/Portfile
+++ b/devel/libpipeline/Portfile
@@ -20,5 +20,3 @@ long_description    libpipeline is a C library for manipulating pipelines of \
 checksums           rmd160   e98387c86a4574ca303908d7b3361f7aa1859ee6 \
                     sha256   5dbf08faf50fad853754293e57fd4e6c69bb8e486f176596d682c67e02a0adb0 \
                     size     994663
-
-configure.args      --prefix=${prefix}


### PR DESCRIPTION
#### Description

A couple minor improvements:

* Use the [nongnu fetch group](https://github.com/macports/macports-ports/blob/master/_resources/port1.0/fetch/mirror_sites.tcl#L502) to get access to a set of worldwide nongnu mirrors
* Don't set `--prefix=${prefix}` in configure.args because MacPorts already sets it for you in configure.pre_args.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14019
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
