### PR TITLE
gobject-introspection: tweak scanner patch

### DIFF
--- a/gnome/gobject-introspection/Portfile
+++ b/gnome/gobject-introspection/Portfile
@@ -5,7 +5,7 @@ PortGroup           active_variants 1.1
 
 name                gobject-introspection
 version             1.60.2
-revision            2
+revision            3
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          gnome
 platforms           darwin

--- a/gnome/gobject-introspection/files/patch-fix-scanner-in-build-execution.diff
+++ b/gnome/gobject-introspection/files/patch-fix-scanner-in-build-execution.diff
@@ -14,7 +14,7 @@
              args.append('-L.')
 --- giscanner/dumper.py.orig
 +++ giscanner/dumper.py
-@@ -236,8 +236,20 @@
+@@ -236,8 +236,29 @@
  
          args.extend(sources)
  
@@ -23,6 +23,15 @@
 +        pkg_config_libs, pkg_config_libs_only_L = pkgconfig.libs(
 +            self._packages, msvc_syntax=self._compiler.check_is_msvc())
 +        this_L = [lib[len('-L'):] for lib in pkg_config_libs_only_L]
++
++        # remove self._options.library_paths entries that are in
++        # "this_L" already, since those are "system" and will be found
++        # via the "runtime_path_envvar" setting below
++        tmp_L = []
++        for t_L in self._options.library_paths:
++            if t_L not in this_L:
++                tmp_L.append (t_L)
++        self._options.library_paths = tmp_L
 +
 +        if os.name == 'nt':
 +            runtime_path_envvar = ['LIB', 'PATH']


### PR DESCRIPTION
Now handles build-provided library paths more robustly, removing those that are already found via PKGCONFIG and are thus clearly "system" paths -- for MacPorts the most critical is `-L${MACPORTS_PREFIX}/lib` ...

Ref: https://trac.macports.org/ticket/61382

Tested on 10.15 and 11.0. Works for py38-gobject3, gexiv2, and libsoup.