### PR TITLE
openjdk: refactor openjdk8 Portfile to openjdk

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -2,16 +2,63 @@
 
 PortSystem       1.0
 
-name             openjdk8
-version          8u275
-revision         0
+name             openjdk
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        darwin
+license          GPL-2
+supported_archs  x86_64
 
-set build        01
-set major        8
+version          11
 
-checksums        rmd160  c59602c9c079d368f06ac8beea51c230f1e09e63 \
+if {${subport} eq "openjdk"} {
+    # The openjdk port is not installable, but recommends users to install the latest Long Term Support (LTS) subport
+    PortGroup    obsolete 1.0
+    replaced_by  openjdk${version}
+}
+
+# Dummy default values for the obsoleted openjdk port
+set major        ${version}
+set build        0
+set openj9_version 0
+
+set long_description_adoptopenjdk_intro \
+   "OpenJDK build provided by AdoptOpenJDK, built from a fully open-source set of build scripts and infrastructure."
+
+set long_description_adoptopenjdk_hotspot \
+    "${long_description_adoptopenjdk_intro} HotSpot is the VM from the OpenJDK community and the most widely used VM.\
+It is suitable for all workloads."
+
+set long_description_adoptopenjdk_openj9 \
+    "${long_description_adoptopenjdk_intro} OpenJ9 is the virtual machine from the Eclipse community. It is an enterprise-grade\
+VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is suitable for running all workloads."
+
+set long_description_adoptopenjdk_openj9xl \
+    "${long_description_adoptopenjdk_openj9} This version uses non-compressed references and should be used for\
+applications which require heaps that are over ~57 GB."
+
+set long_description_graalvm \
+    "GraalVM is a universal virtual machine for running applications written in JavaScript, Python, Ruby, R,\
+    JVM-based languages like Java, Scala, Groovy, Kotlin, Clojure, and LLVM-based languages such as C and C++."
+
+set long_description_oracle_openjdk \
+    "Production-ready, free and open-source build of the Java Development Kit, an implementation of the Java Standard\
+    Edition (SE) ${major} Platform. OpenJDK is the official reference implementation of Java SE. Included components\
+    are the HotSpot virtual machine, the Java class library and the Java compiler."
+
+subport openjdk8 {
+    version      8u275
+    revision     0
+
+    set build    01
+    set major    8
+
+    checksums    rmd160  c59602c9c079d368f06ac8beea51c230f1e09e63 \
                  sha256  4afd2b3d21b625392fe4501e9445d1125498e6e7fb78042495c04e7cfc1b5e69 \
                  size    101776105
+
+    configure.cxx_stdlib libstdc++
+}
 
 subport openjdk8-graalvm {
     version      20.3.0
@@ -31,7 +78,7 @@ subport openjdk8-openj9 {
     set build    01
     set major    8
     set openj9_version 0.23.0
-    
+
     checksums    rmd160  87dbdf04bdb95f872b6a15374c61dc1d5f35837f \
                  sha256  0e19282fe1dae272f1383f726cc6fc70d77816bebe07e0959ac2c9b9b711f709 \
                  size    114196051
@@ -44,7 +91,7 @@ subport openjdk8-openj9-large-heap {
     set build    01
     set major    8
     set openj9_version 0.23.0
-    
+
     checksums    rmd160  11c8c8add75504e72ce7183fe1007216f96c3d2d \
                  sha256  5f2375de68ec0d0ff4d42670aa54416948fcdd62a1cc035023c27d5d090522ab \
                  size    114907169
@@ -53,10 +100,10 @@ subport openjdk8-openj9-large-heap {
 subport openjdk10 {
     version      10.0.2
     revision     2
-    
+
     set build    13
     set major    10
-    
+
     checksums    rmd160  d29498411adc487bf8191adbc4276c72602022cf \
                  sha256  77ea7675ee29b85aa7df138014790f91047bfdafbc997cb41a1030a0417356d7 \
                  size    200916897
@@ -90,9 +137,9 @@ subport openjdk11-openj9 {
     revision     1
 
     set build    11
-    set major    11
     set openj9_version 0.23.0
-    
+    set major    11
+
     checksums    rmd160  459d97290f1a84e53811fc60cd4f3a02008be4b0 \
                  sha256  382238443d4495d976f9e1a66b0f6e3bc250d3d009b64d2c29d44022afd7e418 \
                  size    195535925
@@ -103,9 +150,9 @@ subport openjdk11-openj9-large-heap {
     revision     1
 
     set build    11
-    set major    11
     set openj9_version 0.23.0
-    
+    set major    11
+
     checksums    rmd160  1c87a3ffe4fe32e8482f35ecf59cbb6aa6f5d74d \
                  sha256  dc6987f495c7c16c8f7ad7eee50c6e62afcd3c4279e5c223e302bd529d06fb8d \
                  size    196321048
@@ -117,7 +164,7 @@ subport openjdk12 {
 
     set build    10
     set major    12
-    
+
     checksums    rmd160  298235796f231dcd79baa1eccce40b4eb4aba456 \
                  sha256  9919eee037554d40c7d2f219bbd654f2bf119e16a2f4d284d8dedaf525ee59e6 \
                  size    198392994
@@ -128,9 +175,9 @@ subport openjdk12-openj9 {
     revision     0
 
     set build    10
-    set major    12
     set openj9_version 0.15.1
-    
+    set major    12
+
     checksums    rmd160  eb8b931dc23ff3adb998e9c880e027e03b11e7cf \
                  sha256  20d19ec20f65335edbf4db3861421be393d48720d5a389cd76e1c81a8aff8fee \
                  size    197951754
@@ -141,9 +188,9 @@ subport openjdk12-openj9-large-heap {
     revision     0
 
     set build    10
-    set major    12
     set openj9_version 0.15.1
-    
+    set major    12
+
     checksums    rmd160  01c7e4723cbee7e8a34e605a369a3986ace9d07a \
                  sha256  d7c4c75f04f75767e26ffa0083c8a365ec95e8f5ccddcc0005dbd538954064b4 \
                  size    197960269
@@ -155,7 +202,7 @@ subport openjdk13 {
 
     set build    8
     set major    13
-    
+
     checksums    rmd160  0de593a1b3df57a6a91d9ab3e3d0ee7475bc1e0d \
                  sha256  0ddb24efdf5aab541898d19b7667b149a1a64a8bd039b708fc58ee0284fa7e07 \
                  size    198206427
@@ -166,9 +213,9 @@ subport openjdk13-openj9 {
     revision     0
 
     set build    8
-    set major    13
     set openj9_version 0.18.0
-    
+    set major    13
+
     checksums    rmd160  193fc075719f33545f7f9deafebd783b5d7e8df1 \
                  sha256  dd8d92eec98a3455ec5cd065a0a6672cc1aef280c6a68c507c372ccc1d98fbaa \
                  size    201152468
@@ -179,9 +226,9 @@ subport openjdk13-openj9-large-heap {
     revision     0
 
     set build    8
-    set major    13
     set openj9_version 0.18.0
-    
+    set major    13
+
     checksums    rmd160  7e71c9b1bd5aa8365af66803e3b5292b391e710b \
                  sha256  a9b7cf11ec9c5df29a09336c91dd7e3232f6fae423e10eec60836330efc2c8cc \
                  size    201151793
@@ -193,7 +240,7 @@ subport openjdk14 {
 
     set build    12
     set major    14
-    
+
     checksums    rmd160  2b6beb756626e8ab72eb85d25701be522e5beb3f \
                  sha256  09b7e6ab5d5eb4b73813f4caa793a0b616d33794a17988fa6a6b7c972e8f3dd3 \
                  size    195705010
@@ -204,9 +251,9 @@ subport openjdk14-openj9 {
     revision     0
 
     set build    12
-    set major    14
     set openj9_version 0.21.0
-    
+    set major    14
+
     checksums    rmd160  0ea69114a43e0c4e3e4cb80abf7bcd9bf86c05ca \
                  sha256  95e6abcc12dde676ccd5ba65ab86f06ddaa22749dde00e31f4c6d3ea95277359 \
                  size    200090793
@@ -217,9 +264,9 @@ subport openjdk14-openj9-large-heap {
     revision     0
 
     set build    12
-    set major    14
     set openj9_version 0.21.0
-    
+    set major    14
+
     checksums    rmd160  f77124d360ab493a5f69b3b58e5dd9e8d77c718a \
                  sha256  178270b6cc2213bad148c32e3bced0fb18aafee1f83be735d729e0261b4958da \
                  size    200881593
@@ -231,7 +278,7 @@ subport openjdk15 {
 
     set build    9
     set major    15
-    
+
     checksums    rmd160  ec9c5ee749c16ae2846e4f6e8ff63d4789ba80cb \
                  sha256  d32f9429c4992cef7be559a15c542011503d6bc38c89379800cd209a9d7ec539 \
                  size    195773522
@@ -242,9 +289,9 @@ subport openjdk15-openj9 {
     revision     0
 
     set build    9
-    set major    15
     set openj9_version 0.23.0
-    
+    set major    15
+
     checksums    rmd160  9aeeaec14ed1d44f796c6f3f7e6cb5c545537c00 \
                  sha256  688dea7aa7b077f10ed9af833d0d14fa1770961099f43933bb84724d1f068d6f \
                  size    195840553
@@ -255,28 +302,15 @@ subport openjdk15-openj9-large-heap {
     revision     0
 
     set build    9
-    set major    15
     set openj9_version 0.23.0
-    
+    set major    15
+
     checksums    rmd160  efbbf9c19429915a953d4df681199bd6d45c9058 \
                  sha256  e48fd8ed4ef7386b59229cc86a1718e42b91209ba3b748a258850599ddeed8bb \
                  size    195082957
 }
 
-categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
-license          GPL-2
-supported_archs  x86_64
-
-if {${subport} eq "openjdk8"} {
-    livecheck.url    https://api.adoptopenjdk.net/v2/info/releases/${subport}?release=latest&openjdk_impl=hotspot
-    livecheck.regex  {"release_name": "jdk(\d+u\d+)-b\d+"}
-} else {
-    livecheck.url    https://github.com/AdoptOpenJDK/openjdk-jdk${major}u/releases
-    livecheck.regex  (?c)jdk-(\[0-9.\]+)
-}
-
+# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
 if {${os.platform} eq "darwin" && ${os.major} < 14} {
     known_fail yes
     pre-fetch {
@@ -287,132 +321,73 @@ if {${os.platform} eq "darwin" && ${os.major} < 14} {
 
 if {${subport} eq "openjdk8"} {
     description  Open Java Development Kit ${major} (AdoptOpenJDK) with HotSpot VM
-    long_description OpenJDK build provided by AdoptOpenJDK, built from a fully \
-                 open-source set of build scripts and infrastructure. \
-                 \
-                 HotSpot is the VM from the OpenJDK community and  the most widely used VM. \
-                 It is suitable for all workloads.
+    long_description ${long_description_adoptopenjdk_hotspot}
 
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}/
     distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}b${build}
     worksrcdir   jdk${version}-b${build}
+
     configure.cxx_stdlib libstdc++
 } elseif {${subport} eq "openjdk8-openj9"} {
     description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM
-    long_description AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully \
-                 open-source set of build scripts and infrastructure. \
-                 \
-                 OpenJ9 is the virtual machine from the Eclipse community. It is an enterprise-grade \
-                 VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
-                 suitable for running all workloads.
+    long_description ${long_description_adoptopenjdk_openj9}
 
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}b${build}_openj9-${openj9_version}
     worksrcdir   jdk${version}-b${build}
 } elseif {${subport} eq "openjdk8-openj9-large-heap"} {
     description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM for large heap sizes
-    long_description AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully \
-                 open-source set of build scripts and infrastructure. \
-                 \
-                 OpenJ9 is the virtual machine from the Eclipse community. It is an enterprise-grade \
-                 VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
-                 suitable for running all workloads. \
-                 \
-                 This version uses non-compressed references and should be used for applications which require heaps that are over ~57 GB.
+    long_description ${long_description_adoptopenjdk_openj9xl}
 
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}b${build}_openj9-${openj9_version}
     worksrcdir   jdk${version}-b${build}
 } elseif {${subport} eq "openjdk10"} {
     description  Oracle OpenJDK ${major} with HotSpot VM
-    long_description Production-ready, free and open-source build of the Java \
-                 Development Kit, an implementation of the Java Standard \
-                 Edition (SE) ${major} Platform. OpenJDK is the official reference \
-                 implementation of Java SE. Included components are the \
-                 HotSpot virtual machine, the Java class library and the Java \
-                 compiler.
+    long_description ${long_description_oracle_openjdk}
 
     master_sites https://download.java.net/java/GA/jdk${major}/${version}/19aef61b38124481863b1413dce1855f/${build}/
     distname     openjdk-${version}_osx-x64_bin
     worksrcdir   jdk-${version}.jdk
-} elseif {${subport} eq "openjdk11-openj9"} {
-    # Stealth update for 11.1, remove this for the next release
-    description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM
-    long_description AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully \
-                 open-source set of build scripts and infrastructure. \
-                 \
-                 OpenJ9 is the virtual machine from the Eclipse community. It is an enterprise-grade \
-                 VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
-                 suitable for running all workloads.
-
-    dist_subdir  ${name}/${version}_1
-
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.1_openj9-${openj9_version}/
-    distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
-    worksrcdir   jdk-${version}+${build}
-} elseif {${subport} eq "openjdk11-openj9-large-heap"} {
-    # Stealth update for 11.1, remove this for the next release
-    description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM for large heap sizes
-    long_description AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully \
-                 open-source set of build scripts and infrastructure. \
-                 \
-                 OpenJ9 is the virtual machine from the Eclipse community. It is an enterprise-grade \
-                 VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
-                 suitable for running all workloads. \
-                 \
-                 This version uses non-compressed references and should be used for applications which require heaps that are over ~57 GB.
-
-    dist_subdir  ${name}/${version}_1
-
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.1_openj9-${openj9_version}/
-    distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
-    worksrcdir   jdk-${version}+${build}
 } elseif [string match *-graalvm ${subport}] {
     description  GraalVM Community Edition based on OpenJDK ${major}
-    long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, \
-                 Ruby, R, JVM-based languages like Java, Scala, Groovy, Kotlin, Clojure, and LLVM-based languages \
-                 such as C and C++.
+    long_description ${long_description_graalvm}
 
     master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/
     distname     graalvm-ce-java${major}-darwin-amd64-${version}
     worksrcdir   graalvm-ce-java${major}-${version}
 } elseif [string match *-openj9-large-heap ${subport}] {
     description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM for large heap sizes
-    long_description AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully \
-                 open-source set of build scripts and infrastructure. \
-                 \
-                 OpenJ9 is the virtual machine from the Eclipse community. It is an enterprise-grade \
-                 VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
-                 suitable for running all workloads. \
-                 \
-                 This version uses non-compressed references and should be used for applications which require heaps that are over ~57 GB.
+    long_description ${long_description_adoptopenjdk_openj9xl}
 
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
     worksrcdir   jdk-${version}+${build}
 } elseif [string match *-openj9 ${subport}] {
     description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM
-    long_description AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully \
-                 open-source set of build scripts and infrastructure. \
-                 \
-                 OpenJ9 is the virtual machine from the Eclipse community. It is an enterprise-grade \
-                 VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
-                 suitable for running all workloads.
+    long_description ${long_description_adoptopenjdk_openj9}
 
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
     worksrcdir   jdk-${version}+${build}
 } else {
     description  Open Java Development Kit ${major} (AdoptOpenJDK) with HotSpot VM
-    long_description OpenJDK build provided by AdoptOpenJDK, built from a fully \
-                 open-source set of build scripts and infrastructure. \
-                 \
-                 HotSpot is the VM from the OpenJDK community and  the most widely used VM. \
-                 It is suitable for all workloads.
+    long_description ${long_description_adoptopenjdk_hotspot}
 
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}/
     distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}_${build}
     worksrcdir   jdk-${version}+${build}
+}
+
+# Temporary overrides for stealth updates
+if {${subport} eq "openjdk11-openj9"} {
+    # Stealth update for 11.1, remove this for the next release
+    dist_subdir  ${name}/${version}_1
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.1_openj9-${openj9_version}/
+} elseif {${subport} eq "openjdk11-openj9-large-heap"} {
+    # Stealth update for 11.1, remove this for the next release
+    dist_subdir  ${name}/${version}_1
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.1_openj9-${openj9_version}/
 }
 
 if [string match *-graalvm ${subport}] {
@@ -422,6 +397,8 @@ if [string match *-graalvm ${subport}] {
 } else {
     homepage     https://adoptopenjdk.net
 }
+
+livecheck.type  none
 
 variant Applets \
     description { Advertise the JVM capability "Applets".} {}


### PR DESCRIPTION
#### Description

Refactoring of the `openjdk8` Portfile to `openjdk`, which handles all major JDK versions as subports. The `openjdk` port itself is not installable. Trying to install it will print an error message recommending to install the current Long Term Support (LTS) release instead. This was previously discussed here: https://github.com/macports/macports-ports/pull/9187#issuecomment-731553323

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?