### PR TITLE
samba4: Update to version 4.13.0

### DIFF
--- a/net/samba4/Portfile
+++ b/net/samba4/Portfile
@@ -15,7 +15,7 @@ master_sites		https://download.samba.org/pub/samba/stable
 distname		samba-${version}
 checksums		rmd160  0e0efa2be30af3df3cce92b00496b296cc4c2a0d \
 			sha256  f11d52aee8db0aa50ac614143f2ccefead29e8f8ff585358792221557cade7f6 \
-			size	18406380
+			size    18406380
 
 depends_lib		port:cctools \
 			port:gettext \
@@ -31,10 +31,12 @@ depends_lib		port:cctools \
 			port:readline \
 			port:zlib
 
-patch.pre_args  -Np1
+patch.pre_args		-p1
 
-# patch to fix st_atim, st_ctim and st_mtim calls on MacOS
-patchfiles-append patch-fix-st_atim.diff 
+platform darwin {
+	# patch to fix st_atim, st_ctim and st_mtim calls on MacOS
+	patchfiles-append patch-fix-st_atim.diff
+}
 
 # patch to disable building documentation on MacOS
 # this enables us to have a working samba4 port without docs,
@@ -45,19 +47,29 @@ patchfiles-append patch-no-xsltproc.diff
 configure.ldflags-append -v
 
 set python ${prefix}/bin/python3.8
+
 configure.env-append	YAPP=${prefix}/bin/yapp-5.28
-configure.cmd   ${python} ./buildtools/bin/waf configure
-build.cmd       ${python} ./buildtools/bin/waf -v
+configure.cmd		${python} ./buildtools/bin/waf configure
+configure.args		-C \
+			--enable-fhs \
+			--mandir=${prefix}/share/man \
+			--with-libiconv=${prefix} \
+			--without-acl-support \
+			--without-ad-dc \
+			--disable-avahi \
+			--with-gpgme \
+			--disable-spotlight
+
+build.cmd		${python} ./buildtools/bin/waf -v
 build.pre_args
-build.env-append DESTDIR=${destroot}
-destroot.cmd    ${python} ./buildtools/bin/waf -v
-destroot.env-append DESTDIR=${destroot}
+build.env-append	DESTDIR=${destroot}
+
+destroot.cmd		${python} ./buildtools/bin/waf -v
+destroot.env-append	DESTDIR=${destroot}
 destroot.destdir
 
