### PR TITLE
httpie: set +python38 variant as default

### DIFF
--- a/net/httpie/Portfile
+++ b/net/httpie/Portfile
@@ -20,20 +20,26 @@ platforms           darwin
 license             BSD
 homepage            http://httpie.org
 
-variant python36 conflicts python37 python38 python39 description "Use Python 3.6" {}
-variant python37 conflicts python36 python38 python39 description "Use Python 3.7" {}
-variant python38 conflicts python36 python37 python39 description "Use Python 3.8" {}
-variant python39 conflicts python36 python37 python38 description "Use Python 3.9" {}
+python.versions     36 37 38 39
 
-if {[variant_isset python36]} {
+variant python36 conflicts python37 python38 python39 description {Use Python 3.6} {
     python.default_version 36
-} elseif {[variant_isset python37]} {
+}
+
+variant python37 conflicts python36 python38 python39 description {Use Python 3.7} {
     python.default_version 37
-} elseif {[variant_isset python38]} {
+}
+
+variant python38 conflicts python36 python37 python39 description {Use Python 3.8} {
     python.default_version 38
-} else {
-    default_variants +python39
+}
+
+variant python39 conflicts python36 python37 python38 description {Use Python 3.9} {
     python.default_version 39
+}
+
+if {![variant_isset python36]  && ![variant_isset python37] && ![variant_isset python39]} {
+    default_variants +python38
 }
 
 depends_lib-append  port:py${python.version}-requests \


### PR DESCRIPTION
#### Description

the last change added +python39 variant and made this the default, this PR changes the default variant to +python38 to be conform to https://github.com/macports/macports-ports/blob/master/_resources/port1.0/group/python-1.0.tcl#L76

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
