### PR TITLE
meson: add workaround for Tiger

### DIFF
--- a/devel/meson/Portfile
+++ b/devel/meson/Portfile
@@ -52,6 +52,9 @@ if {${os.platform} eq "darwin" && ${os.major} <= 10} {
                     remove-Wl,-no_weak_imports.patch
 }
 
+# https://github.com/mesonbuild/meson/pull/7871
+patchfiles-append   patch-meson-powermacintosh.diff
+
 # https://github.com/mesonbuild/meson/issues/6187
 patchfiles-append   patch-meson-32bit-apple.diff
 

--- a/devel/meson/Portfile
+++ b/devel/meson/Portfile
@@ -55,6 +55,20 @@ if {${os.platform} eq "darwin" && ${os.major} <= 10} {
 # https://github.com/mesonbuild/meson/issues/6187
 patchfiles-append   patch-meson-32bit-apple.diff
 
+platform darwin 8 {
+
+    # this meson is modified for systems without @rpath support
+    # and is therefore fragile. Keep pegged, and update occasionally
+
+    github.setup        mesonbuild meson 0.55.3
+    revision            0
+    checksums           rmd160  b1e7f12184a7a61ae8bfa7ed210af8020d531009 \
+                        sha256  6bed2a25a128bbabe97cf40f63165ebe800e4fcb46db8ab7ef5c2b5789f092a5 \
+                        size    1740465
+
+    patchfiles-append patch-meson55-tiger-no-rpath-fix.diff
+}
+
 # add a search path for crossfiles in our prefix
 patchfiles-append   patch-meson-search-prefix-for-cross-files.diff
 post-patch {

--- a/devel/meson/files/patch-meson-powermacintosh.diff
+++ b/devel/meson/files/patch-meson-powermacintosh.diff
@@ -1,0 +1,13 @@
+diff --git mesonbuild/environment.py mesonbuild/environment.py
+index e3ea9564a..8c343d654 100644
+--- mesonbuild/environment.py
++++ mesonbuild/environment.py
+@@ -368,7 +368,7 @@ def detect_cpu_family(compilers: CompilersDict) -> str:
+         trial = 'arm'
+     elif trial.startswith(('powerpc64', 'ppc64')):
+         trial = 'ppc64'
+-    elif trial.startswith(('powerpc', 'ppc')) or trial in {'macppc', 'power machintosh'}:
++    elif trial.startswith(('powerpc', 'ppc')) or trial in {'macppc', 'power macintosh'}:
+         trial = 'ppc'
+     elif trial in ('amd64', 'x64', 'i86pc'):
+         trial = 'x86_64'

--- a/devel/meson/files/patch-meson55-tiger-no-rpath-fix.diff
+++ b/devel/meson/files/patch-meson55-tiger-no-rpath-fix.diff
@@ -1,0 +1,91 @@
+diff --git mesonbuild/build.py mesonbuild/build.py
+index a06979c..8b8d6ca 100644
+--- mesonbuild/build.py
++++ mesonbuild/build.py
+@@ -103,7 +103,7 @@ known_jar_kwargs = known_exe_kwargs | {'main_class'}
+ 
+ @lru_cache(maxsize=None)
+ def get_target_macos_dylib_install_name(ld) -> str:
+-    name = ['@rpath/', ld.prefix, ld.name]
++    name = ['@loader_path/', ld.prefix, ld.name]
+     if ld.soversion is not None:
+         name.append('.' + ld.soversion)
+     name.append('.dylib')
+diff --git mesonbuild/linkers.py mesonbuild/linkers.py
+index fe1441e..841fafa 100644
+--- mesonbuild/linkers.py
++++ mesonbuild/linkers.py
+@@ -678,7 +678,7 @@ class AppleDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
+                         is_shared_module: bool) -> T.List[str]:
+         if is_shared_module:
+             return []
+-        install_name = ['@rpath/', prefix, shlib_name]
++        install_name = ['@loader_path/', prefix, shlib_name]
+         if soversion is not None:
+             install_name.append('.' + soversion)
+         install_name.append('.dylib')
+@@ -701,8 +701,8 @@ class AppleDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
+         all_paths = mesonlib.OrderedSet([os.path.join(origin_placeholder, p) for p in processed_rpaths])
+         if build_rpath != '':
+             all_paths.add(build_rpath)
+-        for rp in all_paths:
+-            args.extend(self._apply_prefix('-rpath,' + rp))
++        #KEN for rp in all_paths:
++        #KEN    args.extend(self._apply_prefix('-rpath,' + rp))
+ 
+         return (args, set())
+ 
+diff --git mesonbuild/modules/gnome.py mesonbuild/modules/gnome.py
+index 1faa128..4ef1b07 100644
+--- mesonbuild/modules/gnome.py
++++ mesonbuild/modules/gnome.py
+@@ -277,8 +277,8 @@ class GnomeModule(ExtensionModule):
+         if isinstance(lib, build.SharedLibrary):
+             libdir = os.path.join(state.environment.get_build_dir(), state.backend.get_target_dir(lib))
+             link_command.append('-L' + libdir)
+-            if include_rpath:
+-                link_command.append('-Wl,-rpath,' + libdir)
++            #KEN if include_rpath:
++            #KEN    link_command.append('-Wl,-rpath,' + libdir)
+             depends.append(lib)
+             # Needed for the following binutils bug:
+             # https://github.com/mesonbuild/meson/issues/1911
+@@ -287,8 +287,8 @@ class GnomeModule(ExtensionModule):
+             for d in state.backend.determine_rpath_dirs(lib):
+                 d = os.path.join(state.environment.get_build_dir(), d)
+                 link_command.append('-L' + d)
+-                if include_rpath:
+-                    link_command.append('-Wl,-rpath,' + d)
++                #KEN if include_rpath:
++                #KEN    link_command.append('-Wl,-rpath,' + d)
+         if use_gir_args and self._gir_has_option('--extra-library'):
+             link_command.append('--extra-library=' + lib.name)
+         else:
+@@ -345,8 +345,8 @@ class GnomeModule(ExtensionModule):
+                             getattr(dep, 'is_libtool', False)):
+                         lib_dir = os.path.dirname(lib)
+                         external_ldflags.update(["-L%s" % lib_dir])
+-                        if include_rpath:
+-                            external_ldflags.update(['-Wl,-rpath {}'.format(lib_dir)])
++                        #KEN if include_rpath:
++                        #KEN    external_ldflags.update(['-Wl,-rpath {}'.format(lib_dir)])
+                         libname = os.path.basename(lib)
+                         if libname.startswith("lib"):
+                             libname = libname[3:]
+diff --git mesonbuild/scripts/depfixer.py mesonbuild/scripts/depfixer.py
+index f927693..c1e4541 100644
+--- mesonbuild/scripts/depfixer.py
++++ mesonbuild/scripts/depfixer.py
+@@ -424,9 +424,9 @@ def fix_darwin(fname, new_rpath, final_path, install_name_mappings):
+                                   stdout=subprocess.DEVNULL,
+                                   stderr=subprocess.DEVNULL)
+         args = []
+-        if new_rpath:
+-            args += ['-add_rpath', new_rpath]
+-        # Rewrite -install_name @rpath/libfoo.dylib to /path/to/libfoo.dylib
++        #KEN if new_rpath:
++        #KEN    args += ['-add_rpath', new_rpath]
++        # Rewrite -install_name @loader_path/libfoo.dylib to /path/to/libfoo.dylib
+         if fname.endswith('dylib'):
+             args += ['-id', final_path]
+         if install_name_mappings:


### PR DESCRIPTION
and peg meson at 55.3 on Tiger  as updates are likely fragile
will update meson occasionally, as we do for libuv on Tiger

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.4
Xcode 2.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

So -- keeping Tiger alive -- this latest meson fix tries to work around the lack of rpath support in Tiger.

It largely works -- I think better than before, due to some helpful recent changes in meson upstream wherein they seem to be interested in using loader_path themselves for at least some of the in-tree executables.

Appreciate testing by anyone still interested. Perfection is not guaranteed .. (the opposite!) but improvements seem present.