### PR TITLE
lisaem, ncid: cleanup MacPorts < 2.6.0 handling

### DIFF
--- a/emulators/lisaem/Portfile
+++ b/emulators/lisaem/Portfile
@@ -36,30 +36,17 @@ use_configure           no
 build.cmd               ./build.sh
 build.target            build
 pre-build {
-    if {[vercmp [macports_version] 2.5.99] >= 0} {
     build.env-append    "CC=${configure.cc} [get_canonical_archflags cc] -Wno-error -Wno-return-type" \
                         "CXX=${configure.cxx} [get_canonical_archflags cxx]"
-    } else {
-    build.env-append    CC="${configure.cc} [get_canonical_archflags cc] -Wno-error -Wno-return-type" \
-                        CXX="${configure.cxx} [get_canonical_archflags cxx]"
-    }
 }
 
 destroot.destdir
 pre-destroot {
-    if {[vercmp [macports_version] 2.5.99] >= 0} {
     destroot.env-append "CC=${configure.cc} [get_canonical_archflags cc] -Wno-error -Wno-return-type" \
                         "CXX=${configure.cxx} [get_canonical_archflags cxx]" \
                         PREFIXAPP=${destroot}${applications_dir} \
                         PREFIXBIN=${destroot}${prefix}/bin \
                         PREFIXLIB=${destroot}${prefix}/share
-    } else {
-    destroot.env-append CC="${configure.cc} [get_canonical_archflags cc] -Wno-error -Wno-return-type" \
-                        CXX="${configure.cxx} [get_canonical_archflags cxx]" \
-                        PREFIXAPP=${destroot}${applications_dir} \
-                        PREFIXBIN=${destroot}${prefix}/bin \
-                        PREFIXLIB=${destroot}${prefix}/share
-    }
 }
 
 # the two wxWidgets variants can go away if lisaem gets ported to wxWidgets-3.0

--- a/net/ncid/Portfile
+++ b/net/ncid/Portfile
@@ -65,11 +65,7 @@ if {[variant_isset universal]} {
 } else {
     set archflags ${configure.cc_archflags}
 }
-if {[vercmp [macports_version] 2.5.99] >= 0} {
 build.env               "CC=${configure.cc} ${archflags}"
-} else {
-build.env               CC="${configure.cc} ${archflags}"
-}
 
 livecheck.type          sourceforge
 livecheck.regex         /${name}-(\[0-9.\]+)-src${extract.suffix}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
```
Warning: All compilers are either blacklisted or unavailable; defaulting to first fallback option
--->  Verifying Portfile for lisaem
Warning: missing recommended checksum type: sha256
Warning: missing recommended checksum type: size
--->  0 errors and 2 warnings found.
--->  Verifying Portfile for ncid
Warning: missing recommended checksum type: size
--->  0 errors and 1 warnings found.
```
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
