### PR TITLE
folderify: new port

### DIFF
--- a/sysutils/folderify/Portfile
+++ b/sysutils/folderify/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                folderify
+version             1.2.3
+categories-prepend  sysutils amusements
+platforms           darwin
+license             MIT
+supported_archs     noarch
+
+python.default_version \
+                    39
+
+maintainers         {@harens gmail.com:harensdeveloper} \
+                    openmaintainer
+
+description         Generate pretty, beveled macOS folder icons
+long_description    Generate a native macOS folder icon from a mask file
+
+homepage            https://github.com/lgarron/folderify
+
+checksums           rmd160  4eacf5d159a465c5622e6bce02fbd7b79d5beea1 \
+                    sha256  79432ca22ac8c2a8134093269969a77069a4563b542b482680538d00f0e554bc \
+                    size    3093273
+
+depends_build-append \
+                    port:py${python.version}-setuptools
+
+depends_lib-append \
+                    port:ImageMagick
+
+livecheck.type      pypi


### PR DESCRIPTION
#### Description

Two months after my first PR to MacPorts https://github.com/macports/macports-ports/pull/7925, now that I have some more experience, I thought I'd have another go at [folderify](https://github.com/lgarron/folderify).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.6 19G73
xcode-select version 2373

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
