### PR TITLE
py-gmpy: Add py39 subport

### DIFF
--- a/python/py-gmpy/Portfile
+++ b/python/py-gmpy/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  0465338605fa73695259082c973eab23d7d96cff \
                     sha256  1a79118a5332b40aba6aa24b051ead3a31b9b3b9642288934da754515da8fa14 \
                     size    147636
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:gmp


### PR DESCRIPTION
#### Description

py-gmpy: Add py39 subport

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?