### PR TITLE
py-pyside and py-sphinx_rtd_theme: add py39 subport

### DIFF
--- a/python/py-pyside/Portfile
+++ b/python/py-pyside/Portfile
@@ -8,7 +8,7 @@ github.setup        pyside PySide 1.2.4
 name                py-pyside
 revision            0
 set          qt.ver 4.8
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 python.default_version 27
 categories-append   devel
 maintainers         nomaintainer

--- a/python/py-sphinx_rtd_theme/Portfile
+++ b/python/py-sphinx_rtd_theme/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  4445532bc9604877e8a28c819a403bc47f49895d \
                     sha256  728607e34d60456d736cc7991fd236afb828b21b82f956c5ea75f94c8414040a \
                     size    5391190
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 if {${subport} ne ${name}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

Adds Python 3.9 subports for py-pyside and py-sphinx_rtd_theme.

(Originally part of #8865.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
