### PR TITLE
youtube-viewer: submission of new port (v3.8.0)

### DIFF
--- a/multimedia/youtube-viewer/Portfile
+++ b/multimedia/youtube-viewer/Portfile
@@ -1,0 +1,74 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.require_variant   yes
+perl5.conflict_variants yes
+perl5.branches          5.26 5.28 5.30
+perl5.default_branch    5.28
+perl5.create_variants   ${perl5.branches}
+
+name                youtube-viewer
+perl5.setup         youtube-viewer 3.8.1
+categories          multimedia net
+platforms           darwin
+maintainers         {@thekevjames thekev.in:macports} openmaintainer
+license             {Artistic-1 GPL}
+description         A very easy interface to YouTube.
+long_description    Lightweight app for searching and streaming videos from YouTube
+homepage            https://trizenx.blogspot.com/2012/03/gtk-youtube-viewer.html
+master_sites        https://github.com/trizen/youtube-viewer/archive/
+distfiles           ${version}.tar.gz
+
+checksums           rmd160  e66b188fc8f629ae851bc47550e625502518e8ec \
+                    sha256  fcbebba3e772c262ffe3d8fd6a27cfb0671f0f465e8239253cb7d9c49fc79ab0 \
+                    size    294507
+
+variant readline description {Add GNU readline features} {}
+variant perf description {Include performance improvements} {}
+default_variants    +perf +readline
+
+perl5.use_module_build
+perl5.link_binaries_suffix
+
+# TODO: workaround for https://github.com/macports/macports-ports/pull/9004#issuecomment-722054390
+depends_lib \
+    port:perl${perl5.major} \
+    port:p${perl5.major}-module-build \
+
+depends_build-append \
+    port:p${perl5.major}-cpan-meta \
+    port:p${perl5.major}-inc-latest \
+    port:p${perl5.major}-module-build \
+    port:p${perl5.major}-test-harness
+depends_lib-append \
+    port:p${perl5.major}-data-dump \
+    port:p${perl5.major}-encode \
+    port:p${perl5.major}-file-path \
+    port:p${perl5.major}-getopt-long \
+    port:p${perl5.major}-http-message \
+    port:p${perl5.major}-json \
+    port:p${perl5.major}-libwww-perl \
+    port:p${perl5.major}-lwp-protocol-https \
+    port:p${perl5.major}-mime-base64 \
+    port:p${perl5.major}-pathtools \
+    port:p${perl5.major}-scalar-list-utils \
+    port:p${perl5.major}-term-ansicolor \
+    port:p${perl5.major}-term-readline \
+    port:p${perl5.major}-text-parsewords \
+    port:p${perl5.major}-text-tabsxwrap \
+    port:p${perl5.major}-uri
+depends_run-append \
+    port:mpv \
+    port:p${perl5.major}-mozilla-ca
+
+if {[variant_isset readline]} {
+    depends_lib-append \
+        port:p${perl5.major}-term-readline-gnu
+}
+
+if {[variant_isset perf]} {
+    depends_lib-append \
+        port:p${perl5.major}-json-xs \
+        port:p${perl5.major}-lwp-useragent-cached
+}


### PR DESCRIPTION
#### Description
Create new port for the `youtube-viewer` project. [Link](https://github.com/trizen/youtube-viewer).

This is my first Portfile submission, please let me know if I've made a mistake!

~I'm especially curious if there's a good way to alias the package name -- though this is build as a perl5 package and thus automagically renamed to `p${perl.major}-${full_pkg_namespace}`, I suspect it may be easier for users to find if we could alias `youtube-viewer` to `p5-www-youtubeviewer`. I am not sure if there is a policy in place for perl5 modules which are also end-user applications like this -- please let me know!~

_Solved, thanks @dbevans!_

~This changeset currently includes a second new port (`p5-lwp-useragent-cached`). Please ignore it for now: I've opened #9003 for tracking that particular submission and will rebase this changeset once the other is merged. Since `youtube-viewer` relies on `p5-lsp-useragent-cached` for the `+perf` variant, I figured it would make more sense to introduce them in a dependency chain.~

_Solved and rebased, #9003 has been merged!_

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix
- [x] submission

###### Tested on
macOS 10.15.5 19F101
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
