### PR TITLE
mongo-cxx-driver: attempt to fix macOS 10.9 build

### DIFF
--- a/devel/mongo-cxx-driver/Portfile
+++ b/devel/mongo-cxx-driver/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
+PortGroup           compiler_blacklist_versions 1.0
 
 epoch               1
 github.setup        mongodb mongo-cxx-driver 3.6.1 r
@@ -30,6 +31,9 @@ depends_lib-append  port:mnmlstc-core \
                     port:mongo-c-driver
 
 compiler.cxx_standard 2011
+
+# Segmentation fault observed during build for Xcode 6.2
+compiler.blacklist-append {clang == 600.0.57}
 
 configure.args      -DBSONCXX_POLY_USE_MNMLSTC=ON \
                     -DBSONCXX_POLY_USE_SYSTEM_MNMLSTC=ON \


### PR DESCRIPTION


#### Description
https://build.macports.org/builders/ports-10.9_x86_64-builder/builds/130533/steps/install-port/logs/stdio
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
