### PR TITLE
py-shiboken: add py39 subport

### DIFF
--- a/python/py-shiboken/Portfile
+++ b/python/py-shiboken/Portfile
@@ -6,7 +6,7 @@ PortGroup github 1.0
 
 github.setup        pyside Shiboken 1.2.4
 name                py-shiboken
-revision            1
+revision            2
 python.versions     27 35 36 37 38 39
 python.default_version 27
 categories-append   devel

--- a/python/py-shiboken/Portfile
+++ b/python/py-shiboken/Portfile
@@ -7,7 +7,7 @@ PortGroup github 1.0
 github.setup        pyside Shiboken 1.2.4
 name                py-shiboken
 revision            1
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 python.default_version 27
 categories-append   devel
 maintainers         nomaintainer
@@ -31,7 +31,8 @@ if {${name} ne ${subport}} {
     }
 
     patchfiles          default_visibility.patch \
-                        patch-cmakepkgconfig.diff
+                        patch-cmakepkgconfig.diff \
+                        patch-tpprint-py3.patch
 
     depends_lib-append  port:python${python.version} \
                         port:libxslt \

--- a/python/py-shiboken/files/patch-tpprint-py3.patch
+++ b/python/py-shiboken/files/patch-tpprint-py3.patch
@@ -1,0 +1,12 @@
+--- libshiboken/sbkenum.cpp	2015-10-14 20:12:33.000000000 +0200
++++ libshiboken/sbkenum.cpp	2020-10-20 05:08:31.000000000 +0200
+@@ -529,7 +529,9 @@
+     ::memset(type, 0, sizeof(SbkEnumType));
+     Py_TYPE(type) = &SbkEnumType_Type;
+     type->tp_basicsize = sizeof(SbkEnumObject);
++#ifndef IS_PY3K
+     type->tp_print = &SbkEnumObject_print;
++#endif
+     type->tp_repr = &SbkEnumObject_repr;
+     type->tp_str = &SbkEnumObject_repr;
+     type->tp_flags = Py_TPFLAGS_DEFAULT|Py_TPFLAGS_CHECKTYPES;


### PR DESCRIPTION
#### Description

Adds a py39 subport and a patch that allows it to build successfully.

Since Python 3.9 removed `tp_print` (deprecated since 3.8), a patch was necessary to build `py39-shiboken` successfully. According to the Python docs, `tp_print` has been unused since Python 3.0 anyway.

(Originally part of #8865.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
