### PR TITLE
syncthing: update to 1.11.1

### DIFF
--- a/net/syncthing/Portfile
+++ b/net/syncthing/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/syncthing/syncthing 1.10.0 v
+go.setup            github.com/syncthing/syncthing 1.11.1 v
 categories          net
 platforms           darwin
 license             MPL-2
@@ -18,365 +18,232 @@ long_description    Syncthing replaces proprietary sync and cloud services \
 homepage            https://syncthing.net
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  482ca0d3e61fd5b7e6730a4f9dd9348e2ae9bc93 \
-                        sha256  c989808c66f23dffabed5ca7f809be622d1cf450716735bd00900cc2e455617e \
-                        size    4910311
+                        rmd160  ad23a6c83c7c159519cf591093c099a407eb342e \
+                        sha256  eb71b31f38dcae538eaf88109e9de6537850e4c222e5e373f9dd6a1c5d3c7a97 \
+                        size    4938797
 
-go.vendors          github.com/alecthomas/template \
-                        lock    fb15b899a751 \
-                        rmd160  34faebabc9eeabdf4e3efc70015e1f858ad787cf \
-                        sha256  7bdd81cd04955c4251637e7196751a4626ae822382b9cbb33ea53eb5f8ce00e5 \
-                        size    55322 \
-                    github.com/d4l3k/messagediff \
-                        lock    v1.2.1 \
-                        rmd160  3fe15fd5cf431ac2b6e6efb0a96de2bbe49af65a \
-                        sha256  da946f9c267dc73f01fb14126655c6f5dfe16b84ee91a1e0646f0d88a140cc8d \
-                        size    8066 \
-                    github.com/prometheus/common \
-                        lock    v0.7.0 \
-                        rmd160  71589422d9f6d26d1d28e631322077e19818e554 \
-                        sha256  95baf93244a8160dffe12d220a06c54bf209f7cf0bf1196c686623f3da570fed \
-                        size    100513 \
-                    golang.org/x/xerrors \
-                        lock    5ec99f83aff1 \
-                        rmd160  6e8267f353e153297f205e4be219236d6ae43880 \
-                        sha256  9a500a49d83a09e7de6c71b215d1c14b81e315d26884530ef327c95ddf1f2d28 \
-                        size    13667 \
-                    github.com/lucas-clemente/quic-go \
-                        lock    v0.18.0 \
-                        rmd160  bd251272351789e63b94f6fb406261445df01fec \
-                        sha256  d4c438d4a23aaaa530b4a34e1106f77409133f5c14b8dc81aa5f98fc1e13b06c \
-                        size    488513 \
-                    github.com/mattn/go-colorable \
-                        lock    v0.1.6 \
-                        rmd160  3c6531ff68909aacc83a16f92149722803b465a7 \
-                        sha256  3f3b5a79ae9511dd610d288768d782faffa27bf92ad1d6c8be3f37aa9d3bc975 \
-                        size    9477 \
-                    github.com/oschwald/geoip2-golang \
-                        lock    v1.4.0 \
-                        rmd160  fc325eebed54d5c7c5f7945b8447d807536f0f82 \
-                        sha256  0f702ef1efa02abd2a70a5fbd33353338c7f67acaaafea707a162ec30ddb5d0b \
-                        size    7750 \
-                    github.com/AudriusButkevicius/pfilter \
-                        lock    c55ef6137fc6 \
-                        rmd160  f4a19907214e15e2460a0279c02950a5d21dc1c4 \
-                        sha256  bd4daa7fdd0212753aefbef8818eedb38bbec97b43a3e5465a1891b5f0deb5cc \
-                        size    3244 \
-                    github.com/OneOfOne/xxhash \
-                        lock    v1.2.2 \
-                        rmd160  35e2c7b623c069fc08aec00990ca5c82ad831a22 \
-                        sha256  e6a73b9f6acc9b361ea77edcb6f29103e96ac0c623c6d2882909698180e54694 \
-                        size    13444 \
-                    github.com/chmduquesne/rollinghash \
-                        lock    a60f8e7142b5 \
-                        rmd160  e84dbc6401f822d165bef6c9e158e5676931c739 \
-                        sha256  5301b74a18c8113ec61267dc3e2301d18f5d44b1c40c6bd68f8207bcaa987a79 \
-                        size    22396 \
-                    github.com/dgraph-io/ristretto \
-                        lock    8f368f2f2ab3 \
-                        rmd160  f99c7fbe446e02237d2c373cb6c9047ed624a526 \
-                        sha256  96eb4b33abfe0194bb1f813cdb7c4961ab583f8ea47560555071bf1ffc525d99 \
-                        size    39675 \
-                    github.com/petermattis/goid \
-                        lock    b0b1615b78e5 \
-                        rmd160  67d260bb5f1a1a99879d0d009f7f0e9e2d872584 \
-                        sha256  edff5d2606e098d2418c09b2d9f24ddeb840f1eb22920a8b7e8da2ff39b23d9d \
-                        size    6817 \
-                    github.com/stretchr/testify \
-                        lock    v1.5.1 \
-                        rmd160  db9d43c3c804950ce9650d830f7dea5434ed83c1 \
-                        sha256  e5f566d1c23fb2b987f8a9f139e32866c1eea8c72051da25bbf6880a4f8c541a \
-                        size    78702 \
-                    golang.org/x/crypto \
-                        lock    123391ffb6de \
-                        rmd160  4afdc76f139facd878c228d85dee3698de13f793 \
-                        sha256  1b8f464f2d4faca0ac6ac7eac18b2b1118c1ac9ff8f6b7ffc976fb0ebedc520f \
-                        size    1732579 \
-                    golang.org/x/text \
-                        lock    v0.3.3 \
-                        rmd160  babfa547ba9a9dab7fe08fa5543f1d8e7ae00301 \
-                        sha256  1c4a8c12295d484e0360d8e010ebc4b8a9a05aa2a07c10c3d3e5b17aa063f0db \
-                        size    7745597 \
-                    gopkg.in/yaml.v2 \
+go.vendors          gopkg.in/yaml.v2 \
                         lock    v2.3.0 \
                         rmd160  2f8fa56d8a413b6288132eeb7f0d7c64d27d877f \
                         sha256  a8d1a8bc88239d25507456380b47d59ae3683d4a5f4336da4892db1ce026615f \
                         size    72838 \
