### PR TITLE
rb-rubygems: cleanup pre-activate

### DIFF
--- a/ruby/rb-rubygems/Portfile
+++ b/ruby/rb-rubygems/Portfile
@@ -64,15 +64,6 @@ if {![variant_isset ruby186]} {
     default_variants +ruby
 }
 
-# clean up mess from previous portfile that bypassed the destroot
-pre-activate {
-    set docpath "${prefix}/lib/ruby/gems/1.8/doc/rubygems-1.3.7"
-    set adocfile "${docpath}/rdoc/classes/Gem/Builder.html"
-    if {[file exists $adocfile] && [registry_file_registered $adocfile] == "0"} {
-        delete $docpath
-    }
-}
-
 livecheck.type      regex
 livecheck.url       https://rubygems.org/pages/download
 livecheck.regex     {v([0-9.]+)}


### PR DESCRIPTION
Added 8 years ago in 029a1f4f5

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
