### PR TITLE
aerc: update to 0.5.2

### DIFF
--- a/mail/aerc/Portfile
+++ b/mail/aerc/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           makefile 1.0
 
 name                aerc
-version             0.4.0
+version             0.5.2
 categories          mail
 license             MIT
 maintainers         nomaintainer
@@ -18,9 +18,9 @@ master_sites        https://git.sr.ht/~sircmpwn/aerc/archive/
 distname            ${version}
 worksrcdir          ${name}-${distname}
 
-checksums           rmd160  a7cc2f13f691524cfe9a54e5fea5b83d447ba60d \
-                    sha256  d369462cc0f76c33d804e586463e4d35d81fba9396ec08c3d3d0579e26091e17 \
-                    size    128549
+checksums           rmd160  f935c02ae5bcd37a2100e035bda451045204fa52 \
+                    sha256  87b922440e53b99f260d2332996537decb452c838c774e9340b633296f9f68ee \
+                    size    142415
 
 depends_build       port:go \
                     port:scdoc


### PR DESCRIPTION
#### Description
[Changelog](https://git.sr.ht/~sircmpwn/aerc/refs)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
