### PR TITLE
kermit: fix implicit declaration errors and Portfile formatting

### DIFF
--- a/comms/kermit/Portfile
+++ b/comms/kermit/Portfile
@@ -1,57 +1,60 @@
-PortSystem 1.0
-name			kermit
-version			9.0.302
-categories		comms
-maintainers		nomaintainer
-distname		cku[lindex [split ${version} .] end]
-platforms		darwin freebsd
-license			BSD
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-homepage		http://www.columbia.edu/kermit/ckermit.html
+PortSystem          1.0
 
-master_sites		ftp://kermit.columbia.edu/kermit/archives/ \
-			http://kermit.columbia.edu/ftp/archives/ \
-			ftp://ftp.icm.edu.pl/pub/kermit/archives/
+name                kermit
+version             9.0.302
+categories          comms
+maintainers         nomaintainer
+distname            cku[lindex [split ${version} .] end]
+platforms           darwin freebsd
+license             BSD
 
-description		Serial and network communications package.
-long_description	C-Kermit is a combined serial and network \
-			communication software package offering \
-			a consistent, medium-independent, \
-			cross-platform approach to connection \
-			establishment, terminal sessions, file \
-			transfer, character-set translation, \
-			numeric and alphanumeric paging, and \
-			automation of communication tasks.
+homepage            http://www.columbia.edu/kermit/ckermit.html
 
-checksums		rmd160  ef3a71b5a42868c80408ac09662d00b71da0b0c8 \
-			sha256  0d5f2cd12bdab9401b4c836854ebbf241675051875557783c332a6a40dac0711
+master_sites        ftp://kermit.columbia.edu/kermit/archives/ \
+                    http://kermit.columbia.edu/ftp/archives/ \
+                    ftp://ftp.icm.edu.pl/pub/kermit/archives/
 
-extract.mkdir   yes
+description         Serial and network communications package.
+long_description    C-Kermit is a combined serial and network \
+                    communication software package offering \
+                    a consistent, medium-independent, \
+                    cross-platform approach to connection \
+                    establishment, terminal sessions, file \
+                    transfer, character-set translation, \
+                    numeric and alphanumeric paging, and \
+                    automation of communication tasks.
+
+checksums           rmd160  ef3a71b5a42868c80408ac09662d00b71da0b0c8 \
+                    sha256  0d5f2cd12bdab9401b4c836854ebbf241675051875557783c332a6a40dac0711
+
+extract.mkdir       yes
 build.target
-patchfiles	patch-makefile \
-            patch-ckuus5.c \
-            implicit.patch
+patchfiles          patch-makefile \
+                    patch-ckuus5.c \
+                    implicit.patch
 
 platform darwin {
-	build.target		macosx
+    build.target    macosx
 }
 
 platform freebsd {
-	set major 		[ string index ${os.version} 0 ]
-	set minor		[ string index ${os.version} 2 ]
-	build.target		freebsd${major}${minor}
+    set major       [ string index ${os.version} 0 ]
+    set minor       [ string index ${os.version} 2 ]
+    build.target    freebsd${major}${minor}
 }
 
 configure {
-	reinplace "s|@@prefix@@|${prefix}|g"	${worksrcpath}/ckuus5.c ${worksrcpath}/makefile
-	reinplace {s| CC=$(CC) | CC="$(CC)" |g} ${worksrcpath}/makefile
-	reinplace {s| CC2=$(CC2) | CC2="$(CC2)" |g} ${worksrcpath}/makefile
-	reinplace "s|CC= cc|CC= ${configure.cc} [get_canonical_archflags]|g" ${worksrcpath}/makefile
-	reinplace "s|CC2= cc|CC2= ${configure.cc} [get_canonical_archflags]|g" ${worksrcpath}/makefile
+    reinplace "s|@@prefix@@|${prefix}|g"    ${worksrcpath}/ckuus5.c ${worksrcpath}/makefile
+    reinplace {s| CC=$(CC) | CC="$(CC)" |g} ${worksrcpath}/makefile
+    reinplace {s| CC2=$(CC2) | CC2="$(CC2)" |g} ${worksrcpath}/makefile
+    reinplace "s|CC= cc|CC= ${configure.cc} [get_canonical_archflags]|g" ${worksrcpath}/makefile
+    reinplace "s|CC2= cc|CC2= ${configure.cc} [get_canonical_archflags]|g" ${worksrcpath}/makefile
 }
 
-pre-destroot { 
-	file mkdir ${destroot}${prefix}/share/doc/kermit
+pre-destroot {
+    file mkdir ${destroot}${prefix}/share/doc/kermit
 }
 
 livecheck.type  regexm

--- a/comms/kermit/Portfile
+++ b/comms/kermit/Portfile
@@ -28,7 +28,9 @@ checksums		rmd160  ef3a71b5a42868c80408ac09662d00b71da0b0c8 \
 
 extract.mkdir   yes
 build.target
-patchfiles	patch-makefile patch-ckuus5.c
+patchfiles	patch-makefile \
+            patch-ckuus5.c \
+            implicit.patch
 
 platform darwin {
 	build.target		macosx

--- a/comms/kermit/files/implicit.patch
+++ b/comms/kermit/files/implicit.patch
@@ -1,0 +1,50 @@
+Fix:
+
+ckcmai.c:3160:13: error: implicit declaration of function 'time' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
+
+ckuusx.c:5980:17: error: implicit declaration of function 'tgetent' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
+
+--- ckcmai.c.orig	2011-08-20 23:20:42.000000000 +0200
++++ ckcmai.c	2020-11-07 06:54:10.000000000 +0100
+@@ -1,7 +1,7 @@
+ #define EDITDATE  "20 Aug 2011"		/* Last edit date dd mmm yyyy */
+ #define EDITNDATE "20110820"		/* Keep them in sync */
+ /* Sat Aug 20 17:20:17 2011 */
+-
++#include <time.h>
+ /* ckcmai.c - Main program for C-Kermit plus some miscellaneous functions */
+
+ /*
+
+--- ckuusx.c.orig	2011-06-17 16:11:34.000000000 +0200
++++ ckuusx.c	2020-12-02 09:30:29.000000000 +0100
+@@ -28,6 +28,8 @@
+ #include "ckcker.h"
+ #include "ckuusr.h"
+ #include "ckcxla.h"
++#include <curses.h>
++#include <term.h>
+
+ #ifndef NOHTERMCAP
+ #ifdef NOTERMCAP
+
+--- ckupty.c.orig	2011-06-13 17:34:13.000000000 +0200
++++ ckupty.c	2020-12-02 09:17:03.000000000 +0100
+@@ -56,6 +56,7 @@
+
+ #include "ckcsym.h"
+ #include "ckcdeb.h"			/* To pick up NETPTY definition */
++#include <util.h>
+
+ #ifndef NETPTY				/* Selector for PTY support */
+
+--- ckutio.c.orig	2011-08-20 23:22:35.000000000 +0200
++++ ckutio.c	2020-12-02 09:16:34.000000000 +0100
+@@ -41,6 +41,7 @@
+
+ #include "ckcsym.h"			/* This must go first   */
+ #include "ckcdeb.h"			/* This must go second  */
++#include <util.h>
+
+ #ifdef OSF13
+ #ifdef CK_ANSIC


### PR DESCRIPTION
#### Description
Adds a patch that fixes implicit declaration errors (https://trac.macports.org/ticket/61425) & Portfile indentation is fixed.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
