### PR TITLE
py-crashtest: new port

### DIFF
--- a/python/py-crashtest/Portfile
+++ b/python/py-crashtest/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-crashtest
+version             0.3.1
+platforms           darwin
+license             MIT
+supported_archs     noarch
+
+maintainers         {@harens gmail.com:harensdeveloper} \
+                    openmaintainer
+
+description         Manage Python errors with ease
+long_description    Crashtest is a Python library that makes \
+                    exceptions handling and inspection easier.
+
+homepage            https://github.com/sdispater/crashtest
+
+checksums           rmd160 f420892af730f08358b111fa1d517deb3a6a0b0e \
+                    sha256 42ca7b6ce88b6c7433e2ce47ea884e91ec93104a4b754998be498a8e6c3d37dd \
+                    size   4333
+
+python.versions     38 39
+
+if {${name} ne ${subport}} {
+
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    livecheck.type  none
+}


### PR DESCRIPTION
#### Description

In the hopes of updating [py-clikit](https://ports.macports.org/port/py-clikit/summary), I've added one of its new dependencies.

```
crashtest = { version = "^0.3.0", python = "^3.6" }
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.6 19G73
xcode-select version 2373

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
