### PR TITLE
restic: update to 0.10.0

### DIFF
--- a/sysutils/restic/Portfile
+++ b/sysutils/restic/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/restic/restic v0.10.0 v
+go.setup            github.com/restic/restic 0.10.0 v
 categories          sysutils
 
 license             BSD

--- a/sysutils/restic/Portfile
+++ b/sysutils/restic/Portfile
@@ -19,6 +19,11 @@ checksums           ${distname}${extract.suffix} \
                         sha256  8758130f7aa1639b1b2c24c327114657a819c81cdd229a41f56fe9a6550a2b05 \
                         size    23683647
 
+# FIXME: This port currently can't be built without allowing go mod to fetch
+# dependencies during the build phase. See
+# https://trac.macports.org/ticket/61192
+build.env-delete    GOPROXY=off GO111MODULE=off
+
 set pyver           3.7
 
 variant             docs description {Build the documentation} {

--- a/sysutils/restic/Portfile
+++ b/sysutils/restic/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/restic/restic 0.9.6 v
+go.setup            github.com/restic/restic v0.10.0 v
 categories          sysutils
 
 license             BSD
@@ -14,9 +14,10 @@ long_description    Restic is a program that does backups right. Its design goal
 
 homepage            https://restic.net/
 
-checksums           rmd160  24d2329c034e69d2a0eef477ef78bc9875a7a8af \
-                    sha256  2f46c381b4f2964068e256f85f11cacdda75601cf0ef5069e08b3ed91c2f7c9c \
-                    size    27009000
+checksums           ${distname}${extract.suffix} \
+                        rmd160  f5eb870195c8127742c10ed80575e2f3c16dd6b0 \
+                        sha256  8758130f7aa1639b1b2c24c327114657a819c81cdd229a41f56fe9a6550a2b05 \
+                        size    23683647
 
 set pyver           3.7
 


### PR DESCRIPTION
#### Description

Updates restic to 0.10.0 and re-enables fetching of dependencies (see [comment](https://github.com/macports/macports-ports/pull/8871#issuecomment-714453155))


<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS macOS 10.15.7 19H2
Xcode N/A

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
