### PR TITLE
py-game: add py38 subport

### DIFF
--- a/python/py-game/Portfile
+++ b/python/py-game/Portfile
@@ -22,9 +22,10 @@ python.rootname pygame
 master_sites    pypi:p/pygame
 distname        pygame-${version}
 checksums       rmd160 abe4dc7b5e350617048474a3d168d9d1d09eae2b \
-                sha256 301c6428c0880ecd4a9e3951b80e539c33863b6ff356a443db1758de4f297957
+                sha256 301c6428c0880ecd4a9e3951b80e539c33863b6ff356a443db1758de4f297957 \
+                size 3223131
 
-python.versions 27 35 36 37
+python.versions 27 35 36 37 38
 
 if {$subport ne $name} {
     patchfiles  patch-config_darwin.py.diff \


### PR DESCRIPTION
#### Description

py-game: add py38 subport, add size to make port lint happy

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
