### PR TITLE
gegl: remove disused dependency on w3m

### DIFF
--- a/graphics/gegl/Portfile
+++ b/graphics/gegl/Portfile
@@ -33,7 +33,6 @@ checksums           rmd160  df57119d659c8a5dacae6fcf3783058d7dd10e3f \
 
 depends_build-append \
                     port:pkgconfig \
-                    port:w3m \
                     port:python38
 
 depends_lib         port:babl \


### PR DESCRIPTION
I couldn't find a mention of w3m anywhere in the extracted source, and it builds just fine without it.

See https://trac.macports.org/ticket/61356

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
