### PR TITLE
Libarchive35tigerfix

### DIFF
--- a/archivers/libarchive/Portfile
+++ b/archivers/libarchive/Portfile
@@ -34,6 +34,10 @@ depends_lib      port:bzip2 port:zlib port:libxml2 port:xz \
 
 patchfiles       patch-libarchive__archive_read_support_format_lha.c.diff
 
+platform darwin 8 {
+    patchfiles-append patch-libarchive-3.5-fix-tests-tiger.diff
+}
+
 depends_build    port:pkgconfig
 
 configure.args   --enable-bsdtar=shared --enable-bsdcpio=shared \
@@ -46,6 +50,9 @@ post-destroot {
         ln -s ${prefix}/bin/${program} ${destroot}${prefix}/libexec/${subport}
     }
 }
+
+test.run yes
+test.target check
 
 livecheck.type  regex
 livecheck.regex libarchive-(\[0-9.\]+)\\.tar.gz

--- a/archivers/libarchive/Portfile
+++ b/archivers/libarchive/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
-PortGroup legacysupport 1.1
 PortGroup clang_dependency 1.0
 
 name             libarchive
@@ -18,7 +17,7 @@ long_description \
 platforms        darwin
 
 version          3.5.0
-revision         0
+revision         1
 
 checksums        rmd160  9bbd61e676c7b51f5a66fa80c58dd440bb9d9ccb \
                  sha256  fc4bc301188376adc18780d35602454cc8df6396e1b040fbcbb0d4c0469faf54 \
@@ -33,6 +32,12 @@ depends_lib      port:bzip2 port:zlib port:libxml2 port:xz \
                  port:lz4 port:zstd
 
 patchfiles       patch-libarchive__archive_read_support_format_lha.c.diff
+
+# patch for strnlen -- using legacysupport causes a failure on Tiger
+# due to as-yet unresolved issues there with symlinks
+# see https://trac.macports.org/ticket/61746
+# https://github.com/libarchive/libarchive/issues/1464
+patchfiles-append patch-libarchive-3.5-strnlen.diff
 
 platform darwin 8 {
     patchfiles-append patch-libarchive-3.5-fix-tests-tiger.diff

--- a/archivers/libarchive/files/patch-libarchive-3.5-fix-tests-tiger.diff
+++ b/archivers/libarchive/files/patch-libarchive-3.5-fix-tests-tiger.diff
@@ -1,0 +1,31 @@
+diff --git libarchive/test/test_entry.c libarchive/test/test_entry.c
+index f205764..33cefe4 100644
+--- libarchive/test/test_entry.c
++++ libarchive/test/test_entry.c
+@@ -427,6 +427,9 @@ DEFINE_TEST(test_entry)
+ #endif
+ 
+ #if defined(__FreeBSD__) || defined(__APPLE__)
++#ifndef UF_HIDDEN
++#define UF_HIDDEN   0x00008000
++#endif
+ 	/* Test archive_entry_copy_fflags_text_w() */
+ 	archive_entry_copy_fflags_text_w(e, L" ,nouappnd, nouchg, dump,hidden");
+ 	archive_entry_fflags(e, &set, &clear);
+diff --git tar/test/test_option_acls.c tar/test/test_option_acls.c
+index f7451c8..de9b9b0 100644
+--- tar/test/test_option_acls.c
++++ tar/test/test_option_acls.c
+@@ -44,8 +44,12 @@ static const acl_perm_t acl_perms[] = {
+     ACL_WRITE_EXTATTRIBUTES,
+     ACL_READ_SECURITY,
+     ACL_WRITE_SECURITY,
++#if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1050
+     ACL_CHANGE_OWNER,
+     ACL_SYNCHRONIZE
++#else
++    ACL_CHANGE_OWNER
++#endif
+ #else /* !ARCHIVE_ACL_DARWIN */
+     ACL_EXECUTE,
+     ACL_WRITE,

--- a/archivers/libarchive/files/patch-libarchive-3.5-strnlen.diff
+++ b/archivers/libarchive/files/patch-libarchive-3.5-strnlen.diff
@@ -1,0 +1,25 @@
+diff --git libarchive/archive_read_support_format_mtree.c libarchive/archive_read_support_format_mtree.c
+index 127706d..c74f004 100644
+--- libarchive/archive_read_support_format_mtree.c
++++ libarchive/archive_read_support_format_mtree.c
+@@ -65,6 +65,20 @@ __FBSDID("$FreeBSD: head/lib/libarchive/archive_read_support_format_mtree.c 2011
+ #define O_CLOEXEC	0
+ #endif
+ 
++#ifdef __APPLE__
++#if  __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1070
++static size_t strnlen(const char *s, size_t maxlen) {
++  size_t l = 0;
++  while (l < maxlen && *s) {
++    l++;
++    s++;
++  }
++  return l;
++}
++#endif
++#endif
++
++
+ #define	MTREE_HAS_DEVICE	0x0001
+ #define	MTREE_HAS_FFLAGS	0x0002
+ #define	MTREE_HAS_GID		0x0004


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G6042
Xcode 11.3.1 11C504

macOS 10.4.11 8S165
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0 
Xcode 2.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

see: https://github.com/libarchive/libarchive/issues/1464
