### PR TITLE
py-rich: update to 9.0.0 and add python 3.9

### DIFF
--- a/python/py-rich/Portfile
+++ b/python/py-rich/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-rich
-version             8.0.0
+version             9.0.0
 platforms           darwin
 license             MIT
 supported_archs     noarch
@@ -21,11 +21,11 @@ long_description    {*}${description}. The Rich API makes it easy to add color \
 
 homepage            https://rich.readthedocs.io/en/latest/
 
-checksums           rmd160 4673fe3cc16e26430f06448798054e2a16fc75ac \
-                    sha256 1b5023d2241e6552a24ddfe830a853fc8e53da4e6a6ed6c7105bb262593edf97 \
-                    size   143548
+checksums           rmd160 140a8c23759d70b79a8d42251ffcbf6ada89b077 \
+                    sha256 7d3b7293ca0eb521b971370ff0d817fedca86ce945a361d0f0d70bc0182eb075 \
+                    size   147393
 
-python.versions     38
+python.versions     38 39
 
 if {${name} ne ${subport}} {
 


### PR DESCRIPTION
#### Description

Currently, none of the [eleven other package managers](https://repology.org/project/python:rich/versions) that provide rich have `v9.0.0`. I'm hoping MacPorts will be the first!

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.6 19G73
xcode-select version 2373
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
