### PR TITLE
Wordpress 5.5.1

### DIFF
--- a/www/wordpress/Portfile
+++ b/www/wordpress/Portfile
@@ -1,27 +1,29 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem              1.0
+PortSystem          1.0
 
-name                    wordpress
-version                 4.9.10
-categories              www
-platforms               darwin freebsd
-maintainers             nomaintainer
-license                 GPL-2+
-supported_archs         noarch
+name                wordpress
+version             4.9.10
+revision            0
 
-description             A state-of-the-art semantic personal publishing platform
-long_description        WordPress is a state-of-the-art semantic personal publishing platform \
-                        with a focus on aesthetics, web standards, and usability.
+categories          www
+platforms           darwin freebsd
+maintainers         nomaintainer
+license             GPL-2+
+supported_archs     noarch
 
-homepage                https://wordpress.org/
-master_sites            ${homepage}
+description         A state-of-the-art semantic personal publishing platform
+long_description    WordPress is a state-of-the-art semantic personal publishing platform \
+                    with a focus on aesthetics, web standards, and usability.
 
-checksums               rmd160  96b9549cb6fb37c311c3c1973854f4e37b54a708 \
-                        sha256  359045880c4d49f600acb2c18808a4ba1d50090c1f759d930ee40e8173a77815 \
-                        size    8744264
+homepage            https://wordpress.org/
+master_sites        ${homepage}
 
-worksrcdir              ${name}
+checksums           rmd160  96b9549cb6fb37c311c3c1973854f4e37b54a708 \
+                    sha256  359045880c4d49f600acb2c18808a4ba1d50090c1f759d930ee40e8173a77815 \
+                    size    8744264
+
+worksrcdir          ${name}
 
 # The php variants deliberately do not conflict
 foreach php {php55 php56 php70 php71} {
@@ -38,8 +40,8 @@ if {![variant_isset php55] && ![variant_isset php56] && ![variant_isset php70]} 
     default_variants +php71
 }
 
-use_configure           no
-build                   {}
+use_configure       no
+build               {}
 
 destroot {
     file copy ${worksrcpath} ${destroot}${prefix}/www/${name}
@@ -63,6 +65,6 @@ Alias /wordpress/ \"${prefix}/www/wordpress/\"
 --
 "
 
-livecheck.type          regex
-livecheck.url           ${homepage}download/
-livecheck.regex         "Download&nbsp;WordPress&nbsp;(\\d+(?:\\.\\d+)*)"
+livecheck.type      regex
+livecheck.url       ${homepage}download/
+livecheck.regex     "Download&nbsp;WordPress&nbsp;(\\d+(?:\\.\\d+)*)"

--- a/www/wordpress/Portfile
+++ b/www/wordpress/Portfile
@@ -3,68 +3,85 @@
 PortSystem          1.0
 
 name                wordpress
-version             4.9.10
+version             5.5.1
 revision            0
 
 categories          www
-platforms           darwin freebsd
-maintainers         nomaintainer
 license             GPL-2+
+maintainers         nomaintainer
+platforms           darwin freebsd
 supported_archs     noarch
 
-description         A state-of-the-art semantic personal publishing platform
-long_description    WordPress is a state-of-the-art semantic personal publishing platform \
-                    with a focus on aesthetics, web standards, and usability.
+description         a state-of-the-art semantic personal publishing platform
+long_description    WordPress is {*}${description} with a focus on aesthetics,\
+                    web standards, and usability.
 
 homepage            https://wordpress.org/
 master_sites        ${homepage}
 
-checksums           rmd160  96b9549cb6fb37c311c3c1973854f4e37b54a708 \
-                    sha256  359045880c4d49f600acb2c18808a4ba1d50090c1f759d930ee40e8173a77815 \
-                    size    8744264
+checksums           rmd160  3bf7930b3faa21a0f88395942b899c7397eeac68 \
+                    sha256  66a2ced5f3e240d0612dd3668fbd50308f9649ecb4a6e17d46dc0d8111b99295 \
+                    size    12983648
 
 worksrcdir          ${name}
 
-# The php variants deliberately do not conflict
-foreach php {php55 php56 php70 php71} {
-    variant ${php} description "Use ${php}" "
-        depends_run-append  port:${php}-gd \
-                            port:${php}-mbstring \
-                            port:${php}-mcrypt \
-                            port:${php}-mysql \
-                            port:${php}-zip
-    "
-}
-
-if {![variant_isset php55] && ![variant_isset php56] && ![variant_isset php70]} {
-    default_variants +php71
-}
-
 use_configure       no
 build               {}
+
+# The php variants deliberately do not conflict
+#
+# min req is currently: 5.6
+#   » https://wordpress.org/news/2019/04/minimum-php-version-update/
+foreach v "56 70 71 72 73 74" {
+    variant php${v} description "Use php${v}" {
+        depends_run-append  port:php${v} \
+                            port:php${v}-gd \
+                            port:php${v}-mbstring \
+                            port:php${v}-mcrypt \
+                            port:php${v}-mysql \
+                            port:php${v}-zip
+    }
+}
+
+if {![variant_isset php56] && ![variant_isset php70] &&
+    ![variant_isset php71] && ![variant_isset php72] &&
+    ![variant_isset php73] && ![variant_isset php74]} {
+    default_variants +php74
+}
 
 destroot {
     file copy ${worksrcpath} ${destroot}${prefix}/www/${name}
 }
 
-notes "
-If your webserver is already running with php and mysql, connect on http://localhost/wordpress/ to finish the install.
-Temporarily allow the webserver write access so it can create wp-config.php (or do it yourself)
-$ sudo chmod 1777 ${prefix}/www/wordpress
-$ sudo chmod 755 ${prefix}/www/wordpress
+set conf_file "httpd-${name}.conf"
 
-If Apache is not set, set an alias to the wordpress dir and some access like
--- ${prefix}/apache2/conf/extra/wordpress.conf
-Alias /wordpress/ \"${prefix}/www/wordpress/\"
-<Directory \"${prefix}/www/wordpress\">
-    Options Indexes FollowSymLinks
+notes "
+If your webserver is already running with php and mysql, connect on\
+http://localhost/${name}/ to finish the install. Temporarily allow\
+the webserver write access so it can create wp-config.php (or do it yourself)
+
+    \$ sudo chmod 1777 ${prefix}/www/${name}
+    \$ sudo chmod 755 ${prefix}/www/${name}
+
+If Apache is not set, set an alias to the ${name} dir and some access like:
+
+-- ${prefix}/apache2/conf/extra/${conf_file}
+Alias /${name}/ \"${prefix}/www/${name}/\"
+<Directory \"${prefix}/www/${name}\">
+    Options -Indexes +FollowSymLinks
     AllowOverride None
-    Order allow,deny
-    Allow from all
+    #Require host localhost
+    #Require ip 127.0.0.1
+    Require all granted
 </Directory>
 --
+
+And then include it in httpd.conf, like:
+
+    # ${name}
+    Include etc/apache2/extra/${conf_file}\n—
 "
 
 livecheck.type      regex
 livecheck.url       ${homepage}download/
-livecheck.regex     "Download&nbsp;WordPress&nbsp;(\\d+(?:\\.\\d+)*)"
+livecheck.regex     "Download WordPress (\\d+(?:\\.\\d+)*)"


### PR DESCRIPTION
#### Description

wordpress: upgrade to 5.5.1

  - fix whitespace
  - upgrade to 5.5.1
  - fix broken livecheck
  - update the variants
  - use Apache 2.4 syntax in notes
  - escape the \$ in notes

###### Type(s)

- [x] update
- [x] enhancement

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?