### PR TITLE
emacs: new variant xwidgets

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -247,3 +247,15 @@ if {$subport eq "emacs-app" || $subport eq "emacs-app-devel"} {
 
     default_variants +rsvg
 }
+
+if {$subport eq $name || $subport eq "emacs-devel"} {
+    variant xwidgets requires gtk description {Enable use of xwidgets in Emacs buffers} {
+        configure.args-append  --with-xwidgets
+    }
+} elseif {$subport eq "emacs-app-devel"} {
+    # Quartz support was added after 27.1 had released via commit: d089c4fbfc8be432dc3015a99b4044dab0a0de97
+    # As soon as the next version is released it should support also emacs-app
+    variant xwidgets description {Enable use of xwidgets in Emacs buffers} {
+        configure.args-append  --with-xwidgets
+    }
+}


### PR DESCRIPTION
#### Description

Details: https://github.com/emacs-mirror/emacs/commit/d089c4fbfc8be432dc3015a99b4044dab0a0de97

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.0.1 20B50
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
