### PR TITLE
openjdk11: update to 11.0.9.1

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -63,15 +63,15 @@ subport openjdk10 {
 }
 
 subport openjdk11 {
-    version      11.0.9
-    revision     1
+    version      11.0.9.1
+    revision     0
 
-    set build    11
+    set build    1
     set major    11
 
-    checksums    rmd160  87d9bfe6d83b728b2a38ed374f0ba95f9b0c35c8 \
-                 sha256  7b21961ffb2649e572721a0dfad64169b490e987937b661cb4e13a594c21e764 \
-                 size    186006796
+    checksums    rmd160  26c0fdcd8f7785759b6503ddf79d11bb942f31b4 \
+                 sha256  96bc469f9b02a3b84382a0685b0bd7935e1ad1bd82a0aab9befb5b42a17cbd77 \
+                 size    185368626
 }
 
 subport openjdk11-graalvm {
@@ -335,20 +335,6 @@ if {${subport} eq "openjdk8"} {
     master_sites https://download.java.net/java/GA/jdk${major}/${version}/19aef61b38124481863b1413dce1855f/${build}/
     distname     openjdk-${version}_osx-x64_bin
     worksrcdir   jdk-${version}.jdk
-} elseif {${subport} eq "openjdk11"} {
-    # Stealth update for 11.1, remove this for the next release
-    description  Open Java Development Kit ${major} (AdoptOpenJDK) with HotSpot VM
-    long_description OpenJDK build provided by AdoptOpenJDK, built from a fully \
-                 open-source set of build scripts and infrastructure. \
-                 \
-                 HotSpot is the VM from the OpenJDK community and  the most widely used VM. \
-                 It is suitable for all workloads.
-
-    dist_subdir  ${name}/${version}_1
-
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.1/
-    distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}_${build}
-    worksrcdir   jdk-${version}+${build}
 } elseif {${subport} eq "openjdk11-openj9"} {
     # Stealth update for 11.1, remove this for the next release
     description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM


### PR DESCRIPTION
#### Description

Update to AdoptOpenJDK HotSpot 11.0.9.1.

###### Tested on

macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?