### PR TITLE
py-appnope: Add missing setuptools dependency

### DIFF
--- a/python/py-appnope/Portfile
+++ b/python/py-appnope/Portfile
@@ -25,4 +25,6 @@ checksums           rmd160  8653a709ff95927a7a29dfefaa46f9fcaa0ad632 \
 
 if {${name} ne ${subport}} {
     livecheck.type      none
+    depends_build-append \
+        port:py${python.version}-setuptools
 }


### PR DESCRIPTION
#### Description

The build fails in trace mode without this dependency.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G6042
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
