### PR TITLE
kubectl: fix for older systems

### DIFF
--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem              1.0
 PortGroup               select 1.0
+PortGroup               legacysupport 1.1
 
 name                    kubectl
 categories              sysutils
@@ -151,6 +152,14 @@ if {${subport} == ${name}} {
     destroot {
         xinstall ${distpath}/kubectl \
             ${destroot}${prefix}/bin/kubectl${baseVersion}
+
+        # kubectl works on 10.10 and newer without legacysupport. standard
+        # legacysupport tweaks don't work, since the install here is from
+        # a binary tarball ... have to tweak the binary to use the legacy
+        # support library, which in turn uses the System.B library.
+        if {${os.major} <= 13} {
+            system -W ${destroot}${prefix}/bin "install_name_tool -change /usr/lib/libSystem.B.dylib ${prefix}/lib/libMacportsLegacySupport.dylib kubectl${baseVersion}"
+        }
 
         set completionsPath ${destroot}${prefix}/share/${subport}/completion
         xinstall -d ${completionsPath}


### PR DESCRIPTION
uses legacysupport to provide functions
missing on older system versions

closes: https://trac.macports.org/ticket/59599

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.7
Xcode 4.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
