### PR TITLE
openal-soft: add patch for include issue

### DIFF
--- a/audio/openal-soft/Portfile
+++ b/audio/openal-soft/Portfile
@@ -44,6 +44,10 @@ depends_build-append    port:pkgconfig
 depends_lib-append      port:libmysofa \
                         port:zlib
 
+patchfiles              ${name}-uint64_t-header-check.patch \
+                        ${name}-add-missing-include-coreaudio.patch
+patch.pre_args          -p1
+
 compiler.cxx_standard   2014
 compiler.thread_local_storage   yes
 

--- a/audio/openal-soft/files/openal-soft-add-missing-include-coreaudio.patch
+++ b/audio/openal-soft/files/openal-soft-add-missing-include-coreaudio.patch
@@ -1,0 +1,21 @@
+From aeb7170a8bca0df3719f9c404d2b24090efe0fb8 Mon Sep 17 00:00:00 2001
+From: Chris Robinson <chris.kcat@gmail.com>
+Date: Thu, 5 Nov 2020 05:42:02 -0800
+Subject: [PATCH] Add missing include for the CoreAudio backend
+
+---
+ alc/backends/coreaudio.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/alc/backends/coreaudio.cpp b/alc/backends/coreaudio.cpp
+index 25fb71ab8..6cdbcf423 100644
+--- a/alc/backends/coreaudio.cpp
++++ b/alc/backends/coreaudio.cpp
+@@ -22,6 +22,7 @@
+ 
+ #include "backends/coreaudio.h"
+ 
++#include <inttypes.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>

--- a/audio/openal-soft/files/openal-soft-uint64_t-header-check.patch
+++ b/audio/openal-soft/files/openal-soft-uint64_t-header-check.patch
@@ -1,0 +1,36 @@
+From 40c92c4643193d09c2fd90a5b3df4fe57230a789 Mon Sep 17 00:00:00 2001
+From: Chris Robinson <chris.kcat@gmail.com>
+Date: Thu, 5 Nov 2020 04:41:17 -0800
+Subject: [PATCH] Simplify the [u]int64_t typedef header check
+
+And include the correct header
+---
+ include/AL/alext.h | 9 +++------
+ 1 file changed, 3 insertions(+), 6 deletions(-)
+
+diff --git a/include/AL/alext.h b/include/AL/alext.h
+index ef5e8cb68..57c71cb3c 100644
+--- a/include/AL/alext.h
++++ b/include/AL/alext.h
+@@ -23,18 +23,15 @@
+ 
+ #include <stddef.h>
+ /* Define int64_t and uint64_t types */
+-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+-#include <inttypes.h>
+-#elif defined(__cplusplus) && __cplusplus >= 201103L
+-#include <cinttypes>
+-#elif defined(_WIN32) && defined(__GNUC__)
++#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) ||             \
++    (defined(__cplusplus) && __cplusplus >= 201103L)
+ #include <stdint.h>
+ #elif defined(_WIN32)
+ typedef __int64 int64_t;
+ typedef unsigned __int64 uint64_t;
+ #else
+ /* Fallback if nothing above works */
+-#include <inttypes.h>
++#include <stdint.h>
+ #endif
+ 
+ #include "alc.h"


### PR DESCRIPTION
See https://github.com/kcat/openal-soft/issues/490

#### Description

Sources that include `AL/alext.h` may fail to build due to a mishap in checking for the correct stdint header. This is not yet in a release of openal-soft.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
