### PR TITLE
mtools: Update to 4.0.25

### DIFF
--- a/sysutils/mtools/Portfile
+++ b/sysutils/mtools/Portfile
@@ -11,7 +11,7 @@ checksums           rmd160  402c11222ad1a235f682dd82ed70f2159e3457f9 \
                     size    373184
 
 categories          sysutils
-maintainers         goudal.net:francois
+maintainers         {ryandesign @ryandesign} openmaintainer
 license             GPL-3+
 description         MS-DOS disk access utilities
 long_description    Utilities to access MS-DOS disks from Unix without \

--- a/sysutils/mtools/Portfile
+++ b/sysutils/mtools/Portfile
@@ -4,8 +4,12 @@ PortSystem          1.0
 
 name                mtools
 conflicts           multimarkdown
-version             4.0.24
-revision            1
+version             4.0.25
+revision            0
+checksums           rmd160  402c11222ad1a235f682dd82ed70f2159e3457f9 \
+                    sha256  788dde7f9175a2bcca0c5e4e91e74deb67a1c7e9fb07ea486d074e943c130a20 \
+                    size    373184
+
 categories          sysutils
 maintainers         goudal.net:francois
 license             GPL-3+
@@ -14,14 +18,15 @@ long_description    Utilities to access MS-DOS disks from Unix without \
                     mounting them
 homepage            https://www.gnu.org/software/mtools
 platforms           darwin
+
 master_sites        gnu:mtools
-checksums           rmd160  98c592c5e00c515d9a79e72ea5005970fd95ed63 \
-                    sha256  3483bdf233e77d0cf060de31df8e9f624c4bf26bd8a38ef22e06ca799d60c74e \
-                    size    520902
+use_lzip            yes
+
 depends_lib         port:libiconv
-configure.args      --mandir=${prefix}/share/man \
-                    --infodir=${prefix}/share/info \
-                    --without-x
+
+patchfiles          implicit.patch
+
+configure.args      --without-x
 configure.ldflags-append    -Wl,-liconv
 
 variant x11 {

--- a/sysutils/mtools/files/implicit.patch
+++ b/sysutils/mtools/files/implicit.patch
@@ -1,0 +1,23 @@
+Fix:
+
+config.c:182:8: error: unknown type name 'locale_t'
+config.c:186:6: error: implicit declaration of function 'newlocale' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
+config.c:186:16: error: use of undeclared identifier 'LC_CTYPE_MASK'
+config.c:193:15: error: implicit declaration of function 'toupper_l' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
+config.c:205:12: error: implicit declaration of function 'strncasecmp_l' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
+
+Reported to developers:
+
+https://lists.gnu.org/archive/html/info-mtools/2020-11/msg00001.html
+
+Can hopefully be removed in a future version.
+--- sysincludes.h.orig	2018-12-09 17:28:55.000000000 -0600
++++ sysincludes.h	2020-11-09 03:06:14.000000000 -0600
+@@ -347,6 +347,7 @@
+ #ifdef HAVE_LOCALE_H
+ # include <locale.h>
+ #endif
++#include <xlocale.h>
+ 
+ #ifdef USE_FLOPPYD
+ 


### PR DESCRIPTION
#### Description

mtools: Update to 4.0.25

I've switched to the lzip-compressed distfile because it is smaller.

Added a patch to add a missing `#include` which I also reported to the developers.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14019
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

-----

**PLEASE USE THE SQUASH AND MERGE BUTTON AND REWORD THE COMMIT MESSAGE WHEN MERGING!!!**
