### PR TITLE
py-humanfriendly: update to 8.2, add python 38 and 39

### DIFF
--- a/python/py-humanfriendly/Portfile
+++ b/python/py-humanfriendly/Portfile
@@ -4,10 +4,10 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-humanfriendly
-version             4.18
-checksums           rmd160  3f94abf1bb0ea8748bd874ed1c19454d9f89fdf7 \
-                    sha256  33ee8ceb63f1db61cce8b5c800c531e1a61023ac5488ccde2ba574a85be00a85 \
-                    size    345853
+version             8.2
+checksums           rmd160  ff93f58bfa41e5a1e9ccf588771c6b249f681dd7 \
+                    sha256  bf52ec91244819c780341a3438d5d7b09f431d3f113a475147ac9b7b167a3d12 \
+                    size    358747
 
 categories-append   devel
 platforms           darwin
@@ -16,16 +16,14 @@ maintainers         {ijackson @JacksonIsaac} openmaintainer
 supported_archs     noarch
 
 description         Human friendly output for text interfaces using Python
-long_description    ${description}
+long_description    {*}${description}
 homepage            https://humanfriendly.readthedocs.io/
 
-master_sites        pypi:h/${python.rootname}
-distname            ${python.rootname}-${version}
-
-python.versions     36 37
+python.versions     36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_lib-append  \
         port:py${python.version}-setuptools
     livecheck.type  none
+    notes-append "The CLI tool can be used by running humanfriendly-${python.branch}"
 }


### PR DESCRIPTION
#### Description

Also added a note about how to access the CLI tool

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.6 19G73
xcode-select version 2373

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
