### PR TITLE
global: force realpath(3) to be accepted via extra configure arg

### DIFF
--- a/devel/global/Portfile
+++ b/devel/global/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                global
 version             6.6.4
-revision            1
+revision            2
 categories          devel
 platforms           darwin
 maintainers         nomaintainer
@@ -44,7 +44,8 @@ configure.args      --infodir=${prefix}/share/info \
                     --with-sqlite3
 
 configure.env-append \
-                    "PYTHON=${python_bin}"
+                    "PYTHON=${python_bin}" \
+                    ac_cv_posix1_2008_realpath=yes
 
 test.run            yes
 test.target         check


### PR DESCRIPTION
#### Description

I was recently upgrading GNU `global` after having upgraded my OS from Mojave to Catalina. When I tried to update `global`, it failed and I saw the following errors in `main.log`:

```
:info:configure checking whether POSIX.1-2008 realpath is equipped... no
:info:configure configure: error: POSIX.1-2008 realpath(3) is required.
```

Then I dug a little deeper into `config.log` and found the following lines:

```
configure:14276: checking whether POSIX.1-2008 realpath is equipped
configure:14293: /usr/bin/clang -o conftest -pipe -Os -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk -arch x86_64 -I/opt/local/include -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk -L/opt/local/lib -Wl,-headerpad_max_install_names -Wl,-syslibroot,/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk -arch x86_64 conftest.c  >&5
conftest.c:59:1: warning: type specifier missing, defaults to 'int' [-Wimplicit-int]
main(){ (void)realpath("/./tmp", (void *)0); return 0; }
^
conftest.c:59:15: error: implicit declaration of function 'realpath' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
main(){ (void)realpath("/./tmp", (void *)0); return 0; }
              ^
1 warning and 1 error generated.
...
| main(){ (void)realpath("/./tmp", (void *)0); return 0; }
| 
configure:14304: result: no
configure:14307: error: POSIX.1-2008 realpath(3) is required.
...
ac_cv_posix1_2008_realpath=no
```

I was totally perplexed until I found someone on StackOverflow that had the same error: https://web.archive.org/web/20201110110319/https://stackoverflow.com/questions/64691147/where-to-get-posix-1-2008-realpath-for-macos

To reiterate what they said (in case the archived page goes away):

> I am installing GNU Global on a macOS, but got this error while configuring:
> ```
> checking whether POSIX.1-2008 realpath is equipped... no
> configure: error: POSIX.1-2008 realpath(3) is required.
> ```
>
> I installed coreutils, which contains an realpath command:
>
> ```
> brew install coreutils
> ```
>
> but the error still occured. How can I correct it, thanks a lot.
>
> I'm running a macOS Catalina version 10.15.7 system.
>
> The command for config Global is:
>
> ```
> configure --with-universal-ctags=/usr/local/bin/ctags
> ```

Someone in the comments gave the following insight & advice:

> GNU Coreutils won't help you since that is a collection of system utilities such as `ls` and `realpath`, not a library/framework containing a `realpath` function implementation (`realpath(1)` is a program and `realpath(3)` is a C function for future reference). Check your `config.log` file for the text `realpath is equipped` and examine the associated compilation line and any error that occurs. That should help you understand why the test is failing. If you want to force your system's `realpath` to be accepted, add `ac_cv_posix1_2008_realpath=yes` to the end of your `configure` line.

To which the OP of the question responded:

> thank you, that solved the problem.

It also solved the problem for me when I added this `configure` argument to the Portfile.

I figured we should update the Portfile accordingly. I'm not sure if this needs to be applied only for Catalina, although it seems like a fairly benign option which should not affect older systems adversely. Apparently, all it does is force `configure` to accept macOS's version of `realpath(3)`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
