### PR TITLE
httpie: add python39 variant

### DIFF
--- a/net/httpie/Portfile
+++ b/net/httpie/Portfile
@@ -20,17 +20,20 @@ platforms           darwin
 license             BSD
 homepage            http://httpie.org
 
-variant python36 conflicts python37 python38 description "Use Python 3.6" {}
-variant python37 conflicts python36 python38 description "Use Python 3.7" {}
-variant python38 conflicts python36 python37 description "Use Python 3.8" {}
+variant python36 conflicts python37 python38 python39 description "Use Python 3.6" {}
+variant python37 conflicts python36 python38 python39 description "Use Python 3.7" {}
+variant python38 conflicts python36 python37 python39 description "Use Python 3.8" {}
+variant python39 conflicts python36 python37 python38 description "Use Python 3.9" {}
 
 if {[variant_isset python36]} {
     python.default_version 36
 } elseif {[variant_isset python37]} {
     python.default_version 37
-} else {
-    default_variants +python38
+} elseif {[variant_isset python38]} {
     python.default_version 38
+} else {
+    default_variants +python39
+    python.default_version 39
 }
 
 depends_lib-append  port:py${python.version}-requests \


### PR DESCRIPTION
#### Description

add python39 variant to httpie

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.1 12A7403
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
