### PR TITLE
x264: fix building on apple silicon

### DIFF
--- a/multimedia/x264/Portfile
+++ b/multimedia/x264/Portfile
@@ -35,7 +35,8 @@ depends_build       port:nasm
 
 # as of 20190313 the PPC assembly uses VSX, which is Power7+ only. We could disable asm, but
 # instead we can use the previous ppc assembly,  which does compile and provides the same functions
-patchfiles-append   patch-x264-older-ppc-code.diff
+patchfiles-append   patch-x264-older-ppc-code.diff \
+                    patch-x264-apple-silicon.diff
 
 configure.args      --enable-pic \
                     --enable-shared \

--- a/multimedia/x264/files/patch-x264-apple-silicon.diff
+++ b/multimedia/x264/files/patch-x264-apple-silicon.diff
@@ -1,0 +1,93 @@
+https://code.videolan.org/videolan/x264/-/commit/eb95c2965299ba5b8598e2388d71b02e23c9fba7.patch
+
+From eb95c2965299ba5b8598e2388d71b02e23c9fba7 Mon Sep 17 00:00:00 2001
+From: Damiano Galassi <damiog@gmail.com>
+Date: Thu, 23 Jul 2020 17:23:09 +0200
+Subject: [PATCH] update config.* and configure: add Apple Silicon support.
+
+---
+ config.guess |  3 +++
+ config.sub   |  4 ++--
+ configure    | 24 ++++++++++++------------
+ 3 files changed, 17 insertions(+), 14 deletions(-)
+
+diff --git a/config.guess b/config.guess
+index 2fb9f880..ab192f67 100755
+--- config.guess
++++ config.guess
+@@ -1238,6 +1238,9 @@ EOF
+     *:Rhapsody:*:*)
+ 	echo ${UNAME_MACHINE}-apple-rhapsody${UNAME_RELEASE}
+ 	exit ;;
++    arm64:Darwin:*:*)
++	echo arm64-apple-darwin${UNAME_RELEASE}
++	exit ;;
+     *:Darwin:*:*)
+ 	UNAME_PROCESSOR=`uname -p` || UNAME_PROCESSOR=unknown
+ 	case $UNAME_PROCESSOR in
+diff --git a/config.sub b/config.sub
+index 8df55110..72e9265b 100755
+--- config.sub
++++ config.sub
+@@ -255,7 +255,7 @@ case $basic_machine in
+ 	# Some are omitted here because they have special meanings below.
+ 	1750a | 580 \
+ 	| a29k \
+-	| aarch64 | aarch64_be \
++	| aarch64 | aarch64_be | arm64 \
+ 	| alpha | alphaev[4-8] | alphaev56 | alphaev6[78] | alphapca5[67] \
+ 	| alpha64 | alpha64ev[4-8] | alpha64ev56 | alpha64ev6[78] | alpha64pca5[67] \
+ 	| am33_2.0 \
+@@ -369,7 +369,7 @@ case $basic_machine in
+ 	# Recognize the basic CPU types with company name.
+ 	580-* \
+ 	| a29k-* \
+-	| aarch64-* | aarch64_be-* \
++	| aarch64-* | aarch64_be-* | arm64*-* \
+ 	| alpha-* | alphaev[4-8]-* | alphaev56-* | alphaev6[78]-* \
+ 	| alpha64-* | alpha64ev[4-8]-* | alpha64ev56-* | alpha64ev6[78]-* \
+ 	| alphapca5[67]-* | alpha64pca5[67]-* | arc-* \
+diff --git a/configure b/configure
+index 266fcffa..10aa2fd4 100755
+--- configure
++++ configure
+@@ -821,6 +821,18 @@ case $host_cpu in
+         AS="${AS-${CC}}"
+         AS_EXT=".c"
+         ;;
++    aarch64|arm64*)
++        ARCH="AARCH64"
++        stack_alignment=16
++        if [ "$SYS" = MACOSX ] ; then
++            AS="${AS-${CC}}"
++            ASFLAGS="$ASFLAGS -DPREFIX -DPIC"
++        elif [ "$SYS" = WINDOWS ] && [ "$compiler" = CL ] ; then
++            AS="${AS-${SRCPATH}/tools/gas-preprocessor.pl -arch aarch64 -as-type armasm -- armasm64 -nologo}"
++        else
++            AS="${AS-${CC}}"
++        fi
++        ;;
+     arm*)
+         ARCH="ARM"
+         if [ "$SYS" = MACOSX ] ; then
+@@ -839,18 +851,6 @@ case $host_cpu in
+             AS="${AS-${CC}}"
+         fi
+         ;;
+-    aarch64)
+-        ARCH="AARCH64"
+-        stack_alignment=16
+-        if [ "$SYS" = MACOSX ] ; then
+-            AS="${AS-${CC}}"
+-            ASFLAGS="$ASFLAGS -DPREFIX -DPIC"
+-        elif [ "$SYS" = WINDOWS ] && [ "$compiler" = CL ] ; then
+-            AS="${AS-${SRCPATH}/tools/gas-preprocessor.pl -arch aarch64 -as-type armasm -- armasm64 -nologo}"
+-        else
+-            AS="${AS-${CC}}"
+-        fi
+-        ;;
+     s390|s390x)
+         ARCH="S390"
+         ;;
+--
+GitLab


### PR DESCRIPTION
#### Description

Fix building x264 on Apple Silicon based on upstream patch

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
