### PR TITLE
perl5.28: Fix build with inaccessible parent dir

### DIFF
--- a/lang/perl5/Portfile
+++ b/lang/perl5/Portfile
@@ -30,7 +30,7 @@ set perl5.versions_info {
     5.22 4 5 54fdbcbf249134dc7d82b693417900286201b5e7  8b3122046d1186598082d0e6da53193b045e85e3505e7d37ee0bdd0bdb539b71  13745983
     5.24 4 4 8d6b67fc6d58334b2fdbfa9d6d7456265dca1f4e  e34ff38c54857f431f37403b757267c9998152bf46b5c750b462f62461279b10  14125130
     5.26 3 4 84ed404407c198ca2b8194c374c7914d941b6f49  9ff35a613213f29ab53975141af6825ae7d4408895538cac0922e47ab92a1477  14539342
-    5.28 3 0 d2ae86e19666b689cad4c866e7d95c6491fd50c1  77dc1ddf541643af14d585867d3d0741cce45d0dbe8f1467024e63165d9e2fc5  12382032
+    5.28 3 1 d2ae86e19666b689cad4c866e7d95c6491fd50c1  77dc1ddf541643af14d585867d3d0741cce45d0dbe8f1467024e63165d9e2fc5  12382032
     5.30 3 0 7aaec213f6537a53abd8fd97bb96d91b681cdf1e  6967595f2e3f3a94544c35152f9a25e0cb8ea24ae45f4bf1882f2e33f4a400f4  12375128
 }
 
