### PR TITLE
dav1d: update to version 0.8.0

### DIFF
--- a/multimedia/dav1d/Portfile
+++ b/multimedia/dav1d/Portfile
@@ -5,7 +5,7 @@ PortGroup           meson 1.0
 PortGroup           muniversal 1.0
 
 name                dav1d
-version             0.7.1
+version             0.8.0
 revision            0
 categories          multimedia
 platforms           darwin
@@ -19,9 +19,9 @@ long_description    dav1d is an AV1 decoder that is open-source, cross-platform 
 homepage            https://www.videolan.org/projects/dav1d.html
 master_sites        https://code.videolan.org/videolan/dav1d/-/archive/${version}/
 distname            ${name}_${version}
-checksums           rmd160  4c5ba6ebf1a0dde6321ce14d5502f9cbd2d48c72 \
-                    sha256  1dd0d7ef1c38e92f65380d147ed6d1775bee1472e8ffbb496e279f832f261977 \
-                    size    645194
+checksums           rmd160  5f9a42eb55ad1a6fcc5c7f8bb77354cf628a81c4 \
+                    sha256  f95acff2aa6c68f7f0d3b9acc8993aed3baed0aef5e7a84f541bdb579005465f \
+                    size    668924
 use_bzip2           yes
 
 depends_build-append  port:nasm
@@ -48,7 +48,7 @@ post-destroot {
     xinstall -m 0644 -W ${worksrcpath} \
         CONTRIBUTING.md \
         COPYING \
-        dav1d_logo.png \
+        doc/dav1d_logo.png \
         NEWS \
         README.md \
         THANKS.md \


### PR DESCRIPTION
#### Description

* Update to version 0.8.0. Includes Apple silicon support
* Fixed the path to `dav1d_logo.png`

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? _no tests configured_
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
