### PR TITLE
minicom: make kermit support a variant

### DIFF
--- a/comms/minicom/Portfile
+++ b/comms/minicom/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                minicom
 version             2.7.1
+revision            1
 set download_id     4215
 categories          comms
 maintainers         nomaintainer
@@ -27,16 +28,21 @@ depends_build       port:pkgconfig
 depends_lib         port:gettext \
                     port:ncurses
 
-depends_run         port:kermit \
-                    port:lrzsz
+depends_run         port:lrzsz
 
 post-patch {
     reinplace "s|/usr/local|${prefix}|g" ${worksrcpath}/src/rwconf.c
     reinplace "s|/usr/bin/ascii-xfr|${prefix}/bin/ascii-xfr|g" ${worksrcpath}/src/rwconf.c
 }
 
-configure.args      --enable-lock-dir=/tmp \
-                    --enable-kermit=${prefix}/bin
+configure.args      --enable-lock-dir=/tmp
+
+variant kermit description {Builds minicom with kermit support} {
+    depends_run-append      port:kermit
+    configure.args-append   --enable-kermit=${prefix}/bin
+}
+
+default_variants    +kermit
 
 livecheck.type      regex
 livecheck.url       ${homepage}


### PR DESCRIPTION
#### Description
Currently minicom is built with kermit support by default. Currently kermit fails to build on macOS Big Sur / XCode 12.
This PR creates a kermit variant. By default, this variant is used but users have the option to use minicom without kermit.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
