### PR TITLE
libreoffice: new port

### DIFF
--- a/office/libreoffice/Portfile
+++ b/office/libreoffice/Portfile
@@ -1,0 +1,308 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                libreoffice
+version             7.0.4.1
+categories          office aqua
+license             {LGPL-3 MPL-1.1}
+platforms           macosx
+maintainers         {gmail.com:audvare @Tatsh} openmaintainer
+description         Free, open source office suite.
+long_description    LibreOffice is a free and powerful office suite, and a successor to \
+                    OpenOffice.org (commonly known as OpenOffice). Its clean interface and \
+                    feature-rich tools help you unleash your creativity and enhance your \
+                    productivity.
+homepage            https://www.libreoffice.org
+use_xz              yes
+
+set short_version   [string range $version 0 end-2]
+set main_uri        https://download.documentfoundation.org/${name}/src/${short_version}/
+set addons_uri      https://dev-www.libreoffice.org/src/
+set extern_uri      https://dev-www.libreoffice.org/extern/
+set main_distfile   ${name}-${version}${extract.suffix}
+
+livecheck.type      regex
+livecheck.url       https://downloadarchive.documentfoundation.org/libreoffice/old/latest/src/
+livecheck.regex     "${name}-((?:\\d+\\.\\d+\\.\\d+)(?:\\.\\d+))?${extract.suffix}</a></td>"
+
+extract.only        ${main_distfile} \
+                    ${name}-dictionaries-${version}.tar.xz \
+                    ${name}-translations-${version}.tar.xz
+master_sites        ${main_uri}:main \
+                    ${extern_uri}:opens \
+                    ${addons_uri}:ucpp \
+                    ${addons_uri}:clucene-core \
+                    ${addons_uri}:mythes \
+                    ${addons_uri}:dtoa \
+                    ${addons_uri}:abw \
+                    ${addons_uri}:cmis \
+                    ${addons_uri}:epubgen \
+                    ${addons_uri}:exttextcat \
+                    ${addons_uri}:mwaw \
+                    ${addons_uri}:orcus \
+                    ${addons_uri}:qxp \
+                    ${addons_uri}:libstaroffice \
+                    ${addons_uri}:zmf \
+                    ${addons_uri}:mdds \
+                    ${main_uri}:dicts \
+                    ${main_uri}:translations
+distfiles           ${main_distfile}:main \
+                    ${name}-dictionaries-${version}.tar.xz:dicts \
+                    ${name}-translations-${version}.tar.xz:translations \
+                    0168229624cfac409e766913506961a8-ucpp-1.3.2.tar.gz:ucpp \
+                    48d647fbd8ef8889e5a7f422c1bfda94-clucene-core-2.3.3.4.tar.gz:clucene-core \
+                    884ed41809687c3e168fc7c19b16585149ff058eca79acbf3ee784f6630704cc-opens___.ttf:opens \
+                    a8c2c5b8f09e7ede322d5c602ff6a4b6-mythes-1.2.4.tar.gz:mythes \
+                    dtoa-20180411.tgz:dtoa \
+                    libabw-0.1.3.tar.xz:abw \
+                    libcmis-0.5.2.tar.xz:cmis \
+                    libepubgen-0.1.1.tar.xz:epubgen \
+                    libexttextcat-3.4.5.tar.xz:exttextcat \
+                    libmwaw-0.3.16.tar.xz:mwaw \
+                    liborcus-0.15.4.tar.bz2:orcus \
+                    libqxp-0.0.2.tar.xz:qxp \
+                    libstaroffice-0.0.7.tar.xz:libstaroffice \
+                    libzmf-0.0.2.tar.xz:zmf \
+                    mdds-1.6.0.tar.bz2:mdds
+
+checksums           libreoffice-7.0.4.1.tar.xz \
+                    rmd160  afc2f11635d79c62d59898d0a1a2dd09a4a59f85 \
+                    sha256  8f568ea2ee297b6fbd5d93ac433f4715c50856347529e595f144ccd9c0c7d230 \
+                    size    236440920 \
+                    libreoffice-dictionaries-7.0.4.1.tar.xz \
+                    rmd160  de06bc0a38b7337283aa2632472de4da3cc26749 \
+                    sha256  620ca8dad1c101ba35ba5a6fd8473cd8cb4001a19a443f7d022a3626f5c03d32 \
+                    size    45993220 \
+                    libreoffice-translations-7.0.4.1.tar.xz \
+                    rmd160  0d813461fe4d0585bc1610a387843f04fe038aae \
+                    sha256  7ebeafbdee0e55d37da24ca587749688ffb40c44b4f3e87e13f58583b45f95fc \
+                    size    175336600 \
+                    0168229624cfac409e766913506961a8-ucpp-1.3.2.tar.gz \
+                    rmd160  dbeb7a7f8c89961ca2e544b810345d025561866b \
+                    sha256  983941d31ee8d366085cadf28db75eb1f5cb03ba1e5853b98f12f7f51c63b776 \
+                    size    96939 \
+                    48d647fbd8ef8889e5a7f422c1bfda94-clucene-core-2.3.3.4.tar.gz \
+                    rmd160  5acfc9c8acd167b3684cfc731a60fd9c5465cc9b \
+                    sha256  ddfdc433dd8ad31b5c5819cc4404a8d2127472a3b720d3e744e8c51d79732eab \
+                    size    2241498 \
+                    884ed41809687c3e168fc7c19b16585149ff058eca79acbf3ee784f6630704cc-opens___.ttf \
+                    rmd160  00b1e296adf2caad44c49ad9743e5da7c771e480 \
+                    sha256  884ed41809687c3e168fc7c19b16585149ff058eca79acbf3ee784f6630704cc \
+                    size    207544 \
+                    a8c2c5b8f09e7ede322d5c602ff6a4b6-mythes-1.2.4.tar.gz \
+                    rmd160  4bf022808a362c0711ec857787bc3376e9adb940 \
+                    sha256  1e81f395d8c851c3e4e75b568e20fa2fa549354e75ab397f9de4b0e0790a305f \
+                    size    4910303 \
+                    dtoa-20180411.tgz \
+                    rmd160  8d1bba737d8b58c3fb09533f35af2a03e05d9849 \
+                    sha256  0082d0684f7db6f62361b76c4b7faba19e0c7ce5cb8e36c4b65fea8281e711b4 \
+                    size    48893 \
+                    libabw-0.1.3.tar.xz \
+                    rmd160  3dc267391c6253496767177f8a54d45aa079cf77 \
+                    sha256  e763a9dc21c3d2667402d66e202e3f8ef4db51b34b79ef41f56cacb86dcd6eed \
+                    size    318808 \
+                    libcmis-0.5.2.tar.xz \
+                    rmd160  cb17ab0d699ab56faae46ebaaabca618f3cf8b28 \
+                    sha256  d7b18d9602190e10d437f8a964a32e983afd57e2db316a07d87477a79f5000a2 \
+                    size    484404 \
+                    libepubgen-0.1.1.tar.xz \
+                    rmd160  53bbc182262a0d77e2d19a19d27d850b1e699132 \
+                    sha256  03e084b994cbeffc8c3dd13303b2cb805f44d8f2c3b79f7690d7e3fc7f6215ad \
+                    size    324380 \
+                    libexttextcat-3.4.5.tar.xz \
+                    rmd160  da7b61766ac962abb4e0b2bcb2de6555b49cefc5 \
+                    sha256  13fdbc9d4c489a4d0519e51933a1aa21fe3fb9eb7da191b87f7a63e82797dac8 \
+                    size    1041268 \
+                    libmwaw-0.3.16.tar.xz \
+                    rmd160  111e5dc4e9cefbd812dafd4168ea0c0cc18aca04 \
+                    sha256  0c639edba5297bde5575193bf5b5f2f469956beaff5c0206d91ce9df6bde1868 \
+                    size    1306872 \
+                    liborcus-0.15.4.tar.bz2 \
+                    rmd160  21eac3c9b1f37fdb59031fec606a1b4492f95d7c \
+                    sha256  cfb2aa60825f2a78589ed030c07f46a1ee16ef8a2d1bf2279192fbc1ae5a5f61 \
+                    size    1840593 \
+                    libqxp-0.0.2.tar.xz \
+                    rmd160  3363d46e334124f454c8b928c1e91e8f138ef250 \
+                    sha256  e137b6b110120a52c98edd02ebdc4095ee08d0d5295a94316a981750095a945c \
+                    size    341760 \
+                    libstaroffice-0.0.7.tar.xz \
+                    rmd160  96d41ee09185a39d1dbd5c418705603424e6f66f \
+                    sha256  f94fb0ad8216f97127bedef163a45886b43c62deac5e5b0f5e628e234220c8db \
+                    size    707920 \
+                    libzmf-0.0.2.tar.xz \
+                    rmd160  b0be3dbe0f6bf4565c1668a236850601616f625f \
+                    sha256  27051a30cb057fdb5d5de65a1f165c7153dc76e27fe62251cbb86639eb2caf22 \
+                    size    320952 \
+                    mdds-1.6.0.tar.bz2 \
+                    rmd160  003175ca1b3d1293a6f144490de94eba72cb1697 \
+                    sha256  f1585c9cbd12f83a6d43d395ac1ab6a9d9d5d77f062c7b5f704e24ed72dae07d \
+                    size    350406
+
+depends_build-append \
+    port:autoconf \
+    port:automake \
+    port:bison \
+    port:cppunit \
+    port:flex \
+    port:gettext \
+    port:gperf \
+    port:intltool \
+    port:pkgconfig \
+    port:unixODBC
+depends_lib-append  \
+    port:apr \
+    port:apr-util \
+    port:boost \
+    port:bzip2 \
+    port:curl \
+    port:expat \
+    port:gdbm \
+    port:gettext \
+    port:graphite2 \
+    port:harfbuzz \
+    port:harfbuzz-icu \
+    port:hunspell \
+    port:hyphen \
+    port:icu \
+    port:jpeg \
+    port:lcms2 \
+    port:libcdr-0.1 \
+    port:libe-book \
+    port:libepoxy \
+    port:libetonyek \
+    port:libfreehand \
+    port:libiconv \
+    port:liblangtag \
+    port:libmspub \
+    port:lib/libjpeg.dylib:jpeg \
+    port:libodfgen \
+    port:libpagemaker \
+    port:libpng \
+    port:librevenge \
+    port:libvisio-0.1 \
+    port:libwpd-0.10 \
+    port:libwpg-0.3 \
+    port:libwps \
+    port:libxml2 \
+    port:libxslt \
+    port:ncurses \
+    port:neon \
+    port:nspr \
+    port:nss \
+    path:lib/libssl.dylib:openssl \
+    port:ossp-uuid \
+    port:raptor2 \
+    port:readline \
+    port:redland \
+    port:serf1 \
+    port:sqlite3 \
+    port:xmlsec \
+    port:xz \
+    port:zlib
+# Try to keep this in sync with the Python portgroup.
+set python_version 38
+depends_run-append \
+    port:python${python_version} \
+    port:py${python_version}-lxml
+
+if {${os.major} < 14} {
+    pre-fetch {
+        ui_error "${name} @${version} requires OS X 10.10 or later."
+        return -code error "incompatible OS X version"
+    }
+}
+
+patchfiles \
+    configure.patch \
+    unpack-sources-fix-for-bsd-find.patch
+
+set product_name LibreOffice
+
+pre-configure {
+    system "cd ${worksrcpath} && env NOCONFIGURE=1 ./autogen.sh"
+}
+
+use_xcode           yes
+# CMS_NO_REGISTER_KEYWORD required for C++17 or newer compiler.
+configure.env-append  \
+    "LCMS2_CFLAGS=-I${prefix}/include -DCMS_NO_REGISTER_KEYWORD=1"
+# Most arguments are from
+# https://wiki.documentfoundation.org/LibreOffice_Vanilla_for_Mac#LibreOffice_Vanilla
+configure.args-append  \
+    --disable-breakpad \
+    --disable-bundle-mariadb \
+    --disable-ccache \
+    --disable-coinmp \
+    --disable-epm \
+    --disable-ext-ct2n \
+    --disable-ext-numbertext \
+    --disable-fetch-external \
+    --disable-firebird-sdbc \
+    --disable-ldap \
+    --disable-libnumbertext \
+    --disable-lotuswordpro \
+    --disable-lpsolve \
+    --disable-neon \
+    --disable-odk \
+    --disable-online-update \
+    --disable-pdfimport \
+    --disable-pdfium \
+    --disable-postgresql-sdbc \
+    --disable-qrcodegen \
+    --disable-report-builder \
+    --disable-vlc \
+    --enable-bogus-pkg-config \
+    --enable-cups \
+    --enable-extension-integration \
+    --enable-mpl-subset \
+    --enable-python=system \
+    --enable-readonly-installset \
+    --enable-release-build \
+    --enable-symbols \
+    --with-external-tar=${distpath} \
+    --with-myspell-dicts \
+    --with-package-version=${version} \
+    --with-parallelism=${build.jobs} \
+    --with-product-name=${product_name} \
+    --with-system-epoxy \
+    --with-system-gpgmepp \
+    --with-system-headers \
+    --with-system-hunspell \
+    --with-system-jars \
+    --with-system-libebook \
+    --with-system-libs \
+    --with-system-xmlsec \
+    --with-theme=colibre \
+    --with-tls=nss \
+    --with-vendor=MacPorts \
+    --with-webdav=serf \
+    --without-doxygen \
+    --without-fonts \
+    --without-java \
+    --without-package-format \
+    --without-system-dicts \
+    --without-system-libabw \
+    --without-system-libcmis \
+    --without-system-libepubgen \
+    --without-system-libexttextcat \
+    --without-system-libmwaw \
+    --without-system-libqxp \
+    --without-system-libstaroffice \
+    --without-system-libzmf \
+    --without-system-mdds \
+    --without-system-mythes \
+    --without-system-orcus \
+    --without-system-sane \
+    \"--with-lang=bg br ca ca-valencia cy cs da de el en-US en-GB es et eu fi fr ga gd gl hr hu id is it ja km lt lv nb nl nn pl pt pt-BR ro ru sk sl sv ta tr uk zh-CN zh-TW\"
+# This is not a mistake, despite requiring port:openssl in depends_lib. Some
+# internals still require libcrypto.
+configure.args-append --disable-openssl
+# "Your version of libclucene has contribs-lib missing."
+configure.args-append --without-system-clucene
+
+build.target    build-nocheck
+
+destroot {
+    copy ${worksrcpath}/instdir/${product_name}.app ${destroot}${applications_dir}
+}

