### PR TITLE
py27-tldextract: pin to 2.2.3

### DIFF
--- a/python/py-tldextract/Portfile
+++ b/python/py-tldextract/Portfile
@@ -22,6 +22,14 @@ checksums           rmd160  293e023382d2a3e45dd0eb1388eaa2946327483e \
                     size    99718
 
 if {${name} ne ${subport}} {
+    if {${python.version} == 27} {
+        version     2.2.3
+        revision    0
+        checksums   rmd160  af04d2135cd17f91f5d08da0ceb8ddd157a1e476 \
+                    sha256  fbc5eb6b37345d4e0fb0bd73786e0812e27e16ce1d7c7b1526a582896a4d51b3 \
+                    size    62854
+    }
+
     depends_build-append \
                     port:py${python.version}-setuptools \
                     port:py${python.version}-setuptools_scm


### PR DESCRIPTION
3.0.0 removed support for Python 2.7

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