-                    github.com/cheekybits/genny \
-                        lock    v1.0.0 \
-                        rmd160  c8f3f5af635b83ade08f9f8e08e7f2018cb5879c \
-                        sha256  528d149522e053aed14048608751da8ace5b44466038b1a8d47d04a050d81bdc \
-                        size    15585 \
-                    github.com/greatroar/blobloom \
-                        lock    v0.3.0 \
-                        rmd160  262052aca34896ab979450dea9b031507c137c26 \
-                        sha256  437df85c0084c2377e4ccf85571dcd3a9db782a28549bf3347f0217b9a3b70fd \
-                        size    18782 \
-                    github.com/pmezard/go-difflib \
-                        lock    v1.0.0 \
-                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
-                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
-                        size    11409 \
-                    github.com/vitrun/qart \
-                        lock    bf64b92db6b0 \
-                        rmd160  50ea47d1b1d0b60138845f21d57cad0ac7e5e632 \
-                        sha256  58579d35e03703699b3ea56a096b665739a77b462ac18a29102c7c776e48d279 \
-                        size    23968 \
-                    github.com/oschwald/maxminddb-golang \
-                        lock    v1.6.0 \
-                        rmd160  86c6ca33cd6ac16da7a566946f54a86e140b70b1 \
-                        sha256  8c265096a73a04ece9153ac0138074b0bd40b927e0d32e3b80deadba81c9010d \
-                        size    21377 \
-                    github.com/syndtr/goleveldb \
-                        lock    d9e9293bd0f7 \
-                        rmd160  1c363aa498b3fae0918bf839dcaa673193080f50 \
-                        sha256  9fb936ce779314cfa755bd208b8a5ba7e4f41c23bd7a1d61bda6facb5d13052b \
-                        size    151087 \
-                    golang.org/x/net \
-                        lock    3edf25e44fcc \
-                        rmd160  46d0720f234d9b93602e7aa6ad3fc4c6ed0097f4 \
-                        sha256  179d5d7db70e06ee4ccf6f4f4ec20e93483cb92839b08fd229f5bedb60ce172b \
-                        size    1178535 \
-                    github.com/bradfitz/go-smtpd \
-                        lock    deb6d6237625 \
-                        rmd160  ca7b85badf898d1dff04117538ca5937a7f623a1 \
-                        sha256  c8960be926f13469edb5cd45c0fb13baded4e5452ca4948b505d41d2f8f620cf \
-                        size    4696 \
-                    github.com/go-ldap/ldap \
-                        lock    v3.2.0 \
-                        rmd160  39575e75210aba969b80d24ee41611ca9298bdbd \
-                        sha256  4b701003dc5fb1b4b71d7a50077b95685eb3f799ee178d5bc1b4786a2a5c9e4e \
-                        size    82016 \
-                    github.com/golang/mock \
-                        lock    v1.4.4 \
-                        rmd160  ad4c6bd70c06881810d56fbd5d4b4ddfb701fae0 \
-                        sha256  921ea11f2a10c4f6225fd3057893a5ee8c5d9b2ca17cb8f9de3a361a0f3899a1 \
-                        size    55151 \
-                    github.com/onsi/gomega \
-                        lock    v1.10.1 \
-                        rmd160  fbdb25ab0da7cc358134327f3bf7390aae2a9e7f \
-                        sha256  f5d901f5a7321a7ed7317d1ae305bb27b7c3febc3cede1c887e2d76a8e995da6 \
-                        size    97315 \
-                    github.com/jackpal/go-nat-pmp \
-                        lock    v1.0.2 \
-                        rmd160  84452f7d2cccdff571def7177bc180051eaba388 \
-                        sha256  7c43c94b1194bb43b497ab4e480403403c34076d87715915abb9502120e192ee \
-                        size    4783 \
-                    github.com/mattn/go-isatty \
-                        lock    v0.0.12 \
-                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
-                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
-                        size    4549 \
-                    github.com/matttproud/golang_protobuf_extensions \
-                        lock    v1.0.1 \
-                        rmd160  e28c4169919e72c08ee6520ad2ce16943d18e40c \
-                        sha256  c40d4c38e7dc2a7bae57e3740bb28d463e173d82e4603622d04d01741ff7a083 \
-                        size    37197 \
-                    golang.org/x/time \
-                        lock    9d24e82272b4 \
-                        rmd160  8f037e1cd7a3667593b21ecd73779f9cacd0ca4b \
-                        sha256  c2b48ec888795d12f2f145d636f5e6b9131439c2b5156f6d6cad89d1ef6cbae2 \
-                        size    9314 \
-                    github.com/AudriusButkevicius/recli \
-                        lock    v0.0.5 \
-                        rmd160  1596db1035aafd77ffa11ed3373f9382ada081e2 \
-                        sha256  6ead3d46eebdc505730eeeb67f1f51db8f5685a289a21bb8652ded419e98355c \
-                        size    12375 \
-                    github.com/getsentry/raven-go \
-                        lock    v0.2.0 \
-                        rmd160  c564a8e9061642f60d401b6ab5b26961feec3212 \
-                        sha256  690d7813db5510d0dc739335dc950519c6664cc47ce49029e9c817f4a0c896c1 \
-                        size    19245 \
-                    github.com/golang/protobuf \
-                        lock    v1.4.2 \
-                        rmd160  fbf4477bc008421fde463d79f7bc54a36de91db2 \
-                        sha256  206d74f8fd066bb178135ee9c092e986f8a1e1104df242e148e99e5a839e4ef2 \
-                        size    171802 \
-                    github.com/google/go-cmp \
-                        lock    v0.5.0 \
-                        rmd160  f28cfe463c2aa119f5ea32b5373cdc06e606c3fd \
-                        sha256  4c228ad175fb924cd4c5ab08b281685f636ae28439e5508b3946964919b9c746 \
-                        size    98601 \
-                    github.com/go-ole/go-ole \
-                        lock    v1.2.4 \
-                        rmd160  ff816f1835d4311c60fbed68b0d01838c4265bb6 \
-                        sha256  55590e7d9e56e30094fd487a2dcf4926aa4bb82471f21f33131b606a6ce41294 \
-                        size    51683 \
-                    github.com/gobwas/glob \
-                        lock    v0.2.3 \
-                        rmd160  1f472cf991498a8091446eb788fe85e0c5403185 \
-                        sha256  2de3694ee0ff41a96b66f9aa3eec51048e620cdd09acc8685f18c3abcd6e14ae \
-                        size    25971 \
-                    github.com/DataDog/zstd \
-                        lock    v1.4.1 \
-                        rmd160  86c75e5feafd8e615a7eea3b97680c0543a95380 \
-                        sha256  f62a03934f91b063545ce33c40526d33d52fb07dbfbced5dd5b531295b37af4c \
-                        size    498943 \
-                    github.com/calmh/xdr \
-                        lock    v1.1.0 \
-                        rmd160  944babe70dbef7a20b2db97dfe6bd892f8953ca9 \
-                        sha256  f5a1704fe7db6d3fadf487e4a25b49f70dc2b0d151e78be79511baa2e82e86a0 \
-                        size    10539 \
-                    github.com/davecgh/go-spew \
-                        lock    v1.1.1 \
-                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
-                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
-                        size    42171 \
-                    github.com/fsnotify/fsnotify \
-                        lock    45d7d09e39ef4ac08d493309fa031790c15bfe8a \
-                        rmd160  4660b5721da8aea4c890786e49d7cec39c2e04d3 \
-                        sha256  7920cf1e5ccf268962fcff0b501398ed6c28ed75b1e1281fb17b19a8b0e4db5c \
-                        size    31910 \
-                    github.com/maruel/panicparse \
-                        lock    v1.5.1 \
-                        rmd160  c8ea9da4d1a8fe96cefd2ca3b5ded74bad7b89e3 \
-                        sha256  903a5fd94d31df7ec39c3482926ff69182e0fd9ae5891850d7fb26570eb73f41 \
-                        size    1219072 \
-                    github.com/mgutz/ansi \
-                        lock    9520e82c474b \
-                        rmd160  fea73fc246ac2b229bb91accba053fed2ea63536 \
-                        sha256  75eaed501d7d121ad75c83246fecdc6222dbbbd3fcb4140c8775e219fff440ce \
-                        size    4878 \
-                    github.com/thejerf/suture \
-                        lock    v3.0.2 \
-                        rmd160  6df06f4bd54773997535e47b76a9a7345c9e7b6c \
-                        sha256  d6d7aeebed3a2e404e0f8ca062ea79ea8be60357eb8336fe907cff8952ce36f2 \
-                        size    18049 \
-                    golang.org/x/sync \
-                        lock    42b317875d0f \
-                        rmd160  1cb7dc676b56b5687f384115dda8b608c0855fb6 \
-                        sha256  93014215265c6737487961e64a7218a7144fc93e3dc2923d8e08c10e3fb90d49 \
-                        size    16239 \
-                    github.com/dchest/siphash \
-                        lock    v1.2.1 \
-                        rmd160  78de0b3517652f62068fe6c49c3e140bb4d782df \
-                        sha256  47c06d2961752a3efc4348917af06da4296f52989a62e061385be0c7a8d6026a \
-                        size    10729 \
-                    github.com/gogo/protobuf \
-                        lock    v1.3.1 \
-                        rmd160  16be6b4d8879c774e3b9d9fc29d80cf770632f88 \
-                        sha256  393dda8c157457ce1b3d4003f9012b25528c76b1492d7ba52c9bd7b66c901c13 \
-                        size    2038446 \
-                    github.com/kballard/go-shellquote \
-                        lock    95032a82bc51 \
-                        rmd160  40415cd59ece9fb38b22170feec07f1f48d518a2 \
-                        sha256  41aa42696f96fb2783c5135d71ff1ec5938dfe178b51eb703e509c8ac0e7db4e \
-                        size    4335 \
-                    github.com/kr/pretty \
-                        lock    v0.2.0 \
-                        rmd160  45bbf0be7a3328e33186718ab12cb506c0f5a073 \
-                        sha256  35fb1f8788552fc7df2120bc06dd34e00aa3284d23c250fc1f143eef51d08586 \
-                        size    8762 \
-                    github.com/dgraph-io/badger \
-                        lock    v2.0.3 \
-                        rmd160  fa3b561afae5c30f56812b5dd105857ca47f1400 \
-                        sha256  39507b49d5f0bc50c10dcdc4234a8c4226dbffeb773ede26dcf20f39b87c5f2b \
-                        size    332700 \
-                    github.com/go-asn1-ber/asn1-ber \
-                        lock    v1.5.0 \
-                        rmd160  81e1503e5f18e3a561081732342f24442235cd53 \
-                        sha256  f7d61845a090c672b0475794abdd673a47b85ae35c71b1ebff12716783725df6 \
-                        size    16311 \
-                    github.com/jackpal/gateway \
-                        lock    v1.0.6 \
-                        rmd160  3b78ee895c6d3d02bbc65ad2ed24aee73020815f \
-                        sha256  9ccb9f16909c0a992b2b0f319937d73778c7b97eae57fd6a0a1aa0faf0b11d41 \
-                        size    4907 \
-                    github.com/prometheus/procfs \
-                        lock    v0.0.5 \
-                        rmd160  dde8f0bc104aeac6655947850ec8e8a05a9a9d12 \
-                        sha256  9c445cfa36a01b144eff139afd88dd3c199d54e91d5ae7de6ece0f57b464eebd \
-                        size    112195 \
-                    github.com/Azure/go-ntlmssp \
-                        lock    66371956d46c \
-                        rmd160  74dcc3f7e70c2dbdf032390bd8734e0fc514ce65 \
-                        sha256  0ff7e70a3c8a7b828f007c296d4152b334eaf79715122a5e9bf19f404c901044 \
-                        size    8130 \
-                    github.com/StackExchange/wmi \
-                        lock    cbe66965904d \
-                        rmd160  1c28ff3f595532ab67c85f5232c9228cf97d65d9 \
-                        sha256  01b78146552b0c7d6126b64cdf4f7c40fe1e1e15a9f822d4a1bc6db5df1f48ca \
-                        size    11289 \
-                    github.com/certifi/gocertifi \
-                        lock    a5e0173ced67 \
-                        rmd160  c3d3a5e8a98af89f87f2aea27333dae1bd4b5e81 \
-                        sha256  8b8fd5735cb54e113ea0f42091e0baee170cc0a6917cdb95e6068dbf238109b8 \
-                        size    155587 \
-                    github.com/cpuguy83/go-md2man \
-                        lock    f79a8a8ca69d \
-                        rmd160  85f342c341fa928e9ec874490c277bdabf1c39c6 \
-                        sha256  2f3f8bc701df4890a5a4baf0b632ad3290be1e0aaf572b2e58fd57df93efc306 \
-                        size    52040 \
-                    github.com/shirou/gopsutil \
-                        lock    v2.20.7 \
-                        rmd160  6d8f6cdc07b3688a8fdcb4fb3a7947330d279132 \
-                        sha256  fb92f1357babf7b5ac07ed48740cc840917bbfe31b85f620669f9b648f86d1ba \
-                        size    139662 \
-                    github.com/alecthomas/units \
-                        lock    c3de453c63f4 \
-                        rmd160  5008bfe6af9cfe334d62399db00901ea6a6c1814 \
-                        sha256  c6a733d020cca4f93b44c8a22eb68a90fb38916b4818a9bb569c65ed9322b3f2 \
-                        size    3497 \
-                    github.com/golang/groupcache \
-                        lock    611e8accdfc9 \
-                        rmd160  0813af0565e417ffd221180933222428aa940066 \
-                        sha256  3ba7b454c29e691d7ebe2f786cac2c6c033a0f80ea2508de04079b4ceee91115 \
-                        size    26080 \
-                    github.com/golang/snappy \
-                        lock    v0.0.1 \
-                        rmd160  a10055b1a93ad290e600742c23156dbd55afe046 \
-                        sha256  5ca0dcca007398f298a6386af5d4696faba962b6a625e3aa3961d212078722b8 \
-                        size    62627 \
-                    github.com/onsi/ginkgo \
-                        lock    v1.14.0 \
-                        rmd160  a1ff8b445c4b593fc8c399993c90f8ff423260fa \
-                        sha256  5aec86ace19613b3976cdadf587d42461d47b89b9b02c5dabafa05a86f704fb2 \
-                        size    145828 \
-                    github.com/pkg/errors \
-                        lock    v0.9.1 \
-                        rmd160  dc065c655f8a24c6519b58f9d1202eb266ecda40 \
-                        sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
-                        size    13422 \
-                    gopkg.in/alecthomas/kingpin.v2 \
-                        lock    v2.2.6 \
-                        rmd160  af6db4648ec7638fb5cab49fd9536caa705f5fed \
-                        sha256  31378085783496cff78c7d41479ccd6206c4f4e3892909ef0c2cd39e2de3b039 \
-                        size    44374 \
-                    github.com/beorn7/perks \
-                        lock    v1.0.1 \
-                        rmd160  c6c5c7fd2132f01925c7fccd9d27c9d7a80f2adb \
-                        sha256  78da4421e9f9fa2ee5e3855bdd31cfb04c7e823d9c0ec385cc2c008132d98b96 \
-                        size    10874 \
-                    github.com/ccding/go-stun \
-                        lock    be486d185f3d \
-                        rmd160  98cfa81baa5fb412774e521155dfa5302467a854 \
-                        sha256  aca68ddc25cb11f3ccf988062168295e6acd513295c9e151d3211c4c169bdf11 \
-                        size    14125 \
-                    github.com/cespare/xxhash \
-                        lock    v2.1.0 \
-                        rmd160  55292dc23361fe89ea9f4e462e76d840ea797d80 \
-                        sha256  120da378ec373d6f6b71334b97bcbbefcee25408901f8e9d3482eb393ae81432 \
-                        size    9210 \
-                    github.com/dgryski/go-farm \
-                        lock    6a90982ecee2 \
-                        rmd160  a9f7f2372bd4bce849b55eef441e43b9a09330b0 \
-                        sha256  e90d46f1d9f70d28d20e4791aad8c2dbe7900d65bf42140018c443b3480eef72 \
-                        size    26795 \
-                    github.com/shurcooL/sanitized_anchor_name \
-                        lock    v1.0.0 \
-                        rmd160  c7e5322dba53e10db1711d65c146af5649b0c7c8 \
-                        sha256  ed9418de8c92acfbbd8608745855ebfc67fa686c0a0a5245cf8eece8f540baa9 \
-                        size    2144 \
                     gopkg.in/tomb.v1 \
                         lock    dd632973f1e7 \
                         rmd160  ae07f5ddbbc6afc772d6dc5273bb72eaba50529a \
                         sha256  91c562a4e31c89d13e5391143ff653231fc2d80562743db89ce2172ad8f81008 \
                         size    3636 \
