### PR TITLE
java-1.0 portgroup: temporarily skip exact version check on Big Sur

### DIFF
--- a/_resources/port1.0/group/java-1.0.tcl
+++ b/_resources/port1.0/group/java-1.0.tcl
@@ -34,8 +34,16 @@ pre-fetch {
         java_set_env
         # If still not present, error out
         if { ${java_version_not_found} } {
-            ui_error "${name} requires Java ${java.version} but no such installation could be found."
-            return -code error "missing required Java version"
+            global os.platform os.major
+            if {${os.platform} == "darwin" && ${os.major} == 20} {
+                # The following check is broken on macOS 11 Big Sur so we
+                # temporarily give up on ensuring an exact Java version. See
+                # https://trac.macports.org/ticket/61445
+                ui_warn "Failed to confirm that required Java was installed; see https://trac.macports.org/ticket/61445"
+            } else {
+                ui_error "${name} requires Java ${java.version} but no such installation could be found."
+                return -code error "missing required Java version"
+            }
         }
     }
 }
@@ -47,7 +55,7 @@ proc find_java_home {} {
     # Default setting to found, until proved otherwise below
     global java_version_not_found
     set java_version_not_found no
-    
+
     global java.version java.fallback
     if { ${java.version} ne "" } {
         if { [catch {set val [exec "/usr/libexec/java_home" "-f" "-v" ${java.version}]}] } {
@@ -57,7 +65,7 @@ proc find_java_home {} {
             set java_version_not_found yes
         } else {
             set home_value $val
-            ui_debug "Discovered JAVA_HOME via /usr/libexec/java_home: $home_value"
+            ui_debug "Discovered JAVA_HOME via /usr/libexec/java_home -f -v: $home_value"
         }
     }
 

--- a/_resources/port1.0/group/java-1.0.tcl
+++ b/_resources/port1.0/group/java-1.0.tcl
@@ -35,7 +35,7 @@ pre-fetch {
         # If still not present, error out
         if { ${java_version_not_found} } {
             global os.platform os.major
-            if {${os.platform} == "darwin" && ${os.major} == 20} {
+            if {${os.platform} eq "darwin" && ${os.major} == 20} {
                 # The following check is broken on macOS 11 Big Sur so we
                 # temporarily give up on ensuring an exact Java version. See
                 # https://trac.macports.org/ticket/61445


### PR DESCRIPTION
The java-1.0 portgroup tries to ensure that the Java version specified by `java.version` is installed. Unfortunately it seems that the way it checks is partially broken in Big Sur. See https://trac.macports.org/ticket/61445

This PR prevents failure when the specific version can't be confirmed as installed, so that people can at least install their ports.

In practice this should actually be OK in almost every case, because the fallback OpenJDK port will be installed. At worst, people who already have a non-MacPorts Java will automatically get an extra Java installed.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
