### PR TITLE
kubectl-1.19: update to 1.19.3

### DIFF
--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -20,9 +20,9 @@ subport kubectl_select {}
 set latestVersion       kubectl-1.19
 
 subport kubectl-1.19 {
-    set patchNumber     2
-    checksums           rmd160  fffb505fb2768fdceed2e833a38871c35e2ca5b5 \
-                        sha256  bcce859b6dc7c3dde1a1429b77339c3acf15112d9b77e616b9d969f35a607dee \
+    set patchNumber     3
+    checksums           rmd160  9b26d4aba5d977b8436ac48e14169a0d955ab64d \
+                        sha256  c86f37f2bbac2a0ee1b2d1ea46765fa921bc3143e2531d1676b16d15e485a3bf \
                         size    49458016
 }
 
@@ -91,6 +91,7 @@ subport kubectl-1.10 {
 
 if {${subport} == ${name}} {
     PortGroup           obsolete 1.0
+
     replaced_by         ${latestVersion}
     version             1.16.0
     revision            2
@@ -120,6 +121,7 @@ if {${subport} == ${name}} {
 
 } else {
     PortGroup           github 1.0
+
     supported_archs     x86_64
     depends_run         port:kubectl_select
 


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
