### PR TITLE
Updates to nds2-client-0.16.6 updates to nds2-client-swig-0.16.8

### DIFF
--- a/science/nds2-client-swig/Portfile
+++ b/science/nds2-client-swig/Portfile
@@ -1,11 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem        1.0
-PortGroup         cmake 1.0
+PortGroup         cmake 1.1
 
 name              nds2-client-swig
-version           0.16.3
+version           0.16.10
 revision          0
+
 categories        science
 platforms         darwin
 license           GPL-2
@@ -16,29 +17,26 @@ long_description \
   Client tool for accessing streamed LIGO data using the Network \
   Data Server version 2.
 
-homepage          https://wiki.ligo.org/DASWG/NDSClient
+homepage          https://wiki.ligo.org/Computing/NDSClient
 master_sites      https://software.igwn.org/lscsoft/source/
+use_bzip2         yes
 
-patchfiles        patch-java-rpath.diff \
-                  patch-python-module.diff
-
-checksums         rmd160  f761fb66deab7b3e5d09df4f51500ff39e1c6f83 \
-                  sha256  08b666adaa0697baaa6f76bf96757fa580fbd02186826b37792691776b84c5c6 \
-                  size    195774
+checksums         rmd160  b4ba2c3e17387f13ccffcd496468b8cb1668946c \
+                  sha256  ebc7f66d7c41f154f4a1ab3b2f4c574256c851d54f4e83031a68665c687b813e \
+                  size    164730
 
 depends_build-append \
-    port:pkgconfig \
-    port:swig
+    port:pkgconfig
 
 depends_lib-append \
-    port:nds2-client
+    port:nds2-client \
+    port:swig3
 
 regsub -all -- "-swig$" ${name} {} basename
 
-cmake.out_of_source yes
-
 configure.args    -DPYTHON=false \
                   -DPYTHON_EXECUTABLE=false \
+                  -DSWIG_EXECUTABLE:FILEPATH=${prefix}/bin/swig3 \
                   -DENABLE_SWIG_JAVA=no \
                   -DENABLE_SWIG_MATLAB=no \
                   -DENABLE_SWIG_OCTAVE=no \
@@ -52,28 +50,31 @@ test.run           yes
 test.cmd           ${prefix}/bin/ctest
 test.target        -R '.*'
 
-use_parallel_build yes
-
 livecheck.type     regex
 livecheck.url      ${master_sites}
