### PR TITLE
xdg-utils, xmlto: remove dependency on w3m

### DIFF
--- a/sysutils/xdg-utils/Portfile
+++ b/sysutils/xdg-utils/Portfile
@@ -22,10 +22,9 @@ checksums           rmd160  e09d258c26834555307d6edd6261514d546587ee \
                     sha256  d798b08af8a8e2063ddde6c9fa3398ca81484f27dec642c5627ffcaa0d4051d9 \
                     size    297170
 
-depends_build       port:w3m \
-                    port:xmlto
+depends_build       port:xmlto
 
-license_noconflict  w3m
+license_noconflict  xmlto
 
 livecheck.type      regex
 livecheck.url       [lindex ${master_sites} 0]

--- a/textproc/xmlto/Portfile
+++ b/textproc/xmlto/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                xmlto
 version             0.0.28
-revision            3
+revision            4
 categories          textproc
 license             GPL-2+
 installs_libs       no
@@ -25,7 +25,8 @@ master_sites        https://releases.pagure.org/xmlto/
 use_bzip2           yes
 
 checksums           rmd160  acba3cc9ff46505ae49b91108c611646aeac2b5d \
-                    sha256  1130df3a7957eb9f6f0d29e4aa1c75732a7dfb6d639be013859b5c7ec5421276
+                    sha256  1130df3a7957eb9f6f0d29e4aa1c75732a7dfb6d639be013859b5c7ec5421276 \
+                    size    127921
 
 depends_build       port:getopt
 
@@ -39,12 +40,14 @@ depends_run         port:coreutils \
                     port:gsed \
                     port:libpaper \
                     port:libxml2 \
-                    port:libxslt
+                    port:libxslt \
+                    port:links
 
 patchfiles          searchpath_local.patch \
                     xml-catalog.patch
 
-configure.args      --mandir=${prefix}/share/man
+configure.args      --mandir=${prefix}/share/man \
+                    --with-webbrowser=any
 
 configure.env-append \
     FIND=${prefix}/bin/gfind \
@@ -56,7 +59,8 @@ configure.env-append \
     DBLATEX=${prefix}/bin/dblatex \
     FOP=${prefix}/bin/fop \
     GREP=${prefix}/bin/ggrep \
-    SED=${prefix}/bin/gsed
+    SED=${prefix}/bin/gsed \
+    LINKS=${prefix}/bin/links
 
 build.env-append    XML_CATALOG_FILES=${prefix}/etc/xml/catalog
 


### PR DESCRIPTION
#### Description

xdg-utils uses w3m through xmlto to extract text docs from HTML.

w3m does not currently build on Big Sur and seems to be abandoned.

xmlto can alternatively use other text-based browsers like lynx and links. lynx also did not build for me so I used links.

For some reason xmlto needs to be told the location of links at configure time, so I pushed the dependency back to the xmlto port.

The license_noconflict now points to xmlto according to my understanding of the logic [here](https://github.com/amake/macports-ports/commit/bea8ff0f5763bb79a763fbe93c05712a0b442fac).

See also https://trac.macports.org/ticket/61356

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
