### PR TITLE
browsh: new port

### DIFF
--- a/www/browsh/Portfile
+++ b/www/browsh/Portfile
@@ -1,0 +1,83 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/browsh-org/browsh 1.6.4 v
+revision            0
+
+homepage            https://www.brow.sh
+
+description         ${name} is a fully-modern text-based browser
+
+long_description    {*}${description}. It can render anything that a modern \
+                    browser can: HTML5, CSS3, JS, video and even WebGL.
+
+categories          www
+license             LGPL-2.1
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+
+set browsh_ifacer_path  ${worksrcpath}/interfacer
+set browsh_xpi_file     ${name}-${version}-an.fx.xpi
+
+# In addition to Go source, browsh requires a Firefox web extension XPI file
+distfiles-append        ${browsh_xpi_file}:xpi
+master_sites-append     https://github.com/browsh-org/browsh/releases/download/v${version}:xpi
+
+# Do not attempt to extract the xpi
+extract.only-delete     ${browsh_xpi_file}
+
+# Do not restrict Go from downloading dependencies at build time.
+build.env-delete        GOPROXY=off GO111MODULE=off
+
+depends_build-append    port:dep \
+                        port:go-bindata
+
+installs_libs           no
+
+build.pre_args          -o ${name}
+build.args              ./interfacer/src/main.go
+
+post-extract {
+    copy ${distpath}/${browsh_xpi_file} ${browsh_ifacer_path}/browsh.xpi
+}
+
+pre-build {
+    set browsh_webext_file  ${browsh_ifacer_path}/src/browsh/webextension.go
+
+    # Modify the package import for the interfacer's main.go
+    reinplace "s|browsh/interfacer|${go.package}/interfacer|" \
+        ${browsh_ifacer_path}/src/main.go
+
+    # Download and ensure Go dependencies
+    system -W ${browsh_ifacer_path} "GOPATH=${gopath} dep ensure"
+
+    # Convert the XPI file into an embedded Go binary data file.
+    system -W ${worksrcpath} \
+        "GOPATH=${gopath} XPI_FILE=${browsh_ifacer_path}/browsh.xpi BIN_FILE=${browsh_webext_file} ${browsh_ifacer_path}/contrib/xpi2bin.sh"
+}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}
+
+notes "
+If the firewall is enabled in macOS, explicit exceptions may need to be added for:
+
+    - ${prefix}/bin/${name}
+    - /Applications/Firefox.app
+
+Refer to the Firewall section in System Preferences.
+"
+
+checksums   ${distname}${extract.suffix} \
+                rmd160  89ca7d61a2bf65efa380cf69583d8b37e18d6974 \
+                sha256  bda61190a235d875a0690563cae493fe9f5415dd31ec9927cb5cc7ac880231bf \
+                size    711404 \
+            ${name}-${version}-an.fx.xpi \
+                rmd160  06c4738cbdc9ec3005768ed81b88d19d2e163398 \
+                sha256  b410527a69dba88a30d8a6d341a20eb5cb1f84b684e9bc8bb6bc88a2930e0eea \
+                size    622464


### PR DESCRIPTION
#### Description

New port for the **[browsh](https://www.brow.sh)** text-based web browser.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
