### PR TITLE
mpv: remove cache=

### DIFF
--- a/multimedia/mpv/Portfile
+++ b/multimedia/mpv/Portfile
@@ -6,8 +6,8 @@ PortGroup               waf 1.0
 PortGroup               legacysupport 1.0
 
 # Please revbump mpv whenever ffmpeg{,-devel} is updated!
-github.setup            mpv-player mpv 0.32.0 v
-revision                3
+github.setup            mpv-player mpv 0.33.0 v
+revision                0
 categories              multimedia
 license                 GPL-2+
 maintainers             {ionic @Ionic} {i0ntempest @i0ntempest} openmaintainer

--- a/multimedia/mpv/files/config-maintainer
+++ b/multimedia/mpv/files/config-maintainer
@@ -1,9 +1,7 @@
 # Write your default config options here!
 [default]
 
-vo=opengl
-profile=opengl-hq
-opengl-backend=@@BACKEND@@
+vo=gpu
 ao=coreaudio
 
 sub-scale=3
@@ -18,8 +16,6 @@ framedrop=vo
 @@HWDEC_CUDA@@#hwdec=cuda
 
 #alang=en,eng,de,ger
-
-cache=50700
 
 @@NETWORK@@ytdl
 @@NETWORK@@ytdl-format=best


### PR DESCRIPTION
#### Description

remove `cache=` from `config-maintainer`.  The setting has changed a long time ago and does accept size parameter:

```
--cache=<yes|no|auto>
```

I personally think there is no one size fits all cache setting and as such shouldnt be part of the suggested "default config".

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 11.7 11E801a

###### Verification <!-- (delete not applicable items) -->

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
