### PR TITLE
k9s: update to 0.24.1

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.24.0 v
+go.setup            github.com/derailed/k9s 0.24.1 v
 homepage            https://k9scli.io
 
 categories          sysutils devel
@@ -20,9 +20,9 @@ platforms           darwin
 supported_archs     x86_64
 license             Apache-2
 
-checksums           rmd160  30cc98cf3d53ed765047f33db4e5b1ea10b60c04 \
-                    sha256  d13d84e2184ad50325825a856d5394cec74346ab81dec8b47f9aed93a3f02f6c \
-                    size    6107817
+checksums           rmd160  38e2324b6c0697c39accc09e5099e765d3704f85 \
+                    sha256  df6133c889a4796f032775f26c5e19b24a00994633e895264d9e584216aaf660 \
+                    size    6108140
 
 # Reproduce the "build" target from the upstream Makefile
 set go_ldflags      "-w -s \


### PR DESCRIPTION
#### Description

Update to K9s 0.24.1.

###### Tested on

macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?