### PR TITLE
Floppy&Flow: New ports

### DIFF
--- a/devel/floppy/Portfile
+++ b/devel/floppy/Portfile
@@ -36,7 +36,7 @@ post-patch {
     # newer fortrans have a function range. Rename it.
     reinplace -W ${worksrcpath} "s|RANGE|EGNAR|g" range.for procom.for settyp.for
     # set compiler and additional options
-    reinplace -W ${worksrcpath} "s|f77|${configure.f77} -fdiagnostics-color=always|g" makefile
+    reinplace -W ${worksrcpath} "s|f77|${configure.f77} -fdiagnostics-color=auto|g" makefile
     # fix typo l -> 1
     reinplace -W ${worksrcpath} "s|flow(l)|flow(1)|g" floppy.l
 }

--- a/devel/floppy/Portfile
+++ b/devel/floppy/Portfile
@@ -1,0 +1,62 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+PortGroup       compilers 1.0
+
+name            floppy
+version         7.0
+revision        0
+categories      devel
+platforms       darwin
+license         Restrictive NoMirror
+maintainers     {@kamischi web.de:karl-michael.schindler} openmaintainer
+homepage        http://www.netlib.org/floppy/
+master_sites    ${homepage}
+distfiles       ${name}7.tgz
+dist_subdir     ${name}/${version}
+extract.mkdir   yes
+description     Fortran source code analyzer
+
+long_description \
+FLOPPY is a software tool that takes as input a file of FORTRAN 77 code \
+and checks it according to various 'coding conventions'. Floppy can \
+'tidy' the source FORTRAN, producing a new file with indented DO-loops, \
+block IF-s, and so on. Floppy can be used to generate HTML from the \
+Fortran program. In this case, a new file is written where each module \
+and include file name in the source Fortran is replaced by an HTML Anchor. \
+The format of the source is preserved when the document is browsed by an \
+HTML browser. FLOPPY can also be used to write a binary summary file \
+which is then used as input to the FLOW program.
+
+checksums   rmd160 c7a84b018df98a7a53edb12481e3e29b7f50ea4e \
+            sha256 f76735b24f76ab3c3d2ca6a276416890676694721bdb57f9c74cde36c548c68e \
+            size   175655
+
+post-patch {
+    # newer fortrans have a function range. Rename it.
+    reinplace -W ${worksrcpath} "s|RANGE|EGNAR|g" range.for procom.for settyp.for
+    # set compiler and additional options
+    reinplace -W ${worksrcpath} "s|f77|${configure.f77} -fdiagnostics-color=always|g" makefile
+    # fix typo l -> 1
+    reinplace -W ${worksrcpath} "s|flow(l)|flow(1)|g" floppy.l
+}
+
+compilers.choose    f77
+compilers.setup     require_fortran
+use_configure       no
+build.target        floppy
+build.args          -f makefile
+use_parallel_build  no
+
+destroot {
+    xinstall -m 0755 -W ${worksrcpath} floppy \
+        ${destroot}${prefix}/bin
+    xinstall -d ${destroot}${prefix}/share/man/manl
+    xinstall -m 0444 -W ${worksrcpath} floppy.l \
+        ${destroot}${prefix}/share/man/man1/floppy.1
+    xinstall -d ${destroot}${prefix}/share/doc/floppy
+    xinstall -m 0444 -W ${worksrcpath} copyright floppy.ps readme contents.html \
+        ${destroot}${prefix}/share/doc/floppy
+}
+
+livecheck.type  none

--- a/devel/flow/Portfile
+++ b/devel/flow/Portfile
@@ -27,7 +27,7 @@ checksums   rmd160 7c496a8e3a6f14be360f85e97e025ebad1a8df28 \
 
 post-patch {
     # set compiler and additional options
-    reinplace -W ${worksrcpath} "s|f77|${configure.f77} -fdiagnostics-color=always|g" makefile
+    reinplace -W ${worksrcpath} "s|f77|${configure.f77} -fdiagnostics-color=auto|g" makefile
     # fix typo l -> 1
     reinplace -W ${worksrcpath} "s|floppy(l)|floppy(1)|g" flow.l
 }

--- a/devel/flow/Portfile
+++ b/devel/flow/Portfile
@@ -1,0 +1,53 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+PortGroup       compilers 1.0
+
+name            flow
+version         3.0
+revision        0
+categories      devel
+platforms       darwin
+license         Restrictive NoMirror
+maintainers     {@kamischi web.de:karl-michael.schindler} openmaintainer
+homepage        http://www.netlib.org/floppy/
+master_sites    ${homepage}
+distfiles       ${name}3.tgz
+dist_subdir     ${name}/${version}
+extract.mkdir   yes
+description     Fortran source code analyzer
+
+long_description \
+The FLOW program takes the binary summary file produced by FLOPPY, and can \
+produce various reports on the structure of the original FORTRAN program.
+
+checksums   rmd160 7c496a8e3a6f14be360f85e97e025ebad1a8df28 \
+            sha256 45dd03359464b6a85754c88c30ab2b5578a9862f4eddc80e4a4f220bebfa1372 \
+            size   49364
+
+post-patch {
+    # set compiler and additional options
+    reinplace -W ${worksrcpath} "s|f77|${configure.f77} -fdiagnostics-color=always|g" makefile
+    # fix typo l -> 1
+    reinplace -W ${worksrcpath} "s|floppy(l)|floppy(1)|g" flow.l
+}
+
+compilers.choose    f77
+compilers.setup     require_fortran
+use_configure       no
+build.target        flow
+build.args          -f makefile
+use_parallel_build  no
+
+destroot {
+    xinstall -m 0755 -W ${worksrcpath} flow \
+        ${destroot}${prefix}/bin
+    xinstall -d ${destroot}${prefix}/share/man/man1
+    xinstall -m 0444 -W ${worksrcpath} flow.l \
+        ${destroot}${prefix}/share/man/man1/flow.1
+    xinstall -d ${destroot}${prefix}/share/doc/flow
+    xinstall -m 0444 -W ${worksrcpath} copyright flow.ps readme \
+        ${destroot}${prefix}/share/doc/flow
+}
+
+livecheck.type  none


### PR DESCRIPTION
Floppy and Flow are source code analyzers for legacy Fortran77 sources.

#### Description

Floppy is similar to ftidy. Flow creates the structure of the program.

###### Type(s)

- [*] new
- [*] enhancement

###### Tested on

macOS 10.15.7
Xcode 12.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [*] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [*] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [*] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [*] checked your Portfile with `port lint`?
- [*] tried a full install with `sudo port -vst install`?
- [*] tested basic functionality of all binary files?
