### PR TITLE
rustscan: new port

### DIFF
--- a/net/rustscan/Portfile
+++ b/net/rustscan/Portfile
@@ -1,0 +1,219 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo 1.0
+
+github.setup        RustScan RustScan 2.0.1
+name                rustscan
+revision            0
+
+categories          net
+platforms           darwin
+license             GPL-3
+
+description         The Modern Port Scanner
+
+long_description    {*}${description}. Find ports quickly (3 seconds at \
+                    its fastest). Run scripts through our scripting engine \
+                    (Python, Lua, Shell supported).
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  e62daa87af789518f8201531255ce930ea632233 \
+                    sha256  8d039c7e44af80e1be0676d1f6a066ceb78050c53721c42c0fa3a1ccd4a21eba \
+                    size    3093419
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/${name} ${destroot}${prefix}/bin/
+}
+
+cargo.crates \
+    addr2line                       0.14.0  7c0929d69e78dd9bf5408269919fcbcaeb2e35e5d43e5815517cdc6a8e11a423 \
+    adler                            0.2.3  ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e \
+    aho-corasick                    0.7.15  7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5 \
+    ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
+    ansi_term                       0.12.1  d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2 \
+    anyhow                          1.0.34  bf8dcb5b4bbaa28653b647d8c77bd4ed40183b48882e130c1f1ffb73de069fd7 \
+    arrayref                         0.3.6  a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544 \
+    arrayvec                         0.5.2  23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b \
+    async-channel                    1.5.1  59740d83946db6a5af71ae25ddf9562c2b176b2ca42cf99a455f09f4a220d6b9 \
+    async-executor                   1.3.0  d373d78ded7d0b3fa8039375718cde0aace493f2e34fb60f51cbf567562ca801 \
+    async-global-executor            1.4.3  73079b49cd26b8fd5a15f68fc7707fc78698dc2a3d61430f2a7a9430230dfa04 \
+    async-io                        1.1.10  d54bc4c1c7292475efb2253227dbcfad8fe1ca4c02bc62c510cc2f3da5c4704e \
+    async-mutex                      1.4.0  479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e \
+    async-std                        1.7.0  a7e82538bc65a25dbdff70e4c5439d52f068048ab97cdea0acd73f131594caa1 \
+    async-task                       4.0.3  e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0 \
+    async-trait                     0.1.41  b246867b8b3b6ae56035f1eb1ed557c1d8eae97f0d53696138a50fa0e3a3b8c0 \
+    atomic-waker                     1.0.0  065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a \
+    atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+    autocfg                          1.0.1  cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a \
+    backtrace                       0.3.54  2baad346b2d4e94a24347adeee9c7a93f412ee94b9cc26e5b59dea23848e9f28 \
+    base64                          0.11.0  b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7 \
+    base64                          0.12.3  3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff \
+    bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
+    blake2b_simd                    0.5.11  afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587 \
+    blocking                         1.0.2  c5e170dbede1f740736619b776d7251cb1b9095c435c34d8ca9f57fcd2f335e9 \
+    bumpalo                          3.4.0  2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820 \
+    bytes                            0.5.6  0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38 \
+    cache-padded                     1.1.1  631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba \
+    cc                              1.0.61  ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d \
+    cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
+    cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
+    cidr-utils                       0.5.0  89f7b6372f3c783f6d44c0da283d3694af4104967bf2371cb3bdc9d09e1cfe00 \
+    clap                            2.33.3  37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002 \
+    colored                          2.0.0  b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd \
+    colorful                         0.2.1  0bca1619ff57dd7a56b58a8e25ef4199f123e78e503fe1653410350a1b98ae65 \
+    concurrent-queue                 1.2.2  30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3 \
+    const_fn                         0.4.3  c478836e029dcef17fb47c89023448c64f781a046e0300e257ad8225ae59afab \
+    constant_time_eq                 0.1.5  245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc \
+    crossbeam-utils                  0.7.2  c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8 \
+    crossbeam-utils                  0.8.0  ec91540d98355f690a86367e566ecad2e9e579f230230eb7c21398372be73ea5 \
+    debug-helper                    0.3.10  9a8a5bb894f24f42c247f19b25928a88e31867c0f84552c05df41a9dd527435e \
+    dirs                             3.0.1  142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff \
+    dirs-sys                         0.3.5  8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a \
+    either                           1.6.1  e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457 \
+    enum-as-inner                    0.3.3  7c5f0096a91d210159eceb2ff5e1c4da18388a170e1e3ce948aac9c8fdbbf595 \
+    env_logger                       0.8.1  54532e3223c5af90a6a757c90b5c5521564b07e5e7a958681bcd2afad421cdcd \
+    event-listener                   2.5.1  f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59 \
+    fastrand                         1.4.0  ca5faf057445ce5c9d4329e382b2ce7ca38550ef3b73a5348362d5f24e0c7fe3 \
+    form_urlencoded                  1.0.0  ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00 \
+    fuchsia-zircon                   0.3.3  2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
+    fuchsia-zircon-sys               0.3.3  3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
+    futures                          0.3.7  95314d38584ffbfda215621d723e0a3906f032e03ae5551e650058dac83d4797 \
+    futures-channel                  0.3.7  0448174b01148032eed37ac4aed28963aaaa8cfa93569a08e5b479bbc6c2c151 \
+    futures-core                     0.3.7  18eaa56102984bed2c88ea39026cff3ce3b4c7f508ca970cedf2450ea10d4e46 \
+    futures-executor                 0.3.7  f5f8e0c9258abaea85e78ebdda17ef9666d390e987f006be6080dfe354b708cb \
+    futures-io                       0.3.7  6e1798854a4727ff944a7b12aa999f58ce7aa81db80d2dfaaf2ba06f065ddd2b \
+    futures-lite                    1.11.2  5e6c079abfac3ab269e2927ec048dabc89d009ebfdda6b8ee86624f30c689658 \
+    futures-macro                    0.3.7  e36fccf3fc58563b4a14d265027c627c3b665d7fed489427e88e7cc929559efe \
+    futures-sink                     0.3.7  0e3ca3f17d6e8804ae5d3df7a7d35b2b3a6fe89dac84b31872720fc3060a0b11 \
+    futures-task                     0.3.7  96d502af37186c4fef99453df03e374683f8a1eec9dcc1e66b3b82dc8278ce3c \
+    futures-util                     0.3.7  abcb44342f62e6f3e8ac427b8aa815f724fd705dfad060b18ac7866c15bb8e34 \
+    gcd                              2.0.1  1c7cd301bf2ab11ae4e5bdfd79c221d97a25e46c089144a62ee9d09cb32d2b92 \
+    getrandom                       0.1.15  fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6 \
+    gimli                           0.23.0  f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce \
+    gloo-timers                      0.2.1  47204a46aaff920a1ea58b11d03dec6f704287d27561724a4631e450654a891f \
+    heck                             0.3.1  20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205 \
+    hermit-abi                      0.1.17  5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8 \
+    hostname                         0.3.1  3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867 \
+    humantime                        2.0.1  3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a \
+    idna                             0.2.0  02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9 \
+    instant                          0.1.8  cb1fc4429a33e1f80d41dc9fea4d108a88bec1de8053878898ae448a0b52f613 \
+    iovec                            0.1.4  b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e \
+    ipconfig                         0.2.2  f7e2f18aece9709094573a9f24f483c4f65caa4298e2f7ae1b71cc65d853fad7 \
+    itertools                        0.9.0  284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b \
+    itoa                             0.4.6  dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6 \
+    js-sys                          0.3.45  ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8 \
+    kernel32-sys                     0.2.2  7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d \
+    kv-log-macro                     1.0.7  0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    libc                            0.2.80  4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614 \
+    linked-hash-map                  0.5.3  8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a \
+    log                             0.4.11  4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b \
+    lru-cache                        0.1.2  31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c \
+    match_cfg                        0.1.0  ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4 \
+    matches                          0.1.8  7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
+    memchr                           2.3.4  0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525 \
+    miniz_oxide                      0.4.3  0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d \
+    mio                             0.6.22  fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430 \
+    miow                             0.2.1  8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919 \
+    nb-connect                       1.0.2  8123a81538e457d44b933a02faf885d3fe8408806b23fa700e8f01c6c3a98998 \
+    net2                            0.2.35  3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853 \
+    num-bigint                       0.3.1  5e9a41747ae4633fce5adffb4d2e81ffc5e89593cb19917f8fb2cc5ff76507bf \
+    num-integer                     0.1.44  d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db \
+    num-traits                      0.2.14  9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290 \
+    num_cpus                        1.13.0  05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3 \
+    object                          0.22.0  8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397 \
+    once_cell                        1.4.1  260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad \
+    parking                          2.0.0  427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72 \
+    percent-encoding                 2.1.0  d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
+    pin-project                      1.0.1  ee41d838744f60d959d7074e3afb6b35c7456d0f61cad38a24e35e6553f73841 \
+    pin-project-internal             1.0.1  81a4ffa594b66bff340084d4081df649a7dc049ac8d7fc458d8e628bfbbb2f86 \
+    pin-project-lite                0.1.11  c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b \
+    pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
+    polling                          2.0.2  a2a7bc6b2a29e632e45451c941832803a18cce6781db04de8a04696cdca8bde4 \
+    ppv-lite86                      0.2.10  ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857 \
+    proc-macro-error                 1.0.4  da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c \
+    proc-macro-error-attr            1.0.4  a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869 \
+    proc-macro-hack                 0.5.19  dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5 \
+    proc-macro-nested                0.1.6  eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a \
+    proc-macro2                     1.0.24  1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71 \
+    quick-error                      1.2.3  a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0 \
+    quote                            1.0.7  aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37 \
+    rand                             0.7.3  6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
+    rand_chacha                      0.2.2  f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402 \
+    rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
+    rand_hc                          0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
+    redox_syscall                   0.1.57  41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce \
+    redox_users                      0.3.5  de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d \
+    regex                            1.4.2  38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c \
+    regex-syntax                    0.6.21  3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189 \
+    resolv-conf                      0.6.3  11834e137f3b14e309437a8276714eed3a80d1ef894869e510f2c0c0b98b9f4a \
+    ring                           0.16.15  952cd6b98c85bbc30efa1ba5783b8abf12fec8b3287ffa52605b9432313e34e4 \
+    rlimit                           0.5.2  2ae7aac7f5ad5159594e4e9a59c28949217f9aee8e80c2991d8672453e9e4316 \
+    rust-argon2                      0.8.2  9dab61250775933275e84053ac235621dfb739556d5c54a2f2e9313b7cf43a19 \
+    rustc-demangle                  0.1.18  6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232 \
+    rustls                          0.17.0  c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1 \
+    ryu                              1.0.5  71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e \
+    sct                              0.6.0  e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c \
+    serde                          1.0.117  b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a \
+    serde_derive                   1.0.117  cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e \
+    serde_json                      1.0.59  dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95 \
+    shell-words                      1.0.0  b6fa3938c99da4914afedd13bf3d79bcb6c277d1b2c398d23257a304d9e1b074 \
+    slab                             0.4.2  c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8 \
+    smallvec                         1.4.2  fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252 \
+    socket2                         0.3.15  b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44 \
+    spin                             0.5.2  6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d \
+    strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
+    structopt                       0.3.20  126d630294ec449fae0b16f964e35bf3c74f940da9dca17ee9b905f7b3112eb8 \
+    structopt-derive                0.4.13  65e51c492f9e23a220534971ff5afc14037289de430e3c83f9daf6a1b6ae91e8 \
+    subprocess                       0.2.6  69b9ad6c3e1b525a55872a4d2f2d404b3c959b7bbcbfd83c364580f68ed157bd \
+    syn                             1.0.48  cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac \
+    termcolor                        1.1.0  bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f \
+    text_placeholder                 0.4.0  cbd6afcbe8d748e35406f4c3a79b60567a5104b451f1b618097f139294969ef4 \
+    textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
+    thiserror                       1.0.22  0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e \
+    thiserror-impl                  1.0.22  9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56 \
+    thread_local                     1.0.1  d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14 \
+    tinyvec                          0.3.4  238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117 \
+    tokio                           0.2.22  5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd \
+    tokio-rustls                    0.13.1  15cb62a0d2770787abc96e99c1cd98fcf17f94959f3af63ca85bdfb203f051b4 \
+    toml                             0.5.7  75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645 \
+    trust-dns-proto                 0.19.5  cdd7061ba6f4d4d9721afedffbfd403f20f39a4301fee1b70d6fcd09cca69f28 \
+    trust-dns-resolver              0.19.5  0f23cdfdc3d8300b3c50c9e84302d3bd6d860fb9529af84ace6cf9665f181b77 \
+    trust-dns-rustls                0.19.5  365f4f7efd5f7ab30c143ad4172534077f32ccb16b1977d13e9259d2457744c2 \
+    unicode-bidi                     0.3.4  49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5 \
+    unicode-normalization           0.1.13  6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977 \
+    unicode-segmentation             1.6.0  e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0 \
+    unicode-width                    0.1.8  9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3 \
+    unicode-xid                      0.2.1  f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564 \
+    untrusted                        0.7.1  a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a \
+    url                              2.2.0  5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e \
+    vec-arena                        1.0.0  eafc1b9b2dfc6f5529177b62cf806484db55b32dc7c9658a118e11bbeb33061d \
+    vec_map                          0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
+    version_check                    0.9.2  b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed \
+    wait-timeout                     0.2.0  9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6 \
+    waker-fn                         1.1.0  9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca \
+    wasi      0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
+    wasm-bindgen                    0.2.68  1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42 \
+    wasm-bindgen-backend            0.2.68  f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68 \
+    wasm-bindgen-futures            0.4.18  b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da \
+    wasm-bindgen-macro              0.2.68  6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038 \
+    wasm-bindgen-macro-support      0.2.68  f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe \
+    wasm-bindgen-shared             0.2.68  1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307 \
+    web-sys                         0.3.45  4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d \
+    webpki                          0.21.3  ab146130f5f790d45f82aeeb09e55a256573373ec64409fc19a6fb82fb1032ae \
+    webpki-roots                    0.19.0  f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739 \
+    wepoll-sys                       3.0.1  0fcb14dea929042224824779fbc82d9fab8d2e6d3cbc0ac404de8edf489e77ff \
+    widestring                       0.4.3  c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c \
+    winapi                           0.2.8  167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
+    winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
+    winapi-build                     0.1.1  2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                      0.1.5  70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    winreg                           0.6.2  b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9 \
+    ws2_32-sys                       0.2.1  d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e


### PR DESCRIPTION
#### Description

New port for [RustScan](https://github.com/RustScan/RustScan)

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
