### PR TITLE
syncthing: update to 1.12.0

### DIFF
--- a/net/syncthing/Portfile
+++ b/net/syncthing/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/syncthing/syncthing 1.11.1 v
+go.setup            github.com/syncthing/syncthing 1.12.0 v
 categories          net
 platforms           darwin
 license             MPL-2
@@ -18,11 +18,16 @@ long_description    Syncthing replaces proprietary sync and cloud services \
 homepage            https://syncthing.net
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  ad23a6c83c7c159519cf591093c099a407eb342e \
-                        sha256  eb71b31f38dcae538eaf88109e9de6537850e4c222e5e373f9dd6a1c5d3c7a97 \
-                        size    4938797
+                        rmd160  174051bb18728ed6a47aabd75129ca96b8f6ddad \
+                        sha256  8288a94a8a0ed62d3b7b07607cff7540f30ee9d016db39a658384c6bce6d2385 \
+                        size    5002452
 
-go.vendors          gopkg.in/yaml.v2 \
+go.vendors          gopkg.in/yaml.v3 \
+                        lock    9f266ea9e77c \
+                        rmd160  06dca2ede07b2f31c515b4711fbebc1d5359b5e4 \
+                        sha256  e70dd42fb30b7b2d0129c5cdf0e079caaf5602cab24081fdac830ec01204fa59 \
+                        size    86890 \
+                    gopkg.in/yaml.v2 \
                         lock    v2.3.0 \
                         rmd160  2f8fa56d8a413b6288132eeb7f0d7c64d27d877f \
                         sha256  a8d1a8bc88239d25507456380b47d59ae3683d4a5f4336da4892db1ce026615f \
@@ -32,113 +37,92 @@ go.vendors          gopkg.in/yaml.v2 \
                         rmd160  ae07f5ddbbc6afc772d6dc5273bb72eaba50529a \
                         sha256  91c562a4e31c89d13e5391143ff653231fc2d80562743db89ce2172ad8f81008 \
                         size    3636 \
-                    gopkg.in/fsnotify.v1 \
-                        repo    github.com/fsnotify/fsnotify \
-                        lock    c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9 \
-                        rmd160  24712e412814020224e2779186e634610e2f6926 \
-                        sha256  bc839ee158ad34b81c1f11c3b9e3bcbabfba3297f61d165599880c400b8171dc \
-                        size    31147 \
                     gopkg.in/check.v1 \
                         lock    41f04d3bba15 \
                         rmd160  1e5543a8e6a3159296ee63e28cbde9931a04f6b3 \
                         sha256  c41575a73d10809f89b05ef9e783f2d53facdc6573697770d30efb05a9d2dc28 \
                         size    31612 \
-                    gopkg.in/alecthomas/kingpin.v2 \
-                        lock    v2.2.6 \
-                        rmd160  af6db4648ec7638fb5cab49fd9536caa705f5fed \
-                        sha256  31378085783496cff78c7d41479ccd6206c4f4e3892909ef0c2cd39e2de3b039 \
-                        size    44374 \
                     google.golang.org/protobuf \
                         repo    github.com/protocolbuffers/protobuf-go \
-                        lock    v1.25.0 \
-                        rmd160  ca1a78077118747c660917e50c4273d69b0f04ea \
-                        sha256  5bc3eb5d7160ab9ae45255d6b718c1cf9e9ed80c244b7527bced50370ae18620 \
-                        size    1259096 \
+                        lock    v1.23.0 \
+                        rmd160  b9954ce9dc927216440d55f850073bbf47113143 \
+                        sha256  41a885f3290ce459bcd4251a6df0787ead449c835a718f8f46342cad1dc26b85 \
+                        size    1214926 \
                     golang.org/x/xerrors \
                         lock    5ec99f83aff1 \
                         rmd160  6e8267f353e153297f205e4be219236d6ae43880 \
                         sha256  9a500a49d83a09e7de6c71b215d1c14b81e315d26884530ef327c95ddf1f2d28 \
                         size    13667 \
                     golang.org/x/time \
