### PR TITLE
py-absl: Update to version 0.11.0

### DIFF
--- a/python/py-absl/Portfile
+++ b/python/py-absl/Portfile
@@ -4,30 +4,30 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-absl
-version             0.8.1
+version             0.11.0
 revision            0
+python.rootname     absl-py
 platforms           darwin
 supported_archs     noarch
 license             Apache-2.0
 maintainers         {emcrisostomo @emcrisostomo} openmaintainer
 
 description         Abseil Python Common Libraries
-long_description    ${description}
+long_description    ${python.rootname} is a collection of Python \
+                    library code for building Python applications. The \
+                    code is collected from Google's own Python code \
+                    base, and has been extensively tested and used in \
+                    production.
 
 homepage            https://github.com/abseil/abseil-py
-master_sites        pypi:a/absl-py
-distname            absl-py-${version}
 
-checksums           rmd160  e2fa96fb03bedd2a4d5e4de09969bf116ab7f593 \
-                    sha256  d9129186431e150d7fe455f1cb1ecbb92bb5dba9da9bc3ef7b012d98c4db2526 \
-                    size    103181
+checksums           rmd160  273c9431f2642ffdf6ad5cbf8025e98f3a3d3eac \
+                    sha256  673cccb88d810e5627d0c1c818158485d106f65a583880e2f730c997399bcfa7 \
+                    size    110452
 
-python.versions     27 35 36 37 38
-
-livecheck.name      ${python.rootname}-py
+python.versions     27 36 37 38
 
 if {${name} ne ${subport}} {
-
     depends_build-append \
         port:py${python.version}-setuptools \
         port:py${python.version}-setuptools_scm
@@ -35,10 +35,9 @@ if {${name} ne ${subport}} {
     depends_lib-append \
         port:py${python.version}-six
 
-    post-extract  {
-        file attributes ${worksrcpath}/PKG-INFO -permissions a+r
-        file attributes ${worksrcpath}/absl_py.egg-info/PKG-INFO -permissions a+r
+    if {${python.version} == 27} {
+        depends_lib-append port:py${python.version}-enum34
     }
 
-    livecheck.type      none
+    livecheck.type  none
 }


### PR DESCRIPTION
py-absl: Update to version 0.11.0

* Update to version 0.11.0
* Remove python version 35

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
