### PR TITLE
py27-pandas: fix implicit function declaration

### DIFF
--- a/python/py-pandas/Portfile
+++ b/python/py-pandas/Portfile
@@ -27,11 +27,14 @@ checksums           rmd160  9a4be02e091abb6c15d92e90ad31f3a40f9012ae \
 if {${name} ne ${subport}} {
     if {${python.version} eq 27} {
         version             0.24.2
-        revision            0
+        revision            1
         distname            ${python.rootname}-${version}
         checksums           rmd160  a4b18e58b6be7bf13893dbccaf73542918dda1c8 \
                             sha256  4f919f409c433577a501e023943e582c57355d50a724c589e78bc1d551a535a2 \
                             size    11837693
+
+        # fix implicit declaration of tolower_ascii()
+        patchfiles-append   patch-a3c158dad2.diff
 
         depends_lib-append  port:py${python.version}-scipy \
                             port:py${python.version}-tables \

--- a/python/py-pandas/files/patch-a3c158dad2.diff
+++ b/python/py-pandas/files/patch-a3c158dad2.diff
@@ -1,0 +1,30 @@
+From a3c158dad214a60726cf1332021b083802ac59f9 Mon Sep 17 00:00:00 2001
+From: Vasily Litvinov <45396231+vnlitvin@users.noreply.github.com>
+Date: Fri, 22 Mar 2019 19:18:37 +0300
+Subject: [PATCH] Safe version of ascii macros, add missing tolower_ascii
+ (#25836)
+
+* Safer version of ascii macros in portable.h
+
+* Add missing tolower_ascii macro needed by lowercase() in parse_helper.h
+---
+ pandas/_libs/src/headers/portable.h | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/pandas/_libs/src/headers/portable.h b/pandas/_libs/src/headers/portable.h
+index 9ac4ebc306ba..1976addace3f 100644
+--- pandas/_libs/src/headers/portable.h
++++ pandas/_libs/src/headers/portable.h
+@@ -7,8 +7,9 @@
+ 
+ // GH-23516 - works around locale perf issues
+ // from MUSL libc, MIT Licensed - see LICENSES
+-#define isdigit_ascii(c) ((unsigned)c - '0' < 10)
+-#define isspace_ascii(c) (c == ' ' || (unsigned)c-'\t' < 5)
+-#define toupper_ascii(c) (((unsigned)c-'a' < 26) ? (c & 0x5f) : c)
++#define isdigit_ascii(c) (((unsigned)(c) - '0') < 10u)
++#define isspace_ascii(c) (((c) == ' ') || (((unsigned)(c) - '\t') < 5))
++#define toupper_ascii(c) ((((unsigned)(c) - 'a') < 26) ? ((c) & 0x5f) : (c))
++#define tolower_ascii(c) ((((unsigned)(c) - 'A') < 26) ? ((c) | 0x20) : (c))
+ 
+ #endif


### PR DESCRIPTION


#### Description
Split from #8422 
Fixes error observed with Xcode 12:
```
In file included from pandas/_libs/lib.c:641:
pandas/_libs/src/parse_helper.h:141:26: error: implicit declaration of function 'tolower_ascii' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
    for (; *p; ++p) *p = tolower_ascii(*p);
                         ^
```
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### 
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7
Xcode 12 command line tools


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
