### PR TITLE
ox: new port

### DIFF
--- a/editors/ox/Portfile
+++ b/editors/ox/Portfile
@@ -1,0 +1,83 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo 1.0
+
+github.setup        curlpipe ox 0.2.5
+categories          editors
+platforms           darwin
+license             GPL-2
+
+description         An independent Rust text editor that runs in your terminal!
+
+long_description    Ox is a code editor. It was written in Rust using ANSI \
+                    escape sequences. It assists developers with programming \
+                    by providing several tools to speed up and make \
+                    programming easier and a refreshing alternative to \
+                    heavily bloated and resource hungry editors such as VS \
+                    Code and JetBrains. Ox is lightweight so it can be used \
+                    on older computers.
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  0668245d14f67fdb0cb1b576cbfc22b22630342a \
+                    sha256  ebf162b4be89b1991bbbb56a7b40edf7ae95fe4c506d344fb77e3de9094a9de0 \
+                    size    83006
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+installs_libs       no
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/${name} ${destroot}${prefix}/bin/
+}
+
+cargo.crates \
+    aho-corasick                    0.7.14  b476ce7103678b0c6d3d395dbbae31d48ff910bd28be979ba5d48c6351131d0d \
+    ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
+    arrayref                         0.3.6  a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544 \
+    arrayvec                         0.5.2  23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b \
+    atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+    autocfg                          1.0.1  cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a \
+    base64                          0.12.3  3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff \
+    bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
+    blake2b_simd                    0.5.10  d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a \
+    cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
+    clap                            2.33.3  37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002 \
+    constant_time_eq                 0.1.5  245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc \
+    crossbeam-utils                  0.7.2  c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8 \
+    directories                      3.0.1  f8fed639d60b58d0f53498ab13d26f621fd77569cc6edb031f4cc36a2ad9da0f \
+    dirs                             2.0.2  13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3 \
+    dirs-sys                         0.3.5  8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a \
+    getrandom                       0.1.15  fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6 \
+    hermit-abi                      0.1.17  5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8 \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    libc                            0.2.79  2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743 \
+    memchr                           2.3.3  3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400 \
+    numtoa                           0.1.0  b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef \
+    proc-macro2                     1.0.24  1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71 \
+    quote                            1.0.7  aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37 \
+    redox_syscall                   0.1.57  41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce \
+    redox_termios                    0.1.1  7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76 \
+    redox_users                      0.3.5  de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d \
+    regex                            1.4.1  8963b85b8ce3074fecffde43b4b0dded83ce2f367dc8d363afc56679f3ee820b \
+    regex-syntax                    0.6.20  8cab7a364d15cde1e505267766a2d3c4e22a843e1a601f0fa7564c0f82ced11c \
+    ron                              0.6.2  f8a58080b7bb83b2ea28c3b7a9a994fd5e310330b7c8ca5258d99b98128ecfe4 \
+    rust-argon2                      0.8.2  9dab61250775933275e84053ac235621dfb739556d5c54a2f2e9313b7cf43a19 \
+    serde                          1.0.117  b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a \
+    serde_derive                   1.0.117  cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e \
+    shellexpand                      2.0.0  9a2b22262a9aaf9464d356f656fea420634f78c881c5eebd5ef5e66d8b9bc603 \
+    strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
+    syn                             1.0.46  5ad5de3220ea04da322618ded2c42233d02baca219d6f160a3e9c87cda16c942 \
+    termion                          1.5.5  c22cec9d8978d906be5ac94bceb5a010d885c626c4c8855721a4dbd20e3ac905 \
+    textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
+    thread_local                     1.0.1  d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14 \
+    unicode-segmentation             1.6.0  e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0 \
+    unicode-width                    0.1.8  9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3 \
+    unicode-xid                      0.2.1  f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564 \
+    vec_map                          0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
+    wasi      0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
+    winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f


### PR DESCRIPTION
#### Description

New port for [ox](https://github.com/curlpipe/ox), a terminal editor

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
