### PR TITLE
gnome-system-log: cleanup pre-activate

### DIFF
--- a/gnome/gnome-system-log/Portfile
+++ b/gnome/gnome-system-log/Portfile
@@ -64,21 +64,6 @@ variant zlib description {Enable zlib support} {
     configure.args-append --enable-zlib
 }
 
-# if port gnome-utils is installed
-# and gnome-system-log binary exists
-# and port gnome-system-log is NOT installed
-# deactivate outdated port gnome-utils
- 
-pre-activate {
-    if {![catch {registry_active gnome-utils}]} {
-        if {[file exists ${prefix}/bin/gnome-system-log]} {
-            if {[catch {registry_active gnome-system-log}]} {
-                registry_deactivate_composite gnome-utils "" [list ports_nodepcheck 1]
-            }
-        }
-    }
-}
-
 # port installs hicolor and HighContrast icons, desktop application file, and gschemas
 post-activate {
     system "${prefix}/bin/gtk-update-icon-cache-3.0 -f -t ${prefix}/share/icons/hicolor"


### PR DESCRIPTION
Added over 6 years ago in 0b02d2aa88 following split from `gnome-utils` port

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
