### PR TITLE
beekeeper-studio: update to 1.8.3

### DIFF
--- a/aqua/beekeeper-studio/Portfile
+++ b/aqua/beekeeper-studio/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        beekeeper-studio beekeeper-studio 1.7.5 v
+github.setup        beekeeper-studio beekeeper-studio 1.8.3 v
 revision            0
 
 homepage            https://beekeeperstudio.io/
@@ -29,29 +29,19 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  f2427c9ebb058716e4d68826c4bcbe0aea2b051d \
-                    sha256  a273bc668fdd7a99450c6a1d39e563cb823091abc2fde93c29d3ff6936db98ff \
-                    size    42364384
+                    rmd160  4d4ba245a886a16e26c04f5c5e99235ab474370f \
+                    sha256  803ca01ffa6955bfabbf1fdf7d8eef7838dc81651c5e2b7b066d318775e8c52d \
+                    size    42384487
 
-depends_build       port:go \
-                    port:yarn
-
-use_configure       no
+depends_build       port:yarn
 
 build.env-append    CSC_IDENTITY_AUTO_DISCOVERY=false
 
-build {
-    set gopath ${workpath}/go
+use_configure       no
 
+build {
     # Set up all JS dependencies
     system -W ${worksrcpath} "yarn --frozen-lockfile"
-
-#   # Workaround for: https://trac.macports.org/ticket/60555
-#   # Build app-builder-bin locally and insert it into node_modules
-#   system "GOPATH=${gopath} go get -v github.com/develar/app-builder"
-#   file delete ${worksrcpath}/node_modules/app-builder-bin/mac/app-builder
-#   file link ${worksrcpath}/node_modules/app-builder-bin/mac/app-builder \
-#             ${gopath}/bin/app-builder
 
     # Build electron app
     system -W ${worksrcpath} \


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
