### PR TITLE
quickfix: use compiler.cxx_standard 2011

### DIFF
--- a/devel/quickfix/Portfile
+++ b/devel/quickfix/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cxx11 1.1
 
 name                quickfix
 version             1.14.3
@@ -23,6 +22,8 @@ worksrcdir          ${name}
 checksums           rmd160  369d5bf7044fa4c90d2d74e4470e50c0ad82951b \
                     sha256  f6e8bdb004eaf45e50f63005b8c2611cb0afd42cf70f110f600c852aa572342d \
                     size    21803784
+
+compiler.cxx_standard 2011
 
 depends_lib         port:libxml2
 


### PR DESCRIPTION
…instead of deprecated `cxx11 1.1` portgroup

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
