### PR TITLE
jq: apply patch to earlier macOS versions

### DIFF
--- a/sysutils/jq/Portfile
+++ b/sysutils/jq/Portfile
@@ -34,7 +34,7 @@ configure.args      --disable-docs \
                     --disable-maintainer-mode
 
 platform darwin {
-    if {${os.major} >= 20} {
+    if {${os.major} >= 12} {
         patchfiles      patch-src-builtin.c
     }
 }


### PR DESCRIPTION
Fixes error for Xcode 12 on macOS 10.15
Fixes: https://trac.macports.org/ticket/61354

Avoids warning on older macOS/Xcode versions

#### Description

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
