### PR TITLE
openjdk8: updates to 8u272, 11.0.9 and 15.0.1

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -3,15 +3,15 @@
 PortSystem       1.0
 
 name             openjdk8
-version          8u265
+version          8u272
 revision         0
 
-set build        01
+set build        10
 set major        8
 
-checksums        rmd160  c663ab3056c3731c1e780bd3e37fe59321576330 \
-                 sha256  f316b154e8c4a99b95bc3d07add3c9b19609c541a2f297112f274c1abce1efb4 \
-                 size    101998442
+checksums        rmd160  d8369b4fbb3f542cee52c2bd8eb5a9a269cc41ae \
+                 sha256  091f9ee39b0bdbc8af8ec19f51aaa0f73e416c2e93a8fb2c79b82f4caac83ab6 \
+                 size    101773502
 
 subport openjdk8-graalvm {
     version      20.2.0
@@ -25,29 +25,29 @@ subport openjdk8-graalvm {
 }
 
 subport openjdk8-openj9 {
-    version      8u265
+    version      8u272
     revision     0
 
-    set build    01
+    set build    10
     set major    8
-    set openj9_version 0.21.0
+    set openj9_version 0.23.0
     
-    checksums    rmd160  060f6aa970f9343ee1f303f62a719e5166f0ac40 \
-                 sha256  963683189fe2ab6d35f00d6ad9562fc7e9790e7e82fe3d1b01e6c80bde910c63 \
-                 size    114361837
+    checksums    rmd160  c7b6e70a814634fed5f298021dda38e22f3a5027 \
+                 sha256  694c7f8d6365f6717e9d854fab206053535a403805e7ef2c12d29e8df29083f6 \
+                 size    114902400
 }
 
 subport openjdk8-openj9-large-heap {
-    version      8u265
+    version      8u272
     revision     0
 
-    set build    01
+    set build    10
     set major    8
-    set openj9_version 0.21.0
+    set openj9_version 0.23.0
     
-    checksums    rmd160  b869a0877dcb5f294d211a3809eaacda1fbd5213 \
-                 sha256  2b804a0ac732df6076965b76ac32064ba5eeba205f06d2b4bdefc4356b15069d \
-                 size    113721837
+    checksums    rmd160  749b689d98b096f84c6915a2ff55429328cf26c9 \
+                 sha256  ea6749046313f2eded0c3434342a431c2a62d9ebfa36230b9e7338628853221e \
+                 size    114189123
 }
 
 subport openjdk10 {
@@ -63,15 +63,15 @@ subport openjdk10 {
 }
 
 subport openjdk11 {
-    version      11.0.8
+    version      11.0.9
     revision     0
 
-    set build    10
+    set build    11
     set major    11
     
-    checksums    rmd160  678de7cdaaf6fd8f66bae841fcc0a91977562198 \
-                 sha256  4a8dadd58cdc32c7e59978971d56aec610be7ee0ddf0dc1d137bb8b78456499f \
-                 size    185054456
+    checksums    rmd160  f420714f36088f3ecdad1da3c4798fabc6275a9f \
+                 sha256  e84b00d74f08f059829bbf121c8423dc37ff65135968c1fcda5839600be4f542 \
+                 size    185532704
 }
 
 subport openjdk11-graalvm {
@@ -86,29 +86,29 @@ subport openjdk11-graalvm {
 }
 
 subport openjdk11-openj9 {
-    version      11.0.8
+    version      11.0.9
     revision     0
 
-    set build    10
+    set build    11
     set major    11
-    set openj9_version 0.21.0
+    set openj9_version 0.23.0
     
-    checksums    rmd160  a21fefdde2a624285e10650188198b447cc59506 \
-                 sha256  71df9865d068a2dd1a963636b7e30f4e9188bac73b3935822b76b354f9e30216 \
-                 size    195447520
+    checksums    rmd160  f42f2e8de0b6e9bc7e0deada17ab456c115a9f2d \
+                 sha256  1458ff5261f1f2b1c6ae9f3c17ef7a153d6ee99760820be32258d25fec5202c7 \
+                 size    195536516
 }
 
 subport openjdk11-openj9-large-heap {
-    version      11.0.8
+    version      11.0.9
     revision     0
 
-    set build    10
+    set build    11
     set major    11
-    set openj9_version 0.21.0
+    set openj9_version 0.23.0
     
-    checksums    rmd160  db07b68e990116eae21fcef91c7c1be1b78aa90a \
-                 sha256  c698263cc776f6179a81576a6aefb07fc724c4447cffa40a9055b010aed4231f \
-                 size    194670767
+    checksums    rmd160  aa36b98d6c07c1686bc44acad6ba7c6ea167ef59 \
+                 sha256  9ec7cd671fa417f536ea1a391497c6c439b790a4975d8bb6d58937908a4e3c66 \
+                 size    196318717
 }
 
 subport openjdk12 {
@@ -226,41 +226,41 @@ subport openjdk14-openj9-large-heap {
 }
 
 subport openjdk15 {
-    version      15
+    version      15.0.1
     revision     0
 
-    set build    36
+    set build    9
     set major    15
     
-    checksums    rmd160  86184738b178fc57f8fdd79f2e43e502e1bd1ee2 \
-                 sha256  bd1fc774232e2dfee93056a01f5765bd92ffb19d68dd548c233a82bb5c162be4 \
-                 size    195853361
+    checksums    rmd160  ec9c5ee749c16ae2846e4f6e8ff63d4789ba80cb \
+                 sha256  d32f9429c4992cef7be559a15c542011503d6bc38c89379800cd209a9d7ec539 \
+                 size    195773522
 }
 
 subport openjdk15-openj9 {
-    version      15
+    version      15.0.1
     revision     0
 
-    set build    36
+    set build    9
     set major    15
-    set openj9_version 0.22.0
+    set openj9_version 0.23.0
     
-    checksums    rmd160  ad9af8552346a43a615d5ed9afa835173740f62a \
-                 sha256  d861a0fc91019a0821f83ef8afa5d86443697bfeff76652950fa264d68a3299d \
-                 size    195023238
+    checksums    rmd160  9aeeaec14ed1d44f796c6f3f7e6cb5c545537c00 \
+                 sha256  688dea7aa7b077f10ed9af833d0d14fa1770961099f43933bb84724d1f068d6f \
+                 size    195840553
 }
 
 subport openjdk15-openj9-large-heap {
-    version      15
+    version      15.0.1
     revision     0
 
-    set build    36
+    set build    9
     set major    15
-    set openj9_version 0.22.0
+    set openj9_version 0.23.0
     
-    checksums    rmd160  cecfaa2c933286b23d88d56b399c20f799d32dde \
-                 sha256  461d81284f041ad892f94fb4c33f67003284eaed5dce2ce03ad8dd577823954f \
-                 size    195766581
+    checksums    rmd160  efbbf9c19429915a953d4df681199bd6d45c9058 \
+                 sha256  e48fd8ed4ef7386b59229cc86a1718e42b91209ba3b748a258850599ddeed8bb \
+                 size    195082957
 }
 
 categories       java devel


### PR DESCRIPTION
#### Description

Update to AdoptOpenJDK 8u272, 11.0.9 and 15.0.1.

###### Tested on

macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?