### PR TITLE
minikube: update to 1.15.0

### DIFF
--- a/sysutils/minikube/Portfile
+++ b/sysutils/minikube/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        kubernetes minikube 1.14.2 v
+github.setup        kubernetes minikube 1.15.0 v
 categories          sysutils
 platforms           darwin
 supported_archs     x86_64
@@ -19,9 +19,9 @@ long_description    Minikube runs a single-node Kubernetes cluster inside a VM \
 github.tarball_from releases
 distfiles           minikube-darwin-amd64
 checksums           minikube-darwin-amd64 \
-                    rmd160  95db333a5625283c94b76249bef7092801ff7750 \
-                    sha256  5d72bea6159e41f30865492298aa0e37af164ef22e56165ac78be179947d3b9d \
-                    size    55575896
+                    rmd160  91789e238071afe3b063766a432ed2b40f01eff4 \
+                    sha256  a744ed7fb5c317ef06b2c5ae0d94cec1d41e1d5c2ea40b5ece28e7a340abbad3 \
+                    size    55723064
 dist_subdir         ${name}/${version}
 
 depends_lib         path:${prefix}/bin/kubectl:kubectl-1.19
@@ -32,9 +32,9 @@ default_variants    +hyperkit
 variant hyperkit description {Install Hyperkit driver} {
     distfiles-append    docker-machine-driver-hyperkit
     checksums-append    docker-machine-driver-hyperkit \
-                        rmd160  733657ce5e8dafd6f923df8c4a32e5aaf9f8e5f8 \
-                        sha256  a29d807f86c9f8fb988ffbf71d976cd0ad47891369d7883955b0256aa949f26f \
-                        size    11996260
+                        rmd160  59205b183f64b1ae58f778673afeb139c0ccdc1e \
+                        sha256  64993105b5adaec81648525cec21dda77c4c0c641549f4bcf9428efd55911921 \
+                        size    12000860
 }
 
 build {


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
