### PR TITLE
ali: new port

### DIFF
--- a/www/ali/Portfile
+++ b/www/ali/Portfile
@@ -1,0 +1,257 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/nakabonne/ali 0.5.3 v
+revision            0
+
+description         Generate HTTP load and plot the results in real-time
+
+long_description    {*}${description}. ali comes with an embedded \
+                    terminal-based UI where you can plot the metrics in \
+                    real-time, so lets you perform real-time analysis on the \
+                    terminal.
+
+categories          www net
+license             MIT
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+set build_date      [exec date +%FT%T%z]
+build.pre_args      -ldflags \"-X main.version=${version} \
+                               -X main.date=${build_date}\"
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  8fa8721e183bbb7fa7950c009d992a995c942200 \
+                        sha256  544acd571c72544ab6b3fcf9a9b6de6254a6313b852204a81c24256001a76401 \
+                        size    6852856
+
+go.vendors          pgregory.net/rapid \
+                        repo    github.com/flyingmutant/rapid \
+                        lock    v0.3.3 \
+                        rmd160  359b70e8d66b33ad9935e5b8fb2afa3eb9b79801 \
+                        sha256  7fca0b183e0d3722e200e813d32f874fb9a02fc41c2d6cca5341634257ac0367 \
+                        size    72556 \
+                    gopkg.in/yaml.v3 \
+                        lock    9f266ea9e77c \
+                        rmd160  06dca2ede07b2f31c515b4711fbebc1d5359b5e4 \
+                        sha256  e70dd42fb30b7b2d0129c5cdf0e079caaf5602cab24081fdac830ec01204fa59 \
+                        size    86890 \
+                    gopkg.in/check.v1 \
+                        lock    788fd7840127 \
+                        rmd160  b63165c8909a27edc15dda210df66a1b49efb49e \
+                        sha256  7e5547c6471cc48da89a7c87f965b20ca5311f43fc4d883ca62f9fccf7551630 \
+                        size    31597 \
+                    golang.org/x/tools \
+                        lock    7d206e10da11 \
+                        rmd160  b2a926b02cce4e61ae92f300db29e4902c40ffec \
+                        sha256  f203e89c3330cc240c41e20c513711b2402151f5ca344f956c6ddb8f97241c8c \
+                        size    2298659 \
+                    golang.org/x/text \
+                        lock    v0.3.2 \
+                        rmd160  3b9523084f6a8b2e6a6987e49c56f05e22ad69eb \
+                        sha256  d624899dfd390d9d4a77e5c8e5abd8c45f0b6163e0dc7176aee39f25c5f1bed0 \
+                        size    7168458 \
+                    golang.org/x/sys \
+                        lock    d5e6a3e2c0ae \
+                        rmd160  013d8fa0f0a54aab5bcb8bc874d85f1566182189 \
+                        sha256  bf780ede9ee43be95fc99f13c99c35f5fcb2702eb501c94fb3085b5c616e8d37 \
+                        size    1539166 \
+                    golang.org/x/net \
+                        lock    ba9fcec4b297 \
+                        rmd160  6cad66ee793de24e1e7db92bcea06f6a675e0ac4 \
+                        sha256  781dfe1d221944367d87bdd537b1813d7ab44cba7e921294b0e6179fd8d1dc27 \
+                        size    1099966 \
+                    golang.org/x/lint \
+                        lock    16217165b5de \
+                        rmd160  6ecf457d183d152054cca90b7dff0d2f5dc875b4 \
+                        sha256  36bd7b7dca98c2695b9f19a8e2401a2b4d8f8dabc0282bddde40c1eb5cf27b11 \
+                        size    31434 \
+                    go.uber.org/goleak \
+                        repo    github.com/uber-go/goleak \
+                        lock    v1.1.10 \
+                        rmd160  c14302ab00c2b601bba06dd46b064e403179046f \
+                        sha256  06180861954746fee9f7b43329bb5fa3e1ecc08eceec2ef0876438d9bbc8e479 \
+                        size    12103 \
+                    go.uber.org/atomic \
+                        repo    github.com/uber-go/atomic \
+                        lock    v1.7.0 \
+                        rmd160  90f5738aeea3515c0084dc76639a87de557e8a74 \
+                        sha256  9aa45eeb415a1d252b03d08d46dc1e186f4a8a37ce9dd2c5f9fb61602cade57b \
+                        size    18573 \
+                    github.com/tsenart/vegeta \
+                        lock    v12.8.3 \
+                        rmd160  d3353e45a39b3761fd42a2d18d636296e8326bbe \
+                        sha256  b43e3284c96610d69d20aabfd5e0a405e49d9e4231c0448b634e56d5442ad58a \
+                        size    502669 \
+                    github.com/stretchr/testify \
+                        lock    v1.6.1 \
+                        rmd160  7e5b798212a8f15cd58a63985ae0b928eede8e6b \
+                        sha256  44d77d9b5c1dc08fa710eac9bb324898210660458085cdf965b78a39b1010f2a \
+                        size    84248 \
+                    github.com/streadway/quantile \
+                        lock    b0c588724d25 \
+                        rmd160  ce72c5a57475a08cea43e2ce7c507aad9f72f05e \
+                        sha256  445e81f51f2a83f70391979b8768e26cddf275932e550c7f63e1d218ed56ccee \
+                        size    4870 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.5 \
+                        rmd160  2ce81608a38c6f383a35bccd24d64361df5828c9 \
+                        sha256  7f41acdcba65b1fab5b9b633947a139f9915b60f94bdab486cdbe9d90c54f61e \
+                        size    50815 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/nsf/termbox-go \
+                        lock    4d2b513ad8be \
+                        rmd160  5cdd9fd462274bec0708b02405d8b9afcfc7d415 \
+                        sha256  0a17998d311ea75200c6a8ffbc8a69bde12ac25f4336525d02b2c70cf368f52e \
+                        size    32782 \
+                    github.com/mum4k/termdash \
+                        lock    v0.12.2 \
+                        rmd160  db9c2c4f74652faaa49d54c4e414fd65138e9dc6 \
+                        sha256  e8180f018911ac4f0eaa8ab41e6c9ac6ed88e4657a9f1451f2d1f75202686700 \
+                        size    47284962 \
+                    github.com/mattn/go-runewidth \
+                        lock    v0.0.9 \
+                        rmd160  412c0e508e55f4fe437be0f71d7d22eca2b4366f \
+                        sha256  4f0f4a22257ccecfb6beae88052d850380ecc0e806d6bcc92d3656ebcac3b638 \
+                        size    16716 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.12 \
+                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
+                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
+                        size    4549 \
+                    github.com/mattn/go-colorable \
+                        lock    v0.1.7 \
+                        rmd160  47f774c77efaa0bbcd982cb65bed426d047780ba \
+                        sha256  68de4e31d97da97efc400096c599ea37c6cf1cb91501004f05a1017f4653f926 \
+                        size    9570 \
+                    github.com/mailru/easyjson \
+                        lock    v0.7.0 \
+                        rmd160  93e663b64fc7d0f0f2398543a9b37aebe3a10a41 \
+                        sha256  b8a5f56e207e99493d2953ec01b2f07b4563864cb9d16cd17dfd69b813b32d53 \
+                        size    72823 \
+                    github.com/lucasb-eyer/go-colorful \
+                        lock    v1.0.2 \
+                        rmd160  e851c5a4682fce70eb2f4e5ef56f6adc46b97172 \
+                        sha256  cb365b28527b1b81ff2418802cd2df4be1a1639a7686262de7d369c884f5b5a8 \
+                        size    430547 \
+                    github.com/kylelemons/godebug \
+                        lock    v1.1.0 \
+                        rmd160  917ada648e70d2e339b8ff36d2f86882d0d2efa1 \
+                        sha256  6151c487936ab72cffbf804626228083c9b3abfc908a2bb41b1160e1e5780aaf \
+                        size    17641 \
+                    github.com/kr/text \
+                        lock    v0.1.0 \
+                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
+                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
+                        size    8691 \
+                    github.com/kr/pretty \
+                        lock    v0.1.0 \
+                        rmd160  9aa7a5aad4c48840eecfd0f80186d1fb5ded0fd6 \
+                        sha256  f6c3f89667c63e5b7f1fc6ee2c06b6a6bfdce88f3a965ccd395b64c6f95c9a47 \
+                        size    8553 \
+                    github.com/k0kubun/pp \
+                        lock    v3.0.1 \
+                        rmd160  6126ccc12b66fe9c04daf34acff811246dcbc8a9 \
+                        sha256  6b1c8d5bad8129aa7ad7f51647550ac151b96e9545ab891c36ec0b965846225a \
+                        size    9739 \
+                    github.com/k0kubun/colorstring \
+                        lock    9440f1994b88 \
+                        rmd160  a11723623f8bce0439dfd2bada5be762525d966e \
+                        sha256  a77a5e55d0ad3a44610645aeb044aafb87f4286228b658b114aa0cc07bf75075 \
+                        size    3632 \
+                    github.com/influxdata/tdigest \
+                        lock    a7d76c6f093a \
+                        rmd160  b1f711f505da04e8b6c2b0025ff168d31407dbed \
+                        sha256  ca9e5ff1354fc3aaf9cee4768be65e245eed3f0cd796b5309cf56bcb7cec06da \
+                        size    15723 \
+                    github.com/google/go-cmp \
+                        lock    v0.2.0 \
+                        rmd160  4defcbaf9d26722120790d85670c8dc98df968b7 \
+                        sha256  901195a78019fa669f6a56c48e0d03d86c1473b3e65b65fdb05ff0c389f03ac8 \
+                        size    57880 \
+                    github.com/gonum/stat \
+                        lock    41a0da705a5b \
+                        rmd160  f9db1e244968ca15525c095a97775eb16a593d9c \
+                        sha256  1b785fee9b1ee08197852be88a227cd948ae4e76c1778ca2b2db22caa76874d9 \
+                        size    110828 \
+                    github.com/gonum/matrix \
+                        lock    c518dec07be9 \
+                        rmd160  5915ff5bca0f8853e649e5d0bad3bff09016e07a \
+                        sha256  4fbfcd3a0bd2d2ab4679d6e752a89de015272ee81ce1069ef6c19b6840356faa \
+                        size    108712 \
+                    github.com/gonum/mathext \
+                        lock    8a4bf007ea55 \
+                        rmd160  9d6b8e902e15d09c05608df2954c3197762548ec \
+                        sha256  14c1e7085c7eee972353ccc4d103643072c293d8d1d6f33509f345325edd014a \
+                        size    130348 \
+                    github.com/gonum/lapack \
+                        lock    e4cdc5a0bff9 \
+                        rmd160  2b3c6b097d732d82e6d95f887fb8d7f5606a54ca \
+                        sha256  f970c2f03abff6138ff7704b58815fa87df65b5f920ef45422eb9eef64870f86 \
+                        size    2227047 \
+                    github.com/gonum/internal \
+                        lock    f884aa714029 \
+                        rmd160  2672f01ca9229583273f89a369fdd2469362f443 \
+                        sha256  37e5e4d4c45aac894c60503cf7b233d710bf2c008a73c0fa81aedea67111b5ea \
+                        size    46914 \
+                    github.com/gonum/integrate \
+                        lock    a422b5c0fdf2 \
+                        rmd160  c015e673ee229c440ebce46c2ec92f15db21484a \
+                        sha256  3d536f764865d9107bf07e2345a49e0286e229ccdd4343f1dd19667e901d0305 \
+                        size    402750 \
+                    github.com/gonum/floats \
+                        lock    c233463c7e82 \
+                        rmd160  7796b83c9eb9430b561eb2a00acfb5986440ff39 \
+                        sha256  40e7d9bf2bd7ea4abd50aa3410748815b338a6d4891edc46eb43ae32a0e234e0 \
+                        size    14698 \
+                    github.com/gonum/diff \
+                        lock    500114f11e71 \
+                        rmd160  05f37f6fc175aef5e63f62c9c20e1f6be5ec98e6 \
+                        sha256  bc07444fdb5a8e0f7358a520228473f73eac6855e478bec60db6889fb125567e \
+                        size    8224 \
+                    github.com/gonum/blas \
+                        lock    f22b278b28ac \
+                        rmd160  366bc0781f871d2cb69e907b8285ba66a0e357fb \
+                        sha256  a1ff9b1f5286d311d2ef4482550628435d75f3e8251b884828fc68317f31332c \
+                        size    89999 \
+                    github.com/golang/mock \
+                        lock    v1.4.4 \
+                        rmd160  ad4c6bd70c06881810d56fbd5d4b4ddfb701fae0 \
+                        sha256  921ea11f2a10c4f6225fd3057893a5ee8c5d9b2ca17cb8f9de3a361a0f3899a1 \
+                        size    55151 \
+                    github.com/gdamore/tcell \
+                        lock    v1.3.0 \
+                        rmd160  c0f9ed6375d47639b22e60fbaf9a92f1707b9ebe \
+                        sha256  d50806e75494295f22a87ba45262c641eac89c192919832aec536b44d6197a9b \
+                        size    148681 \
+                    github.com/gdamore/encoding \
+                        lock    v1.0.0 \
+                        rmd160  3ed8916f763a5b51db1bcc8bd3ad06cf3d12ec07 \
+                        sha256  4f470c7308790bea8a526ea26cecbaa22345aad8dc566821cda6175b3d241ee1 \
+                        size    10900 \
+                    github.com/dgryski/go-gk \
+                        lock    201884a44051 \
+                        rmd160  3b6acf2b96aa6c5ea6c8422bd519a0529d21c05c \
+                        sha256  293b51ae281a6b737f43f51d3f1568789b98cacbe5dd40c18f148e0007a6e4ed \
+                        size    2737 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/bmizerany/perks \
+                        lock    d9a9656a3a4b \
+                        rmd160  974e1829607028213f82fe3e7c3f1963ae570696 \
+                        sha256  77fe90f472ac253bc32824066332c6118ffb3b6c7a79fb2e7c00cac220a13da7 \
+                        size    9628


### PR DESCRIPTION
#### Description

New port for the **[ali](https://github.com/nakabonne/ali)** CLI HTTP load-testing tool

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
