### PR TITLE
k9s: update to 0.23.7

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.23.4 v
+go.setup            github.com/derailed/k9s 0.23.7 v
 homepage            https://k9scli.io
 
 categories          sysutils devel
@@ -20,9 +20,9 @@ platforms           darwin
 supported_archs     x86_64
 license             Apache-2
 
-checksums           rmd160  456de8532383976200ffbbe62e7cde68c749ec7f \
-                    sha256  2963c145556ff1c5a4b20e716a30055dec364d077beaff58a96a40c695b48081 \
-                    size    6105997
+checksums           rmd160  9005afb1e7a888e33355d73f1c2adf71e9d93ac0 \
+                    sha256  4f183d3d0ee4c7122e517dab101a8b63b1eb717549d6c0df1f2b85321ca39c7e \
+                    size    6101988
 
 # Reproduce the "build" target from the upstream Makefile
 set go_ldflags      "-w -X ${go.package}/cmd.version=${version} \


### PR DESCRIPTION
#### Description

Update to K9s 0.23.7.

###### Tested on

macOS 10.15.7 19H15
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?