### PR TITLE
openjdk8: update to 8u275

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -3,15 +3,15 @@
 PortSystem       1.0
 
 name             openjdk8
-version          8u272
+version          8u275
 revision         0
 
-set build        10
+set build        01
 set major        8
 
-checksums        rmd160  d8369b4fbb3f542cee52c2bd8eb5a9a269cc41ae \
-                 sha256  091f9ee39b0bdbc8af8ec19f51aaa0f73e416c2e93a8fb2c79b82f4caac83ab6 \
-                 size    101773502
+checksums        rmd160  c59602c9c079d368f06ac8beea51c230f1e09e63 \
+                 sha256  4afd2b3d21b625392fe4501e9445d1125498e6e7fb78042495c04e7cfc1b5e69 \
+                 size    101776105
 
 subport openjdk8-graalvm {
     version      20.2.0
@@ -25,29 +25,29 @@ subport openjdk8-graalvm {
 }
 
 subport openjdk8-openj9 {
-    version      8u272
+    version      8u275
     revision     0
 
-    set build    10
+    set build    01
     set major    8
     set openj9_version 0.23.0
     
-    checksums    rmd160  c7b6e70a814634fed5f298021dda38e22f3a5027 \
-                 sha256  694c7f8d6365f6717e9d854fab206053535a403805e7ef2c12d29e8df29083f6 \
-                 size    114902400
+    checksums    rmd160  87dbdf04bdb95f872b6a15374c61dc1d5f35837f \
+                 sha256  0e19282fe1dae272f1383f726cc6fc70d77816bebe07e0959ac2c9b9b711f709 \
+                 size    114196051
 }
 
 subport openjdk8-openj9-large-heap {
-    version      8u272
+    version      8u275
     revision     0
 
-    set build    10
+    set build    01
     set major    8
     set openj9_version 0.23.0
     
-    checksums    rmd160  749b689d98b096f84c6915a2ff55429328cf26c9 \
-                 sha256  ea6749046313f2eded0c3434342a431c2a62d9ebfa36230b9e7338628853221e \
-                 size    114189123
+    checksums    rmd160  11c8c8add75504e72ce7183fe1007216f96c3d2d \
+                 sha256  5f2375de68ec0d0ff4d42670aa54416948fcdd62a1cc035023c27d5d090522ab \
+                 size    114907169
 }
 
 subport openjdk10 {


### PR DESCRIPTION
#### Description

Update to AdoptOpenJDK 8u275.

###### Tested on

macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?