### PR TITLE
ccls: update version to 0.20201025 and add support for clang-10

### DIFF
--- a/devel/ccls/Portfile
+++ b/devel/ccls/Portfile
@@ -19,7 +19,7 @@ description                 C/C++/ObjC language server supporting cross referenc
                             hierarchies, completion and semantic highlighting
 long_description            {*}${description}
 
-foreach clang_v {7.0 8.0 9.0} {
+foreach clang_v {7.0 8.0 9.0 10} {
     subport ccls-clang-${clang_v} {
         compiler.whitelist    macports-clang-${clang_v}
         configure.args-append -DCMAKE_PREFIX_PATH=${prefix}/libexec/llvm-${clang_v}

--- a/devel/ccls/Portfile
+++ b/devel/ccls/Portfile
@@ -3,7 +3,6 @@
 PortSystem                  1.0
 PortGroup                   cmake 1.1
 PortGroup                   github 1.0
-PortGroup                   cxx11 1.1
 PortGroup                   compiler_blacklist_versions 1.0
 
 name                        ccls
@@ -18,6 +17,8 @@ maintainers                 {egorenar @egorenar} openmaintainer
 description                 C/C++/ObjC language server supporting cross references,\
                             hierarchies, completion and semantic highlighting
 long_description            {*}${description}
+
+compiler.cxx_standard       2017
 
 foreach clang_v {7.0 8.0 9.0 10} {
     subport ccls-clang-${clang_v} {

--- a/devel/ccls/Portfile
+++ b/devel/ccls/Portfile
@@ -7,7 +7,7 @@ PortGroup                   cxx11 1.1
 PortGroup                   compiler_blacklist_versions 1.0
 
 name                        ccls
-github.setup                MaskRay ccls 0.20190823.5
+github.setup                MaskRay ccls 0.20201025
 revision                    0
 categories                  devel
 platforms                   darwin


### PR DESCRIPTION
#### Description
- update version to 0.20201025
- add support for clang 10
- use cxx_standard 2011

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G6042
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
