### PR TITLE
openrct2: update to 0.3.2

### DIFF
--- a/games/openrct2/Portfile
+++ b/games/openrct2/Portfile
@@ -4,22 +4,54 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        OpenRCT2 OpenRCT2 0.1.2 v
+github.setup        OpenRCT2 OpenRCT2 0.3.2 v
+github.tarball_from archive
 name                openrct2
-revision            2
+revision            0
 
 categories          games
 platforms           darwin
 maintainers         nomaintainer
-license             GPL-3+
+license             {GPL-3+ CC-BY-4}
 
 description         An open-source re-implementation of RollerCoaster Tycoon 2.
 long_description    ${description} A construction and management simulation \
                     video game that simulates amusement park management. Requires \
                     files from the original RollerCoaster Tycoon 2 in order to work.
 
-checksums           rmd160  16fe40e2a07034f8571b4020634b23f10506f39a \
-                    sha256  51dd38d028bb352904162f63d1a4093d6580a702d8a4fc54eb98c3466b05ac69
+extract.suffix      .zip
+use_zip             yes
+
+set main_distfile       ${distfiles}
+
+set objects_distfile    objects${extract.suffix}
+set objects_mastersite  https://github.com/${github.author}/objects/releases/download/v1.0.18
+
+set ts_distfile         title-sequences${extract.suffix}
+set ts_mastersite       https://github.com/${github.author}/title-sequences/releases/download/v0.1.2c
+
+distfiles           ${main_distfile}:main \
+                    ${objects_distfile}:objects \
+                    ${ts_distfile}:ts
+
+master_sites        ${github.master_sites}:main \
+                    ${objects_mastersite}:objects \
+                    ${ts_mastersite}:ts
+
+checksums           ${main_distfile} \
+                    rmd160  6475511d470e04bb5242ec588f654440cd36ec81 \
+                    sha256  d8b5ff88fe7500144d93c804656e61f844f9cd653e05aa7b0e41a1295634a86b \
+                    size    14530818 \
+                    ${objects_distfile} \
+                    rmd160  8557456ed463cf231f04bd8cb9da4946182c1d3b \
+                    sha256  bf8a28b7ccebaf58e4e9eb2540534632830534cf0b3f73677521dc555878c682 \
+                    size    3117675 \
+                    ${ts_distfile} \
+                    rmd160  a0d44e1790a67e7400927fe567aa4814403ea5ee \
+                    sha256  5284333fa501270835b5f0cf420cb52155742335f5658d7889ea35d136b52517 \
+                    size    2980030
+
+patchfiles          patch-jsonfwd-hpp.diff
 
 # requires 10.11 or newer at present
 # see https://trac.macports.org/ticket/55591
@@ -43,9 +75,40 @@ depends_lib-append  port:libsdl2 \
                     port:libzip \
                     port:curl \
                     port:freetype \
-                    port:libiconv
+                    port:libiconv \
+                    port:nlohmann-json
 
-compiler.cxx_standard   2014
+compiler.cxx_standard       2017
+configure.cxxflags-append   -std=c++17
+
+post-extract {
+    file mkdir ${worksrcpath}/data/sequence
+    move {*}[glob -nocomplain ${workpath}/*.parkseq] \
+        ${worksrcpath}/data/sequence
+    file mkdir ${worksrcpath}/data/object
+    move ${workpath}/official {*}[glob -nocomplain ${workpath}/rct*] \
+        ${worksrcpath}/data/object
+}
+
+post-patch {
+    reinplace "s|git describe HEAD|echo v${version}|" CMakeLists.txt
+    reinplace "s|git rev-parse --abbrev-ref HEAD|echo master|" CMakeLists.txt
+    reinplace "s|git rev-parse --short HEAD|echo 0000000|" CMakeLists.txt
+}
+
+configure.args-append \
+    -DDISABLE_DISCORD_RPC=ON \
+    -DDISABLE_GOOGLE_BENCHMARK=ON \
+    -DDISABLE_HTTP=OFF \
+    -DDISABLE_NETWORK=OFF \
+    -DDOWNLOAD_OBJECTS=OFF \
+    -DDOWNLOAD_REPLAYS=OFF \
+    -DDOWNLOAD_TITLE_SEQUENCES=OFF \
+    -DENABLE_SCRIPTING=OFF \
+    -DENABLE_LIGHTFX=ON \
+    -DPORTABLE=OFF \
+    -DSTATIC=OFF \
+    -DUSE_MMAP=ON
 
 # prevent unctrl.h from loading - it brings in an error regarding undefined SCREEN*
 # if MacPorts ncurses has been installed

--- a/games/openrct2/files/patch-jsonfwd-hpp.diff
+++ b/games/openrct2/files/patch-jsonfwd-hpp.diff
@@ -1,0 +1,10 @@
+--- src/openrct2/core/JsonFwd.hpp.old	2021-01-09 03:24:15.000000000 -0500
++++ src/openrct2/core/JsonFwd.hpp	2021-01-09 03:24:28.000000000 -0500
+@@ -9,6 +9,6 @@
+ 
+ #pragma once
+ 
+-#include <nlohmann/json_fwd.hpp>
++#include <nlohmann/json.hpp>
+ 
+ using json_t = nlohmann::json;


### PR DESCRIPTION
#### Description

- Update to 0.3.2
- Update dependencies
- Download assets necessary for game to work with MacPorts (do not allow configure stage to do this), and extract them to the correct location
- Set version number in code so update detection works

Running the game requires the game assets (as always) and a command like so:

```shell
openrct2 --rct2-data-path=${HOME}/rct2-data --openrct2-data-path=/opt/local/share/openrct2
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. --> n/a
- [x] checked your Portfile with `port lint`?

This Portfile lacked size in the checksums so I continue the omission.

- [ ] tried existing tests with `sudo port test`? n/a
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
