### PR TITLE
QLColorCode: update to 4.1.0

### DIFF
--- a/sysutils/QLColorCode/Portfile
+++ b/sysutils/QLColorCode/Portfile
@@ -4,28 +4,62 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           xcode 1.0
 
-github.setup        anthonygelibert QLColorCode 2.1.0 release-
-categories          sysutils
+github.setup        anthonygelibert QLColorCode 4.1.0 release-
+worksrcdir          ${github.author}-${name}-749f674
+categories          sysutils aqua
 
 platforms           darwin
-license             GPL-2
+license             {GPL-3 MIT}
 maintainers         nomaintainer
 
-description         Quick Look plugin that renders source code with syntax highlighting
+description         Quick Look plugin that renders source code with syntax highlighting.
 long_description    ${description}
 
-checksums           rmd160  dfc80ca412d9b315ea373b60982d3cb321141a49 \
-                    sha256  08030edbf9f46d50aa8c2e08626c5934dfdee0c992ffa3ac3d36473e6fe8534f \
-                    size    44548
+set lua_version         e2ea3b31c94bb3e1da27c233661cb2a16699c685
+set highlight_version   ecf5d4aa1341908a6b191a47d67e735197dc430d
 
-depends_lib         port:highlight
+master_sites        ${github.homepage}/tarball/${git.branch}:QLColorCode \
+                    https://github.com/lua/lua/archive:lua \
+                    https://gitlab.com/saalen/highlight/-/archive/${highlight_version}:highlight
+
+distfiles           ${name}-${git.branch}.tar.gz:QLColorCode \
+                    ${lua_version}.tar.gz:lua \
+                    highlight-${highlight_version}.tar.gz:highlight
+
+checksums           QLColorCode-release-4.1.0.tar.gz \
+                    rmd160  b45817626018c2cd7d5df4b4430c760e6a18e0d3 \
+                    sha256  d6d878ddbcb5b1f7d9f1656e96e1ab0d5cce2f4208e1e7a6f5a190ff2a6f878a \
+                    size    44683 \
+                    e2ea3b31c94bb3e1da27c233661cb2a16699c685.tar.gz \
+                    rmd160  972fcc46049cf60a780a4dc7bef6a273167dab78 \
+                    sha256  a2e01036021d319fd41e16dfe12cc5fabc7db1337df8605a884ac0b424932d9b \
+                    size    444643 \
+                    highlight-ecf5d4aa1341908a6b191a47d67e735197dc430d.tar.gz \
+                    rmd160  5fe1ca6acbd700138c3f20fbd6bedfcd8faa0e0d \
+                    sha256  770ce8dd4b269963711038748e2505945bee29ed1807ef9c473846717e4500a3 \
+                    size    1589913
+
+depends_build       port:boost
+
 destroot.violate_mtree  yes
+xcode.build.settings \
+    CODE_SIGN_IDENTITY=- \
+    CODE_SIGN_STYLE=Manual \
+    ENABLE_HARDENED_RUNTIME=NO
 
 # remove build phase that copies to the user's home directory
-patchfiles-append   patch-xcode.diff
+patchfiles-append   patch-xcode.diff \
+                    patch-include-path.diff
 
 post-extract {
     reinplace -W ${worksrcpath} "s,open \$PROJECT_DIR/release,," QLColorCode.xcodeproj/project.pbxproj
+}
+
+post-patch {
+    reinplace -W ${worksrcpath} "s/-j9/-j${build.jobs}/g" QLColorCode.xcodeproj/project.pbxproj
+    delete ${worksrcpath}/hl/lua ${worksrcpath}/hl/highlight
+    move ${worksrcpath}/../lua-${lua_version} ${worksrcpath}/hl/lua
+    move ${worksrcpath}/../highlight-${highlight_version} ${worksrcpath}/hl/highlight
 }
 
 destroot {
@@ -41,5 +75,3 @@ post-activate {
 post-deactivate {
     system "qlmanage -r"
 }
-
-github.livecheck.regex  {([^"b]+)}

--- a/sysutils/QLColorCode/files/patch-include-path.diff
+++ b/sysutils/QLColorCode/files/patch-include-path.diff
@@ -1,0 +1,13 @@
+diff --git QLColorCode.xcodeproj/project.pbxproj QLColorCode.xcodeproj/project.pbxproj
+index db203f5..91aadb5 100644
+--- QLColorCode.xcodeproj/project.pbxproj
++++ QLColorCode.xcodeproj/project.pbxproj
+@@ -178,7 +178,7 @@
+ /* Begin PBXLegacyTarget section */
+ 		26BAC9AB257CE89900486D28 /* highlight */ = {
+ 			isa = PBXLegacyTarget;
+-			buildArgumentsString = "-j9 cli LUA_LIBS=../../lua/liblua.a 'CXX_COMPILE=clang++ -Wall -O2 -std=c++11 -D_FILE_OFFSET_BITS=64 -c -I /opt/local/include -I /usr/local/include -I ./include -I ../../lua'";
++			buildArgumentsString = "-j9 cli LUA_LIBS=../../lua/liblua.a 'CXX_COMPILE=clang++ -Wall -O2 -std=c++11 -D_FILE_OFFSET_BITS=64 -c -I ../../lua -I /opt/local/include -I /usr/local/include -I ./include'";
+ 			buildConfigurationList = 26BAC9AC257CE89900486D28 /* Build configuration list for PBXLegacyTarget "highlight" */;
+ 			buildPhases = (
+ 			);

--- a/sysutils/QLColorCode/files/patch-xcode.diff
+++ b/sysutils/QLColorCode/files/patch-xcode.diff
@@ -1,9 +1,8 @@
 --- QLColorCode.xcodeproj/project.pbxproj.orig	2015-10-19 14:46:13.000000000 -0700
 +++ QLColorCode.xcodeproj/project.pbxproj	2015-10-19 14:46:17.000000000 -0700
-@@ -187,8 +187,6 @@
+@@ -216,8 +216,6 @@
  				8D57630F048677EA00EA77CD /* Resources */,
  				8D576311048677EA00EA77CD /* Sources */,
- 				8D576313048677EA00EA77CD /* Frameworks */,
 -				0ECBBA6F0CFCA39E00416538 /* Copy to Library */,
 -				0E1280381061C3EA0078EC05 /* Reset quicklookd */,
  			);


### PR DESCRIPTION
#### Description

Update QLColorCode to 3.1.1 with a few patches. One of the patches fixes selecting the theme.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
