### PR TITLE
mpv: fix building on apple silicon

### DIFF
--- a/multimedia/mpv/Portfile
+++ b/multimedia/mpv/Portfile
@@ -165,7 +165,7 @@ platform macosx {
         compiler.blacklist-append   *gcc* cc macports-*
     }
 
-    if {${os.major} <= 14 || ${configure.build_arch} ne "x86_64"} {
+    if {${os.major} <= 14 || [lsearch -exact [list x86_64 arm64] ${configure.build_arch}] == -1} {
         # Disable Cocoa output.
         # Users on old systems will need to embrace X11.
         configure.args-replace      --enable-cocoa \
@@ -262,7 +262,8 @@ platform darwin {
     }
 
     # Fix for https://trac.macports.org/ticket/61319
-    configure.env-append MACOS_SDK=${configure.sdkroot}
+    configure.env-append   MACOS_SDK=${configure.sdkroot}
+    configure.env-append   MACOS_SDK_VERSION=${configure.sdk_version}
 
     post-extract {
         xinstall -m 0644 -W "${filespath}" config-maintainer "${worksrcpath}/TOOLS/"
@@ -287,7 +288,7 @@ platform darwin {
             reinplace -W "${worksrcpath}/TOOLS" "/@@HWDEC_CUDA@@/d" config-maintainer
         }
 
-        if {${os.major} < 11 || ${configure.build_arch} ne "x86_64"} {
+        if {${os.major} < 11 || [lsearch -exact [list x86_64 arm64] ${configure.build_arch}] == -1} {
             reinplace -W "${worksrcpath}/TOOLS" "s/@@BACKEND@@/x11/" config-maintainer
         } else {
             reinplace -W "${worksrcpath}/TOOLS" "s/@@BACKEND@@/cocoa/" config-maintainer


### PR DESCRIPTION
#### Description

Fix building on Apple Silicon. Also depends on the following patches:

* #9252 libvpx: fix configuration for arm64 
* #9336 x264: fix building on apple silicon 

Possibly also fixes https://trac.macports.org/ticket/61733 due to [upstream no longer hard-coding sdk version](https://github.com/mpv-player/mpv/commit/5ae6f04d6bb3647419b02e0e0f4d8198b9e44bb2). This patch sets `MACOS_SDK_VERSION` directly rather than relying on `-target` parsing in build script.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?