### PR TITLE
Mame: Update to 0.226

### DIFF
--- a/emulators/mame/Portfile
+++ b/emulators/mame/Portfile
@@ -57,19 +57,7 @@ patchfiles          mame-patch-0226-language-portuguese_brazil.diff \
 checksums           mame-0226.tar.gz \
                     rmd160  b9e4ae321b7673790d374c63bbe966d1502d6738 \
                     sha256  7c4c9ec232ba988e65fd29665c9b8e40b5ac3aa9f561eeb107cebbf08ba94baf \
-                    size    196379874 \
-                    mame-patch-0226-language-portuguese_brazil.diff \
-                    rmd160  6eacda9bc43662cc37ad07544fc7e78eb0188b80 \
-                    sha256  63873b094b307d417a0cbc89a23847b876e322466ae809952e8467645cef86f6 \
-                    size    1257 \
-                    mame-patch-0226-scripts-genie-compile-warnings.diff \
-                    rmd160  d45f59b828a0c9cd92d368339852e51b431322e2 \
-                    sha256  4b1f69c8b232b91a667a93d5b904768d4ee082c3aea2051fe8bf279d99010317 \
-                    size    326 \
-                    mame-script-template-launcher.sh \
-                    rmd160  1b752e19fb77b18366f22e86b5578f2682b24c67\
-                    sha256  e7601a1f3fcf9759c42bd5adcbf0d2ba003e91305b8f48dd2e8ed82ff6a5a9d8\
-                    size    280
+                    size    196379874
 
 #------------------------------------------------------------------------------
 # Port-Specific Globals