-                    github.com/francoispqt/gojay \
-                        lock    v1.2.13 \
-                        rmd160  c63b7b72b4a191e72379dd00bc1aee8881a9d28d \
-                        sha256  43123a9b651b186da391e56cf9e644d990a5a48f686b629515c458320684f9f4 \
-                        size    165274 \
+                    gopkg.in/fsnotify.v1 \
+                        repo    github.com/fsnotify/fsnotify \
+                        lock    c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9 \
+                        rmd160  24712e412814020224e2779186e634610e2f6926 \
+                        sha256  bc839ee158ad34b81c1f11c3b9e3bcbabfba3297f61d165599880c400b8171dc \
+                        size    31147 \
+                    gopkg.in/check.v1 \
+                        lock    41f04d3bba15 \
+                        rmd160  1e5543a8e6a3159296ee63e28cbde9931a04f6b3 \
+                        sha256  c41575a73d10809f89b05ef9e783f2d53facdc6573697770d30efb05a9d2dc28 \
+                        size    31612 \
+                    gopkg.in/alecthomas/kingpin.v2 \
+                        lock    v2.2.6 \
+                        rmd160  af6db4648ec7638fb5cab49fd9536caa705f5fed \
+                        sha256  31378085783496cff78c7d41479ccd6206c4f4e3892909ef0c2cd39e2de3b039 \
+                        size    44374 \
+                    google.golang.org/protobuf \
+                        repo    github.com/protocolbuffers/protobuf-go \
+                        lock    v1.25.0 \
+                        rmd160  ca1a78077118747c660917e50c4273d69b0f04ea \
+                        sha256  5bc3eb5d7160ab9ae45255d6b718c1cf9e9ed80c244b7527bced50370ae18620 \
+                        size    1259096 \
+                    golang.org/x/xerrors \
+                        lock    5ec99f83aff1 \
+                        rmd160  6e8267f353e153297f205e4be219236d6ae43880 \
+                        sha256  9a500a49d83a09e7de6c71b215d1c14b81e315d26884530ef327c95ddf1f2d28 \
+                        size    13667 \
+                    golang.org/x/time \
+                        lock    9d24e82272b4 \
+                        rmd160  8f037e1cd7a3667593b21ecd73779f9cacd0ca4b \
+                        sha256  c2b48ec888795d12f2f145d636f5e6b9131439c2b5156f6d6cad89d1ef6cbae2 \
+                        size    9314 \
+                    golang.org/x/text \
+                        lock    v0.3.3 \
+                        rmd160  babfa547ba9a9dab7fe08fa5543f1d8e7ae00301 \
+                        sha256  1c4a8c12295d484e0360d8e010ebc4b8a9a05aa2a07c10c3d3e5b17aa063f0db \
+                        size    7745597 \
+                    golang.org/x/sys \
+                        lock    aee5d888a860 \
+                        rmd160  9d3b513abda2fa75f2dba2c62a484bba28b5177f \
+                        sha256  ac208a9aba50798244004845494d75f8dcc8893d960a89f2b019298c33dfec31 \
+                        size    1065651 \
+                    golang.org/x/sync \
+                        lock    42b317875d0f \
+                        rmd160  1cb7dc676b56b5687f384115dda8b608c0855fb6 \
+                        sha256  93014215265c6737487961e64a7218a7144fc93e3dc2923d8e08c10e3fb90d49 \
+                        size    16239 \
+                    golang.org/x/net \
+                        lock    3edf25e44fcc \
+                        rmd160  46d0720f234d9b93602e7aa6ad3fc4c6ed0097f4 \
+                        sha256  179d5d7db70e06ee4ccf6f4f4ec20e93483cb92839b08fd229f5bedb60ce172b \
+                        size    1178535 \
+                    golang.org/x/crypto \
+                        lock    123391ffb6de \
+                        rmd160  4afdc76f139facd878c228d85dee3698de13f793 \
+                        sha256  1b8f464f2d4faca0ac6ac7eac18b2b1118c1ac9ff8f6b7ffc976fb0ebedc520f \
+                        size    1732579 \
+                    github.com/vitrun/qart \
+                        lock    bf64b92db6b0 \
+                        rmd160  50ea47d1b1d0b60138845f21d57cad0ac7e5e632 \
+                        sha256  58579d35e03703699b3ea56a096b665739a77b462ac18a29102c7c776e48d279 \
+                        size    23968 \
+                    github.com/urfave/cli \
+                        lock    v1.22.2 \
+                        rmd160  746f9142b63e5e1483cba880f2f953a4b04ababc \
+                        sha256  ed8049ce905c5267524ce3208d113bf162e5c53ea4a05d2bb1427fd41b729041 \
+                        size    76137 \
+                    github.com/thejerf/suture \
+                        lock    v3.0.2 \
+                        rmd160  6df06f4bd54773997535e47b76a9a7345c9e7b6c \
+                        sha256  d6d7aeebed3a2e404e0f8ca062ea79ea8be60357eb8336fe907cff8952ce36f2 \
+                        size    18049 \
+                    github.com/syndtr/goleveldb \
+                        lock    d9e9293bd0f7 \
+                        rmd160  1c363aa498b3fae0918bf839dcaa673193080f50 \
+                        sha256  9fb936ce779314cfa755bd208b8a5ba7e4f41c23bd7a1d61bda6facb5d13052b \
+                        size    151087 \
+                    github.com/syncthing/notify \
+                        lock    69c7a957d3e2 \
+                        rmd160  3d333cd938237b648d477739c0b6463ef9a81df0 \
+                        sha256  ab539bdfb1e08ed2f5a73909ca7e6c28448d733640566d61a6f3e9e9ccf27177 \
+                        size    57118 \
+                    github.com/stretchr/testify \
+                        lock    v1.5.1 \
+                        rmd160  db9d43c3c804950ce9650d830f7dea5434ed83c1 \
+                        sha256  e5f566d1c23fb2b987f8a9f139e32866c1eea8c72051da25bbf6880a4f8c541a \
+                        size    78702 \
+                    github.com/spaolacci/murmur3 \
+                        lock    v1.1.0 \
+                        rmd160  53215abb0d59b6c64e926e90fb33da1906a1a525 \
+                        sha256  54d6a3300600dd2f5e444f6d19fe1f91e1174329cdfff1d50dae837689214a68 \
+                        size    7396 \
+                    github.com/sirupsen/logrus \
+                        lock    v1.4.2 \
+                        rmd160  9245d7ebabf259e649892609e598a2284e89e499 \
+                        sha256  c3eaf49a2a03ce42b20b5db84771a7d447465475bf083f289ecee631063e6090 \
+                        size    41379 \
+                    github.com/shurcooL/sanitized_anchor_name \
+                        lock    v1.0.0 \
+                        rmd160  c7e5322dba53e10db1711d65c146af5649b0c7c8 \
+                        sha256  ed9418de8c92acfbbd8608745855ebfc67fa686c0a0a5245cf8eece8f540baa9 \
+                        size    2144 \
+                    github.com/shirou/gopsutil \
+                        lock    v2.20.7 \
+                        rmd160  6d8f6cdc07b3688a8fdcb4fb3a7947330d279132 \
+                        sha256  fb92f1357babf7b5ac07ed48740cc840917bbfe31b85f620669f9b648f86d1ba \
+                        size    139662 \
+                    github.com/sasha-s/go-deadlock \
+                        lock    v0.2.0 \
+                        rmd160  e9a7e7a4994c375c6fbf1a2773e37e1cd3bf2325 \
+                        sha256  5ff9df5b6d65603320a4839fe4ba24ce00284291032f035f17c2ea9ce3fe8676 \
+                        size    9959 \
+                    github.com/russross/blackfriday \
+                        lock    v2.0.1 \
+                        rmd160  99cb49faff9bf24b8637dcdb3602c27c115810f3 \
+                        sha256  4078d2cd3b1c6952133b214e4eaca95f3b31a01f87a03adabd7712e7d5f20f60 \
+                        size    79665 \
+                    github.com/rcrowley/go-metrics \
+                        lock    cac0b30c2563 \
+                        rmd160  10f565254cbcee6a0288d19fcda77964c6cc9689 \
+                        sha256  bd5e5564f6ef65bd7ac946d97cae11ac1b55071bc58109fdc1053a65d3cef544 \
+                        size    37564 \
+                    github.com/prometheus/procfs \
+                        lock    v0.0.5 \
+                        rmd160  dde8f0bc104aeac6655947850ec8e8a05a9a9d12 \
+                        sha256  9c445cfa36a01b144eff139afd88dd3c199d54e91d5ae7de6ece0f57b464eebd \
+                        size    112195 \
+                    github.com/prometheus/common \
+                        lock    v0.7.0 \
+                        rmd160  71589422d9f6d26d1d28e631322077e19818e554 \
+                        sha256  95baf93244a8160dffe12d220a06c54bf209f7cf0bf1196c686623f3da570fed \
+                        size    100513 \
+                    github.com/prometheus/client_model \
+                        lock    14fe0d1b01d4 \
+                        rmd160  bae29b48506431235790421af9f1e0dcbd36baad \
+                        sha256  94563daff6cc4a700ce53e69039fd11a9ddcf35da6ae1048a0d99268d63327ae \
+                        size    57496 \
+                    github.com/prometheus/client_golang \
+                        lock    v1.2.1 \
+                        rmd160  fba18019de66807a9a4a9381f69eb2e7097a0ad0 \
+                        sha256  0bbb4b4c3e907fbcf9475b5ca957fd165e24fd5378751c121a00ea4e6a4da7ca \
+                        size    142483 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/pkg/errors \
+                        lock    v0.9.1 \
+                        rmd160  dc065c655f8a24c6519b58f9d1202eb266ecda40 \
+                        sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
+                        size    13422 \
+                    github.com/petermattis/goid \
+                        lock    b0b1615b78e5 \
+                        rmd160  67d260bb5f1a1a99879d0d009f7f0e9e2d872584 \
+                        sha256  edff5d2606e098d2418c09b2d9f24ddeb840f1eb22920a8b7e8da2ff39b23d9d \
+                        size    6817 \
+                    github.com/oschwald/maxminddb-golang \
+                        lock    v1.6.0 \
+                        rmd160  86c6ca33cd6ac16da7a566946f54a86e140b70b1 \
+                        sha256  8c265096a73a04ece9153ac0138074b0bd40b927e0d32e3b80deadba81c9010d \
+                        size    21377 \
+                    github.com/oschwald/geoip2-golang \
+                        lock    v1.4.0 \
+                        rmd160  fc325eebed54d5c7c5f7945b8447d807536f0f82 \
+                        sha256  0f702ef1efa02abd2a70a5fbd33353338c7f67acaaafea707a162ec30ddb5d0b \
+                        size    7750 \
+                    github.com/onsi/gomega \
+                        lock    v1.10.1 \
+                        rmd160  fbdb25ab0da7cc358134327f3bf7390aae2a9e7f \
+                        sha256  f5d901f5a7321a7ed7317d1ae305bb27b7c3febc3cede1c887e2d76a8e995da6 \
+                        size    97315 \
+                    github.com/onsi/ginkgo \
+                        lock    v1.14.0 \
+                        rmd160  a1ff8b445c4b593fc8c399993c90f8ff423260fa \
+                        sha256  5aec86ace19613b3976cdadf587d42461d47b89b9b02c5dabafa05a86f704fb2 \
+                        size    145828 \
+                    github.com/nxadm/tail \
+                        lock    v1.4.4 \
+                        rmd160  33d7373bd1b164159b9032fc8595bb09b25598f6 \
+                        sha256  16d8773e0be69469d3c296ee785bbef433c3442defb68760682cdbcf80ba40ee \
+                        size    1238830 \
+                    github.com/minio/sha256-simd \
+                        lock    v0.1.1 \
+                        rmd160  50654a6c3da3bcc426cb9189299e1d8d76f52a2b \
+                        sha256  ab49163b74a1b89c8ab795eda31cbf65af572fe3f87028cc1234bac2ae45706c \
+                        size    65042 \
+                    github.com/mgutz/ansi \
+                        lock    9520e82c474b \
+                        rmd160  fea73fc246ac2b229bb91accba053fed2ea63536 \
+                        sha256  75eaed501d7d121ad75c83246fecdc6222dbbbd3fcb4140c8775e219fff440ce \
+                        size    4878 \
+                    github.com/matttproud/golang_protobuf_extensions \
+                        lock    v1.0.1 \
+                        rmd160  e28c4169919e72c08ee6520ad2ce16943d18e40c \
+                        sha256  c40d4c38e7dc2a7bae57e3740bb28d463e173d82e4603622d04d01741ff7a083 \
+                        size    37197 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.12 \
+                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
+                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
+                        size    4549 \
+                    github.com/mattn/go-colorable \
+                        lock    v0.1.6 \
+                        rmd160  3c6531ff68909aacc83a16f92149722803b465a7 \
+                        sha256  3f3b5a79ae9511dd610d288768d782faffa27bf92ad1d6c8be3f37aa9d3bc975 \
+                        size    9477 \
+                    github.com/maruel/panicparse \
+                        lock    v1.5.1 \
+                        rmd160  c8ea9da4d1a8fe96cefd2ca3b5ded74bad7b89e3 \
+                        sha256  903a5fd94d31df7ec39c3482926ff69182e0fd9ae5891850d7fb26570eb73f41 \
+                        size    1219072 \
                     github.com/marten-seemann/qtls-go1-15 \
                         lock    v0.1.0 \
                         rmd160  d14038cf74ece3ff410b88f61a21c818e8b1e8aa \
