### PR TITLE
emacs{,-app}-devel: add nativecomp variant

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -90,7 +90,7 @@ if {$subport eq $name || $subport eq "emacs-app"} {
                     size    65782481
 
     # apply upstream patch to fix configure on arm machines
-    # See https://trac.macports.org/ticket/61594 and 
+    # See https://trac.macports.org/ticket/61594 and
     # https://git.savannah.gnu.org/cgit/emacs.git/commit/configure.ac?id=4cba236749aafade7bd88cf2a10be48f44983faa
     patchfiles-append patch-4cba236749aafade7bd88cf2a10be48f44983faa.diff
     use_autoreconf  yes
@@ -113,6 +113,23 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
     }
 
     livecheck.type none
+
+    variant nativecomp description {Builds emacs with native compilation support} {
+        git.branch  949b49cf771e8f38b23adb3fa4f9d7a9a5e290da
+
+        depends_build-append     port:coreutils
+        depends_lib-append       port:gcc10
+
+        configure.install        ${prefix}/bin/ginstall
+        configure.args-append    --with-nativecomp
+
+        compiler.cpath-prepend   ${prefix}/include/gcc10
+        compiler.library_path-prepend \
+                                 ${prefix}/lib/gcc10
+
+        build.args-append        NATIVE_FULL_AOT=1 \
+            {BYTE_COMPILE_EXTRA_FLAGS='--eval "(setq comp-speed 2)"'}
+    }
 } else {
     livecheck.type  regex
     livecheck.url   https://ftp.gnu.org/gnu/emacs/?C=M&O=D
@@ -191,6 +208,12 @@ if {$subport eq $name || $subport eq "emacs-devel"} {
         xinstall -m 755 -d ${destroot}${prefix}/include/emacs
         xinstall -m 644 ${worksrcpath}/src/emacs-module.h \
                         ${destroot}${prefix}/include/emacs
+
+        if {[variant_isset nativecomp]} {
+            # Make special symlink (temporarily?) necessary for nativecomp on macOS
+            set emacs_version [file tail [glob ${destroot}${prefix}/lib/emacs/*]]
+            ln -s lib/emacs/${emacs_version}/native-lisp ${destroot}${prefix}/native-lisp
+        }
     }
 }
 
@@ -230,6 +253,13 @@ if {$subport eq "emacs-app" || $subport eq "emacs-app-devel"} {
             ${destroot}${applications_dir}/Emacs.app/Contents/Resources/site-lisp
         reinplace "s|__PREFIX__|${prefix}|g" \
             ${destroot}${applications_dir}/Emacs.app/Contents/Resources/site-lisp/site-start.el
+
+        if {[variant_isset nativecomp]} {
+            # Make special symlink (temporarily?) necessary for nativecomp on macOS
+            set app_contents ${destroot}${applications_dir}/Emacs.app/Contents
+            set emacs_version [file tail [glob ${app_contents}/MacOS/lib/emacs/*]]
+            ln -s MacOS/lib/emacs/${emacs_version}/native-lisp ${app_contents}/native-lisp
+        }
     }
 
     variant imagemagick description {Use ImageMagick} {


### PR DESCRIPTION
#### Description

This PR adds a "nativecomp" variant to emacs-devel and emacs-app-devel. This is the so-called [gccemacs](http://akrl.sdf.org/gccemacs.html) experimental JIT speedup.

I should note that because the [upstream repo](https://github.com/emacs-mirror/emacs) is *so* heavy (1GB+), to test this I cloned the upstream repo locally and temporarily overrode `git.url` with a `file://` URL to my local clone.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->