### PR TITLE
py-gmpy2: Add py39 subport

### DIFF
--- a/python/py-gmpy2/Portfile
+++ b/python/py-gmpy2/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  d7a4f6d8fe370e4565f0af00b903d6b6740e4718 \
                     sha256  dd233e3288b90f21b0bb384bcc7a7e73557bb112ccf0032ad52aa614eb373d3f \
                     size    280551
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:gmp port:libmpc port:mpfr


### PR DESCRIPTION
#### Description

py-gmpy2: Add py39 subport

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?