### PR TITLE
emacs: Update emacs and emacs-app subports for Apple silicon

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -92,7 +92,8 @@ if {$subport eq $name || $subport eq "emacs-app"} {
     # apply upstream patch to fix configure on arm machines
     # See https://trac.macports.org/ticket/61594 and 
     # https://git.savannah.gnu.org/cgit/emacs.git/commit/configure.ac?id=4cba236749aafade7bd88cf2a10be48f44983faa
-    patchfiles-append patch-4cba236749aafade7bd88cf2a10be48f44983faa.diff
+    patchfiles-append patch-4cba236749aafade7bd88cf2a10be48f44983faa.diff \
+                      apple-silicon-codesign.diff
     use_autoreconf  yes
 }
 

--- a/editors/emacs/files/apple-silicon-codesign.diff
+++ b/editors/emacs/files/apple-silicon-codesign.diff
@@ -1,0 +1,23 @@
+--- src/Makefile.in.orig	2020-07-29 17:40:42.000000000 -0400
++++ src/Makefile.in	2020-11-29 21:58:28.000000000 -0500
+@@ -337,6 +337,10 @@
+ CHECK_STRUCTS = @CHECK_STRUCTS@
+ HAVE_PDUMPER = @HAVE_PDUMPER@
+ 
++## ARM Macs require that all code have a valid signature.  Since pump
++## invalidates the signature, we must re-sign to fix it.
++DO_CODESIGN=$(patsubst arm-apple-darwin%,yes,@configuration@)
++
+ # 'make' verbosity.
+ AM_DEFAULT_VERBOSITY = @AM_DEFAULT_VERBOSITY@
+ 
+@@ -653,6 +657,9 @@
+ 	  $(ALLOBJS) $(LIBEGNU_ARCHIVE) $(W32_RES_LINK) $(LIBES)
+ ifeq ($(HAVE_PDUMPER),yes)
+ 	$(AM_V_at)$(MAKE_PDUMPER_FINGERPRINT) $@.tmp
++ifeq ($(DO_CODESIGN),yes)
++	codesign -s - -f $@.tmp
++endif
+ endif
+ 	$(AM_V_at)mv $@.tmp $@
+ 	$(MKDIR_P) $(etc)


### PR DESCRIPTION
#### Description

Building emacs modifies the binary, via make-fingerprint, after compilation which
invalidates its code signature. Explicitly re-sign the binary after updating the
fingerprint.

(The emacs-devel and emacs-app-devel subports were already updated to do this.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
