### PR TITLE
GPXSee: update to 7.36

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 7.35
+github.setup        tumic0 GPXSee 7.36
 categories          gis graphics
 platforms           darwin
 license             GPL-3
@@ -16,9 +16,9 @@ long_description    GPXSee is a Qt-based GPS log file viewer and analyzer \
 
 homepage            https://www.gpxsee.org/
 
-checksums           rmd160  50f11cc66f3462846932f6295b3411627d64d69c \
-                    sha256  311362dc16c3359d4ee99c042612300b8df1c39685626255b09c845300e6d413 \
-                    size    5402951
+checksums           rmd160  6c4650c76d023228b50c21b387202734d52cd950 \
+                    sha256  c6edd213c42b020b3fb9961ac8ebac2d93cd9ae86e1f14577e0eea8bf9d36651 \
+                    size    5404955
 
 patchfiles          patch-src_GUI_app_cpp.diff
 


### PR DESCRIPTION
#### Description
[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

cc @cjones051073 