### PR TITLE
nc6: autoreconf to fix implicit function decl

### DIFF
--- a/net/nc6/Portfile
+++ b/net/nc6/Portfile
@@ -4,6 +4,7 @@ PortSystem      1.0
 
 name            nc6
 version         1.0
+revision        1
 categories      net
 license         GPL-2+
 maintainers     {cal @neverpanic} openmaintainer
@@ -17,13 +18,15 @@ homepage        http://www.deepspace6.net/
 master_sites    ftp://ftp.deepspace6.net/pub/ds6/sources/nc6/ \
                 http://ftp.deepspace6.net/pub/ds6/sources/nc6/
 
-checksums       md5 97fb6d871d804eabbc0ec6552d46b6b0 \
-                sha1 50b1a3f7bfa610a2016727e5741791ad3a88bd07 \
-                rmd160 4bd6a0f0fddb544636e5b2265b44cb833342db29
+checksums       rmd160  4bd6a0f0fddb544636e5b2265b44cb833342db29 \
+                sha256  db7462839dd135ff1215911157b666df8512df6f7343a075b2f9a2ef46fe5412 \
+                size    355238
 
-depends_lib     lib:libintl:gettext \
-                lib:libiconv:libiconv
+depends_lib     port:gettext \
+                port:libiconv
 
+use_autoreconf  yes
+autoreconf.args -fvi
 configure.args  --mandir=${prefix}/share/man
 
 post-destroot {


### PR DESCRIPTION
### Description

The configure script shipped with nc6 seems to have an old copy of a check for `fork(2)`, which fails because `HAVE_UNISTD_H` is not defined in the test, which skips the `#include <unistd.h>` required for this test to properly compile with `-Werror=implicit-function-declaration` on Big Sur.

Fix this by running autoreconf `-fvi`, which seems to update to a newer version of the check that does not exhibit the same problem.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G6042
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
