### PR TITLE
vcsn: more robust Python version string handling

### DIFF
--- a/devel/vcsn/Portfile
+++ b/devel/vcsn/Portfile
@@ -28,8 +28,8 @@ checksums           rmd160  bfa67e399a25473a2c449905c19464f4167dc2cf \
 compiler.cxx_standard 2011
 
 # python3.x is required - force dependencies to use it as well
-set python_version  36
-set python_branch   [string range ${python_version} 0 end-1].[string index ${python_version} end]
+set python_branch   3.6
+set python_version  [join [split ${python_branch} "."] ""]
 
 depends_build-append    port:doxygen \
                         port:flex \


### PR DESCRIPTION
#### Description
Needed in case of update to using Python 3.10; see https://lists.macports.org/pipermail/macports-dev/2020-October/042521.html
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
