### PR TITLE
osm2pgsql: cleanup compilers

### DIFF
--- a/gis/osm2pgsql/Portfile
+++ b/gis/osm2pgsql/Portfile
@@ -2,8 +2,6 @@
 
 PortSystem                                      1.0
 PortGroup           cmake                       1.1
-PortGroup           compiler_blacklist_versions 1.0
-PortGroup           cxx11                       1.1
 PortGroup           github                      1.0
 PortGroup           active_variants             1.1
 
@@ -24,7 +22,7 @@ checksums           rmd160  180e37e673adf0c5459eb3f7cc224a67e0bf3ab8 \
                     sha256  e45a3c2761116474edaf06ed263fdc8bbf23e1c3cf30705663ebc456aa02d12d \
                     size    1219280
 
-compiler.blacklist      {clang < 500}
+compiler.cxx_standard 2011
 
 depends_lib-append  port:zlib\
                     port:expat\


### PR DESCRIPTION
`cxx11 1.1` portgroup is deprecated

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
