### PR TITLE
py-gobject: add py39 subport

### DIFF
--- a/python/py-gobject/Portfile
+++ b/python/py-gobject/Portfile
@@ -34,7 +34,7 @@ checksums           rmd160  e9fea538da79ad27c42434d4a2173b3eb636408b \
                     sha256  bb9d25a3442ca7511385a7c01b057492095c263784ef31231ffe589d83a96a5a \
                     size    744584
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 if {${subport} ne ${name}} {
     depends_build-append \
@@ -46,7 +46,7 @@ if {${subport} ne ${name}} {
                     port:py${python.version}-cairo \
                     port:gobject-introspection
 
-    patchfiles  patch-pygi-info.c.diff
+    patchfiles  patch-pygi-info.c.diff patch-tpprint-py3.patch
 
     use_configure           yes
     configure.python        ${python.bin}

--- a/python/py-gobject/files/patch-tpprint-py3.patch
+++ b/python/py-gobject/files/patch-tpprint-py3.patch
@@ -1,0 +1,14 @@
+--- gobject/pygobject.c	2017-10-13 12:01:53.000000000 +0200
++++ gobject/pygobject.c	2020-10-20 07:05:31.000000000 +0200
+@@ -823,7 +823,10 @@
+                                   offsetof(PyTypeObject, tp_iter),
+                                   offsetof(PyTypeObject, tp_repr),
+                                   offsetof(PyTypeObject, tp_str),
+-                                  offsetof(PyTypeObject, tp_print) };
++#if PY_VERSION_HEX < 0x03000000
++                                  offsetof(PyTypeObject, tp_print)
++#endif
++                                  };
+     int i;
+
+     /* Happens when registering gobject.GObject itself, at least. */


### PR DESCRIPTION
#### Description

Since Python 3.9 removed `tp_print` (deprecated since 3.8), a patch was necessary to build `py39-gobject` successfully. According to the Python docs, `tp_print` has been unused since Python 3.0 anyway.

(Originally part of #8865.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
