### PR TITLE
texlive-bin: add patch to fix build on ARM64

### DIFF
--- a/tex/texlive-bin/Portfile
+++ b/tex/texlive-bin/Portfile
@@ -105,6 +105,10 @@ patchfiles-append  patch-libs_luajit_configure.diff \
 # https://trac.macports.org/ticket/60963
 patchfiles-append  patch-texk_kpathsea_configure.diff
 
+# fix build on ARM64, which does not have "finite()"
+# https://trac.macports.org/ticket/61547
+patchfiles-append  patch-texk_web2c_luatexdir_luafontloader_fontforge_fontforge-fix_finite.diff
+
 post-patch {
     reinplace "s|@@TEXMFDIST@@|${texlive_texmfdist}|" ${worksrcpath}/texk/texlive/linked_scripts/Makefile.in
 #    reinplace "s|@@TEXMFDIST@@|${texlive_texmfdist}|" ${worksrcpath}/texk/texlive/tl_scripts/Makefile.in

--- a/tex/texlive-bin/files/patch-texk_web2c_luatexdir_luafontloader_fontforge_fontforge-fix_finite.diff
+++ b/tex/texlive-bin/files/patch-texk_web2c_luatexdir_luafontloader_fontforge_fontforge-fix_finite.diff
@@ -1,0 +1,39 @@
+--- texk/web2c/luatexdir/luafontloader/fontforge/fontforge/psread.c.orig
++++ texk/web2c/luatexdir/luafontloader/fontforge/fontforge/psread.c
+@@ -531,7 +531,7 @@
+ 	    }
+ 	} else {
+ 	    *val = strtod(tokbuf,&end);
+-	    if ( !finite(*val) ) {
++	    if ( !isfinite(*val) ) {
+ /* GT: NaN is a concept in IEEE floating point which means "Not a Number" */
+ /* GT: it is used to represent errors like 0/0 or sqrt(-1). */
+ 		LogError( _("Bad number, infinity or nan: %s\n"), tokbuf );
+@@ -677,14 +677,14 @@
+ }
+ 
+ static void CheckMakeB(BasePoint *test, BasePoint *good) {
+-    if ( !finite(test->x) || test->x>100000 || test->x<-100000 ) {
++    if ( !isfinite(test->x) || test->x>100000 || test->x<-100000 ) {
+ 	LogError( _("Value out of bounds in spline.\n") );
+ 	if ( good!=NULL )
+ 	    test->x = good->x;
+ 	else
+ 	    test->x = 0;
+     }
+-    if ( !finite(test->y) || test->y>100000 || test->y<-100000 ) {
++    if ( !isfinite(test->y) || test->y>100000 || test->y<-100000 ) {
+ 	LogError( _("Value out of bounds in spline.\n") );
+ 	if ( good!=NULL )
+ 	    test->y = good->y;
+--- texk/web2c/luatexdir/luafontloader/fontforge/fontforge/splinerefigure.c.orig
++++ texk/web2c/luatexdir/luafontloader/fontforge/fontforge/splinerefigure.c
+@@ -75,7 +75,7 @@
+ 	if ( ysp->a==0 && xsp->a==0 && ysp->b==0 && xsp->b==0 )
+ 	    spline->islinear = true;	/* This seems extremely unlikely... */
+     }
+-    if ( !finite(ysp->a) || !finite(xsp->a) || !finite(ysp->c) || !finite(xsp->c) || !finite(ysp->d) || !finite(xsp->d))
++    if ( !isfinite(ysp->a) || !isfinite(xsp->a) || !isfinite(ysp->c) || !isfinite(xsp->c) || !isfinite(ysp->d) || !isfinite(xsp->d))
+ 	IError("NaN value in spline creation");
+     LinearApproxFree(spline->approx);
+     spline->approx = NULL;


### PR DESCRIPTION
#### Description

Use "infinite" rather than "finite" since Apple seems to have removed support for the latter in favor of the former on ARM64 only. Support remains for Intel 32 and 64 bit for both versions (See math.h line 550). This PR might also allow the port to build on PPC 32/64.

Closes: https://trac.macports.org/ticket/61547

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0.1 20B29
Xcode 12.2 12B5035g

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
