### PR TITLE
py-zope-*: remove pre-activate

### DIFF
--- a/python/py-zope-deferredimport/Portfile
+++ b/python/py-zope-deferredimport/Portfile
@@ -34,10 +34,3 @@ if {${name} ne ${subport}} {
     livecheck.type  regex
     livecheck.regex ${real_name}-(\[0-9.\]+)${extract.suffix}
 }
-
-pre-activate {
-    # deactivate py-zopedeferredimport
-    if {![catch {set installed [lindex [registry_active py${python.version}-zopedeferredimport] 0]}]} {
-        registry_deactivate_composite py${python.version}-zopedeferredimport "" [list ports_nodepcheck 1]
-    }
-}

--- a/python/py-zope-deprecation/Portfile
+++ b/python/py-zope-deprecation/Portfile
@@ -33,14 +33,3 @@ if {${name} ne ${subport}} {
     livecheck.type  regex
     livecheck.regex ${real_name}-(\[0-9.\]+)${extract.suffix}
 }
-
-# py-zope-deprecation was orginally named py-zopedeprecation
-# Use deactivate hack
-pre-activate {
-    if {![catch {set installed [lindex [registry_active py${python.version}-zopedeprecation] 0]}]} {
-        set _version [lindex $installed 1]
-        if {[vercmp $_version 4.4.0] < 0} {
-            registry_deactivate_composite py${python.version}-zopedeprecation "" [list ports_nodepcheck 1]
-        }
-    }
-}

--- a/python/py-zope-hookable/Portfile
+++ b/python/py-zope-hookable/Portfile
@@ -41,10 +41,3 @@ if {${name} ne ${subport}} {
     livecheck.type  regex
     livecheck.regex ${real_name}-(\[0-9.\]+)${extract.suffix}
 }
-
-pre-activate {
-    # deactivate py-zopedeferredimport
-    if {![catch {set installed [lindex [registry_active py${python.version}-zopehookable] 0]}]} {
-        registry_deactivate_composite py${python.version}-zopehookable "" [list ports_nodepcheck 1]
-    }
-}

--- a/python/py-zope-proxy/Portfile
+++ b/python/py-zope-proxy/Portfile
@@ -35,10 +35,3 @@ if {${name} ne ${subport}} {
     livecheck.type  regex
     livecheck.regex ${real_name}-(\[0-9.\]+)${extract.suffix}
 }
-
-pre-activate {
-    # deactivate py-zopeproxy
-    if {![catch {set installed [lindex [registry_active py${python.version}-zopeproxy] 0]}]} {
-        registry_deactivate_composite py${python.version}-zopeproxy "" [list ports_nodepcheck 1]
-    }
-}


### PR DESCRIPTION
Added in 0d6ee4fd64, 71f7d8fe6b, 974c379ddd, 4c7c9c070a
after ports were renamed over a year ago.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### 
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
