### PR TITLE
gcc-devel: get building on ARM64

### DIFF
--- a/lang/gcc-devel/Portfile
+++ b/lang/gcc-devel/Portfile
@@ -6,9 +6,16 @@ PortGroup           compiler_blacklist_versions  1.0
 PortGroup           active_variants              1.1
 PortGroup           conflicts_build              1.0
 
-epoch               4
+# for devel
+PortGroup github    1.0
+github.setup        iains gcc-darwin-arm64 6b589e6cb14fb74eaac99411a64083ff32fada85
+
+checksums           rmd160  005cdb1c71ee78234d3db08853e873cbae320854 \
+                    sha256  fe70b2caedf6f23b1caa9bf478b195be7d6801bd10836fb2419c85446034bbe9 \
+                    size    121028082
+
 name                gcc-devel
-version             11-20201025
+version             11-20201122
 revision            0
 subport             libgcc-devel { revision 0 }
 platforms           darwin
@@ -23,30 +30,30 @@ long_description    The GNU compiler collection, including front ends for \
 
 homepage            https://gcc.gnu.org/
 
-# Primary releases
-master_sites        https://ftpmirror.gnu.org/gcc/gcc-${version}/ \
-                    https://mirror.its.dal.ca/gnu/gcc/gcc-${version}/ \
-                    https://mirrors.kernel.org/gnu/gcc/gcc-${version}/ \
-                    https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/gcc/gcc-${version}/ \
-                    https://ftp-stud.hs-esslingen.de/pub/Mirrors/ftp.gnu.org/gcc/gcc-${version}/ \
-                    https://mirror.yongbok.net/gnu/gcc/gcc-${version}/ \
-                    http://mirror.koddos.net/gcc/releases/gcc-${version}/ \
-                    ftp://ftp.gwdg.de/pub/linux/gcc/releases/gcc-${version}/ \
-                    ftp://gcc.ftp.nluug.nl/mirror/languages/gcc/releases/gcc-${version}/ \
-                    ftp://gcc.gnu.org/pub/gcc/releases/gcc-${version}/ \
-                    gnu:gcc/gcc-${version}
-# snapshots and RC candidates
-master_sites-append https://mirror.koddos.net/gcc/snapshots/${version}/ \
-                    https://bigsearcher.com/mirrors/gcc/snapshots/${version}/ \
-                    ftp://ftp.funet.fi/pub/mirrors/sources.redhat.com/pub/gcc/snapshots/${version}/ \
-                    ftp://gcc.gnu.org/pub/gcc/snapshots/${version}/
-
-distname            gcc-${version}
-use_xz              yes
-
-checksums           rmd160  df883a558afbdacac2152432873e2fd74c3c7125 \
-                    sha256  dd59afe340edc66b62626117790f0310d088b52d350118e48c061c08a6422be1 \
-                    size    72628316
+# # Primary releases
+# master_sites        https://ftpmirror.gnu.org/gcc/gcc-${version}/ \
+#                     https://mirror.its.dal.ca/gnu/gcc/gcc-${version}/ \
+#                     https://mirrors.kernel.org/gnu/gcc/gcc-${version}/ \
+#                     https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/gcc/gcc-${version}/ \
+#                     https://ftp-stud.hs-esslingen.de/pub/Mirrors/ftp.gnu.org/gcc/gcc-${version}/ \
+#                     https://mirror.yongbok.net/gnu/gcc/gcc-${version}/ \
+#                     http://mirror.koddos.net/gcc/releases/gcc-${version}/ \
+#                     ftp://ftp.gwdg.de/pub/linux/gcc/releases/gcc-${version}/ \
+#                     ftp://gcc.ftp.nluug.nl/mirror/languages/gcc/releases/gcc-${version}/ \
+#                     ftp://gcc.gnu.org/pub/gcc/releases/gcc-${version}/ \
+#                     gnu:gcc/gcc-${version}
+# # snapshots and RC candidates
+# master_sites-append https://mirror.koddos.net/gcc/snapshots/${version}/ \
+#                     https://bigsearcher.com/mirrors/gcc/snapshots/${version}/ \
+#                     ftp://ftp.funet.fi/pub/mirrors/sources.redhat.com/pub/gcc/snapshots/${version}/ \
+#                     ftp://gcc.gnu.org/pub/gcc/snapshots/${version}/
+# 
+# distname            gcc-${version}
+# use_xz              yes
+# 
+# checksums           rmd160  df883a558afbdacac2152432873e2fd74c3c7125 \
+#                     sha256  dd59afe340edc66b62626117790f0310d088b52d350118e48c061c08a6422be1 \
+#                     size    72628316
 
 depends_lib-append  port:cctools \
                     port:gmp \
@@ -58,6 +65,8 @@ depends_lib-append  port:cctools \
                     port:zlib
 depends_run-append  port:gcc_select \
                     port:libgcc-devel
+
+depends_build-append port:texinfo
 
 depends_skip_archcheck-append gcc_select ld64 cctools
 license_noconflict  gmp mpfr ppl libmpc zlib
@@ -173,7 +182,7 @@ conflicts_build-append libunwind-headers
 # Note that we really don't want to include libgcc_ext.10.[45].dylib here, but install_name_tool
 # doesn't know how to change the id of stubs, and it's easier than recreating them for each
 # gcc port.
-set dylibs {libgcc_ext.10.4.dylib libgcc_ext.10.5.dylib libgcc_s.1.dylib libgfortran.5.dylib libquadmath.0.dylib libstdc++.6.dylib libobjc-gnu.4.dylib libgomp.1.dylib libitm.1.dylib libssp.0.dylib libasan.6.dylib libubsan.1.dylib libatomic.1.dylib}
+set dylibs {libgcc_ext.10.4.dylib libgcc_ext.10.5.dylib libgcc_s.1.dylib libgcc_s.2.dylib libgfortran.5.dylib libquadmath.0.dylib libstdc++.6.dylib libobjc-gnu.4.dylib libgomp.1.dylib libitm.1.dylib libssp.0.dylib libasan.6.dylib libubsan.1.dylib libatomic.1.dylib}
 
 if {${subport} eq "libgcc-devel"} {
 


### PR DESCRIPTION
#### Description

Updates to the Portfile for `gcc-devel` to make `gcc-devel` and `libgcc-devel` build on ARM64 (using the latest commit from http://github.com/iains/gcc-darwin-arm64).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0.1
Xcode 12.2 (12B45b)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
