### PR TITLE
wimlib: add +fuse and +ntfs variants, fix port

### DIFF
--- a/archivers/wimlib/Portfile
+++ b/archivers/wimlib/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                wimlib
 version             1.13.2
-revision            0
+revision            1
 checksums           rmd160  dfc13fd5380db2263ec710905a97d6f4b5ded372 \
                     sha256  7295be7ef00d265aef4090c9d26af82097db651c5f8399db9d44c60f47f5a945 \
                     size    1030542
@@ -29,21 +29,32 @@ master_sites        ${homepage}/downloads/
 depends_build       port:pkgconfig
 
 depends_lib         port:libxml2 \
-                    port:ntfs-3g \
-                    path:lib/libssl.dylib:openssl \
-                    port:osxfuse
+                    path:lib/libssl.dylib:openssl
 
 depends_run         port:cabextract \
                     port:cdrtools \
                     port:mtools
 
-# ntfs-3g is not universal
-universal_variant   no
-
 configure.args      --disable-silent-rules \
+                    --with-libcrypto \
                     --without-fuse \
-                    --with-ntgs-3g \
-                    --with-libcrypto
+                    --without-ntfs-3g
+
+variant fuse description {Mount WIM images with FUSE} {
+  depends_lib-append      port:osxfuse
+  configure.args-replace  --without-fuse --with-fuse
+
+  # osxfuse is not universal
+  universal_variant       no
+}
+
+variant ntfs description {Capture/apply images directly from/to NTFS volumes} {
+  depends_lib-append      port:ntfs-3g
+  configure.args-replace  --without-ntfs-3g --with-ntfs-3g
+
+  # ntfs-3g is not universal
+  universal_variant       no
+}
 
 livecheck.type      regex
 livecheck.url       ${homepage}

--- a/archivers/wimlib/Portfile
+++ b/archivers/wimlib/Portfile
@@ -44,12 +44,6 @@ configure.args      --disable-silent-rules \
                     --without-fuse \
                     --without-ntfs-3g
 
-variant fuse conflicts universal description {Mount WIM images with FUSE} {
-    # osxfuse is not universal
-    depends_lib-append      port:osxfuse
-    configure.args-replace  --without-fuse --with-fuse
-}
-
 variant ntfs conflicts universal description {Capture/apply images directly from/to NTFS volumes} {
     # ntfs-3g is not universal
     depends_lib-append      port:ntfs-3g

--- a/archivers/wimlib/Portfile
+++ b/archivers/wimlib/Portfile
@@ -35,25 +35,25 @@ depends_run         port:cabextract \
                     port:cdrtools \
                     port:mtools
 
+# cdrtools is not universal but we're only using its programs, not its
+# libraries.
+depends_skip_archcheck cdrtools
+
 configure.args      --disable-silent-rules \
                     --with-libcrypto \
                     --without-fuse \
                     --without-ntfs-3g
 
-variant fuse description {Mount WIM images with FUSE} {
-  depends_lib-append      port:osxfuse
-  configure.args-replace  --without-fuse --with-fuse
-
-  # osxfuse is not universal
-  universal_variant       no
+variant fuse conflicts universal description {Mount WIM images with FUSE} {
+    # osxfuse is not universal
+    depends_lib-append      port:osxfuse
+    configure.args-replace  --without-fuse --with-fuse
 }
 
-variant ntfs description {Capture/apply images directly from/to NTFS volumes} {
-  depends_lib-append      port:ntfs-3g
-  configure.args-replace  --without-ntfs-3g --with-ntfs-3g
-
-  # ntfs-3g is not universal
-  universal_variant       no
+variant ntfs conflicts universal description {Capture/apply images directly from/to NTFS volumes} {
+    # ntfs-3g is not universal
+    depends_lib-append      port:ntfs-3g
+    configure.args-replace  --without-ntfs-3g --with-ntfs-3g
 }
 
 livecheck.type      regex


### PR DESCRIPTION
The Portfile for wimlib was broken: it specified port:ntfs-3g and
port:osxfuse in depends_lib, but did not actually use either.
configure.args contained --without-fuse, and while it seems to have
intended to enable NTFS support, it did so by specifying --with-ntgs-3g,
a typo that prevented NTFS support from being enabled. Meanwhile,
because of the sorry state of osxfuse, the port was difficult to install
on some systems (https://github.com/osxfuse/osxfuse/issues/590,
https://github.com/macports/macports-ports/pull/4601), rendering this
port essentially unusable simply because it specified osxfuse as a
dependency, but did not use it.

This introduces +fuse and +ntfs variants. +ntfs must be a variant too,
because ntfs-3g depends on osxfuse. Because the previous revision of the
Portfile did not properly enable either fuse or ntfs-3g support, neither
of these variants are selected by default. This assures maximum
compatibility with all macOS systems without any loss of functionality
relative to the previous revision of this port.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.2 12B5035g

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
