### PR TITLE
bochs: Fix build on Big Sur

### DIFF
--- a/emulators/bochs/Portfile
+++ b/emulators/bochs/Portfile
@@ -24,6 +24,7 @@ checksums           sha256  63897b41fbbbdfb1c492d3c4dee1edb4224282a07bbdf442a4a6
 
 patchfiles          patch-.bochsrc.diff \
                     patch-bxhub.cc.diff \
+                    patch-configure.diff \
                     patch-dbg_main.cc.diff \
                     patch-eth_socket.cc.diff
 

--- a/emulators/bochs/files/patch-configure.diff
+++ b/emulators/bochs/files/patch-configure.diff
@@ -1,0 +1,47 @@
+--- configure.orig	2020-11-20 08:43:19.000000000 -0500
++++ configure	2020-11-20 08:44:11.000000000 -0500
+@@ -7674,7 +7674,7 @@
+           10.[012])
+             allow_undefined_flag='-flat_namespace -undefined suppress'
+             ;;
+-          10.*)
++          *)
+             allow_undefined_flag='-undefined dynamic_lookup'
+             ;;
+         esac
+@@ -9221,7 +9221,7 @@
+           10.[012])
+             allow_undefined_flag='-flat_namespace -undefined suppress'
+             ;;
+-          10.*)
++          *)
+             allow_undefined_flag='-undefined dynamic_lookup'
+             ;;
+         esac
+@@ -10233,7 +10233,7 @@
+           10.[012])
+             allow_undefined_flag_CXX='-flat_namespace -undefined suppress'
+             ;;
+-          10.*)
++          *)
+             allow_undefined_flag_CXX='-undefined dynamic_lookup'
+             ;;
+         esac
+@@ -13745,7 +13745,7 @@
+           10.[012])
+             allow_undefined_flag_F77='-flat_namespace -undefined suppress'
+             ;;
+-          10.*)
++          *)
+             allow_undefined_flag_F77='-undefined dynamic_lookup'
+             ;;
+         esac
+@@ -16022,7 +16022,7 @@
+           10.[012])
+             allow_undefined_flag_GCJ='-flat_namespace -undefined suppress'
+             ;;
+-          10.*)
++          *)
+             allow_undefined_flag_GCJ='-undefined dynamic_lookup'
+             ;;
+         esac


### PR DESCRIPTION

#### Description

Fix macOS version checking in configure script to pick up the right flags.

See: [#61488](https://trac.macports.org/ticket/61488)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
