### PR TITLE
Revbump leftovers from GCC symlink fix

### DIFF
--- a/lang/apple-gcc42/Portfile
+++ b/lang/apple-gcc42/Portfile
@@ -5,7 +5,7 @@ PortGroup xcodeversion 1.0
 name			apple-gcc42
 version			5666.3
 set gcc_version		4.2.1
-revision		15
+revision		16
 categories		lang
 platforms		darwin
 license			{GPL-2+ Permissive}

--- a/lang/apple-gcc42/files/apple-gcc42
+++ b/lang/apple-gcc42/files/apple-gcc42
@@ -1,6 +1,5 @@
 bin/gcc-apple-4.2
 bin/cpp-apple-4.2
-bin/c++-apple-4.2
 bin/g++-apple-4.2
 -
 bin/gcov-apple-4.2

--- a/lang/llvm-gcc42/Portfile
+++ b/lang/llvm-gcc42/Portfile
@@ -4,7 +4,7 @@ PortGroup compiler_blacklist_versions 1.0
 
 name                    llvm-gcc42
 version                 2336.11
-revision                3
+revision                4
 set gcc_version         4.2.1
 categories              lang
 platforms               darwin

--- a/lang/llvm-gcc42/files/mp-llvm-gcc42
+++ b/lang/llvm-gcc42/files/mp-llvm-gcc42
@@ -1,6 +1,5 @@
 bin/llvm-gcc-4.2
 bin/llvm-cpp-4.2
-bin/llvm-c++-4.2
 bin/llvm-g++-4.2
 -
 -


### PR DESCRIPTION
#### Description

This adds the missing revbumps mentioned in #8831.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
