### PR TITLE
vtk: Fix FT_CALLBACK_DEF with updated freetype

### DIFF
--- a/graphics/vtk/Portfile
+++ b/graphics/vtk/Portfile
@@ -9,9 +9,9 @@ PortGroup           compiler_blacklist_versions 1.0
 # Require C++11
 compiler.cxx_standard 2011
 
-# some older Clang say they support C++11 when they don't 
-# this is the same blacklisting as for jsoncpp, on which vtk depends. 
-compiler.blacklist-append {clang < 900} 
+# some older Clang say they support C++11 when they don't
+# this is the same blacklisting as for jsoncpp, on which vtk depends.
+compiler.blacklist-append {clang < 900}
 
 name                vtk
 version             8.2.0
@@ -62,13 +62,15 @@ depends_lib-append \
 
 mpi.enforce_variant hdf5
 
+# FT_CALLBACK_DEF: https://gitlab.kitware.com/vtk/vtk/-/issues/18033 
 patchfiles          patch-pugixml.diff \
-                    patch-IOMovie-module.cmake.diff
+                    patch-IOMovie-module.cmake.diff \
+                    patch-FT_CALLBACK_DEF.diff
 
 if {[variant_isset python38]} {
     # https://gitlab.kitware.com/vtk/vtk/-/commit/257b9d7b18d5f3db3fe099dc18f230e23f7dfbab
     # Remove this when upgrading the version, because it was merged for VTK9
-    patchfiles-append  patch-python38-tp_print.diff  
+    patchfiles-append  patch-python38-tp_print.diff
 }
 
 configure.pre_args-delete \

--- a/graphics/vtk/files/patch-FT_CALLBACK_DEF.diff
+++ b/graphics/vtk/files/patch-FT_CALLBACK_DEF.diff
@@ -1,0 +1,18 @@
+--- ThirdParty/freetype/vtk_freetype.h.in.orig	2019-01-30 18:15:13.000000000 +0100
++++ ThirdParty/freetype/vtk_freetype.h.in	2020-10-17 00:03:32.730820908 +0200
+@@ -20,6 +20,15 @@
+ 
+ #ifdef VTK_USE_SYSTEM_FREETYPE
+ # include <ft2build.h>
++/* FT_CALLBACK_DEF no longer exported since freetype-2.10.3 */
++/* has been moved to <freetype/internal/compiler-macros.h> */
++# ifndef FT_CALLBACK_DEF
++#  ifdef __cplusplus
++#   define FT_CALLBACK_DEF( x )  extern "C"  x
++#  else
++#   define FT_CALLBACK_DEF( x )  static  x
++#  endif
++# endif /* FT_CALLBACK_DEF */
+ #else
+ # include <vtkfreetype/include/ft2build.h>
+ #endif


### PR DESCRIPTION
#### Description

`vtk` does not build anymore with new freetype

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
