### PR TITLE
asciinema: update Python dependency to version 3.8

### DIFF
--- a/sysutils/asciinema/Portfile
+++ b/sysutils/asciinema/Portfile
@@ -21,7 +21,7 @@ long_description    Forget screen recording apps and blurry video. \
 homepage            https://asciinema.org
 
 python.default_version \
-                    37
+                    38
 
 depends_lib         port:py${python.version}-setuptools
 


### PR DESCRIPTION
#### Description
* updates Python dependency to version 3.8
* fixes the port failing to install in Apple Silicon

Closes: https://trac.macports.org/ticket/61338

###### Type(s)
- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
