### PR TITLE
k6: use golang-1.0 portgroup

### DIFF
--- a/net/k6/Portfile
+++ b/net/k6/Portfile
@@ -1,9 +1,9 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
+PortGroup           golang 1.0
 
-github.setup        loadimpact k6 0.28.0 v
+go.setup            github.com/loadimpact/k6 0.28.0 v
 categories          net
 platforms           darwin
 license             AGPL-3+
@@ -20,28 +20,13 @@ checksums           rmd160  1800fe901795ae2e8f07adb81c2822ce781f87e5 \
                     sha256  143cde4d941567869da1087ec3d53de0e7b403f3ba233951ece66891ff33710a \
                     size    5779649
 
-set goproj          github.com/${github.author}/${github.project}
-
-depends_build       port:go
-use_configure       no
-worksrcdir          src/${goproj}
-
-post-extract {
-    xinstall -d ${workpath}/src/github.com/${github.author}
-    move ${workpath}/${name}-${github.version} \
-        ${worksrcpath}
-}
-
-build {
-    system -W ${worksrcpath} "GOPATH=${workpath} \
-      ${prefix}/bin/go build -v -o ${workpath}/${github.project}"
-}
+build.env-delete    GO111MODULE=off
 
 destroot {
-    xinstall ${workpath}/${github.project} ${destroot}${prefix}/bin
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
 
     set docdir ${prefix}/share/doc/${name}
     xinstall -d ${destroot}${docdir}
-    xinstall -m 644 -W ${worksrcpath} README.md LICENSE.md \
+    xinstall -m 0644 -W ${worksrcpath} README.md LICENSE.md \
         ${destroot}${docdir}
 }


### PR DESCRIPTION
#### Description

~This port was not using the golang-1.0 portgroup so I missed it when compiling the list at https://trac.macports.org/ticket/61192, but this is also a golang port that automatically downloads its dependencies at build time.~

I mistakenly thought this port was downloading dependencies at build time, but as [pointed out](https://github.com/macports/macports-ports/pull/8951#pullrequestreview-517671790) that is not the case because the project vendors its dependencies.

This PR thus merely simplifies the port by using the golang-1.0 portgroup.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->