### PR TITLE
pinentry-mac: fix signing issue

### DIFF
--- a/aqua/pinentry-mac/Portfile
+++ b/aqua/pinentry-mac/Portfile
@@ -85,3 +85,4 @@ platform macosx {
 
 xcode.target            ${name}
 xcode.configuration     Release
+xcode.build.settings    CODE_SIGN_IDENTITY=- CODE_SIGN_STYLE=Manual


### PR DESCRIPTION
#### Description

Was getting this error:

```
:info:build error: No signing certificate "Mac Development" found: No "Mac Development" signing certificate matching team ID "..." with a private key was found. (in target 'pinentry-mac' from project 'pinentry-mac')
```

My machine keeps trying to sign this with my old team ID (`security find-identity -v -p codesigning` does not list this ID) and I am not sure why. MacPorts should not allow Xcode to implicitly sign as it does by default when these arguments are not passed.

Really I am desiring `xcode.build.settings` and destroot to have these options by default at some point:

```
    CODE_SIGN_IDENTITY=-
    CODE_SIGN_STYLE=Manual
    ENABLE_HARDENED_RUNTIME=NO
```

`ENABLE_HARDENED_RUNTIME=NO` is needed for some projects because the hardened runtime requires signing.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. --> n/a
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
