### PR TITLE
argon2: Don't use rpath or -march=native; do install manpage

### DIFF
--- a/devel/argon2/Portfile
+++ b/devel/argon2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        P-H-C phc-winner-argon2 20190702
-revision            0
+revision            1
 name                argon2
 categories          devel
 platforms           darwin
@@ -22,18 +22,26 @@ checksums           rmd160  05b78cfa2309a25b6fed447236f1f37f92732cee \
                     sha256  3fa0b89e4db51141a071fae29387b08c23dc97813be04c2e15dcc1a9f6db2c00 \
                     size    1505325
 
+patchfiles          install-manpage.patch \
+                    no-rpath.patch
+
 use_configure no
 
 variant universal {}
+build.args-append   OPTTEST=1
 build.env-append    CC=${configure.cc} \
                     "CFLAGS=${configure.cflags} [get_canonical_archflags cc]" \
-                    "LDFLAGS=${configure.ldflags} [get_canonical_archflags ld]"
+                    "LDFLAGS=${configure.ldflags} [get_canonical_archflags ld]" \
+                    PREFIX=${prefix}
 destroot.destdir    PREFIX=${destroot}${prefix}
+destroot.args-append \
+                    OPTTEST=1
 destroot.env-append CC=${configure.cc} \
                     "CFLAGS=${configure.cflags} [get_canonical_archflags cc]" \
                     "LDFLAGS=${configure.ldflags} [get_canonical_archflags ld]"
 
 test.run            yes
+test.args-append    OPTTEST=1
 test.env-append     CC=${configure.cc} \
                     "CFLAGS=${configure.cflags} [get_canonical_archflags cc]" \
                     "LDFLAGS=${configure.ldflags} [get_canonical_archflags ld]"

--- a/devel/argon2/files/install-manpage.patch
+++ b/devel/argon2/files/install-manpage.patch
@@ -1,0 +1,59 @@
+Install manpage.
+https://github.com/P-H-C/phc-winner-argon2/pull/273
+--- Makefile.orig
++++ Makefile
+@@ -19,6 +19,7 @@ RUN = argon2
+ BENCH = bench
+ GENKAT = genkat
+ ARGON2_VERSION ?= ZERO
++MAN = man/argon2.1
+ 
+ # installation parameters for staging area and final installation path
+ # Note; if Linux and not Debian/Ubuntu version also add lib override to make command-line
+@@ -136,6 +137,7 @@ ifeq ($(KERNEL_NAME), $(filter $(KERNEL_NAME),DragonFly FreeBSD))
+ BINARY_REL ?= bin
+ INCLUDE_REL ?= include
+ LIBRARY_REL ?= lib
++MAN_REL ?= share/man/man1
+ PKGCONFIG_REL ?= libdata
+ 
+ else ifeq ($(KERNEL_NAME)-$(MACHINE_NAME), Linux-x86_64)
+@@ -144,6 +146,7 @@ else ifeq ($(KERNEL_NAME)-$(MACHINE_NAME), Linux-x86_64)
+ BINARY_REL ?= bin
+ INCLUDE_REL ?= include
+ LIBRARY_REL ?= lib/x86_64-linux-gnu
++MAN_REL ?= share/man/man1
+ PKGCONFIG_REL ?= $(LIBRARY_REL)
+ 
+ else
+@@ -152,6 +155,7 @@ else
+ BINARY_REL ?= bin
+ INCLUDE_REL ?= include
+ LIBRARY_REL ?= lib
++MAN_REL ?= share/man/man1
+ PKGCONFIG_REL ?= $(LIBRARY_REL)
+ 
+ endif
+@@ -160,6 +164,7 @@ endif
+ INST_INCLUDE = $(DESTDIR)$(PREFIX)/$(INCLUDE_REL)
+ INST_LIBRARY = $(DESTDIR)$(PREFIX)/$(LIBRARY_REL)
+ INST_BINARY = $(DESTDIR)$(PREFIX)/$(BINARY_REL)
++INST_MAN = $(DESTDIR)$(PREFIX)/$(MAN_REL)
+ INST_PKGCONFIG = $(DESTDIR)$(PREFIX)/$(PKGCONFIG_REL)/pkgconfig
+ 
+ # main target
+@@ -242,6 +247,8 @@ ifdef LINKED_LIB_SH
+ endif
+ 	$(INSTALL) -d $(INST_BINARY)
+ 	$(INSTALL) $(RUN) $(INST_BINARY)
++	$(INSTALL) -d $(INST_MAN)
++	$(INSTALL) -m 0644 $(MAN) $(INST_MAN)
+ 	$(INSTALL) -d $(INST_PKGCONFIG)
+ 	$(INSTALL) -m 0644 $(PC_NAME) $(INST_PKGCONFIG)
+ 
+@@ -250,4 +257,5 @@ uninstall:
+ 	cd $(INST_INCLUDE) && rm -f $(notdir $(HEADERS))
+ 	cd $(INST_LIBRARY) && rm -f $(notdir $(LIBRARIES) $(LINKED_LIB_SH))
+ 	cd $(INST_BINARY) && rm -f $(notdir $(RUN))
++	cd $(INST_MAN) && rm -f $(notdir $(MAN))
+ 	cd $(INST_PKG_CONFIG) && rm -f $(notdir $(PC_NAME))

