### PR TITLE
qt4-mac: Tweak OS version handling logic for macOS 11

### DIFF
--- a/aqua/qt4-mac/Portfile
+++ b/aqua/qt4-mac/Portfile
@@ -50,17 +50,28 @@ depends_lib-append  port:zlib \
 # value will be X.  The type is this variable is integer, so we can
 # use "==" and so forth for comparison.
 
-global MINOR
+global MINOR, MAJOR
+set MAJOR ""
 set MINOR ""
 
 # hopefully the MACOSX_DEPLOYMENT_TARGET exists and is set by now.  if
 # not, last resort (which is not desirable) is to use the os.version.
 
 if {${macosx_deployment_target} ne ""} {
+    set MAJOR [lindex [split ${macosx_deployment_target} "."] 0]
     set MINOR [lindex [split ${macosx_deployment_target} "."] 1]
 } else {
-    set MINOR [expr [lindex [split ${os.version} "."] 0] - 4]
+    # Do we really need this branch still ??
+    if { ${os.major} < 20 } {
+        set MAJOR 10
+        set MINOR [expr [lindex [split ${os.version} "."] 0] - 4]
+    } else {
+        # Bit of a guess, and will not work once we have macOS 12
+        set MAJOR 11
+        set MINOR [expr [lindex [split ${os.version} "."] 0] - 20]
+    }
 }
+ui_debug "Deduced OS MAJOR.MINOR = ${MAJOR}.${MINOR}"
 
 ###############################################
 # Patches are used to both fix compiling on various OS versions, and
@@ -223,7 +234,7 @@ patchfiles-append   \
 # (20) Under 10.8 and 10.9: Patch to fix corelib linking
 
 platform darwin {
-    if {${MINOR} >= 8} {
+    if {${MAJOR} > 10 || ${MINOR} >= 8} {
         patchfiles-append patch-src_corelib_corelib.pro.diff
     }
 }
@@ -270,7 +281,7 @@ patchfiles-append   \
 # https://trac.macports.org/ticket/52332
 
 platform darwin {
-    if {${MINOR} >= 12} {
+    if {${MAJOR} > 10 || ${MINOR} >= 12} {
         patchfiles-append patch-src_gui_kernel_qmime_mac.cpp.diff
     }
 }
@@ -376,15 +387,16 @@ post-extract {
         ${worksrcpath}/src/3rdparty/javascriptcore/VERSION.txt
 }
 
-# error out if trying to build on a new OSX version (> 10.15).
+# error out if trying to build on a new OSX version (> 11.0).
 
 platform darwin {
-    if {${MINOR} > 15} {
+    if { ( ${MAJOR} == 10 && ${MINOR} > 15 ) ||
+         ( ${MAJOR} == 11 && ${MINOR} > 0 ) } {
         # This project needs to be updated to build with clang++ against libc++
         depends_lib
         depends_run
         pre-fetch {
-            ui_error "$name does not currently build on Mac OS X later than 10.15 'Catalina'."
+            ui_error "$name does not currently build on Mac OS X later than 11.0 'Big Sur'."
             error "unsupported platform"
         }
     }
@@ -405,11 +417,11 @@ set SDK ${configure.sdkroot}
 if {${SDK} eq ""} {
     # set SDK version depending on OS version
     set sdk_version ""
-    if {${MINOR} == 4} {
+    if { ${MAJOR} == 10 && ${MINOR} == 4 } {
         # OSX 10.4 requires an additional 'u'
-        set sdk_version "10.4u"
+        set sdk_version "${MAJOR}.4u"
     } else {
-        set sdk_version "10.${MINOR}"
+        set sdk_version "${MAJOR}.${MINOR}"
     }
     if {[vercmp ${xcodeversion} 4.3] < 0} {
         set SDK ${developer_dir}/SDKs/MacOSX${sdk_version}.sdk
@@ -437,7 +449,7 @@ post-patch {
     # were all patched in (2) above, and can be easily changed or
     # overridden by the user in a project-local qmake .pro script.
 
-    set TARGET "10.${MINOR}"
+    set TARGET "${MAJOR}.${MINOR}"
     foreach fixfile {configure mkspecs/common/g++-macx.conf \
                      mkspecs/common/mac.conf qmake/qmake.pri \
                      src/tools/bootstrap/bootstrap.pro } {
@@ -663,11 +675,11 @@ pre-configure {
 
     # for 10.4 or 10.5 32-bit PPC, build as Carbon only, not Cocoa
 
-    if {${MINOR} == 4} {
+    if {${MAJOR} == 10 && ${MINOR} == 4} {
 
         configure.args-append -carbon
 
-    } elseif {${MINOR} == 5 &&
+    } elseif {${MAJOR} == 10 && ${MINOR} == 5 &&
               [llength ${qt_arch_types}] == 1 &&
               [lsearch -exact ${qt_arch_types} ppc] == 0} {
 
@@ -688,7 +700,7 @@ pre-configure {
         # not building for native arch: disable optimizing qmake
         configure.args-delete -optimized-qmake
 
-    } elseif {${MINOR} == 6 &&
+    } elseif {${MAJOR} == 10 && ${MINOR} == 6 &&
               [llength ${qt_arch_types}] == 1 &&
               [lsearch -exact ${qt_arch_types} x86] == 0} {
 


### PR DESCRIPTION
#### Description

Minor fixes to version logic in qt4-mac to fix builds on macOS 11

Tested by building a few ports that depend on it (e.g. x2goclient) and all seems OK

Note, Apple appears to have changed a bit its philosophy when it comes to version numbers with Big Sur. 

Previously, MAJOR.MINOR.PATCH version numbers where such that MAJOR effectively never changed, it was 10, MINOR in fact represented the 'major' year OS updates and PATCH was the incremental updates to each.

Now it appears Apple has shifted this meaning one to the left. So MAJOR now has more meaning, and represents the major OS version (so now 11, and will be 12 next year and so on). MINOR.PATCH now represents the minor updates to each release, with each incrementing depending on what each update does.

TBH, the new scheme makes a lot more sense really, and matches how the numbering works for Apples's other OSes, like iOS. Its seems though, beyond the fixes here, MacPorts is likely going to have to see what this means and might need to tweak a bit how we use each of these fields going forward..

Thats beyond this MR though, which is just to get things moving on macOS 11 for this port...

Closes: https://trac.macports.org/ticket/60833

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
