### PR TITLE
emacs: added git depth for devel subport

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -106,7 +106,7 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
     revision        1
 
     fetch.type      git
-    git.url         https://github.com/emacs-mirror/emacs.git
+    git.url         --depth=1000 https://github.com/emacs-mirror/emacs.git
     git.branch      a7825c4be06b7c0b544df34555ecf586276245e6
 
     pre-configure {


### PR DESCRIPTION
#### Description

`--depth=1000` allows to download as less as 46 MiB instead 1.2 GiB of full repository and it still has hsitory for about a year to be on safe side..

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.0.1 20B50
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
