### PR TITLE
tmux: update to 3.1c

### DIFF
--- a/sysutils/tmux/Portfile
+++ b/sysutils/tmux/Portfile
@@ -3,14 +3,14 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    tmux tmux 3.1b
+github.setup    tmux tmux 3.1c
 if {${subport} eq ${name}} {
     revision        0
     conflicts       tmux-devel
 }
 subport tmux-devel {
-    github.setup    tmux tmux a08f1c8c59787408529463c985929e5ae1c67211
-    version         20200504-[string range ${github.version} 0 6]
+    github.setup    tmux tmux d0640609044c06ffa5aeb7a509965ce3f0b1a412
+    version         20201030-[string range ${github.version} 0 6]
     revision        0
     conflicts       tmux
 }
@@ -30,14 +30,14 @@ depends_lib     port:libevent port:ncurses
 
 if {${subport} eq ${name}} {
     github.tarball_from     releases
-    checksums               rmd160  10bd0c871da3fd9c450408c96bbc7231257e40e4 \
-                            sha256  d93f351d50af05a75fe6681085670c786d9504a5da2608e481c47cf5e1486db9 \
-                            size    561152
+    checksums               rmd160  3c1ab6dcb1120129f66a6639214126565a7388e8 \
+                            sha256  918f7220447bef33a1902d4faff05317afd9db4ae1c9971bef5c787ac6c88386 \
+                            size    561323
 }
 subport tmux-devel {
-    checksums               rmd160  c379f7faa81473a610380261d0110ab580c053de \
-                            sha256  6ea3edc022326df0d902b3260c8f568bb0eae49b13e9952338ee8dc700e8e85c \
-                            size    751410
+    checksums               rmd160  512dc627c4be71e12038b032ac9a059a508bcc8f \
+                            sha256  b5bd972eab8318faf0728d0946080e59c80212d4e8cfd0335609d2c8da3fe5ee \
+                            size    788088
 
     use_autoreconf          yes
     autoreconf.cmd          ./autogen.sh


### PR DESCRIPTION
#### Description

###### Type(s)

- [x] update

###### Tested on

macOS 10.14.6 18G6032
Xcode 11.3.1 11C504

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?