### PR TITLE
podman: update to 2.2.0

### DIFF
--- a/sysutils/podman/Portfile
+++ b/sysutils/podman/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/containers/podman 2.1.1 v
+go.setup            github.com/containers/podman 2.2.0 v
 revision            0
 
 categories          sysutils
@@ -20,9 +20,9 @@ long_description    Podman is a tool for running Linux containers. \
 maintainers         nomaintainer
 
 checksums           ${distname}${extract.suffix} \
-    rmd160          7fe72e973991dd3a336f5a76eeb6bb9c9a99a73b \
-    sha256          10d8f2e14fa5f3a7f11bb12edbb848b6bb199b03983fbda4aaee74832fc82261 \
-    size            9443428
+    rmd160          d750b637b6b1dc3a22bd33996a90ebdb82a244f5 \
+    sha256          b0344977a80a3b67edcaaf274ee979ac427fabc4c72ddecd96c2b2a71d415b55 \
+    size            9647499
 
 
 post-extract {
@@ -42,17 +42,27 @@ variant bash_completion {
     post-destroot {
         set completions_path ${prefix}/share/bash-completion/completions
         xinstall -d ${destroot}${completions_path}
-        xinstall -m 0644 {*}[glob ${worksrcpath}/completions/bash/*] ${destroot}${completions_path}/
+        xinstall -m 0644 ${worksrcpath}/completions/bash/${name}-remote ${destroot}${completions_path}/
     }
 }
 
-variant zsh_completion description {Completion functions for zsh} {
+variant zsh_completion description {Enable completion support for zsh} {
     depends_run-append path:${prefix}/bin/zsh:zsh
 
     post-destroot {
         set site-functions ${destroot}${prefix}/share/zsh/site-functions
         xinstall -d ${site-functions}
-        xinstall -m 0644 {*}[glob ${worksrcpath}/completions/zsh/*] ${site-functions}/
+        xinstall -m 0644 ${worksrcpath}/completions/zsh/_${name}-remote ${site-functions}/
+    }
+}
+
+variant fish_completion description {Enable completion support for fish} {
+    depends_run-append path:${prefix}/bin/fish:fish
+
+    post-destroot {
+        set completions_path ${prefix}/share/fish/completions
+        xinstall -d ${destroot}${completions_path}
+        xinstall -m 644 ${worksrcpath}/completions/fish/${name}-remote.fish ${destroot}${completions_path}/
     }
 }
 


### PR DESCRIPTION
#### Description

- install only `podman-remote` completions
- enable fish completion

###### Type(s)

- [x] update
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.0.1 20B50
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
