### PR TITLE
openjdk8: update GraalVM subports to 20.3.0

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -14,14 +14,14 @@ checksums        rmd160  c59602c9c079d368f06ac8beea51c230f1e09e63 \
                  size    101776105
 
 subport openjdk8-graalvm {
-    version      20.2.0
+    version      20.3.0
     revision     0
 
     set major    8
     
-    checksums    rmd160  0bf3977fec6ad8a12fbdb5b1f0b52453d2fe19d7 \
-                 sha256  a1f524788354cfd2434566f0de972372f4a7743919bae49a9d508f2080385e7b \
-                 size    330118707
+    checksums    rmd160  5dfe16a90a2c6cc893d169029c77f891dda023fd \
+                 sha256  01e84c44032f8932ed04b2b829e0454973145bf55ddeeeed0ce71220c2213ae7 \
+                 size    347626453
 }
 
 subport openjdk8-openj9 {
@@ -75,14 +75,14 @@ subport openjdk11 {
 }
 
 subport openjdk11-graalvm {
-    version      20.2.0
+    version      20.3.0
     revision     0
 
     set major    11
     
-    checksums    rmd160  829239c28ecee8be0b8206645d597819684b895b \
-                 sha256  e9df2caace6f90fcfbc623c184ef1bbb053de20eb4cf5b002d708c609340ba7a \
-                 size    422700256
+    checksums    rmd160  897ea6614ee32d4a52cf0cc97dd0ad26e2a26fb3 \
+                 sha256  22b869fbf590c461278efae5e06fdd5ba32b4d5b302da838d9f50cb71aa20d01 \
+                 size    445970375
 }
 
 subport openjdk11-openj9 {


### PR DESCRIPTION
#### Description

Update to GraalVM Community Edition 20.3.0.

###### Tested on

macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?