### PR TITLE
minikube: update to 1.14.1

### DIFF
--- a/sysutils/minikube/Portfile
+++ b/sysutils/minikube/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        kubernetes minikube 1.13.1 v
+github.setup        kubernetes minikube 1.14.1 v
 categories          sysutils
 platforms           darwin
 supported_archs     x86_64
@@ -19,9 +19,9 @@ long_description    Minikube runs a single-node Kubernetes cluster inside a VM \
 github.tarball_from releases
 distfiles           minikube-darwin-amd64
 checksums           minikube-darwin-amd64 \
-                    rmd160  35b4527237f5e8b09c42629daf190d3a920a8ec5 \
-                    sha256  cc7eaadea2becc48eee78136f8d569df55a28c46d58d1c8bb434895382aced78 \
-                    size    58280600
+                    rmd160  bbef1f667a3472cea47f2d889267a12ef4339e29 \
+                    sha256  d07db8343d06caa484a645bdd84d72d9babba81a18a7a50729616571b5e6702a \
+                    size    55575896
 dist_subdir         ${name}/${version}
 
 depends_lib         path:${prefix}/bin/kubectl:kubectl-1.19
@@ -32,9 +32,9 @@ default_variants    +hyperkit
 variant hyperkit description {Install Hyperkit driver} {
     distfiles-append    docker-machine-driver-hyperkit
     checksums-append    docker-machine-driver-hyperkit \
-                        rmd160  070f32be46c792f42632641fb32b88b179c148f7 \
-                        sha256  31b21e23a8038fb57f4520dfe05f9b45e54007b1d6acbb28e549030663188c40 \
-                        size    11434364
+                        rmd160  4928ec91b43e6cb1cce88e2f56f84be228a33ffd \
+                        sha256  16a9f4b6c0561a031612db5f95aa2a162924c89752e60b477302592c597cdecc \
+                        size    11996260
 }
 
 build {


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
