### PR TITLE
octave-ltfat: Update to 2.4.0

### DIFF
--- a/math/octave-ltfat/Portfile
+++ b/math/octave-ltfat/Portfile
@@ -1,16 +1,17 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           octave 1.0
 PortGroup           compilers 1.0
+PortGroup           github 1.0
+PortGroup           octave 1.0
 
-octave.setup        ltfat 2.3.1
-revision            3
+octave.setup        ltfat 2.4.0
+revision            0
+checksums           rmd160  dfeec21ea3c1afb5480365b06d3a5c16f066b8c6 \
+                    sha256  fe37b31bc2dae97d1b5e1389d856cc354f21dcd77f5df67c2a025fdae8c8d5fe \
+                    size    3290078
 
-checksums           rmd160  cf4d59beba504a3000ba63becceb600425f4f45d \
-                    sha256  3063eced0aa185162f3049e37c2ca8076985b76b7173738e7389184e5481f03d \
-                    size    3236417
-
+github.setup        ltfat ltfat ${version}
 platforms           darwin
 license             GPL-3+ BSD
 maintainers         {mps @Schamschula} openmaintainer
@@ -22,6 +23,10 @@ long_description    ${description} (LTFAT) is a Matlab/Octave toolbox for workin
                     provides a large number of linear transforms including Gabor and \
                     wavelet transforms along with routines for constructing windows \
                     (filter prototypes) and routines for manipulating coefficients.
+
+homepage            https://ltfat.github.io
+github.tarball_from releases
+distname            ltfat-${version}-of
 
 compilers.choose    fc f77 f90
 compilers.setup     require_fortran


### PR DESCRIPTION
#### Description

octave-ltfat: Update to 2.4.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14019
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
