### PR TITLE
k9s: update to 0.23.4

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.23.3 v
+go.setup            github.com/derailed/k9s 0.23.4 v
 homepage            https://k9scli.io
 
 categories          sysutils devel
@@ -20,9 +20,9 @@ platforms           darwin
 supported_archs     x86_64
 license             Apache-2
 
-checksums           rmd160  3cf635d6faa69a021149a5d322046eb937c8d3f4 \
-                    sha256  000ef015d9cb12ce4b51fed3ca6ee08341773c6f99246e7721aeb5ff4881297c \
-                    size    6106043
+checksums           rmd160  456de8532383976200ffbbe62e7cde68c749ec7f \
+                    sha256  2963c145556ff1c5a4b20e716a30055dec364d077beaff58a96a40c695b48081 \
+                    size    6105997
 
 # Reproduce the "build" target from the upstream Makefile
 set go_ldflags      "-w -X ${go.package}/cmd.version=${version} \


### PR DESCRIPTION
#### Description

Update to K9s 0.23.4.

###### Tested on

macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?