### PR TITLE
kustomize: update to 3.8.6

### DIFF
--- a/devel/kustomize/Portfile
+++ b/devel/kustomize/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/kubernetes-sigs/kustomize 3.8.5 kustomize/v
+go.setup            github.com/kubernetes-sigs/kustomize 3.8.6 kustomize/v
 revision            0
 
 categories          devel
@@ -23,9 +23,9 @@ long_description    kustomize lets you customize raw, template-free YAML files f
 
 homepage            https://kustomize.io
 
-checksums           rmd160  ddc3a2b0c580f84f3aee68f433b5d8b36fb101b8 \
-                    sha256  ecbe8a98e4795b956f1def3f93637e941b23977123716ef9873bf8e8d5b04cde \
-                    size    26009191
+checksums           rmd160  56a31be9456e7d888a96fee88a13cb39d4a05671 \
+                    sha256  c17fdf4c1b66d0fae0cf276e7ab940a66aad85bad499dee3422ec08c0e7ae7f1 \
+                    size    26030359
 
 build.dir           ${worksrcpath}/${name}
 


### PR DESCRIPTION
#### Description

Update to Kustomize 3.8.6.

###### Tested on

macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?