### PR TITLE
ripgrep-all: new port

### DIFF
--- a/textproc/ripgrep-all/Portfile
+++ b/textproc/ripgrep-all/Portfile
@@ -1,0 +1,193 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo 1.0
+
+github.setup        phiresky ripgrep-all 0.9.6 v
+categories          textproc
+platforms           darwin
+license             AGPL
+
+description         rga: ripgrep, but also search in PDFs, E-Books, Office \
+                    documents, zip, tar.gz, etc.
+
+long_description    rga is a line-oriented search tool that allows you to \
+                    look for a regex in a multitude of file types. rga wraps \
+                    the awesome ripgrep and enables it to search in pdf, \
+                    docx, sqlite, jpg, movie subtitles (mkv, mp4), etc.
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums-append    ${distname}${extract.suffix} \
+                    rmd160  c63b8e7ff4a8985b94d62d4acf8d810118e47340 \
+                    sha256  1f26056eff2852512badec707fa02ae1a397422b81545c7bb20538a69deef11e \
+                    size    6429551
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/rga \
+        ${destroot}${prefix}/bin/
+}
+
+cargo.crates \
+    addr2line                       0.12.0  456d75cbb82da1ad150c8a9d97285ffcd21c9931dcb11e995903e7d75141b38b \
+    adler32                          1.0.4  5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2 \
+    aho-corasick                    0.7.10  8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada \
+    ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
+    arrayref                         0.3.6  a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544 \
+    atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+    autocfg                          0.1.7  1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2 \
+    autocfg                          1.0.0  f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d \
+    backtrace                       0.3.48  0df2f85c8a2abbe3b7d7e748052fdd9b76a0458fdeb16ad4223f5eca78c7c130 \
+    bincode                          1.2.1  5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf \
+    bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
+    byteorder                        1.3.4  08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de \
+    bzip2                            0.3.3  42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b \
+    bzip2-sys                  0.1.8+1.0.8  05305b41c5034ff0e93937ac64133d109b5a2660114ec45e9760bc6816d83038 \
+    cachedir                         0.1.1  c06509d1f4ffa658939bd23f076cd929ef218241363796551528e7eec69128c8 \
+    cc                              1.0.53  404b1fe4f65288577753b17e3b36a04596ee784493ec249bf81c7f2d2acd751c \
+    cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
+    chrono                          0.4.11  80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2 \
+    clap                            2.33.1  bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129 \
+    cloudabi                         0.0.3  ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
+    crc32fast                        1.2.0  ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1 \
+    crossbeam                        0.7.3  69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e \
+    crossbeam-channel                0.4.2  cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061 \
+    crossbeam-deque                  0.7.3  9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285 \
+    crossbeam-epoch                  0.8.2  058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace \
+    crossbeam-queue                  0.2.1  c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db \
+    crossbeam-utils                  0.7.2  c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8 \
+    encoding_rs                     0.8.23  e8ac63f94732332f44fe654443c46f6375d1939684c17b0afb6cb56b0456e171 \
+    encoding_rs_io                   0.1.7  1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83 \
+    env_logger                       0.7.1  44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36 \
+    exitfailure                      0.5.1  2ff5bd832af37f366c6c194d813a11cd90ac484f124f079294f28e357ae40515 \
+    failure                          0.1.8  d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86 \
+    failure_derive                   0.1.8  aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4 \
+    fallible-iterator                0.2.0  4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7 \
+    fallible-streaming-iterator      0.1.9  7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a \
+    filetime                        0.2.10  affc17579b132fc2461adf7c575cc6e8b134ebca52c51f5411388965227dc695 \
+    fixedbitset                      0.1.9  86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33 \
+    flate2                          1.0.14  2cfff41391129e0a856d6d822600b8d71179d46879e310417eb9c762eb178b42 \
+    fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
+    fuchsia-cprng                    0.1.1  a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba \
+    generic-array                   0.12.3  c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec \
+    getrandom                       0.1.14  7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb \
+    gimli                           0.21.0  bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c \
+    glob                             0.3.0  9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574 \
+    heck                             0.3.1  20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205 \
+    hermit-abi                      0.1.13  91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71 \
+    humantime                        1.3.0  df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f \
+    idna                             0.2.0  02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9 \
+    itoa                             0.4.5  b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e \
+    jobserver                       0.1.21  5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2 \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    libc                            0.2.70  3baa92041a6fec78c687fa0cc2b3fae8884f743d672cf551bed1d6dac6988d0f \
+    libsqlite3-sys                  0.18.0  1e704a02bcaecd4a08b93a23f6be59d0bd79cd161e0963e9499165a0a35df7bd \
+    linked-hash-map                  0.5.3  8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a \
+    lmdb-rkv                        0.14.0  447a296f7aca299cfbb50f4e4f3d49451549af655fb7215d7f8c0c3d64bad42b \
+    lmdb-rkv-sys                    0.11.0  b27470ac25167b3afdfb6af8fcd3bc1be67de50ffbdaf4073378cfded6ae24a5 \
+    lock_api                         0.2.0  ed946d4529956a20f2d63ebe1b69996d5a2137c91913fe3ebbeff957f5bca7ff \
+    log                              0.4.8  14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7 \
+    lru-cache                        0.1.2  31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c \
+    lzma-sys                        0.1.16  f24f76ec44a8ac23a31915d6e326bca17ce88da03096f1ff194925dc714dac99 \
+    matches                          0.1.8  7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
+    maybe-uninit                     2.0.0  60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00 \
+    memchr                           2.3.3  3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400 \
+    memoffset                        0.5.4  b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8 \
+    miniz_oxide                      0.3.6  aa679ff6578b1cddee93d7e82e263b94a575e0bfced07284eb0c037c1d2416a5 \
+    nom                              2.2.1  cf51a729ecf40266a2368ad335a5fdde43471f545a967109cd62146ecf8b66ff \
+    num                              0.2.1  b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36 \
+    num-complex                      0.2.4  b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95 \
+    num-integer                     0.1.42  3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba \
+    num-iter                        0.1.40  dfb0800a0291891dd9f4fe7bd9c19384f98f7fbe0cd0f39a2c6b88b9868bbc00 \
+    num-rational                     0.2.4  5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef \
+    num-traits                      0.2.11  c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096 \
+    object                          0.19.0  9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2 \
+    ordered-float                    1.0.2  18869315e81473c951eb56ad5558bbc56978562d3ecfb87abb7a1e944cea4518 \
+    ordermap                         0.3.5  a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063 \
+    parking_lot                      0.8.0  fa7767817701cce701d5585b9c4db3cdd02086398322c1d7e8bf5094a96a2ce7 \
+    parking_lot_core                 0.5.0  cb88cb1cb3790baa6776844f968fea3be44956cf184fa1be5a03341f5491278c \
+    paste                           0.1.12  0a229b1c58c692edcaa5b9b0948084f130f55d2dcc15b02fcc5340b2b4521476 \
+    paste-impl                      0.1.12  2e0bf239e447e67ff6d16a8bb5e4d4bd2343acf5066061c0e8e06ac5ba8ca68c \
+    path-clean                       0.1.0  ecba01bf2678719532c5e3059e0b5f0811273d94b397088b82e3bd0a78c78fdd \
+    percent-encoding                 2.1.0  d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
+    petgraph                        0.4.13  9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f \
+    pkg-config                      0.3.17  05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677 \
+    podio                            0.1.6  780fb4b6698bbf9cf2444ea5d22411cef2953f0824b98f33cf454ec5615645bd \
+    ppv-lite86                       0.2.8  237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea \
+    proc-macro-error                 1.0.2  98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678 \
+    proc-macro-error-attr            1.0.2  4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53 \
+    proc-macro-hack                 0.5.15  0d659fe7c6d27f25e9d80a1a094c223f5246f6a6596453e09d7229bf42750b63 \
+    proc-macro2                     1.0.13  53f5ffe53a6b28e37c9c1ce74893477864d64f74778a93a4beb43c8fa167f639 \
+    quick-error                      1.2.3  a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0 \
+    quote                            1.0.6  54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea \
+    rand                             0.6.5  6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca \
+    rand                             0.7.3  6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
+    rand_chacha                      0.1.1  556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef \
+    rand_chacha                      0.2.2  f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402 \
+    rand_core                        0.3.1  7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b \
+    rand_core                        0.4.2  9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc \
+    rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
+    rand_hc                          0.1.0  7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4 \
+    rand_hc                          0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
+    rand_isaac                       0.1.1  ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08 \
+    rand_jitter                      0.1.4  1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b \
+    rand_os                          0.1.3  7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071 \
+    rand_pcg                         0.1.2  abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44 \
+    rand_xorshift                    0.1.1  cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c \
+    rdrand                           0.4.0  678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2 \
+    redox_syscall                   0.1.56  2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84 \
+    regex                            1.3.7  a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692 \
+    regex-syntax                    0.6.17  7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae \
+    remove_dir_all                   0.5.2  4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e \
+    rkv                             0.10.4  30a3dbc1f4971372545ed4175f23ef206c81e5874cd574d153646e7ee78f6793 \
+    rusqlite                        0.23.1  45d0fd62e1df63d254714e6cb40d0a0e82e7a1623e7a27f679d851af092ae58b \
+    rustc-demangle                  0.1.16  4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783 \
+    rustc_version                    0.2.3  138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a \
+    ryu                              1.0.4  ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1 \
+    scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
+    semver                           0.9.0  1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403 \
+    semver-parser                    0.7.0  388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
+    serde                          1.0.110  99e7b308464d16b56eba9964e4972a3eee817760ab60d88c3f86e1fecb08204c \
+    serde_derive                   1.0.110  818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984 \
+    serde_json                      1.0.53  993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2 \
+    size_format                      1.0.2  6ed5f6ab2122c6dec69dca18c72fa4590a27e581ad20d44960fe74c032a0b23b \
+    smallvec                        0.6.13  f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6 \
+    smallvec                         1.4.0  c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4 \
+    strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
+    structopt                       0.3.14  863246aaf5ddd0d6928dfeb1a9ca65f505599e4e1b399935ef7e75107516b4ef \
+    structopt-derive                 0.4.7  d239ca4b13aee7a2142e6795cbd69e457665ff8037aed33b3effdc430d2f927a \
+    syn                             1.0.22  1425de3c33b0941002740a420b1a906a350b88d08b82b2c8a01035a3f9447bac \
+    syn-mid                          0.5.0  7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a \
+    synstructure                    0.12.3  67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545 \
+    tar                             0.4.26  b3196bfbffbba3e57481b6ea32249fbaf590396a52505a2615adbb79d9d826d3 \
+    tempfile                         3.1.0  7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9 \
+    term_size                        0.3.2  1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9 \
+    termcolor                        1.1.0  bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f \
+    textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
+    thread_local                     1.0.1  d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14 \
+    time                            0.1.43  ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438 \
+    tree_magic_fork                  0.2.2  aab921ca9b828f83389f3f3c5e77404612547081e5222eb3a23d06184f6813af \
+    typenum                         1.12.0  373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33 \
+    unicode-bidi                     0.3.4  49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5 \
+    unicode-normalization           0.1.12  5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4 \
+    unicode-segmentation             1.6.0  e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0 \
+    unicode-width                    0.1.7  caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479 \
+    unicode-xid                      0.2.0  826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c \
+    url                              2.1.1  829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb \
+    uuid                             0.8.1  9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11 \
+    vcpkg                            0.2.8  3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168 \
+    vec_map                          0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
+    version_check                    0.9.1  078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce \
+    wasi      0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
+    winapi                           0.3.8  8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6 \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                      0.1.5  70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    xattr                            0.2.2  244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c \
+    xz2                              0.1.6  c179869f34fc7c01830d3ce7ea2086bc3a07e0d35289b667d0a8bf910258926c \
+    zip                              0.5.5  6df134e83b8f0f8153a094c7b0fd79dfebe437f1d76e7715afa18ed95ebe2fd7 \
+    zstd                  0.5.1+zstd.1.4.4  5c5d978b793ae64375b80baf652919b148f6a496ac8802922d9999f5a553194f \
+    zstd-safe             2.0.3+zstd.1.4.4  bee25eac9753cfedd48133fa1736cbd23b774e253d89badbeac7d12b23848d3f \
+    zstd-sys             1.4.15+zstd.1.4.4  89719b034dc22d240d5b407fb0a3fe6d29952c181cff9a9f95c0bd40b4f8f7d8


### PR DESCRIPTION
#### Description

New port for **[ripgrep-all](https://github.com/phiresky/ripgrep-all)**, an enhanced version of ripgrep

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