-                        lock    9d24e82272b4 \
-                        rmd160  8f037e1cd7a3667593b21ecd73779f9cacd0ca4b \
-                        sha256  c2b48ec888795d12f2f145d636f5e6b9131439c2b5156f6d6cad89d1ef6cbae2 \
-                        size    9314 \
+                        lock    3af7569d3a1e \
+                        rmd160  6ec4017fbe0897df74acfb012623482602c33dae \
+                        sha256  c918feb3b40248a7b153f402b25a1fed5726ff73fa448c067cd9a1899df5e1f5 \
+                        size    9625 \
                     golang.org/x/text \
-                        lock    v0.3.3 \
-                        rmd160  babfa547ba9a9dab7fe08fa5543f1d8e7ae00301 \
-                        sha256  1c4a8c12295d484e0360d8e010ebc4b8a9a05aa2a07c10c3d3e5b17aa063f0db \
-                        size    7745597 \
+                        lock    v0.3.4 \
+                        rmd160  2b9cc1c618efac6184ba3cc497945bfe8299878b \
+                        sha256  4f7508324739fdddcc1bf653a755608aa8ed0119d297ba7460d812e67d661e6a \
+                        size    8347767 \
                     golang.org/x/sys \
-                        lock    aee5d888a860 \
-                        rmd160  9d3b513abda2fa75f2dba2c62a484bba28b5177f \
-                        sha256  ac208a9aba50798244004845494d75f8dcc8893d960a89f2b019298c33dfec31 \
-                        size    1065651 \
-                    golang.org/x/sync \
-                        lock    42b317875d0f \
-                        rmd160  1cb7dc676b56b5687f384115dda8b608c0855fb6 \
-                        sha256  93014215265c6737487961e64a7218a7144fc93e3dc2923d8e08c10e3fb90d49 \
-                        size    16239 \
+                        lock    da207088b7d1 \
+                        rmd160  8c8111fa56a17c9a6dc921bbde2495f3b8bca3c9 \
+                        sha256  0e42fcc8a45bf8c25a070d0f7245f8a62b45bb9a4966c893c1bc8506b011e88c \
+                        size    1085059 \
                     golang.org/x/net \
-                        lock    3edf25e44fcc \
-                        rmd160  46d0720f234d9b93602e7aa6ad3fc4c6ed0097f4 \
-                        sha256  179d5d7db70e06ee4ccf6f4f4ec20e93483cb92839b08fd229f5bedb60ce172b \
-                        size    1178535 \
+                        lock    ff519b6c9102 \
+                        rmd160  78d6174e2b669f537a5df1e2945d47f737b9e7ae \
+                        sha256  abe822419126a02ff65c26fe14994787b0d29a1b7633471fd3ed04c3e6b1c150 \
+                        size    1248882 \
                     golang.org/x/crypto \
-                        lock    123391ffb6de \
-                        rmd160  4afdc76f139facd878c228d85dee3698de13f793 \
-                        sha256  1b8f464f2d4faca0ac6ac7eac18b2b1118c1ac9ff8f6b7ffc976fb0ebedc520f \
-                        size    1732579 \
+                        lock    9e8e0b390897 \
+                        rmd160  bd4738a1bbf4d94ec5f840e7425ffa473c6b97bd \
+                        sha256  1b740a92e71e7215af0a8c3651c5e4925eaaf0f49e718ffd2dc8310452894236 \
+                        size    1732591 \
                     github.com/vitrun/qart \
                         lock    bf64b92db6b0 \
                         rmd160  50ea47d1b1d0b60138845f21d57cad0ac7e5e632 \
                         sha256  58579d35e03703699b3ea56a096b665739a77b462ac18a29102c7c776e48d279 \
                         size    23968 \
                     github.com/urfave/cli \
-                        lock    v1.22.2 \
-                        rmd160  746f9142b63e5e1483cba880f2f953a4b04ababc \
-                        sha256  ed8049ce905c5267524ce3208d113bf162e5c53ea4a05d2bb1427fd41b729041 \
-                        size    76137 \
+                        lock    v1.22.4 \
+                        rmd160  fc14cf328e371c1f0f3baceea5df4d4de63ca134 \
+                        sha256  60f4eecd8fe79ace077fe6517f0d4f3950901bfbcc66ddc83cd944e7ddab4c79 \
+                        size    78058 \
                     github.com/thejerf/suture \
