### PR TITLE
virtuoso-7: allow implicit function declarations

### DIFF
--- a/devel/virtuoso-7/Portfile
+++ b/devel/virtuoso-7/Portfile
@@ -23,6 +23,11 @@ checksums           rmd160  be53878442f9e98f01057bfcf42ee8a843e741ab \
                     sha256  826477d25a8493a68064919873fb4da4823ebe09537c04ff4d26ba49d9543d64 \
                     size    120299376
 
+# https://trac.macports.org/ticket/61216
+patchfiles-append   patch-libsrc-Wi-numeric.c.diff
+configure.cflags-append \
+                    -Wno-error=implicit-function-declaration
+
 supported_archs     x86_64
 conflicts           virtuoso-6
 conflicts_build     chicken

--- a/devel/virtuoso-7/files/patch-libsrc-Wi-numeric.c.diff
+++ b/devel/virtuoso-7/files/patch-libsrc-Wi-numeric.c.diff
@@ -1,0 +1,11 @@
+Upstream-Status: Submitted (https://github.com/openlink/virtuoso-opensource/pull/931)
+--- libsrc/Wi/numeric.c.orig
++++ libsrc/Wi/numeric.c
+@@ -27,6 +27,7 @@
+ 
+ #include "Dk.h"
+ #include "numeric.h"
++#include "util/strfuns.h"
+ 
+ /* activates code for divmod, modulo, powmod, pow, sqr */
+ #define NUMERIC_EXTS	1


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/61216

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 (19H2)
Xcode 12.2 command line tools

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
