### PR TITLE
eigen3: Include upstream OpenMP fix.

### DIFF
--- a/math/eigen3/Portfile
+++ b/math/eigen3/Portfile
@@ -19,9 +19,10 @@ depends_build-append    port:pkgconfig
 
 if {${subport} eq ${name}} {
     gitlab.setup        libeigen eigen 3.3.8
-    revision            0
+    revision            1
     conflicts           eigen3-devel
 
+    patchfiles          openmp_fix.diff
     checksums \
         rmd160  af037485f91b43ef4e6622b14ba9c0de1b521679 \
         sha256  0215c6593c4ee9f1f7f28238c4e8995584ebf3b556e9dbf933d84feb98d5b9ef \

--- a/math/eigen3/files/openmp_fix.diff
+++ b/math/eigen3/files/openmp_fix.diff
@@ -1,0 +1,43 @@
+https://gitlab.com/libeigen/eigen/-/issues/2011
+--- Eigen/src/Core/products/Parallelizer.h.orig
++++ Eigen/src/Core/products/Parallelizer.h
+@@ -132,8 +132,7 @@ void parallelize_gemm(const Functor& func, Index rows, Index cols, Index depth,
+ 
+   ei_declare_aligned_stack_constructed_variable(GemmParallelInfo<Index>,info,threads,0);
+ 
+-  int errorCount = 0;
+-  #pragma omp parallel num_threads(threads) reduction(+: errorCount)
++  #pragma omp parallel num_threads(threads)
+   {
+     Index i = omp_get_thread_num();
+     // Note that the actual number of threads might be lower than the number of request ones.
+@@ -152,14 +151,11 @@ void parallelize_gemm(const Functor& func, Index rows, Index cols, Index depth,
+     info[i].lhs_start = r0;
+     info[i].lhs_length = actualBlockRows;
+ 
+-    EIGEN_TRY {
+-      if(transpose) func(c0, actualBlockCols, 0, rows, info);
+-      else          func(0, rows, c0, actualBlockCols, info);
+-    } EIGEN_CATCH(...) {
+-      ++errorCount;
+-    }
++    if(transpose)
++      func(c0, actualBlockCols, 0, rows, info);
++    else
++      func(0, rows, c0, actualBlockCols, info);
+   }
+-  if (errorCount) EIGEN_THROW_X(Eigen::eigen_assert_exception());
+ #endif
+ }
+ 
+--- test/CMakeLists.txt.orig
++++ test/CMakeLists.txt
+@@ -163,7 +163,7 @@ ei_add_test(constructor)
+ ei_add_test(linearstructure)
+ ei_add_test(integer_types)
+ ei_add_test(unalignedcount)
+-if(NOT EIGEN_TEST_NO_EXCEPTIONS)
++if(NOT EIGEN_TEST_NO_EXCEPTIONS AND NOT EIGEN_TEST_OPENMP)
+   ei_add_test(exceptions)
+ endif()
+ ei_add_test(redux)


### PR DESCRIPTION
Maintainer update. Pulling in this fix while waiting for upstream to cut new release.