### PR TITLE
emacs-deve: upgrade nativecomp branch

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -103,12 +103,11 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
     legacysupport.newest_darwin_requires_legacy 13
 
     epoch           1
-    version         20201127
-    revision        2
+    version         20201224
 
     fetch.type      git
     git.url         --depth=1000 https://github.com/emacs-mirror/emacs.git
-    git.branch      a7825c4be06b7c0b544df34555ecf586276245e6
+    git.branch      81fe928a769d9a63078aa1144335c204a2541595
 
     pre-configure {
         system -W ${worksrcpath} "sh ./autogen.sh"
@@ -118,7 +117,7 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
 
     variant nativecomp description {Builds emacs with native compilation support} {
         git.url-prepend  --branch feature/native-comp
-        git.branch  949b49cf771e8f38b23adb3fa4f9d7a9a5e290da
+        git.branch       981240078cddbd26b35a65e5311350196542b42b
 
         depends_build-append     port:coreutils
         depends_lib-append       port:gcc10


### PR DESCRIPTION
#### Description

The cause of this upgrade is to include[^1] fix for bug 44968[^2] that my crash emacs on some simple cases like:
 - `(setq )`,
 - reply to email via wanderlust that contanins have HTML content.

Desire commit: https://github.com/emacs-mirror/emacs/commit/21104e6808a4496afb8163d92c6fb4d59e3010b7

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 11.0.1 20B50
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

[^1]: https://github.com/emacs-mirror/emacs/commit/21104e6808a4496afb8163d92c6fb4d59e3010b7

[^2]: https://debbugs.gnu.org/cgi/bugreport.cgi?bug=44968
