### PR TITLE
libomp: update to 10.0.1; add arm64 patch

### DIFF
--- a/lang/libomp/Portfile
+++ b/lang/libomp/Portfile
@@ -32,7 +32,7 @@ if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} ne "libstdc++"} {
         version                 11.0.0
         checksums \
             rmd160  24d25065c3ccff430995a903d62843f0bcd63670 \
-            sha256  d19f728c8e04fb1e94566c8d76aef50ec926cd2f95ef3bf1e0a5de4909b28b44 \
+            sha256  2d704df8ca67b77d6d94ebf79621b0f773d5648963dd19e0f78efef4404b684c \
             size    975108
 
         livecheck.regex         {"llvmorg-([0-9.rc-]+)".*}

--- a/lang/libomp/Portfile
+++ b/lang/libomp/Portfile
@@ -29,19 +29,19 @@ subport                 libomp-devel {}
 
 if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} ne "libstdc++"} {
     if { ${subport} eq "libomp-devel" } {
-        version                 10.0.1-rc1
+        version                 11.0.0
         checksums \
-            rmd160  0481fc3468617bf4b4c90db9fbe91fc0db48f0f0 \
-            sha256  7e652770b02afb803fbcce47ca11116d383cccc932eddc0260d128e655f2df66 \
-            size    958200
+            rmd160  24d25065c3ccff430995a903d62843f0bcd63670 \
+            sha256  d19f728c8e04fb1e94566c8d76aef50ec926cd2f95ef3bf1e0a5de4909b28b44 \
+            size    975108
 
         livecheck.regex         {"llvmorg-([0-9.rc-]+)".*}
     } else {
-        version                 10.0.0
+        version                 10.0.1
         checksums \
-            rmd160  818001eb0d6f92592af75a87ccd8e05ccc7f8b4d \
-            sha256  3b9ff29a45d0509a1e9667a0feb43538ef402ea8cfc7df3758a01f20df08adfa \
-            size    959016
+            rmd160  8655b63982229d726ba1d4838651a2b6a2671841 \
+            sha256  d19f728c8e04fb1e94566c8d76aef50ec926cd2f95ef3bf1e0a5de4909b28b44 \
+            size    955492
 
         livecheck.regex         {"llvmorg-([0-9.]+)".*}
     }
@@ -60,7 +60,11 @@ if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} ne "libstdc++"} {
     dist_subdir             openmp-release
     worksrcdir              ${distname}
     set rtpath              "runtime/"
-    patchfiles-append       patch-libomp-use-gettid-on-Leopard.diff
+    
+    # D88252 is to enable arm64 support
+    patchfiles-append       patch-libomp-use-gettid-on-Leopard.diff \
+                            reviews.llvm.org_D88252.diff
+
     livecheck.url           https://api.github.com/repos/llvm/llvm-project/tags
 } else {
     if { ${subport} eq "libomp-devel" } {

--- a/lang/libomp/Portfile
+++ b/lang/libomp/Portfile
@@ -19,7 +19,7 @@ long_description        ${description} is intended to contain all of the\
 
 categories              lang
 platforms               darwin
-supported_archs         i386 x86_64
+supported_archs         arm64 i386 x86_64
 license                 {MIT NCSA}
 
 # Moved to epoch 1 for svn # -> version # change.

--- a/lang/libomp/files/reviews.llvm.org_D88252.diff
+++ b/lang/libomp/files/reviews.llvm.org_D88252.diff
@@ -1,0 +1,20 @@
+Index: z_Linux_asm_ifelf.S
+===================================================================
+--- runtime/src/z_Linux_asm.S
++++ runtime/src/z_Linux_asm.S
+@@ -1746,10 +1746,12 @@
+     .comm .gomp_critical_user_,32,8
+     .data
+     .align 8
+-    .global __kmp_unnamed_critical_addr
+-__kmp_unnamed_critical_addr:
++    .global KMP_PREFIX_UNDERSCORE(__kmp_unnamed_critical_addr)
++KMP_PREFIX_UNDERSCORE(__kmp_unnamed_critical_addr):
+     .8byte .gomp_critical_user_
+-    .size __kmp_unnamed_critical_addr,8
++#if __ELF__
++    .size KMP_PREFIX_UNDERSCORE(__kmp_unnamed_critical_addr),8
++#endif
+ #endif /* KMP_ARCH_PPC64 || KMP_ARCH_AARCH64 || KMP_ARCH_MIPS64 ||
+           KMP_ARCH_RISCV64 */
+ 

--- a/lang/libomp/files/reviews.llvm.org_D88252.diff
+++ b/lang/libomp/files/reviews.llvm.org_D88252.diff
@@ -1,6 +1,6 @@
-Index: z_Linux_asm_ifelf.S
-===================================================================
---- runtime/src/z_Linux_asm.S
+Add arm64 support.
+https://reviews.llvm.org/D88252
+--- runtime/src/z_Linux_asm.S.orig
 +++ runtime/src/z_Linux_asm.S
 @@ -1746,10 +1746,12 @@
      .comm .gomp_critical_user_,32,8


### PR DESCRIPTION
This incorporates the patch found [here](https://reviews.llvm.org/D88252) to enable building libomp on AARCH64.

Note I do not have access to the appropriate architectures to test this.

See also [this](https://lists.macports.org/pipermail/macports-dev/2020-October/042519.html) mailing list thread.

As I recall, there is no actual difference in the libomp codebase itself between llvm's 10.0.0 and 10.0.1, but just updating to have it recorded rather than bumping the revision.