### PR TITLE
igraph: update to 0.8.4

### DIFF
--- a/math/igraph/Portfile
+++ b/math/igraph/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        igraph igraph 0.8.3
+github.setup        igraph igraph 0.8.4
 github.tarball_from releases
 
 categories          math science devel
@@ -18,14 +18,14 @@ platforms           darwin
 depends_lib         port:gmp \
                     port:libxml2
 
-checksums           rmd160  e000e51d3fe0457b746541d84b7f32e5cf4e8bf6 \
-                    sha256  cc935826d3725a9d95f1b0cc46e3c08c554b29cdd6943f0286d965898120b3f1 \
-                    size    3636192
+checksums           rmd160  2e47ea898e34945ffb3076bf7f850d24274e3443 \
+                    sha256  ceef4e169777bdfb94673a068d128e189c311d6de62fe88569bbae090836f888 \
+                    size    3302695
 
 test.run            yes
 test.target         check
 
-# igraph 0.8.3 embeds GLPK 4.45. Currently GLPK is at version 4.65.
+# igraph 0.8.4 embeds GLPK 4.45. Currently GLPK is at version 4.65.
 # Some igraph functions perform better with this new GLPK version.
 
 variant external_glpk description {Build with external GLPK} {


### PR DESCRIPTION
#### Description

 - update to 0.8.4

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G6042
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