@@ -387,113 +254,246 @@ go.vendors          github.com/alecthomas/template \
                         rmd160  560c030e5cd2045dc65345b67ce0257ec709ac65 \
                         sha256  9db255f013988eee87447b47a3510b56cfb3e0acb1e4f0af13215b971a82f6b4 \
                         size    403908 \
-                    github.com/prometheus/client_model \
-                        lock    14fe0d1b01d4 \
-                        rmd160  bae29b48506431235790421af9f1e0dcbd36baad \
-                        sha256  94563daff6cc4a700ce53e69039fd11a9ddcf35da6ae1048a0d99268d63327ae \
-                        size    57496 \
-                    github.com/rcrowley/go-metrics \
-                        lock    cac0b30c2563 \
-                        rmd160  10f565254cbcee6a0288d19fcda77964c6cc9689 \
-                        sha256  bd5e5564f6ef65bd7ac946d97cae11ac1b55071bc58109fdc1053a65d3cef544 \
-                        size    37564 \
-                    github.com/flynn-archive/go-shlex \
-                        lock    3f9db97f8568 \
-                        rmd160  ec42eaffe2cf17a46e12c7c2a7d436c0f68ba655 \
-                        sha256  b4205ec400df652238f7ed287c4b77b5f17a17d5793cd5371b7cc5e0f07dfeed \
-                        size    7690 \
-                    github.com/nxadm/tail \
-                        lock    v1.4.4 \
-                        rmd160  33d7373bd1b164159b9032fc8595bb09b25598f6 \
-                        sha256  16d8773e0be69469d3c296ee785bbef433c3442defb68760682cdbcf80ba40ee \
-                        size    1238830 \
-                    google.golang.org/protobuf \
-                        repo    github.com/protocolbuffers/protobuf-go \
-                        lock    v1.25.0 \
-                        rmd160  ca1a78077118747c660917e50c4273d69b0f04ea \
-                        sha256  5bc3eb5d7160ab9ae45255d6b718c1cf9e9ed80c244b7527bced50370ae18620 \
-                        size    1259096 \
-                    gopkg.in/check.v1 \
-                        lock    41f04d3bba15 \
-                        rmd160  1e5543a8e6a3159296ee63e28cbde9931a04f6b3 \
-                        sha256  c41575a73d10809f89b05ef9e783f2d53facdc6573697770d30efb05a9d2dc28 \
-                        size    31612 \
-                    gopkg.in/fsnotify.v1 \
-                        repo    github.com/fsnotify/fsnotify \
-                        lock    v1.4.7 \
-                        rmd160  24712e412814020224e2779186e634610e2f6926 \
-                        sha256  bc839ee158ad34b81c1f11c3b9e3bcbabfba3297f61d165599880c400b8171dc \
-                        size    31147 \
-                    github.com/dustin/go-humanize \
-                        lock    v1.0.0 \
-                        rmd160  e8641035159ea3e8839ee086f01f966443956303 \
-                        sha256  e45e3181c07b3e2dad8e1317e91a5bbbee4845067e3e3879a585a5254bc6a334 \
-                        size    17273 \
+                    github.com/lucas-clemente/quic-go \
+                        lock    v0.18.0 \
+                        rmd160  bd251272351789e63b94f6fb406261445df01fec \
+                        sha256  d4c438d4a23aaaa530b4a34e1106f77409133f5c14b8dc81aa5f98fc1e13b06c \
+                        size    488513 \
                     github.com/lib/pq \
                         lock    v1.2.0 \
                         rmd160  603d1ccb9fa23ba97f9c07922270270101dec935 \
                         sha256  05784d4f62cfa2c79416a62fcd3a854b3d6b8cef690119fd9c091300ccb92190 \
                         size    96102 \