-                        lock    v3.0.2 \
-                        rmd160  6df06f4bd54773997535e47b76a9a7345c9e7b6c \
-                        sha256  d6d7aeebed3a2e404e0f8ca062ea79ea8be60357eb8336fe907cff8952ce36f2 \
-                        size    18049 \
+                        lock    v4.0.0 \
+                        rmd160  8d577b993b9e9014c30103bc664e89e67e60d7f7 \
+                        sha256  b64ec71c02bc46d3f700c5adf4e36b08e6ab5e99f43298f82dd6ee9386f539ba \
+                        size    37634 \
                     github.com/syndtr/goleveldb \
                         lock    d9e9293bd0f7 \
                         rmd160  1c363aa498b3fae0918bf839dcaa673193080f50 \
                         sha256  9fb936ce779314cfa755bd208b8a5ba7e4f41c23bd7a1d61bda6facb5d13052b \
                         size    151087 \
                     github.com/syncthing/notify \
-                        lock    69c7a957d3e2 \
-                        rmd160  3d333cd938237b648d477739c0b6463ef9a81df0 \
-                        sha256  ab539bdfb1e08ed2f5a73909ca7e6c28448d733640566d61a6f3e9e9ccf27177 \
-                        size    57118 \
+                        lock    9a0e44181151 \
+                        rmd160  44aaebc5bfd99c236bd39a067b72bacd197c8d98 \
+                        sha256  a445d3ffc362cb2a96f2601cfed00a831be9d75db47f11be7df8be433112e88d \
+                        size    57446 \
                     github.com/stretchr/testify \
-                        lock    v1.5.1 \
-                        rmd160  db9d43c3c804950ce9650d830f7dea5434ed83c1 \
-                        sha256  e5f566d1c23fb2b987f8a9f139e32866c1eea8c72051da25bbf6880a4f8c541a \
-                        size    78702 \
+                        lock    v1.6.1 \
+                        rmd160  7e5b798212a8f15cd58a63985ae0b928eede8e6b \
+                        sha256  44d77d9b5c1dc08fa710eac9bb324898210660458085cdf965b78a39b1010f2a \
+                        size    84248 \
                     github.com/spaolacci/murmur3 \
                         lock    v1.1.0 \
                         rmd160  53215abb0d59b6c64e926e90fb33da1906a1a525 \
                         sha256  54d6a3300600dd2f5e444f6d19fe1f91e1174329cdfff1d50dae837689214a68 \
                         size    7396 \
-                    github.com/sirupsen/logrus \
-                        lock    v1.4.2 \
-                        rmd160  9245d7ebabf259e649892609e598a2284e89e499 \
-                        sha256  c3eaf49a2a03ce42b20b5db84771a7d447465475bf083f289ecee631063e6090 \
-                        size    41379 \
                     github.com/shurcooL/sanitized_anchor_name \
                         lock    v1.0.0 \
                         rmd160  c7e5322dba53e10db1711d65c146af5649b0c7c8 \
                         sha256  ed9418de8c92acfbbd8608745855ebfc67fa686c0a0a5245cf8eece8f540baa9 \
                         size    2144 \
                     github.com/shirou/gopsutil \
-                        lock    v2.20.7 \
-                        rmd160  6d8f6cdc07b3688a8fdcb4fb3a7947330d279132 \
-                        sha256  fb92f1357babf7b5ac07ed48740cc840917bbfe31b85f620669f9b648f86d1ba \
-                        size    139662 \
+                        lock    v3.20.10 \
+                        rmd160  a805ad80e2bc80782911443c0726ae653a90dde8 \
+                        sha256  6e30413c9644817d228e258aeea6134ef01dcac80fadfa9f5175a1910cb561c7 \
+                        size    278035 \
                     github.com/sasha-s/go-deadlock \
                         lock    v0.2.0 \
                         rmd160  e9a7e7a4994c375c6fbf1a2773e37e1cd3bf2325 \
