### PR TITLE
Introduced variant icu_config

### DIFF
--- a/devel/icu/Portfile
+++ b/devel/icu/Portfile
@@ -122,7 +122,13 @@ subport ${name}-lx {
 }
 
 if {${subport} eq ${name}} {
-    revision                2
+    revision                3
+
+    configure.args-append  --disable-icu-config
+
+    variant icu_config description {Enable icu-config} {
+        configure.args-replace  --disable-icu-config --enable-icu-config
+    }
 }
 
 if { ${subport} ne "${name}-docs" } {


### PR DESCRIPTION
#### Description

The cause to have this variant is simple: icu-config doesn't work on arm64.

As result it is blocking to install nodejs for such machines.

`--disable-icu-config` and `--enable-icu-config` was added quite a while ago:
https://unicode-org.atlassian.net/browse/ICU-10464

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.0.1 20B50
Xcode 12.2 12B45b

and 

macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/ticket/45268) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
