### PR TITLE
jc: new port

### DIFF
--- a/textproc/jc/Portfile
+++ b/textproc/jc/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               python 1.0
+
+name                    jc
+version                 1.13.4
+revision                0
+
+platforms               darwin
+license                 MIT
+
+categories              textproc python sysutils
+
+homepage                https://pypi.org/project/jc
+
+description             ${name} converts the output of popular command-line \
+                        tools and file-types to JSON.
+
+long_description        {*}${description} This allows for piping the output \
+                        to tools like jq, and/or for easier parsing within \
+                        scripts.
+
+checksums               rmd160  1c370160b6a2fb19ecc6f1e0063fddda76f94899 \
+                        sha256  45480ac3d399f70b57d8cc97a6795ea875a19863c55a56eae596c6e67303c5b8 \
+                        size    90374
+
+maintainers             {gmail.com:herby.gillot @herbygillot} \
+                        openmaintainer
+
+python.default_version  38
+
+depends_build-append    port:py${python.version}-setuptools
+
+depends_lib-append      port:py${python.version}-ruamel-yaml  \
+                        port:py${python.version}-pygments     \
+                        port:py${python.version}-xmltodict


### PR DESCRIPTION
#### Description

New port for the **[jc utility](https://pypi.org/project/jc/)**, which converts common command-line output to JSON

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
