### PR TITLE
py36-astropy: revert to 4.1

### DIFF
--- a/python/py-astropy/Portfile
+++ b/python/py-astropy/Portfile
@@ -62,6 +62,15 @@ if {${name} ne ${subport}} {
         build.cmd  ${python.bin} setup.py --no-user-cfg --offline --no-git
         destroot.cmd  ${python.bin} setup.py --no-user-cfg --offline --no-git
     } else {
+        if {${python.version} < 37} {
+            epoch           1
+            version         4.1
+            revision        0
+            checksums       rmd160  536dc3c4623dd24c4a7a5e19ec16f3ec554f53d3 \
+                            sha256  a3bad6e1c2619135ad33e4d80452866eb9468f610bf00754da4001c63c1f7049 \
+                            size    7835617
+        }
+
         depends_build-append \
                             port:py${python.version}-extension-helpers \
                             port:py${python.version}-setuptools_scm \


### PR DESCRIPTION
Astropy 4.2 requires Python 3.7

#### Description
As reported by https://lists.macports.org/pipermail/macports-users/2020-November/049012.html:
```
astropy.UnsupportedPythonError: Astropy does not support Python < 3.7
```
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### 
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
Untested

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
