### PR TITLE
vim: fix implicit-function-decl error

### DIFF
--- a/editors/MacVim/Portfile
+++ b/editors/MacVim/Portfile
@@ -5,6 +5,7 @@ PortGroup           compiler_blacklist_versions 1.0
 set vim_version     8.2
 set snapshot        166
 github.setup        macvim-dev macvim ${snapshot} snapshot-
+revision            1
 name                MacVim
 version             ${vim_version}.snapshot${snapshot}
 categories          editors
@@ -32,7 +33,8 @@ depends_lib         port:ncurses \
 supported_archs     x86_64
 
 patchfiles          patch-remove-sparkle.diff \
-                    patch-remove-Homebrew-python.diff
+                    patch-remove-Homebrew-python.diff \
+                    ce7be3a0e6f19bc85990bb8fcfe5e208944777b4.patch
 
 pre-fetch {
     if {${os.platform} eq "darwin" && ${os.major} < 12} {

--- a/editors/MacVim/files/ce7be3a0e6f19bc85990bb8fcfe5e208944777b4.patch
+++ b/editors/MacVim/files/ce7be3a0e6f19bc85990bb8fcfe5e208944777b4.patch
@@ -1,0 +1,62 @@
+From ce7be3a0e6f19bc85990bb8fcfe5e208944777b4 Mon Sep 17 00:00:00 2001
+From: Bram Moolenaar <Bram@vim.org>
+Date: Thu, 26 Nov 2020 20:11:11 +0100
+Subject: [PATCH] patch 8.2.2056: configure fails when building with
+ implicit-function-declaration
+
+Problem:    Configure fails when building with the
+            "implicit-function-declaration" error enabled, specifically on Mac.
+Solution:   Declear the functions like in the source code. (suggestion by
+            Clemens Lang, closes #7380)
+Upstream-Status: Backport [https://github.com/vim/vim/commit/ce7be3a0e6f19bc85990bb8fcfe5e208944777b4]
+---
+ src/auto/configure | 10 +++++++++-
+ src/configure.ac   | 10 +++++++++-
+ src/version.c      |  2 ++
+ 3 files changed, 20 insertions(+), 2 deletions(-)
+
+diff --git a/src/auto/configure b/src/auto/configure
+index 13eaea6f853..d1359485b60 100755
+--- ./src/auto/configure
++++ ./src/auto/configure
+@@ -12350,10 +12350,18 @@ if test -c /dev/ptmx ; then
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++// These should be in stdlib.h, but it depends on _XOPEN_SOURCE.
++char *ptsname(int);
++int unlockpt(int);
++int grantpt(int);
++
+ int
+ main ()
+ {
+-ptsname(0);grantpt(0);unlockpt(0);
++
++		ptsname(0);
++		grantpt(0);
++		unlockpt(0);
+   ;
+   return 0;
+ }
+diff --git a/src/configure.ac b/src/configure.ac
+index 457f2b82b13..010cc8f09ca 100644
+--- ./src/configure.ac
++++ ./src/configure.ac
+@@ -3593,7 +3593,15 @@ fi
+ 
+ AC_MSG_CHECKING(for SVR4 ptys)
+ if test -c /dev/ptmx ; then
+-  AC_TRY_LINK([], [ptsname(0);grantpt(0);unlockpt(0);],
++  AC_TRY_LINK([
++// These should be in stdlib.h, but it depends on _XOPEN_SOURCE.
++char *ptsname(int);
++int unlockpt(int);
++int grantpt(int);
++	       ], [
++		ptsname(0);
++		grantpt(0);
++		unlockpt(0);],
+ 	AC_MSG_RESULT(yes); AC_DEFINE(HAVE_SVR4_PTYS),
+ 	AC_MSG_RESULT(no))
+ else

--- a/editors/vim/Portfile
+++ b/editors/vim/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 set vim_version     8.2
 set vim_patchlevel  1719
 github.setup        vim vim ${vim_version}.${vim_patchlevel} v
-revision            0
+revision            1
 
 categories          editors
 platforms           darwin freebsd
@@ -27,6 +27,8 @@ checksums           rmd160  c2580b2bbd62a5008fc851a6d52a72f32f4351ed \
 depends_lib         port:ncurses \
                     port:gettext \
                     port:libiconv
+
+patchfiles          ce7be3a0e6f19bc85990bb8fcfe5e208944777b4.patch
 
 post-patch {
     set features [open ${worksrcpath}/src/feature.h a+]

--- a/editors/vim/files/ce7be3a0e6f19bc85990bb8fcfe5e208944777b4.patch
+++ b/editors/vim/files/ce7be3a0e6f19bc85990bb8fcfe5e208944777b4.patch
@@ -1,0 +1,62 @@
+From ce7be3a0e6f19bc85990bb8fcfe5e208944777b4 Mon Sep 17 00:00:00 2001
+From: Bram Moolenaar <Bram@vim.org>
+Date: Thu, 26 Nov 2020 20:11:11 +0100
+Subject: [PATCH] patch 8.2.2056: configure fails when building with
+ implicit-function-declaration
+
+Problem:    Configure fails when building with the
+            "implicit-function-declaration" error enabled, specifically on Mac.
+Solution:   Declear the functions like in the source code. (suggestion by
+            Clemens Lang, closes #7380)
+Upstream-Status: Backport [https://github.com/vim/vim/commit/ce7be3a0e6f19bc85990bb8fcfe5e208944777b4]
+---
+ src/auto/configure | 10 +++++++++-
+ src/configure.ac   | 10 +++++++++-
+ src/version.c      |  2 ++
+ 3 files changed, 20 insertions(+), 2 deletions(-)
+
+diff --git a/src/auto/configure b/src/auto/configure
+index 13eaea6f853..d1359485b60 100755
+--- ./src/auto/configure
++++ ./src/auto/configure
+@@ -12350,10 +12350,18 @@ if test -c /dev/ptmx ; then
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++// These should be in stdlib.h, but it depends on _XOPEN_SOURCE.
++char *ptsname(int);
++int unlockpt(int);
++int grantpt(int);
++
+ int
+ main ()
+ {
+-ptsname(0);grantpt(0);unlockpt(0);
++
++		ptsname(0);
++		grantpt(0);
++		unlockpt(0);
+   ;
+   return 0;
+ }
+diff --git a/src/configure.ac b/src/configure.ac
+index 457f2b82b13..010cc8f09ca 100644
+--- ./src/configure.ac
++++ ./src/configure.ac
+@@ -3593,7 +3593,15 @@ fi
+ 
+ AC_MSG_CHECKING(for SVR4 ptys)
+ if test -c /dev/ptmx ; then
+-  AC_TRY_LINK([], [ptsname(0);grantpt(0);unlockpt(0);],
++  AC_TRY_LINK([
++// These should be in stdlib.h, but it depends on _XOPEN_SOURCE.
++char *ptsname(int);
++int unlockpt(int);
++int grantpt(int);
++	       ], [
++		ptsname(0);
++		grantpt(0);
++		unlockpt(0);],
+ 	AC_MSG_RESULT(yes); AC_DEFINE(HAVE_SVR4_PTYS),
+ 	AC_MSG_RESULT(no))
+ else


### PR DESCRIPTION
#### Description

vim's configure script disables functionality that is available on macOS because the configure check incorrectly determines that some functions are not available because it does not include the headers to declare the functions. Since Apple made `-Werror=implicit-function-declarations` the default for Big Sur, the result of the configure check changed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G6042
Xcode 11.3.1 11C505


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
