### PR TITLE
lego: new port

### DIFF
--- a/security/lego/Portfile
+++ b/security/lego/Portfile
@@ -1,0 +1,42 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/go-acme/lego 4.1.3 v
+revision            0
+
+categories          security
+license             MIT
+
+description         Let's Encrypt client and ACME library written in Go
+
+long_description    {*}${description}. Supports ACME v2 RFC 8555.  Allows \
+                    registering with a CA, obtaining certificates (both from \
+                    scratch, or with an existing CSR), renewing certificates, \
+                    revoking certificates, SAN certificate support, support \
+                    for ACME challenges (HTTP, DNS, TLS), certificate \
+                    bundling, and more.
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+build.pre_args      -o ./dist/${name} -ldflags '-X \"main.version=${version}\"'
+build.args          ./cmd/lego
+
+installs_libs       no
+
+# Do not restrict Go from downloading dependencies at build time.
+build.env-delete    GOPROXY=off GO111MODULE=off
+
+checksums           rmd160  3ef7bdebd943803e075077426c3b4c69ea894921 \
+                    sha256  4c56449d66d15ff0b32d2ffbe28f596aecfb835b7cfa082ee7b7bbd6b775b12a \
+                    size    418697
+
+pre-build {
+    file mkdir ${worksrcpath}/dist
+}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/dist/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

New port for the [lego](https://github.com/go-acme/lego) ACME client for working with LetsEncrypt and other CAs.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
