### PR TITLE
nvm: update to 0.37.0

### DIFF
--- a/devel/nvm/Portfile
+++ b/devel/nvm/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        nvm-sh nvm 0.35.3 v
+github.setup        nvm-sh nvm 0.37.0 v
 
 categories          devel
 platforms           darwin
@@ -14,9 +14,9 @@ maintainers         {@FranklinYu hotmail.com:franklinyu} openmaintainer
 description         Node version manager
 long_description    NVM is a simple shell script to manage multiple active Node.js versions.
 
-checksums           rmd160  27abd02a040642b559e4686df56e4940b72c01c5 \
-                    sha256  151e4967cb80b9439698d3ec69b8a41bf52367580bc1a8d1ebb2dff43d8e978c \
-                    size    130537
+checksums           rmd160  761cafa8c3de26800b2fa5ff4760ddf90aa64b61 \
+                    sha256  e1926622d8f1d92c4e794223da9dadcd4a521ce2b76f6a16f010a7c5ef64273e \
+                    size    136272
 
 use_configure       no
 


### PR DESCRIPTION
#### Description

This is a version bump for Node Version Manager (nvm) from 0.35.3 to 0.37.0.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0.1 20B5022a
Xcode 12.2 12B5044c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
