### PR TITLE
kotlin: fixed livecheck

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -57,5 +57,5 @@ destroot {
 supported_archs     noarch
 
 livecheck.type      regex
-livecheck.url       https://kotlinlang.org/
-livecheck.regex     "Latest version: (\\d+(?:\\.\\d+)*(?:-\\d+)?)</p>"
+livecheck.url       https://github.com/JetBrains/kotlin/releases/latest
+livecheck.regex     ${name}-compiler-(\\d+\\.\\d+\\.\\d+).zip


### PR DESCRIPTION
#### Description

Fixed broken livecheck.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?