--- a/emulators/mame/Portfile
+++ b/emulators/mame/Portfile
@@ -193,6 +193,17 @@ if {$build_arch in [list arm64 x86_64 ppc64]} {
 build.target
 
 #------------------------------------------------------------------------------
+# Test Support
+#
+# Note: At the time of this writing (12/2020), Mame's test suite is quite
+# limited. And it does not require a build. But it's still worthwhile, to
+# provide some basic sanity checks.
+#------------------------------------------------------------------------------
+
+test.run      yes
+test.target   tests
+
+#------------------------------------------------------------------------------
 # Procs - Low Level
 #
 # Should only be called by High-Level procs!

--- a/emulators/mame/Portfile
+++ b/emulators/mame/Portfile
@@ -1,13 +1,24 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem          1.0
-PortGroup github    1.0
+#------------------------------------------------------------------------------
+# Portfile Style Notes
+#
+# * For cases where local variables are created within phases, they are
+#   explicitly unset when no longer being used. This is a conscious choice,
+#   and helps avoid any possible clashes elsewhere.
+# * To aid readability, intermediate variables, lists, etc, are often
+#   employed. While that makes the portfile longer, it also assists when
+#   trying to understand what is being done... aiding in diagnosing and
+#   debugging issues. Again, this is a conscious choice.
+#------------------------------------------------------------------------------
 
-github.setup        mamedev mame 0206 mame
+PortSystem          1.0
+
+PortGroup           github 1.0
+PortGroup           compiler_blacklist_versions 1.0
+
+github.setup        mamedev mame 0226 mame
 revision            0
-checksums           rmd160  d8d5a4bbd94a8f1bb980b0ff9e2b62ea9f29e58b \
-                    sha256  8e4c04c724964ca0c22f65181a84261b01ca49f51f4266c084b2d6b5a81e1e8d \
-                    size    145788806
 
 version             [string index ${github.version} 0].[string range ${github.version} 1 end]
 categories          emulators
@@ -22,6 +33,80 @@ long_description    The purpose of MAME is to preserve decades of software histo
     "vintage" software from being lost and forgotten. This is achieved by documenting \
     the hardware and how it functions. The source code to MAME serves as this \
     documentation.
+
+github.tarball_from archive
+
+#------------------------------------------------------------------------------
+# Patches and Checksums
+#------------------------------------------------------------------------------
+
+# Patch 'language-portuguese_brazil' is only applicable to release 0.226.
+# Fix was submitted, and merged, by Mame maintainers... and will be part of
+# official Mame releases from 0.227 onward. Net-Net, this particular patch can
+# be removed starting with 0.227. Tracked by Mame issue:
+# https://github.com/mamedev/mame/issues/7510
+#
+# Conversely, patch 'scripts-genie-compile-warnings' is not specific to any
+# particular Mame release. Indeed, it is technically not required at all.
+# However, it eliminates spurious warnings due to use of deprecated types
+# and/or calls... and reduces pollution in the build log.
+
+patchfiles          mame-patch-0226-language-portuguese_brazil.diff \
+                    mame-patch-0226-scripts-genie-compile-warnings.diff
+
+checksums           mame-0226.tar.gz \
+                    rmd160  b9e4ae321b7673790d374c63bbe966d1502d6738 \
+                    sha256  7c4c9ec232ba988e65fd29665c9b8e40b5ac3aa9f561eeb107cebbf08ba94baf \
+                    size    196379874 \
+                    mame-patch-0226-language-portuguese_brazil.diff \
+                    rmd160  6eacda9bc43662cc37ad07544fc7e78eb0188b80 \
+                    sha256  63873b094b307d417a0cbc89a23847b876e322466ae809952e8467645cef86f6 \
+                    size    1257 \
+                    mame-patch-0226-scripts-genie-compile-warnings.diff \
+                    rmd160  d45f59b828a0c9cd92d368339852e51b431322e2 \
+                    sha256  4b1f69c8b232b91a667a93d5b904768d4ee082c3aea2051fe8bf279d99010317 \
+                    size    326 \
+                    mame-script-template-launcher.sh \
+                    rmd160  1b752e19fb77b18366f22e86b5578f2682b24c67\
+                    sha256  e7601a1f3fcf9759c42bd5adcbf0d2ba003e91305b8f48dd2e8ed82ff6a5a9d8\
+                    size    280
+
+#------------------------------------------------------------------------------
+# Port-Specific Globals
+#------------------------------------------------------------------------------
+
+# Python version info, populated by python* variants.
+set g_mame_python_info_dict \
+    [dict create \
+        ver_major "" \
+        ver_minor "" \
+        py_bin "" \
+        sphinx_bin "" \
+    ]
+
+# Documentation build targets.
+set g_mame_build_targets_docs_list \
+    [list \
+        "man" \
+    ]
+
+# Documentation build args.
+# Note: Dynamic values populated in phase 'pre-build'.
+set g_mame_build_args_docs_list \
+    [list \
+    ]
+
+# Main build targets.
+# Note: Target 'all' must be run before 'translation', or latter will fail.
+set g_mame_build_targets_main_list \
+    [list \
+        "all" \
+        "translation" \
+    ]
+
+#------------------------------------------------------------------------------
+# Dependencies
+#------------------------------------------------------------------------------
 
 depends_build-append \
                     port:asio \
@@ -41,20 +126,45 @@ depends_lib-append  \
                     port:sqlite3 \
                     port:zlib
 
+# Note: Port 'coreutils' needed for 'grealpath', used in launcher script.
+depends_run-append  \
+                    port:coreutils
+
+#------------------------------------------------------------------------------
+# Build Options
+#------------------------------------------------------------------------------
+
+use_parallel_build  yes
+
 use_configure       no
 
+# https://github.com/mamedev/mame/issues/6004
+compiler.blacklist  {clang < 1000}
+
 # https://github.com/mamedev/mame/issues/3788
-if {${os.platform} eq "darwin" && ([vercmp $xcodeversion 9.0] < 0)} {
-    configure.cxxflags-append -DMAME_DEVCB_GNUC_BROKEN_FRIEND
-}
+# As long as we're blacklisting clangs from the affected Xcode versions,
+# we don't need to add this flag.
+#if {${os.platform} eq "darwin" && ([vercmp $xcodeversion 9.0] < 0)} {
+#    configure.cxxflags-append -DMAME_DEVCB_GNUC_BROKEN_FRIEND
+#}
 
 compiler.cxx_standard   2014
 
+# Note: Compiler optimization level is controlled by makefile variable 'OPTIMIZE', below.
+configure.cxxflags  -stdlib=libc++
+
+# TODO: Disable debugging, via 'DEBUG=0'?
 build.args-append   ARCHOPTS="${configure.cxxflags}" \
                     CC="${configure.cc}" \
                     CXX="${configure.cxx}" \
-                    LDOPTS="-L${prefix}/lib -lSDL2" \
+                    OVERRIDE_CC="${configure.cc}" \
+                    OVERRIDE_CXX="${configure.cxx}" \
+                    CFLAGS="-isystem${prefix}/include" \
+                    LDOPTS="-L${prefix}/lib" \
+                    LDOPTS="-lSDL2" \
+                    OPTIMIZE=2 \
                     NOWERROR=1 \
+                    VERBOSE=1 \
                     USE_LIBSDL=1 \
                     USE_SYSTEM_LIB_ASIO=1 \
                     USE_SYSTEM_LIB_EXPAT=1 \
@@ -66,20 +176,317 @@ build.args-append   ARCHOPTS="${configure.cxxflags}" \
                     USE_SYSTEM_LIB_PUGIXML=1 \
                     USE_SYSTEM_LIB_SQLITE3=1 \
                     USE_SYSTEM_LIB_UTF8PROC=1 \
-                    USE_SYSTEM_LIB_ZLIB=1 \
-                    VERBOSE=1
+                    USE_SYSTEM_LIB_ZLIB=1
 
-if {$build_arch in {x86_64 ppc64}} {
-    build.args-append   PTR64=1
-    set executable  mame64
+if {$build_arch in [list arm64 x86_64 ppc64]} {
+    build.args-append \
+        PTR64=1
+    set executable mame64
 } else {
-    build.args-append   PTR64=0
-    set executable  mame
+    build.args-append \
+        PTR64=0
+    set executable mame
 }
 
-destroot {
-    xinstall ${worksrcpath}/${executable} ${destroot}${prefix}/bin
+# Clear 'build.target', to avoid contaminating 'build.pre_args'.
+# Note that we cannot rely on default build logic, as multiple makefiles are involved.
+build.target
+
+#------------------------------------------------------------------------------
+# Procs - Low Level
+#
+# Should only be called by High-Level procs!
+#------------------------------------------------------------------------------
+
+# Populate global Python info dictionary, for specified version
+proc mame_python_populate_info {p_ver_major p_ver_minor} {
+    global prefix
+    global g_mame_python_info_dict
+
+    # Version info
+    dict set g_mame_python_info_dict ver_major ${p_ver_major}
+    dict set g_mame_python_info_dict ver_minor ${p_ver_minor}
+
+    # Paths to executables
+    dict set g_mame_python_info_dict py_bin \
+        "${prefix}/bin/python${p_ver_major}.${p_ver_minor}"
+    dict set g_mame_python_info_dict sphinx_bin \
+        "${prefix}/bin/sphinx-build-${p_ver_major}.${p_ver_minor}"
+
+    ui_debug "mame_python_populate_info: g_mame_python_info_dict: ${g_mame_python_info_dict}"
+
+    return 0
 }
+
+# Update dependencies, based on global Python info dictionary.
+# Note: Proc 'mame_python_populate_info' must be called first!
+proc mame_python_add_deps {} {
+    global g_mame_python_info_dict
+
+    set ver_major [dict get ${g_mame_python_info_dict} ver_major]
+    set ver_minor [dict get ${g_mame_python_info_dict} ver_minor]
+
+    depends_build-append \
+        "port:python${ver_major}${ver_minor}" \
+        "port:py${ver_major}${ver_minor}-sphinx" \
+        "port:py${ver_major}${ver_minor}-sphinxcontrib-svg2pdfconverter"
+
+    return 0
+}
+
+#------------------------------------------------------------------------------
+# Procs - High Level - Variant Support
+#------------------------------------------------------------------------------
+
+proc mame_variant_tools_setup {} {
+    build.args-append \
+        "TOOLS=1"
+
+    return 0
+}
+
+# Wrapper for python* variants to call, limiting copy-and-paste mayhem.
+proc mame_variant_python_setup {p_ver_major p_ver_minor} {
+    mame_python_populate_info ${p_ver_major} ${p_ver_minor}
+    mame_python_add_deps
+
+    return 0
+}
+
+#------------------------------------------------------------------------------
+# Procs - High Level - Phase Support
+#------------------------------------------------------------------------------
+
+proc mame_build_run {p_work_path p_target p_build_args_list} {
+    global build.cmd
+    global build.jobs
+    global build.pre_args
+
+    ui_debug "mame_build_run: p_work_path: ${p_work_path}"
+    ui_debug "mame_build_run: p_target: ${p_target}"
+    ui_debug "mame_build_run: p_build_args_list: ${p_build_args_list}"
+
+    set build_cmd_line \
+        "${build.cmd} \
+            --jobs=${build.jobs} \
+            [join ${build.pre_args}] \
+            ${p_target} \
+            [join ${p_build_args_list}]"
+
+    ui_debug "mame_build_run: build_cmd_line: ${build_cmd_line}"
+
+    system -W \
+        ${p_work_path} \
+        ${build_cmd_line}
+
+    return 0
+}
+
+#------------------------------------------------------------------------------
+# Variants
+#------------------------------------------------------------------------------
+
+variant tools \
+        description {Compile and install the mame tools like chdman and others} {
+    mame_variant_tools_setup
+}
+
+variant python36 \
+        description {Use python 3.6 for build} \
+        conflicts python37 python38 python39 {
+    mame_variant_python_setup 3 6
+}
+
+variant python37 \
+        description {Use python 3.7 for build} \
+        conflicts python36 python38 python39 {
+    mame_variant_python_setup 3 7
+}
+
+variant python38 \
+        description {Use python 3.8 for build} \
+        conflicts python36 python37 python39 {
+    mame_variant_python_setup 3 8
+}
+
+variant python39 \
+        description {Use python 3.9 for build} \
+        conflicts python36 python37 python38 {
+    mame_variant_python_setup 3 9
+}
+
+default_variants   +tools
 
 # Universal variant is untested
 universal_variant   no
+
+# Ensure one python* variant is selected by default, if not specified by user
+if {![variant_isset python36] && ![variant_isset python37] && ![variant_isset python38] && ![variant_isset python39]} {
+    default_variants +python39
+}
+
+#------------------------------------------------------------------------------
+# Phases
+#------------------------------------------------------------------------------
+
+pre-build {
+    # Update build args for documentation build
+    set sphinx_bin [dict get ${g_mame_python_info_dict} sphinx_bin]
+    set build_args_docs \
+        [list \
+            "SPHINXBUILD=${sphinx_bin}" \
+        ]
+    set g_mame_build_args_docs_list \
+        [concat \
+            ${g_mame_build_args_docs_list} \
+            ${build_args_docs} \
+        ]
+    unset build_args_docs
+    unset sphinx_bin
+
+    # Update build args for main build
+    set py_bin [dict get ${g_mame_python_info_dict} py_bin]
+    build.args-append \
+        "PYTHON_EXECUTABLE=${py_bin}"
+    unset py_bin
+
+    ui_debug "Phase pre-build: g_mame_build_args_docs_list: ${g_mame_build_args_docs_list}"
+}
+
+# Override the standard build phase, to include both documentation and code
+build {
+    # Documentation build; iterate over targets
+    foreach target ${g_mame_build_targets_docs_list} {
+        ui_msg "Building documentation target: ${target}"
+        mame_build_run \
+            "${worksrcpath}/docs" \
+            ${target} \
+            ${g_mame_build_args_docs_list}
+    }
+
+    # Main build; iterate over targets
+    foreach target ${g_mame_build_targets_main_list} {
+        ui_msg "Building main target: ${target}"
+        mame_build_run \
+            ${worksrcpath} \
+            ${target} \
+            ${build.args}
+    }
+
+    unset target
+}
+
+destroot {
+    set mame_target_dir "${destroot}${prefix}/libexec/mame"
+    set mame_share_dir "${destroot}${prefix}/share/mame"
+
+    # Main
+    xinstall -m 755 -d ${mame_target_dir}
+    copy ${worksrcpath}/${executable} ${mame_target_dir}
+    copy ${worksrcpath}/artwork ${mame_target_dir}
+    copy ${worksrcpath}/bgfx ${mame_target_dir}
+    xinstall -m 755 -d ${mame_target_dir}/cfg
+    xinstall -m 755 -d ${mame_target_dir}/cheat
+    xinstall -m 755 -d ${mame_target_dir}/comments
+    xinstall -m 755 -d ${mame_target_dir}/crsshair
+    copy ${worksrcpath}/ctrlr ${mame_target_dir}
+    xinstall -m 755 -d ${mame_target_dir}/diff
+    xinstall -m 755 -d ${mame_target_dir}/fonts
+    copy ${worksrcpath}/hash ${mame_target_dir}
+    copy ${worksrcpath}/hlsl ${mame_target_dir}
+    copy ${worksrcpath}/ini ${mame_target_dir}
+    xinstall -m 755 -d ${mame_target_dir}/inp
+    copy ${worksrcpath}/keymaps ${mame_target_dir}
+    copy ${worksrcpath}/language ${mame_target_dir}
+    xinstall -m 755 -d ${mame_target_dir}/nvram
+    copy ${worksrcpath}/plugins ${mame_target_dir}
+    copy ${worksrcpath}/roms ${mame_target_dir}
+    copy ${worksrcpath}/samples ${mame_target_dir}
+    copy ${worksrcpath}/scripts ${mame_target_dir}
+    xinstall -m 755 -d ${mame_target_dir}/software
+    xinstall -m 755 -d ${mame_target_dir}/snap
+    xinstall -m 755 -d ${mame_target_dir}/sta
+
+    # Docs
+    xinstall -m 755 -d ${mame_share_dir}
+    copy ${worksrcpath}/docs/build/man ${mame_share_dir}
+
+    # Tools
+    if {[variant_isset tools]} {
+        xinstall -m 755 \
+            ${worksrcpath}/aueffectutil \
+            ${worksrcpath}/castool \
+            ${worksrcpath}/chdman \
+            ${worksrcpath}/floptool \
+            ${worksrcpath}/imgtool \
+            ${worksrcpath}/jedutil \
+            ${worksrcpath}/ldresample \
+            ${worksrcpath}/ldverify \
+            ${worksrcpath}/nltool \
+            ${worksrcpath}/nlwav \
+            ${worksrcpath}/pngcmp \
+            ${worksrcpath}/regrep \
+            ${worksrcpath}/romcmp \
+            ${worksrcpath}/split \
+            ${worksrcpath}/srcclean \
+            ${worksrcpath}/testkeys \
+            ${worksrcpath}/unidasm \
+            ${mame_target_dir}
+    }
+
+    unset mame_share_dir
+    unset mame_target_dir
+}
+
+post-destroot {
+    set mp_man_dest_dir "${destroot}${prefix}/share/man/man1"
+    set mame_target_dir "${destroot}${prefix}/libexec/mame"
+    set mame_share_dir "${destroot}${prefix}/share/mame"
+    set mame_launch_script "${mame_target_dir}/mame.sh"
+    set mame_launch_link "${destroot}${prefix}/bin/mame"
+
+    # Create launch wrapper script
+    xinstall -m 755 "${distpath}/mame-script-template-launcher.sh" \
+        ${mame_launch_script}
+    # Substitute placeholder with real executable name
+    reinplace "s|@@MACPORTS_MAME_EXECUTABLE@@|${executable}|g" \
+        ${mame_launch_script}
+
+    # Create soft link 'mame', to launch wrapper script
+    ln -s "${prefix}/libexec/mame/mame.sh" \
+        ${mame_launch_link}
+
+    # Create soft link to man page
+    xinstall -d -m 755 ${mp_man_dest_dir}
+    ln -s "${prefix}/share/mame/man/MAME.1" \
+        "${mp_man_dest_dir}/mame.1"
+
+    unset mame_launch_link
+    unset mame_launch_script
+    unset mame_share_dir
+    unset mame_target_dir
+    unset mp_man_dest_dir
+}
+
+#------------------------------------------------------------------------------
+# Notes
+#------------------------------------------------------------------------------
+
+notes {
+    Mame is launched via command 'mame'.
+
+    If a blank screen is encountered, press ESC to exit, and then re-launch
+    with an alternative video option.
+
+    Examples:
+        mame -video accel
+        mame -video opengl
+}
+
+if {[variant_isset tools]} {
+    notes-append {
+    --------------------------------------------------------------------------
+    Mame tools are available in path ${prefix}/libexec/mame
+    }
+}
+

--- a/emulators/mame/Portfile
+++ b/emulators/mame/Portfile
@@ -474,7 +474,7 @@ post-destroot {
 notes {
     Mame is launched via command 'mame'.
 
-    If a blank screen is encountered, press ESC to exit, and then re-launch
+    If a blank screen is encountered, press ESC to exit, and then re-launch\
     with an alternative video option.
 
     Examples:

--- a/emulators/mame/Portfile
+++ b/emulators/mame/Portfile
@@ -54,8 +54,7 @@ github.tarball_from archive
 patchfiles          mame-patch-0226-language-portuguese_brazil.diff \
                     mame-patch-0226-scripts-genie-compile-warnings.diff
 
-checksums           mame-0226.tar.gz \
-                    rmd160  b9e4ae321b7673790d374c63bbe966d1502d6738 \
+checksums           rmd160  b9e4ae321b7673790d374c63bbe966d1502d6738 \
                     sha256  7c4c9ec232ba988e65fd29665c9b8e40b5ac3aa9f561eeb107cebbf08ba94baf \
                     size    196379874
 
@@ -321,7 +320,7 @@ universal_variant   no
 
 # Ensure one python* variant is selected by default, if not specified by user
 if {![variant_isset python36] && ![variant_isset python37] && ![variant_isset python38] && ![variant_isset python39]} {
-    default_variants +python39
+    default_variants +python38
 }
 
 #------------------------------------------------------------------------------

--- a/emulators/mame/Portfile
+++ b/emulators/mame/Portfile
@@ -139,7 +139,7 @@ compiler.blacklist  {clang < 1000}
 compiler.cxx_standard   2014
 
 # Note: Compiler optimization level is controlled by makefile variable 'OPTIMIZE', below.
-configure.cxxflags  -stdlib=libc++
+configure.cxxflags-delete -O1 -O2 -O3 -Os
 
 # TODO: Disable debugging, via 'DEBUG=0'?
 build.args-append   ARCHOPTS="${configure.cxxflags}" \

--- a/emulators/mame/Portfile
+++ b/emulators/mame/Portfile
@@ -22,7 +22,7 @@ revision            0
 
 version             [string index ${github.version} 0].[string range ${github.version} 1 end]
 categories          emulators
-maintainers         nomaintainer
+maintainers         {@mascguy} openmaintainer
 platforms           darwin
 license             GPL-2+
 homepage            https://www.mamedev.org

--- a/emulators/mame/Portfile
+++ b/emulators/mame/Portfile
@@ -457,7 +457,7 @@ post-destroot {
     set mame_launch_link "${destroot}${prefix}/bin/mame"
 
     # Create launch wrapper script
-    xinstall -m 755 "${distpath}/mame-script-template-launcher.sh" \
+    xinstall ${filespath}/mame-script-template-launcher.sh \
         ${mame_launch_script}
     # Substitute placeholder with real executable name
     reinplace "s|@@MACPORTS_MAME_EXECUTABLE@@|${executable}|g" \
@@ -500,4 +500,3 @@ if {[variant_isset tools]} {
     Mame tools are available in path ${prefix}/libexec/mame
     }
 }
-

--- a/emulators/mame/files/mame-patch-0226-language-portuguese_brazil.diff
+++ b/emulators/mame/files/mame-patch-0226-language-portuguese_brazil.diff
@@ -1,0 +1,31 @@
+--- language/Portuguese_Brazil/strings.po	2020-11-26 15:11:29.000000000 -0500
++++ language/Portuguese_Brazil/strings.po	2020-11-26 15:14:15.000000000 -0500
+@@ -1690,7 +1690,7 @@
+ 
+ #: src/frontend/mame/ui/selgame.cpp:1136
+ msgid "Mag. Drum\tImperfect\n"
+-msgstr "Cab. Mag.\Imperfeito\n"
++msgstr "Cab. Mag.\tImperfeito\n"
+ 
+ #: src/frontend/mame/ui/selgame.cpp:1139
+ msgid "(EP)ROM\tUnimplemented\n"
+@@ -3020,15 +3020,15 @@
+ msgid ""
+ "Use this if you want to poke the Slot 1 value (eg. You started with "
+ "something but lost it)"
+-msgstr "Use isto se quiser fazer um poke o Slot 1 (Quando você
+-começa com algo mas o perde)"
++msgstr "Use isto se quiser fazer um poke o Slot 1 (Quando você "
++"começa com algo mas o perde)"
+ 
+ #: plugins/cheatfind/init.lua:740
+ msgid ""
+ "Use this if you want to poke the Last Slot value (eg. You started without an "
+ "item but finally got it)"
+-msgstr "Use isto se quiser fazer um poke com o valor do Último Slot (Quando você começa
+-sem um item e depois você o consegue por exemplo)"
++msgstr "Use isto se quiser fazer um poke com o valor do Último Slot (Quando você começa "
++"sem um item e depois você o consegue por exemplo)"
+ 
+ #: plugins/cheatfind/init.lua:742
+ msgid "Use this if you want to poke 0x00"

--- a/emulators/mame/files/mame-patch-0226-scripts-genie-compile-warnings.diff
+++ b/emulators/mame/files/mame-patch-0226-scripts-genie-compile-warnings.diff
@@ -1,0 +1,10 @@
+--- scripts/genie.lua	2020-11-28 16:02:27.000000000 -0500
++++ scripts/genie.lua	2020-11-28 17:01:38.000000000 -0500
+@@ -1002,6 +1002,7 @@
+ 		"-Wno-sign-compare",
+ 		"-Wno-conversion",
+ 		"-Wno-error=deprecated-declarations",
++		"-Wno-deprecated-declarations",
+ 	}
+ -- warnings only applicable to C compiles
+ 	buildoptions_c {

--- a/emulators/mame/files/mame-script-template-launcher.sh
+++ b/emulators/mame/files/mame-script-template-launcher.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+#
+# Obtain path to script.
+#
+# Note that 'grealpath' provides reliable soft-link resolution, without requiring
+# any Bash gymnastics.
+#
+script_file=$(grealpath "${0}")
+script_dir=$(dirname "${script_file}")
+
+cd "${script_dir}"
+
+./@@MACPORTS_MAME_EXECUTABLE@@ "${@}"
+


### PR DESCRIPTION
#### Description

Materials encompassing Mame 0.226 update.

Tracked by issue:
https://trac.macports.org/ticket/61482

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G2136
Xcode 9.2 9C40b

macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
