### PR TITLE
OpenBLAS: update release to 0.3.11 and devel to 20201019-8e20ab21

### DIFF
--- a/math/OpenBLAS/Portfile
+++ b/math/OpenBLAS/Portfile
@@ -41,11 +41,11 @@ if {![info exists blas_arch]} {
 subport OpenBLAS-devel {}
 if {[string first "-devel" $subport] > 0} {
 
-    github.setup    xianyi OpenBLAS 33d22f99f188216fca6b5b7fdcd6b65cc58645eb
-    version         20200923-[string range ${github.version} 0 7]
-    checksums       rmd160  09c8b9d3266391d918caf94bc49829f1ff61ca02 \
-                    sha256  c7f61f54134c3fe292d59ebc186a796e464c71f4a536e3a87721424eec52f040 \
-                    size    12312100
+    github.setup    xianyi OpenBLAS 8e20ab21c841d36ae2a7ae3d05456a82b289b560
+    version         20201019-[string range ${github.version} 0 7]
+    checksums       rmd160  79fe8028e8966b68e8b55865c0b0094d70b38f29 \
+                    sha256  cd4c97d3a6876cd63e55fd59dea5106409d78bd79d2d71adcad50b8b4359954f \
+                    size    12332340
     revision        0
 
     name            ${github.project}-devel
@@ -61,11 +61,11 @@ if {[string first "-devel" $subport] > 0} {
 
 } else {
 
-    github.setup    xianyi OpenBLAS 0.3.10 v
-    checksums       rmd160  4bfbdbc17a6fc4f1fa8ab8500068a4852ef5086a \
-                    sha256  308398cb50689baa328a3b0612b159a708b193304367cef00722fd70147bdc36 \
-                    size    12249713
-    revision        1
+    github.setup    xianyi OpenBLAS 0.3.11 v
+    checksums       rmd160  eedeb42bc0703dfe8ba311ae17ffa4638bf656d6 \
+                    sha256  e587be98027d9075c7a463bcc6ec5ee3e27ec9dce3fff8fb79b49e748f62be25 \
+                    size    12329247
+    revision        0
 
     conflicts       OpenBLAS-devel
 

--- a/math/OpenBLAS/files/patch-libnoarch.devel.diff
+++ b/math/OpenBLAS/files/patch-libnoarch.devel.diff
@@ -1,6 +1,6 @@
 --- Makefile.system.orig
 +++ Makefile.system
-@@ -1393,11 +1393,11 @@
+@@ -1418,11 +1418,11 @@
  
  ifneq ($(DYNAMIC_ARCH), 1)
  ifndef SMP

--- a/math/OpenBLAS/files/patch-libnoarch.release.diff
+++ b/math/OpenBLAS/files/patch-libnoarch.release.diff
@@ -1,6 +1,6 @@
 --- Makefile.system.orig
 +++ Makefile.system
-@@ -1244,11 +1244,11 @@
+@@ -1418,11 +1418,11 @@
  
  ifneq ($(DYNAMIC_ARCH), 1)
  ifndef SMP


### PR DESCRIPTION
Basic updates to OpenBLAS. I can't test on my primary system at the moment, so I'm relying on CI here as well as others' testing.