-configure.args	-C --enable-fhs --mandir=${prefix}/share/man --with-libiconv=${prefix} --without-acl-support --without-ad-dc --disable-avahi --with-gpgme --disable-spotlight
-
 post-destroot {
-    # add a postfix of '4' to all executables to avoid file conflicts
+	# add a postfix of '4' to all executables to avoid file conflicts
 	foreach dir {bin sbin} {
 		foreach bin [glob -directory "${destroot}${prefix}/${dir}" -type f *] {
 			file rename "${bin}" "${bin}4"

--- a/net/samba4/Portfile
+++ b/net/samba4/Portfile
@@ -1,45 +1,66 @@
 PortSystem 1.0
 
 name			samba4
-version			4.0.0tp5
-revision		5
+version			4.13.0
 categories		net
 platforms		darwin
 maintainers		nomaintainer
 license			GPL-3
-description		SMB/CIFS server and client, ALPHA release
+description		SMB/CIFS server and client
 long_description	Samba is an software suite that provides seamless file \
-			and print services to SMB/CIFS clients. \
-			This is an ALPHA release!
+			and print services to SMB/CIFS clients.
 
 homepage		http://www.samba.org/
-master_sites		http://download.samba.org/samba/ftp/samba4/ \
-			ftp://de.samba.org/samba.org/samba4/
+master_sites		https://download.samba.org/pub/samba/stable
 distname		samba-${version}
-checksums           md5     dbc2e04455d67b01d2020808065b96df \
-                    sha1    8897cc7a824a594b3543245cdbbceaea32e9e08d \
-                    rmd160  1870f67aa851751e381a3b03dadfa1d0afa28a12
+checksums		rmd160  0e0efa2be30af3df3cce92b00496b296cc4c2a0d \
+			sha256  f11d52aee8db0aa50ac614143f2ccefead29e8f8ff585358792221557cade7f6 \
+			size	18406380
 
-depends_lib		port:gnutls port:readline port:libiconv port:popt port:sqlite3 port:zlib port:gettext
+depends_lib		port:cctools \
+			port:gettext \
+			port:gnutls \
+			port:gpgme \
+			port:jansson \
+			port:libarchive \
+			port:libiconv \
+			port:openldap \
+			port:p5.28-parse-yapp \
+			port:popt \
+			port:python38 \
+			port:readline \
+			port:zlib
 
-worksrcdir		samba-${version}/source
+patch.pre_args  -Np1
 
-configure.args		--with-fhs \
-			--mandir=${prefix}/share/man \
-			--with-libiconv=${prefix} --with-readline=${prefix} --with-sqlite3
+# patch to fix st_atim, st_ctim and st_mtim calls on MacOS
+patchfiles-append patch-fix-st_atim.diff 
 
-destroot.target-append	installman
+# patch to disable building documentation on MacOS
+# this enables us to have a working samba4 port without docs,
+# rather than not having samba4 at all. Can be removed when
+# doc build issues are resolved.
+patchfiles-append patch-no-xsltproc.diff
+
+configure.ldflags-append -v
+
+set python ${prefix}/bin/python3.8
+configure.env-append	YAPP=${prefix}/bin/yapp-5.28
+configure.cmd   ${python} ./buildtools/bin/waf configure
+build.cmd       ${python} ./buildtools/bin/waf -v
+build.pre_args
+build.env-append DESTDIR=${destroot}
+destroot.cmd    ${python} ./buildtools/bin/waf -v
+destroot.env-append DESTDIR=${destroot}
+destroot.destdir
+
+configure.args	-C --enable-fhs --mandir=${prefix}/share/man --with-libiconv=${prefix} --without-acl-support --without-ad-dc --disable-avahi --with-gpgme --disable-spotlight
+
 post-destroot {
-	# add a postfix of '4' to all executables to avoid file conflicts
+    # add a postfix of '4' to all executables to avoid file conflicts
 	foreach dir {bin sbin} {
 		foreach bin [glob -directory "${destroot}${prefix}/${dir}" -type f *] {
 			file rename "${bin}" "${bin}4"
-		}
-	}
-	# ..and also to the manpages
-	foreach dir [glob -directory "${destroot}${prefix}/share/man" "man\[138\]"] {
-		foreach man [glob -directory "${dir}" -type f *] {
-			file rename "${man}" [string range "${man}" 0 [expr [string last . "${man}"] - 1]]4[string range "${man}" [string last . "${man}"] [string length "${man}"]]
 		}
 	}
 }
@@ -47,4 +68,3 @@ post-destroot {
 livecheck.type	regex
 livecheck.url	http://us4.samba.org/samba/ftp/samba4/?M=D
 livecheck.regex	samba-(\[0-9a-z.\]+)\\.tar\\.gz
-

--- a/net/samba4/files/patch-fix-st_atim.diff
+++ b/net/samba4/files/patch-fix-st_atim.diff
@@ -1,0 +1,53 @@
+diff --git a/source3/libsmb/libsmb_stat.c b/source3/libsmb/libsmb_stat.c
+index 790934b..7372881 100644
+--- a/source3/libsmb/libsmb_stat.c
++++ b/source3/libsmb/libsmb_stat.c
+@@ -102,18 +102,18 @@ void setup_stat(struct stat *st,
+ 	}
+ 
+ 	st->st_dev = dev;
+-	st->st_atim = access_time_ts;
+-	st->st_ctim = change_time_ts;
+-	st->st_mtim = write_time_ts;
++	st->st_atimespec = access_time_ts;
++	st->st_ctimespec = change_time_ts;
++	st->st_mtimespec = write_time_ts;
+ }
+ 
+ void setup_stat_from_stat_ex(const struct stat_ex *stex,
+ 			     const char *fname,
+ 			     struct stat *st)
+ {
+-	st->st_atim = stex->st_ex_atime;
+-	st->st_ctim = stex->st_ex_ctime;
+-	st->st_mtim = stex->st_ex_mtime;
++	st->st_atimespec = stex->st_ex_atime;
++	st->st_ctimespec = stex->st_ex_ctime;
++	st->st_mtimespec = stex->st_ex_mtime;
+ 
+ 	st->st_mode = stex->st_ex_mode;
+ 	st->st_size = stex->st_ex_size;
+diff --git a/source4/torture/libsmbclient/libsmbclient.c b/source4/torture/libsmbclient/libsmbclient.c
+index 3f39925..0ed93da 100644
+--- a/source4/torture/libsmbclient/libsmbclient.c
++++ b/source4/torture/libsmbclient/libsmbclient.c
+@@ -1231,8 +1231,8 @@ static bool torture_libsmbclient_utimes(struct torture_context *tctx)
+ 	ret = smbc_fstat(fhandle, &st);
+ 	torture_assert_int_not_equal(tctx, ret, -1, "smbc_fstat failed");
+ 
+-	tbuf[0] = convert_timespec_to_timeval(st.st_atim);
+-	tbuf[1] = convert_timespec_to_timeval(st.st_mtim);
++	tbuf[0] = convert_timespec_to_timeval(st.st_atimespec);
++	tbuf[1] = convert_timespec_to_timeval(st.st_mtimespec);
+ 
+ 	tbuf[1] = timeval_add(&tbuf[1], 0, 100000); /* 100 msec */
+ 
+@@ -1244,7 +1244,7 @@ static bool torture_libsmbclient_utimes(struct torture_context *tctx)
+ 
+ 	torture_assert_int_equal(
+ 		tctx,
+-		st.st_mtim.tv_nsec / 1000,
++		st.st_mtimespec.tv_nsec / 1000,
+ 		tbuf[1].tv_usec,
+ 		"smbc_utimes did not update msec");
+ 

--- a/net/samba4/files/patch-no-xsltproc.diff
+++ b/net/samba4/files/patch-no-xsltproc.diff
@@ -1,0 +1,45 @@
+--- ./buildtools/wafsamba/samba_conftests.py	2019-09-13 09:43:36.000000000 +0200
++++ ./buildtools/wafsamba/orig.samba_conftests.py	2018-01-14 21:41:58.000000000 +0100
+@@ -481,7 +481,7 @@
+ 
+ 
+     if not conf.CONFIG_SET('XSLTPROC'):
+-        conf.find_program('xsltproc', var='XSLTPROC')
++        conf.find_program('NOTxsltproc', var='XSLTPROC')
+     if not conf.CONFIG_SET('XSLTPROC'):
+         return False
+ 
+Exit 1
+--- ./ctdb/wscript	2019-09-13 09:43:47.000000000 +0200
++++ ./ctdb/orig.wscript	2018-08-24 09:58:20.000000000 +0200
+@@ -1014,7 +1014,7 @@
+     BASE_URL = 'http://docbook.sourceforge.net/release/xsl/current'
+     MAN_XSL = '%s/manpages/docbook.xsl' % BASE_URL
+     HTML_XSL = '%s/html/docbook.xsl' % BASE_URL
+-    CMD_TEMPLATE = 'xsltproc --xinclude -o %s --nonet %s %s'
++    CMD_TEMPLATE = 'NOTxsltproc --xinclude -o %s --nonet %s %s'
+     manpages = manpages_binary + manpages_misc + manpages_etcd + manpages_ceph
+     for t in manpages:
+         cmd = CMD_TEMPLATE % ('doc/%s' % t, MAN_XSL, 'doc/%s.xml' % t)
+Exit 1
+--- ./lib/ldb/wscript	2019-09-13 09:42:28.000000000 +0200
++++ ./lib/ldb/orig.wscript	2018-08-24 09:58:20.000000000 +0200
+@@ -60,5 +60,5 @@
+
+     conf.RECURSE('lib/replace')
+-    conf.find_program('xsltproc', var='XSLTPROC')
++    conf.find_program('NOTxsltproc', var='XSLTPROC')
+     conf.SAMBA_CHECK_PYTHON()
+     conf.SAMBA_CHECK_PYTHON_HEADERS()
+Exit 1
+--- ./wscript	2019-09-13 09:43:26.000000000 +0200
++++ ./orig.wscript	2018-11-26 08:54:31.000000000 +0100
+@@ -122,7 +122,7 @@
+     conf.RECURSE('examples/fuse')
+ 
+     conf.SAMBA_CHECK_PERL(mandatory=True)
+-    conf.find_program('xsltproc', var='XSLTPROC')
++    conf.find_program('NOTxsltproc', var='XSLTPROC')
+ 
+     if conf.env.disable_python:
+         if not (Options.options.without_ad_dc):


### PR DESCRIPTION
#### Description

samba4: Update to version 4.13.0

fixes: https://trac.macports.org/ticket/61380

###### Type(s)
- [x] update
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7
Xcode 12.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?