### PR TITLE
triage: new port

### DIFF
--- a/devel/triage/Portfile
+++ b/devel/triage/Portfile
@@ -1,0 +1,156 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/tj/triage 1.0.0 v
+revision            0
+
+description         Interactive command-line GitHub issue & notification \
+                    triaging tool
+
+long_description    {*}${description}. Triage allows you to quickly view and \
+                    search notifications (even without marking them as read), \
+                    view issue details, labels and comments, add comments to \
+                    issues, add and remove labels to issues, and unsubscribe \
+                    from repositories & notifications.
+
+categories          devel
+license             MIT
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+build.target        ./cmd/triage
+
+installs_libs       no
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  751b9294b44bbfcdffbe1cb7449f11b5f9881147 \
+                        sha256  c8816d7f10e74504ef842327c16cc433f9f2e2595378c694d967234d2a1c4231 \
+                        size    17106
+
+go.vendors          golang.org/x/sys \
+                        lock    e07cf5db2756 \
+                        rmd160  a045a0cbf1ed44af257cc6864396b47f766b03b5 \
+                        sha256  73c45c1d576a7a57571b72387d3ff605efe826b237f0c173bd7b81719f73e94e \
+                        size    1448754 \
+                    golang.org/x/oauth2 \
+                        lock    d2e6202438be \
+                        rmd160  08949da5fbafadd0c3bc746eea5d382c54b98dcb \
+                        sha256  9051bf1f6effb830dd5fa5a9ccbab623dbbba8955d36547b9352f28701f7e54c \
+                        size    43178 \
+                    golang.org/x/net \
+                        lock    d8887717615a \
+                        rmd160  e419a2a31e7ca2aec6cdea04ffd1faa257a81d77 \
+                        sha256  231ffc1555dcbdcf4819d2abe63720090d833688c902d23fb0df6c0ff930460b \
+                        size    974026 \
+                    golang.org/x/crypto \
+                        lock    c2843e01d9a2 \
+                        rmd160  35481af319848c87b8a91b708c1e045831062227 \
+                        sha256  f8e063af716f960d2bc47bac8f0c84e353797f791a955dd52c2a745396e930be \
+                        size    1650814 \
+                    github.com/tj/go-terminput \
+                        lock    v1.0.0 \
+                        rmd160  0665d1c4181694c656e7844bc8036988956c81af \
+                        sha256  de1fcb80004c9fa0ea28ef30ce6804e4d4bdaae84a0b0ac245c679aef62baa1e \
+                        size    5063 \
+                    github.com/tj/go-termd \
+                        lock    v0.0.1 \
+                        rmd160  80e3bf9557fff2331fdcee1a112dd3f3adb931d5 \
+                        sha256  83554c4aa11eaa59375aee17e31a55b6cbe10cc59af9e533f0e887151df4ad13 \
+                        size    8969 \
+                    github.com/tj/go-tea \
+                        lock    v0.2.0 \
+                        rmd160  d7c588158eaae083c2672f843a11d68941fa7d42 \
+                        sha256  baabd667e8a940be085f8f1dffe33b6cd1a7f718ec7d56720262fa818862b63c \
+                        size    9087 \
+                    github.com/tj/go-css \
+                        lock    220a796d1705 \
+                        rmd160  1bf5b7c1ae5b799549e6c46b78243f06198cb3ef \
+                        sha256  d06ba90d12b9a59a2f4c879e43c84d231126b5c63ef9fd45c7773fa46b056fea \
+                        size    3020 \
+                    github.com/tj/go-config \
+                        lock    v1.3.0 \
+                        rmd160  3dbe857d62bf96fad6d78e2a16296749263d52ad \
+                        sha256  4d6185444a7c5cb8c40af2fa8c5044d60d686450809a36ff956559856260b7be \
+                        size    2862 \
+                    github.com/shurcooL/sanitized_anchor_name \
+                        lock    v1.0.0 \
+                        rmd160  c7e5322dba53e10db1711d65c146af5649b0c7c8 \
+                        sha256  ed9418de8c92acfbbd8608745855ebfc67fa686c0a0a5245cf8eece8f540baa9 \
+                        size    2144 \
+                    github.com/russross/blackfriday \
+                        lock    v2.0.0 \
+                        rmd160  4dc2779838fc868d60c858a5b80928b180b2c77b \
+                        sha256  74376bcfc65d5fd9045ed9763eb671407268a1e22f578c2a71e363dcf9f00c63 \
+                        size    77723 \
+                    github.com/pkg/term \
+                        lock    aa71e9d9e942 \
+                        rmd160  8329f2d607e0926bb679c2af74f7a5b0ec50aaa8 \
+                        sha256  c820baf08d8f0932f97160e7e62201a9b2e5b1ef79ae4ef6b8d4c32d676df5f4 \
+                        size    9498 \
+                    github.com/pkg/browser \
+                        lock    0a3d74bf9ce4 \
+                        rmd160  e3e3a35fb29124fbd1a1fce1bbfa5b1dc705f725 \
+                        sha256  ed5cff3df42f8e71c1b639f426e3b481c23c22040f267cdfca411c48c6aa9232 \
+                        size    3011 \
+                    github.com/mitchellh/go-wordwrap \
+                        lock    v1.0.0 \
+                        rmd160  9019795baad40dfcaa09ac4b45a8ebc3ff13b6f0 \
+                        sha256  319bf49230fa54f8cf5f18cbfcf5f22fca4aae90a517c77ae5d1fbb13684afa5 \
+                        size    2781 \
+                    github.com/kyokomi/emoji \
+                        lock    v2.1.0 \
+                        rmd160  cca5593b9eca36f86f3614f1cbcf9727eeed9c97 \
+                        sha256  dfd9b15dc00e20b010c4491ead363dfeb926a04b41b4fddcac55f45161a9bfa0 \
+                        size    60121 \
+                    github.com/kr/text \
+                        lock    v0.1.0 \
+                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
+                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
+                        size    8691 \
+                    github.com/google/go-querystring \
+                        lock    v1.0.0 \
+                        rmd160  48593728f6bf361fa168bdc87737ee30de24f34b \
+                        sha256  0add5428914c2a378cd9e6e120a4b1e84d69df504b983f99a86aea98a52c5a57 \
+                        size    7536 \
+                    github.com/google/go-github \
+                        lock    v28.1.1 \
+                        rmd160  1b47c6bf9f0a03f0d7936c030a54537bf42f6638 \
+                        sha256  5bfbf776e2f675ec9f1140d79ac1bf7aa02badf0ebc495db70d9e5c2a31fdb75 \
+                        size    255837 \
+                    github.com/dustin/go-humanize \
+                        lock    v1.0.0 \
+                        rmd160  e8641035159ea3e8839ee086f01f966443956303 \
+                        sha256  e45e3181c07b3e2dad8e1317e91a5bbbee4845067e3e3879a585a5254bc6a334 \
+                        size    17273 \
+                    github.com/dlclark/regexp2 \
+                        lock    v1.1.6 \
+                        rmd160  a09a0b9239c37f7eab416f4ca3bf7629ea3cf272 \
+                        sha256  639de46d07f244354882f7945a0e17517ef8d503d32fea1a9bbf6508d60dd1b5 \
+                        size    203408 \
+                    github.com/danwakefield/fnmatch \
+                        lock    cbb64ac3d964 \
+                        rmd160  19ae7b520847e16b0e8ac23ee5e6c51db3831f46 \
+                        sha256  2b045b8a716e3ca32d2a930781cd421b042d0e861fa3d36a79ed5535b2e5308a \
+                        size    4960 \
+                    github.com/aybabtme/rgbterm \
+                        lock    cc83f3b3ce59 \
+                        rmd160  20cdbada3fd59bac221d81aea950e795bec088e1 \
+                        sha256  aca9a1740510be28cc93206f6b12122a7f455a09e402f85472fc0e23ba06d704 \
+                        size    9372 \
+                    github.com/alecthomas/chroma \
+                        lock    v0.6.8 \
+                        rmd160  67095b77e30f8d969c8b6bfd9b7a0fbfba8651f8 \
+                        sha256  5a806c3c0eea2a35532659ac52c4c9a2bb820707679b9ed501673b57be4ffab5 \
+                        size    581877 \
+                    github.com/AstromechZA/terminfo \
+                        lock    e59d11a175fb \
+                        rmd160  25b85303205a74e1608061170f8a9580b6889ace \
+                        sha256  dc87464ae73c31ce0695c29910fbae071c0e1099c7e5f18b414e927954690802 \
+                        size    2631


### PR DESCRIPTION
#### Description

New port for the [triage](https://github.com/tj/triage) Github issue & notification triage tool.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
