### PR TITLE
bpytop: new port

### DIFF
--- a/sysutils/bpytop/Portfile
+++ b/sysutils/bpytop/Portfile
@@ -1,0 +1,44 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           makefile 1.0
+
+github.setup        aristocratos bpytop 1.0.44 v
+revision            0
+
+description         Linux/OSX/FreeBSD resource monitor
+
+long_description    {*}${description}. Resource monitor that shows usage and \
+                    stats for processor, memory, disks, network and \
+                    processes.  Python port of bashtop.
+
+categories          sysutils
+license             Apache-2
+platforms           darwin linux
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  7264d4b70b39a753cb0098254b249f174f06237a \
+                    sha256  5040281e1afefca116ae9bdbc37adcb27826236ebf877ea0f17de6e7d17922fb \
+                    size    606004
+
+set python_version  38
+set python_branch   [string range ${python_version} 0 end-1].[string index ${python_version} end]
+set python_bin      ${prefix}/bin/python${python_branch}
+
+depends_run-append  port:python${python_version} \
+                    port:py${python_version}-psutil
+
+makefile.has_destdir yes
+
+post-extract {
+    reinplace "s|/usr/bin/env python3|${python_bin}|" ${worksrcpath}/bpytop.py
+}
+
+notes "
+  On macOS, ${name} will not display correctly in the standard terminal! 
+
+  The recommended alternative is iTerm2.
+"

--- a/sysutils/bpytop/Portfile
+++ b/sysutils/bpytop/Portfile
@@ -7,7 +7,7 @@ PortGroup           makefile 1.0
 github.setup        aristocratos bpytop 1.0.44 v
 revision            0
 
-description         Linux/OSX/FreeBSD resource monitor
+description         Linux/macOS/FreeBSD resource monitor
 
 long_description    {*}${description}. Resource monitor that shows usage and \
                     stats for processor, memory, disks, network and \
@@ -33,7 +33,7 @@ depends_run-append  port:python${python_version} \
 
 makefile.has_destdir yes
 
-post-extract {
+post-patch {
     reinplace "s|/usr/bin/env python3|${python_bin}|" ${worksrcpath}/bpytop.py
 }
 


### PR DESCRIPTION
#### Description

New port for [bpytop](https://github.com/aristocratos/bpytop)

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
