### PR TITLE
py-argcomplete: update to 1.12.1 and add python 3.9

### DIFF
--- a/python/py-argcomplete/Portfile
+++ b/python/py-argcomplete/Portfile
@@ -4,23 +4,21 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-argcomplete
-version             1.12.0
+version             1.12.1
 platforms           darwin
 license             Apache-2
 maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
 
 description         Bash tab completion for argparse
-long_description    ${description}
+long_description    {*}${description}
 
-homepage            https://argcomplete.readthedocs.io
-master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
-distname            ${python.rootname}-${version}
+homepage            https://kislyuk.github.io/argcomplete
 
-checksums           rmd160  9fb4b724d2bc2faf9e722ce667948f4ff91bce16 \
-                    sha256  2fbe5ed09fd2c1d727d4199feca96569a5b50d44c71b16da9c742201f7cc295c \
-                    size    53625
+checksums           rmd160  a053b13d9f42f347b83f2fe906d19066feb5a35c \
+                    sha256  849c2444c35bb2175aea74100ca5f644c29bf716429399c0f2203bb5d9a8e4e6 \
+                    size    53677
 
-python.versions     36 37 38
+python.versions     36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_build   port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

Homepage also updated since current url returns `Documentation for this project has moved`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.6 19G73
xcode-select version 2373

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
