### PR TITLE
p5-class-refresh: new port

### DIFF
--- a/perl/p5-class-refresh/Portfile
+++ b/perl/p5-class-refresh/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.branches      5.26 5.28 5.30
+perl5.setup         Class-Refresh 0.07
+
+platforms           darwin
+maintainers         nomaintainer
+license             {Artistic-1 GPL}
+
+supported_archs     noarch
+
+description         Class::Refresh - refresh your classes during runtime
+
+long_description    ${description}
+
+checksums           rmd160  cda28360399fb59659b297d3577877db6ba32f64 \
+                    sha256  e3b0035355cbb35a2aee3f223688d578946a7a7c570acd398b28cddb1fd4beb3 \
+                    size    21794
+
+if {${perl5.major} ne ""} {
+    depends_build-append \
+                    port:p${perl5.major}-test-fatal \
+                    port:p${perl5.major}-test-requires
+
+    depends_lib-append \
+                    port:p${perl5.major}-class-load \
+                    port:p${perl5.major}-class-unload \
+                    port:p${perl5.major}-devel-overrideglobalrequire \
+                    port:p${perl5.major}-try-tiny
+
+    depends_test-append \
+                    port:p${perl5.major}-moose
+}


### PR DESCRIPTION
#### Description
Another dependency that would be needed for Perl::LanguageServer.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7
Perl 5.30.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
