### PR TITLE
iTerm2: disable automatic update functionality

### DIFF
--- a/aqua/iTerm2/Portfile
+++ b/aqua/iTerm2/Portfile
@@ -11,7 +11,8 @@ if {${os.major} > 16} {
     checksums           rmd160  37d4204f97ac42431c5774a943ca0ab8f9a4c669 \
                         sha256  6eeeb3215d6725aa789d39108a8ebedbe1aa9f6d058dd33056d72471ecd02e14 \
                         size    20602868
-    patchfiles          patch-Makefile-XC10.diff
+    patchfiles          patch-Makefile-XC10.diff \
+                        patch-remove-sparkle.diff
 } else {
     version             3.2.0
     revision            0

--- a/aqua/iTerm2/Portfile
+++ b/aqua/iTerm2/Portfile
@@ -12,14 +12,16 @@ if {${os.major} > 16} {
                         sha256  6eeeb3215d6725aa789d39108a8ebedbe1aa9f6d058dd33056d72471ecd02e14 \
                         size    20602868
     patchfiles          patch-Makefile-XC10.diff \
-                        patch-remove-sparkle.diff
+                        patch-remove-sparkle.diff \
+                        patch-nsur.diff
 } else {
     version             3.2.0
     revision            0
     checksums           rmd160  07915ff5db0545c0c059f47e7f71761e023a26e1 \
                         sha256  017aff348352369abcc994caaca0f6112e1f17c4d65041acdb9f19830b2b96bd \
                         size    11969144
-    patchfiles          patch-Makefile.diff
+    patchfiles          patch-Makefile.diff \
+                        patch-nsur.diff
 }
 
 github.setup        gnachman iTerm2 ${version} v

--- a/aqua/iTerm2/files/patch-nsur.diff
+++ b/aqua/iTerm2/files/patch-nsur.diff
@@ -1,0 +1,24 @@
+From a793c88dcfdcd17c42909d8f3ed461bc44aaa53e Mon Sep 17 00:00:00 2001
+From: Andrew Udvare <audvare@gmail.com>
+Date: Sat, 7 Nov 2020 01:32:23 -0500
+Subject: [PATCH] Guard against NS_WARN_UNUSED_RESULT not defined
+
+---
+ sources/iTerm2.pch | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git sources/iTerm2.pch sources/iTerm2.pch
+index 3108a3a09..028db831c 100644
+--- sources/iTerm2.pch
++++ sources/iTerm2.pch
+@@ -5,4 +5,6 @@ _Pragma("clang diagnostic ignored \"-Wpartial-availability\"")
+ #define ITERM_IGNORE_PARTIAL_END \
+ _Pragma("clang diagnostic pop")
+ 
+-
++#ifndef NS_WARN_UNUSED_RESULT
++#define NS_WARN_UNUSED_RESULT
++#endif
+-- 
+2.29.2
+

--- a/aqua/iTerm2/files/patch-remove-sparkle.diff
+++ b/aqua/iTerm2/files/patch-remove-sparkle.diff
@@ -1,0 +1,210 @@
+From 12ed6ad18ed8e7390b9fa6681487c75a0eb9c979 Mon Sep 17 00:00:00 2001
+From: Andrew Udvare <audvare@gmail.com>
+Date: Fri, 6 Nov 2020 16:40:20 -0500
+Subject: [PATCH] Remove update stuff
+
+---
+ Interfaces/MainMenu.xib                    | 10 ---------
+ Interfaces/PreferencePanel.xib             | 26 ----------------------
+ sources/GeneralPreferencesViewController.m | 16 -------------
+ sources/iTermApplicationDelegate.m         |  8 -------
+ sources/iTermController.m                  |  2 +-
+ sources/iTermLaunchExperienceController.m  |  2 +-
+ sources/iTermPreferences.m                 |  2 +-
+ 7 files changed, 3 insertions(+), 63 deletions(-)
+
+diff --git Interfaces/MainMenu.xib Interfaces/MainMenu.xib
+index 093a4958c..76521fa89 100644
+--- Interfaces/MainMenu.xib
++++ Interfaces/MainMenu.xib
+@@ -28,14 +28,6 @@
+                                     <action selector="showTipOfTheDay:" target="201" id="mc2-ec-uGY"/>
+                                 </connections>
+                             </menuItem>
+-                            <menuItem isSeparatorItem="YES" id="Dxk-DH-qzi">
+-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+-                            </menuItem>
+-                            <menuItem title="Check For Updates…" identifier="Check For Updates…" id="880">
+-                                <connections>
+-                                    <action selector="checkForUpdatesFromMenu:" target="201" id="vmh-LD-TwW"/>
+-                                </connections>
+-                            </menuItem>
+                             <menuItem isSeparatorItem="YES" id="Dpc-y9-dq3">
+                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                             </menuItem>
+@@ -1336,7 +1328,6 @@ DQ
+                 <outlet property="maximizePane" destination="1233" id="1237"/>
+                 <outlet property="selectTab" destination="847" id="863"/>
+                 <outlet property="showFullScreenTabs" destination="1257" id="1260"/>
+-                <outlet property="suUpdater" destination="879" id="FRj-mW-Vma"/>
+                 <outlet property="toolbeltMenu" destination="1296" id="1299"/>
+                 <outlet property="useTransparency" destination="1228" id="1230"/>
+                 <outlet property="windowArrangementsAsTabs_" destination="z6V-EJ-Ntf" id="wse-Wc-WVw"/>
+@@ -1344,7 +1335,6 @@ DQ
+             </connections>
+         </customObject>
+         <customObject id="266" userLabel="Font Manager" customClass="NSFontManager"/>
+-        <customObject id="879" userLabel="SUUpdater" customClass="SUUpdater"/>
+         <menuItem isSeparatorItem="YES" id="TYx-JS-5H0"/>
+         <menuItem title="Mouse Reporting" id="y5H-9R-t1f">
+             <modifierMask key="keyEquivalentModifierMask"/>
+diff --git Interfaces/PreferencePanel.xib Interfaces/PreferencePanel.xib
+index e0df82e16..e9716d6fb 100644
+--- Interfaces/PreferencePanel.xib
++++ Interfaces/PreferencePanel.xib
+@@ -1225,8 +1225,6 @@ DQ
+                 <outlet property="_autoHideTmuxClientSession" destination="6366" id="V9B-um-JRL"/>
+                 <outlet property="_autoSaveOnQuit" destination="tYA-B3-SU5" id="9Yr-NX-xsX"/>
+                 <outlet property="_browseCustomFolder" destination="5618" id="0Ty-gp-K5Q"/>
+-                <outlet property="_checkTestRelease" destination="5049" id="mCk-NA-PO2"/>
+-                <outlet property="_checkUpdate" destination="5048" id="Oi0-3Y-fu1"/>
+                 <outlet property="_confirmClosingMultipleSessions" destination="1996" id="1wi-R8-LGb"/>
+                 <outlet property="_copyLastNewline" destination="5747" id="y4f-IT-rUT"/>
+                 <outlet property="_doubleClickPerformsSmartSelection" destination="wgv-Ah-fFr" id="OZU-W2-nQN"/>
+@@ -4705,30 +4703,6 @@ DQ
+                                                 </buttonCell>
+                                                 <connections>
+                                                     <action selector="settingChanged:" target="9Se-ld-UJa" id="eVv-Yn-zdl"/>
+-                                                    <outlet property="nextKeyView" destination="5048" id="uHG-f2-Hoi"/>
+-                                                </connections>
+-                                            </button>
+-                                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5049">
+-                                                <rect key="frame" x="18" y="18" width="195" height="18"/>
+-                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+-                                                <buttonCell key="cell" type="check" title="Update to Beta test releases" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="5065">
+-                                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+-                                                    <font key="font" metaFont="system"/>
+-                                                </buttonCell>
+-                                                <connections>
+-                                                    <action selector="settingChanged:" target="9Se-ld-UJa" id="jqK-dm-ssy"/>
+-                                                </connections>
+-                                            </button>
+-                                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5048">
+-                                                <rect key="frame" x="18" y="38" width="287" height="18"/>
+-                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+-                                                <buttonCell key="cell" type="check" title="Check for updates automatically" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="5066">
+-                                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+-                                                    <font key="font" metaFont="system"/>
+-                                                </buttonCell>
+-                                                <connections>
+-                                                    <action selector="settingChanged:" target="9Se-ld-UJa" id="SDz-wA-BhL"/>
+-                                                    <outlet property="nextKeyView" destination="5049" id="5197"/>
+                                                 </connections>
+                                             </button>
+                                         </subviews>
+diff --git sources/GeneralPreferencesViewController.m sources/GeneralPreferencesViewController.m
+index 572346fd9..0b437dd2f 100644
+--- sources/GeneralPreferencesViewController.m
++++ sources/GeneralPreferencesViewController.m
+@@ -64,12 +64,6 @@ enum {
+     // Enable bonjour
+     IBOutlet NSButton *_enableBonjour;
+ 
+-    // Check for updates automatically
+-    IBOutlet NSButton *_checkUpdate;
+-
+-    // Prompt for test-release updates
+-    IBOutlet NSButton *_checkTestRelease;
+-
+     // Load prefs from custom folder
+     IBOutlet NSButton *_loadPrefsFromCustomFolder;  // Should load?
+     IBOutlet NSTextField *_prefsCustomFolder;  // Path or URL text field
+@@ -304,16 +298,6 @@ enum {
+             relatedView:nil
+                    type:kPreferenceInfoTypeCheckbox];
+ 
+-    [self defineControl:_checkUpdate
+-                    key:kPreferenceKeyCheckForUpdatesAutomatically
+-            relatedView:nil
+-                   type:kPreferenceInfoTypeCheckbox];
+-
+-    [self defineControl:_checkTestRelease
+-                    key:kPreferenceKeyCheckForTestReleases
+-            relatedView:nil
+-                   type:kPreferenceInfoTypeCheckbox];
+-
+     // ---------------------------------------------------------------------------------------------
+     info = [self defineControl:_loadPrefsFromCustomFolder
+                            key:kPreferenceKeyLoadPrefsFromCustomFolder
+diff --git sources/iTermApplicationDelegate.m sources/iTermApplicationDelegate.m
+index 1702d1cb0..20e8949f9 100644
+--- sources/iTermApplicationDelegate.m
++++ sources/iTermApplicationDelegate.m
+@@ -182,7 +182,6 @@ static BOOL hasBecomeActive = NO;
+     IBOutlet NSMenuItem *showFullScreenTabs;
+     IBOutlet NSMenuItem *useTransparency;
+     IBOutlet NSMenuItem *maximizePane;
+-    IBOutlet SUUpdater * suUpdater;
+     IBOutlet NSMenuItem *_showTipOfTheDay;  // Here because we must remove it for older OS versions.
+     BOOL quittingBecauseLastWindowClosed_;
+ 
+@@ -1190,11 +1189,6 @@ static BOOL hasBecomeActive = NO;
+ 
+     [self updateBuriedSessionsMenu:_statusIconBuriedSessions];
+ 
+-    item = [[[NSMenuItem alloc] initWithTitle:@"Check For Updates"
+-                                       action:@selector(checkForUpdatesFromMenu:)
+-                                keyEquivalent:@""] autorelease];
+-    [menu addItem:item];
+-
+     item = [[[NSMenuItem alloc] initWithTitle:@"Quit iTerm2"
+                                        action:@selector(terminate:)
+                                 keyEquivalent:@""] autorelease];
+@@ -1350,7 +1344,6 @@ static BOOL hasBecomeActive = NO;
+                                silenceable:kiTermWarningTypeSilenceableForOneMonth
+                                     window:nil];
+         if (selection == kiTermWarningSelection1) {
+-            [[SUUpdater sharedUpdater] checkForUpdates:nil];
+         }
+     }
+ }
+@@ -1473,7 +1466,6 @@ static BOOL hasBecomeActive = NO;
+ }
+ 
+ - (IBAction)checkForUpdatesFromMenu:(id)sender {
+-    [suUpdater checkForUpdates:(sender)];
+ }
+ 
+ #pragma mark - Main Menu
+diff --git sources/iTermController.m sources/iTermController.m
+index 5054f89d9..a5fef1132 100644
+--- sources/iTermController.m
++++ sources/iTermController.m
+@@ -1175,7 +1175,7 @@ static iTermController *gSharedInstance;
+ }
+ 
+ - (void)refreshSoftwareUpdateUserDefaults {
+-    BOOL checkForTestReleases = [iTermPreferences boolForKey:kPreferenceKeyCheckForTestReleases];
++    BOOL checkForTestReleases = NO;
+     NSString *appCast = checkForTestReleases ?
+         [[NSBundle mainBundle] objectForInfoDictionaryKey:@"SUFeedURLForTesting"] :
+         [[NSBundle mainBundle] objectForInfoDictionaryKey:@"SUFeedURLForFinal"];
+diff --git sources/iTermLaunchExperienceController.m sources/iTermLaunchExperienceController.m
+index 2a31322d1..d89935b0c 100644
+--- sources/iTermLaunchExperienceController.m
++++ sources/iTermLaunchExperienceController.m
+@@ -110,7 +110,7 @@ typedef NS_ENUM(NSUInteger, iTermLaunchExperienceChoice) {
+     self = [super init];
+     if (self) {
+         const NSInteger runCount = [iTermLaunchExperienceController incrementRunCount];
+-        if (runCount == 2 && ![[SUUpdater sharedUpdater] automaticallyChecksForUpdates]) {
++        if (runCount == 2) {
+             // Sparkle will do its thing this launch.
+             _choice = iTermLaunchExperienceChoiceNone;
+         } else if ([iTermLaunchExperienceController quelled]) {
+diff --git sources/iTermPreferences.m sources/iTermPreferences.m
+index 04b1fe381..629f2377f 100644
+--- sources/iTermPreferences.m
++++ sources/iTermPreferences.m
+@@ -279,7 +279,7 @@ static NSString *sPreviousVersion;
+                   kPreferenceKeyInstantReplayMemoryMegabytes: @4,
+                   kPreferenceKeySavePasteAndCommandHistory: @NO,
+                   kPreferenceKeyAddBonjourHostsToProfiles: @NO,
+-                  kPreferenceKeyCheckForUpdatesAutomatically: @YES,
++                  kPreferenceKeyCheckForUpdatesAutomatically: @NO,
+                   kPreferenceKeyCheckForTestReleases: @NO,
+                   kPreferenceKeyLoadPrefsFromCustomFolder: @NO,
+                   kPreferenceKeyNeverRemindPrefsChangesLostForFileHaveSelection: @NO,
+-- 
+2.29.2
+


### PR DESCRIPTION
#### Description

https://trac.macports.org/ticket/56840

Hoping this patch can last a few versions as I do not expect the lines it modifies to change very much.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.1 12A7403


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? n/a
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