-                    github.com/sasha-s/go-deadlock \
-                        lock    v0.2.0 \
-                        rmd160  e9a7e7a4994c375c6fbf1a2773e37e1cd3bf2325 \
-                        sha256  5ff9df5b6d65603320a4839fe4ba24ce00284291032f035f17c2ea9ce3fe8676 \
-                        size    9959 \
-                    github.com/sirupsen/logrus \
-                        lock    v1.4.2 \
-                        rmd160  9245d7ebabf259e649892609e598a2284e89e499 \
-                        sha256  c3eaf49a2a03ce42b20b5db84771a7d447465475bf083f289ecee631063e6090 \
-                        size    41379 \
-                    github.com/minio/sha256-simd \
-                        lock    v0.1.1 \
-                        rmd160  50654a6c3da3bcc426cb9189299e1d8d76f52a2b \
-                        sha256  ab49163b74a1b89c8ab795eda31cbf65af572fe3f87028cc1234bac2ae45706c \
-                        size    65042 \
-                    github.com/prometheus/client_golang \
-                        lock    v1.2.1 \
-                        rmd160  fba18019de66807a9a4a9381f69eb2e7097a0ad0 \
-                        sha256  0bbb4b4c3e907fbcf9475b5ca957fd165e24fd5378751c121a00ea4e6a4da7ca \
-                        size    142483 \
-                    github.com/russross/blackfriday \
-                        lock    v2.0.1 \
-                        rmd160  99cb49faff9bf24b8637dcdb3602c27c115810f3 \
-                        sha256  4078d2cd3b1c6952133b214e4eaca95f3b31a01f87a03adabd7712e7d5f20f60 \
-                        size    79665 \
-                    github.com/syncthing/notify \
-                        lock    69c7a957d3e2 \
-                        rmd160  3d333cd938237b648d477739c0b6463ef9a81df0 \
-                        sha256  ab539bdfb1e08ed2f5a73909ca7e6c28448d733640566d61a6f3e9e9ccf27177 \
-                        size    57118 \
-                    golang.org/x/sys \
-                        lock    d785dc25833f \
-                        rmd160  cc1d9b4388fbeef9d7a6b548f467985f73470d5a \
-                        sha256  36cf79162a1237f2aba93f61b31fbaf717407ac9b32932e3376a84c0bd002402 \
-                        size    1060875 \
-                    github.com/bkaradzic/go-lz4 \
-                        lock    7224d8d8f27e \
-                        rmd160  3cc78bfe1511e3b5446655a45ab2bc848ccce774 \
-                        sha256  9611c4bc0faa98fab24039c98d8e6a4a6cc9160b2586d4f0cbfe83350e63c978 \
-                        size    232979 \
-                    github.com/hpcloud/tail \
-                        lock    v1.0.0 \
-                        rmd160  2c6daf876a9a3ff47d239f3485810799ae9ced66 \
-                        sha256  aa9d7b729c8ee8b00c1a755ade77024e6b3ec4ac88585a39e31882260249f86b \
-                        size    37817 \
                     github.com/kr/text \
                         lock    v0.1.0 \
                         rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
                         sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
                         size    8691 \
