### PR TITLE
cc65: update 2.19

### DIFF
--- a/lang/cc65/Portfile
+++ b/lang/cc65/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           makefile 1.0
 
-github.setup        cc65 cc65 2.18 V
+github.setup        cc65 cc65 2.19 V
 conflicts           grc
 categories          lang
 platforms           darwin
@@ -14,14 +14,16 @@ description         6502 C compiler
 long_description    cc65 is a complete cross development package for 65(C)02 \
                     systems, including a powerful macro assembler, a C compiler, \
                     linker, librarian and several other tools.
-license             CC-BY-SA 
+license             CC-BY-SA
 
 homepage            http://cc65.github.io/cc65
 
 github.tarball_from archive
-checksums           rmd160  602e4956e4699103ab66dd654bfa53bce0766a85 \
-                    sha256  d14a22fb87c7bcbecd8a83d5362d5d317b19c6ce2433421f2512f28293a6eaab \
-                    size    2254374
+checksums           rmd160  a1476c2854f66f210b79861f249cc80ce4860280 \
+                    sha256  157b8051aed7f534e5093471e734e7a95e509c577324099c3c81324ed9d0de77 \
+                    size    2284735
+
+patchfiles          patch-doc-Makefile.diff
 
 use_configure       no
 

--- a/lang/cc65/files/patch-doc-Makefile.diff
+++ b/lang/cc65/files/patch-doc-Makefile.diff
@@ -1,0 +1,18 @@
+--- doc/Makefile.orig	2020-11-29 16:45:43.822813150 +0100
++++ doc/Makefile	2020-11-29 16:45:48.392571961 +0100
+@@ -34,13 +34,13 @@
+ 	@mkdir $@
+ 
+ ../html/%.html: %.sgml header.html | ../html
+-	@cd ../html && linuxdoc -B html -s 0 -T $(TOC_LEVEL) -H ../doc/header.html ../doc/$<
++	@-cd ../html && linuxdoc -B html -s 0 -T $(TOC_LEVEL) -H ../doc/header.html ../doc/$<
+ 
+ ../html/doc.%: doc.% | ../html
+ 	cp $< ../html
+ 
+ ../info/%.info: %.sgml | ../info
+-	@cd ../info && linuxdoc -B info ../doc/$<
++	@-cd ../info && linuxdoc -B info ../doc/$<
+ 
+ clean:
+ 	$(RM) -r ../html ../info


### PR DESCRIPTION
#### Description

* Update to version 2.19
* patch doc file creation: some warnings are treated as errors.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification 

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?