### PR TITLE
at-spi2-core: workaround no rpath on Tiger

### DIFF
--- a/gnome/at-spi2-core/Portfile
+++ b/gnome/at-spi2-core/Portfile
@@ -53,4 +53,13 @@ if {[variant_isset universal]} {
     destroot.env-append    "CC=${configure.cc} ${configure.cc_archflags}"
 }
 
+platform darwin 8 {
+    # meson on Tiger cannot use rpaths, so we workaround with this to find dylib
+    if {[info exists muniversal.current_arch]} {
+        destroot.env-append    "DYLD_LIBRARY_PATH=${build_dir}-${muniversal.current_arch}/atspi"
+        } else {
+        destroot.env-append    "DYLD_LIBRARY_PATH=${build_dir}/atspi"
+    }
+}
+
 livecheck.type      gnome


### PR DESCRIPTION
meson uses @rpaths but Tiger does not support them.
This workaround allows the dylibs to be found by
gobject-introspection during installation

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.4
Xcode 2.5