@@ -150,30 +134,30 @@ go.vendors          gopkg.in/yaml.v2 \
                         sha256  4078d2cd3b1c6952133b214e4eaca95f3b31a01f87a03adabd7712e7d5f20f60 \
                         size    79665 \
                     github.com/rcrowley/go-metrics \
-                        lock    cac0b30c2563 \
-                        rmd160  10f565254cbcee6a0288d19fcda77964c6cc9689 \
-                        sha256  bd5e5564f6ef65bd7ac946d97cae11ac1b55071bc58109fdc1053a65d3cef544 \
-                        size    37564 \
+                        lock    10cdbea86bc0 \
+                        rmd160  7b4f842f6213dba7801a22e09d51c7af089a8251 \
+                        sha256  8d07891e7f30110a7fc528237b86b067e1ade791f38d68019a5030a29081fbc9 \
+                        size    37568 \
                     github.com/prometheus/procfs \
-                        lock    v0.0.5 \
-                        rmd160  dde8f0bc104aeac6655947850ec8e8a05a9a9d12 \
-                        sha256  9c445cfa36a01b144eff139afd88dd3c199d54e91d5ae7de6ece0f57b464eebd \
-                        size    112195 \
+                        lock    v0.2.0 \
+                        rmd160  7ce571274023d4a96649d6e9216a79a43469523d \
+                        sha256  88ef0f9d6f482b5d9d45f2668bca578096114fd959b1e01f1272e57ab5f8ce77 \
+                        size    157409 \
                     github.com/prometheus/common \
-                        lock    v0.7.0 \
-                        rmd160  71589422d9f6d26d1d28e631322077e19818e554 \
-                        sha256  95baf93244a8160dffe12d220a06c54bf209f7cf0bf1196c686623f3da570fed \
-                        size    100513 \
+                        lock    v0.14.0 \
+                        rmd160  3d5ae8b32dc487071c5534703c64d845f4c818ed \
+                        sha256  87d2b4bdfd7a09edd3b695cb40e391f5dae87ae4c0114fa5700afa4c36e3e124 \
+                        size    124246 \
                     github.com/prometheus/client_model \
-                        lock    14fe0d1b01d4 \
-                        rmd160  bae29b48506431235790421af9f1e0dcbd36baad \
-                        sha256  94563daff6cc4a700ce53e69039fd11a9ddcf35da6ae1048a0d99268d63327ae \
-                        size    57496 \
+                        lock    v0.2.0 \
+                        rmd160  9b5b538e80eeb491b02806cc1cb87a83e62a9577 \
+                        sha256  55c1223bb5d1ae7e33527bc0ce80e3ab5153c47d396a9f864feea150b301f690 \
+                        size    10985 \
                     github.com/prometheus/client_golang \
-                        lock    v1.2.1 \
-                        rmd160  fba18019de66807a9a4a9381f69eb2e7097a0ad0 \
-                        sha256  0bbb4b4c3e907fbcf9475b5ca957fd165e24fd5378751c121a00ea4e6a4da7ca \
-                        size    142483 \
+                        lock    v1.8.0 \
+                        rmd160  bb9642634eb3d2d57591edd2c45e6a91f98505be \
+                        sha256  37366f9bc01b5f804c29064d80f7c629c3a2104be9ae24134b6e6b47a1259775 \
+                        size    175680 \
                     github.com/pmezard/go-difflib \
                         lock    v1.0.0 \
                         rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
@@ -214,16 +198,16 @@ go.vendors          gopkg.in/yaml.v2 \
                         rmd160  33d7373bd1b164159b9032fc8595bb09b25598f6 \
                         sha256  16d8773e0be69469d3c296ee785bbef433c3442defb68760682cdbcf80ba40ee \
                         size    1238830 \
