### PR TITLE
beekeeper-studio: update to 1.85

### DIFF
--- a/databases/beekeeper-studio/Portfile
+++ b/databases/beekeeper-studio/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        beekeeper-studio beekeeper-studio 1.8.3 v
+github.setup        beekeeper-studio beekeeper-studio 1.8.5 v
 revision            0
 
 homepage            https://beekeeperstudio.io/
@@ -21,7 +21,7 @@ long_description    Beekeeper Studio is a free and open source SQL editor and \
                     for later, query run-history so you can find that one \
                     query you got working 3 days ago, and a default dark theme.
 
-categories          aqua databases
+categories          databases
 license             MIT
 platforms           darwin
 
@@ -29,9 +29,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  4d4ba245a886a16e26c04f5c5e99235ab474370f \
-                    sha256  803ca01ffa6955bfabbf1fdf7d8eef7838dc81651c5e2b7b066d318775e8c52d \
-                    size    42384487
+                    rmd160  41967e92d2c5fc57d81a4d89d6e120a27d71a9bb \
+                    sha256  c2f45c5fc49e3dddba6d52d98414603922483039eeaca86a6a103ed7e17af09e \
+                    size    42384555
 
 depends_build       port:yarn
 


### PR DESCRIPTION
- move from aqua to databases category

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
