### PR TITLE
spring-boot-cli: update to 2.4.0

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            spring-boot-cli
-version         2.3.5
+version         2.4.0
 revision        0
 
 categories      java
@@ -26,13 +26,13 @@ long_description The Spring Boot CLI is a command line tool that can be used \
                 off the ground.
 
 homepage        https://projects.spring.io/spring-boot/
-master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/${version}.RELEASE/
+master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/${version}/
 
-distname        ${name}-${version}.RELEASE-bin
+distname        ${name}-${version}-bin
 
-checksums       rmd160  a402a157112bc7283b0ef1ec400af4debbe4db0b \
-                sha256  f8e499983da3fe53d15cc7fad66cafcc9dc82e6df87cc09bffaaf5a085455761 \
-                size    11615785
+checksums       rmd160  3eb31fe759fb55ef4da0d4b6fbc1af7ad56bb64c \
+                sha256  145c16802906b5bc5a51d2f7ff69928cb6388740520660ccfe52ee6b0e64da26 \
+                size    11701382
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
#### Description

Update to Spring Boot CLI 2.4.0.

###### Tested on

macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?