### PR TITLE
fortio: new port

### DIFF
--- a/net/fortio/Portfile
+++ b/net/fortio/Portfile
@@ -1,0 +1,43 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/fortio/fortio 1.10.1 v
+
+homepage            https://fortio.org
+
+description         Fortio is a load testing library, command line tool, \
+                    advanced echo server and web UI in go (golang).
+
+long_description    {*}${description} Allows to specify a set \
+                    query-per-second load and record latency histograms and \
+                    other useful stats. Fortio runs at a specified query per \
+                    second (qps) and records an histogram of execution time \
+                    and calculates percentiles (e.g. p99 ie the response time \
+                    such as 99% of the requests take less than that number \
+                    (in seconds, SI unit)). It can run for a set duration, \
+                    for a fixed number of calls, or until interrupted (at a \
+                    constant target QPS, or max speed/load per \
+                    connection/thread).
+
+platforms           darwin
+categories          net www
+license             Apache-2
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  6d8ebeadcfa0b99974315260c4a66e03c0726aef \
+                    sha256  4d799b84dc2f6f70e8fe343048667bd3aa3e5886c54735457cf87835f1dea2f0 \
+                    size    255896
+
+# Allow fetching build dependencies at build time
+# See: http://trac.macports.org/ticket/61192
+build.env-delete    GO111MODULE=off GOPROXY=off
+
+installs_libs       no
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}
+}


### PR DESCRIPTION
#### Description

New port for [Fortio](https://fortio.org)

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