-                    github.com/urfave/cli \
-                        lock    v1.22.2 \
-                        rmd160  746f9142b63e5e1483cba880f2f953a4b04ababc \
-                        sha256  ed8049ce905c5267524ce3208d113bf162e5c53ea4a05d2bb1427fd41b729041 \
-                        size    76137 \
-                    github.com/spaolacci/murmur3 \
+                    github.com/kr/pretty \
+                        lock    v0.2.0 \
+                        rmd160  45bbf0be7a3328e33186718ab12cb506c0f5a073 \
+                        sha256  35fb1f8788552fc7df2120bc06dd34e00aa3284d23c250fc1f143eef51d08586 \
+                        size    8762 \
+                    github.com/kballard/go-shellquote \
+                        lock    95032a82bc51 \
+                        rmd160  40415cd59ece9fb38b22170feec07f1f48d518a2 \
+                        sha256  41aa42696f96fb2783c5135d71ff1ec5938dfe178b51eb703e509c8ac0e7db4e \
+                        size    4335 \
+                    github.com/jackpal/go-nat-pmp \
+                        lock    v1.0.2 \
+                        rmd160  84452f7d2cccdff571def7177bc180051eaba388 \
+                        sha256  7c43c94b1194bb43b497ab4e480403403c34076d87715915abb9502120e192ee \
+                        size    4783 \
+                    github.com/jackpal/gateway \
+                        lock    v1.0.6 \
+                        rmd160  3b78ee895c6d3d02bbc65ad2ed24aee73020815f \
+                        sha256  9ccb9f16909c0a992b2b0f319937d73778c7b97eae57fd6a0a1aa0faf0b11d41 \
+                        size    4907 \
+                    github.com/hpcloud/tail \
+                        lock    v1.0.0 \
+                        rmd160  2c6daf876a9a3ff47d239f3485810799ae9ced66 \
+                        sha256  aa9d7b729c8ee8b00c1a755ade77024e6b3ec4ac88585a39e31882260249f86b \
+                        size    37817 \
+                    github.com/greatroar/blobloom \
+                        lock    v0.3.0 \
+                        rmd160  262052aca34896ab979450dea9b031507c137c26 \
+                        sha256  437df85c0084c2377e4ccf85571dcd3a9db782a28549bf3347f0217b9a3b70fd \
+                        size    18782 \
+                    github.com/google/go-cmp \
+                        lock    v0.5.0 \
+                        rmd160  f28cfe463c2aa119f5ea32b5373cdc06e606c3fd \
+                        sha256  4c228ad175fb924cd4c5ab08b281685f636ae28439e5508b3946964919b9c746 \
+                        size    98601 \
+                    github.com/golang/snappy \
+                        lock    v0.0.1 \
+                        rmd160  a10055b1a93ad290e600742c23156dbd55afe046 \
+                        sha256  5ca0dcca007398f298a6386af5d4696faba962b6a625e3aa3961d212078722b8 \
+                        size    62627 \
+                    github.com/golang/protobuf \
+                        lock    v1.4.2 \
+                        rmd160  fbf4477bc008421fde463d79f7bc54a36de91db2 \
+                        sha256  206d74f8fd066bb178135ee9c092e986f8a1e1104df242e148e99e5a839e4ef2 \
+                        size    171802 \
+                    github.com/golang/mock \
+                        lock    v1.4.4 \
+                        rmd160  ad4c6bd70c06881810d56fbd5d4b4ddfb701fae0 \
+                        sha256  921ea11f2a10c4f6225fd3057893a5ee8c5d9b2ca17cb8f9de3a361a0f3899a1 \
+                        size    55151 \
+                    github.com/golang/groupcache \
+                        lock    611e8accdfc9 \
+                        rmd160  0813af0565e417ffd221180933222428aa940066 \
+                        sha256  3ba7b454c29e691d7ebe2f786cac2c6c033a0f80ea2508de04079b4ceee91115 \
+                        size    26080 \
+                    github.com/gogo/protobuf \
+                        lock    v1.3.1 \
+                        rmd160  16be6b4d8879c774e3b9d9fc29d80cf770632f88 \
+                        sha256  393dda8c157457ce1b3d4003f9012b25528c76b1492d7ba52c9bd7b66c901c13 \
+                        size    2038446 \
+                    github.com/gobwas/glob \
+                        lock    v0.2.3 \
+                        rmd160  1f472cf991498a8091446eb788fe85e0c5403185 \
+                        sha256  2de3694ee0ff41a96b66f9aa3eec51048e620cdd09acc8685f18c3abcd6e14ae \
+                        size    25971 \
+                    github.com/go-ole/go-ole \
+                        lock    v1.2.4 \
+                        rmd160  ff816f1835d4311c60fbed68b0d01838c4265bb6 \
+                        sha256  55590e7d9e56e30094fd487a2dcf4926aa4bb82471f21f33131b606a6ce41294 \
+                        size    51683 \
+                    github.com/go-ldap/ldap \
+                        lock    v3.2.0 \
+                        rmd160  39575e75210aba969b80d24ee41611ca9298bdbd \
+                        sha256  4b701003dc5fb1b4b71d7a50077b95685eb3f799ee178d5bc1b4786a2a5c9e4e \
+                        size    82016 \
+                    github.com/go-asn1-ber/asn1-ber \
+                        lock    v1.5.0 \
+                        rmd160  81e1503e5f18e3a561081732342f24442235cd53 \
+                        sha256  f7d61845a090c672b0475794abdd673a47b85ae35c71b1ebff12716783725df6 \
+                        size    16311 \
+                    github.com/getsentry/raven-go \
+                        lock    v0.2.0 \
+                        rmd160  c564a8e9061642f60d401b6ab5b26961feec3212 \
+                        sha256  690d7813db5510d0dc739335dc950519c6664cc47ce49029e9c817f4a0c896c1 \
+                        size    19245 \
+                    github.com/fsnotify/fsnotify \
+                        lock    v1.4.9 \
+                        rmd160  4660b5721da8aea4c890786e49d7cec39c2e04d3 \
+                        sha256  7920cf1e5ccf268962fcff0b501398ed6c28ed75b1e1281fb17b19a8b0e4db5c \
+                        size    31910 \
+                    github.com/francoispqt/gojay \
+                        lock    v1.2.13 \
+                        rmd160  c63b7b72b4a191e72379dd00bc1aee8881a9d28d \
+                        sha256  43123a9b651b186da391e56cf9e644d990a5a48f686b629515c458320684f9f4 \
+                        size    165274 \
+                    github.com/flynn-archive/go-shlex \
+                        lock    3f9db97f8568 \
+                        rmd160  ec42eaffe2cf17a46e12c7c2a7d436c0f68ba655 \
+                        sha256  b4205ec400df652238f7ed287c4b77b5f17a17d5793cd5371b7cc5e0f07dfeed \
+                        size    7690 \
+                    github.com/dustin/go-humanize \
+                        lock    v1.0.0 \
+                        rmd160  e8641035159ea3e8839ee086f01f966443956303 \
+                        sha256  e45e3181c07b3e2dad8e1317e91a5bbbee4845067e3e3879a585a5254bc6a334 \
+                        size    17273 \
+                    github.com/dgryski/go-farm \
+                        lock    6a90982ecee2 \
+                        rmd160  a9f7f2372bd4bce849b55eef441e43b9a09330b0 \
+                        sha256  e90d46f1d9f70d28d20e4791aad8c2dbe7900d65bf42140018c443b3480eef72 \
+                        size    26795 \
+                    github.com/dgraph-io/ristretto \
+                        lock    8f368f2f2ab3 \
+                        rmd160  f99c7fbe446e02237d2c373cb6c9047ed624a526 \
+                        sha256  96eb4b33abfe0194bb1f813cdb7c4961ab583f8ea47560555071bf1ffc525d99 \
+                        size    39675 \
+                    github.com/dgraph-io/badger \
+                        lock    v2.0.3 \
+                        rmd160  fa3b561afae5c30f56812b5dd105857ca47f1400 \
+                        sha256  39507b49d5f0bc50c10dcdc4234a8c4226dbffeb773ede26dcf20f39b87c5f2b \
+                        size    332700 \
+                    github.com/dchest/siphash \
+                        lock    v1.2.1 \
+                        rmd160  78de0b3517652f62068fe6c49c3e140bb4d782df \
+                        sha256  47c06d2961752a3efc4348917af06da4296f52989a62e061385be0c7a8d6026a \
+                        size    10729 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/d4l3k/messagediff \
+                        lock    v1.2.1 \
+                        rmd160  3fe15fd5cf431ac2b6e6efb0a96de2bbe49af65a \
+                        sha256  da946f9c267dc73f01fb14126655c6f5dfe16b84ee91a1e0646f0d88a140cc8d \
+                        size    8066 \
+                    github.com/cpuguy83/go-md2man \
+                        lock    f79a8a8ca69d \
+                        rmd160  85f342c341fa928e9ec874490c277bdabf1c39c6 \
+                        sha256  2f3f8bc701df4890a5a4baf0b632ad3290be1e0aaf572b2e58fd57df93efc306 \
+                        size    52040 \
+                    github.com/chmduquesne/rollinghash \
+                        lock    a60f8e7142b5 \
+                        rmd160  e84dbc6401f822d165bef6c9e158e5676931c739 \
+                        sha256  5301b74a18c8113ec61267dc3e2301d18f5d44b1c40c6bd68f8207bcaa987a79 \
+                        size    22396 \
+                    github.com/cheekybits/genny \
+                        lock    v1.0.0 \
+                        rmd160  c8f3f5af635b83ade08f9f8e08e7f2018cb5879c \
+                        sha256  528d149522e053aed14048608751da8ace5b44466038b1a8d47d04a050d81bdc \
+                        size    15585 \
+                    github.com/cespare/xxhash \
+                        lock    v2.1.0 \
+                        rmd160  55292dc23361fe89ea9f4e462e76d840ea797d80 \
+                        sha256  120da378ec373d6f6b71334b97bcbbefcee25408901f8e9d3482eb393ae81432 \
+                        size    9210 \
+                    github.com/certifi/gocertifi \
+                        lock    a5e0173ced67 \
+                        rmd160  c3d3a5e8a98af89f87f2aea27333dae1bd4b5e81 \
+                        sha256  8b8fd5735cb54e113ea0f42091e0baee170cc0a6917cdb95e6068dbf238109b8 \
+                        size    155587 \
+                    github.com/ccding/go-stun \
+                        lock    be486d185f3d \
+                        rmd160  98cfa81baa5fb412774e521155dfa5302467a854 \
+                        sha256  aca68ddc25cb11f3ccf988062168295e6acd513295c9e151d3211c4c169bdf11 \
+                        size    14125 \
+                    github.com/calmh/xdr \
                         lock    v1.1.0 \
