### PR TITLE
py-*: py39 support for matplotlib dependencies

### DIFF
--- a/devel/dbus-python/Portfile
+++ b/devel/dbus-python/Portfile
@@ -5,11 +5,11 @@ PortSystem      1.0
 name            dbus-python
 version         1.2.16
 
-set python_versions {27 35 36 37 38}
+set python_versions {27 35 36 37 38 39}
 
 # this default version should stay synchronized with python_get_default_version
 #    in the python PortGroup
-set python_default_version 38
+set python_default_version 39
 
 maintainers     {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
 license         MIT
@@ -107,7 +107,7 @@ foreach python_version ${python_versions} {
         }
 
         # pyXY-gobject, which is required to test, is only supported on certain versions of python
-        if { [lsearch -exact {27 34 35 36 37 38} ${python_version}] != -1 } {
+        if { [lsearch -exact {27 34 35 36 37 38 39} ${python_version}] != -1 } {
             variant test {}
 
             test.run yes

--- a/python/py-gobject/Portfile
+++ b/python/py-gobject/Portfile
@@ -34,7 +34,7 @@ checksums           rmd160  e9fea538da79ad27c42434d4a2173b3eb636408b \
                     sha256  bb9d25a3442ca7511385a7c01b057492095c263784ef31231ffe589d83a96a5a \
                     size    744584
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 if {${subport} ne ${name}} {
     depends_build-append \
@@ -46,7 +46,7 @@ if {${subport} ne ${name}} {
                     port:py${python.version}-cairo \
                     port:gobject-introspection
 
-    patchfiles  patch-pygi-info.c.diff
+    patchfiles  patch-pygi-info.c.diff patch-tpprint-py3.patch
 
     use_configure           yes
     configure.python        ${python.bin}

--- a/python/py-gobject/files/patch-tpprint-py3.patch
+++ b/python/py-gobject/files/patch-tpprint-py3.patch
@@ -1,0 +1,14 @@
+--- gobject/pygobject.c	2017-10-13 12:01:53.000000000 +0200
++++ gobject/pygobject.c	2020-10-20 07:05:31.000000000 +0200
+@@ -823,7 +823,10 @@
+                                   offsetof(PyTypeObject, tp_iter),
+                                   offsetof(PyTypeObject, tp_repr),
+                                   offsetof(PyTypeObject, tp_str),
+-                                  offsetof(PyTypeObject, tp_print) };
++#if PY_VERSION_HEX < 0x03000000
++                                  offsetof(PyTypeObject, tp_print)
++#endif
++                                  };
+     int i;
+
+     /* Happens when registering gobject.GObject itself, at least. */

--- a/python/py-pyqt4/Portfile
+++ b/python/py-pyqt4/Portfile
@@ -24,7 +24,7 @@ set patch       [lindex [split ${version} .] 2]
 
 # pre-declare provided subports
 
-python.versions 27 35 36 37 38
+python.versions 27 35 36 37 38 39
 python.default_version 27
 
 foreach py_ver ${python.versions} {

--- a/python/py-pyqt5/Portfile
+++ b/python/py-pyqt5/Portfile
@@ -34,7 +34,7 @@ if {[vercmp ${qt5.version} 5.11] < 0} {
                         size    3264559
 }
 
-python.versions 27 35 36 37 38
+python.versions 27 35 36 37 38 39
 subport "${name}-common" {}
 
 foreach py_ver ${python.versions} {

--- a/python/py-pyside/Portfile
+++ b/python/py-pyside/Portfile
@@ -8,7 +8,7 @@ github.setup        pyside PySide 1.2.4
 name                py-pyside
 revision            0
 set          qt.ver 4.8
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 python.default_version 27
 categories-append   devel
 maintainers         nomaintainer

--- a/python/py-shiboken/Portfile
+++ b/python/py-shiboken/Portfile
@@ -7,7 +7,7 @@ PortGroup github 1.0
 github.setup        pyside Shiboken 1.2.4
 name                py-shiboken
 revision            1
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 python.default_version 27
 categories-append   devel
 maintainers         nomaintainer
@@ -31,7 +31,8 @@ if {${name} ne ${subport}} {
     }
 
     patchfiles          default_visibility.patch \
-                        patch-cmakepkgconfig.diff
+                        patch-cmakepkgconfig.diff \
+                        patch-tpprint-py3.patch
 
     depends_lib-append  port:python${python.version} \
                         port:libxslt \

--- a/python/py-shiboken/files/patch-tpprint-py3.patch
+++ b/python/py-shiboken/files/patch-tpprint-py3.patch
@@ -1,0 +1,12 @@
+--- libshiboken/sbkenum.cpp	2015-10-14 20:12:33.000000000 +0200
++++ libshiboken/sbkenum.cpp	2020-10-20 05:08:31.000000000 +0200
+@@ -529,7 +529,9 @@
+     ::memset(type, 0, sizeof(SbkEnumType));
+     Py_TYPE(type) = &SbkEnumType_Type;
+     type->tp_basicsize = sizeof(SbkEnumObject);
++#ifndef IS_PY3K
+     type->tp_print = &SbkEnumObject_print;
++#endif
+     type->tp_repr = &SbkEnumObject_repr;
+     type->tp_str = &SbkEnumObject_repr;
+     type->tp_flags = Py_TPFLAGS_DEFAULT|Py_TPFLAGS_CHECKTYPES;

--- a/python/py-sip/Portfile
+++ b/python/py-sip/Portfile
@@ -54,7 +54,7 @@ epoch               1
 # SIP 4.16.[1-7] provides SIP API 11.1.
 # SIP 4.15.5 provided SIP API 11.0.
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 python.default_version 27
 
 if {${name} ne ${subport}} {

--- a/python/py-sphinx_rtd_theme/Portfile
+++ b/python/py-sphinx_rtd_theme/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  4445532bc9604877e8a28c819a403bc47f49895d \
                     sha256  728607e34d60456d736cc7991fd236afb828b21b82f956c5ea75f94c8414040a \
                     size    5391190
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 if {${subport} ne ${name}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

Adds py39 support for these Python packages:

* dbus-python
* py-gobject
* py-pyqt4
* py-pyqt5
* py-pyside
* py-shiboken
* py-sip
* py-sphinx_rtd_theme

This shoud allow all py-matplotlib variants to be installed without dependency issues.

Since Python 3.9 removed `tp_print` (deprecated since 3.8), a patch was necessary to build `py-gobject` and `py-shiboken` successfully. According to the Python docs, `tp_print` has not done anything since Python 3.0.

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
