### PR TITLE
go-bindata: new port

### DIFF
--- a/devel/go-bindata/Portfile
+++ b/devel/go-bindata/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/shuLhan/go-bindata 3.4.0 v
+
+description         A small utility which generates Go code from any file. \
+                    Useful for embedding binary data in a Go program.
+
+long_description    {*}${description} The file data is optionally gzip \
+                    compressed before being converted to a raw byte slice.
+
+categories          devel
+
+# Creative Commons Zero v1.0 Universal
+license             public-domain
+
+checksums           rmd160  5cec86f1eb987bc5dca3f65d27b9e63234230654 \
+                    sha256  b794a03f2379e0870ed8ce9ff82b363f55f45cd2680416a306f92429130adc34 \
+                    size    27531
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+build.target        ./cmd/go-bindata
+
+installs_libs       no
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
New port for the [go-bindata](https://github.com/shuLhan/go-bindata) utility.

Not sure about the license: https://github.com/shuLhan/go-bindata/blob/master/LICENSE
It looks like Creative Commons Zero 1.0: https://spdx.org/licenses/CC0-1.0.html

However I'm not sure how that should be specified in MacPorts according to [this list](https://trac.macports.org/wiki/PortfileRecipes#licensekeyword), so I currently have `CC-BY`, though I don't think that's correct.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