+                    github.com/miscreant/miscreant.go \
+                        lock    26d376326b75 \
+                        rmd160  cd64e010e3f36e163e269369dc7fb0c710ca41a9 \
+                        sha256  a949004fc78e2d46faa48efbc8d6e00fa6bc12602ccc9338e0490d12e0707ce8 \
+                        size    21288 \
                     github.com/minio/sha256-simd \
                         lock    v0.1.1 \
                         rmd160  50654a6c3da3bcc426cb9189299e1d8d76f52a2b \
                         sha256  ab49163b74a1b89c8ab795eda31cbf65af572fe3f87028cc1234bac2ae45706c \
                         size    65042 \
-                    github.com/mgutz/ansi \
-                        lock    9520e82c474b \
-                        rmd160  fea73fc246ac2b229bb91accba053fed2ea63536 \
-                        sha256  75eaed501d7d121ad75c83246fecdc6222dbbbd3fcb4140c8775e219fff440ce \
-                        size    4878 \
                     github.com/matttproud/golang_protobuf_extensions \
                         lock    v1.0.1 \
                         rmd160  e28c4169919e72c08ee6520ad2ce16943d18e40c \
@@ -234,11 +218,6 @@ go.vendors          gopkg.in/yaml.v2 \
                         rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
                         sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
                         size    4549 \
-                    github.com/mattn/go-colorable \
-                        lock    v0.1.6 \
-                        rmd160  3c6531ff68909aacc83a16f92149722803b465a7 \
-                        sha256  3f3b5a79ae9511dd610d288768d782faffa27bf92ad1d6c8be3f37aa9d3bc975 \
-                        size    9477 \
                     github.com/maruel/panicparse \
                         lock    v1.5.1 \
                         rmd160  c8ea9da4d1a8fe96cefd2ca3b5ded74bad7b89e3 \
@@ -255,30 +234,35 @@ go.vendors          gopkg.in/yaml.v2 \
                         sha256  9db255f013988eee87447b47a3510b56cfb3e0acb1e4f0af13215b971a82f6b4 \
                         size    403908 \
                     github.com/lucas-clemente/quic-go \
-                        lock    v0.18.0 \
-                        rmd160  bd251272351789e63b94f6fb406261445df01fec \
-                        sha256  d4c438d4a23aaaa530b4a34e1106f77409133f5c14b8dc81aa5f98fc1e13b06c \
-                        size    488513 \
+                        lock    v0.18.1 \
+                        rmd160  fa742ed3bfd5b74e7c8d8b86eb18a1313a9685e3 \
+                        sha256  de1608164707258a25fc9f7293068cb1b6f975b593834e71fa1327ed8d3086e6 \
+                        size    488876 \
                     github.com/lib/pq \
-                        lock    v1.2.0 \
-                        rmd160  603d1ccb9fa23ba97f9c07922270270101dec935 \
-                        sha256  05784d4f62cfa2c79416a62fcd3a854b3d6b8cef690119fd9c091300ccb92190 \
-                        size    96102 \
+                        lock    v1.8.0 \
+                        rmd160  3bdbb0bd8abc244e2a17318be93ca6e9ba11d982 \
+                        sha256  429ff821078da5e4b4e4d8b7fc7dd9d9bd5c625164f5fb20d2af14d3ce2bebdd \
+                        size    101968 \
                     github.com/kr/text \
                         lock    v0.1.0 \
                         rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
                         sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
                         size    8691 \
                     github.com/kr/pretty \
-                        lock    v0.2.0 \
-                        rmd160  45bbf0be7a3328e33186718ab12cb506c0f5a073 \
-                        sha256  35fb1f8788552fc7df2120bc06dd34e00aa3284d23c250fc1f143eef51d08586 \
-                        size    8762 \
+                        lock    v0.1.0 \
+                        rmd160  9aa7a5aad4c48840eecfd0f80186d1fb5ded0fd6 \
+                        sha256  f6c3f89667c63e5b7f1fc6ee2c06b6a6bfdce88f3a965ccd395b64c6f95c9a47 \
+                        size    8553 \
                     github.com/kballard/go-shellquote \
                         lock    95032a82bc51 \
                         rmd160  40415cd59ece9fb38b22170feec07f1f48d518a2 \
                         sha256  41aa42696f96fb2783c5135d71ff1ec5938dfe178b51eb703e509c8ac0e7db4e \
                         size    4335 \
