### PR TITLE
LaTeXML: update to version 0.8.5

### DIFF
--- a/tex/LaTeXML/Portfile
+++ b/tex/LaTeXML/Portfile
@@ -17,7 +17,7 @@ long_description \
 
 # Written in Perl, but it is an application, not just modules
 PortGroup           perl5 1.0
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.28
 perl5.setup         ${name} ${version}
 perl5.link_binaries_suffix
 

--- a/tex/LaTeXML/Portfile
+++ b/tex/LaTeXML/Portfile
@@ -4,10 +4,10 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                LaTeXML
-version             0.8.4
-checksums           rmd160  902a574fbd1439017cec3117fefbecac50745ed4 \
-                    sha256  92599b45fb587ac14b2ba9cc84b85d9ddc2deaf1cbdc2e89e7a6559e1fbb34cc \
-                    size    11502627
+version             0.8.5
+checksums           rmd160  22a13fbd2a6bf65f2d65162f6c555bb9b7e2273e \
+                    sha256  1de821d0df8c88041ee10820188f33feac77d5618de4c0798a296a425f4e2637 \
+                    size    13083829
 
 license             public-domain
 maintainers         {nist.gov:bruce.miller @brucemiller}
@@ -17,13 +17,14 @@ long_description \
 
 # Written in Perl, but it is an application, not just modules
 PortGroup           perl5 1.0
-perl5.branches      5.28
+perl5.branches      5.26 5.28 5.30
 perl5.setup         ${name} ${version}
 perl5.link_binaries_suffix
 
 categories          tex
-homepage            http://dlmf.nist.gov/LaTeXML/
-master_sites        ${homepage}releases/
+homepage            https://dlmf.nist.gov/LaTeXML/
+master_sites        ${homepage}releases/ \
+                    https://cpan.metacpan.org/authors/id/B/BR/BRMILLER/
 
 platforms           darwin
 supported_archs     noarch


### PR DESCRIPTION
#### Description

Update LaTeXML to version 0.8.5

###### Type(s)

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
