### PR TITLE
abduco: new port

### DIFF
--- a/sysutils/abduco/Portfile
+++ b/sysutils/abduco/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           makefile 1.0
+
+github.setup        martanne abduco 0.6 v
+revision            0
+
+description         abduco is a tool for session \{at,de\}tach support
+
+long_description    {*}${description}. abduco provides session management \
+                    i.e. it allows programs to be run independently from \
+                    their controlling terminal. That is programs can be \
+                    detached - run in the background - and then later \
+                    reattached. Together with dvtm it provides a simpler and \
+                    cleaner alternative to tmux or screen.
+
+categories          sysutils
+license             ISC
+platforms           darwin linux freebsd
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  b47f2c4d5efd1ac2872200c722aa1f58d118596f \
+                    sha256  89ed094a605d63cbf153af53c24b24cec08de201ff5cea4d792153725e4eb302 \
+                    size    15774
+
+makefile.has_destdir yes
+
+platform darwin {
+    configure.cflags-append -D_DARWIN_C_SOURCE
+}


### PR DESCRIPTION
#### Description

New port for [abduco](https://github.com/martanne/abduco)

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
