### PR TITLE
e2fsprogs: Fix build with Big Sur

### DIFF
--- a/sysutils/e2fsprogs/Portfile
+++ b/sysutils/e2fsprogs/Portfile
@@ -4,7 +4,6 @@ PortSystem                  1.0
 
 name                        e2fsprogs
 version                     1.45.6
-revision                    1
 checksums                   rmd160  541a235a3f3122f03fcf612e2339176572597edd \
                             sha256  5f64ac50a2b60b8e67c5b382bb137dec39344017103caffc3a61554424f2d693 \
                             size    7938544

--- a/sysutils/e2fsprogs/Portfile
+++ b/sysutils/e2fsprogs/Portfile
@@ -4,6 +4,7 @@ PortSystem                  1.0
 
 name                        e2fsprogs
 version                     1.45.6
+revision                    1
 checksums                   rmd160  541a235a3f3122f03fcf612e2339176572597edd \
                             sha256  5f64ac50a2b60b8e67c5b382bb137dec39344017103caffc3a61554424f2d693 \
                             size    7938544
@@ -30,7 +31,8 @@ depends_lib                 port:gettext
 # Report this bug to the developers
 depends_build-append        port:coreutils
 
-patchfiles                  patch-lib__Makefile.darwin-lib.diff
+patchfiles                  patch-lib__Makefile.darwin-lib.diff \
+                            patch-probe.c.diff
 
 configure.args-append       --enable-bsd-shlibs
 

--- a/sysutils/e2fsprogs/files/patch-probe.c.diff
+++ b/sysutils/e2fsprogs/files/patch-probe.c.diff
@@ -1,0 +1,10 @@
+--- lib/blkid/probe.c	2020-11-15 14:19:10.000000000 -0500
++++ lib/blkid/probe.c.fixed	2020-11-15 14:21:25.000000000 -0500
+@@ -17,6 +17,7 @@
+ #include <stdio.h>
+ #include <string.h>
+ #include <stdlib.h>
++#include <time.h>
+ #include <unistd.h>
+ #include <fcntl.h>
+ #include <ctype.h>


### PR DESCRIPTION
The following changes have been made:
  * Add patch for probe.c to include time.h header
  * Increment revision in Portfile

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
