### PR TITLE
py27-curl: fixed port

### DIFF
--- a/python/py-curl/Portfile
+++ b/python/py-curl/Portfile
@@ -28,16 +28,25 @@ checksums           rmd160  4846e373c848930b2a0c17e6aa7d5e3ee2323a95 \
 
 python.versions     27 37 38 39
 
-if {${name} ne ${subport}} {
-    if {${python.version} == 27} {
-        github.setup    pycurl pycurl 7_43_0_3 REL_
-        version     [string map {_ .} ${github.version}]
-        revision    1
-        checksums   rmd160  6891ba8ee4d79fd5a10e824db47b9083309306b3 \
+
+livecheck.type      regex
+livecheck.url       ${homepage}
+livecheck.regex     PYCURL (\[0-9\.\]+)
+livecheck.version   ${version}
+
+subport py27-curl {
+
+    github.setup    pycurl pycurl 7_43_0_3 REL_
+    version         [string map {_ .} ${github.version}]
+    revision        1
+
+    checksums       rmd160  6891ba8ee4d79fd5a10e824db47b9083309306b3 \
                     sha256  553047902a738cc2e6b1cd42783a9d0992e47086773be30027a71e1293493c39 \
                     size    208879
-    }
 
+}
+
+if {${name} ne ${subport}} {
     worksrcdir      ${github.project}-${git.branch}
 
     depends_lib-append  port:curl \
@@ -52,9 +61,4 @@ if {${name} ne ${subport}} {
     destroot.args   ${build.args}
 
     livecheck.type  none
-} else {
-    livecheck.type  regex
-    livecheck.url   ${homepage}
-    livecheck.regex PYCURL (\[0-9\.\]+)
-    livecheck.version   ${version}
 }


### PR DESCRIPTION
#### Description

fixed checksums at py27-curl

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 11.0.1 20B50
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
