### PR TITLE
py-curl: update to 7.43.0.6

### DIFF
--- a/python/py-curl/Portfile
+++ b/python/py-curl/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        pycurl pycurl 7_43_0_5 REL_
+github.setup        pycurl pycurl 7_43_0_6 REL_
 github.tarball_from archive
 name                py-curl
 version             [string map {_ .} ${github.version}]
@@ -22,11 +22,11 @@ long_description    Python module interface to the cURL library which \
 
 homepage            http://pycurl.io/
 
-checksums           rmd160  4c16edbbfeaa82b8b552f91bc0f0efe3e88ce68a \
-                    sha256  33c8a7f7664c4259af5f03da4cbf7191d97f50223c4b093d2718fc4b4ac5f72e \
-                    size    214487
+checksums           rmd160  4846e373c848930b2a0c17e6aa7d5e3ee2323a95 \
+                    sha256  1c37a37f1ea5b422bb8b1b524f565ac927d23b7afad65ae13a7ebf7f65d7ab6c \
+                    size    217856
 
-python.versions     27 37 38
+python.versions     27 37 38 39
 
 if {${name} ne ${subport}} {
     if {${python.version} == 27} {


### PR DESCRIPTION
#### Description

 - update to 7.43.0.6
 - enable python39

###### Type(s)
- [x] update
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 11.0.1 20B50
Xcode 12.2 12B45b


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
