### PR TITLE
vcs_blackbox: update to 1.20200429

### DIFF
--- a/security/vcs_blackbox/Portfile
+++ b/security/vcs_blackbox/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        StackExchange blackbox 1.20160122 v
+github.setup        StackExchange blackbox 1.20200429 v
 name                vcs_blackbox
 categories          security
 platforms           darwin
@@ -18,8 +18,9 @@ long_description    Storing secrets such as passwords, certificates and private 
                     to store secrets safely using GPG encryption. They can be easily \
                     decrypted for editing or use in production.
 
-checksums           rmd160  9dd7ae3d7aba11be98b2f8b600a235cfbcdc5319 \
-                    sha256  4e7e156bb46713cab7a0283a5dc02e9da4bc0316ffcabc7e2af1bce6c31fae4a
+checksums           rmd160  a10cf4df9abdf9d281a99dd6c51ead916e42f7bd \
+                    sha256  a8ea3e8e00d8e42a495a60065f2f8a5443e5c7e70922ec06ed0de1fe126b0f65 \
+                    size    43236
 
 use_configure       no
 


### PR DESCRIPTION
#### Description

Update vcs_blackbox to 1.20200429

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? n/a
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
