### PR TITLE
git: fix trace build, patch fuzz and offsets

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -52,7 +52,10 @@ depends_run-append  port:p${perl5.major}-authen-sasl \
                     port:p${perl5.major}-cgi \
                     port:rsync
 
-patchfiles          patch-Makefile.diff patch-git-subtree.1.diff patch-sha1dc-older-apple-gcc-versions.diff
+patchfiles          patch-Makefile.diff \
+                    patch-git-gui-Makefile.diff \
+                    patch-git-subtree.1.diff \
+                    patch-sha1dc-older-apple-gcc-versions.diff
 patch.pre_args      -p1
 
 extract.only        git-${version}${extract.suffix} \

--- a/devel/git/files/patch-Makefile.diff
+++ b/devel/git/files/patch-Makefile.diff
@@ -1,6 +1,6 @@
 --- a/Makefile.orig
 +++ b/Makefile
-@@ -1065,7 +1065,7 @@
+@@ -1257,7 +1257,7 @@
  ifeq ($(COMPUTE_HEADER_DEPENDENCIES),auto)
  dep_check = $(shell $(CC) $(ALL_CFLAGS) \
  	-c -MF /dev/null -MQ /dev/null -MMD -MP \

--- a/devel/git/files/patch-git-gui-Makefile.diff
+++ b/devel/git/files/patch-git-gui-Makefile.diff
@@ -1,0 +1,11 @@
+--- ./git-gui/Makefile.orig	2020-10-23 00:31:53.000000000 +0200
++++ ./git-gui/Makefile	2020-10-29 13:49:22.000000000 +0100
+@@ -104,7 +104,7 @@ else
+ endif
+
+ ifeq ($(uname_S),Darwin)
+-	TKFRAMEWORK = /Library/Frameworks/Tk.framework/Resources/Wish.app
++	TKFRAMEWORK = /System/Library/Frameworks/Tk.framework/Resources/Wish.app
+ 	ifeq ($(shell echo "$(uname_R)" | awk -F. '{if ($$1 >= 9) print "y"}')_$(shell test -d $(TKFRAMEWORK) || echo n),y_n)
+ 		TKFRAMEWORK = /System/Library/Frameworks/Tk.framework/Resources/Wish.app
+ 		ifeq ($(shell test -d $(TKFRAMEWORK) || echo n),n)

--- a/devel/git/files/patch-sha1dc-older-apple-gcc-versions.diff
+++ b/devel/git/files/patch-sha1dc-older-apple-gcc-versions.diff
@@ -2,14 +2,14 @@ diff --git a/sha1dc/sha1.c b/sha1dc/sha1.c
 index 25eded1..5faf5a5 100644
 --- a/sha1dc/sha1.c
 +++ b/sha1dc/sha1.c
-@@ -92,6 +92,10 @@
+@@ -102,6 +102,10 @@
   */
  #define SHA1DC_BIGENDIAN
  
 +#elif (defined(__APPLE__) && defined(__BIG_ENDIAN__) && !defined(SHA1DC_BIGENDIAN))
-+/* older gcc compilers which are the default  on Apple PPC do not define __BYTE_ORDER__ */
++/* older gcc compilers which are the default on Apple PPC do not define __BYTE_ORDER__ */
 +#define SHA1DC_BIGENDIAN
 +
- /* Not under GCC-alike or glibc or *BSD or newlib or <processor whitelist> */
+ /* Not under GCC-alike or glibc or *BSD or newlib or <processor whitelist> or <os whitelist> */
  #elif defined(SHA1DC_ON_INTEL_LIKE_PROCESSOR)
  /*


### PR DESCRIPTION
#### Description

git: fix trace build, patch fuzz and offsets

  - add patch-git-gui-Makefile.diff
  - fix patch offsets and fuzz
  - Closes: https://trac.macports.org/ticket/61381

###### Type(s)

- [x] bugfix

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?