### PR TITLE
git: update to 2.29.0

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 name                git
-version             2.28.0
-revision            1
+version             2.29.0
+revision            0
 
 description         A fast version control system
 long_description    Git is a fast, scalable, distributed open source version \
@@ -24,13 +24,13 @@ distfiles           git-${version}${extract.suffix} \
                     git-manpages-${version}${extract.suffix}
 
 checksums           git-${version}.tar.xz \
-                    rmd160  e67938072b14b8be06e562666a66a1a5d659fbb9 \
-                    sha256  dfa5d1a253aa451465478fe45c6a40ab8605b340fdb4c4e80b16d7f87708439d \
-                    size    6117608 \
+                    rmd160  0d96330e93cdbc3ed791be65847e5105d2adc42b \
+                    sha256  28432d995257c4626fe0fb2091f588df6eed98e9571419e72c83bc23372e6b89 \
+                    size    6187748 \
                     git-manpages-${version}.tar.xz \
-                    rmd160  acfd90d2696a852385f18010acfdfb785213c881 \
-                    sha256  665a7fa41f9a39248e48422dcf533e1a0133a4a6eddfc25ee55e28e42fc07cb7 \
-                    size    472524 \
+                    rmd160  a13845d501b6569738d049e3bb3e7dd0beccd0c0 \
+                    sha256  8d2e44513a58833fdd737ef9f262b3c4a390726df660548b44404fb4c25af0cb \
+                    size    478456
 
 perl5.require_variant   yes
 perl5.conflict_variants yes
@@ -147,9 +147,9 @@ variant pcre description {Use pcre} {
 variant doc description {Install HTML and plaintext documentation} {
     distfiles-append        git-htmldocs-${version}${extract.suffix}
     checksums-append        git-htmldocs-${version}.tar.xz \
-                            rmd160  7670eea059ee92fb11d0204710528b2d4614fd42 \
-                            sha256  24feed3b584e2121418de9bde9f2e23fdcf78e4f914279787f669d3dc375bfe6 \
-                            size    1347596
+                            rmd160  b52c5dbce4cf416d1d17097233548f31aa48ad4b \
+                            sha256  c281a4f3486362b19f7f632260a120fa77bb085d1815ea3059df87962dd02628 \
+                            size    1364672
 
     patchfiles-append       patch-git-subtree.html.diff
 


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.0.1 12A7300

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
