### PR TITLE
py-requests-oauthlib: add py39 subport to this and dependencies

### DIFF
--- a/python/py-blinker/Portfile
+++ b/python/py-blinker/Portfile
@@ -26,7 +26,7 @@ checksums           sha256  471aee25f3992bd325afa3772f1063dbdbbca947a041b8b89466
                     rmd160  54a649ae37e54924ebfe75149c3d19b0d25aa1a4 \
                     size    111476
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
     livecheck.type  none

--- a/python/py-jwt/Portfile
+++ b/python/py-jwt/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  bfe7a0ea07327593b728ba82766d809ae4c1be75 \
                     sha256  8d59a976fb773f3e6a39c85636357c4f0e242707394cadadd9814f5cbaa20e96 \
                     size    41979
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools \

--- a/python/py-oauthlib/Portfile
+++ b/python/py-oauthlib/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-oauthlib
-version             1.0.3
-revision            1
+version             3.1.0
+revision            0
 
 categories-append   net security
 platforms           darwin
@@ -21,11 +21,11 @@ homepage            https://github.com/oauthlib/oauthlib
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  07c48a5947b47d4511428c690452569f2191cc11 \
-                    sha256  ef4bfe4663ca3b97a995860c0173b967ebd98033d02f38c9e1b2cbb6c191d9ad \
-                    size    109095
+checksums           rmd160  9f860862bed7fda84d53f2882cef33dc15133dc8 \
+                    sha256  bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889 \
+                    size    155362
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
@@ -35,13 +35,7 @@ if {${name} ne ${subport}} {
                             port:py${python.version}-jwt
 
     depends_test-append \
-                    port:py${python.version}-nose \
                     port:py${python.version}-mock
-
-    if {${python.version} eq 27} {
-        depends_test-append \
-                    port:py${python.version}-unittest2
-    }
 
     test.run        yes
 

--- a/python/py-requests-oauthlib/Portfile
+++ b/python/py-requests-oauthlib/Portfile
@@ -20,7 +20,7 @@ checksums           rmd160  8f6a80350eb0dd2a336fa3c7565a3a7865c6e858 \
                     sha256  1bbea903af00869f60e975e8a645108b70923aaf3c29d9477226d5181cd90e04 \
                     size    45436
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

This adds a py39 subport to py-requests-oauthlib and dependencies py-oauthlib, py-blinker, and py-jwt.

py-oauthlib is updated to the current released version, 3.1.0. It was 1.0.3. All other ports were already at their current released versions. py-requests-oauthlib 1.3.0 is actually incompatible with py-oauthlib 1.0.3: [its requirements.txt](https://github.com/requests/requests-oauthlib/blob/v1.3.0/requirements.txt) specifies `requests>=2.0.0`, so py-requests-oauthlib for any Python version was actually already broken.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 11.7 11E801a

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