-                        rmd160  53215abb0d59b6c64e926e90fb33da1906a1a525 \
-                        sha256  54d6a3300600dd2f5e444f6d19fe1f91e1174329cdfff1d50dae837689214a68 \
-                        size    7396
+                        rmd160  944babe70dbef7a20b2db97dfe6bd892f8953ca9 \
+                        sha256  f5a1704fe7db6d3fadf487e4a25b49f70dc2b0d151e78be79511baa2e82e86a0 \
+                        size    10539 \
+                    github.com/bradfitz/go-smtpd \
+                        lock    deb6d6237625 \
+                        rmd160  ca7b85badf898d1dff04117538ca5937a7f623a1 \
+                        sha256  c8960be926f13469edb5cd45c0fb13baded4e5452ca4948b505d41d2f8f620cf \
+                        size    4696 \
+                    github.com/bkaradzic/go-lz4 \
+                        lock    7224d8d8f27e \
+                        rmd160  3cc78bfe1511e3b5446655a45ab2bc848ccce774 \
+                        sha256  9611c4bc0faa98fab24039c98d8e6a4a6cc9160b2586d4f0cbfe83350e63c978 \
+                        size    232979 \
+                    github.com/beorn7/perks \
+                        lock    v1.0.1 \
+                        rmd160  c6c5c7fd2132f01925c7fccd9d27c9d7a80f2adb \
+                        sha256  78da4421e9f9fa2ee5e3855bdd31cfb04c7e823d9c0ec385cc2c008132d98b96 \
+                        size    10874 \
+                    github.com/alecthomas/units \
+                        lock    c3de453c63f4 \
+                        rmd160  5008bfe6af9cfe334d62399db00901ea6a6c1814 \
+                        sha256  c6a733d020cca4f93b44c8a22eb68a90fb38916b4818a9bb569c65ed9322b3f2 \
+                        size    3497 \
+                    github.com/alecthomas/template \
+                        lock    fb15b899a751 \
+                        rmd160  34faebabc9eeabdf4e3efc70015e1f858ad787cf \
+                        sha256  7bdd81cd04955c4251637e7196751a4626ae822382b9cbb33ea53eb5f8ce00e5 \
+                        size    55322 \
+                    github.com/StackExchange/wmi \
+                        lock    cbe66965904d \
+                        rmd160  1c28ff3f595532ab67c85f5232c9228cf97d65d9 \
+                        sha256  01b78146552b0c7d6126b64cdf4f7c40fe1e1e15a9f822d4a1bc6db5df1f48ca \
+                        size    11289 \
+                    github.com/OneOfOne/xxhash \
+                        lock    v1.2.2 \
+                        rmd160  35e2c7b623c069fc08aec00990ca5c82ad831a22 \
+                        sha256  e6a73b9f6acc9b361ea77edcb6f29103e96ac0c623c6d2882909698180e54694 \
+                        size    13444 \
+                    github.com/DataDog/zstd \
+                        lock    v1.4.1 \
+                        rmd160  86c75e5feafd8e615a7eea3b97680c0543a95380 \
+                        sha256  f62a03934f91b063545ce33c40526d33d52fb07dbfbced5dd5b531295b37af4c \
+                        size    498943 \
+                    github.com/Azure/go-ntlmssp \
+                        lock    66371956d46c \
+                        rmd160  74dcc3f7e70c2dbdf032390bd8734e0fc514ce65 \
+                        sha256  0ff7e70a3c8a7b828f007c296d4152b334eaf79715122a5e9bf19f404c901044 \
+                        size    8130 \
+                    github.com/AudriusButkevicius/recli \
+                        lock    v0.0.5 \
+                        rmd160  1596db1035aafd77ffa11ed3373f9382ada081e2 \
+                        sha256  6ead3d46eebdc505730eeeb67f1f51db8f5685a289a21bb8652ded419e98355c \
+                        size    12375 \
+                    github.com/AudriusButkevicius/pfilter \
+                        lock    c55ef6137fc6 \
+                        rmd160  f4a19907214e15e2460a0279c02950a5d21dc1c4 \
+                        sha256  bd4daa7fdd0212753aefbef8818eedb38bbec97b43a3e5465a1891b5f0deb5cc \
+                        size    3244
 
 build.cmd           ${go.bin} run build.go
 build.target        install syncthing


### PR DESCRIPTION
#### Description

Updates syncthing to 1.11.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0.1 20B5022a
Xcode 12.2 12B5044c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
