### PR TITLE
notmuch: Rename version files to fix build errors with old OS X versions

### DIFF
--- a/mail/notmuch/Portfile
+++ b/mail/notmuch/Portfile
@@ -6,7 +6,7 @@ PortGroup           conflicts_build             1.0
 
 name                notmuch
 version             0.31
-revision            1
+revision            2
 
 categories          mail
 platforms           darwin
@@ -49,7 +49,12 @@ depends_lib         port:gmime3 \
                     port:xapian-core \
                     port:zlib
 
-patchfiles          realpath.patch
+pre-patch {
+    move ${worksrcpath}/version ${worksrcpath}/version.txt
+    move ${worksrcpath}/bindings/python-cffi/version ${worksrcpath}/bindings/python-cffi/version.txt
+}
+
+patchfiles          realpath.patch version.patch
 
 conflicts_build     ${name} xcbuild
 

--- a/mail/notmuch/files/version.patch
+++ b/mail/notmuch/files/version.patch
@@ -1,0 +1,51 @@
+diff --git Makefile.global Makefile.global
+index cd489ef2..8477468d 100644
+--- Makefile.global
++++ Makefile.global
+@@ -17,7 +17,7 @@ else
+ DATE:=$(shell date +%F)
+ endif
+ 
+-VERSION:=$(shell cat ${srcdir}/version)
++VERSION:=$(shell cat ${srcdir}/version.txt)
+ ELPA_VERSION:=$(subst ~,_,$(VERSION))
+ ifeq ($(filter release release-message pre-release update-versions,$(MAKECMDGOALS)),)
+ ifeq ($(IS_GIT),yes)
+diff --git Makefile.local Makefile.local
+index c65cee7c..dde7981b 100644
+--- Makefile.local
++++ Makefile.local
+@@ -19,7 +19,7 @@ endif
+ 
+ # Depend (also) on the file 'version'. In case of ifeq ($(IS_GIT),yes)
+ # this file may already have been updated.
+-version.stamp: $(srcdir)/version
++version.stamp: $(srcdir)/version.txt
+ 	echo $(VERSION) > $@
+ 
+ $(TAR_FILE):
+diff --git bindings/python-cffi/setup.py bindings/python-cffi/setup.py
+index b0060835..cda52338 100644
+--- bindings/python-cffi/setup.py
++++ bindings/python-cffi/setup.py
+@@ -1,6 +1,6 @@
+ import setuptools
+ 
+-with open('version') as fp:
++with open('version.txt') as fp:
+     VERSION = fp.read().strip()
+ 
+ setuptools.setup(
+diff --git doc/conf.py doc/conf.py
+index 94e266af..11bed51d 100644
+--- doc/conf.py
++++ doc/conf.py
+@@ -19,7 +19,7 @@ copyright = u'2009-2020, Carl Worth and many others'
+ location = os.path.dirname(__file__)
+ 
+ for pathdir in ['.', '..']:
+-    version_file = os.path.join(location,pathdir,'version')
++    version_file = os.path.join(location,pathdir,'version.txt')
+     if os.path.exists(version_file):
+         with open(version_file,'r') as infile:
+             version=infile.read().replace('\n','')


### PR DESCRIPTION
The upstream distribution archive contains two files named _version_ which cause [compile errors](https://trac.macports.org/ticket/61378) on old OS X versions like 10.6. The files are now renamed to _version.txt_ and the build files are patched accordingly.