### PR TITLE
gimp2: Bump revision to rebuild against ghostscript

### DIFF
--- a/graphics/gimp2/Portfile
+++ b/graphics/gimp2/Portfile
@@ -8,7 +8,7 @@ name                gimp2
 conflicts           gimp2-devel gimp3-devel
 # please remember to update the gimp metapackage to match
 version             2.10.22
-revision            0
+revision            1
 set branch          [join [lrange [split ${version} .] 0 1] .]
 license             GPL-3+
 categories          graphics


### PR DESCRIPTION
### Description

```
Could not open /opt/local/lib/libgs.9.52.dylib: Error opening or reading file (referenced from /opt/local/lib/gimp/2.0/plug-ins/file-ps/file-ps)
```


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G6042
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?