### PR TITLE
babl: make w3m an optional dependency via +doc variant

### DIFF
--- a/graphics/babl/Portfile
+++ b/graphics/babl/Portfile
@@ -28,8 +28,7 @@ checksums           rmd160  4d1a990773217d2a2536c773f6621fa511dd5598 \
 
 depends_build-append \
                     port:pkgconfig \
-                    port:librsvg \
-                    port:w3m
+                    port:librsvg
 
 depends_lib-append  port:lcms2 \
                     port:gobject-introspection \
@@ -58,6 +57,10 @@ if {[variant_isset universal]} {
 } else {
     build.env-append       "CC=${configure.cc} ${configure.cc_archflags}"
     destroot.env-append    "CC=${configure.cc} ${configure.cc_archflags}"
+}
+
+variant docs description {Generate optional docs} {
+    depends_build-append  port:w3m
 }
 
 livecheck.type      regex


### PR DESCRIPTION
w3m does not build on Big Sur and is not actively maintained. It is only used
for generating an optional readme file.

See https://trac.macports.org/ticket/61356

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
