### PR TITLE
samba4: Fix linking issues

### DIFF
--- a/net/samba4/Portfile
+++ b/net/samba4/Portfile
@@ -74,12 +74,128 @@ destroot.cmd		${configure.python} ./buildtools/bin/waf -v
 destroot.env-append	DESTDIR=${destroot}
 destroot.destdir
 
+# this will be used on Darwin, to correct the IDs of a binary's library dependencies
+# so that they will be found in the location where they are actually installed.
+options changelist
+changelist
+
 post-destroot {
-	# add a postfix of '4' to all executables to avoid file conflicts
-	foreach dir {bin sbin} {
-		foreach bin [glob -directory "${destroot}${prefix}/${dir}" -type f *] {
-			file rename "${bin}" "${bin}4"
+	platform darwin {
+		# install a file missed by the build system:
+		xinstall -m 755 ${worksrcpath}/bin/shared/private/libdnsserver-common-samba4.dylib ${destroot}${prefix}/lib/samba
+
+		# On Darwin the build system fails to set library install names AND uses absolute paths
+		# into the build directory (-o ${build.dir}/path/to/libfoo.dylib).
+		# We want to run without need for ${build.dir} so we need to fix the IDs and the "rpaths".
+		proc canonical {lf} {
+			set l [file normalize ${lf}]
+			if {[file type ${l}] eq "link"} {
+				set target [file readlink ${l}]
+				if {[file pathtype ${target}] eq "relative"} {
+					return [file normalize [file join [file dirname ${l}] ${target}]]
+				} else {
+					return [file normalize ${target}]
+				}
+			} else {
+				return ${l}
+			}
 		}
+
+		# First, find all .dylib files, record their current ID (in changelist) and correct it
+		ui_msg "--->  Fixing dylib IDs"
+		array set libdone {}
+		catch {exec -ignorestderr find ${destroot}${prefix} -regex {.*/lib[^.]*\.[0-9]\.dylib}} versioneddylibs err
+		foreach lf ${versioneddylibs} {
+			# we may get output from `find` that's not a file, so check
+			if {[file exists ${lf}]} {
+				set l [canonical ${lf}]
+				if {[string first ${destroot} ${l}] < 0} {
+					# shouldn't happen but better safe than sorry
+					ui_warn "${lf} -> ${l} !"
+				} else {
+					# NB: the install name is based on the symlink, not the target!
+					set id [exec otool -D ${lf} | tail -1]
+					# the new install name == ID: the full path minus ${destroot}.
+					set instname [string map [list ${destroot} ""] ${lf}]
+					if {${instname} ne ${id}} {
+						system "install_name_tool -id ${instname} ${l}"
+						# the current ID must be changed to the new one in all files that depend on it:
+						changelist-append -change ${id} ${instname}
+						# annoyingly some libraries will still their intermediate library ID
+						# and who knows if other binaries depend on those IDs
+						# Just change both...
+						if {[string last ".inst.dylib" ${id}] >= 0} {
+							set id2 "[file rootname [file rootname ${id}]].dylib"
+						} else {
+							set id2 "[file rootname ${id}].inst.dylib"
+						}
+						changelist-append -change ${id2} ${instname}
+					}
+					# mark the actual file we just processed as "done".
+					set libdone(${l}) yes
+				}
+			}
+		}
+		# idem for the unversioned libraries - by finding all and then ignoring those already processed.
+		catch {exec -ignorestderr find ${destroot}${prefix} -name "*.dylib"} otherdylibs err
+		foreach lf ${otherdylibs} {
+			if {[file exists ${lf}]} {
+				set l [canonical ${lf}]
+				if {[string first ${destroot} ${l}] < 0} {
+					# shouldn't happen but better safe than sorry
+					ui_warn "${lf} -> ${l} !"
+				} elseif {![info exists libdone(${l})]} {
+					set id [exec otool -D ${lf} | tail -1]
+					set instname [string map [list ${destroot} ""] ${lf}]
+					if {${instname} ne ${id}} {
+						system "install_name_tool -id ${instname} ${l}"
+						changelist-append -change ${id} ${instname}
+						if {[string last ".inst.dylib" ${id}] >= 0} {
+							set id2 "[file rootname [file rootname ${id}]].dylib"
+						} else {
+							set id2 "[file rootname ${id}].inst.dylib"
+						}
+						changelist-append -change ${id2} ${instname}
+					}
+				} else {
+					ui_debug "Library ${l} has already been fixed"
+				}
+			}
+		}
+		ui_debug "Changelist:"
+		ui_debug "${changelist}"
+		ui_msg "--->  Updating all binaries with the new IDs"
+		# reset libdone
+		array unset libdone
+		catch {exec -ignorestderr find ${destroot}${prefix} -name "*.dylib" -o -name "*.so"} alllibs err
+		foreach lf ${alllibs} {
+			if {[file exists ${lf}]} {
+				set exe [canonical ${lf}]
+				if {![info exists libdone(${exe})]} {
+					system "install_name_tool ${changelist} ${exe}"
+					set libdone(${exe}) yes
+				}
+			}
+		}
+		foreach exe [glob ${destroot}${prefix}/bin/*] {
+			if {[file exists ${exe}]} {
+				# catch because we could encounter scripts
+				catch {system "install_name_tool ${changelist} ${exe}"}
+			}
+		}
+		foreach exe [glob ${destroot}${prefix}/sbin/*] {
+			if {[file exists ${exe}]} {
+				# catch because we could encounter scripts
+				catch {system "install_name_tool ${changelist} ${exe}"}
+			}
+		}
+		foreach exe [glob ${destroot}${prefix}/libexec/samba/*] {
+			if {[file exists ${exe}]} {
+				# catch because we could encounter scripts
+				catch {system "install_name_tool ${changelist} ${exe}"}
+			}
+		}
+		# All done, "already"!
 	}
 }
 


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/61385

#### Description
This is to fix broken dylib ID and linking issue on MacOS.
entire commit is the work of @RJVB , and copied from [macstrop](https://github.com/RJVB/macstrop/blob/master/net/samba4/Portfile)

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7
Xcode 12.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
