### PR TITLE
promu: update to 0.7.0

### DIFF
--- a/devel/promu/Portfile
+++ b/devel/promu/Portfile
@@ -1,9 +1,9 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
+PortGroup           golang 1.0
 
-github.setup        prometheus promu 0.6.0 v
+go.setup            github.com/prometheus/promu 0.7.0 v
 
 platforms           darwin
 categories          devel
@@ -18,28 +18,191 @@ description         The Prometheus Utility Tool
 long_description    A utility tool for building and releasing Prometheus \
                     projects.
 
-fetch.type          git
+depends_build-append \
+                    port:golangci-lint
 
-depends_build       port:golangci-lint \
-                    port:go
-
-use_configure       no
 use_parallel_build  no
 
-switch ${build_arch} {
-    i386    { set goarch 386 }
-    x86_64  { set goarch amd64 }
-    default { set goarch {} }
-}
-
-build.env           GOPATH=${workpath} GOOS=${os.platform} GOARCH=${goarch}
-build.target        build
+build.cmd           make
+build.pre_args      GO111MODULE=off
+build.args          build
 
 post-extract {
-    file mkdir ${workpath}/bin
-    ln -s ${prefix}/bin/golangci-lint ${workpath}/bin/
+    # The promu makefile builds promu in two phases:
+    #
+    # 1. Build promu using the standard Go build process
+    # 2. Build promu again using promu
+    #
+    # For 1., we build with GO111MODULE=off to ensure deps are not downloaded
+    # at build time (they have already been fetched with go.vendors).
+    #
+    # For 2., promu itself will build using -mod=vendor, requesting that Go
+    # use dependencies vendored inside the source tree.  When doing this, Go
+    # requires that GO111MODULE be on.
+    #
+    # We modify the makefile to set GO111MODULE=on, but GOPROXY=off when
+    # invoking promu in phase 2.  GO111MODULE=on will allow the build to
+    # happen with -mod=vendor, but GOPROXY=off will ensure nothing will
+    # be downloaded, ensuring we use dependencies that have already been
+    # vendored into place by MacPorts.
+    reinplace \
+        "s|GO111MODULE=\$(GO111MODULE) \$(PROMU)|GO111MODULE=on GOPROXY=off \$(PROMU)|" \
+        ${worksrcpath}/Makefile
 }
 
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}
 }
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  34310d1bdca080f919ac354026ba3b8c1a9461b0 \
+                        sha256  3b72cd3c86026f5b0d864bfeb8136ce0d4339a6b86859bba73e1fde448794580 \
+                        size    1707109
+
+go.vendors          gopkg.in/yaml.v2 \
+                        lock    v2.3.0 \
+                        rmd160  2f8fa56d8a413b6288132eeb7f0d7c64d27d877f \
+                        sha256  a8d1a8bc88239d25507456380b47d59ae3683d4a5f4336da4892db1ce026615f \
+                        size    72838 \
+                    gopkg.in/check.v1 \
+                        lock    41f04d3bba15 \
+                        rmd160  1e5543a8e6a3159296ee63e28cbde9931a04f6b3 \
+                        sha256  c41575a73d10809f89b05ef9e783f2d53facdc6573697770d30efb05a9d2dc28 \
+                        size    31612 \
+                    gopkg.in/alecthomas/kingpin.v2 \
+                        lock    v2.2.6 \
+                        rmd160  af6db4648ec7638fb5cab49fd9536caa705f5fed \
+                        sha256  31378085783496cff78c7d41479ccd6206c4f4e3892909ef0c2cd39e2de3b039 \
+                        size    44374 \
+                    google.golang.org/protobuf \
+                        repo    github.com/protocolbuffers/protobuf-go \
+                        lock    v1.23.0 \
+                        rmd160  b9954ce9dc927216440d55f850073bbf47113143 \
+                        sha256  41a885f3290ce459bcd4251a6df0787ead449c835a718f8f46342cad1dc26b85 \
+                        size    1214926 \
+                    google.golang.org/appengine \
+                        repo    github.com/golang/appengine \
+                        lock    v1.4.0 \
+                        rmd160  89579aa4261e212522229aca528448582e93f3b8 \
+                        sha256  c970d1b6a96274796ed3c58c581b2064d3721f38caf9443b804735cb36dbcc9d \
+                        size    325795 \
+                    golang.org/x/xerrors \
+                        lock    9bdfabe68543 \
+                        rmd160  eee9929ac1c0380402c45b388077c5c505f13311 \
+                        sha256  dc1be1d7efb43643507e87352ae7161883c48cb5116a20a1739ab93ab558bccf \
+                        size    13661 \
+                    golang.org/x/sys \
+                        lock    ddb9806d33ae \
+                        rmd160  6a1cfca6d58d5319cf083131491a82e296103826 \
+                        sha256  a0421fb3e8d5b9987b6e37f73f06f05a275ba869aafd4bef02b0d9bab4daa7d9 \
+                        size    1054767 \
+                    golang.org/x/oauth2 \
+                        lock    bf48bf16ab8d \
+                        rmd160  c1d307776adc90ce1a323b0a6cacab759bf1671e \
+                        sha256  ff3e74cdfe9c0b13d9d8e6f04551460efc01ca58b2332ebeb6f93b6c09c789bc \
+                        size    47023 \
+                    golang.org/x/net \
+                        lock    4c5254603344 \
+                        rmd160  d3f4db29b17ff45805d136a43c0ede36f4008195 \
+                        sha256  41af8bea71fad512c681c00c6f28e47f71be911869eef06e4f8ee05e382a3dd9 \
+                        size    1177498 \
+                    github.com/stretchr/testify \
+                        lock    v1.4.0 \
+                        rmd160  86bd663e13ea7266334c47689074df16252db5ff \
+                        sha256  8ed95078bfd318ea477da509e6b16e6cf8d0d1b6b8d93b1f6097c6ba2a6df788 \
+                        size    110114 \
+                    github.com/prometheus/procfs \
+                        lock    v0.1.3 \
+                        rmd160  09c46345460bbb240bce03454125ec5f466f550f \
+                        sha256  c8ab80b697f68253d1c8bfdabc65c4b8e4c2f4e48259cee90603d6428f49a7b7 \
+                        size    156895 \
+                    github.com/prometheus/common \
+                        lock    v0.13.0 \
+                        rmd160  3ef67dfb3b94e7d4c54142b99c13735efe20159a \
+                        sha256  2b3b04ec09b9ac27e413fc102f9e7f52e8fefd5630ef073181f9b7f638b5d910 \
+                        size    124210 \
+                    github.com/prometheus/client_model \
+                        lock    v0.2.0 \
+                        rmd160  9b5b538e80eeb491b02806cc1cb87a83e62a9577 \
+                        sha256  55c1223bb5d1ae7e33527bc0ce80e3ab5153c47d396a9f864feea150b301f690 \
+                        size    10985 \
+                    github.com/prometheus/client_golang \
+                        lock    v1.7.1 \
+                        rmd160  5003390ec9cd00953f122368f82efa0738cae2b3 \
+                        sha256  19ad18a065f8a74b9632efa5f56356bd1fa5b33b6bb9a32e1aaae5b58aff63ea \
+                        size    160083 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/pkg/errors \
+                        lock    v0.9.1 \
+                        rmd160  dc065c655f8a24c6519b58f9d1202eb266ecda40 \
+                        sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
+                        size    13422 \
+                    github.com/matttproud/golang_protobuf_extensions \
+                        lock    v1.0.1 \
+                        rmd160  e28c4169919e72c08ee6520ad2ce16943d18e40c \
+                        sha256  c40d4c38e7dc2a7bae57e3740bb28d463e173d82e4603622d04d01741ff7a083 \
+                        size    37197 \
+                    github.com/kr/text \
+                        lock    v0.1.0 \
+                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
+                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
+                        size    8691 \
+                    github.com/kr/pretty \
+                        lock    v0.1.0 \
+                        rmd160  9aa7a5aad4c48840eecfd0f80186d1fb5ded0fd6 \
+                        sha256  f6c3f89667c63e5b7f1fc6ee2c06b6a6bfdce88f3a965ccd395b64c6f95c9a47 \
+                        size    8553 \
+                    github.com/google/go-querystring \
+                        lock    v1.0.0 \
+                        rmd160  48593728f6bf361fa168bdc87737ee30de24f34b \
+                        sha256  0add5428914c2a378cd9e6e120a4b1e84d69df504b983f99a86aea98a52c5a57 \
+                        size    7536 \
+                    github.com/google/go-github \
+                        lock    v25.1.3 \
+                        rmd160  2d9bf69726ada8a693544bee3f068489ed8bb8c6 \
+                        sha256  6e925c4f9750361052452176ecac9454e463846b5090813ce2652670bb25cd29 \
+                        size    231374 \
+                    github.com/google/go-cmp \
+                        lock    v0.4.0 \
+                        rmd160  2d73ccb9863b49adb03196aff7c41a7048e646fb \
+                        sha256  e7274fa6cc337c12123a02acc907524b7c3c234af59b2c924664300a57cb3ea0 \
+                        size    81597 \
+                    github.com/golang/protobuf \
+                        lock    v1.4.2 \
+                        rmd160  fbf4477bc008421fde463d79f7bc54a36de91db2 \
+                        sha256  206d74f8fd066bb178135ee9c092e986f8a1e1104df242e148e99e5a839e4ef2 \
+                        size    171802 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/cespare/xxhash \
+                        lock    v2.1.1 \
+                        rmd160  0c0da0840864215209db2afcd2ee92a52ca2d4d1 \
+                        sha256  7416baf9eeefe07e3c50c57826d839cdbba125ea0a6d74af378e865df4f25e00 \
+                        size    9300 \
+                    github.com/beorn7/perks \
+                        lock    v1.0.1 \
+                        rmd160  c6c5c7fd2132f01925c7fccd9d27c9d7a80f2adb \
+                        sha256  78da4421e9f9fa2ee5e3855bdd31cfb04c7e823d9c0ec385cc2c008132d98b96 \
+                        size    10874 \
+                    github.com/alecthomas/units \
+                        lock    f65c72e2690d \
+                        rmd160  b2e546a67c8fc98bcb78645cb7432db04a959b47 \
+                        sha256  d3cf74fc50db9c23dd095994a98712431a8e29c3fc34ac958073c5d548de94a7 \
+                        size    4925 \
+                    github.com/alecthomas/template \
+                        lock    fb15b899a751 \
+                        rmd160  34faebabc9eeabdf4e3efc70015e1f858ad787cf \
+                        sha256  7bdd81cd04955c4251637e7196751a4626ae822382b9cbb33ea53eb5f8ce00e5 \
+                        size    55322 \
+                    github.com/Masterminds/semver \
+                        lock    v1.5.0 \
+                        rmd160  362cf71258d78f9533f669fa2b346ad12fe8b101 \
+                        sha256  e391f4be56118fa384f9a36d3e1e8094effc11c7eaf74db3d997e15bc0eb1fe7 \
+                        size    21198


### PR DESCRIPTION
- use the golang portgroup
- vendor Go dependencies to prevent downloading them at build time
  See: https://trac.macports.org/ticket/61192

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
