### PR TITLE
screen: add fixes to allow building using Xcode 12

### DIFF
--- a/sysutils/screen/Portfile
+++ b/sysutils/screen/Portfile
@@ -42,13 +42,25 @@ checksums           ${distname}${extract.suffix} \
                     size    4883
 
 patchfiles          patch-apple.diff \
-                    patch-config.h.in.diff
+                    patch-config.h.in.diff \
+                    patch-configure_no_implicit_defs.diff \
+                    patch-xcode-12-implicit-function-fixes.diff
 depends_lib         port:ncurses
 
 extract.only        ${distname}${extract.suffix}
 post-extract {
     file copy ${distpath}/18 ${workpath}
 }
+
+use_autoconf    yes
+autoconf.cmd    ./autogen.sh
+
+# need for autoconf
+depends_build-append \
+    port:autoconf    \
+    port:automake    \
+    port:libtool
+
 configure.args      --mandir=${prefix}/share/man \
                     --infodir=${prefix}/share/info \
                     --enable-telnet \

--- a/sysutils/screen/files/patch-apple.diff
+++ b/sysutils/screen/files/patch-apple.diff
@@ -59,21 +59,6 @@ diff -rU 3 screen.c screen.c
     *  start detached. From now on we should not refer to 'LoginName'
     *  any more, use users->u_name instead.
 
-diff -rU 3 gsocket.c gsocket.c
---- socket.c	2020-02-05 15:09:38.000000000 -0500
-+++ socket.c	2020-02-07 21:17:51.107393457 -0500
-@@ -1419,7 +1419,10 @@
-   char *p;
-   int pid;
-   int noshowwin;
-+
-+#ifndef __APPLE__
-   struct win *wi;
-+#endif
- 
-   ASSERT(display);
-   pid = D_userpid;
-
 diff -rU 3 gwindow.c gwindow.c
 --- window.c	2020-02-05 15:09:38.000000000 -0500
 +++ window.c	2020-02-07 21:17:51.108845249 -0500

