### PR TITLE
gnupg2: Update to 2.2.25, fix +openldap on Big Sur

### DIFF
--- a/mail/gnupg2/Portfile
+++ b/mail/gnupg2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 set my_name         gnupg
 name                ${my_name}2
-version             2.2.24
+version             2.2.25
 categories          mail security
 maintainers         {jann @roederja} {ionic @Ionic} openmaintainer
 license             GPL-3+
@@ -23,9 +23,9 @@ master_sites        ${my_name}:${my_name}
 
 use_bzip2           yes
 
-checksums           rmd160  6d69ede08c5607714ecbe90bb3fe5c8c6a91b038 \
-                    sha256  9090b400faae34f08469d78000cfec1cee5b9c553ce11347cc96ef16eab98c46 \
-                    size    7196489
+checksums           rmd160  8e2a92a23241568356dc2915a3322327ac092b1c \
+                    sha256  c55307b247af4b6f44d2916a25ffd1fb64ce2e509c3c3d028dbe7fbf309dc30a \
+                    size    7195857
 
 platform darwin {
     if {![variant_isset pinentry] && ![variant_isset pinentry_mac]} {
@@ -82,6 +82,8 @@ variant pinentry_mac conflicts pinentry description {Handle user input via pinen
 configure.args-append --disable-openldap --with-ldap=no
 variant openldap description {Support openldap} {
     depends_lib-append      port:openldap
+    configure.cppflags-append \
+                            -DLDAP_DEPRECATED=1
     configure.args-delete   --disable-openldap
     configure.args-delete   --with-ldap=no
     configure.args-append   --with-ldap=${prefix}


### PR DESCRIPTION
### Description

Update gnupg2 to the latest version 2.2.25.

> Noteworthy changes in version 2.2.25
> ====================================
>
>   * scd: Fix regression in 2.2.24 requiring gpg --card-status before
>     signing or decrypting.
>     https://dev.gnupg.org/T5065
>
>   * gpgsm: Using Libksba 1.5.0 signatures with a rarely used
>     combination of attributes can now be verified.
>     https://dev.gnupg.org/T5146
>
>   Release-info: https://dev.gnupg.org/T5140

Additionally, fix a failure to correctly compile against OpenLDAP when +openldap is enabled (which is the default) due to `-Werror=implicit-function-declaration`.

```
conftest.c:84:1: error: implicit declaration of function 'ldap_open' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
ldap_open("foobar",1234);
^
conftest.c:84:1: note: did you mean 'ldap_turn'?
/opt/local/include/ldap.h:2097:1: note: 'ldap_turn' declared here
ldap_turn LDAP_P(( LDAP *ld,
^
1 error generated.
```

This happens because the configure script checks for `ldap_open(3)`, which was deprecated 20 years ago in [\[1\]][1], and hidden behind a preprocessor define 16 years ago in [\[2\]][2]. With `-Werror=implicit-function-declaration`, the unavailability of the function declaration makes the configure test fail and gnupg2 build without LDAP support.

Fix this by adding `-DLDAP_DEPRECATED=1` to the preprocessor flags, which makes the configure test pass again. This is a stop-gap measure, and if the LDAP support in gnupg depends on code that was deprecated 16 years ago, maybe it should just be disabled, or at least removed from the default variants.

[1]: https://git.openldap.org/openldap/openldap/-/commit/5417fdfea7004888c3f40840f8ed1c29fa738581
[2]: https://git.openldap.org/openldap/openldap/-/commit/4d29df5bd1fabcdc50975651c746365686b62b53

See: https://trac.macports.org/ticket/60583
See: https://github.com/macports/macports-ports/pull/2625
See: https://github.com/macports/macports-ports/pull/3214


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G6042
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
