### PR TITLE
qtplay: fix build on macOS 10.11. Add recommended checksums

### DIFF
--- a/audio/qtplay/Portfile
+++ b/audio/qtplay/Portfile
@@ -18,7 +18,9 @@ long_description \
     Special flag for simply playing CDs, for lazy people. \
     Playlist features such as loop, shuffle, and random. \
     Special flag for reading playlist via standard input. \
-    Support for process signals: SIGINT, SIGTSTP, and SIGCONT.
+    Support for process signals: SIGINT, SIGTSTP, and SIGCONT. \
+    Note that this port does not work on macOS newer \
+    than 10.11 (El Capitan).
 
 homepage                https://sites.google.com/site/rainbowflight2/#qtplay
 master_sites            https://sites.google.com/site/rainbowflight2/
@@ -26,7 +28,10 @@ distname                ${name}${version}
 
 checksums               md5     f6cb47521afbfc5b40efdd2d8433830d \
                         sha1    fd7394675c972377a48c2ff8e0a774853c0be6a3 \
-                        rmd160  4c97ee8d38537f52547cb7a4d31eced0a93f2054
+                        rmd160  4c97ee8d38537f52547cb7a4d31eced0a93f2054 \
+                        sha256  5d0d5bda455d77057a2372925a2c1da09ef82b5969ef0342e61d8b63876ed840 \
+                        size  29339
+    
 
 use_parallel_build      no
 
@@ -56,7 +61,7 @@ destroot {
         ${destroot}${prefix}/share/man/man1
 }
 
-if {${os.platform} eq "darwin" && ${os.major} > 11} {
+if {${os.platform} eq "darwin" && ${os.major} > 15 } {
     known_fail          yes
     pre-fetch {
         ui_error "${name} @${version} requires OS X 10.11 or older."


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
