### PR TITLE
llvm/clang/lldb-devel: bump to 20201115

### DIFF
--- a/lang/llvm-devel/Portfile
+++ b/lang/llvm-devel/Portfile
@@ -16,22 +16,22 @@ legacysupport.newest_darwin_requires_legacy 13
 
 # for devel
 PortGroup github        1.0
-set llvm-commit         77e1181df446b54391acad08512b540e174cf6e6
-set date                20200531
+set llvm-commit         6ddc2377669243e93c1d6fa931f3eaef370e55e0
+set date                20201115
 set llvm_version        devel
 
 # for release
-# set llvm_version 11
+# set llvm_version 12
 
-set llvm_version_no_dot 11
-set clang_executable_version 11
-set lldb_executable_version 11
+set llvm_version_no_dot 12
+set clang_executable_version 12
+set lldb_executable_version 12
 
 github.setup            llvm llvm-project ${llvm-commit}
 
-checksums               rmd160  de9bc39195c5525b85c891ccc83b7dce3cbc28fd \
-                        sha256  409d5fa4236a738bf4297a75ba09b9561766cdf2e75ee93d7d17d3ecedd2814d \
-                        size    119507490
+checksums               rmd160  303053eb55a604b11b16a68e05c45679c21b8209 \
+                        sha256  0dbebb86def35e01040ff9b67a91a9e739914da0e543ef511dc3da019f360458 \
+                        size    128781060
 
 # for release, use      ${llvm_version}
 # version                 ${llvm_version}
@@ -39,7 +39,7 @@ version                 ${date}-[string range ${llvm-commit} 0 7]
 
 
 name                    llvm-${llvm_version}
-revision                1
+revision                0
 subport                 clang-${llvm_version} { revision 0 }
 subport                 lldb-${llvm_version} { revision 0 }
 set suffix              mp-${llvm_version}
@@ -115,7 +115,7 @@ post-extract {
         file rename ${workpath}/llvm-project/compiler-rt                      ${worksrcpath}/projects/compiler-rt
         file rename ${workpath}/llvm-project/libcxx                           ${worksrcpath}/projects/libcxx
         file rename ${workpath}/llvm-project/libcxxabi                        ${worksrcpath}/projects/libcxxabi
-        file rename ${workpath}/llvm-project/clang-tools-extra                ${worksrcpath}/tools/clang/tools/extra
+        file copy   ${workpath}/llvm-project/clang-tools-extra                ${worksrcpath}/tools/clang/tools/extra
     } elseif {${subport} eq "lldb-${llvm_version}"} {
         file rename ${workpath}/llvm-project/clang                            ${worksrcpath}/tools/clang
         file rename ${workpath}/llvm-project/lldb                             ${worksrcpath}/tools/lldb
@@ -135,13 +135,11 @@ if {${subport} eq "clang-${llvm_version}"} {
     patchfiles-append \
         1001-MacPorts-Only-Prepare-clang-format-for-replacement-w.patch \
         1002-MacPorts-Only-Fix-name-of-scan-view-executable-insid.patch \
-        1003-Default-to-ppc7400-for-OSX-10.5.patch \
         1004-Default-to-fragile-ObjC-runtime-when-targeting-darwi.patch \
         1005-Fixup-libstdc-header-search-paths-for-older-versions.patch \
         1007-Fix-float.h-to-work-on-Snow-Leopard-and-earlier.patch \
         1008-compilerrt-fuzzer-missingdefs.diff \
         1009-compilerrt-sanitizer-missingdefs.diff \
-        2002-Work-around-no-libdispatch-on-10.6.patch \
         3001-Fix-missing-long-long-math-prototypes-when-using-the.patch \
         3002-implement-atomic-using-mutex-lock_guard-for-64b-ops-.patch \
         openmp-locations.patch \
@@ -149,9 +147,9 @@ if {${subport} eq "clang-${llvm_version}"} {
         5000-patch-compilerrtdarwinutils-find-macosxsdkversion.diff \
         5002-patch-toolchains-darwin-add-back-pre-10.6-link-libs.diff
 
-    # fix incorrect disabling of bad_optional/variant/any_access on 10.13
-    # https://github.com/macports/macports-base/pull/179
-    patchfiles-append patch-libcxx-includes-config-optional-1013.diff
+# these don't apply at present
+#         1003-Default-to-ppc7400-for-OSX-10.5.patch \
+#         2002-Work-around-no-libdispatch-on-10.6.patch \
 
 }
 
@@ -160,11 +158,14 @@ if {${subport} eq "lldb-${llvm_version}"} {
     patchfiles-append \
         1001-MacPorts-Only-Prepare-clang-format-for-replacement-w.patch \
         1002-MacPorts-Only-Fix-name-of-scan-view-executable-insid.patch \
-        1003-Default-to-ppc7400-for-OSX-10.5.patch \
         1004-Default-to-fragile-ObjC-runtime-when-targeting-darwi.patch \
         1005-Fixup-libstdc-header-search-paths-for-older-versions.patch \
         1007-Fix-float.h-to-work-on-Snow-Leopard-and-earlier.patch \
         openmp-locations.patch
+
+# does not apply at present
+#         1003-Default-to-ppc7400-for-OSX-10.5.patch \
+
 }
 
 configure.post_args         ../${worksrcdir}
@@ -258,8 +259,8 @@ if {[lsearch -exact $PortInfo(depends_build) port:cctools] != -1} {
         -DCMAKE_LIBTOOL=${prefix}/bin/libtool
 }
 
-depends_lib-append      port:python38
-set pythonfullpath      ${prefix}/bin/python3.8
+depends_lib-append      port:python39
+set pythonfullpath      ${prefix}/bin/python3.9
 configure.args-append   -D_Python3_EXECUTABLE=${pythonfullpath}
 
 platform darwin {
@@ -470,8 +471,10 @@ if {${subport} eq "llvm-${llvm_version}"} {
 
             # pythonfullpath is set above, depending on presence of system python2.7
             reinplace "s|/usr/bin/env python|${pythonfullpath}|g" \
-                ${worksrcpath}/tools/clang/tools/scan-build/bin/set-xcode-analyzer \
-                ${worksrcpath}/tools/clang/tools/scan-view/bin/scan-view
+                 ${worksrcpath}/tools/clang/tools/scan-view/bin/scan-view
+
+            reinplace "s|/usr/bin/python|${pythonfullpath}|g" \
+                ${worksrcpath}/tools/clang/tools/scan-build/bin/set-xcode-analyzer
         }
     }
 


### PR DESCRIPTION
- change to python 3.9
- fix one errant reinplace
- disable two patches that don't apply at present

not yet tested on older systems

running this past the CI systems.