### PR TITLE
git-crypt: use compiler.cxx_standard 2011

### DIFF
--- a/devel/git-crypt/Portfile
+++ b/devel/git-crypt/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem              1.0
 PortGroup               github 1.0
-PortGroup               cxx11 1.1
 
 github.setup            AGWA git-crypt 0.6.0
 revision                2
@@ -27,6 +26,8 @@ long_description        git-crypt enables transparent encryption and \
                         keys or passwords) in the same repository as your \
                         code, without requiring you to lock down your entire \
                         repository.
+
+compiler.cxx_standard   2011
 
 depends_lib-append      path:lib/libssl.dylib:openssl
 


### PR DESCRIPTION
…instead of deprecated `cxx11 1.1` portgroup

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### 
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
