### PR TITLE
magic-wormhole: new port

### DIFF
--- a/net/magic-wormhole/Portfile
+++ b/net/magic-wormhole/Portfile
@@ -1,0 +1,51 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                magic-wormhole
+version             0.12.0
+revision            0
+
+homepage            https://magic-wormhole.readthedocs.io
+
+description         Securely transfer data between computers.
+
+long_description    {*}${description} This package provides a library and a \
+                    command-line tool named wormhole, which makes it possible \
+                    to get arbitrary-sized files and directories (or short \
+                    pieces of text) from one computer to another. The two \
+                    endpoints are identified by using identical \
+                    “wormhole codes”: in general, the sending machine \
+                    generates and displays the code, which must then be typed \
+                    into the receiving machine.
+
+categories          net python sysutils
+platforms           darwin
+license             MIT
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  bbb9d49f4520e5168f95b35264a4fce7ce4732a7 \
+                    sha256  1b0fd8a334da978f3dd96b620fa9b9348cabedf26a87f74baac7a37052928160 \
+                    size    262269
+
+python.default_version  38
+
+depends_build-append port:py${python.version}-setuptools
+
+depends_lib-append  port:libsodium                      \
+                    port:py${python.version}-attrs      \
+                    port:py${python.version}-autobahn   \
+                    port:py${python.version}-automat    \
+                    port:py${python.version}-click      \
+                    port:py${python.version}-hkdf       \
+                    port:py${python.version}-humanize   \
+                    port:py${python.version}-pynacl     \
+                    port:py${python.version}-six        \
+                    port:py${python.version}-spake2     \
+                    port:py${python.version}-tqdm       \
+                    port:py${python.version}-txtorcon   \
+                    port:py${python.version}-twisted
+


### PR DESCRIPTION
###### Description

New port for [magic-wormhole](https://magic-wormhole.readthedocs.io)

Closes: https://trac.macports.org/ticket/61294

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.0.1 12A7300

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
