### PR TITLE
py-sh: update to 1.14.0, remove github portgroup

### DIFF
--- a/python/py-sh/Portfile
+++ b/python/py-sh/Portfile
@@ -2,11 +2,9 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
-PortGroup           github 1.0
 
-github.setup        amoffat sh 1.13.1
 name                py-sh
-
+version             1.14.0
 categories-append   devel
 license             MIT
 platforms           darwin
@@ -14,13 +12,15 @@ supported_archs     noarch
 maintainers         nomaintainer
 
 description         sh (previously pbs) is a full-fledged subprocess interface
-long_description    ${description} \
-                    for Python 2.6 - 3.5 that allows you to call any program as \
+long_description    {*}${description} \
+                    for Python 2.6 - 3.8 that allows you to call any program as \
                     if it were a function
 
-checksums           rmd160  4326f6db7be0890ce83a05a4f648d617fd58c6bf \
-                    sha256  ff3e50295dc9367ae760742dec9aa325638b830629f7abad454bba08afc1ed26 \
-                    size    344215
+homepage            https://amoffat.github.io/sh/
+
+checksums           rmd160  f883874c7f228ef3101042b084ffc881b7d0ae40 \
+                    sha256  05c7e520cdf70f70a7228a03b589da9f96c6e0d06fc487ab21fc62b26a592e59 \
+                    size    63313
 
 python.versions     27 35 36 37 38 39
 


### PR DESCRIPTION
#### Description

There is no tag for `1.14.0` on the [GitHub releases page](https://github.com/amoffat/sh/releases). However, this version is available on [PyPi](https://pypi.python.org/pypi/sh). I therefore removed the github portgroup to download from PyPi instead.

The version numbers mentioned in the `long_description` have also been updated in accordance with the [README](https://github.com/amoffat/sh/blob/develop/README.rst).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.6 19G73
xcode-select version 2373

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
