### PR TITLE
zulu-jdk: add zulu-jdk8 port

### DIFF
--- a/java/zulu-jdk/Portfile
+++ b/java/zulu-jdk/Portfile
@@ -1,0 +1,287 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                 1.0
+
+name                       zulu-jdk8
+set jdk_version(aarch64)   8.0.275
+set jdk_version(x64)       8.0.275
+set zulu_version(aarch64)  8.50.0.1017
+set zulu_version(x64)      8.50.0.51
+set major                  8
+revision                   0
+
+supported_archs            x86_64 arm64
+
+set zulu_build             ca
+
+checksums                  zulu${zulu_version(aarch64)}-ca-jdk${jdk_version(aarch64)}-macos_aarch64.zip \
+    rmd160                 015684cce43fce8430365e44eca0f0a0e02cf8c3 \
+    sha256                 7f34ea5344741ae370b78a55d25258277c55c9a8b61df99f8c93cf9509a7805d \
+    size                   110218823 \
+                           zulu${zulu_version(x64)}-${zulu_build}-jdk${jdk_version(x64)}-macosx_x64.zip \
+    rmd160                 6e467cee8f0efcdf9804d41ac26b3a6851007d2d \
+    sha256                 88ae35653a4b20c38e76a78d7f617d3f2eb7f3643e440ee3eae184b5b9052142 \
+    size                   112351456
+
+subport zulu-jdk7 {
+
+    set jdk_version(x64)       7.0.285
+    set zulu_version(x64)      7.42.0.51
+    set major                  7
+    revision                   0
+
+    supported_archs            x86_64
+
+    checksums                  zulu${zulu_version(x64)}-${zulu_build}-jdk${jdk_version(x64)}-macosx_x64.zip \
+        rmd160                 6abb91781f1f224cc78bdb090ef4dec7eb46947d \
+        sha256                 68141d1b5a31b01574d443c9b8ceb516aaebbb33ed366a724ec5d516ca7c26cd \
+        size                   70803383
+
+    set zulu_use_rosetta       yes
+
+    variant without_xawt description "Xawt is linking with X11 at /opt/X11/lib that should be installed separately" {
+        set zulu_without_jre_xawt  yes
+    }
+
+    default_variants           +without_xawt
+}
+
+subport zulu-jdk9 {
+
+    set jdk_version(x64)       9.0.7
+    set zulu_version(x64)      9.0.7.1
+    set major                  9
+    revision                   0
+
+    supported_archs            x86_64
+
+    checksums                  zulu${zulu_version(x64)}-${zulu_build}-jdk${jdk_version(x64)}-macosx_x64.zip \
+        rmd160                 0edab1af1873860d28844f9e8deae145e3601af7 \
+        sha256                 4b1f8529ff3a8bebc974e2a22395cb27ad8750e386c8c4d1b0a1b16f89cfcf66 \
+        size                   195923680
+
+    set zulu_no_bundle         yes
+    set zulu_use_rosetta       yes
+}
+
+subport zulu-jdk10 {
+
+    set jdk_version(x64)       10.0.2
+    set zulu_version(x64)      10.3.5
+    set major                  10
+    revision                   0
+
+    supported_archs            x86_64
+
+    checksums                  zulu${zulu_version(x64)}-${zulu_build}-jdk${jdk_version(x64)}-macosx_x64.zip \
+        rmd160                 874308e47bd8bebc0783b182a081fcf21ed88004 \
+        sha256                 ffeada0b80d51f1d18a703926538c2f9e1cfe1f51f968a726b866387ac74fd16 \
+        size                   208176633
+
+    set zulu_no_bundle         yes
+    set zulu_use_rosetta       yes
+}
+
+subport zulu-jdk11 {
+
+    set jdk_version(aarch64)   11.0.9.1
+    set jdk_version(x64)       11.0.9.1
+    set zulu_version(aarch64)  11.43.1015
+    set zulu_version(x64)      11.43.55
+    set major                  11
+    revision                   0
+
+    checksums                  zulu${zulu_version(aarch64)}-${zulu_build}-jdk${jdk_version(aarch64)}-macos_aarch64.zip \
+        rmd160                 0cc662e1f06fc2e15d36f94a444e8fcdc0f5d9d3 \
+        sha256                 f1da4e367cedaf24f7ce934d2b32d304c4fd160e2d7888f7f151657e1e7f7e28 \
+        size                   182869605 \
+                               zulu${zulu_version(x64)}-${zulu_build}-jdk${jdk_version(x64)}-macosx_x64.zip \
+        rmd160                 b318b00d2b3c3fe419efd596a8e23bd7e003623b \
+        sha256                 45a3d08a6ef21404975433bd8babe4e04c0dbfe8f6e5f34561d89af50b874006 \
+        size                   199869567
+}
+
+subport zulu-jdk12 {
+
+    set jdk_version(x64)       12.0.2
+    set zulu_version(x64)      12.3.11
+    set major                  12
+    revision                   0
+
+    supported_archs            x86_64
+
+    checksums                  zulu${zulu_version(x64)}-${zulu_build}-jdk${jdk_version(x64)}-macosx_x64.zip \
+        rmd160                 ec52ca999579f607bd7a278f2340ee052e429505 \
+        sha256                 8e8b686c625c95ed693c039b27f81751c58fba8090b8141ea632877de5503639 \
+        size                   203549959
+
+    set zulu_no_bundle         yes
+    set zulu_use_rosetta       yes
+}
+
+subport zulu-jdk13 {
+
+    set jdk_version(aarch64)   13.0.5.1
+    set jdk_version(x64)       13.0.5.1
+    set zulu_version(aarch64)  13.35.1017
+    set zulu_version(x64)      13.35.51
+    set major                  13
+    revision                   0
+
+    checksums                  zulu${zulu_version(aarch64)}-${zulu_build}-jdk${jdk_version(aarch64)}-macos_aarch64.zip \
+        rmd160                 09b736925f5627dd4c670b8e2e3ecc48d709f64f \
+        sha256                 4cc3fe2eefb285ba21cab8a066a5b33fb871e2f8b026429509a96432f2da211a \
+        size                   183302696 \
+                               zulu${zulu_version(x64)}-${zulu_build}-jdk${jdk_version(x64)}-macosx_x64.zip \
+        rmd160                 5a4bd2136bf11587e133c3cb19a27f52dcdb16f7 \
+        sha256                 10a83975421aaaa78412de6a5d4a3e52c4ef393097ca40cd5ab60a3f82e71af2 \
+        size                   204880815
+}
+
+subport zulu-jdk14 {
+
+    set jdk_version(x64)       14.0.2
+    set zulu_version(x64)      14.29.23
+    set major                  14
+    revision                   0
+
+    supported_archs            x86_64
+
+    checksums                  zulu${zulu_version(x64)}-${zulu_build}-jdk${jdk_version(x64)}-macosx_x64.zip \
+        rmd160                 f97f9d7d7ad526797ff8dcd32ab9c5187aa4f5cb \
+        sha256                 57e737d639a6927c82626fd18257751e6bb4d64e291b8fac62ddad01255a1d77 \
+        size                   207255111
+
+    set zulu_use_rosetta       yes
+}
+
+subport zulu-jdk15 {
+
+    set jdk_version(x64)       15.0.1
+    set zulu_version(x64)      15.28.51
+    set major                  15
+    revision                   0
+
+    supported_archs            x86_64
+
+    checksums                  zulu${zulu_version(x64)}-${zulu_build}-jdk${jdk_version(x64)}-macosx_x64.zip \
+        rmd160                 20f1b78a26beab1cd71c2fd99107704df53fc3e7 \
+        sha256                 084c67b6ada87e8ba1f8abf35af2c8a56b204ccf513600af6e09ae7880824a84 \
+        size                   206369908
+
+    set zulu_use_rosetta       yes
+}
+
+subport zulu-jdk16 {
+
+    set jdk_version(aarch64)   16.0.0-ea.24
+    set jdk_version(x64)       16.0.0-ea.24
+    set zulu_version(aarch64)  16.0.65
+    set zulu_version(x64)      16.0.59
+    set major                  16
+    revision                   0
+
+    supported_archs            x86_64
+
+    set zulu_build             ea
+
+    checksums                  zulu${zulu_version(aarch64)}-${zulu_build}-jdk${jdk_version(aarch64)}-macos_aarch64.zip \
+        rmd160                 6d14b2977e132e1e220321f5e00b23ede2166d7d \
+        sha256                 0f54d48b1fbe6b1d39796612a8c4d26494692048dbc7bed3e382ee5d69a18590 \
+        size                   198727610 \
+                               zulu${zulu_version(x64)}-${zulu_build}-jdk${jdk_version(x64)}-macosx_x64.zip \
+        rmd160                 a63dbf28c9b639465f2e0f1bddd9c3610ff4d429 \
+        sha256                 add17bbb32c1e8498f9150574c716757b66e430c293bcdac6a33b1f06e359f33 \
+        size                   209804565
+
+    # 16.0.59 isn't bundle yet
+    if {$build_arch eq "x86_64"} {
+        set zulu_no_bundle         yes
+    }
+}
+
+categories       java devel
+maintainers      nomaintainer
+platforms        darwin
+license          GPL-2
+homepage         https://www.azul.com/downloads/zulu-community/
+
+
+set zulu_arch(arm64)       aarch64
+set zulu_arch(x86_64)      x64
+
+if {![info exists zulu_arch(${build_arch})]} {
+    set zulu_arch(${build_arch}) ${build_arch}
+}
+
+set zulu_name(arm64)       macos
+set zulu_name(x86_64)      macosx
+
+if {![info exists zulu_arch(${build_arch})]} {
+    set zulu_arch(${build_arch}) macosx
+}
+
+if {[info exists zulu_use_rosetta]} {
+    set zulu_arch(arm64)     $zulu_arch(x86_64)
+    set zulu_name(arm64)     $zulu_name(x86_64)
+}
+
+set version  $zulu_version($zulu_arch($build_arch))
+
+if {${os.platform} eq "darwin" && ${os.major} < 14} {
+    known_fail yes
+    pre-fetch {
+        ui_error "${name} ${version} is only supported on OS X 10.10 Yosemite or later."
+        return -code error
+    }
+}
+
+description  Open Java Development Kit ${major} (Zulu) with HotSpot VM
+long_description OpenJDK build provided by Azul, built from a fully \
+    open-source set of build scripts and infrastructure. \
+    \
+    HotSpot is the VM from the OpenJDK community and  the most widely used VM. \
+    It is suitable for all workloads.
+
+master_sites   https://cdn.azul.com/zulu/bin/
+distname       zulu$zulu_version($zulu_arch($build_arch))-${zulu_build}-jdk$jdk_version($zulu_arch($build_arch))-$zulu_name($build_arch)_$zulu_arch($build_arch)
+use_zip        yes
+worksrcdir     zulu$zulu_version($zulu_arch($build_arch))
+use_configure  no
+
+if {$major < 9} {
+    configure.cxx_stdlib libstdc
+}
+
+
+build {}
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/${subport}
+set destroot_target ${destroot}${target}
+
+destroot {
+    if {[info exists zulu_no_bundle]} {
+        xinstall -m 755 -d ${destroot_target}/Contents/Home
+        copy {*}[glob ${worksrcpath}/*] ${destroot_target}/Contents/Home
+    } else {
+        xinstall -m 755 -d ${destroot_target}
+        copy ${worksrcpath}/zulu-${major}.jdk/Contents ${destroot_target}
+    }
+    if {[info exists zulu_without_jre_xawt]} {
+        file delete -force ${destroot_target}/Contents/Home/jre/lib/xawt
+    }
+}
+
+notes "
+If you have more than one JDK installed you can make ${subport} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${target}/Contents/Home
+"
+
+livecheck.type       regex
+livecheck.url        [lindex ${master_sites} 0]
+livecheck.regex      zulu(\[0-9.\]+)-${zulu_build}-jdk$major\.\[0-9.\\-ea\]+-$zulu_name($build_arch)_$zulu_arch($build_arch)\.zip


### PR DESCRIPTION
#### Description

Let introduce some JDK that is working on apple's M1.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.0.1 20B50
Xcode 12.2 12B45b

and

macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
