### PR TITLE
lens: new port

### DIFF
--- a/sysutils/lens/Portfile
+++ b/sysutils/lens/Portfile
@@ -1,0 +1,47 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        lensapp lens 4.0.4 v
+revision            0
+
+homepage            https://k8slens.dev
+
+description         Lens - The Kubernetes IDE
+
+long_description    Lens is the most powerful IDE for people who need to deal \
+                    with Kubernetes clusters on a daily basis. Ensure your \
+                    clusters are properly setup and configured. Enjoy \
+                    increased visibility, real time statistics, log streams \
+                    and hands-on troubleshooting capabilities.
+
+categories          sysutils
+license             MIT
+platforms           darwin
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  e374b41eca51d9f69a5ac1ed3d0ef0ca231301d5 \
+                    sha256  285f5689d13cea70cb43beef51665cef93a03fb179550bbd76bb58af6eb9d147 \
+                    size    10034977
+
+depends_build       port:npm6 \
+                    port:yarn
+
+build.target        build
+
+use_configure       no
+use_parallel_build  no
+use_xcode           yes
+
+post-patch {
+    reinplace "s|yarn dist$|yarn dist:dir|g" ${worksrcpath}/Makefile
+}
+
+destroot {
+    copy ${worksrcpath}/dist/mac/Lens.app ${destroot}${applications_dir}/
+}
+
+github.livecheck.regex {([0-9.]+)}


### PR DESCRIPTION
#### Description

New port for the [Lens](https://k8slens.dev) Kubernetes "IDE"

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
