### PR TITLE
k9s: update to 0.24.0

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.23.10 v
+go.setup            github.com/derailed/k9s 0.24.0 v
 homepage            https://k9scli.io
 
 categories          sysutils devel
@@ -20,9 +20,9 @@ platforms           darwin
 supported_archs     x86_64
 license             Apache-2
 
-checksums           rmd160  774ac9eb83b3f3d2c17d4a6d6ea7d7831734b571 \
-                    sha256  4ae4a72350eccdc1b8973b02acbde7aa7f4582111bac91e9fbf79345ef8a2ba2 \
-                    size    6103015
+checksums           rmd160  30cc98cf3d53ed765047f33db4e5b1ea10b60c04 \
+                    sha256  d13d84e2184ad50325825a856d5394cec74346ab81dec8b47f9aed93a3f02f6c \
+                    size    6107817
 
 # Reproduce the "build" target from the upstream Makefile
 set go_ldflags      "-w -s \


### PR DESCRIPTION
#### Description

Update to K9s 0.24.0

###### Tested on

macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?