### PR TITLE
wp-cli: upgrade to 2.4.0

### DIFF
--- a/www/wp-cli/Portfile
+++ b/www/wp-cli/Portfile
@@ -3,29 +3,43 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup wp-cli wp-cli 1.4.1 v
-github.tarball_from releases
+github.setup        wp-cli wp-cli 2.4.0 v
+revision            0
+
 categories          www php devel
-platforms           darwin
-supported_archs     noarch
 license             MIT
 maintainers         {takeshi @tenomoto} openmaintainer
+platforms           darwin
+supported_archs     noarch
+
 description         A command line interface for WordPress
-long_description \
-    WP-CLI is a set of command-line tools for managing WordPress installations. \
-    You can update plugins, set up multisite installs and much more, without using a web browser.
-homepage            http://wp-cli.org
+long_description    WP-CLI is a set of command-line tools for managing\
+                    WordPress installations. You can update plugins, set\
+                    up multisite installs and much more, without using a\
+                    web browser.
+
+github.tarball_from releases
+livecheck.url       ${homepage}/${github.tarball_from}/latest
+
+homepage            https://${name}.org
+
+checksums           rmd160  260fab9c22a64fbefb46722e30ee0c0af0ad6d24 \
+                    sha256  139dcc86ed39ef751679efbdaf57a53528f1afda972c4e3622667cc27397b540 \
+                    size    5568133
+
 extract.suffix      .phar
-
-checksums           rmd160  4a62ab068802fed86df54d8f6d0a6325b00ee10c \
-                    sha256  325924cf161856f9478f2a154572698ecb5d1054e620843b9c43a7baf4e5ce3b
-
 extract.only
+
 use_configure       no
 build {}
-notes {
-    Install and run MySQL server to use wp db.
-}
+
 destroot {
     xinstall -m 755 ${distpath}/${distfiles} ${destroot}${prefix}/bin/wp
 }
+
+notes "
+WordPress recommend servers running version 7.4 or greater of PHP and MySQL\
+version 5.6 OR MariaDB version 10.1 or greater. They also recommend either\
+Apache or Nginx as the most robust options for running WordPress, but neither\
+is required.
+"


### PR DESCRIPTION
#### Description

wp-cli: upgrade to 2.4.0

  - upgrade to 2.4.0 (stable)
  - add default revision
  - add size to checksums
  - use livecheck.url to latest (stable) release
  - notes: use the text from worpress.org (requirements)

###### Type(s)

- [x] update
- [x] enhancement

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?