### PR TITLE
qgis: cleanup compilers

### DIFF
--- a/gis/qgis/Portfile
+++ b/gis/qgis/Portfile
@@ -2,8 +2,6 @@
 
 PortSystem          1.0
 PortGroup           cmake   1.1
-PortGroup           compiler_blacklist_versions 1.0
-PortGroup           cxx11   1.1
 PortGroup           github  1.0
 PortGroup           qt4     1.0
 
@@ -55,7 +53,7 @@ post-patch {
 #    reinplace -E "s|Clang|AppleClang|" ${worksrcpath}/CMakeLists.txt
 }
 
-compiler.blacklist  {clang < 500}
+compiler.cxx_standard   2011
 
 set Py_FRM              ${frameworks_dir}/Python.framework/Versions/2.7
 


### PR DESCRIPTION
Use `compiler.cxx_standard 2011` instead of deprecated `cxx11 1.1` portgroup

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
