### PR TITLE
sbcl: add CLOCK_REALTIME

### DIFF
--- a/lang/sbcl/Portfile
+++ b/lang/sbcl/Portfile
@@ -34,7 +34,8 @@ use_bzip2       yes
 
 patchfiles \
     patch-contrib-sb-posix-posix-tests.lisp.diff \
-    patch-use-right-gcc.diff 
+    patch-use-right-gcc.diff \
+    patch-sbcl-realtime.diff
 
 distfiles       ${name}-${version}-source${extract.suffix}:sbcl
 worksrcdir      ${name}-${version}

--- a/lang/sbcl/files/patch-sbcl-realtime.diff
+++ b/lang/sbcl/files/patch-sbcl-realtime.diff
@@ -1,0 +1,58 @@
+--- ./src/runtime/runtime.c.orig	2020-11-22 16:30:31.000000000 -0800
++++ ./src/runtime/runtime.c	2020-11-22 16:39:49.000000000 -0800
+@@ -62,6 +62,37 @@
+ #include "genesis/static-symbols.h"
+ #include "genesis/symbol.h"
+ 
++#if defined(__APPLE__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 101200
++#include <sys/time.h>
++#include <mach/mach_time.h>
++
++int clock_gettime( clockid_t clk_id, struct timespec *ts )
++{
++  int ret = -1;
++  if ( ts )
++  {
++    if      ( CLOCK_REALTIME == clk_id )
++    {
++      struct timeval tv;
++      ret = gettimeofday(&tv, NULL);
++      ts->tv_sec  = tv.tv_sec;
++      ts->tv_nsec = tv.tv_usec * 1000;
++    }
++    else if ( CLOCK_MONOTONIC == clk_id )
++    {
++      const uint64_t t = mach_absolute_time();
++      mach_timebase_info_data_t timebase;
++      mach_timebase_info(&timebase);
++      const uint64_t tdiff = t * timebase.numer / timebase.denom;
++      ts->tv_sec  = tdiff / 1000000000;
++      ts->tv_nsec = tdiff % 1000000000;
++      ret = 0;
++    }
++  }
++  return ret;
++}
++#endif
++
+ struct timespec lisp_init_time;
+ 
+ static char libpath[] = "../lib/sbcl";
+--- ./src/runtime/runtime.h.orig	2020-11-22 16:30:42.000000000 -0800
++++ ./src/runtime/runtime.h	2020-11-22 16:41:14.000000000 -0800
+@@ -490,4 +490,15 @@
+  */
+ #define TINY_BOXED_NWORDS(obj) ((HeaderValue(obj) & 0xFF) | 1)
+ 
++/* One define types and methods if not already defined. */
++#if !defined(CLOCK_REALTIME) && !defined(CLOCK_MONOTONIC) && !defined(CLOCK_PROCESS_CPUTIME_ID)
++
++#define CLOCK_REALTIME  0
++#define CLOCK_MONOTONIC 6
++#define CLOCK_PROCESS_CPUTIME_ID 12
++typedef int clockid_t;
++extern int clock_gettime( clockid_t clk_id, struct timespec *ts );
++
++#endif /* !defined(CLOCK_REALTIME) && !defined(CLOCK_MONOTONIC) && !defined(CLOCK_PROCESS_CPUTIME_ID) */
++
+ #endif /* _SBCL_RUNTIME_H_ */


### PR DESCRIPTION
using legacysupport directly did not work
possibly as this port does not use a
configure phase and seems to santize it's
environment during the build

so just patched it instead

closes: https://trac.macports.org/ticket/61384

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
