### PR TITLE
gnupg2: Remove +openldap from default variants

### DIFF
--- a/mail/gnupg2/Portfile
+++ b/mail/gnupg2/Portfile
@@ -89,8 +89,6 @@ variant openldap description {Support openldap} {
     configure.args-append   --with-ldap=${prefix}
 }
 
-default_variants    +openldap
-
 test.run            yes
 test.dir            ${worksrcpath}/tests
 test.target         check


### PR DESCRIPTION
#### Description

Both maintainers agree that this is the way to go:
 - https://github.com/macports/macports-ports/pull/9242#issuecomment-734127410
 - https://trac.macports.org/ticket/60583#comment:2

Closes: https://trac.macports.org/ticket/60583

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G6042
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
