### PR TITLE
gdb: Update version to 10.1

### DIFF
--- a/devel/gdb/Portfile
+++ b/devel/gdb/Portfile
@@ -5,7 +5,7 @@ PortGroup       muniversal 1.0
 PortGroup       compiler_blacklist_versions 1.0
 
 name            gdb
-version         9.2
+version         10.1
 revision        0
 categories      devel
 license         GPL-3+
@@ -33,9 +33,9 @@ supported_archs x86_64 i386
 
 master_sites    gnu
 
-checksums       rmd160  bcb0e1a53bedac611556dc501a4b38221e0ed7f4 \
-                sha256  38ef247d41ba7cc3f6f93a612a78bab9484de9accecbe3b0150a3c0391a3faf0 \
-                size    39264162
+checksums       rmd160  87163d96863e4923691f0c1bd34f58e30f2685e8 \
+                sha256  f12f388b99e1408c01308c3f753313fafa45517740c81ab7ed0d511b13e2cf55 \
+                size    40245323
 
 # these dependencies are listed under depends_lib rather than depends_build
 # because gdb will link with libraries they provide if installed.
@@ -110,6 +110,7 @@ foreach s ${pythons_suffixes} {
 }
 
 variant multiarch description {Support all target architectures} {
+    patchfiles-append        patch-elf-bfd.h.diff
     configure.args-append    --enable-targets=all
 }
 

--- a/devel/gdb/files/patch-elf-bfd.h.diff
+++ b/devel/gdb/files/patch-elf-bfd.h.diff
@@ -1,0 +1,10 @@
+--- bfd/elf-bfd.h.orig	2020-11-20 00:47:34.000000000 -0500
++++ bfd/elf-bfd.h	2020-11-20 00:48:08.000000000 -0500
+@@ -22,6 +22,7 @@
+ #ifndef _LIBELF_H_
+ #define _LIBELF_H_ 1
+ 
++#include <string.h>
+ #include "elf/common.h"
+ #include "elf/external.h"
+ #include "elf/internal.h"


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

The following changes have been made:
- Version has been updated to 10.1
- A patch has been added for bfd/elf-bfd.h in the multiarch variant.
  This is needed on Big Sur to support ELF.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
