### PR TITLE
libpointing: use known_fail yes

### DIFF
--- a/devel/libpointing/Portfile
+++ b/devel/libpointing/Portfile
@@ -39,8 +39,9 @@ build.env           CXX=${configure.cxx} \
                     PREFIX=${prefix}
 destroot.env        PREFIX=${prefix}
 
-pre-fetch {
-    if {${os.platform} eq "darwin" && ${os.major} < 13} {
+if {${os.platform} eq "darwin" && ${os.major} < 13} {
+    known_fail yes
+    pre-fetch {
         ui_error "${name} requires macOS 10.9 or above."
         return -code error "incompatible Mac OS X version"
     }


### PR DESCRIPTION
#### Description
Skip on builders for macOS 10.8 and earlier

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
