### PR TITLE
py-tmuxp: fix 1.6.3 checksums

### DIFF
--- a/python/py-tmuxp/Portfile
+++ b/python/py-tmuxp/Portfile
@@ -28,9 +28,10 @@ if {${name} ne ${subport}} {
                             port:py${python.version}-kaptan \
                             port:py${python.version}-libtmux
 
-    checksums           rmd160  e2e598467633719895978414662fd763089efa26 \
-                        sha256  feec0be98a60c8cd8557bce388156202496dd9c8998e6913e595e939aeb0f735 \
-                        size    81031
+    checksums           rmd160  7cf48d719f690035b7d3bd5b477f50952494dff5 \
+                        sha256  4bc52d6683235307c92ddbb164c84e3e892ee2d00afa16ed89eca0fa7f85029e \
+                        size    81771
+
     livecheck.type      none
 } else {
     livecheck.type  pypi


### PR DESCRIPTION
#### Description

Fixed checksums from #9212.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
