### PR TITLE
pgbouncer: update to 1.14.0

### DIFF
--- a/databases/pgbouncer/Portfile
+++ b/databases/pgbouncer/Portfile
@@ -3,10 +3,10 @@
 PortSystem 1.0
 
 name			pgbouncer
-version			1.4.2
-revision        2
+version			1.14.0
 categories		databases
 platforms		darwin
+license             ISC
 maintainers		nomaintainer
 description		Lightweight connection pooler for PostgreSQL
 long_description	pgbouncer is a PostgreSQL connection pooler. \
@@ -15,34 +15,17 @@ long_description	pgbouncer is a PostgreSQL connection pooler. \
 			and pgbouncer will manage to connect to the \
 			server, or to reuse one of its existing	connections.
 
-homepage		http://pgbouncer.projects.postgresql.org/
-master_sites		http://pgfoundry.org/frs/download.php/3085/
+homepage		https://www.pgbouncer.org
+master_sites		${homepage}/downloads/files/${version}/
 
 
-checksums           md5     5083110b5b4f2127234bfc7b1f451f8d \
-                    sha1    610198c3f2186d70267275f554e23bd43598e4b5 \
-                    rmd160  055796e23dd7029d3f4a2c882cf24399a5481cb1
+checksums           rmd160  32af583b75a189fc295fec0880d6af2a6b8d7ce4 \
+                    sha256  a0c13d10148f557e36ff7ed31793abb7a49e1f8b09aa2d4695d1c28fa101fee7 \
+                    size    578955
 
-configure.env		PATH=$env(PATH):${prefix}/lib/postgresql90/bin
-
-depends_build		port:postgresql90
-depends_lib             port:libevent
+depends_build		port:gmake port:pkgconfig
+depends_lib             port:libevent path:lib/libssl.dylib:openssl
 
 livecheck.type	regex
-livecheck.url	http://pgfoundry.org/frs/?group_id=1000258
-livecheck.regex	pgbouncer-(\[0-9\\.\]+)\\.tgz
-
-variant postgresql82 description {uses postgresql82 installation} {
-	depends_build		port:postgresql82
-	configure.env		PATH=$env(PATH):${prefix}/lib/postgresql82/bin
-}
-
-variant postgresql83 description {uses postgresql83 installation} {
-	depends_build		port:postgresql83
-	configure.env		PATH=$env(PATH):${prefix}/lib/postgresql83/bin
-}
-
-variant postgresql84 description {uses postgresql84 installation} {
-	depends_build		port:postgresql84
-	configure.env		PATH=$env(PATH):${prefix}/lib/postgresql84/bin
-}
+livecheck.url	https://www.pgbouncer.org/downloads/
+livecheck.regex	pgbouncer-(\[0-9\\.\]+)\\.tar\\.gz

--- a/databases/pgbouncer/Portfile
+++ b/databases/pgbouncer/Portfile
@@ -2,30 +2,32 @@
 
 PortSystem 1.0
 
-name			pgbouncer
-version			1.14.0
-categories		databases
-platforms		darwin
+name                pgbouncer
+version             1.14.0
+categories          databases
+platforms           darwin
 license             ISC
-maintainers		nomaintainer
-description		Lightweight connection pooler for PostgreSQL
-long_description	pgbouncer is a PostgreSQL connection pooler. \
-			Any target application can be connected to \
-			pgbouncer as if it were a PostgreSQL server, \
-			and pgbouncer will manage to connect to the \
-			server, or to reuse one of its existing	connections.
+maintainers         nomaintainer
+description         Lightweight connection pooler for PostgreSQL
+long_description    pgbouncer is a PostgreSQL connection pooler. \
+                    Any target application can be connected to \
+                    pgbouncer as if it were a PostgreSQL server, \
+                    and pgbouncer will manage to connect to the \
+                    server, or to reuse one of its existing connections.
 
-homepage		https://www.pgbouncer.org
-master_sites		${homepage}/downloads/files/${version}/
+homepage            https://www.pgbouncer.org
+master_sites        ${homepage}/downloads/files/${version}/
 
 
 checksums           rmd160  32af583b75a189fc295fec0880d6af2a6b8d7ce4 \
                     sha256  a0c13d10148f557e36ff7ed31793abb7a49e1f8b09aa2d4695d1c28fa101fee7 \
                     size    578955
 
-depends_build		port:gmake port:pkgconfig
-depends_lib             port:libevent path:lib/libssl.dylib:openssl
+depends_build       port:gmake \
+                    port:pkgconfig
+depends_lib         port:libevent \
+                    path:lib/libssl.dylib:openssl
 
-livecheck.type	regex
-livecheck.url	https://www.pgbouncer.org/downloads/
-livecheck.regex	pgbouncer-(\[0-9\\.\]+)\\.tar\\.gz
+livecheck.type      regex
+livecheck.url       https://www.pgbouncer.org/downloads/
+livecheck.regex     pgbouncer-(\[0-9\\.\]+)\\.tar\\.gz


### PR DESCRIPTION
#### Description
Note the dropped dependency on postgresql. I guess at some point in the past decade they ditched libpq entirely, because the package definitely doesn't require it anymore to compile. I verified that it wasn't sneakily linking against Postgres with otool -L

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
macOS 10.15.7 19H2
Xcode 12.0.1 12A7300

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
