### PR TITLE
go: update to 1.15.6

### DIFF
--- a/lang/go/Portfile
+++ b/lang/go/Portfile
@@ -8,7 +8,8 @@ legacysupport.newest_darwin_requires_legacy 13
 
 name                go
 epoch               2
-version             1.15.5
+version             1.15.6
+revision            0
 categories          lang
 platforms           darwin freebsd linux
 license             BSD
@@ -31,9 +32,9 @@ master_sites        https://storage.googleapis.com/golang/
 distfiles           ${name}${version}.src.tar.gz
 worksrcdir          ${name}
 
-checksums           rmd160  c5c60ae185efd5b399d222e2430380da7d3bf5e0 \
-                    sha256  c1076b90cf94b73ebed62a81d802cd84d43d02dea8c07abdc922c57a071c84f1 \
-                    size    23019303
+checksums           rmd160  e5455b5c4269582b5577d4ccb61e33d36ce9d877 \
+                    sha256  890bba73c5e2b19ffb1180e385ea225059eb008eb91b694875dd86ea48675817 \
+                    size    23019337
 
 depends_build       port:go-1.4
 


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