-livecheck.regex    {nds2-client-swig-(\d+(?:\.\d+)*).tar.gz}
+livecheck.regex    {nds2-client-swig-(\d+(?:\.\d+)*).tar.bz2}
 
 #========================================================================
 # Create subports for Java
 #========================================================================
 
 subport ${basename}-java {
+  PortGroup             java 1.0
+
+  revision              0
+
   categories-append     java
   description           Java bindings for ${description}
   long_description      ${long_description} This package provides Java \
                         bindings, modules, and scripts.
 
-  # Need GNU Classpath to get jni.h header
-  depends_build-append      port:swig-java port:gnu-classpath
+  java.version              1.7+
+  # Set fallback to an LTS Java version
+  java.fallback             openjdk8
 
-  depends_lib-append        bin:java:kaffe
+  depends_build-append  port:swig3-java
 
-  configure.javac           /usr/bin/javac -source 1.6 -target 1.6
+  configure.javac           /usr/bin/javac -source 1.7 -target 1.7
   configure.args-replace    -DENABLE_SWIG_JAVA=no -DENABLE_SWIG_JAVA=yes
 
   destroot.target           install
@@ -87,18 +88,27 @@ subport ${basename}-java {
 #========================================================================
 
 subport ${basename}-matlab {
+  PortGroup                 java 1.0
+
+  revision              0
+
   categories-append         matlab
   description               MATLAB bindings for ${description}
   long_description          ${long_description} This package provides MATLAB \
                             bindings, modules, and scripts.
 
-  # Need GNU Classpath to get jni.h header
-  depends_build-append      port:swig-java port:gnu-classpath
+  java.version              1.7+
+  # Set fallback to an LTS Java version
+  java.fallback             openjdk8
+  depends_build-append  port:swig3-java
+
+  configure.javac           /usr/bin/javac -source 1.7 -target 1.7
+  configure.args-replace    -DENABLE_SWIG_JAVA=no -DENABLE_SWIG_JAVA=yes
+
   depends_lib-append        port:${basename}-java
 
   destroot.target           install
 
-  configure.args-replace    -DENABLE_SWIG_JAVA=no -DENABLE_SWIG_JAVA=yes
   configure.args-replace    -DENABLE_SWIG_MATLAB=no -DENABLE_SWIG_MATLAB=yes
 
   destroot.args-append      -C ${worksrcpath}/../build/matlab
@@ -111,13 +121,13 @@ subport ${basename}-matlab {
 #========================================================================
 
 subport ${basename}-octave {
-  revision                  2
+  revision                  0
   categories-append         octave
   description               Octave bindings for ${description}
   long_description          ${long_description} This package provides Octave \
                             bindings, modules, and scripts.
 
-  depends_build-append      port:swig-octave
+  depends_build-append  port:swig3-octave
   depends_lib-append        path:bin/octave:octave
 
   destroot.target           install
@@ -136,7 +146,7 @@ subport ${basename}-octave {
 #========================================================================
 # Create subports for each supported Python version
 #========================================================================
-foreach v {27 35 36 37 38} {
+foreach v {27 35 36 37 38 39} {
   set python.version          ${v}
   set python.branch           [string index ${python.version} 0].[string range ${python.version} 1 end]
   set python.bin              ${prefix}/bin/python${python.branch}
@@ -145,12 +155,14 @@ foreach v {27 35 36 37 38} {
   set python.pkgname          ""
 
   subport py${v}-${basename} {
+    revision                  0
     categories-append         python
     description               Python ${python.version} bindings for ${description}
     long_description          ${long_description} This package provides Python \
                               ${python.version} bindings, modules, and scripts.
 
-    depends_build-append      port:swig-python
+    depends_build-append      port:swig3-python
+
     depends_lib-append        port:python${python.version}
     depends_lib-append        port:py${python.version}-numpy
 

--- a/science/nds2-client-swig/Portfile
+++ b/science/nds2-client-swig/Portfile
@@ -1,86 +1,85 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem        1.0
-PortGroup         cmake 1.1
+PortSystem          1.0
+PortGroup           cmake 1.1
 
-name              nds2-client-swig
-version           0.16.10
-revision          0
+name                nds2-client-swig
+version             0.16.10
+revision            0
 
-categories        science
-platforms         darwin
-license           GPL-2
-maintainers       {ligo.org:ed.maros @emaros} openmaintainer
+categories          science
+platforms           darwin
+license             GPL-2
+maintainers         {ligo.org:ed.maros @emaros} openmaintainer
 
-description       Network Data Server Client
-long_description \
-  Client tool for accessing streamed LIGO data using the Network \
-  Data Server version 2.
+description         Network Data Server Client
+long_description    Client tool for accessing streamed LIGO data using the Network \
+                    Data Server version 2.
 
-homepage          https://wiki.ligo.org/Computing/NDSClient
-master_sites      https://software.igwn.org/lscsoft/source/
-use_bzip2         yes
+homepage            https://wiki.ligo.org/Computing/NDSClient
+master_sites        https://software.igwn.org/lscsoft/source/
+use_bzip2           yes
 
-checksums         rmd160  b4ba2c3e17387f13ccffcd496468b8cb1668946c \
-                  sha256  ebc7f66d7c41f154f4a1ab3b2f4c574256c851d54f4e83031a68665c687b813e \
-                  size    164730
+checksums           rmd160  b4ba2c3e17387f13ccffcd496468b8cb1668946c \
+                    sha256  ebc7f66d7c41f154f4a1ab3b2f4c574256c851d54f4e83031a68665c687b813e \
+                    size    164730
 
 depends_build-append \
-    port:pkgconfig
+                    port:pkgconfig
 
 depends_lib-append \
-    port:nds2-client \
-    port:swig3
+                    port:nds2-client \
+                    port:swig3
 
 regsub -all -- "-swig$" ${name} {} basename
 
-configure.args    -DPYTHON=false \
-                  -DPYTHON_EXECUTABLE=false \
-                  -DSWIG_EXECUTABLE:FILEPATH=${prefix}/bin/swig3 \
-                  -DENABLE_SWIG_JAVA=no \
-                  -DENABLE_SWIG_MATLAB=no \
-                  -DENABLE_SWIG_OCTAVE=no \
-                  -DENABLE_SWIG_PYTHON2=no \
-                  -DENABLE_SWIG_PYTHON3=no \
-                  -DCMAKE_INSTALL_SYSCONFDIR=${prefix}/etc \
-                  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-                  -DCMAKE_EXPORT_COMPILE_COMMANDS=1
+configure.args      -DPYTHON=false \
+                    -DPYTHON_EXECUTABLE=false \
+                    -DSWIG_EXECUTABLE:FILEPATH=${prefix}/bin/swig3 \
+                    -DENABLE_SWIG_JAVA=no \
+                    -DENABLE_SWIG_MATLAB=no \
+                    -DENABLE_SWIG_OCTAVE=no \
+                    -DENABLE_SWIG_PYTHON2=no \
+                    -DENABLE_SWIG_PYTHON3=no \
+                    -DCMAKE_INSTALL_SYSCONFDIR=${prefix}/etc \
+                    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+                    -DCMAKE_EXPORT_COMPILE_COMMANDS=1
 
-test.run           yes
-test.cmd           ${prefix}/bin/ctest
-test.target        -R '.*'
+test.run            yes
+test.cmd            ${prefix}/bin/ctest
+test.target         -R '.*'
 
-livecheck.type     regex
-livecheck.url      ${master_sites}
-livecheck.regex    {nds2-client-swig-(\d+(?:\.\d+)*).tar.bz2}
+livecheck.type      regex
+livecheck.url       ${master_sites}
+livecheck.regex     {nds2-client-swig-(\d+(?:\.\d+)*).tar.bz2}
 
 #========================================================================
 # Create subports for Java
 #========================================================================
 
 subport ${basename}-java {
-  PortGroup             java 1.0
+    PortGroup               java 1.0
 
-  revision              0
+    revision                0
 
-  categories-append     java
-  description           Java bindings for ${description}
-  long_description      ${long_description} This package provides Java \
-                        bindings, modules, and scripts.
+    categories-append       java
+    description             Java bindings for ${description}
+    long_description        ${long_description} This package provides Java \
+                            bindings, modules, and scripts.
 
-  java.version              1.7+
-  # Set fallback to an LTS Java version
-  java.fallback             openjdk8
+    java.version            1.7+
+    # Set fallback to an LTSava version
+    java.fallback           openjdk8
 
-  depends_build-append  port:swig3-java
+    depends_build-append    port:swig3-java
 
-  configure.javac           /usr/bin/javac -source 1.7 -target 1.7
-  configure.args-replace    -DENABLE_SWIG_JAVA=no -DENABLE_SWIG_JAVA=yes
+    configure.javac         /usr/bin/javac -source 1.7 -target 1.7
+    configure.args-replace  -DENABLE_SWIG_JAVA=no -DENABLE_SWIG_JAVA=yes
 
-  destroot.target           install
-  destroot.args-append      -C ${worksrcpath}/../build/java
+    destroot.target         install
+    destroot.args-append    -C ${worksrcpath}/../build/java
 
-  livecheck.type            none
+    livecheck.type          none
 }
 
 #========================================================================
@@ -88,32 +87,33 @@ subport ${basename}-java {
 #========================================================================
 
 subport ${basename}-matlab {
-  PortGroup                 java 1.0
+    PortGroup               java 1.0
 
-  revision              0
+    revision                0
 
-  categories-append         matlab
-  description               MATLAB bindings for ${description}
-  long_description          ${long_description} This package provides MATLAB \
+    categories-append       matlab
+    description             MATLAB bindings for ${description}
+    long_description        ${long_description}. This package provides MATLAB \
                             bindings, modules, and scripts.
 
-  java.version              1.7+
-  # Set fallback to an LTS Java version
-  java.fallback             openjdk8
-  depends_build-append  port:swig3-java
+    java.version            1.7+
+    # Set fallback to an LTS Java version
+    java.fallback           openjdk8
 
-  configure.javac           /usr/bin/javac -source 1.7 -target 1.7
-  configure.args-replace    -DENABLE_SWIG_JAVA=no -DENABLE_SWIG_JAVA=yes
+    depends_build-append    port:swig3-java
 
-  depends_lib-append        port:${basename}-java
+    configure.javac         /usr/bin/javac -source 1.7 -target 1.7
+    configure.args-replace  -DENABLE_SWIG_JAVA=no -DENABLE_SWIG_JAVA=yes
 
-  destroot.target           install
+    depends_lib-append      port:${basename}-java
 
-  configure.args-replace    -DENABLE_SWIG_MATLAB=no -DENABLE_SWIG_MATLAB=yes
+    destroot.target         install
 
-  destroot.args-append      -C ${worksrcpath}/../build/matlab
+    configure.args-replace  -DENABLE_SWIG_MATLAB=no -DENABLE_SWIG_MATLAB=yes
 
-  livecheck.type            none
+    destroot.args-append    -C ${worksrcpath}/../build/matlab
+
+    livecheck.type          none
 }
 
 #========================================================================
@@ -121,65 +121,73 @@ subport ${basename}-matlab {
 #========================================================================
 
 subport ${basename}-octave {
-  revision                  0
-  categories-append         octave
-  description               Octave bindings for ${description}
-  long_description          ${long_description} This package provides Octave \
+    revision                0
+    categories-append       octave
+    description             Octave bindings for ${description}
+    long_description        ${long_description}. This package provides Octave \
                             bindings, modules, and scripts.
 
-  depends_build-append  port:swig3-octave
-  depends_lib-append        path:bin/octave:octave
+    depends_build-append    port:swig3-octave
 
-  destroot.target           install
-  destroot.args-append      pkgoctexecdir="${prefix}/share/octave/site/m"
+    depends_lib-append      path:bin/octave:octave
 
-  # At least as of Octave 3.2.4, the Octave C++ API does not work with clang.
-  # compiler.blacklist-append *clang*
+    destroot.target         install
+    destroot.args-append    pkgoctexecdir="${prefix}/share/octave/site/m"
 
-  configure.args-replace    -DENABLE_SWIG_OCTAVE=no -DENABLE_SWIG_OCTAVE=yes
+    # At least as of Octave 3.2.4, the Octave C++ API does not work with clang.
+    # compiler.blacklist-append *clang*
+    configure.args-replace  -DENABLE_SWIG_OCTAVE=no -DENABLE_SWIG_OCTAVE=yes
 
-  destroot.args-append      -C ${worksrcpath}/../build/octave
+    destroot.args-append    -C ${worksrcpath}/../build/octave
 
-  livecheck.type            none
+    livecheck.type          none
 }
 
 #========================================================================
 # Create subports for each supported Python version
 #========================================================================
 foreach v {27 35 36 37 38 39} {
-  set python.version          ${v}
-  set python.branch           [string index ${python.version} 0].[string range ${python.version} 1 end]
-  set python.bin              ${prefix}/bin/python${python.branch}
-  set python.prefix           ${frameworks_dir}/Python.framework/Versions/${python.branch}
-  set python.site_packages    "${python.prefix}/lib/python${python.branch}/site-packages"
-  set python.pkgname          ""
+    set python.version      ${v}
+    set python.branch       [string range ${python.version} 0 end-1].[string index ${python.version} end]
+    set python.bin          ${prefix}/bin/python${python.branch}
+    set python.prefix       ${frameworks_dir}/Python.framework/Versions/${python.branch}
+    set python.site_packages \
+                            "${python.prefix}/lib/python${python.branch}/site-packages"
+    set python.pkgname      ""
 
-  subport py${v}-${basename} {
-    revision                  0
-    categories-append         python
-    description               Python ${python.version} bindings for ${description}
-    long_description          ${long_description} This package provides Python \
-                              ${python.version} bindings, modules, and scripts.
+    subport py${v}-${basename} {
+        revision            0
+        categories-append   python
+        description         Python ${python.version} bindings for ${description}
+        long_description    ${long_description}. This package provides Python \
+                            ${python.version} bindings, modules, and scripts.
 
-    depends_build-append      port:swig3-python
+        depends_build-append \
+                            port:swig3-python
 
-    depends_lib-append        port:python${python.version}
-    depends_lib-append        port:py${python.version}-numpy
+        depends_lib-append  port:python${python.version} \
+                            port:py${python.version}-numpy
 
-    configure.python          ${python.bin}
-    configure.args-replace    -DPYTHON=false -DPYTHON=${python.bin}
-    configure.args-replace    -DPYTHON_EXECUTABLE=false -DPYTHON_EXECUTABLE=${python.bin}
-    switch -glob -- ${v} {
-        "2*" { configure.args-replace    -DENABLE_SWIG_PYTHON2=no "-DENABLE_SWIG_PYTHON2=yes -DPYTHON2_VERSION=${python.branch}" }
-        "3*" -
-        default { configure.args-replace -DENABLE_SWIG_PYTHON3=no "-DENABLE_SWIG_PYTHON3=yes -DPYTHON3_VERSION=${python.branch}" }
-    }
-    configure.args-append     -DPYTHON${python.version}_MODULE_INSTALL_DIR="${python.site_packages}" \
-                              -DPYTHON${python.version}_EXTMODULE_INSTALL_DIR="${python.site_packages}" \
-                              -DSWIG_CPPFLAGS="-I${python.prefix}/include"
+        configure.python    ${python.bin}
+        configure.args-replace  \
+                            -DPYTHON=false -DPYTHON=${python.bin} \
+                            -DPYTHON_EXECUTABLE=false -DPYTHON_EXECUTABLE=${python.bin}
 
-    destroot.target           install
-    destroot.args-append      -C ${worksrcpath}/../build/python
+        switch -glob -- ${v} {
+            "2*" { configure.args-replace \
+                -DENABLE_SWIG_PYTHON2=no "-DENABLE_SWIG_PYTHON2=yes -DPYTHON2_VERSION=${python.branch}" }
+            "3*" -
+            default { configure.args-replace \
+                -DENABLE_SWIG_PYTHON3=no "-DENABLE_SWIG_PYTHON3=yes -DPYTHON3_VERSION=${python.branch}" }
+        }
+        configure.args-append \
+                            -DPYTHON${python.version}_MODULE_INSTALL_DIR="${python.site_packages}" \
+                            -DPYTHON${python.version}_EXTMODULE_INSTALL_DIR="${python.site_packages}" \
+                            -DSWIG_CPPFLAGS="-I${python.prefix}/include"
+
+        destroot.target     install
+        destroot.args-append \
+                            -C ${worksrcpath}/../build/python
 
     post-destroot {
       if {${subport} eq "py27-${basename}"} {
@@ -189,6 +197,6 @@ foreach v {27 35 36 37 38 39} {
       }
     }
 
-    livecheck.type            none
+    livecheck.type          none
   }
 }

--- a/science/nds2-client/Portfile
+++ b/science/nds2-client/Portfile
@@ -1,10 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem        1.0
-PortGroup         cmake 1.0
+PortGroup         cmake 1.1
+PortGroup         boost 1.0
 
 name              nds2-client
-version           0.16.2
+version           0.16.7
 revision          0
 categories        science
 platforms         darwin
@@ -16,21 +17,22 @@ long_description \
   Client tool for accessing streamed LIGO data using the Network \
   Data Server version 2.
 
-homepage          https://wiki.ligo.org/DASWG/NDSClient
+homepage          https://wiki.ligo.org/Computing/NDSClient
 master_sites      https://software.igwn.org/lscsoft/source/
+use_bzip2         yes
 
-checksums         rmd160  9653ad19cc2af2d194c8331e5cac99c6beb95119 \
-                  sha256  485ce5cc1650f384897e5ddcd259ad2f4f6b63e309372990b997d86b54cf529e \
-                  size    535845
+checksums         rmd160  3c5ea66f482eade3cd5d1a49f11a193705701424 \
+                  sha256  3d800c91aa7de328baf356d4a9e49a8eb53c0c7f5bbfa9423d2cd717a476c306 \
+                  size    556064
 
 depends_build-append \
                   port:doxygen \
                   path:bin/dot:graphviz \
-                  port:pkgconfig
+                  port:pkgconfig \
+
+boost.depends_type  build
 
 default_variants  +gssapi
-
-cmake.out_of_source yes
 
 compiler.cxx_standard 2011
 
@@ -59,8 +61,6 @@ test.run           yes
 test.cmd           ${prefix}/bin/ctest
 test.target        -R '.*'
 
-use_parallel_build yes
-
 livecheck.type     regex
 livecheck.url      ${master_sites}
-livecheck.regex    {nds2-client-(\d+(?:\.\d+)*).tar.gz}
+livecheck.regex    {nds2-client-(\d+(?:\.\d+)*).tar.bz2}

--- a/science/nds2-client/Portfile
+++ b/science/nds2-client/Portfile
@@ -1,66 +1,63 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem        1.0
-PortGroup         cmake 1.1
-PortGroup         boost 1.0
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           boost 1.0
 
-name              nds2-client
-version           0.16.7
-revision          0
-categories        science
-platforms         darwin
-license           GPL-2
-maintainers       {ligo.org:ed.maros @emaros} openmaintainer
+name                nds2-client
+version             0.16.7
+revision            0
 
-description       Network Data Server Client
-long_description \
-  Client tool for accessing streamed LIGO data using the Network \
-  Data Server version 2.
+categories          science
+platforms           darwin
+license             GPL-2
+maintainers         {ligo.org:ed.maros @emaros} openmaintainer
 
-homepage          https://wiki.ligo.org/Computing/NDSClient
-master_sites      https://software.igwn.org/lscsoft/source/
-use_bzip2         yes
+description         Network Data Server Client
+long_description    Client tool for accessing streamed LIGO data using the Network \
+                    Data Server version 2.
 
-checksums         rmd160  3c5ea66f482eade3cd5d1a49f11a193705701424 \
-                  sha256  3d800c91aa7de328baf356d4a9e49a8eb53c0c7f5bbfa9423d2cd717a476c306 \
-                  size    556064
+homepage            https://wiki.ligo.org/Computing/NDSClient
+master_sites        https://software.igwn.org/lscsoft/source/
+use_bzip2           yes
+
+checksums           rmd160  3c5ea66f482eade3cd5d1a49f11a193705701424 \
+                    sha256  3d800c91aa7de328baf356d4a9e49a8eb53c0c7f5bbfa9423d2cd717a476c306 \
+                    size    556064
 
 depends_build-append \
-                  port:doxygen \
-                  path:bin/dot:graphviz \
-                  port:pkgconfig \
+                    port:doxygen \
+                    path:bin/dot:graphviz \
+                    port:pkgconfig \
 
 boost.depends_type  build
 
-default_variants  +gssapi
+default_variants    +gssapi
 
 compiler.cxx_standard 2011
 
-configure.args    -DPYTHON=false \
-                  -DPYTHON_EXECUTABLE=false \
-                  -DWITH_SASL=no \
-                  -DWITH_GSSAPI=no \
-                  -DCMAKE_INSTALL_SYSCONFDIR=${prefix}/etc \
-                  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-                  -DCMAKE_EXPORT_COMPILE_COMMANDS=1
+configure.args      -DPYTHON=false \
+                    -DPYTHON_EXECUTABLE=false \
+                    -DWITH_SASL=no \
+                    -DWITH_GSSAPI=no \
+                    -DCMAKE_INSTALL_SYSCONFDIR=${prefix}/etc \
+                    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+                    -DCMAKE_EXPORT_COMPILE_COMMANDS=1
 
 variant sasl description "Use cyrus-sasl2 for authentication" conflicts gssapi {
-
-    configure.args-replace          -DWITH_SASL=no -DWITH_SASL=${prefix}
-    depends_lib-append              port:cyrus-sasl2
+    configure.args-replace  -DWITH_SASL=no -DWITH_SASL=${prefix}
+    depends_lib-append      port:cyrus-sasl2
 }
 
 variant gssapi description "Use kerberos5 gssapi for authentication" conflicts sasl {
-
-    configure.args-replace          -DWITH_GSSAPI=no -DWITH_GSSAPI=${prefix}
-    depends_lib-append              port:kerberos5
-
+    configure.args-replace  -DWITH_GSSAPI=no -DWITH_GSSAPI=${prefix}
+    depends_lib-append      port:kerberos5
 }
 
-test.run           yes
-test.cmd           ${prefix}/bin/ctest
-test.target        -R '.*'
+test.run            yes
+test.cmd            ${prefix}/bin/ctest
+test.target         -R '.*'
 
-livecheck.type     regex
-livecheck.url      ${master_sites}
-livecheck.regex    {nds2-client-(\d+(?:\.\d+)*).tar.bz2}
+livecheck.type      regex
+livecheck.url       ${master_sites}
+livecheck.regex     {nds2-client-(\d+(?:\.\d+)*).tar.bz2}


### PR DESCRIPTION
#### Description

This updates the Portfiles for the most recent public releases of nds2-client and nds2-client-swig.
Use of Java PortGroup has been added.

This should supersede pull request #8022

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.

-->
macOS 10.12
Xcode 9.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
