### PR TITLE
k9s: update to 0.23.9

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.23.7 v
+go.setup            github.com/derailed/k9s 0.23.9 v
 homepage            https://k9scli.io
 
 categories          sysutils devel
@@ -20,12 +20,13 @@ platforms           darwin
 supported_archs     x86_64
 license             Apache-2
 
-checksums           rmd160  9005afb1e7a888e33355d73f1c2adf71e9d93ac0 \
-                    sha256  4f183d3d0ee4c7122e517dab101a8b63b1eb717549d6c0df1f2b85321ca39c7e \
-                    size    6101988
+checksums           rmd160  10d8d98f1366d17034714c8fe98487154dd7f90c \
+                    sha256  3f4082d1ca2afe2ad6172f007caca7b2319fb713643d78b1368a00baf6a1b1e8 \
+                    size    6102831
 
 # Reproduce the "build" target from the upstream Makefile
-set go_ldflags      "-w -X ${go.package}/cmd.version=${version} \
+set go_ldflags      "-w -s \
+    -X ${go.package}/cmd.version=v${version} \
     -X ${go.package}/cmd.commit=unknown \
     -X ${go.package}/cmd.date=unknown"
 build.args          -ldflags \"${go_ldflags}\" ${go.package}


### PR DESCRIPTION
#### Description

Update to K9s 0.23.9.

###### Tested on

macOS 10.15.7 19H15
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?