### PR TITLE
py-kaptan: add Python 3.9 support

### DIFF
--- a/python/py-kaptan/Portfile
+++ b/python/py-kaptan/Portfile
@@ -13,17 +13,15 @@ license             BSD
 maintainers         {@egorenar posteo.net:egorenar-dev} openmaintainer
 
 description         Configuration parser.
-long_description    ${description}
-
+long_description    Configuration parser with dict, JSON, YAML, .ini \
+                    and python file handlers.
 homepage            https://github.com/emre/kaptan
-master_sites        pypi:k/${python.rootname}/
-distname            ${python.rootname}-${version}
 
 checksums           rmd160  f815b558ccb87e79a9240f40ba65a23313a6e25b \
                     sha256  1abd1f56731422fce5af1acc28801677a51e56f5d3c3e8636db761ed143c3dd2 \
                     size    10539
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_lib-append \
@@ -48,4 +46,8 @@ if {${name} ne ${subport}} {
     }
 
     livecheck.type  none
+
+} else {
+
+    livecheck.type  pypi
 }


### PR DESCRIPTION
#### Description

py-kaptan: add Python 3.9 support

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
