### PR TITLE
py-httpcore: new port

### DIFF
--- a/python/py-httpcore/Portfile
+++ b/python/py-httpcore/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-httpcore
+version             0.12.0
+platforms           darwin
+license             BSD
+maintainers         nomaintainer
+
+description         A minimal low level HTTP client.
+long_description    {*}${description}
+
+homepage            https://github.com/encode/httpcore
+
+checksums           rmd160  2243bd83a143ce17ed77ea02cd7df0f8ee93d0f5 \
+                    sha256  2526a38f31ac5967d38b7f593b5d8c4bd3fa82c21400402f866ba3312946acbf \
+                    size    40748
+
+python.versions     38 39
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-h11      \
+                    port:py${python.version}-sniffio
+}


### PR DESCRIPTION
#### Description

New port for [py-httpcore](https://github.com/encode/httpcore)

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
