### PR TITLE
py-yapf: add py39 subport

### DIFF
--- a/python/py-yapf/Portfile
+++ b/python/py-yapf/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  2c1f9e2dfa6f6479b3c18b084ea20fbedc4ce05b \
                     sha256  91fd45b4def04a3c5632e9207f523a8b21c29bdd5f2c6af236d827a08155d3c7 \
                     size    168307
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 if {${subport} ne ${name}} {
     depends_lib-append \

--- a/python/py-yapf/files/py39-yapf
+++ b/python/py-yapf/files/py39-yapf
@@ -1,0 +1,1 @@
+${frameworks_dir}/Python.framework/Versions/3.9/bin/yapf


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.2 12B5035g

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
