### PR TITLE
py-sniffio: update to 1.2.0, enable for Python 3.9

### DIFF
--- a/python/py-sniffio/Portfile
+++ b/python/py-sniffio/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-sniffio
-version             1.1.0
+version             1.2.0
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
 license             {Apache-2 MIT}
 
-python.versions     36 37 38
+python.versions     36 37 38 39
 
 maintainers         {@jandemter demter.de:jan} openmaintainer
 
@@ -19,13 +19,10 @@ long_description    This is a tiny package whose only purpose is to let you \
                     detect which async library your code is running under.
 
 homepage            https://github.com/python-trio/sniffio
-master_sites        pypi:s/sniffio
 
-distname            sniffio-${version}
-
-checksums           rmd160  b7e4a4e9e6761ba5aabbe8839dae683e9c9abf92 \
-                    sha256  8e3810100f69fe0edd463d02ad407112542a11ffdc29f67db2bf3771afb87a21 \
-                    size    15285
+checksums           rmd160  9dceca9fc75a0cc0048e4d9faea1102dc7ff7170 \
+                    sha256  c4666eecec1d3f50960c6bdf61ab7bc350648da6c126e3cf6898d8cd4ddcd3de \
+                    size    17132
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
