### PR TITLE
minipro: update 0.4

### DIFF
--- a/devel/minipro/Portfile
+++ b/devel/minipro/Portfile
@@ -1,9 +1,9 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
 
-github.setup        vdudouyt minipro 0.0.1
+name                minipro
+version             0.4
 categories          devel
 maintainers         openmaintainer {gmail.com:ranauei @ranauei}
 platforms           darwin
@@ -14,9 +14,15 @@ long_description    Opensource tool that aims to create a complete cross-platfor
                     Currently it supports more than 13000 of target devices including \
                     AVRs, PICs as well as a huge number of other microcontrollers and \
                     various BIOSes.
+homepage            https://gitlab.com/DavidGriffith/minipro
 
-checksums           rmd160  8cc7d90a90ea4a57e7f5562699049d6bfb9d9359 \
-                    sha256  6231364e7e278b2a75889b1b9764689e9361487c152621746061a6c8e5e8a658
+master_sites        https://gitlab.com/DavidGriffith/minipro/-/archive/${version}
+
+distfiles           minipro-${version}.tar.gz
+
+checksums           rmd160  22851971833fab8c947a06ea3bdde86c4ebb3ff0 \
+                    sha256  05e0090eab33a236992f5864f3485924fb5dfad95d8f16916a17296999c094cc \
+                    size    363052
 
 depends_build       port:pkgconfig
 
@@ -31,6 +37,10 @@ variant universal {}
 build.args-append   CC="${configure.cc} [get_canonical_archflags cc]"
 
 destroot {
-    xinstall -W ${worksrcpath} ${name} ${name}-query-db ${name}hex ${destroot}${prefix}/bin
+    xinstall -W ${worksrcpath} ${name} ${name}hex ${destroot}${prefix}/bin
     xinstall -m 644 ${worksrcpath}/man/${name}.1 ${destroot}${prefix}/share/man/man1
 }
+
+livecheck.type      regex
+livecheck.url       https://gitlab.com/DavidGriffith/minipro/-/tags
+livecheck.regex     "tags/v(\\d+(?:\\.\\d+)*)"


### PR DESCRIPTION
#### Description

* project moved from github to gitlab
* current version is 0.4
* minipro-query-db command has been removed

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?