### PR TITLE
wireguard-go: update to 0.0.20201118

### DIFF
--- a/net/wireguard-go/Portfile
+++ b/net/wireguard-go/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-go
-version             0.0.20200320
+version             0.0.20201118
 revision            0
-checksums           rmd160  acb5defeb676ae02cadada7be13d274b1fc4bc83 \
-                    sha256  c8262da949043976d092859843d3c0cdffe225ec6f1398ba119858b6c1b3552f \
-                    size    80556
+checksums           rmd160  40604d819312c6523f921e5661e67b53e0d9e3d0 \
+                    sha256  8b9f3dd5f7083118fae9259868f994562270167a7ee9db28c53f415f0b20a388 \
+                    size    73512
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
#### Description

###### Tested on
macOS 10.14.6 18G6020
Xcode 11.3.1 11C504

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?