### PR TITLE
spring-boot-cli: fix livecheck

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -71,7 +71,3 @@ variant bash_completion {
              ${destroot}${prefix}/etc/bash_completion.d/spring
     }
 }
-
-livecheck.type  regex
-livecheck.url   http://repo.spring.io/release/org/springframework/boot/${name}/
-livecheck.regex (\[0-9.\]+).RELEASE


### PR DESCRIPTION
#### Description

Remove broken livecheck.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?