### PR TITLE
google-cloud-sdk: update to 315.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             314.0.0
+version             315.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  b3e65617eb2effd18d4f2bff4ccf250c8bf1fdfb \
-                    sha256  0fc8a85deb89cdab577838ff2ee33a12590f747cd2a7d9eccd33a561bb79f65f \
-                    size    85365578
+    checksums       rmd160  080b94854f8bc998864ec8da46da0640e7fa9686 \
+                    sha256  de1b9ce2f5170dcd0e48fb688df6c9c6d7b7247bee92204b870b1675bf85b50c \
+                    size    85475652
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  be87b4e4d475dfc83073d362ac7bb43b17e58da4 \
-                    sha256  c6a1c29612ad5d680aefe0c2b440f584b2274c52d34a480dd9238a9e57057c5f \
-                    size    86377353
+    checksums       rmd160  2cdf6952c6a9ea6f1446add85444c35eed32cd95 \
+                    sha256  95443eb20d212890e9b811548207fef2c44bad74b83affe2442a8e83248d75d2 \
+                    size    86489111
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 315.0.0.

###### Tested on

macOS 10.15.7 19H2
Xcode 12.0.1 12A7300

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?