--- a/sysutils/screen/files/patch-configure_no_implicit_defs.diff
+++ b/sysutils/screen/files/patch-configure_no_implicit_defs.diff
@@ -1,0 +1,195 @@
+--- configure.ac.orig
++++ configure.ac
+@@ -284,10 +284,14 @@
+ dnl
+ 
+ AC_CHECKING(select)
+-AC_TRY_LINK(,[select(0, 0, 0, 0, 0);],, 
++AC_TRY_LINK([
++#include <sys/select.h>
++],[select(0, 0, 0, 0, 0);],,
+ LIBS="$LIBS -lnet -lnsl"
+ AC_CHECKING(select with $LIBS)
+-AC_TRY_LINK(,[select(0, 0, 0, 0, 0);],, 
++AC_TRY_LINK([
++#include <sys/select.h>
++],[select(0, 0, 0, 0, 0);],,
+ AC_MSG_ERROR(!!! no select - no screen))
+ )
+ dnl
+@@ -303,6 +307,7 @@
+ #include <sys/time.h>
+ #include <sys/types.h>
+ #include <unistd.h>
++#include <stdlib.h>
+ 
+ #include <sys/stat.h>
+ #include <fcntl.h>
+@@ -374,6 +379,7 @@
+ #include <sys/time.h>
+ #include <sys/types.h>
+ #include <unistd.h>
++#include <stdlib.h>
+ 
+ #include <sys/stat.h>
+ #include <fcntl.h>
+@@ -429,6 +435,9 @@
+ #include <sys/time.h>
+ #include <sys/types.h>
+ #include <unistd.h>
++#include <stdlib.h>
++#include <string.h>
++#include <signal.h>
+ 
+ #include <sys/stat.h>
+ #include <fcntl.h>
+@@ -486,6 +495,8 @@
+ #include <sys/time.h>
+ #include <sys/types.h>
+ #include <unistd.h>
++#include <stdlib.h>
++#include <string.h>
+ 
+ #include <sys/stat.h>
+ #include <sys/socket.h>
+@@ -532,6 +543,9 @@
+ #include <sys/time.h>
+ #include <sys/types.h>
+ #include <unistd.h>
++#include <stdlib.h>
++#include <string.h>
++#include <signal.h>
+ 
+ #include <sys/stat.h>
+ #include <fcntl.h>
+@@ -624,11 +638,17 @@
+ dnl    ****  termcap or terminfo  ****
+ dnl
+ AC_CHECKING(for tgetent)
+-AC_TRY_LINK(,tgetent((char *)0, (char *)0);,,
++AC_TRY_LINK([
++#include <termcap.h>
++],tgetent((char *)0, (char *)0);,,
+ olibs="$LIBS"
+ LIBS="-lcurses $olibs"
+ AC_CHECKING(libcurses)
+-AC_TRY_LINK(,[
++AC_TRY_LINK([
++#include <termcap.h>
++#include <stdlib.h>
++#include <string.h>
++],[
+ #ifdef __hpux
+ __sorry_hpux_libcurses_is_totally_broken_in_10_10();
+ #else
+@@ -637,25 +657,52 @@
+ ],,
+ LIBS="-ltermcap $olibs"
+ AC_CHECKING(libtermcap)
+-AC_TRY_LINK(,tgetent((char *)0, (char *)0);,,
++AC_TRY_LINK([
++#include <termcap.h>
++#include <stdlib.h>
++#include <string.h>
++],tgetent((char *)0, (char *)0);,,
+ LIBS="-ltermlib $olibs"
+ AC_CHECKING(libtermlib)
+-AC_TRY_LINK(,tgetent((char *)0, (char *)0);,,
++AC_TRY_LINK([
++#include <termcap.h>
++#include <stdlib.h>
++#include <string.h>
++],tgetent((char *)0, (char *)0);,,
+ LIBS="-lncursesw $olibs"
+ AC_CHECKING(libncursesw)
+-AC_TRY_LINK(,tgetent((char *)0, (char *)0);,,
++AC_TRY_LINK([
++#include <termcap.h>
++#include <stdlib.h>
++#include <string.h>
++],tgetent((char *)0, (char *)0);,,
+ LIBS="-ltinfow $olibs"
+ AC_CHECKING(libtinfow)
+-AC_TRY_LINK(,tgetent((char *)0, (char *)0);,,
++AC_TRY_LINK([
++#include <termcap.h>
++#include <stdlib.h>
++#include <string.h>
++],tgetent((char *)0, (char *)0);,,
+ LIBS="-lncurses $olibs"
+ AC_CHECKING(libncurses)
+-AC_TRY_LINK(,tgetent((char *)0, (char *)0);,,
++AC_TRY_LINK([
++#include <termcap.h>
++#include <stdlib.h>
++#include <string.h>
++],tgetent((char *)0, (char *)0);,,
+ LIBS="-ltinfo $olibs"
+ AC_CHECKING(libtinfo)
+-AC_TRY_LINK(,tgetent((char *)0, (char *)0);,,
++AC_TRY_LINK([
++#include <termcap.h>
++#include <stdlib.h>
++#include <string.h>
++],tgetent((char *)0, (char *)0);,,
+ AC_MSG_ERROR(!!! no tgetent - no screen)))))))))
+ 
+ AC_TRY_RUN([
++#include <termcap.h>
++#include <stdlib.h>
++#include <string.h>
+ main()
+ {
+  exit(strcmp(tgoto("%p1%d", 0, 1), "1") ? 0 : 1);
+@@ -735,6 +782,8 @@
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <stdio.h>
++#include <stdlib.h>
++#include <string.h>
+ main()
+ {
+   struct stat sb;
+@@ -1156,6 +1205,10 @@
+ 
+ AC_CHECKING(whether memcpy/memmove/bcopy handles overlapping arguments)
+ AC_TRY_RUN([
++#include <stdlib.h>
++#include <string.h>
++#include <strings.h>
++#include <stdlib.h>
+ main() {
+   char buf[10];
+   strcpy(buf, "abcdefghi");
+@@ -1170,6 +1223,9 @@
+ }], AC_DEFINE(USEBCOPY),,:)
+ 
+ AC_TRY_RUN([
++#include <stdlib.h>
++#include <string.h>
++#include <stdlib.h>
+ #define bcopy(s,d,l) memmove(d,s,l)
+ main() {
+   char buf[10];
+@@ -1187,6 +1243,9 @@
+ 
+ 
+ AC_TRY_RUN([
++#include <stdlib.h>
++#include <string.h>
++#include <stdlib.h>
+ #define bcopy(s,d,l) memcpy(d,s,l)
+ main() {
+   char buf[10];
+@@ -1204,7 +1263,10 @@
+ AC_SYS_LONG_FILE_NAMES
+ 
+ AC_MSG_CHECKING(for vsprintf)
+-AC_TRY_LINK([#include <stdarg.h>],[va_list valist; vsprintf(0,0,valist);], AC_MSG_RESULT(yes);AC_DEFINE(USEVARARGS), AC_MSG_RESULT(no))
++AC_TRY_LINK([
++#include <stdarg.h>
++#include <stdio.h>
++],[va_list valist; vsprintf(0,0,valist);], AC_MSG_RESULT(yes);AC_DEFINE(USEVARARGS), AC_MSG_RESULT(no))
+ 
+ AC_HEADER_DIRENT
+ 

--- a/sysutils/screen/files/patch-xcode-12-implicit-function-fixes.diff
+++ b/sysutils/screen/files/patch-xcode-12-implicit-function-fixes.diff
@@ -1,0 +1,36 @@
+--- pty.c.orig
++++ pty.c
+@@ -30,6 +30,9 @@
+ #include <sys/stat.h>
+ #include <fcntl.h>
+ #include <signal.h>
++#ifdef __APPLE__
++#include <util.h>
++#endif
+ 
+ #include "config.h"
+ #include "screen.h"
+--- screen.c.orig
++++ screen.c
+@@ -47,6 +47,9 @@
+ #include <string.h>
+ #include <unistd.h>
+ #include <fcntl.h>
++#ifdef __APPLE__
++#include <err.h>
++#endif
+ 
+ #if defined(__sun)
+ # include <limits.h>
+--- socket.c.orig
++++ socket.c
+@@ -1419,7 +1419,9 @@
+   char *p;
+   int pid;
+   int noshowwin;
++#ifdef UTMPOK
+   struct win *wi;
++#endif
+ 
+   ASSERT(display);
+   pid = D_userpid;


### PR DESCRIPTION
screen: add fixes to allow building using Xcode 12

avoid implicit functions:
+ in configure.ac
+ in source code

Requires using autoconf because of changes to configure.ac.

These changes should be fairly backwards compatible with older macOS ... hopefully! Part of the point of this PR is to get testing going on older macOS to see if there are further fixes required.

Closes: https://trac.macports.org/ticket/61211

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0 20A5395g
Xcode 12.2 12B5025f

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
