### PR TITLE
py-h5py: Update (py36+ only) to 3.0.0

### DIFF
--- a/python/py-h5py/Portfile
+++ b/python/py-h5py/Portfile
@@ -5,10 +5,25 @@ PortGroup               github 1.0
 PortGroup               python 1.0
 PortGroup               mpi 1.0
 
-github.setup            h5py h5py 2.10.0
 name                    py-h5py
-# h5py needs to be re-built after hdf5 upgrades
-revision                2
+if {${python.version} >= 36} {
+    github.setup            h5py h5py 3.0.0
+    checksums \
+        rmd160  9ed7ed6ac70a7e3bc6b44431c181d959cb03c546 \
+        sha256  3de8e052e8170530b2d806f5186155e29a153d4909902078bc67fc9035b78f8c \
+        size    389748
+    # h5py needs to be re-built after hdf5 upgrades
+    revision                0
+    depends_lib-append      port:py${python.version}-cached-property
+} else {
+    github.setup            h5py h5py 2.10.0
+    checksums \
+        rmd160  43834284330c96de74b9998c440185ce79bafd91 \
+        sha256  f1a2ed05943845480a4bb9b5907600ffa24bb9c199f3b520f2b811b847e7178d \
+        size    314470
+    # h5py needs to be re-built after hdf5 upgrades
+    revision                2
+}
 
 platforms               darwin
 license                 BSD
@@ -31,10 +46,6 @@ homepage                https://www.h5py.org
 python.versions         27 35 36 37 38
 python.default_version  37
 
-checksums \
-    rmd160  43834284330c96de74b9998c440185ce79bafd91 \
-    sha256  f1a2ed05943845480a4bb9b5907600ffa24bb9c199f3b520f2b811b847e7178d \
-    size    314470
 
 # Only check against releases.
 github.livecheck.regex      {([0-9.]+)}
@@ -47,6 +58,14 @@ if {${name} ne ${subport}} {
                             port:py${python.version}-six \
                             port:py${python.version}-pkgconfig \
                             port:hdf5
+
+    if {${python.version} >= 36} {
+        build.env-append        HDF5_DIR=${prefix}
+        destroot.env-append     HDF5_DIR=${prefix}
+        post-patch {
+            reinplace "/=={np_min}/s/==/>=/" setup.py
+        }
+    }
 
     post-destroot {
         system -W ${destroot}${prefix} "mkdir -p share/doc/${subport}"
@@ -62,10 +81,15 @@ if {${name} ne ${subport}} {
         mpi.enforce_variant     hdf5 \
                                 py${python.version}-mpi4py
 
-        use_configure           yes
-        configure.cmd           ${build.cmd} configure
-        configure.args          --mpi
-        configure.pre_args
+        if {${python.version} >= 36} {
+            build.env-append        HDF5_MPI=ON
+            destroot.env-append     HDF5_MPI=ON
+        } else {
+            use_configure           yes
+            configure.cmd           ${build.cmd} configure
+            configure.args          --mpi
+            configure.pre_args
+        }
     }
 
     livecheck.type          none


### PR DESCRIPTION
Maintainer update.