### PR TITLE
librsvg: revert to pre-cargo version on Apple Silicon

### DIFF
--- a/graphics/librsvg/Portfile
+++ b/graphics/librsvg/Portfile
@@ -55,7 +55,10 @@ depends_run         port:python[join [split ${pyversion} "."] ""]
 # rust @1.30.1 fails to build on 10.10 and earlier
 # https://trac.macports.org/ticket/57768
 
-if {${os.platform} eq "darwin" && ${os.major} < 15} {
+# rust does not yet support Apple Silicon
+# https://github.com/rust-lang/rust/issues/73908
+
+if {${os.platform} eq "darwin" && (${os.major} < 15 || ${build_arch} eq "arm64" || [variant_isset universal])} {
     # revert to latest pre-cargo version
     version         2.40.20
     revision        4


### PR DESCRIPTION
* Add arm64/universal to the list of platforms under which the pre-cargo
  version of librsvg should be used.

References: https://trac.macports.org/ticket/61668

#### Description

Rust is [not yet supported on Apple Silicon macs](https://github.com/rust-lang/rust/issues/73908), which prevents the latest version of librsvg from building. However, the latest pre-cargo version of librsvg does work.

There is one test failure with `sudo port test`, but this happens on `x86` as well. The failure was [reported upstream](https://gitlab.gnome.org/GNOME/librsvg/-/issues/173), and appears to be due to a change in the freetype library since the "ground truth" test outputs were generated (i.e., not really an error).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0.1
Xcode 12.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
