### PR TITLE
openmpi: add clang-10

### DIFF
--- a/science/openmpi/Portfile
+++ b/science/openmpi/Portfile
@@ -72,6 +72,7 @@ array set clist {
     clang70 {macports-clang-7.0}
     clang80 {macports-clang-8.0}
     clang90 {macports-clang-9.0}
+    clang10 {macports-clang-10}
     gcc5    {macports-gcc-5}
     gcc6    {macports-gcc-6}
     gcc7    {macports-gcc-7}

--- a/science/openmpi/files/openmpi-clang10
+++ b/science/openmpi/files/openmpi-clang10
@@ -1,0 +1,11 @@
+bin/mpicc-openmpi-clang10
+-
+bin/mpicxx-openmpi-clang10
+bin/mpiexec-openmpi-clang10
+bin/mpirun-openmpi-clang10
+-
+-
+-
+lib/openmpi-clang10/pkgconfig/ompi.pc
+lib/openmpi-clang10/pkgconfig/orte.pc
+-

--- a/science/openmpi/files/openmpi-clang10-fortran
+++ b/science/openmpi/files/openmpi-clang10-fortran
@@ -1,0 +1,11 @@
+bin/mpicc-openmpi-clang10
+-
+bin/mpicxx-openmpi-clang10
+bin/mpiexec-openmpi-clang10
+bin/mpirun-openmpi-clang10
+bin/mpif77-openmpi-clang10
+bin/mpif90-openmpi-clang10
+-
+lib/openmpi-clang10/pkgconfig/ompi.pc
+lib/openmpi-clang10/pkgconfig/orte.pc
+bin/mpifort-openmpi-clang10

--- a/science/openmpi/files/openmpi-devel-clang10
+++ b/science/openmpi/files/openmpi-devel-clang10
@@ -1,0 +1,11 @@
+bin/mpicc-openmpi-clang10
+-
+bin/mpicxx-openmpi-clang10
+bin/mpiexec-openmpi-clang10
+bin/mpirun-openmpi-clang10
+-
+-
+-
+lib/openmpi-clang10/pkgconfig/ompi.pc
+lib/openmpi-clang10/pkgconfig/orte.pc
+-

--- a/science/openmpi/files/openmpi-devel-clang10-fortran
+++ b/science/openmpi/files/openmpi-devel-clang10-fortran
@@ -1,0 +1,11 @@
+bin/mpicc-openmpi-clang10
+-
+bin/mpicxx-openmpi-clang10
+bin/mpiexec-openmpi-clang10
+bin/mpirun-openmpi-clang10
+bin/mpif77-openmpi-clang10
+bin/mpif90-openmpi-clang10
+-
+lib/openmpi-clang10/pkgconfig/ompi.pc
+lib/openmpi-clang10/pkgconfig/orte.pc
+bin/mpifort-openmpi-clang10


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/60584

#### Description
Add the openmpi-clang10 subport.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
