### PR TITLE
nccmp: update to 1.8.8.0

### DIFF
--- a/science/nccmp/Portfile
+++ b/science/nccmp/Portfile
@@ -6,7 +6,7 @@ PortSystem          1.0
 #PortGroup          cmake 1.1
 
 name                nccmp
-version             1.8.7.0
+version             1.8.8.0
 revision            0
 categories          science
 maintainers         {noaa.gov:dave.allured @Dave-Allured} openmaintainer
@@ -21,9 +21,9 @@ homepage            https://gitlab.com/remikz/nccmp
 master_sites        https://gitlab.com/remikz/nccmp/-/archive/${version}/
 use_bzip2           yes
 
-checksums           rmd160  42091f567a4a0bafe86de6078353bdc8037b73ff \
-                    sha256  67af5fc38610a1716c21d388c1e854e9c95a11f6a14369afbaefc38126075f3b \
-                    size    309826
+checksums           rmd160  5c92858e96da806564d427081ad0557b4fd3f0df \
+                    sha256  580eccd11bcd0f55dc334cba033a56d7f95a066de85b5f9c07e4c957b637dc90 \
+                    size    310053
 
 depends_lib         port:netcdf
 


### PR DESCRIPTION
update to 1.8.8.0

* Improved error message
* See https://gitlab.com/remikz/nccmp/-/releases

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G6032
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
* 74 tests passed, 4 non-critical fails, all 4 reported upstream
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->