### PR TITLE
erlang: Update to 23.1 and fix build on macOS 11 and arm64

### DIFF
--- a/lang/erlang/Portfile
+++ b/lang/erlang/Portfile
@@ -132,17 +132,9 @@ variant ssl description {Build SSL support} {
     depends_lib-append          path:lib/libssl.dylib:openssl
 }
 
-variant hipe conflicts nohipe description {Enable HiPE (native-code bytecode compiler)} {
+variant hipe description {Enable HiPE (native-code bytecode compiler)} {
     configure.args-delete       --disable-hipe
     configure.args-append       --enable-hipe
-}
-
-variant nohipe conflicts hipe description {Legacy compatibility variant} {}
-
-if {[variant_isset nohipe]} {
-    default_variants -hipe
-} else {
-    default_variants +hipe
 }
 
 variant odbc description {Build ODBC support} {
@@ -153,7 +145,6 @@ variant odbc description {Build ODBC support} {
 
 default_variants    +ssl
 
-# Livecheck
 livecheck.type      regex
 livecheck.version   ${version}
 livecheck.url       ${homepage}download/

--- a/lang/erlang/Portfile
+++ b/lang/erlang/Portfile
@@ -78,9 +78,16 @@ depends_lib         port:ncurses
 # GCC 4.2 also fails: https://trac.macports.org/ticket/52507
 compiler.blacklist  {clang < 300} gcc-4.2
 
+# shellescape will be in MacPorts 2.7.0.
+if {[vercmp [macports_version] 2.6.99] < 0} {
+    proc shellescape {arg} {
+        return [regsub -all -- {[^A-Za-z0-9.:@%/+=_-]} $arg {\\&}]
+    }
+}
+
 post-destroot   {
-    system "tar -C ${destroot}${prefix}/lib/erlang -zxvf ${distpath}/otp_doc_html_${version}${extract.suffix}"
-    system "tar -C ${destroot}${prefix}/lib/erlang -zxvf ${distpath}/otp_doc_man_${version}${extract.suffix}"
+    system "tar -C ${destroot}${prefix}/lib/erlang -zxvf [shellescape ${distpath}/otp_doc_html_${version}${extract.suffix}]"
+    system "tar -C ${destroot}${prefix}/lib/erlang -zxvf [shellescape ${distpath}/otp_doc_man_${version}${extract.suffix}]"
  
     set erts_dir            erts-11.0
     set erl_interface_dir   erl_interface-4.0

--- a/lang/erlang/Portfile
+++ b/lang/erlang/Portfile
@@ -5,7 +5,7 @@ PortGroup           wxWidgets 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 name                erlang
-version             23.0
+version             23.1
 revision            0
 
 categories          lang erlang
@@ -42,23 +42,24 @@ distfiles           otp_src_${version}${extract.suffix}                    \
                     otp_doc_man_${version}${extract.suffix}                \
                     otp_doc_html_${version}${extract.suffix}
 
-checksums           otp_src_23.0.tar.gz \
-                    rmd160  2d6949131c3bcfa0e1d9bb9fefa79f40fbd21d1d \
-                    sha256  42dcf3c721f4de59fe74ae7b65950c2174c46dc8d1dd4e27c0594d86f606a635 \
-                    size    88865562 \
-                    otp_doc_man_23.0.tar.gz \
-                    rmd160  f3241039f75a869623bac700dd3d69015930b0cf \
-                    sha256  c0804cb5bead8780de24cf9ba656efefd9307a457e0541cc513109523731bf6f \
-                    size    1383486 \
-                    otp_doc_html_23.0.tar.gz \
-                    rmd160  187c4cc724bf5bce56fe66b3427bc31438c58d38 \
-                    sha256  4da19f0de96d1c516d91c621a5ddf20837303cc25695b944e263e3ea46dd31da \
-                    size 36238699
+checksums           otp_src_23.1.tar.gz \
+                    rmd160  9eefc2a9ab080fe32631a4bd3abc322cdf609c0d \
+                    sha256  cb5b7246eeaac9298c51c9915386df2f784e82a3f7ff93b68453591f0b370400 \
+                    size    89063191 \
+                    otp_doc_man_23.1.tar.gz \
+                    rmd160  6d34113ccda6de7b1ca68149bba40420f8726e3b \
+                    sha256  f49ecbb05b0895ec54fc66ea65b4e7cf593a4877748acc4d549f7613c92b94a9 \
+                    size    1384042 \
+                    otp_doc_html_23.1.tar.gz \
+                    rmd160  2a51abbe2a1da25750738628da66a11e16e95afa \
+                    sha256  0e0075f174db2f9b5a0f861263062942e5a721c40ec747356e482e3be2fb8931 \
+                    size    36285075
 
 worksrcdir          otp_src_${version}
 
 # http://www.erlang.org/pipermail/erlang-bugs/2009-January/001171.html
 patchfiles          patch-erts_emulator_Makefile.in.diff
+patchfiles-append   patch-make-configure.diff
 
 configure.args      --prefix=${prefix}       \
                     --enable-threads         \
@@ -114,7 +115,7 @@ platform darwin 10 {
 }
 
 platform darwin {
-    if {${configure.build_arch} eq "x86_64" || ${configure.build_arch} eq "ppc64"} {
+    if {${configure.build_arch} in [list arm64 ppc64 x86_64]} {
         configure.args-append   --enable-darwin-64bit
     } else {
         configure.args-append   --disable-darwin-64-bit
@@ -142,6 +143,8 @@ variant ssl description {Build SSL support} {
     depends_lib-append          path:lib/libssl.dylib:openssl
 }
 
+# HiPE will go away in a future version of erlang so this variant can be removed then.
+# See https://github.com/erlang/otp/pull/2854
 variant hipe description {Enable HiPE (native-code bytecode compiler)} {
     configure.args-delete       --disable-hipe
     configure.args-append       --enable-hipe

--- a/lang/erlang/Portfile
+++ b/lang/erlang/Portfile
@@ -86,13 +86,17 @@ post-destroot   {
     set erl_interface_dir   erl_interface-4.0
     set wx_dir              wx-1.9.1
 
-    foreach x {dialyzer ear ecc elink epmd erl erlc escript run_erl start to_erl typer} { file delete -force ${destroot}${prefix}/bin/${x} }
-    foreach x {dialyzer erl erlc escript run_erl start to_erl typer} { system "ln -s ../lib/erlang/bin/${x} ${destroot}${prefix}/bin/${x}" }
+    foreach x {dialyzer ear ecc elink epmd erl erlc escript run_erl start to_erl typer} {
+        delete ${destroot}${prefix}/bin/${x}
+    }
+    foreach x {dialyzer erl erlc escript run_erl start to_erl typer} {
+        ln -s ../lib/erlang/bin/${x} ${destroot}${prefix}/bin/${x}
+    }
 
-    file delete -force ${destroot}${prefix}/lib/erlang/bin/epmd
-    system "ln -s ../${erts_dir}/bin/epmd ${destroot}${prefix}/lib/erlang/bin/epmd"
-    system "ln -s ../lib/erlang/${erts_dir}/bin/epmd ${destroot}${prefix}/bin/epmd"
-    system "ln -s ../lib/erlang/lib/${erl_interface_dir}/bin/erl_call ${destroot}${prefix}/bin/erl_call"
+    delete ${destroot}${prefix}/lib/erlang/bin/epmd
+    ln -s ../${erts_dir}/bin/epmd ${destroot}${prefix}/lib/erlang/bin/epmd
+    ln -s ../lib/erlang/${erts_dir}/bin/epmd ${destroot}${prefix}/bin/epmd
+    ln -s ../lib/erlang/lib/${erl_interface_dir}/bin/erl_call ${destroot}${prefix}/bin/erl_call
 }
 
 platform darwin 10 {

--- a/lang/erlang/Portfile
+++ b/lang/erlang/Portfile
@@ -117,7 +117,6 @@ platform darwin {
 
 variant wxwidgets description {Build wxWidgets support} {
     wxWidgets.use               wxWidgets-3.0
-    patchfiles-delete           patch-disable_wx.diff
     patchfiles-append           patch-lib_wx_configure.in.diff
     depends_lib-append          port:${wxWidgets.port}
     depends_lib-append          port:libGLU

--- a/lang/erlang/files/patch-erts_emulator_Makefile.in.diff
+++ b/lang/erlang/files/patch-erts_emulator_Makefile.in.diff
@@ -1,6 +1,8 @@
---- erts/emulator/Makefile.in.orig
-+++ erts/emulator/Makefile.in
-@@ -46,7 +46,12 @@ THR_DEFS=@EMU_THR_DEFS@
+HiPE will be removed so maybe the first part of the patch can go away then.
+See https://github.com/erlang/otp/pull/2854
+--- erts/emulator/Makefile.in.orig	2020-09-22 14:11:38.000000000 -0500
++++ erts/emulator/Makefile.in	2020-11-17 12:58:50.000000000 -0600
+@@ -60,7 +60,12 @@
  M4FLAGS=
  CREATE_DIRS=
  
@@ -13,8 +15,8 @@
 +LDFLAGS=@LDFLAGS@ -pagezero_size 0x400000
  ARFLAGS=rc
  OMIT_OMIT_FP=no
- 
-@@ -125,7 +130,7 @@ else
+ TYPE_LIBS=
+@@ -170,7 +175,7 @@
  override TYPE=opt
  PURIFY =
  TYPEMARKER =

--- a/lang/erlang/files/patch-erts_emulator_sys_unix_ddll.c.diff
+++ b/lang/erlang/files/patch-erts_emulator_sys_unix_ddll.c.diff
@@ -1,6 +1,6 @@
---- erts/emulator/sys/unix/erl_unix_sys_ddll.c.orig
-+++ erts/emulator/sys/unix/erl_unix_sys_ddll.c
-@@ -49,6 +49,13 @@ static char **errcodes = NULL;
+--- erts/emulator/sys/unix/erl_unix_sys_ddll.c.orig	2020-09-22 14:11:38.000000000 -0500
++++ erts/emulator/sys/unix/erl_unix_sys_ddll.c	2020-11-17 13:09:11.000000000 -0600
+@@ -50,6 +50,13 @@
  static int num_errcodes = 0;
  static int num_errcodes_allocated = 0;
  

--- a/lang/erlang/files/patch-lib_wx_configure.in.diff
+++ b/lang/erlang/files/patch-lib_wx_configure.in.diff
@@ -1,6 +1,6 @@
---- lib/wx/configure.in.orig
-+++ lib/wx/configure.in
-@@ -545,10 +545,10 @@ AC_CHECK_TYPES([GLintptr, GLintptrARB, GLchar,
+--- lib/wx/configure.in.orig	2020-09-22 14:11:38.000000000 -0500
++++ lib/wx/configure.in	2020-11-17 13:09:59.000000000 -0600
+@@ -569,10 +569,10 @@
  	       [#ifdef WIN32
  		# include <windows.h>
  	        # include <gl/gl.h>
@@ -13,7 +13,7 @@
  		#endif 
  		])
   
-@@ -563,10 +563,10 @@ AC_TRY_COMPILE([
+@@ -587,10 +587,10 @@
                  #ifdef WIN32
  		# include <windows.h>
  	        # include <gl/glu.h>
@@ -26,7 +26,7 @@
  		#endif 
  		#ifndef CALLBACK
  		# define CALLBACK
-@@ -613,10 +613,10 @@ AC_LINK_IFELSE([AC_LANG_SOURCE([
+@@ -637,10 +637,10 @@
  		#ifdef WIN32
  		# include <windows.h>
  	        # include <gl/gl.h>

--- a/lang/erlang/files/patch-make-configure.diff
+++ b/lang/erlang/files/patch-make-configure.diff
@@ -1,0 +1,70 @@
+Do not check the macOS version. The test is broken on some OS versions
+and nobody remembers why the check was being done.
+See https://github.com/erlang/otp/pull/2871
+--- make/configure.orig	2020-09-22 14:11:38.000000000 -0500
++++ make/configure	2020-11-17 13:14:22.000000000 -0600
+@@ -4649,64 +4649,6 @@
+ fi
+ 
+ 
+-if test $CROSS_COMPILING = no; then
+-   case $host_os in
+-   	darwin*)
+-	   macosx_version=`sw_vers -productVersion`
+-	   test $? -eq 0 || {
+-	   	as_fn_error $? "Failed to execute 'sw_vers'; please provide it in PATH" "$LINENO" 5
+-	   }
+-	   case "$macosx_version" in
+-	       [1-9][0-9].[0-9])
+-	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)|\10\200|'`;;
+-	       [1-9][0-9].[0-9].[0-9])
+-	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)\.\([^\.]*\)|\1\2\3|'`;;
+-	       [1-9][0-9].[1-9][0-9])
+-	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)|\1\200|'`;;
+-	       [1-9][0-9].[1-9][0-9].[0-9])
+-	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)\.\([^\.]*\)|\1\20\3|'`;;
+-	       [1-9][0-9].[1-9][0-9].[1-9][0-9])
+-	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)\.\([^\.]*\)|\1\2\3|'`;;
+-	       *)
+-		  int_macosx_version=unexpected;;
+-	   esac
+-	   test $int_macosx_version != unexpected || {
+-	   	as_fn_error $? "Unexpected MacOSX version ($macosx_version) returned by 'sw_vers -productVersion'; this configure script probably needs to be updated" "$LINENO" 5
+-	   }
+-
+-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-
+-#if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ > $int_macosx_version
+-#error Compiling for a newer MacOSX version...
+-#endif
+-
+-int
+-main ()
+-{
+-;
+-  ;
+-  return 0;
+-}
+-_ACEOF
+-if ac_fn_c_try_compile "$LINENO"; then :
+-
+-else
+-  as_fn_error $? "
+-
+-  You are natively building Erlang/OTP for a later version of MacOSX
+-  than current version ($macosx_version). You either need to
+-  cross-build Erlang/OTP, or set the environment variable
+-  MACOSX_DEPLOYMENT_TARGET to $macosx_version (or a lower version).
+-
+-" "$LINENO" 5
+-fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+-	   ;;
+-	*)
+-	   ;;
+-   esac
+-fi
+ 
+ ac_ext=c
+ ac_cpp='$CPP $CPPFLAGS'


### PR DESCRIPTION
#### Description

erlang: Update to 23.1 and fix build on macOS 11 and arm64. Also some other fixes; see individual commit messages.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14019
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
