### PR TITLE
gcal: Update to 4.1; Fix for Big Sur and Apple Silicon

### DIFF
--- a/science/gcal/Portfile
+++ b/science/gcal/Portfile
@@ -1,7 +1,7 @@
 PortSystem      1.0
 
 name            gcal
-version         3.6.3
+version         4.1
 categories      science
 license         GPL-3+
 maintainers     gmail.com:j.hafey openmaintainer
@@ -21,7 +21,11 @@ long_description                                                             \
 homepage        https://www.gnu.org/software/gcal/
 master_sites    gnu
 use_xz          yes
-checksums       rmd160  9474081c5c0ce6da55c8540076c39e4107fe8be2 \
-                sha256  6742913a1d011ac109ad713ef4a8263eaf4c5cfd315471626a92f094e3e4b31b
+checksums       rmd160  8283119af8e6c6c45ff36500e59a30e141c977a5 \
+                sha256  91b56c40b93eee9bda27ec63e95a6316d848e3ee047b5880ed71e5e8e60f61ab \
+                size    1658948
+
+patchfiles      patch-ioctl-implicit-declaration-fix.diff \
+                patch-fix-segfault.diff
 
 depends_lib     port:gettext

--- a/science/gcal/files/patch-fix-segfault.diff
+++ b/science/gcal/files/patch-fix-segfault.diff
@@ -1,0 +1,11 @@
+--- src/utils.c.orig	2020-11-27 23:18:52.000000000 +1300
++++ src/utils.c	2020-12-05 00:12:49.000000000 +1300
+@@ -1354,7 +1354,7 @@
+ 
+ 
+ 	  len = (int) strlen (s) - 1;
+-	  mayname = (char *) my_malloc (len,
++	  mayname = (char *) my_malloc (len + 2,
+ 					ERR_NO_MEMORY_AVAILABLE,
+ 					__FILE__, ((long) __LINE__) - 2L,
+ 					"mayname", 0);

--- a/science/gcal/files/patch-ioctl-implicit-declaration-fix.diff
+++ b/science/gcal/files/patch-ioctl-implicit-declaration-fix.diff
@@ -1,0 +1,11 @@
+--- src/tty.c.orig	2020-11-27 23:18:52.000000000 +1300
++++ src/tty.c	2021-01-21 23:47:04.000000000 +1300
+@@ -39,7 +39,7 @@
+ # if defined(UNIX) && !defined(DJG)
+ #  if HAVE_TERMIOS_H && HAVE_TERMIOS_FUNCS
+ #   include <termios.h>
+-#   if HAVE_SYS_IOCTL_H && !defined(TIOCGWINSZ)
++#   if HAVE_SYS_IOCTL_H
+ #    include <sys/ioctl.h>
+ #   endif
+ #  else	/* !HAVE_TERMIOS_H || !HAVE_TERMIOS_FUNCS */


### PR DESCRIPTION
#### Description

This updates gcal to 4.1 and provides a couple of fixes for Big Sur and Apple Silicon.
* Fixes up implicit function definition
* Includes upstream fix (not yet part of release) to fix bug causing segfault/trap (Thanks @oleg-derevenetz).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
