### PR TITLE
gitlint: update to 0.15.0

### DIFF
--- a/devel/gitlint/Portfile
+++ b/devel/gitlint/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                gitlint
-version             0.14.0
+version             0.15.0
 categories-prepend  devel
 platforms           darwin
 license             MIT
@@ -22,9 +22,9 @@ long_description    Git commit message linter written in Python. \
 
 homepage            http://jorisroovers.github.io/gitlint
 
-checksums           rmd160  67c63fe9550cd4065adcf938a35a73d13d7dda22 \
-                    sha256  df28d82c2e2aaa48d6d89bed6af08d8b9706c2e8b3ce968decc87e86b1461edc \
-                    size    37056
+checksums           rmd160  c573395bc1f3489bc613164844ce2d84fa0f1689 \
+                    sha256  aae7e966d765a818d941398f2d3aff6ec7f30a7251dd5c915846b7e82f4f7776 \
+                    size    35792
 
 depends_build-append \
                     port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.6 19G73
xcode-select version 2373

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