+                    github.com/julienschmidt/httprouter \
+                        lock    v1.3.0 \
+                        rmd160  c66409268fd53c29510615f7d96dd86cc20db6c5 \
+                        sha256  e000a864e6297a04dcb6766bcce502953026354925f6bf7ace04d352b7498cf6 \
+                        size    23889 \
                     github.com/jackpal/go-nat-pmp \
                         lock    v1.0.2 \
                         rmd160  84452f7d2cccdff571def7177bc180051eaba388 \
@@ -289,41 +273,36 @@ go.vendors          gopkg.in/yaml.v2 \
                         rmd160  3b78ee895c6d3d02bbc65ad2ed24aee73020815f \
                         sha256  9ccb9f16909c0a992b2b0f319937d73778c7b97eae57fd6a0a1aa0faf0b11d41 \
                         size    4907 \
-                    github.com/hpcloud/tail \
-                        lock    v1.0.0 \
-                        rmd160  2c6daf876a9a3ff47d239f3485810799ae9ced66 \
-                        sha256  aa9d7b729c8ee8b00c1a755ade77024e6b3ec4ac88585a39e31882260249f86b \
-                        size    37817 \
                     github.com/greatroar/blobloom \
-                        lock    v0.3.0 \
-                        rmd160  262052aca34896ab979450dea9b031507c137c26 \
-                        sha256  437df85c0084c2377e4ccf85571dcd3a9db782a28549bf3347f0217b9a3b70fd \
-                        size    18782 \
-                    github.com/google/go-cmp \
                         lock    v0.5.0 \
-                        rmd160  f28cfe463c2aa119f5ea32b5373cdc06e606c3fd \
-                        sha256  4c228ad175fb924cd4c5ab08b281685f636ae28439e5508b3946964919b9c746 \
-                        size    98601 \
+                        rmd160  57f4c4fbc0679178345214eb6eea91fb81743434 \
+                        sha256  4ce1f963d013784a2fd2ca195a857825ce7a9ec6929aa495dc21b558964e0c19 \
+                        size    21793 \
+                    github.com/google/go-cmp \
+                        lock    v0.4.0 \
+                        rmd160  2d73ccb9863b49adb03196aff7c41a7048e646fb \
+                        sha256  e7274fa6cc337c12123a02acc907524b7c3c234af59b2c924664300a57cb3ea0 \
+                        size    81597 \
                     github.com/golang/snappy \
                         lock    v0.0.1 \
                         rmd160  a10055b1a93ad290e600742c23156dbd55afe046 \
                         sha256  5ca0dcca007398f298a6386af5d4696faba962b6a625e3aa3961d212078722b8 \
                         size    62627 \
                     github.com/golang/protobuf \
-                        lock    v1.4.2 \
-                        rmd160  fbf4477bc008421fde463d79f7bc54a36de91db2 \
-                        sha256  206d74f8fd066bb178135ee9c092e986f8a1e1104df242e148e99e5a839e4ef2 \
-                        size    171802 \
+                        lock    v1.4.3 \
+                        rmd160  f07e841d9c9706e08d3ec3b6440a6b7e42d54392 \
+                        sha256  a53f353ad911974ab0483ae25d4f0cdb4f0ea508b69a786062e4743df2ab3959 \
+                        size    171996 \
                     github.com/golang/mock \
                         lock    v1.4.4 \
                         rmd160  ad4c6bd70c06881810d56fbd5d4b4ddfb701fae0 \
                         sha256  921ea11f2a10c4f6225fd3057893a5ee8c5d9b2ca17cb8f9de3a361a0f3899a1 \
                         size    55151 \
                     github.com/golang/groupcache \
