### PR TITLE
groovy: update to 3.0.7

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            groovy
-version         3.0.6
+version         3.0.7
 revision        0
 
 categories      lang java
@@ -41,9 +41,9 @@ master_sites    https://dl.bintray.com/${name}/maven/
 distname        apache-${name}-binary-${version}
 use_zip         yes
 
-checksums       rmd160  b3cf2c24ca93f842f17c24d302fc954b2fef7e85 \
-                sha256  6e0cc2d5b8a7b8585f15816c7d5cae1b09b4003ced0002e79abe7b4b1ebb35f2 \
-                size    43587616
+checksums       rmd160  5b7152283a2d50ef6db2a31dc174963963737de9 \
+                sha256  b9e2041cb83a963922f6761a0b037c5784670616632142b8d7002b7c3a96b7f5 \
+                size    43340743
 
 worksrcdir      ${name}-${version}
 


### PR DESCRIPTION
#### Description

Update to Groovy 3.0.7.

###### Tested on

macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?