### PR TITLE
spring-boot-cli: update to 2.3.5

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            spring-boot-cli
-version         2.3.4
+version         2.3.5
 revision        0
 
 categories      java
@@ -30,9 +30,9 @@ master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/
 
 distname        ${name}-${version}.RELEASE-bin
 
-checksums       rmd160  b6662b062010bc345717abd8fa509d84912bb8b2 \
-                sha256  1e8d49e2c27d1953266d2b55d0ba5c5df95a8225f2074dc9dc44c774beed7a92 \
-                size    11612321
+checksums       rmd160  a402a157112bc7283b0ef1ec400af4debbe4db0b \
+                sha256  f8e499983da3fe53d15cc7fad66cafcc9dc82e6df87cc09bffaaf5a085455761 \
+                size    11615785
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
#### Description

Update to Spring Boot CLI 2.3.5.RELEASE.

###### Tested on

macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?