### PR TITLE
podman: new port

### DIFF
--- a/sysutils/podman/Portfile
+++ b/sysutils/podman/Portfile
@@ -1,0 +1,60 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/containers/podman 2.1.1 v
+revision            0
+
+categories          sysutils
+license             Apache-2
+platforms           darwin
+
+description         Tool for managing OCI containers and pods.
+
+long_description    Podman is a tool for running Linux containers. \
+                    You can do this from a MacOS desktop as long as you have access to a linux box \
+                    either running inside of a VM on the host, or available via the network. \
+                    You need to install the remote client and then setup ssh connection information.
+
+maintainers         nomaintainer
+
+checksums           ${distname}${extract.suffix} \
+    rmd160          7fe72e973991dd3a336f5a76eeb6bb9c9a99a73b \
+    sha256          10d8f2e14fa5f3a7f11bb12edbb848b6bb199b03983fbda4aaee74832fc82261 \
+    size            9443428
+
+
+post-extract {
+    reinplace "s|-mod=vendor||g" ${worksrcpath}/Makefile
+}
+
+build.cmd           make
+build.target        ${name}-remote-darwin
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/bin/${name}-remote-darwin ${destroot}${prefix}/bin/${name}-remote
+}
+
+variant bash_completion {
+    depends_run-append path:etc/bash_completion:bash-completion
+
+    post-destroot {
+        set completions_path ${prefix}/share/bash-completion/completions
+        xinstall -d ${destroot}${completions_path}
+        xinstall -m 0644 {*}[glob ${worksrcpath}/completions/bash/*] ${destroot}${completions_path}/
+    }
+}
+
+variant zsh_completion description {Completion functions for zsh} {
+    depends_run-append path:${prefix}/bin/zsh:zsh
+
+    post-destroot {
+        set site-functions ${destroot}${prefix}/share/zsh/site-functions
+        xinstall -d ${site-functions}
+        xinstall -m 0644 {*}[glob ${worksrcpath}/completions/zsh/*] ${site-functions}/
+    }
+}
+
+github.livecheck.regex  {([^"r-]+)}
+


### PR DESCRIPTION
#### Description

A quite simple port that installs a remote client for podman. One day, podman can be ported to mac OS (I doubt it very much).

Right now it isntall only podman-remote. The only binary that can be build on macOS.

And bash/zsh completions :)

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.0.1 20B50
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
