### PR TITLE
Mame: Portfile license fix, allowing binaries to be published

### DIFF
--- a/emulators/mame/Portfile
+++ b/emulators/mame/Portfile
@@ -18,7 +18,7 @@ PortGroup           github 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        mamedev mame 0226 mame
-revision            1
+revision            0
 
 version             [string index ${github.version} 0].[string range ${github.version} 1 end]
 categories          emulators

--- a/emulators/mame/Portfile
+++ b/emulators/mame/Portfile
@@ -18,7 +18,7 @@ PortGroup           github 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        mamedev mame 0226 mame
-revision            0
+revision            1
 
 version             [string index ${github.version} 0].[string range ${github.version} 1 end]
 categories          emulators
@@ -228,6 +228,9 @@ proc mame_python_add_deps {} {
         "port:python${ver_major}${ver_minor}" \
         "port:py${ver_major}${ver_minor}-sphinx" \
         "port:py${ver_major}${ver_minor}-sphinxcontrib-svg2pdfconverter"
+
+    # License fix, to allow port binaries to be published
+    license_noconflict  python${ver_major}${ver_minor}
 
     return 0
 }


### PR DESCRIPTION
#### Description

Mame Portfile Changes:
* Added statement 'license_noconflict', allowing binary package publish.
* Note: Revision not updated, since no effect on existing installs.

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14019
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
