### PR TITLE
dog: new port

### DIFF
--- a/net/dog/Portfile
+++ b/net/dog/Portfile
@@ -1,0 +1,57 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        ogham dog 0.1.0 v
+revision            0
+
+homepage            https://dns.lookup.dog
+
+description         ${name} is a command-line DNS client
+
+long_description    Dogs can look up! dog is a command-line DNS client, \
+                    like dig. It has colourful output, understands normal \
+                    command-line argument syntax, supports the DNS-over-TLS \
+                    and DNS-over-HTTPS protocols, and can emit JSON.
+
+categories          net sysutils
+platforms           darwin
+supported_archs     x86_64
+license             MIT
+
+checksums           rmd160  712de148301083163d46a9849316c5adf99c8070 \
+                    sha256  97b749124e3bdcb1c3a97076a2fb3dee29dfc16a29c9f638bdae1060ad4e3d89 \
+                    size    271723
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+github.tarball_from releases
+distname            ${name}-v${version}-x86_64-apple-darwin
+use_zip             yes
+
+worksrcdir
+
+use_configure       no
+
+set dog_share_path  ${prefix}/share/dog
+set dog_comp_path   ${dog_share_path}/completions
+
+build {}
+
+destroot {
+    move ${workpath}/bin/dog ${destroot}${prefix}/bin/
+    
+    xinstall -d -m 0755 ${destroot}${dog_share_path}
+    xinstall -d -m 0755 ${destroot}${dog_comp_path}
+
+    foreach _shell {bash fish zsh} {
+        move ${workpath}/completions/dog.${_shell} \
+            ${destroot}${dog_comp_path}
+    }
+
+    move ${workpath}/man/dog.1 ${destroot}${prefix}/share/man/man1/
+}
+
+notes "Shell completions for ${name} can be found at: ${dog_comp_path}"


### PR DESCRIPTION
#### Description

New port for the [dog DNS utility](https://dns.lookup.dog/)

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
