### PR TITLE
nodejs14/15: don't require xcode. Allow ccache.

### DIFF
--- a/devel/nodejs14/Portfile
+++ b/devel/nodejs14/Portfile
@@ -43,8 +43,6 @@ depends_lib             port:icu \
                         port:python38 \
                         path:lib/libssl.dylib:openssl
 
-use_xcode               yes
-
 proc rec_glob {basedir pattern} {
     set files [glob -directory $basedir -nocomplain -type f $pattern]
     foreach dir [glob -directory $basedir -nocomplain -type d *] {
@@ -85,9 +83,6 @@ configure.args-append   --shared-openssl-libpath=${prefix}/lib
 supported_archs         i386 x86_64
 
 universal_variant       no
-
-# "V8 doesn't like cache."
-configure.ccache        no
 
 test.run                yes
 test.cmd                ${build.cmd} -j${build.jobs}

--- a/devel/nodejs15/Portfile
+++ b/devel/nodejs15/Portfile
@@ -43,8 +43,6 @@ depends_lib             port:icu \
                         port:python38 \
                         path:lib/libssl.dylib:openssl
 
-use_xcode               yes
-
 proc rec_glob {basedir pattern} {
     set files [glob -directory $basedir -nocomplain -type f $pattern]
     foreach dir [glob -directory $basedir -nocomplain -type d *] {
@@ -85,9 +83,6 @@ configure.args-append   --shared-openssl-libpath=${prefix}/lib
 supported_archs         i386 x86_64 arm64
 
 universal_variant       no
-
-# "V8 doesn't like cache."
-configure.ccache        no
 
 test.run                yes
 test.cmd                ${build.cmd} -j${build.jobs}


### PR DESCRIPTION
#### Description

https://trac.macports.org/ticket/60973

I believe these options are outdated and just a copy-paste from the old versions of nodejs port.

I have no issies building nodejs without XCode and with ccache enabled.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 11.0.1 20B29
Xcode N/A
CLT 12.2.0.0.1.1604076827

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

`sudo port -vst install` fails with `Too many open files`.
`sudo port -vs install` works.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
