### PR TITLE
py-commonmark: add python 3.9

### DIFF
--- a/python/py-commonmark/Portfile
+++ b/python/py-commonmark/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160 87a980080d252986c782720cbb3e834ca4ede9da \
                     sha256 452f9dc859be7f06631ddcb328b6919c67984aca654e5fefb3914d54691aed60 \
                     size   95764
 
-python.versions     38
+python.versions     38 39
 
 if {${name} ne ${subport}} {
 


### PR DESCRIPTION
#### Description

In order to update the [rich](https://ports.macports.org/port/py-rich/summary) port, I've added the `python 3.9` variant to py-commonmark.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.6 19G73
xcode-select version 2373

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
