### PR TITLE
packr: new port

### DIFF
--- a/devel/packr/Portfile
+++ b/devel/packr/Portfile
@@ -1,0 +1,159 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/gobuffalo/packr 2.8.0 v
+revision            0
+
+description         The simple and easy way to embed static files into Go \
+                    binaries.
+
+long_description    Packr is a simple solution for bundling static assets \
+                    inside of Go binaries. Most importantly it does it in a \
+                    way that is friendly to developers while they are \
+                    developing.
+
+categories          devel
+license             MIT
+
+checksums           rmd160  5d2dff73f3f39aa29ff04f2a0eb468197dc3daed \
+                    sha256  380b90b193613ed5a70a7c0a086ec94be8e686c93a1f8b6206edd4263b09a1b1 \
+                    size    83500
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+build.target        ./v2/packr2
+
+installs_libs       no
+
+destroot {
+    copy ${worksrcpath}/packr2 ${destroot}${prefix}/bin/
+}
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  5d2dff73f3f39aa29ff04f2a0eb468197dc3daed \
+                        sha256  380b90b193613ed5a70a7c0a086ec94be8e686c93a1f8b6206edd4263b09a1b1 \
+                        size    83500
+
+go.vendors          gopkg.in/yaml.v2 \
+                        lock    v2.2.2 \
+                        rmd160  03aea7b7e847179b29044d5a928b9f8a889fe87b \
+                        sha256  da1e31b7beb9a6907947caa794134bdc2501d1a3474568b61cc2562a398d3d87 \
+                        size    70676 \
+                    gopkg.in/check.v1 \
+                        lock    788fd7840127 \
+                        rmd160  b63165c8909a27edc15dda210df66a1b49efb49e \
+                        sha256  7e5547c6471cc48da89a7c87f965b20ca5311f43fc4d883ca62f9fccf7551630 \
+                        size    31597 \
+                    golang.org/x/tools \
+                        lock    11ec41452d41 \
+                        rmd160  4ba03aa5fa3d28d4e71658e3b373a32a274a387b \
+                        sha256  634926e6a3c7e3812f1a87d6923b6863747865a832901f9ec5231097724cd452 \
+                        size    2374996 \
+                    golang.org/x/sys \
+                        lock    953cdadca894 \
+                        rmd160  90545cb43bdf3167990cc178e2c360cb39962024 \
+                        sha256  1aba7b97d0779fb393839fe2ad95e4520b8158913e53df6c0862799c05f63b71 \
+                        size    1353384 \
+                    golang.org/x/sync \
+                        lock    cd5d95a43a6e \
+                        rmd160  8bef422550566dc5e53557a975560a4f0224e509 \
+                        sha256  0b7b3e06ee571c92736ea8f11b6d2d075ca6e75008f16e8653be49c33e2876a3 \
+                        size    16964 \
+                    golang.org/x/net \
+                        lock    3b0461eec859 \
+                        rmd160  24dae39afb612a8977e6f4a91596c64d15dd3664 \
+                        sha256  15f077bb408fb71b22e4015312be5fab7010576e824fdbfdfdb697b611621197 \
+                        size    1099249 \
+                    golang.org/x/crypto \
+                        lock    ac88ee75c92c \
+                        rmd160  5404185c7f2717983f6c08af54e861ae552fb5cc \
+                        sha256  3e55c4fccf615b4ab793a516d77e2b3a894645df18e9ebc3532f6dfd4d47d924 \
+                        size    1711806 \
+                    github.com/stretchr/testify \
+                        lock    v1.5.1 \
+                        rmd160  db9d43c3c804950ce9650d830f7dea5434ed83c1 \
+                        sha256  e5f566d1c23fb2b987f8a9f139e32866c1eea8c72051da25bbf6880a4f8c541a \
+                        size    78702 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.3 \
+                        rmd160  32abdd77a987af95ce5b647846bfdbb2d8db91a0 \
+                        sha256  046b6b81e3925ffe60e2213e9a239303ff98a51e76764590b807b591fedf2d1e \
+                        size    46029 \
+                    github.com/spf13/cobra \
+                        lock    v0.0.6 \
+                        rmd160  ae15786490f8d48d0cb17b2c98fa55ef744f1c66 \
+                        sha256  2e38b4a8b346588459c4503410e1575c9966043380be71af9a6a15f27702465c \
+                        size    117326 \
+                    github.com/sirupsen/logrus \
+                        lock    v1.4.2 \
+                        rmd160  9245d7ebabf259e649892609e598a2284e89e499 \
+                        sha256  c3eaf49a2a03ce42b20b5db84771a7d447465475bf083f289ecee631063e6090 \
+                        size    41379 \
+                    github.com/rogpeppe/go-internal \
+                        lock    v1.5.2 \
+                        rmd160  b548fabd47c81c9830845063dcead0fa9b179884 \
+                        sha256  2cf697f2741088ba096df533769a29730bbef1379f68d0432e9bc0b1d548cffc \
+                        size    121296 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/markbates/safe \
+                        lock    v1.0.1 \
+                        rmd160  6ec0e8a1c7b9cd9446c1bcf90a2478ca1b6a02b0 \
+                        sha256  0f4a1f8a3a6c9b2469eb36a65e9f0c2fdd4bcf797ae8e090e37a38f2bf9ac16e \
+                        size    2893 \
+                    github.com/markbates/oncer \
+                        lock    v1.0.0 \
+                        rmd160  b5b66234f30c1d196ed2aba4e5848d38d9ed9250 \
+                        sha256  692ff60449691162dacb4df3a2a33c480caff0a6f694aeaf20ea314092027c70 \
+                        size    3857 \
+                    github.com/markbates/errx \
+                        lock    v1.1.0 \
+                        rmd160  fda626316930bcf571593127d20d34d1844e8224 \
+                        sha256  7bb0da7750624def72a3ffde919ded0408b458cb86d82bba169351760a3b3aa0 \
+                        size    2659 \
+                    github.com/kr/text \
+                        lock    v0.1.0 \
+                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
+                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
+                        size    8691 \
+                    github.com/kr/pretty \
+                        lock    v0.1.0 \
+                        rmd160  9aa7a5aad4c48840eecfd0f80186d1fb5ded0fd6 \
+                        sha256  f6c3f89667c63e5b7f1fc6ee2c06b6a6bfdce88f3a965ccd395b64c6f95c9a47 \
+                        size    8553 \
+                    github.com/konsorten/go-windows-terminal-sequences \
+                        lock    v1.0.2 \
+                        rmd160  9b5e034c9a2fbbe2c4a3768d00d6337a8e06ab74 \
+                        sha256  0a29b8c0a24ace07e3280feb5ee7b71ddb965a894ace70d8c77c0a4f330a8dbb \
+                        size    1987 \
+                    github.com/karrick/godirwalk \
+                        lock    v1.15.3 \
+                        rmd160  59e1385fbe8e949e7465e0857ec22b1158b2d46f \
+                        sha256  6cb8db78a92a5902776e5eba6b3b14d826ed789e97c4cd245d90724f2bf60d3a \
+                        size    24195 \
+                    github.com/inconshreveable/mousetrap \
+                        lock    v1.0.0 \
+                        rmd160  5c617a09f1432fc543672a0e0c1e13d3752030c2 \
+                        sha256  0e6bae2849f13d12fe361ecac087728e4e97f3482f4cec44f6e7a2c53bb9cd0c \
+                        size    2291 \
+                    github.com/gobuffalo/packd \
+                        lock    v1.0.0 \
+                        rmd160  6e2e371a48e595b85e833fb8ba7a459ecb1fe85d \
+                        sha256  ebbce3c29247785c3e3e09cd8955aa65757404326868fa340a88f37f217c2c6a \
+                        size    8874 \
+                    github.com/gobuffalo/logger \
+                        lock    v1.0.3 \
+                        rmd160  79ded26f6362c53bda3b9549a29fb84927594206 \
+                        sha256  da7fd6d1daf33d4ed0ca0044c95c6d1e33f64f416f8e3156572693fe2e4b7b03 \
+                        size    6411 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171


### PR DESCRIPTION
#### Description

New port for [packr](https://github.com//gobuffalo/packr)

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
