### PR TITLE
google-cloud-sdk: update to 317.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             316.0.0
+version             317.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  3635ae55964bc2666e1140bf11128f84439e36ea \
-                    sha256  725989d748f319e3518024d2c551f9d8f62c29e9a5f6ee97aaf9fdcbd1afb10b \
-                    size    85533975
+    checksums       rmd160  eed46208bf3fd731786c6c026ffb548c7c2ca927 \
+                    sha256  d86ad8f2e9b442d2fc6d9c0703b290023acb89dfd8a277ef3cf29032315d58a1 \
+                    size    85618121
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  98c698b1af72874f3ef6748b1943a3495125fbd7 \
-                    sha256  a478e4d66b75d686cbbe951ec6aa43ccd57d946461554af385c2dc6887b6a5a9 \
-                    size    86547373
+    checksums       rmd160  b391e64d9d858fe0381d3648b5c6f93369ad9243 \
+                    sha256  3873c60474754192371d4b7d801848d148da620640721c08b757644b47daab4c \
+                    size    86629132
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 317.0.0.

###### Tested on

macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?