### PR TITLE
gitlab-runner: update to 13.5.0

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 13.4.1 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 13.5.0 v
 
 categories          devel
 platforms           darwin
@@ -23,9 +23,9 @@ homepage            https://docs.gitlab.com/runner/
 master_sites        https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v${version}/
 distname            gitlab-runner-v${version}
 
-checksums           rmd160  ab369a76bdc9191e0ec1115af6aeda134b727dac \
-                    sha256  4f3441c6833c3edbdba8452d25bbaeb592e4c078f48358bbc9d18fbd798ce336 \
-                    size    8063918
+checksums           rmd160  52e256becf4a4ac671b7fb8650b346ee1c95da3a \
+                    sha256  765c1556ed9dd4c1b36f9946224c62f068b171e2c1581eeb8f71055327d8a274 \
+                    size    8148346
 
 # Reproduce the "build_simple" target from the upstream Makefile
 set go_ldflags      "-X ${go.package}/common.NAME=${go.package} \


### PR DESCRIPTION
#### Description

Update to GitLab Runner 13.5.0.

###### Tested on

macOS 10.15.7 19H2
Xcode 12.0.1 12A7300

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?