### PR TITLE
sops: new port

### DIFF
--- a/security/sops/Portfile
+++ b/security/sops/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/mozilla/sops 3.6.1 v
+revision            0
+
+description         Simple and flexible tool for managing secrets
+
+long_description    {*}${description}. sops is an editor of encrypted files \
+                    that supports YAML, JSON, ENV, INI and BINARY formats and \
+                    encrypts with AWS KMS, GCP KMS, Azure Key Vault and PGP.
+
+categories          security
+license             MPL-2.0
+
+checksums           rmd160  bc5e99aec4ffa480fc482ebfa975226f2f7a84be \
+                    sha256  be1b845b308e624a1ea7092749006f752578bc7b71e3b68a4aa914f0b1b5c530 \
+                    size    185459
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+# Allow Go to download dependencies at build time for now.
+# https://trac.macports.org/ticket/61192
+build.env-delete    GOPROXY=off GO111MODULE=off
+build.env-append    GO15VENDOREXPERIMENT=1
+
+build.target        ./cmd/sops
+
+installs_libs       no
+
+destroot {
+    copy ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

New port for Mozilla's [sops](https://github.com/mozilla/sops)

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
