### PR TITLE
ethr: new port

### DIFF
--- a/net/ethr/Portfile
+++ b/net/ethr/Portfile
@@ -1,0 +1,57 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/microsoft/ethr 0.9.0 v
+revision            0
+
+description         Ethr is a Network Performance Measurement Tool for TCP, \
+                    UDP & HTTP.
+
+long_description    Ethr is a cross platform network performance measurement \
+                    tool written in golang. The goal of this project is to \
+                    provide a native tool for comprehensive network \
+                    performance measurements of bandwidth, connections/s, \
+                    packets/s, latency, loss & jitter, across multiple \
+                    protocols such as TCP, UDP, HTTP, HTTPS, and across \
+                    multiple platforms such as Windows, Linux and other Unix \
+                    systems.
+
+categories          net sysutils www
+license             MIT
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+installs_libs       no
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  1dba01d32f9add1a9d5338987808d7afcc7dcb98 \
+                        sha256  2778cfa165917aed12715f640f0c9160a5daefeabc56bc9b18bb9cdde47c1e80 \
+                        size    39057
+
+go.vendors          golang.org/x/sys \
+                        lock    af09f7315aff \
+                        rmd160  2e2294bcbcefb80f8ad5a51d474a18f08f8ffcdb \
+                        sha256  9ee36a2c435fda5e5b9d80c764d9972d5110a232418ec1f4f0fb9e5307e0cd51 \
+                        size    1063406 \
+                    golang.org/x/net \
+                        lock    69a78807bb2b \
+                        rmd160  9d9b9b6183f9323be728839f7968e30b66a1f301 \
+                        sha256  4f74691f4cebc852ccba579a15bf33272a95d18b7ad745820c15f4b645f3eff8 \
+                        size    1248832 \
+                    github.com/nsf/termbox-go \
+                        lock    38ba6e5628f1 \
+                        rmd160  a99c5ed0fab4285172d060988708e3c818a00fc0 \
+                        sha256  8eab5b10ae2b57adc8f03ca852d328e3cf12dfcc6053c9f9e97e12afea60bd7c \
+                        size    32822 \
+                    github.com/mattn/go-runewidth \
+                        lock    v0.0.9 \
+                        rmd160  412c0e508e55f4fe437be0f71d7d22eca2b4366f \
+                        sha256  4f0f4a22257ccecfb6beae88052d850380ecc0e806d6bcc92d3656ebcac3b638 \
+                        size    16716


### PR DESCRIPTION
#### Description

New port for the [Ethr](https://github.com/microsoft/ethr) network performance tool from Microsoft.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
