### PR TITLE
lwp-useragent-cached: submission of new port (v0.08)

### DIFF
--- a/perl/p5-lwp-useragent-cached/Portfile
+++ b/perl/p5-lwp-useragent-cached/Portfile
@@ -1,0 +1,21 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.branches      5.26 5.28 5.30
+perl5.setup         LWP-UserAgent-Cached 0.08
+
+platforms           darwin
+maintainers         {@thekevjames thekev.in:macports} openmaintainer
+license             {Artistic-1 GPL}
+description         LWP::UserAgent with simple caching mechanism
+long_description    LWP::UserAgent::Cached is yet another LWP::UserAgent subclass with cache support. It stores cache in the files on local filesystem and if response already available in the cache returns it instead of making HTTP request.
+
+checksums           rmd160  ccee3a4cc1143e6cac8f754d7bdaa4ab1241d97c \
+                    sha256  3dce5ab4c78041656ce78564f76033e5bd1ec386f54d2e7b30740ae48ee787c3 \
+                    size    8527
+
+if {${perl5.major} != ""} {
+    depends_lib-append \
+        port:p${perl5.major}-libwww-perl
+}


### PR DESCRIPTION
#### Description
Create new port for the `perl5` module `LSP::UserAgent::Cached`. [Link](https://metacpan.org/pod/LWP::UserAgent::Cached).

This is my first Portfile submission, please let me know if I've made a mistake!

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix
- [x] submission

###### Tested on
macOS 10.15.5 19F101
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
