### PR TITLE
restic: update to 0.11.0

### DIFF
--- a/sysutils/restic/Portfile
+++ b/sysutils/restic/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/restic/restic 0.10.0 v
+go.setup            github.com/restic/restic 0.11.0 v
 categories          sysutils
 
 license             BSD
@@ -15,9 +15,9 @@ long_description    Restic is a program that does backups right. Its design goal
 homepage            https://restic.net/
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  f5eb870195c8127742c10ed80575e2f3c16dd6b0 \
-                        sha256  8758130f7aa1639b1b2c24c327114657a819c81cdd229a41f56fe9a6550a2b05 \
-                        size    23683647
+                        rmd160  89c0647a53dcb1333371734ce8c57cb26d91ffb8 \
+                        sha256  3fee12f2bf405e28cc35e8fe8379d9d73345a79ee8347f4928701158495bb266 \
+                        size    23760697
 
 # FIXME: This port currently can't be built without allowing go mod to fetch
 # dependencies during the build phase. See


### PR DESCRIPTION
#### Description

Update restic to 0.11.0

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS macOS 11.0.1 20B29
Xcode None

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
