### PR TITLE
temporal-cli: new port

### DIFF
--- a/devel/temporal-cli/Portfile
+++ b/devel/temporal-cli/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/temporalio/temporal 1.1.0 v
+name                temporal-cli
+
+homepage            https://temporal.io
+
+description         CLI for Temporal
+
+long_description    {*}${description}. Temporal is the open source \
+                    microservices orchestration platform for running mission \
+                    critical code at any scale.
+
+categories          devel sysutils
+license             MIT
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  d6ae255a9da1f8c4bf54b234bd5894cca0de01f1 \
+                    sha256  fc4e531135629f927c37439e9a8676e1b386fb7a843e8b682f4e67dd637dbefa \
+                    size    1671707
+
+build.env-append    GO111MODULE=on \
+                    GOPROXY=direct
+build.cmd           make
+build.target        tctl
+
+installs_libs       no
+use_parallel_build  no
+
+notes "temporal-cli is installed as tctl"
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/tctl ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

New port for CLI for [Temporal](https://docs.temporal.io)

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.0.1 12A7300

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
