### PR TITLE
google-cloud-sdk: update to 318.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             317.0.0
+version             318.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  eed46208bf3fd731786c6c026ffb548c7c2ca927 \
-                    sha256  d86ad8f2e9b442d2fc6d9c0703b290023acb89dfd8a277ef3cf29032315d58a1 \
-                    size    85618121
+    checksums       rmd160  5aa2cdb39343cdfc8d8c0621c3c891ae3fd73de5 \
+                    sha256  bb17dca842fccc842aa853df104812b5fe6a9da83a5d712742c618ea7ccb4f57 \
+                    size    85700523
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  b391e64d9d858fe0381d3648b5c6f93369ad9243 \
-                    sha256  3873c60474754192371d4b7d801848d148da620640721c08b757644b47daab4c \
-                    size    86629132
+    checksums       rmd160  19291067120b6e7a78bcc9e06dd43682dc9083d7 \
+                    sha256  55d4dcb5e47a9aa7b4a46e6ea1f1f3108bbe898ff68ca4c80e355e7dadece608 \
+                    size    86713211
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 318.0.0.

###### Tested on

macOS 10.15.7 19H15
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?