### PR TITLE
osc: update to 0.171.0

### DIFF
--- a/devel/osc/Portfile
+++ b/devel/osc/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        openSUSE osc 0.160.0
+github.setup        openSUSE osc 0.171.0
 categories          devel python
 platforms           darwin
 supported_archs     noarch
@@ -21,17 +21,16 @@ long_description    osc is a subversion-like client written in Python. \
 
 homepage            https://en.opensuse.org/openSUSE:OSC
 
-checksums           rmd160  c3915c31af985c645f902e9f9be840c24c0d297d \
-                    sha256  668d319c5ead8d879120c27638925e7476ccafa1144c047b56ccef10b0dd2689 \
-                    size    340944
+checksums           rmd160  333dff85a056f9f09298a1fdf660fb1795f20d7d \
+                    sha256  447158eed1252227315902af14a58f94ae17863c2db18f7fbfa80e214d0c25b1 \
+                    size    360443
 
 patchfiles          patch-config.diff \
                     patch-build-disable.diff
 
-python.default_version 27
+python.default_version 38
 
-depends_lib-append  port:py${python.version}-elementtree \
-                    port:py${python.version}-urlgrabber \
+depends_lib-append  port:py${python.version}-chardet \
                     port:py${python.version}-m2crypto
 
 depends_run         path:share/curl/curl-ca-bundle.crt:curl-ca-bundle \


### PR DESCRIPTION
#### Description

- update to 0.171.0
- switch to python 3.9

this PR is depends on:
 - [py-curl: update to 7.43.0.6](https://github.com/macports/macports-ports/pull/9321)
 - [py-m2crypto: update to 0.36.0](https://github.com/macports/macports-ports/pull/9322)

###### Type(s)

- [x] update
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.0.1 20B50
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

