### PR TITLE
gobject-introspection: add libtool library path tweaks to scanner

### DIFF
--- a/gnome/gobject-introspection/Portfile
+++ b/gnome/gobject-introspection/Portfile
@@ -5,7 +5,7 @@ PortGroup           active_variants 1.1
 
 name                gobject-introspection
 version             1.60.2
-revision            3
+revision            4
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          gnome
 platforms           darwin

--- a/gnome/gobject-introspection/files/patch-fix-scanner-in-build-execution.diff
+++ b/gnome/gobject-introspection/files/patch-fix-scanner-in-build-execution.diff
@@ -14,7 +14,7 @@
              args.append('-L.')
 --- giscanner/dumper.py.orig
 +++ giscanner/dumper.py
-@@ -236,8 +236,29 @@
+@@ -236,8 +236,28 @@
  
          args.extend(sources)
  
@@ -24,25 +24,24 @@
 +            self._packages, msvc_syntax=self._compiler.check_is_msvc())
 +        this_L = [lib[len('-L'):] for lib in pkg_config_libs_only_L]
 +
-+        # remove self._options.library_paths entries that are in
-+        # "this_L" already, since those are "system" and will be found
-+        # via the "runtime_path_envvar" setting below
-+        tmp_L = []
-+        for t_L in self._options.library_paths:
-+            if t_L not in this_L:
-+                tmp_L.append (t_L)
-+        self._options.library_paths = tmp_L
++        # uniquely merge pkg_config and options library paths
++        self._options.library_paths = list (set().union (self._options.library_paths,
++                                                         this_L))
++
++        # remove anything in LIBRARY_PATH
++        env_LIBRARY_PATH = os.environ['LIBRARY_PATH'].split(':') if \
++            'LIBRARY_PATH' in os.environ else []
++        self._options.library_paths = [l for l in self._options.library_paths
++                                           if l not in env_LIBRARY_PATH]
 +
 +        if os.name == 'nt':
 +            runtime_path_envvar = ['LIB', 'PATH']
 +        else:
 +            runtime_path_envvar = ['LIBRARY_PATH']
 +        for envvar in runtime_path_envvar:
-+            if envvar in os.environ:
-+                os.environ[envvar] = \
-+                    os.pathsep.join(this_L + [os.environ[envvar]])
-+            else:
-+                os.environ[envvar] = os.pathsep.join(this_L)
++            os.environ[envvar] = os.pathsep.join \
++                (list (set().union (os.environ[envvar].split(':'), this_L))) \
++                    if envvar in os.environ else os.pathsep.join(this_L)
  
          if not self._options.external_library:
              self._compiler.get_internal_link_flags(args,


### PR DESCRIPTION
#### Description

add libtool library path tweaks to giscanner from gobject-introspection

Hopefully the final tweaks, since they now handle both libtool and non-libtool library references, both in-build and outside-build.

Now works work: gobject-introspection, poppler, gstreamer1-gst-plugins-base, py38-gobject3, gexiv2, and libsoup

Ref: https://trac.macports.org/ticket/61427

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0.1 20B5012d
Xcode 12.2 12B5035g

will also test on macOS 10.15 latest once this PR is in place

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
