### PR TITLE
dejagnu: Avoid problematic multilib setup.

### DIFF
--- a/devel/dejagnu/Portfile
+++ b/devel/dejagnu/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                dejagnu
 version             1.6.2
+revision            1
 categories          devel
 platforms           darwin
 license             GPL-3+
@@ -21,12 +22,18 @@ homepage            https://www.gnu.org/software/dejagnu
 
 # Use the system expect and tcl if possible, but tcl is too old on <10.6.
 if {${os.platform} eq "darwin" && ${os.major} < 10} {
-    depends_lib         port:expect port:tcl
+    depends_lib     port:expect port:tcl
 } else {
-    depends_run     bin:expect:expect
+    depends_run     bin:expect:expect bin:tclsh:tcl
 }
 
 master_sites        gnu
 checksums           rmd160  4afec31883a6d6d9d36f0bda404a9f636fe3c30a \
                     sha256  0d0671e1b45189c5fc8ade4b3b01635fb9eeab45cf54f57db23e4c4c1a17d261 \
                     size    525879
+
+# Avoid the multilib setup that may involve the troublesome -dumpspecs
+patchfiles          patch-no-multilib.diff
+
+test.run            yes
+test.target         check

--- a/devel/dejagnu/files/patch-no-multilib.diff
+++ b/devel/dejagnu/files/patch-no-multilib.diff
@@ -1,0 +1,12 @@
+--- ./baseboards/unix.exp.orig	2017-10-15 20:44:19.000000000 -0700
++++ ./baseboards/unix.exp	2020-11-02 19:16:18.000000000 -0800
+@@ -39,3 +39,9 @@ if { [istarget "alpha*-*"] } {
+ if { [istarget "sparc64-*-linux-gnu"] } {
+     set_board_info gdb,no_hardware_watchpoints 1
+ }
++
++# Avoid multitop on Darwin, where it's at best useless, and attempts to
++# determine it may cause failures with the use of the -dumpspecs option.
++if { [istarget "*-*-darwin*"] } {
++    set_board_info multitop ""
++}


### PR DESCRIPTION
DejaGnu's get_multilibs function never produces useful results on the
Mac, and it may try to invoke the compiler with the gcc-only
-dumpspecs option.  That produces failures when the compiler is clang,
and bloats the logfile when the compiler is gcc.

This change sets the board's multitop variable empty on Darwin, short-
circuiting the troublesome code.  It can be seen more readably at:

	   https://github.com/fhgwright/dejagnu/tree/macports-1.6.2r1

This may not be the final upstream fix, but it achieves the desired
effect.  There won't be any upstream fix until at least 1.6.4.

Also enables the test phase.

Also adds the (purely academic) bin:tclsh dependency for >=10.6.

Also fixes some whitespace.

TESTED:
Built and ran tests on 10.4-10.5 ppc, 10.4-10.6 i386, and 10.6-10.15
x86_64.  Also ran libffi tests on all of the above, where the C++
tests no longer failed due to the -dumpspecs issue.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14033, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G6042, x86_64, Xcode 11.3.1 11C505
macOS 10.15.6 19G2021, x86_64, Xcode 12.0.1 12A7300

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
