### PR TITLE
py-m2crypto: update to 0.36.0

### DIFF
--- a/python/py-m2crypto/Portfile
+++ b/python/py-m2crypto/Portfile
@@ -4,7 +4,7 @@ PortSystem         1.0
 PortGroup          python 1.0
 
 name               py-m2crypto
-version            0.35.2
+version            0.36.0
 revision           1
 categories-append  crypto devel
 platforms          darwin
@@ -18,11 +18,11 @@ homepage           https://pypi.python.org/pypi/${python.rootname}
 
 master_sites       pypi:m/${python.rootname}/
 distname           M2Crypto-${version}
-checksums          size    1117706 \
-                   rmd160  1620100aaedb4dd52e9e5dc1fc189b247db610ff \
-                   sha256  4c6ad45ffb88670c590233683074f2440d96aaccb05b831371869fc387cbd127
+checksums          size    1127584 \
+                   rmd160  e813fd1da12a8b8a5550931129d29977a25cef5d \
+                   sha256  1542c18e3ee5c01db5031d0b594677536963e3f54ecdf5315aeecb3a595b4dc1
 
-python.versions    27 35 36 37
+python.versions    27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
   depends_build      port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

- update to 0.36.0
- enable python 3.8 and 3.9

###### Type(s)

- [x] update
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.0.1 20B50
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