-                        lock    611e8accdfc9 \
-                        rmd160  0813af0565e417ffd221180933222428aa940066 \
-                        sha256  3ba7b454c29e691d7ebe2f786cac2c6c033a0f80ea2508de04079b4ceee91115 \
-                        size    26080 \
+                        lock    8c9f03a8e57e \
+                        rmd160  b2514822acfad511ef9c9909f251cf18a3347ccd \
+                        sha256  ba910d9b0c49b9e15e605c6f5f373e2a2eeae2e7c59ed72bd6866446f6a5f94e \
+                        size    26050 \
                     github.com/gogo/protobuf \
                         lock    v1.3.1 \
                         rmd160  16be6b4d8879c774e3b9d9fc29d80cf770632f88 \
@@ -340,15 +319,15 @@ go.vendors          gopkg.in/yaml.v2 \
                         sha256  55590e7d9e56e30094fd487a2dcf4926aa4bb82471f21f33131b606a6ce41294 \
                         size    51683 \
                     github.com/go-ldap/ldap \
-                        lock    v3.2.0 \
-                        rmd160  39575e75210aba969b80d24ee41611ca9298bdbd \
-                        sha256  4b701003dc5fb1b4b71d7a50077b95685eb3f799ee178d5bc1b4786a2a5c9e4e \
-                        size    82016 \
+                        lock    v3.2.4 \
+                        rmd160  65db901b347e566447389d2610ac64497d63ff17 \
+                        sha256  d4abc208216be303cf853d386e06fd6c86945afccee6660d7575219f290a7505 \
+                        size    86908 \
                     github.com/go-asn1-ber/asn1-ber \
-                        lock    v1.5.0 \
-                        rmd160  81e1503e5f18e3a561081732342f24442235cd53 \
-                        sha256  f7d61845a090c672b0475794abdd673a47b85ae35c71b1ebff12716783725df6 \
-                        size    16311 \
+                        lock    v1.5.1 \
+                        rmd160  7713d9357f56bee2c54d80f56268903abfc30145 \
+                        sha256  fcf9c74ff49338b5ef8a57555fcfb0d279999c3b4a4fcb9754fbf3772a77b208 \
+                        size    16310 \
                     github.com/getsentry/raven-go \
                         lock    v0.2.0 \
                         rmd160  c564a8e9061642f60d401b6ab5b26961feec3212 \
@@ -359,11 +338,6 @@ go.vendors          gopkg.in/yaml.v2 \
                         rmd160  4660b5721da8aea4c890786e49d7cec39c2e04d3 \
                         sha256  7920cf1e5ccf268962fcff0b501398ed6c28ed75b1e1281fb17b19a8b0e4db5c \
                         size    31910 \
-                    github.com/francoispqt/gojay \
-                        lock    v1.2.13 \
-                        rmd160  c63b7b72b4a191e72379dd00bc1aee8881a9d28d \
-                        sha256  43123a9b651b186da391e56cf9e644d990a5a48f686b629515c458320684f9f4 \
-                        size    165274 \
                     github.com/flynn-archive/go-shlex \
                         lock    3f9db97f8568 \
                         rmd160  ec42eaffe2cf17a46e12c7c2a7d436c0f68ba655 \
@@ -390,10 +364,10 @@ go.vendors          gopkg.in/yaml.v2 \
                         sha256  39507b49d5f0bc50c10dcdc4234a8c4226dbffeb773ede26dcf20f39b87c5f2b \
                         size    332700 \
                     github.com/dchest/siphash \
-                        lock    v1.2.1 \
-                        rmd160  78de0b3517652f62068fe6c49c3e140bb4d782df \
-                        sha256  47c06d2961752a3efc4348917af06da4296f52989a62e061385be0c7a8d6026a \
-                        size    10729 \
+                        lock    v1.2.2 \
+                        rmd160  2bd73ba3ee5e184fa5dfb3c05f1d09677cf40d01 \
+                        sha256  f54e1c29a8f84902be054c9c4c7593532fc8448b9de68d38e16b46499b546911 \
+                        size    10713 \
                     github.com/davecgh/go-spew \
                         lock    v1.1.1 \
                         rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
