### PR TITLE
emacs-mac-app{,-devel}: fix build for apple silicon

### DIFF
--- a/aqua/emacs-mac-app/Portfile
+++ b/aqua/emacs-mac-app/Portfile
@@ -33,7 +33,8 @@ depends_lib         port:ncurses \
                     port:gmp \
                     port:jansson
 
-patchfiles          patch-src_emacs.c.diff
+patchfiles          patch-src_emacs.c.diff \
+                    patch-apple-silicon.diff
 
 if {${subport} eq ${name}} {
     conflicts       emacs-mac-app-devel

--- a/aqua/emacs-mac-app/files/patch-apple-silicon.diff
+++ b/aqua/emacs-mac-app/files/patch-apple-silicon.diff
@@ -1,0 +1,43 @@
+https://bitbucket.org/mituharu/emacs-mac/commits/ef4507125fdad5c3f079dde555b61febde2d43f7
+
+From ef4507125fdad5c3f079dde555b61febde2d43f7 Mon Sep 17 00:00:00 2001
+From: Itai Seggev <is+apple@cs.hmc.edu>
+Date: Tue, 24 Nov 2020 06:52:27 +0100
+Subject: [PATCH] Codesign the executable on recene MacOS systems
+
+* src/Makefile.in (temacs$(EXEEXT)): Codesign the executable on
+recent (ARM) MacOS systems (bug#43878).  Without this, building
+Emacs fails.
+
+Copyright-paperwork-exempt: yes
+---
+ src/Makefile.in | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/src/Makefile.in b/src/Makefile.in
+index 533b4e8..58a7f22 100644
+--- src/Makefile.in
++++ src/Makefile.in
+@@ -344,6 +344,10 @@ DUMPING=@DUMPING@
+ CHECK_STRUCTS = @CHECK_STRUCTS@
+ HAVE_PDUMPER = @HAVE_PDUMPER@
+
++## ARM Macs require that all code have a valid signature.  Since pump
++## invalidates the signature, we must re-sign to fix it.
++DO_CODESIGN=$(patsubst aarch64-apple-darwin%,yes,@configuration@)
++
+ # 'make' verbosity.
+ AM_DEFAULT_VERBOSITY = @AM_DEFAULT_VERBOSITY@
+
+@@ -660,6 +664,9 @@ temacs$(EXEEXT): $(LIBXMENU) $(ALLOBJS) $(LIBEGNU_ARCHIVE) $(EMACSRES) \
+ 	  $(ALLOBJS) $(LIBEGNU_ARCHIVE) $(W32_RES_LINK) $(LIBES)
+ ifeq ($(HAVE_PDUMPER),yes)
+ 	$(AM_V_at)$(MAKE_PDUMPER_FINGERPRINT) $@.tmp
++ifeq ($(DO_CODESIGN),yes)
++	codesign -s - -f $@.tmp
++endif
+ endif
+ 	$(AM_V_at)mv $@.tmp $@
+ 	$(MKDIR_P) $(etc)
+--
+2.10.5


### PR DESCRIPTION
#### Description
Imported from [upstream](https://bitbucket.org/mituharu/emacs-mac/commits/ef4507125fdad5c3f079dde555b61febde2d43f7). For some reason this requires different triplets than the patch in `emacs`.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
