### PR TITLE
kustomize: update to 3.8.7

### DIFF
--- a/devel/kustomize/Portfile
+++ b/devel/kustomize/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/kubernetes-sigs/kustomize 3.8.6 kustomize/v
+go.setup            github.com/kubernetes-sigs/kustomize 3.8.7 kustomize/v
 revision            0
 
 categories          devel
@@ -23,9 +23,9 @@ long_description    kustomize lets you customize raw, template-free YAML files f
 
 homepage            https://kustomize.io
 
-checksums           rmd160  56a31be9456e7d888a96fee88a13cb39d4a05671 \
-                    sha256  c17fdf4c1b66d0fae0cf276e7ab940a66aad85bad499dee3422ec08c0e7ae7f1 \
-                    size    26030359
+checksums           rmd160  192fe4bd54e6376d0eeed99f17ed32027770a831 \
+                    sha256  5123c2053c0dd8ccc25594c8535eb3c3b220fc8c9eec609f6d67069270427841 \
+                    size    26130313
 
 build.dir           ${worksrcpath}/${name}
 


### PR DESCRIPTION
#### Description

Update to Kustomize 3.8.7.

###### Tested on

macOS 10.15.7 19H15
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?