### PR TITLE
smithy: new port

### DIFF
--- a/devel/smithy/Portfile
+++ b/devel/smithy/Portfile
@@ -1,0 +1,318 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/honza/smithy 0.1.0 v
+revision            0
+
+description         A tiny git forge written in Go
+
+long_description    Smithy is a web frontend for git repositories. It's \
+                    implemented entirely in Golang, compiles to a single \
+                    binary, and it's fast and easy to deploy. Smithy is an \
+                    alternative to cgit or gitweb, and doesn't seek to \
+                    compete with Gitea and the like.
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+categories          devel
+license             GPL-3
+
+depends_build-append \
+                    port:statik
+
+build.cmd           make
+build.pre_args      BUILD_VERSION=v${version}
+build.args          all
+
+installs_libs       no
+
+post-extract {
+    # Do not download and build statik.  Instead use the one already provided
+    # in Macports
+    file mkdir ${worksrcpath}/bin
+    ln -s ${prefix}/bin/statik ${worksrcpath}/bin/
+    reinplace "s|all: bin/statik|all:|g" ${worksrcpath}/Makefile
+}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  6740ef6ff13fb8844ab9424c210e2d56ed563eb2 \
+                        sha256  40b5f271f5e9e60ca8424aca1546e0709277dd7868b9806bcde2566393ae7fe6 \
+                        size    62375
+
+go.vendors          gopkg.in/yaml.v2 \
+                        lock    v2.2.8 \
+                        rmd160  cd9df3ede3e0a28cc30fa7f41f59f20acb91edbf \
+                        sha256  7c8b9e36fac643f1b4a5fc1dc578fb569fc3a1d611c02c3338f4efa84de729fa \
+                        size    72749 \
+                    gopkg.in/warnings.v0 \
+                        lock    v0.1.2 \
+                        rmd160  e0245ded51f41ce8051ae561d1a0b844f4b8f181 \
+                        sha256  547803dff3ec1c7adb69c411e7b3846595c3265d22a8888001661504d23bd4fb \
+                        size    3772 \
+                    gopkg.in/check.v1 \
+                        lock    8fa46927fb4f \
+                        rmd160  c84f37dc900224c5e9e6e16ed5acc0d625583bc1 \
+                        sha256  c41439b343f3fc3c0b6f943b4aae642f10f19451e945c23dfb324c9c8f87d0b7 \
+                        size    31616 \
+                    golang.org/x/text \
+                        lock    v0.3.2 \
+                        rmd160  3b9523084f6a8b2e6a6987e49c56f05e22ad69eb \
+                        sha256  d624899dfd390d9d4a77e5c8e5abd8c45f0b6163e0dc7176aee39f25c5f1bed0 \
+                        size    7168458 \
+                    golang.org/x/sys \
+                        lock    669c56c373c4 \
+                        rmd160  efe6cf198633c8bc8296abcb2af7dffe328b7480 \
+                        sha256  618f48fa0592e76c24d4e461c17715eaa0a07578a77da58f3deb0eb468b9272a \
+                        size    1050383 \
+                    golang.org/x/net \
+                        lock    244492dfa37a \
+                        rmd160  e63ff90e39b777708ccef76f0ce1cb24ab762c8a \
+                        sha256  a8ba70fc7b2dca4e4b3ff7ec45ffc44eca1a6b831d19c38aa9d314e646ec858f \
+                        size    1172488 \
+                    golang.org/x/crypto \
+                        lock    78000ba7a073 \
+                        rmd160  9a12d00c20ae0a4dba65e412ecf221bb30753394 \
+                        sha256  057fd9d742d083c627242afe24658be0475262dee7aff210ee36fd66b9a2b856 \
+                        size    1727061 \
+                    github.com/yuin/goldmark \
+                        lock    v1.2.1 \
+                        rmd160  bfa2a3a3a6f25b7f40c4436e6e479d65e36d68aa \
+                        sha256  25cb7a8140e2488912f3423da2dbe754ef03fc92cd2545048c1897a0bda2d863 \
+                        size    228498 \
+                    github.com/xanzy/ssh-agent \
+                        lock    v0.2.1 \
+                        rmd160  356547460413381067ab37d9a8ce904dc91e5d9b \
+                        sha256  0e439b2a0962200a2e7872fb8cfe8f9be6942aa66a89230c805aac3ddc456664 \
+                        size    7623 \
+                    github.com/ugorji/go \
+                        lock    v1.1.7 \
+                        rmd160  a30b19f3dbc6ed0555183380f7a3a2e0d90033d7 \
+                        sha256  7e7d86a2f01eac594c05e807fa77005c92122bcec661d9128dee4f6510449714 \
+                        size    293743 \
+                    github.com/stretchr/testify \
+                        lock    v1.4.0 \
+                        rmd160  86bd663e13ea7266334c47689074df16252db5ff \
+                        sha256  8ed95078bfd318ea477da509e6b16e6cf8d0d1b6b8d93b1f6097c6ba2a6df788 \
+                        size    110114 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.3 \
+                        rmd160  32abdd77a987af95ce5b647846bfdbb2d8db91a0 \
+                        sha256  046b6b81e3925ffe60e2213e9a239303ff98a51e76764590b807b591fedf2d1e \
+                        size    46029 \
+                    github.com/spf13/cobra \
+                        lock    v1.0.0 \
+                        rmd160  73602c4d37ad508ba8b35812c793e1df3eda7bb9 \
+                        sha256  6cdf3f445559b8f41f5288366a4c26e8d1b1601dac6924af091a49f1f6b11396 \
+                        size    128931 \
+                    github.com/sergi/go-diff \
+                        lock    v1.1.0 \
+                        rmd160  6449feb5884c316206f256e55b81aba3e6a78a9f \
+                        sha256  026d3d6db40ad086954214a7f3f84b66e352d47ce259bb59b7c2b9bd843b9935 \
+                        size    43569 \
+                    github.com/rakyll/statik \
+                        lock    v0.1.7 \
+                        rmd160  9263c6a794ace45c4314bd0c4c6629dda03436ae \
+                        sha256  1441248897eb6351a1647e341d7be8deb8cd42a910496630d757619492987828 \
+                        size    178426 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/pkg/errors \
+                        lock    v0.9.1 \
+                        rmd160  dc065c655f8a24c6519b58f9d1202eb266ecda40 \
+                        sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
+                        size    13422 \
+                    github.com/niemeyer/pretty \
+                        lock    a10e7caefd8e \
+                        rmd160  46bcfc3db9e3d98acbacd1f96d9483fa360f88b7 \
+                        sha256  97b952a32175ba84349ef352e523bfa15bf3a06e07e44458a908061fbc519b40 \
+                        size    9405 \
+                    github.com/modern-go/reflect2 \
+                        lock    v1.0.1 \
+                        rmd160  5cdaa26d1ee453e37f3a26635aac40397e2f28fa \
+                        sha256  5bcbe1f4c0fa1d853c066a4e6f58eaa5d31ac370c97a3c87e99a6ffecf7b5a65 \
+                        size    14407 \
+                    github.com/modern-go/concurrent \
+                        lock    bacd9c7ef1dd \
+                        rmd160  b039328d6fd40b97513dea8bf5b00adfdd53f14b \
+                        sha256  2f3333805bef60544e64ac9a734522205b513f5c461ba19f3d557510bb205afb \
+                        size    7533 \
+                    github.com/mitchellh/go-homedir \
+                        lock    v1.1.0 \
+                        rmd160  44b3985e40e5bbb22d11f8622c340f9ed727ea91 \
+                        sha256  024c8a57316c7fbc0eb23cdbfd57f72a74b51beb83d714034d67ee9aba48100c \
+                        size    3366 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.12 \
+                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
+                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
+                        size    4549 \
+                    github.com/leodido/go-urn \
+                        lock    v1.2.0 \
+                        rmd160  511c197355986e3222e1434446d1085bca6aec19 \
+                        sha256  2a2dcbad59406556838a985812e86b45eea0815b8b563e786783b084af6f0150 \
+                        size    1102403 \
+                    github.com/kr/text \
+                        lock    v0.2.0 \
+                        rmd160  48558c7e8ff67d510f83c66883907e95f4783163 \
+                        sha256  2f2e21ac8a9d523e88cbba4039441defc4a66bfaa78811c900a88fcf28729c4c \
+                        size    8702 \
+                    github.com/kevinburke/ssh_config \
+                        lock    01f96b0aa0cd \
+                        rmd160  c962defaa545cfeafa69e015b409607091fa81ee \
+                        sha256  d1c0dd1bc30b97aa5fbbd5092aa90acb4f456aba9cc4f1843cb6d54f1265aacc \
+                        size    17343 \
+                    github.com/json-iterator/go \
+                        lock    v1.1.9 \
+                        rmd160  ba7b2bd1b31ca0b1e90cf1b42008cab35be4edfa \
+                        sha256  57813157d3f9049e0afe962c8eff32cd7589936d14f162bd8cb478c57411e404 \
+                        size    79628 \
+                    github.com/jbenet/go-context \
+                        lock    d14ea06fba99 \
+                        rmd160  37097898ecea5e875655fde48f48f126e0331246 \
+                        sha256  ce27afd2576a5bc82565c8aa2ef108b1bb3c4dd80ebb4939455cab2495b74a2f \
+                        size    5943 \
+                    github.com/inconshreveable/mousetrap \
+                        lock    v1.0.0 \
+                        rmd160  5c617a09f1432fc543672a0e0c1e13d3752030c2 \
+                        sha256  0e6bae2849f13d12fe361ecac087728e4e97f3482f4cec44f6e7a2c53bb9cd0c \
+                        size    2291 \
+                    github.com/imdario/mergo \
+                        lock    v0.3.9 \
+                        rmd160  7a66d9534dce8695eca218269e89837325aaea9c \
+                        sha256  ebfc936c04b3676e5ce8bb1bba848b94f1fe3d64af842451ff7b863841bb1286 \
+                        size    18920 \
+                    github.com/google/go-cmp \
+                        lock    v0.3.0 \
+                        rmd160  023b52ba78fcaa734cfa0f54111e6ee8aba4777b \
+                        sha256  0672ceb4418adc04c39047892ec8f6322165c099ac3755c491ff722c47897cae \
+                        size    76135 \
+                    github.com/golang/protobuf \
+                        lock    v1.3.3 \
+                        rmd160  44fed0d95147da951b52df0248141f1d059d8ba6 \
+                        sha256  3ce6f97ad7ec0b9b5681f983dcc714ace9d2eda4decb1a3e5e08b3799ec286e7 \
+                        size    315440 \
+                    github.com/go-playground/validator \
+                        lock    v10.2.0 \
+                        rmd160  27cfc3fbb5eccb6dac35e4140f850425a0089a8c \
+                        sha256  5149dc8de3f9c636784b5a1423517531c3075fd6e7721a185316abc7188ad6da \
+                        size    150387 \
+                    github.com/go-playground/universal-translator \
+                        lock    v0.17.0 \
+                        rmd160  af69564aaac9a8c02b17d40bfbc057bf301684f1 \
+                        sha256  4272670a016909c65e8789f62f5804cf54c045b010d4d3d29d71f46fc791db95 \
+                        size    36838 \
+                    github.com/go-playground/locales \
+                        lock    v0.13.0 \
+                        rmd160  89550915ead759ae6afd9b3a7db1a06dc40effd1 \
+                        sha256  3e0a7c7223e05b9e563f86d0890899e23ddf1017db3e95817caffa848679b722 \
+                        size    4227226 \
+                    github.com/go-playground/assert \
+                        lock    v2.0.1 \
+                        rmd160  df4fdb03cce7c990dfa073aaa56f9512175343bd \
+                        sha256  4bdd6ae00ba0378c51c507ed9e0e0e2d849b1514fb4417db54f836adcb0e5b29 \
+                        size    4203 \
+                    github.com/go-git/go-git-fixtures \
+                        lock    v4.0.1 \
+                        rmd160  c7e0b6d8009f1eff4c7fe12dea8d4a6daff6ea5c \
+                        sha256  3fd5dd24ab464182af7101b6fdf5c18cc428776641998520b8d176544be799d6 \
+                        size    98104601 \
+                    github.com/go-git/go-git \
+                        lock    v5.1.0 \
+                        rmd160  4e9eb8e8c9931e7bd9cfc53887d808af0dae86f5 \
+                        sha256  98f322ea0ccb50c4edeb858c5a83222d7c5b9ca12cf3c544fa9bc20fe5e0d39f \
+                        size    451279 \
+                    github.com/go-git/go-billy \
+                        lock    v5.0.0 \
+                        rmd160  f11fe7645d65d1981a0d69e75bb8983ef944e367 \
+                        sha256  22ebd4234d9dc54f926f5b1c30c857c75d5342b25508b3961415210efa77ed44 \
+                        size    27963 \
+                    github.com/go-git/gcfg \
+                        lock    v1.5.0 \
+                        rmd160  06a73e4c1e53089b6db690754fa04807e5c4a2e1 \
+                        sha256  f5d75c45f9c00c769bb9c85d4d90ebed5a93d24d47d615ef4ca052093ab9f692 \
+                        size    28538 \
+                    github.com/gliderlabs/ssh \
+                        lock    v0.2.2 \
+                        rmd160  1fef7211bf32e04b3daa1f2dcfb5e56afcff6cd1 \
+                        sha256  fab13a77bd8c2ec9e8f441b81515016f2783fa348405676d9952f2ad78412ca2 \
+                        size    21484 \
+                    github.com/gin-gonic/gin \
+                        lock    v1.6.3 \
+                        rmd160  70af77dff26595ac0f8377d34c132fabb4a3267d \
+                        sha256  bdbafc06ad1936b60cad6e755d2a70f0aa87a1947f6f89cef1380deb19d6451b \
+                        size    132491 \
+                    github.com/gin-contrib/sse \
+                        lock    v0.1.0 \
+                        rmd160  13fcc4b8d3f6bb01e0c281a8e1abea601e9af809 \
+                        sha256  f021daeb55664e0eb4013e89f95bbcd235c34d39521a32a60d74b906527a5f41 \
+                        size    6121 \
+                    github.com/flynn/go-shlex \
+                        lock    3f9db97f8568 \
+                        rmd160  ec42eaffe2cf17a46e12c7c2a7d436c0f68ba655 \
+                        sha256  b4205ec400df652238f7ed287c4b77b5f17a17d5793cd5371b7cc5e0f07dfeed \
+                        size    7690 \
+                    github.com/emirpasic/gods \
+                        lock    v1.12.0 \
+                        rmd160  5633e4a005c1e335bc00708aefebb0f475d30774 \
+                        sha256  c379f9a4fae5a2defdaa314deab1e201228e866a502afa8948117e52cf644ce2 \
+                        size    76836 \
+                    github.com/dlclark/regexp2 \
+                        lock    v1.2.0 \
+                        rmd160  6df6fe44029a4e40275a928ea6dd4d41040172f9 \
+                        sha256  b836f5cbf685a4247e3cc92e243113478bb7a8dba33380e6c1d036a727305c67 \
+                        size    204592 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/danwakefield/fnmatch \
+                        lock    cbb64ac3d964 \
+                        rmd160  19ae7b520847e16b0e8ac23ee5e6c51db3831f46 \
+                        sha256  2b045b8a716e3ca32d2a930781cd421b042d0e861fa3d36a79ed5535b2e5308a \
+                        size    4960 \
+                    github.com/armon/go-socks5 \
+                        lock    e75332964ef5 \
+                        rmd160  22c2f6c6cfb6fc9e445df5d6e3d7d41d96984e02 \
+                        sha256  30b0b6e33f090505354e6f86d4da39d93d9d31221d354f3166b676f4db30a387 \
+                        size    8583 \
+                    github.com/anmitsu/go-shlex \
+                        lock    648efa622239 \
+                        rmd160  2cd39571128de9ea259f8ebafc292db77bfbc33e \
+                        sha256  ce0cf5fc33466e610f1605683f2e2bcb1e8212cece926074095a80f1326ed15f \
+                        size    3862 \
+                    github.com/alecthomas/repr \
+                        lock    117648cd9897 \
+                        rmd160  1f78bc0844f7ca6ccb93808bb367080e4c3accf8 \
+                        sha256  6715287714f895ceeed848842618084ea0fb4a53f0b904d9c456bea28ea31e16 \
+                        size    4649 \
+                    github.com/alecthomas/colour \
+                        lock    60882d9e2721 \
+                        rmd160  9f588ca134237b19f19199a088974aefebe3b301 \
+                        sha256  9178279e7dbff10a8325724c84b344dfcf365578d30d3f436db5fb1cba1030d5 \
+                        size    3484 \
+                    github.com/alecthomas/chroma \
+                        lock    v0.8.1 \
+                        rmd160  14d34738959e9bba287fde95b8cc01adf393f8d9 \
+                        sha256  f56cbcff9d57fda9be1934277c1becd28138f616070913677193235e90588dc3 \
+                        size    627710 \
+                    github.com/alecthomas/assert \
+                        lock    405dbfeb8e38 \
+                        rmd160  5d141a90e1e313657b558c19d51c3bdd65b0e5e5 \
+                        sha256  8c445be2c7daa6b680bfbf96823192076bbf9c0f514642687d6487fd95630a5e \
+                        size    71075 \
+                    github.com/alcortesm/tgz \
+                        lock    9c5fe88206d7 \
+                        rmd160  8871d33b125cb1f85571855293f6b9131496aa51 \
+                        sha256  b834470efd98946b981c77fcfcfb6ac181e675a4599b5799257347e7b7ea4d04 \
+                        size    4129


### PR DESCRIPTION
#### Description

New port for the [smithy](https://github.com/honza/smithy) Git Web UI

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
