### PR TITLE
thefuck: add missing dep

### DIFF
--- a/python/thefuck/Portfile
+++ b/python/thefuck/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                thefuck
 version             3.30
-revision            0
+revision            1
 
 categories-append   sysutils
 platforms           darwin
@@ -28,7 +28,8 @@ depends_build-append    port:py${python.version}-setuptools
 depends_lib-append      port:py${python.version}-colorama \
                         port:py${python.version}-decorator \
                         port:py${python.version}-psutil \
-                        port:py${python.version}-pyte
+                        port:py${python.version}-pyte \
+                        port:py${python.version}-six
 
 livecheck.type      pypi
 


### PR DESCRIPTION
#### Description

thefuck: add missing dep
    
  - add py-six (appears to be a missing dep)
  - Closes: https://trac.macports.org/ticket/61389

###### Type(s)

- [x] update

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?