### PR TITLE
age: new port

### DIFF
--- a/security/age/Portfile
+++ b/security/age/Portfile
@@ -1,0 +1,94 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/FiloSottile/age 1.0.0-beta5 v
+revision            0
+
+go.package          filippo.io/age
+
+homepage            https://age-encryption.org
+
+description         A simple, modern and secure encryption tool with small \
+                    explicit keys, no config options, and UNIX-style \
+                    composability.
+
+long_description    {*}${description}
+
+categories          security
+license             BSD
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+build.pre_args      -o ./_dist/
+build.args          ./cmd/...
+
+installs_libs       no
+
+pre-build {
+    file mkdir ${worksrcpath}/_dist
+}
+
+destroot {
+    foreach age_bin [glob ${worksrcpath}/_dist/*] {
+        xinstall -m 755 ${age_bin} ${destroot}${prefix}/bin/
+    }
+}
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  10776a7985f29726d3179d677766f167408ff06a \
+                        sha256  3d663fd1c0077f79c4e9035916eb4b57dd0cd368309511109fd7f82a2d49f9f9 \
+                        size    38758
+
+go.vendors          gopkg.in/yaml.v2 \
+                        lock    v2.2.4 \
+                        rmd160  e7d6084770eadd1aea75e3e6ad70962436c22989 \
+                        sha256  14dda753969aacb4366477ac95e2b371e1ee940e7e76bfffdec737a55dbd27e0 \
+                        size    72218 \
+                    gopkg.in/check.v1 \
+                        lock    41f04d3bba15 \
+                        rmd160  1e5543a8e6a3159296ee63e28cbde9931a04f6b3 \
+                        sha256  c41575a73d10809f89b05ef9e783f2d53facdc6573697770d30efb05a9d2dc28 \
+                        size    31612 \
+                    golang.org/x/sys \
+                        lock    97732733099d \
+                        rmd160  d83b94fd587bc3799316510e1e5cfda7ff2425e8 \
+                        sha256  62c7cd8777af259c0266055a99d3d67c80a77506104a14a9678547c808010f73 \
+                        size    1350306 \
+                    golang.org/x/crypto \
+                        lock    0ec3e9974c59 \
+                        rmd160  f6b84b267673d7c369504d9d3fd1733adb82702a \
+                        sha256  8a7868bca28251b1db06da1085e9ea4437fc2c51a5bb6c9756d7f465b273265c \
+                        size    1728327 \
+                    github.com/stretchr/testify \
+                        lock    v1.4.0 \
+                        rmd160  86bd663e13ea7266334c47689074df16252db5ff \
+                        sha256  8ed95078bfd318ea477da509e6b16e6cf8d0d1b6b8d93b1f6097c6ba2a6df788 \
+                        size    110114 \
+                    github.com/sergi/go-diff \
+                        lock    v1.1.0 \
+                        rmd160  6449feb5884c316206f256e55b81aba3e6a78a9f \
+                        sha256  026d3d6db40ad086954214a7f3f84b66e352d47ce259bb59b7c2b9bd843b9935 \
+                        size    43569 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/kr/text \
+                        lock    v0.1.0 \
+                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
+                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
+                        size    8691 \
+                    github.com/kr/pretty \
+                        lock    v0.1.0 \
+                        rmd160  9aa7a5aad4c48840eecfd0f80186d1fb5ded0fd6 \
+                        sha256  f6c3f89667c63e5b7f1fc6ee2c06b6a6bfdce88f3a965ccd395b64c6f95c9a47 \
+                        size    8553 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171


### PR DESCRIPTION
#### Description

New port for the [age](https://filippo.io/age) encryption tool.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.2 12B45b


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
