### PR TITLE
Travis: Add Xcode 11 to Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: c
 matrix:
   include:
   - os: osx
+    osx_image: xcode11.6
+  - os: osx
     osx_image: xcode10.3
   - os: osx
     osx_image: xcode9.4
@@ -11,6 +13,8 @@ matrix:
   - os: osx
     osx_image: xcode7.3
   allow_failures:
+  - os: osx
+    osx_image: xcode11.6
   - os: osx
     osx_image: xcode10.3
   - os: osx


### PR DESCRIPTION
#### Description

Travis CI has been supporting Xcode 11 for long (now even Xcode 12 is out). See: https://docs.travis-ci.com/user/reference/osx#macos-version

I know that we do check Xcode 11 and Xcode 12 in Azure, but I guess it doesn’t harm to have more checks?

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2
Xcode 12.1 12A7403

###### Verification
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?