### PR TITLE
httpie: update to 2.3.0

### DIFF
--- a/net/httpie/Portfile
+++ b/net/httpie/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        jakubroztocil httpie 2.2.0
+github.setup        jakubroztocil httpie 2.3.0
 
 maintainers         {g5pw @g5pw} openmaintainer
 categories          net
@@ -34,10 +34,12 @@ if {[variant_isset python36]} {
 }
 
 depends_lib-append  port:py${python.version}-requests \
-                    port:py${python.version}-pygments
+                    port:py${python.version}-requests-toolbelt \
+                    port:py${python.version}-pygments \
+                    port:py${python.version}-socks
 
-checksums           rmd160  130bf5fc79562e39497e16d96eb7aa6c806494c2 \
-                    sha256  5d0dddeb491176ba5c3c46ef233871cee31b8ff2886584ca0f0d0a369afedc1d \
-                    size    1761920
+checksums           rmd160  b136b1fecbe99d3a5a43ccb0da8e83104cd3a28b \
+                    sha256  a305991cd22ccf6d0a50a7cfd0913102ec986dcd487286fada779638f7ae3a87 \
+                    size    1769435
 
 python.link_binaries_suffix


### PR DESCRIPTION
#### Description

Updates httpie to version 2.3.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