--- a/devel/argon2/files/no-rpath.patch
+++ b/devel/argon2/files/no-rpath.patch
@@ -1,0 +1,13 @@
+Don't use @rpath.
+https://github.com/P-H-C/phc-winner-argon2/pull/309
+--- Makefile.orig	2019-05-20 04:18:00.000000000 -0500
++++ Makefile	2020-12-03 14:31:31.000000000 -0600
+@@ -83,7 +83,7 @@
+ endif
+ ifeq ($(KERNEL_NAME), Darwin)
+ 	LIB_EXT := $(ABI_VERSION).dylib
+-	LIB_CFLAGS := -dynamiclib -install_name @rpath/lib$(LIB_NAME).$(LIB_EXT)
++	LIB_CFLAGS = -dynamiclib -install_name $(PREFIX)/$(LIBRARY_REL)/lib$(LIB_NAME).$(LIB_EXT)
+ 	LINKED_LIB_EXT := dylib
+ 	PC_EXTRA_LIBS ?=
+ endif

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -395,10 +395,10 @@ subport ${php} {
         5.6.40              {revision 4}
         7.0.33              {revision 3}
         7.1.33              {revision 1}
-        7.2.34              {revision 1}
-        7.3.25              {revision 1}
-        7.4.13              {revision 1}
-        8.0.0               {revision 1}
+        7.2.34              {revision 2}
+        7.3.25              {revision 2}
+        7.4.13              {revision 2}
+        8.0.0               {revision 2}
     }
     
     depends_run             port:php_select
@@ -545,10 +545,10 @@ subport ${php}-apache2handler {
         5.6.40              {revision 1}
         7.0.33              {revision 1}
         7.1.33              {revision 1}
-        7.2.34              {revision 1}
-        7.3.25              {revision 1}
-        7.4.13              {revision 1}
-        8.0.0               {revision 1}
+        7.2.34              {revision 2}
+        7.3.25              {revision 2}
+        7.4.13              {revision 2}
+        8.0.0               {revision 2}
     }
     
     description             ${php} Apache 2 Handler SAPI
@@ -610,10 +610,10 @@ subport ${php}-cgi {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.33              {revision 0}
-        7.2.34              {revision 1}
-        7.3.25              {revision 1}
-        7.4.13              {revision 1}
-        8.0.0               {revision 1}
+        7.2.34              {revision 2}
+        7.3.25              {revision 2}
+        7.4.13              {revision 2}
+        8.0.0               {revision 2}
     }
 
     description             ${php} CGI SAPI
@@ -651,10 +651,10 @@ subport ${php}-fpm {
         5.6.40              {revision 1}
         7.0.33              {revision 1}
         7.1.33              {revision 1}
-        7.2.34              {revision 1}
-        7.3.25              {revision 1}
-        7.4.13              {revision 1}
-        8.0.0               {revision 1}
+        7.2.34              {revision 2}
+        7.3.25              {revision 2}
+        7.4.13              {revision 2}
+        8.0.0               {revision 2}
     }
 
     description             ${php} FPM SAPI

--- a/security/KeePassXC/Portfile
+++ b/security/KeePassXC/Portfile
@@ -21,6 +21,7 @@ license                 GPL-2+
 license_noconflict      openssl
 
 github.setup            keepassxreboot keepassxc 2.6.2
+revision                1
 github.tarball_from     releases
 distname                keepassxc-${version}-src
 use_xz                  yes


### PR DESCRIPTION
#### Description

argon2: Don't use rpath or -march=native; do install manpage

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14019
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
