### PR TITLE
openjdk8: update to AdoptOpenJDK 11.0.9+11.1

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -64,14 +64,14 @@ subport openjdk10 {
 
 subport openjdk11 {
     version      11.0.9
-    revision     0
+    revision     1
 
     set build    11
     set major    11
-    
-    checksums    rmd160  f420714f36088f3ecdad1da3c4798fabc6275a9f \
-                 sha256  e84b00d74f08f059829bbf121c8423dc37ff65135968c1fcda5839600be4f542 \
-                 size    185532704
+
+    checksums    rmd160  87d9bfe6d83b728b2a38ed374f0ba95f9b0c35c8 \
+                 sha256  7b21961ffb2649e572721a0dfad64169b490e987937b661cb4e13a594c21e764 \
+                 size    186006796
 }
 
 subport openjdk11-graalvm {
@@ -87,28 +87,28 @@ subport openjdk11-graalvm {
 
 subport openjdk11-openj9 {
     version      11.0.9
-    revision     0
+    revision     1
 
     set build    11
     set major    11
     set openj9_version 0.23.0
     
-    checksums    rmd160  f42f2e8de0b6e9bc7e0deada17ab456c115a9f2d \
-                 sha256  1458ff5261f1f2b1c6ae9f3c17ef7a153d6ee99760820be32258d25fec5202c7 \
-                 size    195536516
+    checksums    rmd160  459d97290f1a84e53811fc60cd4f3a02008be4b0 \
+                 sha256  382238443d4495d976f9e1a66b0f6e3bc250d3d009b64d2c29d44022afd7e418 \
+                 size    195535925
 }
 
 subport openjdk11-openj9-large-heap {
     version      11.0.9
-    revision     0
+    revision     1
 
     set build    11
     set major    11
     set openj9_version 0.23.0
     
-    checksums    rmd160  aa36b98d6c07c1686bc44acad6ba7c6ea167ef59 \
-                 sha256  9ec7cd671fa417f536ea1a391497c6c439b790a4975d8bb6d58937908a4e3c66 \
-                 size    196318717
+    checksums    rmd160  1c87a3ffe4fe32e8482f35ecf59cbb6aa6f5d74d \
+                 sha256  dc6987f495c7c16c8f7ad7eee50c6e62afcd3c4279e5c223e302bd529d06fb8d \
+                 size    196321048
 }
 
 subport openjdk12 {
@@ -335,6 +335,52 @@ if {${subport} eq "openjdk8"} {
     master_sites https://download.java.net/java/GA/jdk${major}/${version}/19aef61b38124481863b1413dce1855f/${build}/
     distname     openjdk-${version}_osx-x64_bin
     worksrcdir   jdk-${version}.jdk
+} elseif {${subport} eq "openjdk11"} {
+    # Stealth update for 11.1, remove this for the next release
+    description  Open Java Development Kit ${major} (AdoptOpenJDK) with HotSpot VM
+    long_description OpenJDK build provided by AdoptOpenJDK, built from a fully \
+                 open-source set of build scripts and infrastructure. \
+                 \
+                 HotSpot is the VM from the OpenJDK community and  the most widely used VM. \
+                 It is suitable for all workloads.
+
+    dist_subdir  ${name}/${version}_1
+
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.1/
+    distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}_${build}
+    worksrcdir   jdk-${version}+${build}
+} elseif {${subport} eq "openjdk11-openj9"} {
+    # Stealth update for 11.1, remove this for the next release
+    description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM
+    long_description AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully \
+                 open-source set of build scripts and infrastructure. \
+                 \
+                 OpenJ9 is the virtual machine from the Eclipse community. It is an enterprise-grade \
+                 VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
+                 suitable for running all workloads.
+
+    dist_subdir  ${name}/${version}_1
+
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.1_openj9-${openj9_version}/
+    distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
+    worksrcdir   jdk-${version}+${build}
+} elseif {${subport} eq "openjdk11-openj9-large-heap"} {
+    # Stealth update for 11.1, remove this for the next release
+    description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM for large heap sizes
+    long_description AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully \
+                 open-source set of build scripts and infrastructure. \
+                 \
+                 OpenJ9 is the virtual machine from the Eclipse community. It is an enterprise-grade \
+                 VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
+                 suitable for running all workloads. \
+                 \
+                 This version uses non-compressed references and should be used for applications which require heaps that are over ~57 GB.
+
+    dist_subdir  ${name}/${version}_1
+
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.1_openj9-${openj9_version}/
+    distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
+    worksrcdir   jdk-${version}+${build}
 } elseif [string match *-graalvm ${subport}] {
     description  GraalVM Community Edition based on OpenJDK ${major}
     long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, \


### PR DESCRIPTION
#### Description

Update to AdoptOpenJDK 11.0.9+11.1 (stealth update).

###### Tested on

macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?