### PR TITLE
pagerduty-notifier: new port

### DIFF
--- a/sysutils/pagerduty-notifier/Portfile
+++ b/sysutils/pagerduty-notifier/Portfile
@@ -1,0 +1,76 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/trustpilot/pagerduty-notifier 20200817-0652
+
+description         PagerDuty native macOS notifications
+
+long_description    PagerDuty Notifier polls the PagerDuty API for new \
+                    incidents and sends native macOS notifications. You can \
+                    control the notification style as you normally would in \
+                    System Preferences.
+
+categories          sysutils
+license             MIT
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+installs_libs       no
+
+build.cmd           make
+build.target        build
+build.env-append    GO111MODULE=off \
+                    GOPROXY=off
+destroot {
+    file copy ${worksrcpath}/dist/PagerdutyNotifier.app \
+        ${destroot}${applications_dir}/
+}
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  44a529f2203b4b501098de420133d18e29c8b05b \
+                        sha256  4e143e274e46dabb1dee5ff4307b6c1e49a4e08d8ecbbb4e766e00c2ccea2f27 \
+                        size    209676
+
+go.vendors          github.com/smartystreets/goconvey \
+                        lock    v1.6.4 \
+                        rmd160  a3dfad6131b94d809efad84d30ce45828c6da756 \
+                        sha256  a03963296bb6d031934a651c1e637e8ab2ce9604ce6a16c158ff551e44e7ba79 \
+                        size    1478824 \
+                    github.com/smartystreets/assertions \
+                        lock    b2de0cb4f26d \
+                        rmd160  32d7082172ea8c4a03119f3ffb803f8aad9744ce \
+                        sha256  469875871db96f87e62f76f0bfc4b3b0b9e4761c2a14d4ce12f246797a7c342c \
+                        size    52177 \
+                    github.com/shurcooL/trayhost \
+                        lock    114974ef9e16 \
+                        rmd160  2af93fa7d585b850a0baef716bedbd6388364d5c \
+                        sha256  06949cdf53a27442c8f8d4be01aae684abd48e07383077642a08f1792a58bf9d \
+                        size    12329 \
+                    github.com/jtolds/gls \
+                        lock    v4.20.0 \
+                        rmd160  31d8656bd6c1426338ceaac9535198244248b254 \
+                        sha256  04069406ca336d355eab62b4ab9e84b820ac968ac1e20bd3777efec2d3843446 \
+                        size    7305 \
+                    github.com/gopherjs/gopherjs \
+                        lock    0766667cb4d1 \
+                        rmd160  fe92e39110b5c188dcce98abb3b9aa1b64d68f94 \
+                        sha256  abe56698d0855027a1f6030a44924895d781b19526aa8f9b3ef49ed4199f7c57 \
+                        size    217261 \
+                    github.com/google/go-querystring \
+                        lock    v1.0.0 \
+                        rmd160  48593728f6bf361fa168bdc87737ee30de24f34b \
+                        sha256  0add5428914c2a378cd9e6e120a4b1e84d69df504b983f99a86aea98a52c5a57 \
+                        size    7536 \
+                    github.com/go-ini/ini \
+                        lock    v1.55.0 \
+                        rmd160  e7d69395e826ce30d10696dcf4fd87b6451569e1 \
+                        sha256  fbf07204aa317ee8d5d49aa888d1789e32adbeafa6b56293a56d567934b42288 \
+                        size    47210 \
+                    github.com/PagerDuty/go-pagerduty \
+                        lock    v1.1.2 \
+                        rmd160  dddeafda5eb3228667eb7eb7fd9858df9a990b9f \
+                        sha256  74bd429e46c56227e8da0bbc9547c0c72254adad824205873d4154e6918e8c00 \
+                        size    47481


### PR DESCRIPTION
#### Description

New port for Trustpilot's [pagerduty-notifier](https://github.com/trustpilot/pagerduty-notifier)

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.0.1 12A7300

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
