### PR TITLE
py-pydantic: update to 1.7.2, add py39 subport

### DIFF
--- a/python/py-pydantic/Portfile
+++ b/python/py-pydantic/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pydantic
-version             1.5.1
+version             1.7.2
 categories-append   devel
 platforms           darwin
 license             MIT
 
-python.versions     37 38
+python.versions     37 38 39
 
 maintainers         {@jandemter demter.de:jan} openmaintainer
 
@@ -21,9 +21,9 @@ long_description    Fast and extensible, pydantic plays nicely \
 
 homepage            https://github.com/samuelcolvin/pydantic
 
-checksums           rmd160  7fab2abf0c94c3fc618ab57d5d0cf5042afb5d58 \
-                    sha256  f0018613c7a0d19df3240c2a913849786f21b6539b9f23d85ce4067489dfacfa \
-                    size    114535
+checksums           rmd160  e65928e8b9a2224d11db18aa2b5a84e7ddcf2956 \
+                    sha256  c8200aecbd1fb914e1bd061d71a4d1d79ecb553165296af0c14989b89e90d09b \
+                    size    223158
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools \


### PR DESCRIPTION
#### Description

py-pydantic: update to 1.7.2, add Python 3.9 subport

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
