### PR TITLE
nedi: cleanup pre-activate

### DIFF
--- a/net/nedi/Portfile
+++ b/net/nedi/Portfile
@@ -115,17 +115,6 @@ post-destroot {
         ${destroot}/Library/LaunchDaemons
 }
 
-pre-activate {
-    # nedi < 1.0.9 installed this symlink directly, bypassing the destroot.
-    # Remove it if found to prevent activation failure.
-    set f /Library/LaunchDaemons/org.macports.nedisyslog.plist
-    if {![catch {file type ${f}}] && [registry_file_registered ${f}] == "0"} {
-        if {[catch {delete ${f}}]} {
-            ui_warn "Cannot delete ${f}; please remove it manually"
-        }
-    }
-}
-
 notes \
   "**** To complete the NeDi OS X installation ****
 


### PR DESCRIPTION
Added in 548d4263f5 almost 5 years ago

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
