### PR TITLE
py-mergedeep: new port

### DIFF
--- a/python/py-mergedeep/Portfile
+++ b/python/py-mergedeep/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-mergedeep
+version             1.3.0
+categories-append   devel
+platforms           darwin
+supported_archs     noarch
+license             MIT
+
+python.versions     38 39
+
+maintainers         nomaintainer
+
+description         A deep merge function for Python
+long_description    {*}${description}
+
+homepage            https://mergedeep.readthedocs.io
+
+checksums           rmd160  9c6091d82513077603c820616e65bf5fa0e13b8d \
+                    sha256  19a91123e71ae27cb22335f4d03aec040026c89d4ff6df42595f7e7223a83dfb \
+                    size    4583
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools
+}


### PR DESCRIPTION


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
