### PR TITLE
OpenBLAS: update to version 0.3.12, update *-devel to latest commit

### DIFF
--- a/math/OpenBLAS/Portfile
+++ b/math/OpenBLAS/Portfile
@@ -41,11 +41,11 @@ if {![info exists blas_arch]} {
 subport OpenBLAS-devel {}
 if {[string first "-devel" $subport] > 0} {
 
-    github.setup    xianyi OpenBLAS 33d22f99f188216fca6b5b7fdcd6b65cc58645eb
-    version         20200923-[string range ${github.version} 0 7]
-    checksums       rmd160  09c8b9d3266391d918caf94bc49829f1ff61ca02 \
-                    sha256  c7f61f54134c3fe292d59ebc186a796e464c71f4a536e3a87721424eec52f040 \
-                    size    12312100
+    github.setup    xianyi OpenBLAS 76203e212074de14c2ad136c0575559bf83c156f
+    version         20201026-[string range ${github.version} 0 7]
+    checksums       rmd160  e91d907fb275962a981035677c471bdf6b31a7db \
+                    sha256  4eed0af7ba505ee01420c4c3a8413179190f627f1f4d94c0e7f93f8356b79ef2 \
+                    size    12329007
     revision        0
 
     name            ${github.project}-devel
@@ -61,11 +61,11 @@ if {[string first "-devel" $subport] > 0} {
 
 } else {
 
-    github.setup    xianyi OpenBLAS 0.3.10 v
-    checksums       rmd160  4bfbdbc17a6fc4f1fa8ab8500068a4852ef5086a \
-                    sha256  308398cb50689baa328a3b0612b159a708b193304367cef00722fd70147bdc36 \
-                    size    12249713
-    revision        1
+    github.setup    xianyi OpenBLAS 0.3.12 v
+    checksums       rmd160  cbdef2d6ca019cec74dd211ebe14689d12dc8a09 \
+                    sha256  5cfa5c8a993ff8813849e95317e9b1820dfb0ac63e0adc6e95d43030ca5e9a1f \
+                    size    12329032
+    revision        0
 
     conflicts       OpenBLAS-devel
 


### PR DESCRIPTION
#### Description

Update of OpenBLAS, after version 0.3.11 was announced to have issues (and was thus skipped, see #8863)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

The result of Cl builds should be carefully checked, as there were issues in case of 0.3.11.