### PR TITLE
commitizen: update to 2.10.0 and add bash completion

### DIFF
--- a/devel/commitizen/Portfile
+++ b/devel/commitizen/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                commitizen
-version             2.9.0
+version             2.10.0
 categories-prepend  devel
 platforms           darwin
 license             MIT
@@ -25,14 +25,14 @@ long_description    Commitizen is a tool designed for teams. Its main purpose is
 
 homepage            https://commitizen-tools.github.io/commitizen/
 
-checksums           rmd160  cff681cfa397a8e1c9e1718cda4d39584014b82f \
-                    sha256  9d1b92688d417d600257e50d55c1f9aa61dea0588ac4272d33b75caf02687ca6 \
-                    size    29386
+checksums           rmd160  59ed92de84ef7d097c9eeb6a8d80cab278ea8388 \
+                    sha256  33e515940e49355381d29f41081124c0203d92dfce399b82ea4b04a74fc16cba \
+                    size    29807
 
 depends_build-append \
     port:py${python.version}-setuptools
 
-depends_lib-append \
+depends_run-append \
     port:py${python.version}-colorama \
     port:py${python.version}-decli \
     port:py${python.version}-jinja2 \
@@ -41,5 +41,17 @@ depends_lib-append \
     port:py${python.version}-termcolor \
     port:py${python.version}-tomlkit \
     port:py${python.version}-yaml
+
+default_variants    +bash
+
+variant bash description {Include Bash completion support} {
+    depends_run-append \
+        port:py${python.version}-argcomplete \
+        port:bash
+
+    notes-append "
+        To use bash completion, run the following:
+            register-python-argcomplete-${python.branch} cz >> ~/.bashrc"
+}
 
 livecheck.type      pypi


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.6 19G73
xcode-select version 2373

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
