### PR TITLE
go-mockgen: new port

### DIFF
--- a/devel/go-mockgen/Portfile
+++ b/devel/go-mockgen/Portfile
@@ -1,0 +1,45 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/golang/mock 1.4.4 v
+revision            0
+name                go-mockgen
+
+description         GoMock is a mocking framework for the Go programming \
+                    language.
+
+long_description    {*}${description}  It integrates well with Go's built-in \
+                    testing package, but can be used in other contexts too.
+
+categories          devel
+license             Apache-2
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+build.pre_args      -ldflags \"-X main.version=${version}\" -o ./dist/mockgen
+build.args          ./mockgen
+
+destroot {
+    copy ${worksrcpath}/dist/mockgen ${destroot}${prefix}/bin/
+}
+
+installs_libs       no
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  ad4c6bd70c06881810d56fbd5d4b4ddfb701fae0 \
+                        sha256  921ea11f2a10c4f6225fd3057893a5ee8c5d9b2ca17cb8f9de3a361a0f3899a1 \
+                        size    55151
+
+go.vendors          golang.org/x/tools \
+                        lock    36563e24a262 \
+                        rmd160  1972dde442d0c984d9f4ac71a1d4e6f652ecb853 \
+                        sha256  e924891fd48d0da4e011f6b3e9f7ddbfc5bdecd6c78539dcc605992ddcc3c4a8 \
+                        size    2085672 \
+                    golang.org/x/text \
+                        lock    v0.3.0 \
+                        rmd160  81061ce2006da3d6f7a8ef8dae237d65305513d3 \
+                        sha256  6243d5bbd9d8550bc44cb58a0d70180f7a3f6767299b490015107b4d27c604ae \
+                        size    6102563


### PR DESCRIPTION
#### Description

New port for [GoMock's mockgen](https://github.com/golang/mock)

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
