### PR TITLE
emacs{,-app}-devel: fix fetch for +nativecomp

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -117,6 +117,7 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
     livecheck.type none
 
     variant nativecomp description {Builds emacs with native compilation support} {
+        git.url-prepend  --branch feature/native-comp
         git.branch  949b49cf771e8f38b23adb3fa4f9d7a9a5e290da
 
         depends_build-append     port:coreutils


### PR DESCRIPTION
#### Description

In https://github.com/macports/macports-ports/commit/68c42a1a1bff35daea513a761bdf9da6cf95192e the git fetch was made shallow, but

1. ~Using `--depth` is sub-optimal because it doesn't guarantee our commit will be included (though as noted a depth of 1000 should be OK for quite a while)~
2. ~It also over-fetches~
3. `--depth` implies `--single-branch`, which breaks the `nativecomp` variant because it needs a commit that is not on the default branch

This PR solves ~the first two issues with [--shallow-since](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---shallow-sinceltdategt) (available since [git 2.11.0](https://github.com/git/git/blob/454cb6bd52a4de614a3633e4f547af03d5c3b640/Documentation/RelNotes/2.11.0.txt#L471)), and~ the third one by specifying the branch when appropriate. `--shallow-since` is too new for a certain window of OS versions to use without adding the git port as a build dependency ([details](https://github.com/macports/macports-ports/pull/9295#discussion_r532636749)).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->