### PR TITLE
pinentry: fix build on Big Sur

### DIFF
--- a/security/pinentry/Portfile
+++ b/security/pinentry/Portfile
@@ -34,6 +34,8 @@ configure.args              --with-libiconv-prefix=${prefix} \
                             --disable-pinentry-qt5 \
                             --disable-pinentry-fltk
 
+configure.cflags-append     -DNCURSES_WIDECHAR=1
+
 # Fix picking up the correct assuan version.
 # -isystem has the added benefit of moving the include
 # directory specified to the end of the include path list.


### PR DESCRIPTION
Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>

#### Description

pinentry fails to build on Big Sur with multiple identical errors:
```
error: implicit declaration of function 'addnwstr' is invalid in C99
```
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0.1 20B29
Xcode 12.2.0.0.1.1603499215
(I only have CLT, version is checked using `pkgutil --pkg-info=com.apple.pkg.CLTools_Executables`)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