@@ -130,6 +130,14 @@ foreach {perl5.v perl5.subversion perl5.revision perl5.rmd160 perl5.sha256 perl5
             # Apple has deprecated syscall() on Sierra but it is still available
             patchfiles-append \
                             ${perl5.major}/enable-syscall-on-sierra.patch
+        }
+        if {${perl5.major} == 5.28} {
+            # Fix build failure when parent paths are not completely accessible.
+            # https://github.com/perl/perl5/issues/16903#issuecomment-544100709
+            patchfiles-append \
+                            ${perl5.major}/add-internals-getcwd.patch \
+                            ${perl5.major}/dont-write-invalid-write_buildcustomize.pl.patch \
+                            ${perl5.major}/fallback-to-built-in-getcwd.patch \
         }
 
         post-patch {

--- a/lang/perl5/files/5.28/add-internals-getcwd.patch
+++ b/lang/perl5/files/5.28/add-internals-getcwd.patch
@@ -1,0 +1,77 @@
+From 15f67d146cf1f32504e8a11de3faa2abc0f467cd Mon Sep 17 00:00:00 2001
+From: Tony Cook <tony@develop-help.com>
+Date: Mon, 25 Mar 2019 16:48:40 +1100
+Subject: [PATCH] (perl #133951) add Internals::getcwd
+--- MANIFEST
++++ MANIFEST
+@@ -5425,6 +5425,7 @@ t/io/errno.t			See if $! is correctly set
+ t/io/errnosig.t			Test case for restoration $! when leaving signal handlers
+ t/io/fflush.t			See if auto-flush on fork/exec/system/qx works
+ t/io/fs.t			See if directory manipulations work
++t/io/getcwd.t			See if Internals::getcwd is sane
+ t/io/inplace.t			See if inplace editing works
+ t/io/iofile.t			See if we can load IO::File on demand
+ t/io/iprefix.t			See if inplace editing works with prefixes
+--- /dev/null
++++ t/io/getcwd.t
+@@ -0,0 +1,22 @@
++#!./perl -w
++
++BEGIN {
++    chdir 't' if -d 't';
++    require "./test.pl";
++    set_up_inc('../lib');
++}
++
++use Config;
++
++$Config{d_getcwd}
++  or plan skip_all => "no getcwd";
++
++my $cwd = Internals::getcwd();
++ok(!defined $cwd || $cwd ne "",
++   "Internals::getcwd() returned a reasonable result");
++
++if (defined $cwd) {
++    ok(-d $cwd, "check a success result is a directory");
++}
++
++done_testing();
+--- universal.c
++++ universal.c
+@@ -986,6 +986,25 @@ XS(XS_re_regexp_pattern)
+     NOT_REACHED; /* NOTREACHED */
+ }
+ 
++#ifdef HAS_GETCWD
++
++XS(XS_Internals_getcwd)
++{
++    dXSARGS;
++    SV *sv = sv_newmortal();
++
++    if (items != 0)
++        croak_xs_usage(cv, "");
++
++    (void)getcwd_sv(sv);
++
++    SvTAINTED_on(sv);
++    PUSHs(sv);
++    XSRETURN(1);
++}
++
++#endif
++
+ #include "vutil.h"
+ #include "vxs.inc"
+ 
+@@ -1020,6 +1039,9 @@ static const struct xsub_details these_details[] = {
+     {"re::regnames", XS_re_regnames, ";$"},
+     {"re::regnames_count", XS_re_regnames_count, ""},
+     {"re::regexp_pattern", XS_re_regexp_pattern, "$"},
++#ifdef HAS_GETCWD
++    {"Internals::getcwd", XS_Internals_getcwd, ""},
++#endif
+ };
+ 
+ STATIC OP*

--- a/lang/perl5/files/5.28/dont-write-invalid-write_buildcustomize.pl.patch
+++ b/lang/perl5/files/5.28/dont-write-invalid-write_buildcustomize.pl.patch
@@ -1,0 +1,22 @@
+From 05fed879afada2f6ac1f1b5b6962e06190f5b9f6 Mon Sep 17 00:00:00 2001
+From: Tony Cook <tony@develop-help.com>
+Date: Mon, 25 Mar 2019 16:11:16 +1100
+Subject: [PATCH] (perl #133951) don't write an invalid lib/buildcustomize.pl
+
+Cwd under miniperl (at this point) can't determine the current
+directory if some ancestor directory isn't readable.
+
+So Cwd::getcwd() would return undef, and write_buildcustomize.pl
+would write out a list of paths relative to / rather than to the cwd.
+--- write_buildcustomize.pl
++++ write_buildcustomize.pl
+@@ -61,6 +61,9 @@
+ 
+ my $cwd  = Cwd::getcwd();
+ 
++defined $cwd
++  or die "$0: Can't determine current working directory\n";
++
+ # lib must be last, as the toolchain modules write themselves into it
+ # as they build, and it's important that @INC order ensures that the partially
+ # written files are always masked by the complete versions.

--- a/lang/perl5/files/5.28/fallback-to-built-in-getcwd.patch
+++ b/lang/perl5/files/5.28/fallback-to-built-in-getcwd.patch
@@ -1,0 +1,44 @@
+From 0a4d1779402e8824dd675302ad6a1914ea6ccf23 Mon Sep 17 00:00:00 2001
+From: Tony Cook <tony@develop-help.com>
+Date: Tue, 26 Mar 2019 14:23:53 +1100
+Subject: [PATCH] (perl #133951) fallback to the built-in getcwd if we can
+--- dist/PathTools/Cwd.pm
++++ dist/PathTools/Cwd.pm
+@@ -659,6 +659,10 @@ if (exists $METHOD_MAP{$^O}) {
+   }
+ }
+ 
++# built-in from 5.30
++*getcwd = \&Internals::getcwd
++  if !defined &getcwd && defined &Internals::getcwd;
++
+ # In case the XS version doesn't load.
+ *abs_path = \&_perl_abs_path unless defined &abs_path;
+ *getcwd = \&_perl_getcwd unless defined &getcwd;
+--- dist/PathTools/t/cwd.t
++++ dist/PathTools/t/cwd.t
+@@ -10,6 +10,7 @@ chdir 't';
+ use Config;
+ use File::Spec;
+ use File::Path;
++use Errno qw(EACCES);
+ 
+ use lib File::Spec->catdir('t', 'lib');
+ use Test::More;
+@@ -208,7 +209,15 @@ SKIP: {
+ 
+     like($abs_path,      qr|$want$|i, "Cwd::abs_path produced $abs_path");
+     like($fast_abs_path, qr|$want$|i, "Cwd::fast_abs_path produced $fast_abs_path");
+-    like($pas,           qr|$want$|i, "Cwd::_perl_abs_path produced $pas") if $EXTRA_ABSPATH_TESTS;
++    if ($EXTRA_ABSPATH_TESTS) {
++        # _perl_abs_path() can fail if some ancestor directory isn't readable
++        if (defined $pas) {
++            like($pas,           qr|$want$|i, "Cwd::_perl_abs_path produced $pas");
++        }
++        else {
++            is($!+0, EACCES, "check we got the expected error on failure");
++        }
++    }
+ 
+     rmtree($test_dirs[0], 0, 0);
+     1 while unlink $file;


### PR DESCRIPTION
#### Description

This fix is already in perl5.30 and doesn't appear to affect perl5.26.

Closes: https://trac.macports.org/ticket/61577

Increase revision because installed files change (${prefix}/lib/perl5/5.28/darwin-thread-multi-2level/Cwd.pm).


This should fix the build on the arm64 buildbot worker on which /opt is a mountpoint for a separate volume which apparently confuses perl's build script.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.0.1 20B29
Xcode 12.2 12B45b

macOS 10.13.6 17G14019
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
