### PR TITLE
rzip64: New port, version 3.0

### DIFF
--- a/archivers/rzip64/Portfile
+++ b/archivers/rzip64/Portfile
@@ -1,0 +1,52 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           muniversal 1.0
+
+name                rzip64
+version             3.0
+revision            0
+checksums           rmd160  d4fd1d841ceea3dba5fd0cf8ec965ef63c4eb7d5 \
+                    sha256  98e94a8021fdcff5d79e5fd3112dbb4c6136359e938503528f688df7c2af7c13 \
+                    size    159223
+
+categories          archivers
+platforms           darwin
+maintainers         {ryandesign @ryandesign} openmaintainer
+license             GPL-3+
+installs_libs       no
+
+description         a parallelized large file compression program
+
+long_description    ${name} is a file compression program designed for very \
+                    large files. \
+                    ${name} can utilize multiple CPU cores. \
+                    ${name} can also be interrupted at any time and be \
+                    restarted later. \
+                    ${name} uses very large amounts of memory.
+
+livecheck.version   [string map {. -} ${version}]
+livecheck.regex     ${name}-(\[0-9.-\]+)\\.
+
+homepage            http://rzip64.ghsi.eu
+master_sites        ${homepage}
+distname            ${name}-${livecheck.version}
+extract.suffix      .tgz
+extract.mkdir       yes
+
+depends_lib         port:bzip2
+
+post-extract {
+    # Source tarball includes ELF objects and binary.
+    delete ${worksrcpath}/${name} {*}[glob ${worksrcpath}/*.o]
+}
+
+patchfiles          Makefile.in.patch \
+                    runzip.c.patch \
+                    rzip64.h.patch
+
+post-destroot {
+    set docdir ${prefix}/share/doc/${subport}
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 ${worksrcpath}/COPYING ${destroot}${docdir}
+}

--- a/archivers/rzip64/files/Makefile.in.patch
+++ b/archivers/rzip64/files/Makefile.in.patch
@@ -1,0 +1,29 @@
+Manpages go in share/man.
+
+Add support for DESTDIR.
+--- Makefile.in.orig	2010-12-19 12:21:17.000000000 -0600
++++ Makefile.in	2020-11-12 10:24:12.000000000 -0600
+@@ -4,7 +4,7 @@
+ prefix=@prefix@
+ exec_prefix=@exec_prefix@
+ INSTALL_BIN=$(exec_prefix)/bin
+-INSTALL_MAN=$(prefix)/man
++INSTALL_MAN=$(prefix)/share/man
+ 
+ LIBS=@LIBS@
+ CC=@CC@
+@@ -31,10 +31,10 @@
+ man: rzip64.1 
+ 
+ install: all
+-	-mkdir -p ${INSTALL_BIN}
+-	${INSTALLCMD} -m 755 rzip64 ${INSTALL_BIN}
+-	-mkdir -p ${INSTALL_MAN}/man1
+-	${INSTALLCMD} -m 644 $(srcdir)/rzip64.1 ${INSTALL_MAN}/man1/
++	-mkdir -p $(DESTDIR)$(INSTALL_BIN)
++	$(INSTALLCMD) -m 755 rzip64 $(DESTDIR)$(INSTALL_BIN)
++	-mkdir -p $(DESTDIR)$(INSTALL_MAN)/man1
++	$(INSTALLCMD) -m 644 $(srcdir)/rzip64.1 $(DESTDIR)$(INSTALL_MAN)/man1/
+ 
+ rzip64: $(OBJS)
+ 	$(CC) $(CFLAGS) -o rzip64 $(OBJS) $(LIBS)

--- a/archivers/rzip64/files/runzip.c.patch
+++ b/archivers/rzip64/files/runzip.c.patch
@@ -1,0 +1,14 @@
+Fix error that prevents removing the compressed file when decompressing:
+
+Failed to unlink (null): Bad address
+Fatal error - exiting
+--- runzip.c.orig	2010-12-19 12:12:30.000000000 -0600
++++ runzip.c	2013-02-21 10:28:58.000000000 -0600
+@@ -181,7 +181,6 @@
+ {
+ 	off_t total = 0;
+ 
+-	control->infile = 0;
+ 	while (total < expected_size) {
+ 		total += runzip_chunk(fd_in, fd_out, fd_hist);
+ 	}

--- a/archivers/rzip64/files/rzip64.h.patch
+++ b/archivers/rzip64/files/rzip64.h.patch
@@ -1,0 +1,15 @@
+Fix build error on macOS:
+
+error: use of undeclared identifier '__sighandler_t'
+--- rzip64.h.orig	2010-12-19 11:48:44.000000000 -0600
++++ rzip64.h	2020-11-13 08:17:12.000000000 -0600
+@@ -120,6 +120,9 @@
+ #define TRUE 1
+ #endif
+ 
++#ifndef __sighandler_t
++#define __sighandler_t sig_t
++#endif
+ 
+ #if !HAVE_STRERROR
+ extern char *sys_errlist[];


### PR DESCRIPTION
#### Description

New port for rzip64 3.0

Needs to be squashed when merged.


###### Tested on
macOS 10.13.6 17G14019
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
