### PR TITLE
julia: Update to 1.5.3

### DIFF
--- a/lang/julia/Portfile
+++ b/lang/julia/Portfile
@@ -8,7 +8,7 @@ PortGroup           compilers 1.0
 compilers.choose    fc f77 f90
 compilers.setup     require_fortran -g95
 
-github.setup        JuliaLang julia 1.5.2 v
+github.setup        JuliaLang julia 1.5.3 v
 revision            0
 categories-append   lang math science
 maintainers         {ieee.org:s.t.smith @essandess} openmaintainer
@@ -26,9 +26,9 @@ github.tarball_from releases
 distfiles           ${name}-${version}-full${extract.suffix}
 
 checksums           ${name}-${version}-full${extract.suffix} \
-                    rmd160  018533d63887392bb66862a7351547500ed5058e \
-                    sha256  850aed3fe39057488ec633f29af705f5ada87e3058fd65e48ad26f91b713a19a \
-                    size    138261762 \
+                    rmd160  df4f63f7d2db6df2143cf7b3e7d1a8c300f731d7 \
+                    sha256  fb69337ca037576758547c7eed9ae8f153a9c052318327b6b7f1917408c14d91 \
+                    size    138278314
 
 extract.only        ${distfiles}
 
@@ -40,7 +40,9 @@ if {[option gpg_verify.use_gpg_verification]} {
                     ${name}-${version}-full${extract.suffix}.asc
     checksums-append \
                     ${name}-${version}-full${extract.suffix}.asc \
-                    size    866
+                    size    866 \
+                    rmd160  aed07c2e553aec2a030491a2a9c69206b69292ad \
+                    sha256  3128c1ae0392008c92798b4e4cbd076088579fcbfbb11a2fdeb5a47a136c3857
 
     post-checksum {
         gpg_verify.verify_gpg_signature \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

Note: I ran the Julia self-tests, but not all tests succeeded. However, some tests fail even when I install Julia independently of MacPorts.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
