### PR TITLE
libpointing: use compiler.cxx_standard 2011, add GitHub handles for maintainers

### DIFF
--- a/devel/libpointing/Portfile
+++ b/devel/libpointing/Portfile
@@ -1,13 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cxx11 1.1
 PortGroup           github 1.0
 
 github.setup        INRIA libpointing 1.0.7 v
 categories          devel
 platforms           darwin
-maintainers         univ-lille1.fr:gery.casiez gmail.com:izzatbek openmaintainer
+maintainers         {@casiez univ-lille1.fr:gery.casiez} \
+                    {@Izzatbek gmail.com:izzatbek} \
+                    openmaintainer
 license             GPL-2+
 
 description         An open-source cross-platform library to get raw events \
@@ -26,6 +27,8 @@ checksums           rmd160  7319611b11625f0730090fbd512b3ca372f49ce7 \
                     sha256  29f12da75727d1b03ff952a2754ce79b88aec39b5e03a52d3b0ff7440f08f147
 
 patchfiles          patch-Makefile.diff
+
+compiler.cxx_standard 2011
 
 use_configure       no
 


### PR DESCRIPTION
…instead of deprecated `cxx11 1.1` portgroup

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
