### PR TITLE
fftw-3: Make +pfft_patches build with recent compiler

### DIFF
--- a/math/fftw-3/files/patch-pfft.diff
+++ b/math/fftw-3/files/patch-pfft.diff
@@ -23,12 +23,16 @@
 
 --- mpi/mpi-transpose.h	2014-03-04 19:41:03.000000000 +0100
 +++ mpi/mpi-transpose.h	2015-09-05 05:53:19.085516467 +0200
-@@ -59,3 +59,5 @@ int XM(mkplans_posttranspose)(const prob
+@@ -59,3 +59,9 @@ int XM(mkplans_posttranspose)(const prob
  void XM(transpose_pairwise_register)(planner *p);
  void XM(transpose_alltoall_register)(planner *p);
  void XM(transpose_recurse_register)(planner *p);
 +void XM(transpose_pairwise_transposed_register)(planner *p);
 +void XM(transpose_alltoall_transposed_register)(planner *p);
++int XM(mkplans_pretranspose)(const problem_mpi_transpose *p, planner *plnr,
++                             R *I, R *O, int my_pe,
++                             plan **cld2, plan **cld2rest, plan **cld3,
++                             INT *rest_Ioff, INT *rest_Ooff);
 
 --- mpi/transpose-alltoall-transposed.c	1970-01-01 01:00:00.000000000 +0100
 +++ mpi/transpose-alltoall-transposed.c	2015-09-05 05:53:19.085516467 +0200


### PR DESCRIPTION
#### Description

`fftw_mpi_mkplans_pretranspose` was implicitly declared in the patch, so we need to patch the appropriate declaration into the header file as well. Older Apple Clang versions seemed to not care, but at some point in the past year they evidently got more strict and started printing error messages:

```
transpose-alltoall-transposed.c:206:24: error: implicit declaration of function 'fftw_mpi_mkplans_pretranspose' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
```

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.0.1 20B50
Xcode 12.2 12B45b


###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
