### PR TITLE
libomp: Use clang_dependency; add 10.0

### DIFF
--- a/_resources/port1.0/group/clang_dependency-1.0.tcl
+++ b/_resources/port1.0/group/clang_dependency-1.0.tcl
@@ -11,4 +11,4 @@ proc clang_dependency.extra_versions {versions} {
     }
 }
 
-clang_dependency.extra_versions {devel 9.0 8.0 7.0 6.0 5.0}
+clang_dependency.extra_versions {devel 10.0 9.0 8.0 7.0 6.0 5.0}

--- a/_resources/port1.0/group/clang_dependency-1.0.tcl
+++ b/_resources/port1.0/group/clang_dependency-1.0.tcl
@@ -11,4 +11,4 @@ proc clang_dependency.extra_versions {versions} {
     }
 }
 
-clang_dependency.extra_versions {devel 10.0 9.0 8.0 7.0 6.0 5.0}
+clang_dependency.extra_versions {devel 10 9.0 8.0 7.0 6.0 5.0}

--- a/lang/libomp/Portfile
+++ b/lang/libomp/Portfile
@@ -5,6 +5,7 @@ PortGroup               cmake 1.0
 if {${os.major} <= 17} {
     PortGroup               muniversal 1.0
 }
+PortGroup               clang_dependency 1.0
 PortGroup               compiler_blacklist_versions 1.0
 
 name                    libomp
@@ -91,14 +92,6 @@ cmake.out_of_source     yes
 
 # According to documentation builds with clang >= 3.3
 compiler.blacklist-append {clang < 500} *gcc*
-
-# Avoid dependency cycle
-# https://trac.macports.org/ticket/53110
-foreach ver {3.8 3.9 4.0 5.0 6.0 7.0 8.0 9.0 devel} {
-    if {![file exists ${prefix}/bin/clang-mp-${ver}]} {
-        compiler.blacklist-append macports-clang-${ver}
-    }
-}
 
 if {${os.major} <= 17} {
     default_variants        +universal


### PR DESCRIPTION
Ref: https://trac.macports.org/ticket/59279

I also added 10.0 to the clang_dependency port group; hopefully that seems reasonable.