### PR TITLE
soxr: arm64 support (fix build on Apple Silicon)

### DIFF
--- a/audio/soxr/Portfile
+++ b/audio/soxr/Portfile
@@ -34,4 +34,6 @@ checksums           rmd160  11aea28f2a944982bcd42b1724150e1bf3d80779 \
 configure.args-append \
                     -DBUILD_TESTS=no
 
+patchfiles          patch-pffft.c.diff
+
 livecheck.regex     "${name}-(\\d+(?:\\.\\d+)*)-Source"

--- a/audio/soxr/files/patch-pffft.c.diff
+++ b/audio/soxr/files/patch-pffft.c.diff
@@ -1,0 +1,20 @@
+--- src/pffft.c.orig	2020-11-26 15:41:52.000000000 -0800
++++ src/pffft.c	2020-11-26 15:41:57.000000000 -0800
+@@ -157,7 +157,7 @@
+ /*
+   ARM NEON support macros
+ */
+-#elif !defined(PFFFT_SIMD_DISABLE) && defined(__arm__)
++#elif !defined(PFFFT_SIMD_DISABLE) && ( defined(__arm__) || defined(__arm64__) )
+ #  include <arm_neon.h>
+ typedef float32x4_t v4sf;
+ #  define SIMD_SZ 4
+@@ -1732,7 +1732,7 @@
+   const v4sf * RESTRICT vb = (const v4sf*)b;
+   v4sf * RESTRICT vab = (v4sf*)ab;
+ 
+-#ifdef __arm__
++#if defined(__arm__) || defined(__arm64__)
+   __builtin_prefetch(va);
+   __builtin_prefetch(vb);
+   __builtin_prefetch(vab);


### PR DESCRIPTION
* Patch pffft.c to check for `__arm64__` instead of just `__arm__`

#### Description

Changes to get soxr building on Apple Silicon

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0.1
Xcode 12.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
