### PR TITLE
wordpress: update to 5.5.2

### DIFF
--- a/www/wordpress/Portfile
+++ b/www/wordpress/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 
 name                wordpress
-version             5.5.1
-revision            1
+version             5.5.2
+revision            0
 
 categories          www
 license             GPL-2+
@@ -16,12 +16,12 @@ description         a state-of-the-art semantic personal publishing platform
 long_description    WordPress is {*}${description} with a focus on aesthetics,\
                     web standards, and usability.
 
-homepage            https://wordpress.org/
+homepage            https://${name}.org/
 master_sites        ${homepage}
 
-checksums           rmd160  3bf7930b3faa21a0f88395942b899c7397eeac68 \
-                    sha256  66a2ced5f3e240d0612dd3668fbd50308f9649ecb4a6e17d46dc0d8111b99295 \
-                    size    12983648
+checksums           rmd160  6d98fe0ea30eb9947da78b7e6259ee1c85b828b5 \
+                    sha256  c90c73a668c3137d0008216a3a3a628add3fddf054bcfdd4b1ab7b0bf66aced5 \
+                    size    12987891
 
 worksrcdir          ${name}
 


### PR DESCRIPTION
#### Description

wordpress: update to 5.5.2

- <https://wordpress.org/news/2020/10/wordpress-5-5-2-security-and-maintenance-release/>

###### Type(s)

- [x] update

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?