@@ -420,30 +394,25 @@ go.vendors          gopkg.in/yaml.v2 \
                         sha256  528d149522e053aed14048608751da8ace5b44466038b1a8d47d04a050d81bdc \
                         size    15585 \
                     github.com/cespare/xxhash \
-                        lock    v2.1.0 \
-                        rmd160  55292dc23361fe89ea9f4e462e76d840ea797d80 \
-                        sha256  120da378ec373d6f6b71334b97bcbbefcee25408901f8e9d3482eb393ae81432 \
-                        size    9210 \
+                        lock    v2.1.1 \
+                        rmd160  0c0da0840864215209db2afcd2ee92a52ca2d4d1 \
+                        sha256  7416baf9eeefe07e3c50c57826d839cdbba125ea0a6d74af378e865df4f25e00 \
+                        size    9300 \
                     github.com/certifi/gocertifi \
-                        lock    a5e0173ced67 \
-                        rmd160  c3d3a5e8a98af89f87f2aea27333dae1bd4b5e81 \
-                        sha256  8b8fd5735cb54e113ea0f42091e0baee170cc0a6917cdb95e6068dbf238109b8 \
-                        size    155587 \
+                        lock    2c3bb06c6054 \
+                        rmd160  ecd5d6480238932222640c0486475ae516e9f318 \
+                        sha256  7d4569b405660ffcd4eb36d911a112d0e88a2c20141275e2aaad46b112d032c7 \
+                        size    158977 \
                     github.com/ccding/go-stun \
-                        lock    be486d185f3d \
-                        rmd160  98cfa81baa5fb412774e521155dfa5302467a854 \
-                        sha256  aca68ddc25cb11f3ccf988062168295e6acd513295c9e151d3211c4c169bdf11 \
-                        size    14125 \
+                        lock    v0.1.2 \
+                        rmd160  74e2d7c70fcbd544cc5623641ceed2d35dbb5bef \
+                        sha256  8472b29182200724c4758b5b4e5d0105c53b91ed1cff0091ec0443f597f72f43 \
+                        size    14119 \
                     github.com/calmh/xdr \
                         lock    v1.1.0 \
                         rmd160  944babe70dbef7a20b2db97dfe6bd892f8953ca9 \
                         sha256  f5a1704fe7db6d3fadf487e4a25b49f70dc2b0d151e78be79511baa2e82e86a0 \
                         size    10539 \
-                    github.com/bradfitz/go-smtpd \
-                        lock    deb6d6237625 \
-                        rmd160  ca7b85badf898d1dff04117538ca5937a7f623a1 \
-                        sha256  c8960be926f13469edb5cd45c0fb13baded4e5452ca4948b505d41d2f8f620cf \
-                        size    4696 \
                     github.com/bkaradzic/go-lz4 \
                         lock    7224d8d8f27e \
                         rmd160  3cc78bfe1511e3b5446655a45ab2bc848ccce774 \
@@ -454,16 +423,6 @@ go.vendors          gopkg.in/yaml.v2 \
                         rmd160  c6c5c7fd2132f01925c7fccd9d27c9d7a80f2adb \
                         sha256  78da4421e9f9fa2ee5e3855bdd31cfb04c7e823d9c0ec385cc2c008132d98b96 \
                         size    10874 \
-                    github.com/alecthomas/units \
-                        lock    c3de453c63f4 \
-                        rmd160  5008bfe6af9cfe334d62399db00901ea6a6c1814 \
-                        sha256  c6a733d020cca4f93b44c8a22eb68a90fb38916b4818a9bb569c65ed9322b3f2 \
-                        size    3497 \
-                    github.com/alecthomas/template \
-                        lock    fb15b899a751 \
-                        rmd160  34faebabc9eeabdf4e3efc70015e1f858ad787cf \
-                        sha256  7bdd81cd04955c4251637e7196751a4626ae822382b9cbb33ea53eb5f8ce00e5 \
-                        size    55322 \
                     github.com/StackExchange/wmi \
                         lock    cbe66965904d \
                         rmd160  1c28ff3f595532ab67c85f5232c9228cf97d65d9 \


### PR DESCRIPTION
#### Description

Updates syncthing to 1.12.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
