### PR TITLE
minikube: update to 1.15.1

### DIFF
--- a/sysutils/minikube/Portfile
+++ b/sysutils/minikube/Portfile
@@ -3,13 +3,15 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        kubernetes minikube 1.15.0 v
+github.setup        kubernetes minikube 1.15.1 v
 categories          sysutils
 platforms           darwin
 supported_archs     x86_64
 license             Apache-2
 
-maintainers         {lbschenkel @lbschenkel} openmaintainer
+maintainers         {lbschenkel @lbschenkel} \
+                    {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
 
 description         Run Kubernetes locally
 long_description    Minikube runs a single-node Kubernetes cluster inside a VM \
@@ -19,9 +21,9 @@ long_description    Minikube runs a single-node Kubernetes cluster inside a VM \
 github.tarball_from releases
 distfiles           minikube-darwin-amd64
 checksums           minikube-darwin-amd64 \
-                    rmd160  91789e238071afe3b063766a432ed2b40f01eff4 \
-                    sha256  a744ed7fb5c317ef06b2c5ae0d94cec1d41e1d5c2ea40b5ece28e7a340abbad3 \
-                    size    55723064
+                    rmd160  64034e7aefc1de0b3471bb1d87911e05abbe056f \
+                    sha256  ab47a4e3ff742db8a88d7bf0fe9cb9c6805e6f1df2545d8888f196c46b96f714 \
+                    size    55727224
 dist_subdir         ${name}/${version}
 
 depends_lib         path:${prefix}/bin/kubectl:kubectl-1.19
@@ -32,8 +34,8 @@ default_variants    +hyperkit
 variant hyperkit description {Install Hyperkit driver} {
     distfiles-append    docker-machine-driver-hyperkit
     checksums-append    docker-machine-driver-hyperkit \
-                        rmd160  59205b183f64b1ae58f778673afeb139c0ccdc1e \
-                        sha256  64993105b5adaec81648525cec21dda77c4c0c641549f4bcf9428efd55911921 \
+                        rmd160  88e7c0653a001bbaf9254a593d50e145d2d770ea \
+                        sha256  17e11dfdc3052ffca3a28b33a079bc7b80d22c857a19b18ede6143de9c6efed4 \
                         size    12000860
 }
 


### PR DESCRIPTION
- add @herbygillot to maintainer's list

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
