### PR TITLE
py-pip: disable vendoring of packages on non-deprecated versions

### DIFF
--- a/python/py-cachecontrol/Portfile
+++ b/python/py-cachecontrol/Portfile
@@ -12,7 +12,7 @@ platforms           darwin
 license             Apache-2
 supported_archs     noarch
 
-python.versions     37 38
+python.versions     27 36 37 38 39
 
 maintainers         {gmail.com:davidgilman1 @dgilman} openmaintainer
 

--- a/python/py-contextlib2/Portfile
+++ b/python/py-contextlib2/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             PSF
 supported_archs     noarch
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-distlib/Portfile
+++ b/python/py-distlib/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  e90930fec905210f528d20e24990b600b04dec76 \
                     size    578925
 
 # keep version for PY27 and PY34, these are (indirect) dependencies of py-virtualenv
-python.versions     27 34 35 36 37 38
+python.versions     27 34 35 36 37 38 39
 
 if {${name} ne ${subport}} {
     test.run        yes

--- a/python/py-pep517/Portfile
+++ b/python/py-pep517/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           python 1.0
+
+name                py-pep517
+version             0.8.2
+license             MIT
+platforms           darwin
+maintainers         {danchr @danchr} openmaintainer
+description         Wrappers to build Python packages using PEP 517 hooks.
+
+long_description    ${description} PEP 517 specifies a standard API for \
+                    systems which build Python packages.
+
+homepage            https://github.com/pypa/pep517
+
+checksums           rmd160 0b2cc28ff3fbdab2fdcd7a1bf6a5311af48be5a0 \
+                    sha256 8e6199cf1288d48a0c44057f112acf18aa5ebabbf73faa242f598fbe145ba29e \
+                    size 20440
+
+python.versions     27 36 37 38 39
+
+if {${name} ne ${subport}} {
+    depends_build   port:py${python.version}-toml
+
+    livecheck.type  none
+}

--- a/python/py-pip/Portfile
+++ b/python/py-pip/Portfile
@@ -6,7 +6,7 @@ PortGroup           select 1.0
 
 name                py-pip
 version             20.2.4
-revision            0
+revision            1
 categories-append   www
 platforms           darwin
 license             MIT
@@ -48,24 +48,61 @@ if {${name} ne ${subport}} {
         checksums           rmd160  9cf0429a7a7e9897339ffc5a141e9b2e1da8086e \
                             sha256  7bf48f9a693be1d58f49f7af7e0ae9fe29fd671cde8a55e6edca3581c4ef5796 \
                             size    1343076
-    }
-
-    if {[lsearch {33} ${python.version}] != -1} {
+    } elseif {[lsearch {33} ${python.version}] != -1} {
         version             10.0.1
         revision            0
         distname            ${python.rootname}-${version}
         checksums           rmd160  008e4a069e4969ee08ad383eb1d0070eeb63b405 \
                             sha256  f2bd08e0cd1b06e10218feaf6fef299f473ba706582eb3bd9d52203fdbd7ee68 \
                             size    1246072
-    }
-
-    if {[lsearch {34} ${python.version}] != -1} {
+    } elseif {[lsearch {34} ${python.version}] != -1} {
         version             18.1
         revision            0
         distname            ${python.rootname}-${version}
         checksums           rmd160  53409af5e0f06b66656d2d0d81c79ff0a7aba29f \
                             sha256  c0a292bd977ef590379a3f05d7b7f65135487b67470f6281289a94e015650ea1 \
                             size    1259370
+    } else {
+        # Pip bundles quite a lot packages since so that it can
+        # bootstrap itself. We disable this bundling, but only on the
+        # latest Python versions; once a release reaches EOL, bump the
+        # check here.
+
+        patchfiles-append   patch-debundle.diff
+        depends_lib-append  port:py${python.version}-appdirs \
+                            port:py${python.version}-cachecontrol \
+                            port:py${python.version}-certifi \
+                            port:py${python.version}-chardet \
+                            port:py${python.version}-colorama \
+                            port:py${python.version}-contextlib2 \
+                            port:py${python.version}-distlib \
+                            port:py${python.version}-distro \
+                            port:py${python.version}-html5lib \
+                            port:py${python.version}-idna \
+                            port:py${python.version}-ipaddress \
+                            port:py${python.version}-msgpack \
+                            port:py${python.version}-packaging \
+                            port:py${python.version}-pep517 \
+                            port:py${python.version}-progress \
+                            port:py${python.version}-parsing \
+                            port:py${python.version}-requests \
+                            port:py${python.version}-resolvelib \
+                            port:py${python.version}-retrying \
+                            port:py${python.version}-six \
+                            port:py${python.version}-toml \
+                            port:py${python.version}-urllib3 \
+                            port:py${python.version}-webencodings \
+                            port:py${python.version}-openssl \
+                            port:py${python.version}-cryptography \
+                            port:py${python.version}-idna
+
+        post-patch {
+            foreach f [glob -directory ${worksrcpath}/src/pip/_vendor *] {
+                if {[file rootname [file tail ${f}]] != "__init__"} {
+                    delete ${f}
+                }
+            }
+        }
     }
 
     post-destroot {

--- a/python/py-pip/files/patch-debundle.diff
+++ b/python/py-pip/files/patch-debundle.diff
@@ -1,0 +1,27 @@
+diff --git a/src/pip/_vendor/__init__.py b/src/pip/_vendor/__init__.py
+--- src/pip/_vendor/__init__.py
++++ src/pip/_vendor/__init__.py
+@@ -14,7 +14,7 @@ import sys
+ # Downstream redistributors which have debundled our dependencies should also
+ # patch this value to be true. This will trigger the additional patching
+ # to cause things like "six" to be available as pip.
+-DEBUNDLED = False
++DEBUNDLED = True
+ 
+ # By default, look in this directory for a bunch of .whl files which we will
+ # add to the beginning of sys.path before attempting to import anything. This
+@@ -85,14 +85,11 @@ if DEBUNDLED:
+     vendored("requests.packages.urllib3.connection")
+     vendored("requests.packages.urllib3.connectionpool")
+     vendored("requests.packages.urllib3.contrib")
+-    vendored("requests.packages.urllib3.contrib.ntlmpool")
+     vendored("requests.packages.urllib3.contrib.pyopenssl")
+     vendored("requests.packages.urllib3.exceptions")
+     vendored("requests.packages.urllib3.fields")
+     vendored("requests.packages.urllib3.filepost")
+     vendored("requests.packages.urllib3.packages")
+-    vendored("requests.packages.urllib3.packages.ordered_dict")
+-    vendored("requests.packages.urllib3.packages.six")
+     vendored("requests.packages.urllib3.packages.ssl_match_hostname")
+     vendored("requests.packages.urllib3.packages.ssl_match_hostname."
+              "_implementation")

--- a/python/py-progress/Portfile
+++ b/python/py-progress/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
+
+name                py-progress
+github.setup        verigak progress 1.5
+maintainers         {danchr @danchr} openmaintainer
+platforms           darwin
+license             MIT
+
+description         Easy progress reporting for Python
+long_description    ${description}
+
+checksums           rmd160  6db0b637871793280297b9da1165321456db3e86 \
+                    sha256  76d878c8db0b6148ea44c74c96a1b21ea887329831a678cf84b31e0b2d52eb7e \
+                    size    620093
+
+python.versions     27 36 37 38 39
+
+if {${name} ne ${subport}} {
+    depends_lib-append \
+                    port:py${python.version}-setuptools \
+
+    livecheck.type      none
+}

--- a/python/py-resolvelib/Portfile
+++ b/python/py-resolvelib/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
+
+name                py-resolvelib
+github.setup        sarugaku resolvelib 0.4.0
+maintainers         {danchr @danchr} openmaintainer
+platforms           darwin
+license             MIT
+
+description         Easy progress reporting for Python
+long_description    ${description}
+
+checksums           rmd160  9f3c88f78af3c7c35d164f48844e806e30a7d941 \
+                    sha256  5fa3801f22547a4e79faad22066232776751663851378e1f4567a26f2242735f \
+                    size    607768
+
+python.versions     27 36 37 38 39
+
+if {${name} ne ${subport}} {
+    depends_lib-append \
+                    port:py${python.version}-setuptools
+
+    livecheck.type      none
+}

--- a/python/py-retrying/Portfile
+++ b/python/py-retrying/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
+
+name                py-retrying
+github.setup        rholder retrying 1.3.3 v
+maintainers         {danchr @danchr} openmaintainer
+platforms           darwin
+license             Apache-2.0
+
+description         Retrying library
+long_description    ${description}.
+
+checksums           rmd160  16db655d33253df042cf294d9c60ebbfc980300a \
+                    sha256  acc40a5ddd22db143f7fea7da7a2d4fef88dd32f849845b3a49684732d91e113 \
+                    size    11661
+
+python.versions     27 36 37 38 39
+
+if {${name} ne ${subport}} {
+    depends_lib-append \
+                    port:py${python.version}-setuptools \
+
+    livecheck.type      none
+}


### PR DESCRIPTION
#### Description

This is similar to, and inspired by, what Ubuntu and Debian do. I restricted the change to actually supported versions. Pip patches some of its dependencies, but only one of these seems relevant:

https://github.com/pypa/pip/blob/master/tools/automation/vendoring/patches/appdirs.patch

I'm not sure whether we should apply that one.

See: https://pip.pypa.io/en/stable/development/vendoring-policy/#debundling

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
