### PR TITLE
arc, ha, unarj: ports abandoned, cleanup MacPorts < 2.6.0 handling, fix implicit function declaration

### DIFF
--- a/archivers/arc/Portfile
+++ b/archivers/arc/Portfile
@@ -7,7 +7,7 @@ version             5.21p
 categories          archivers sysutils
 license             GPL-2
 description         create and extract files from dos .arc archives
-maintainers         crazic.ru:jc
+maintainers         nomaintainer
 platforms           darwin
 long_description    ${description}
 homepage            http://arc.sourceforge.net/

--- a/archivers/arc/Portfile
+++ b/archivers/arc/Portfile
@@ -20,22 +20,15 @@ patchfiles          patch-gcc-warnings.diff \
                     patch-Makefile.diff \
                     patch-man-spelling.diff \
                     patch-manpage-section.diff \
-                    patch-marc.c
+                    patch-marc.c.diff
 
 use_configure       no
 
 variant universal {}
-if {[vercmp [macports_version] 2.5.99] >= 0} {
 build.env-append    "CC=${configure.cc} [get_canonical_archflags cc]" \
                     "CFLAGS=${configure.cflags} [get_canonical_archflags cc]" \
                     "LDFLAGS=${configure.ldflags} [get_canonical_archflags ld]" \
                     PREFIX=${prefix}
-} else {
-build.env-append    CC="${configure.cc} [get_canonical_archflags cc]" \
-                    CFLAGS='${configure.cflags} [get_canonical_archflags cc]' \
-                    LDFLAGS='${configure.ldflags} [get_canonical_archflags ld]' \
-                    PREFIX='${prefix}'
-}
 
 destroot {
     xinstall -W ${worksrcpath} ${name} m${name} ${destroot}${prefix}/bin

--- a/archivers/arc/files/patch-marc.c.diff
+++ b/archivers/arc/files/patch-marc.c.diff
@@ -1,18 +1,20 @@
---- marc.c.orig	2007-04-11 11:52:45.000000000 -0700
-+++ marc.c	2007-04-11 11:53:14.000000000 -0700
-@@ -53,7 +53,6 @@ main(nargs,arg)			       /* system entry
+--- marc.c.orig	2010-08-07 08:06:42.000000000 -0500
++++ marc.c	2020-11-18 14:44:43.000000000 -0600
+@@ -54,7 +54,7 @@ main(nargs,arg)			       /* system entry
  int nargs;			       /* number of arguments */
  char *arg[];			       /* pointers to arguments */
  {
 -    char *makefnam();
++    char *makefnam(char *rawfn, char *template, char *result);
      char *envfind();
  #if	!_MTS
-     char *arctemp2, *mktemp();		/* temp file stuff */
-@@ -319,7 +318,6 @@ int n;				       /* number of entry to e
+     char *arctemp2;		       /* temp file stuff */
+@@ -326,7 +326,7 @@ int n;				       /* number of entry to e
      char buf[100];		       /* input buffer */
      int x;			       /* index */
      char *p = lst[n]+1;		       /* filename pointer */
 -    char *makefnam();
++    char *makefnam(char *rawfn, char *template, char *result);
  
      if(*p)			       /* use name if one was given */
      {	 makefnam(p,".CMD",buf);

--- a/archivers/ha/Portfile
+++ b/archivers/ha/Portfile
@@ -21,6 +21,10 @@ checksums   md5 77f3266a451712bec55d60df67f61486 \
 
 extract.mkdir   yes
 
+# Fix implicit function declarations
+patchfiles-append \
+            patch-machine.c.diff
+
 post-patch {
     reinplace -E "s|(malloc.h)|malloc/\\1|" \
         ${worksrcpath}/c/hsc.c \
@@ -34,7 +38,9 @@ configure {
 }
 
 build.target
-build.args	-f makefile.nix
+build.args	-f makefile.nix \
+            "CC=${configure.cc}" \
+            "CPP=${configure.cpp}"
 
 destroot {
     xinstall ${worksrcpath}/ha ${destroot}${prefix}/bin

--- a/archivers/ha/Portfile
+++ b/archivers/ha/Portfile
@@ -7,7 +7,7 @@ categories	archivers sysutils
 platforms	darwin
 license		GPL-2
 description	The \"HA\" archiver, based on arithmetic/Markov coder.
-maintainers	crazic.ru:jc
+maintainers	nomaintainer
 homepage	ftp://ftp.kiarchive.ru/pub/unix/arcers/
 
 long_description ${description}

--- a/archivers/ha/files/patch-machine.c.diff
+++ b/archivers/ha/files/patch-machine.c.diff
@@ -1,0 +1,10 @@
+--- nix/machine.c.orig	1995-01-12 00:53:00.000000000 -0600
++++ nix/machine.c	2020-11-18 14:05:34.000000000 -0600
+@@ -22,6 +22,7 @@
+ #include <stdlib.h>
+ #include <ctype.h>
+ #include <stdio.h>
++#include <string.h>
+ #include <sys/types.h>
+ #include <utime.h>
+ #include <time.h>

--- a/archivers/unarj/Portfile
+++ b/archivers/unarj/Portfile
@@ -6,7 +6,7 @@ revision          1
 categories        archivers sysutils
 platforms         darwin
 description       extract files from dos .arj archives
-maintainers       crazic.ru:jc
+maintainers       nomaintainer
 
 long_description  ${description}
 

--- a/archivers/unarj/Portfile
+++ b/archivers/unarj/Portfile
@@ -17,7 +17,11 @@ checksums         md5 a83d139c245f911f22cb1b611ec9768f \
                   sha1 abd35d894444fea1a0bdc7472ed2346f0f8c6ba4 \
                   rmd160 cebee016ffc2b7eb74a13f8246d82ea68519e500
 
+# Fix implicit function declaration
+patchfiles-append patch-environ.c.diff
+
 build.target      unarj
+build.args-append  "CC=${configure.cc}"
 
 configure {
     reinplace -E "/^CFLAGS/s|-ansi -pedantic|[join ${configure.cflags} " "]|" ${worksrcpath}/Makefile

--- a/archivers/unarj/files/patch-environ.c.diff
+++ b/archivers/unarj/files/patch-environ.c.diff
@@ -1,0 +1,10 @@
+--- environ.c.orig	2000-10-02 07:33:08.000000000 -0500
++++ environ.c	2020-11-18 11:59:24.000000000 -0600
+@@ -431,6 +431,7 @@
+ #define SUBS_DEFINED
+ 
+ #include <time.h>
++#include <utime.h>
+ 
+ #ifndef time_t
+ #define time_t long


### PR DESCRIPTION
No MX record for maintainer email address domain.
Maintainer was removed from other ports as early as 2008.
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
```
--->  Verifying Portfile for arc
Warning: missing recommended checksum type: size
--->  0 errors and 1 warnings found.
--->  Verifying Portfile for ha
Warning: missing recommended checksum type: sha256
Warning: missing recommended checksum type: size
--->  0 errors and 2 warnings found.
--->  Verifying Portfile for unarj
Warning: missing recommended checksum type: sha256
Warning: missing recommended checksum type: size
Warning: no license set
--->  0 errors and 3 warnings found.
```
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
