### PR TITLE
libsbml: update to version 5.19.0

### DIFF
--- a/science/libsbml/Portfile
+++ b/science/libsbml/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 
 name                libsbml
-version             5.17.0
+version             5.19.0
 categories          science
 platforms           darwin
 maintainers         {@funasoul gmail.com:funasoul} openmaintainer
@@ -20,19 +20,25 @@ long_description    LibSBML is a free, open-source programming library to \
 
 homepage            http://sbml.org/Software/libSBML
 master_sites        sourceforge:project/sbml/libsbml/${version}/experimental/source
-patchfiles          patch-python-mp.diff
+patchfiles          patch-python-mp.diff \
+                    patch-readSBML-py.diff
 
 distname            libSBML-${version}-Source
 
-checksums           rmd160  67f35b4b5eaf049c34e53ddc22fac1cbf449c86f \
-                    sha256  d2160c06c8b5f849913165c468a87b23960c24cf6f6309e9c0022cd86d2f7ee4 \
-                    size    17257347
+checksums           rmd160  a462e9c497ed5072a3fc9ad24280b6fc0cadc6b8 \
+                    sha256  b2bcea187060e4fb4e6f51a69cc84a22f39cf45bc41fc4e1534ce5e4ef579b58 \
+                    size    16948303
 
-depends_lib-append  port:bzip2 \
-                    port:zlib \
+depends_build-append port:check \
                     port:pkgconfig
 
-configure.args-append -DWITH_EXAMPLES:BOOL=ON
+depends_lib-append  port:bzip2 \
+                    port:zlib
+
+configure.args-append -DWITH_EXAMPLES:BOOL=ON -DWITH_CHECK:BOOL=ON
+
+test.run            yes
+test.target         check
 
 variant arrays description {Enable libSBML support for the SBML Level 3 Arrays and Sets ('arrays')} {
     configure.args-append   -DENABLE_ARRAYS:BOOL=ON
@@ -70,7 +76,7 @@ variant groups description {Enable libSBML support for the SBML Level 3 Groups (
 }
 
 variant java description {Configure to use Java} {
-    depends_build-append   port:swig port:swig-java
+    depends_build-append   port:swig-java
     configure.args-append  -DWITH_JAVA:BOOL=ON
 }
 
@@ -89,22 +95,40 @@ variant multi description {Enable libSBML support for the SBML Level 3 Multistat
     configure.args-append   -DENABLE_MULTI:BOOL=ON
 }
 
-variant python27 conflicts python35 python36 description {Configure to use Python version 2.7} {
-    depends_build-append  port:swig port:swig-python
+variant python27 conflicts python35 python36 python37 python38 python39 description {Configure to use Python version 2.7} {
+    depends_build-append  port:swig-python
     depends_lib-append      port:python27
     configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python2.7 -DPYTHON_USE_DYNAMIC_LOOKUP:BOOL=ON
 }
 
-variant python35 conflicts python27 python36 description {Configure to use Python version 3.5} {
-    depends_build-append  port:swig port:swig-python
+variant python35 conflicts python27 python36 python37 python38 python39 description {Configure to use Python version 3.5} {
+    depends_build-append  port:swig-python
     depends_lib-append      port:python35
     configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python3.5 -DPYTHON_USE_DYNAMIC_LOOKUP:BOOL=ON
 }
 
-variant python36 conflicts python27 python35 description {Configure to use Python version 3.6} {
-    depends_build-append  port:swig port:swig-python
+variant python36 conflicts python27 python35 python37 python38 python39 description {Configure to use Python version 3.6} {
+    depends_build-append  port:swig-python
     depends_lib-append      port:python36
     configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python3.6 -DPYTHON_USE_DYNAMIC_LOOKUP:BOOL=ON
+}
+
+variant python37 conflicts python27 python35 python36 python38 python39 description {Configure to use Python version 3.7} {
+    depends_build-append  port:swig-python
+    depends_lib-append      port:python37
+    configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python3.7 -DPYTHON_USE_DYNAMIC_LOOKUP:BOOL=ON
+}
+
+variant python38 conflicts python27 python35 python36 python37 python39 description {Configure to use Python version 3.8} {
+    depends_build-append  port:swig-python
+    depends_lib-append      port:python38
+    configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python3.8 -DPYTHON_USE_DYNAMIC_LOOKUP:BOOL=ON
+}
+
+variant python39 conflicts python27 python35 python36 python37 python38 description {Configure to use Python version 3.9} {
+    depends_build-append  port:swig-python
+    depends_lib-append      port:python39
+    configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python3.9 -DPYTHON_USE_DYNAMIC_LOOKUP:BOOL=ON
 }
 
 variant qual description {Enable libSBML support for the SBML Level 3 Qualitative Models ('qual')} {

--- a/science/libsbml/files/patch-readSBML-py.diff
+++ b/science/libsbml/files/patch-readSBML-py.diff
@@ -1,0 +1,20 @@
+--- examples/python/readSBML.py.dist	2020-11-19 20:17:49.000000000 +0900
++++ examples/python/readSBML.py	2020-12-01 03:30:25.000000000 +0900
+@@ -54,7 +54,7 @@
+       return 1
+ 
+   filename = args[1]
+-  current = time.clock()
++  current = time.time()
+   document = readSBML(filename)
+ 
+   errors = document.getNumErrors()
+@@ -62,7 +62,7 @@
+   print()
+   print("            filename: " + filename)
+   print("           file size: " + str(os.stat(filename).st_size))
+-  print("      read time (ms): " + str(time.clock() - current))
++  print("      read time (ms): " + str((time.time() - current)*1000))
+   print(" validation error(s): " + str(errors))
+   print()
+   document.printErrors()


### PR DESCRIPTION
* update to version 5.19.0
* add Python37, Python38, and Python39 bindings
* add "port:check" as depends_build to support `port test`
* fixed an issue in original code which does not work with py38 and py39

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G6032
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
