### PR TITLE
libhttpseverywhere: download rules

### DIFF
--- a/www/libhttpseverywhere/Portfile
+++ b/www/libhttpseverywhere/Portfile
@@ -23,14 +23,29 @@ long_description    ${description}. HTTPSEverywhere is a browser plugin \
                     GLib-based library you can link/bind against \
                     in almost all languages
 
-homepage            https://git.gnome.org/browse/${name}
-master_sites        gnome:sources/${name}/${branch}/
-
 use_xz              yes
 
-checksums           rmd160  67ecbcfbfe5eba4eba47b38099ddc4ebae847403 \
+set main_distfile   ${distfiles}
+set rules_distfile  default.rulesets-2019.1.7
+set rules_commit    9c43785fe5ce13c70b8a1abfece834d12fc9d0fb
+
+extract.only        ${main_distfile}
+
+distfiles           ${main_distfile}:main \
+                    ${rules_distfile}:rules
+
+homepage            https://git.gnome.org/browse/${name}
+master_sites        gnome:sources/${name}/${branch}/:main \
+                    https://gitlab.gnome.org/GNOME/libhttpseverywhere/-/raw/${rules_commit}/data/default.rulesets?inline=false&dummy=:rules
+
+checksums           ${main_distfile} \
+                    rmd160  67ecbcfbfe5eba4eba47b38099ddc4ebae847403 \
                     sha256  1c006f5633842a2b131c1cf644ab929556fc27968a60da55c00955bd4934b6ca \
-                    size    1139192
+                    size    1139192 \
+                    ${rules_distfile} \
+                    rmd160  7b444fe306b26c11856ca9ecb28b092f3359151c \
+                    sha256  e4c78743cd11eb718c4d218273c61a1f597610a6c3177b2a5576078c95a01564 \
+                    size    6992700
 
 depends_build-append \
                     port:pkgconfig
@@ -49,7 +64,7 @@ patchfiles          patch-vala-0.42.diff \
 
 post-patch {
     # update rulesets to 2019.1.7
-    xinstall -m 644 ${filespath}/default.rulesets ${worksrcpath}/data
+    xinstall -m 644 ${distpath}/${rules_distfile} ${worksrcpath}/data/default.rulesets
     reinplace "s|@@LIB_DIR@@|${prefix}/lib|" ${worksrcpath}/src/meson.build
 }
 


### PR DESCRIPTION
rather than having them as a large file
in the files dir