--- a/office/libreoffice/files/configure.patch
+++ b/office/libreoffice/files/configure.patch
@@ -1,0 +1,25 @@
+diff --git configure.ac configure.ac
+index e4ef8bec2b3e..402979d77ffe 100644
+--- configure.ac
++++ configure.ac
+@@ -8845,10 +8845,6 @@ AC_SUBST(XMLLINT)
+ # Optionally user can pass an option to configure, i. e.
+ # ./configure PYTHON=/usr/bin/python
+ # =====================================================================
+-if test $_os = Darwin -a "$enable_python" != fully-internal -a "$enable_python" != internal; then
+-    # Only allowed choices for macOS are 'internal' (default) and 'fully-internal'
+-    enable_python=internal
+-fi
+ if test "$build_os" != "cygwin" -a "$enable_python" != fully-internal; then
+     if test -n "$PYTHON"; then
+         PYTHON_FOR_BUILD=$PYTHON
+@@ -8918,9 +8914,6 @@ fully-internal)
+     ;;
+ system)
+     AC_MSG_RESULT([system])
+-    if test "$_os" = Darwin; then
+-        AC_MSG_ERROR([--enable-python=system doesn't work on macOS because the version provided is obsolete])
+-    fi
+     ;;
+ *)
+     AC_MSG_ERROR([Incorrect --enable-python option])

--- a/office/libreoffice/files/unpack-sources-fix-for-bsd-find.patch
+++ b/office/libreoffice/files/unpack-sources-fix-for-bsd-find.patch
@@ -1,0 +1,13 @@
+--- bin/unpack-sources.old	2020-11-11 04:47:35.000000000 -0500
++++ bin/unpack-sources	2020-11-11 04:53:29.000000000 -0500
+@@ -85,7 +85,7 @@
+     fi
+ 
+     # create symlinks for module directories; ignore git-hooks directory
+-    for dir in `find "$lo_src_dir/$tarname" -mindepth 1 -maxdepth 1 -type d -path $lo_src_dir/$tarname/git-hooks -o -printf "$tarname/%f\n"` ; do
+-        ln -sf "src/$dir" "$start_dir"
+-    done
++    while read -r dir; do
++        ln -sf "src/${tarname}/$(basename "$dir")" "$start_dir"
++    done < <(find "$lo_src_dir/$tarname" -mindepth 1 -maxdepth 1 -type d -path $lo_src_dir/$tarname/git-hooks)
+ done


### PR DESCRIPTION
#### Description

LibreOffice, built from source. Mostly the same as the official build and LibreOffice Vanilla.

No variants because that would be way too difficult to keep maintained and working. Because of this, all languages that LibreOffice Vanilla comes with are included.

There is an opportunity to brand this build of LibreOffice so it might have a MacPorts logo, or a special version of the icon, etc. Gentoo does this:

<img src="https://i.ytimg.com/vi/uWBWDYzVD8w/hqdefault.jpg">

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? n/a <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? n/a
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
