### PR TITLE
py27-twython: fix build

### DIFF
--- a/python/py-twython/Portfile
+++ b/python/py-twython/Portfile
@@ -21,5 +21,8 @@ checksums           rmd160  7208e3d189b278d181a13188ad30b56e77e11b2d \
                     size    373927
 
 if {${name} ne ${subport}} {
+    # https://github.com/ryanmcgrath/twython/pull/534
+    patchfiles-append   patch-ccf20e3261.diff
+
     depends_lib-append  port:py${python.version}-requests-oauthlib
 }

--- a/python/py-twython/files/patch-ccf20e3261.diff
+++ b/python/py-twython/files/patch-ccf20e3261.diff
@@ -1,0 +1,29 @@
+From ccf20e32614e3124278bbc9aabeb77866d63e167 Mon Sep 17 00:00:00 2001
+From: Christopher Toth <q.alpha@gmail.com>
+Date: Fri, 12 Jun 2020 22:06:27 -0600
+Subject: [PATCH] Fix to setup.py to work on Python 2 and 3
+
+---
+ setup.py | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git setup.py setup.py
+index 3742f24..cc46495 100755
+--- setup.py
++++ setup.py
+@@ -1,5 +1,6 @@
+ #!/usr/bin/env python
+ 
++import io
+ import os
+ import sys
+ 
+@@ -30,7 +31,7 @@
+     url='https://github.com/ryanmcgrath/twython/tree/master',
+     keywords='twitter search api tweet twython stream',
+     description='Actively maintained, pure Python wrapper for the Twitter API. Supports both normal and streaming Twitter APIs',
+-    long_description=open('README.md', encoding='utf-8').read() + '\n\n' +open('HISTORY.md', encoding='utf-8').read(),
++    long_description=io.open('README.md', encoding='utf-8').read() + '\n\n' +io.open('HISTORY.md', encoding='utf-8').read(),
+     long_description_content_type='text/markdown',
+     include_package_data=True,
+     packages=packages,


### PR DESCRIPTION
#### Description
Use patch submitted upstream to fix failure due to Python 3.x syntax present in setup.py:
```
Traceback (most recent call last):
  File "setup.py", line 33, in <module>
    long_description=open('README.md', encoding='utf-8').read() + '\n\n' +open('HISTORY.md', encoding='utf-8').read(),
TypeError: 'encoding' is an invalid keyword argument for this function
```
See https://github.com/ryanmcgrath/twython/issues/533, https://github.com/ryanmcgrath/twython/pull/534
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
Only patch phase is tested

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
