### PR TITLE
docker-machine-parallels: update to 2.0.1

### DIFF
--- a/devel/docker-machine-parallels/Portfile
+++ b/devel/docker-machine-parallels/Portfile
@@ -4,7 +4,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        Parallels docker-machine-parallels 1.3.0 v
+github.setup        Parallels docker-machine-parallels 2.0.1 v
 categories          devel
 platforms           darwin
 license             Apache-2
@@ -16,9 +16,9 @@ long_description    A plugin for Docker Machine allowing to \
 
 depends_lib         port:docker-machine
 
-checksums           rmd160  9877664c7a255ca5b03960ae9fd87b3f64aded20 \
-                    sha256  f39cbd40b654d4945c15c2fea04e00f6d0bbec613e1174995d6d27d8651337ea \
-                    size    739901
+checksums           rmd160  f73c598447ed4266a28ee2d4ed738b4ec75ea509 \
+                    sha256  d815f1229f76a5b636eddf8806163c34482c992946ff8590094f4fab05d61628 \
+                    size    17425
 
 build.target        build
 build.env           GOPATH=${workpath}/go


### PR DESCRIPTION
#### Description

Update to docker-machine-parallels 2.0.1

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
