### PR TITLE
gpac: update to 1.0.1

### DIFF
--- a/multimedia/gpac/Portfile
+++ b/multimedia/gpac/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        gpac gpac 0.8.0 v
-revision            1
+github.setup        gpac gpac 1.0.1 v
+revision            0
 categories          multimedia
 platforms           darwin
 maintainers         nomaintainer
@@ -20,9 +20,10 @@ long_description    GPAC is an Open Source multimedia framework for \
 
 homepage            http://gpac.wp.mines-telecom.fr/
 
-checksums           rmd160  9a95cf4b2bd0a98e995b21e13ba3ad1ccdb29246 \
-                    sha256  c5ac9846b313a718b030de629d9ed9c0a5db9fec40fdb4f803a571525eb63a8d \
-                    size    11406479
+github.tarball_from archive
+checksums           rmd160  1e19dba1a2770268f64947f6ba34fb458028764f \
+                    sha256  3b0ffba73c68ea8847027c23f45cd81d705110ec47cf3c36f60e669de867e0af \
+                    size    10352926
 
 depends_build       port:pkgconfig \
                     port:zlib
@@ -31,7 +32,6 @@ depends_lib         port:a52dec \
                     port:faad2 \
                     path:lib/libavcodec.dylib:ffmpeg \
                     port:jpeg \
-                    port:openjpeg15 \
                     port:libmad \
                     port:libogg \
                     port:libpng \
@@ -68,11 +68,10 @@ if {${os.platform} eq "darwin" && ${os.major} < 12} {
 
 # external spidermonkey (--use-js=no) is not recognized because it doesn't provide a pkg-config file and build fails with local copy
 # pulseaudio is recognized if installed but build fails
-# builds with openjpeg15 if include path is added, build fails using openjpeg 2.1
 
 configure.args      --cc="${configure.cc}" \
                     --cxx="${configure.cxx}" \
-                    --extra-cflags="-I${prefix}/include/openjpeg-1.5 ${configure.cc_archflags}" \
+                    --extra-cflags="${configure.cc_archflags}" \
                     --extra-ldflags="${configure.ld_archflags}" \
                     --mandir=${prefix}/share/man \
                     --X11-path=${prefix} \

--- a/multimedia/gpac/files/patch-configure.diff
+++ b/multimedia/gpac/files/patch-configure.diff
@@ -1,9 +1,11 @@
---- configure.orig	2016-03-04 10:03:40.000000000 -0600
-+++ configure	2016-04-17 14:20:52.000000000 -0500
-@@ -552,16 +552,7 @@
-         xul_flags=-DXP_MAC
+diff --git configure configure
+index de8ea9965..017b55aa9 100755
+--- configure
++++ configure
+@@ -554,16 +554,7 @@ EOF
+     Darwin)
          CFLAGS_DIR="-I$prefix/include"
-         LDFLAGS="-L$prefix/lib"
+         LDFLAGS="-L$prefix/$libdir"
 -        if test -d /sw/bin ; then
 -            alt_macosx_dir="/sw"
 -            CFLAGS_DIR="-I/sw/include $CFLAGS_DIR"

--- a/multimedia/gpac/files/patch-no-hevc-yosemite.diff
+++ b/multimedia/gpac/files/patch-no-hevc-yosemite.diff
@@ -1,31 +1,20 @@
-diff --git modules/vtb_decode/vtb_decode.c modules/vtb_decode/vtb_decode.c
-index af0e9be78..176ce0e2e 100644
---- modules/vtb_decode/vtb_decode.c
-+++ modules/vtb_decode/vtb_decode.c
-@@ -275,6 +275,7 @@ static GF_Err VTBDec_InitDecoder(VTBDec *ctx)
+diff --git src/filters/dec_vtb.c src/filters/dec_vtb.c
+index 9ad6e6d4a..1a012e8b8 100644
+--- src/filters/dec_vtb.c
++++ src/filters/dec_vtb.c
+@@ -468,6 +468,7 @@ static GF_Err vtbdec_init_decoder(GF_Filter *filter, GF_VTBDecCtx *ctx)
  		}
          break;
  
 +#ifdef AVAILABLE_MAC_OS_X_VERSION_10_11_AND_LATER
-     case GPAC_OTI_VIDEO_HEVC:
+     case GF_CODECID_HEVC:
  		if (gf_list_count(ctx->SPSs) && gf_list_count(ctx->PPSs) && gf_list_count(ctx->VPSs)) {
  			s32 idx;
-@@ -426,6 +427,7 @@ static GF_Err VTBDec_InitDecoder(VTBDec *ctx)
+@@ -614,6 +615,7 @@ static GF_Err vtbdec_init_decoder(GF_Filter *filter, GF_VTBDecCtx *ctx)
  			gf_free(dsi_data);
  		}
          break;
 +#endif
  
- 	case GPAC_OTI_VIDEO_MPEG2_SIMPLE:
- 	case GPAC_OTI_VIDEO_MPEG2_MAIN:
-@@ -1548,8 +1550,10 @@ static const char *VTBDec_GetCodecName(GF_BaseDecoder *dec)
- 	switch (ctx->vtb_type) {
- 	case kCMVideoCodecType_H264:
- 		return ctx->is_hardware ? "VTB hardware AVC|H264" : "VTB software AVC|H264";
-+#ifdef AVAILABLE_MAC_OS_X_VERSION_10_11_AND_LATER
- 	case kCMVideoCodecType_HEVC:
- 		return ctx->is_hardware ? "VTB hardware HEVC" : "VTB software HEVC";
-+#endif
- 	case kCMVideoCodecType_MPEG2Video:
- 		return ctx->is_hardware ? "VTB hardware MPEG-2" : "VTB software MPEG-2";
-     case  kCMVideoCodecType_MPEG4Video:
+ 	case GF_CODECID_MPEG2_SIMPLE:
+ 	case GF_CODECID_MPEG2_MAIN:


### PR DESCRIPTION
#### Description

This sets the openjpeg dep to 2.3.1 (port: openjpeg).

I have attempted to retain support for Yosemite's lack of HEVC support but I cannot test this.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
  - https://trac.macports.org/ticket/61459
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
