### PR TITLE
pinentry-mac: fix implicit function declaration

### DIFF
--- a/aqua/pinentry-mac/Portfile
+++ b/aqua/pinentry-mac/Portfile
@@ -25,7 +25,8 @@ checksums               rmd160 b4023708d1320bd1b0ad5ce0dc35ec71fc68b33c \
 supported_archs         x86_64
 installs_libs           no
 
-patchfiles              patch-includes-quotes.diff
+patchfiles              patch-includes-quotes.diff \
+                        patch-includes-quotes-2.diff
 patch.pre_args          -p1
 
 # This is a temporary kludge. The new Xcode build system fails to

--- a/aqua/pinentry-mac/files/patch-includes-quotes-2.diff
+++ b/aqua/pinentry-mac/files/patch-includes-quotes-2.diff
@@ -1,0 +1,20 @@
+Fix implicit function declaration (error as of Xcode 12):
+secmem_free() is declared in "memory.h" rather than <memory.h>
+(the <memory.h> system header merely inludes <string.h>)
+https://trac.macports.org/ticket/61421
+
+Upstream-Status: Submitted (https://github.com/GPGTools/pinentry-mac/pull/8)
+
+diff --git a/Source/pinentry-0.9.4/pinentry/pinentry-curses.c b/Source/pinentry-0.9.4/pinentry/pinentry-curses.c
+index fc27d81..4279aff 100644
+--- a/Source/pinentry-0.9.4/pinentry/pinentry-curses.c
++++ b/Source/pinentry-0.9.4/pinentry/pinentry-curses.c
+@@ -44,7 +44,7 @@
+ #include <utime.h>
+ #endif /*HAVE_UTIME_H*/
+ 
+-#include <memory.h>
++#include "memory.h"
+ 
+ #ifdef HAVE_WCHAR_H
+ #include <wchar.h>


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/61421

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
Only the patch phase is tested: see if Azure CI Xcode 12 build succeeds.
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
