### PR TITLE
py-uncertainties: update to 3.1.5, add py39

### DIFF
--- a/python/py-lmfit/Portfile
+++ b/python/py-lmfit/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  e641f717229828c32375e6d4f22c66bc998e3a55 \
                     sha256  d249eb756899360f4d2a544c9458f47fc8f765ac22c09e099530585fd64e286e \
                     size    258368
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 if {${subport} ne ${name}} {
     if {${python.version} eq 27} {

--- a/python/py-uncertainties/Portfile
+++ b/python/py-uncertainties/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 PortGroup               github 1.0
 
-github.setup            lebigot uncertainties 3.1.4
+github.setup            lebigot uncertainties 3.1.5
 revision                0
 
 name                    py-uncertainties
@@ -17,11 +17,11 @@ long_description        The uncertainties package transparently handles\
 platforms               darwin
 supported_archs         noarch
 
-checksums               rmd160  9e3841cb210964d715a4dc42e2609089632e1142 \
-                        sha256  58b308c255c7004a1b7a0ce84c8eaf0ffdc9609d414f715fa373e2ab4fa32f37 \
-                        size    148972
+checksums               rmd160  f0ed42646b54bca698419cc94f539cedab6d40ad \
+                        sha256  ca47739f37788f0a6aebab70411c6f55b4b4730f283b0a7314a6acdb997f9b57 \
+                        size    149780
 
-python.versions         27 35 36 37 38
+python.versions         27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_build-append  \


### PR DESCRIPTION
#### Description
The addition of the py39 subport is needed for py39-lmfit, and while we're at it also update to the latest version.

###### Tested on
macOS 10.15.7 19H15
Xcode 12.2 12B45b

on failure for py39-uncertainties, but 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
One failure with PY39 (AssertionError: filter ('', PendingDeprecationWarning) did not catch any warning) but to me that one seems harmless.