### PR TITLE
k9s: update to 0.24.2

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.24.1 v
+go.setup            github.com/derailed/k9s 0.24.2 v
 homepage            https://k9scli.io
 
 categories          sysutils devel
@@ -20,9 +20,9 @@ platforms           darwin
 supported_archs     x86_64
 license             Apache-2
 
-checksums           rmd160  38e2324b6c0697c39accc09e5099e765d3704f85 \
-                    sha256  df6133c889a4796f032775f26c5e19b24a00994633e895264d9e584216aaf660 \
-                    size    6108140
+checksums           rmd160  dd04ff16073e42b6ace63e3cc9634a189f7b0185 \
+                    sha256  8fd17f788b0b952974716c557a159287d5e38e8eb0b8aa5c177b1d1034a3192a \
+                    size    6181931
 
 # Reproduce the "build" target from the upstream Makefile
 set go_ldflags      "-w -s \


### PR DESCRIPTION
#### Description

Update to K9s 0.24.2.

###### Tested on

macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?