### PR TITLE
libomp: Update to 11.0.0; add 11 to clang_dep PG

### DIFF
--- a/_resources/port1.0/group/clang_dependency-1.0.tcl
+++ b/_resources/port1.0/group/clang_dependency-1.0.tcl
@@ -11,4 +11,4 @@ proc clang_dependency.extra_versions {versions} {
     }
 }
 
-clang_dependency.extra_versions {devel 10 9.0 8.0 7.0 6.0 5.0}
+clang_dependency.extra_versions {devel 11 10 9.0 8.0 7.0 6.0 5.0}

--- a/lang/libomp/Portfile
+++ b/lang/libomp/Portfile
@@ -38,11 +38,11 @@ if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} ne "libstdc++"} {
 
         livecheck.regex         {"llvmorg-([0-9.rc-]+)".*}
     } else {
-        version                 10.0.1
+        version                 11.0.0
         checksums \
-            rmd160  8655b63982229d726ba1d4838651a2b6a2671841 \
-            sha256  d19f728c8e04fb1e94566c8d76aef50ec926cd2f95ef3bf1e0a5de4909b28b44 \
-            size    955492
+            rmd160  24d25065c3ccff430995a903d62843f0bcd63670 \
+            sha256  2d704df8ca67b77d6d94ebf79621b0f773d5648963dd19e0f78efef4404b684c \
+            size    975108
 
         livecheck.regex         {"llvmorg-([0-9.]+)".*}
     }


### PR DESCRIPTION
Maintainer update (for libomp); added 11 to clang_dependency port group.