### PR TITLE
skaffold: update to 1.17.0

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 1.16.0 v
+github.setup        GoogleContainerTools skaffold 1.17.0 v
 revision            0
 
 categories          devel
@@ -23,9 +23,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  fa4ceaf6ccb8a70fd32f0df1c88abaa7d93a66eb \
-                    sha256  8ab37c155fc3a68eebfa3f9a94fd9196b207762f666f88f940911105c9d61eee \
-                    size    27452554
+checksums           rmd160  30b3b474e57be35af3ebc38d50069447667b9ba0 \
+                    sha256  ebf059f14f555a99d3fb7f42efe910f6a6adf1153ccd0ff73cb3f252898febe0 \
+                    size    27526424
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 1.17.0.

###### Tested on

macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?