### PR TITLE
py-psycopg2: add python39, default to postgresql13

### DIFF
--- a/python/py-psycopg2/Portfile
+++ b/python/py-psycopg2/Portfile
@@ -18,14 +18,11 @@ long_description    Psycopg2 is a postgresql database adapter for python. \
                     designed for heavily multi-threaded applications \
                     featuring connection pooling.
 
-python.versions     27 35 36 37 38
+python.versions     27 36 37 38 39
 
-homepage            http://initd.org/psycopg/
-master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
-distname            ${python.rootname}-${version}
+homepage            https://www.psycopg.org
 
-checksums           md5     ae2ff92f1cfcd890bd5f09f4d1d7d60c \
-                    rmd160  aea153e22c9ac8b1b504c7e8abcad4310aa12cae \
+checksums           rmd160  aea153e22c9ac8b1b504c7e8abcad4310aa12cae \
                     sha256  fb23f6c71107c37fd667cb4ea363ddeb936b348bbd6449278eb92c189699f543 \
                     size    383797
 
@@ -35,6 +32,12 @@ if {${name} ne ${subport}} {
     patchfiles  patch-setup.cfg.diff
 
     post-patch {
+        if {[variant_isset postgresql13]} {
+            reinplace \
+                s|@PG_CONFIG@|${prefix}/lib/postgresql13/bin/pg_config|g \
+                ${worksrcpath}/setup.cfg
+        }
+
         if {[variant_isset postgresql12]} {
             reinplace \
                 s|@PG_CONFIG@|${prefix}/lib/postgresql12/bin/pg_config|g \
@@ -72,38 +75,44 @@ if {${name} ne ${subport}} {
         }
     }
 
+    variant postgresql13 conflicts postgresql94 postgresql95 postgresql96 \
+            postgresql10 postgresql11 postgresql12 \
+            description "Build using postgresql v13" {
+                depends_lib-append  port:postgresql13
+    }
+
     variant postgresql12 conflicts postgresql94 postgresql95 postgresql96 \
-            postgresql10 postgresql11 \
+            postgresql10 postgresql11 postgresql13 \
             description "Build using postgresql v12" {
                 depends_lib-append  port:postgresql12
     }
 
     variant postgresql11 conflicts postgresql94 postgresql95 postgresql96 \
-            postgresql10 postgresql12 \
+            postgresql10 postgresql12 postgresql13 \
             description "Build using postgresql v11" {
                 depends_lib-append  port:postgresql11
     }
 
     variant postgresql10 conflicts postgresql94 postgresql95 postgresql96 \
-            postgresql11 postgresql12 \
+            postgresql11 postgresql12 postgresql13 \
             description "Build using postgresql v10" {
                 depends_lib-append  port:postgresql10
     }
 
     variant postgresql96 conflicts postgresql94 postgresql95 \
-            postgresql10 postgresql11 postgresql12 \
+            postgresql10 postgresql11 postgresql12 postgresql13 \
             description "Build using postgresql v9.6" {
                 depends_lib-append  port:postgresql96
     }
 
     variant postgresql95 conflicts postgresql94 postgresql96 \
-            postgresql10 postgresql11 postgresql12 \
+            postgresql10 postgresql11 postgresql12 postgresql13 \
             description "Build using postgresql v9.5" {
                 depends_lib-append  port:postgresql95
     }
 
     variant postgresql94 conflicts postgresql95 postgresql96 \
-            postgresql10 postgresql11 postgresql12 \
+            postgresql10 postgresql11 postgresql12 postgresql13 \
             description "Build using postgresql v9.4" {
                 depends_lib-append  port:postgresql94
     }
@@ -114,9 +123,10 @@ if {${name} ne ${subport}} {
         ![variant_isset postgresql96] &&
         ![variant_isset postgresql10] &&
         ![variant_isset postgresql11] &&
-        ![variant_isset postgresql12]
+        ![variant_isset postgresql12] &&
+        ![variant_isset postgresql13]
     } {
-        default_variants +postgresql12
+        default_variants +postgresql13
     }
 
     livecheck.type      none


### PR DESCRIPTION
###### Type(s)
- [x] enhancement

###### Tested on
macOS 10.15.7 19H2
Xcode 12.0.1 12A7300

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?