### PR TITLE
R-app: update to 1.73 & workaround Xcode 12 implicit declaration error

### DIFF
--- a/math/R-app/Portfile
+++ b/math/R-app/Portfile
@@ -4,8 +4,8 @@ PortSystem 1.0
 PortGroup xcode 1.0
 
 name                    R-app
-version                 1.68
-revision                1
+version                 1.73
+revision                0
 categories              math science aqua
 maintainers             {me.com:kjell.konis @kjellpk} {@i0ntempest me.com:szf1234} openmaintainer
 license                 GPL-2+
@@ -22,8 +22,9 @@ master_sites            http://cran.rstudio.com/bin/macosx/ \
 
 distname                Mac-GUI-${version}
 
-checksums               rmd160  5ea4a9c722b1ca465bca1cc67f5d4b14370682e2 \
-                        sha256  7dff17659a69e3c492fdfc3fb765e3c9537157d50b6886236bee7ad873eb416d
+checksums               rmd160  944f10da58cb99168958aa8df77d8066e0486c7c \
+                        sha256  82a82f089bf64a3623e87c02eea25011699b656da7cbcafac85956a925bbe996 \
+                        size    1311664
 
 post-patch {
     reinplace "s|/Library/Frameworks/R.framework|${frameworks_dir}/R.framework|g" \
@@ -38,10 +39,18 @@ universal_variant       no
 
 xcode.project           R.xcodeproj
 xcode.target            R
-xcode.configuration     SnowLeopard64
+xcode.configuration     Release
 
 xcode.build.settings    FRAMEWORK_SEARCH_PATHS=${frameworks_dir}
 xcode.destroot.settings FRAMEWORK_SEARCH_PATHS=${frameworks_dir}
+
+if {[vercmp ${xcodeversion} 10.0] >= 0} {
+    destroot.pre_args  -UseNewBuildSystem=NO
+}
+
+if {[vercmp ${xcodeversion} 12.0] >= 0} {
+    patchfiles-append patch-implicit-function-declaration.diff
+}
 
 post-destroot {
     delete ${destroot}${applications_dir}/sush

--- a/math/R-app/Portfile
+++ b/math/R-app/Portfile
@@ -7,7 +7,7 @@ name                    R-app
 version                 1.68
 revision                1
 categories              math science aqua
-maintainers             {me.com:kjell.konis @kjellpk}
+maintainers             {me.com:kjell.konis @kjellpk} {@i0ntempest me.com:szf1234} openmaintainer
 license                 GPL-2+
 
 description             R GUI for Mac OS X

--- a/math/R-app/files/patch-implicit-function-declaration.diff
+++ b/math/R-app/files/patch-implicit-function-declaration.diff
@@ -1,0 +1,11 @@
+--- R.xcodeproj/project.pbxproj	2020-03-04 21:42:59.000000000 -0500
++++ R.xcodeproj/project.pbxproj	2020-10-19 00:58:26.000000000 -0400
+@@ -167,7 +167,7 @@
+ 		68DEAEE8083271CA00C5D76C /* RTextView.h in Headers */ = {isa = PBXBuildFile; fileRef = 68DEAEE6083271CA00C5D76C /* RTextView.h */; };
+ 		68DEAEE9083271CA00C5D76C /* RTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 68DEAEE7083271CA00C5D76C /* RTextView.m */; };
+ 		8D1107280486CEB800E47090 /* R_Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = 32CA4F630368D1EE00C91783 /* R_Prefix.pch */; };
+-		8D11072D0486CEB800E47090 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; settings = {ATTRIBUTES = (); }; };
++		8D11072D0486CEB800E47090 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; settings = {ATTRIBUTES = (); COMPILER_FLAGS = "-Wno-error=implicit-function-declaration"; }; };
+ 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
+ 		BC03E662133AA8E100456B01 /* Quartz.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BC03E661133AA8E100456B01 /* Quartz.framework */; };
+ 		BC0D319A1334B1410071B76A /* NSTextView_RAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = BC0D31981334B1410071B76A /* NSTextView_RAdditions.h */; };


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
