### PR TITLE
babl-devel: make w3m an optional dependency via +docs variant

### DIFF
--- a/graphics/babl-devel/Portfile
+++ b/graphics/babl-devel/Portfile
@@ -27,10 +27,12 @@ fetch.type          git
 git.url             --depth 200 https://gitlab.gnome.org/GNOME/babl.git
 git.branch          ${git_commit}
 
+configure.args-append \
+                    -Dwith-docs=false
+
 depends_build-append \
                     port:pkgconfig \
-                    port:librsvg \
-                    port:w3m
+                    port:librsvg
 
 depends_lib-append  port:lcms2 \
                     port:gobject-introspection
@@ -58,6 +60,19 @@ if {[variant_isset universal]} {
 } else {
     build.env-append       "CC=${configure.cc} ${configure.cc_archflags}"
     destroot.env-append    "CC=${configure.cc} ${configure.cc_archflags}"
+}
+
+variant docs description {Generate optional docs} {
+    depends_build-append   port:w3m
+
+    configure.args-delete  -Dwith-docs=false
+    configure.args-append  -Dwith-docs=true
+
+    post-destroot {
+        xinstall -m 0755 -d ${destroot}${prefix}/share/doc/${name}
+        xinstall -m 0644 -W ${build.dir} README \
+            ${destroot}${prefix}/share/doc/${name}
+    }
 }
 
 livecheck.type      none


### PR DESCRIPTION
#### Description

w3m was not building on Big Sur (save for a workaround) and is not actively maintained. It is only used for generating an optional readme file, which we weren't even installing.

I removed w3m from babl in https://github.com/macports/macports-ports/pull/9176 and https://github.com/macports/macports-ports/commit/401f239a887a9a66688c32eee8c15e596bc2c1a2.

See https://trac.macports.org/ticket/61356

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->