### PR TITLE
go: update to 1.15.4

### DIFF
--- a/lang/go/Portfile
+++ b/lang/go/Portfile
@@ -8,12 +8,14 @@ legacysupport.newest_darwin_requires_legacy 13
 
 name                go
 epoch               2
-version             1.15.3
+version             1.15.4
 revision            0
 categories          lang
 platforms           darwin freebsd linux
 license             BSD
-maintainers         {ciserlohn @ci42} openmaintainer
+maintainers         {ciserlohn @ci42} \
+                    {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
 description         compiled, garbage-collected, concurrent programming \
                     language developed by Google Inc.
 long_description    \
@@ -32,9 +34,9 @@ master_sites        https://storage.googleapis.com/golang/
 distfiles           ${name}${version}.src.tar.gz
 worksrcdir          ${name}
 
-checksums           rmd160  f53c1ba66a7323ca8fe23fb34672dcf4dc5b9acf \
-                    sha256  896a602570e54c8cdfc2c1348abd4ffd1016758d0bd086ccd9787dbfc9b64888 \
-                    size    23015071
+checksums           rmd160  5edf9a8f8b2a4894dd07081a49629870e4d9e23c \
+                    sha256  063da6a9a4186b8118a0e584532c8c94e65582e2cd951ed078bfd595d27d2367 \
+                    size    23017785
 
 depends_build       port:go-1.4
 


### PR DESCRIPTION

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
