### PR TITLE
lynx: allow configure to use implicit function declaration

### DIFF
--- a/www/lynx/Portfile
+++ b/www/lynx/Portfile
@@ -39,6 +39,8 @@ configure.args      --datadir=${prefix}/share/doc \
                     --enable-local-docs \
                     --enable-nls
 
+configure.env       -Wno-error=implicit-function-declaration
+
 destroot.target-append  install-doc install-help
 
 if {![variant_isset gnutls]} {


### PR DESCRIPTION
#### Description
Lynx configuration requires implicit function declaration, which now
presents an error by default. Upstream plans to update the configuration
script, but until then, it needs to not be an error.

Closes: https://trac.macports.org/ticket/61068

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C5048k
Command line tools  12.3.0.0.1.1605054730

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
