### PR TITLE
gqrx: Don't set name in a subport

### DIFF
--- a/science/gqrx/Portfile
+++ b/science/gqrx/Portfile
@@ -35,7 +35,6 @@ if {${subport} eq ${name}} {
 
 subport gqrx-devel {
 
-    name            gqrx-devel
     github.setup    csete gqrx 19772b1acbce74889234ec43a4d9b10aac1a43eb
     version         20201016-[string range ${github.version} 0 7]
     checksums       rmd160  3c4fb7ede57a6609b6af502253f89c30f1615fb1 \


### PR DESCRIPTION
#### Description

`name` should never be overridden in a subport.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

