### PR TITLE
py-rfc6555: new port

### DIFF
--- a/python/py-rfc6555/Portfile
+++ b/python/py-rfc6555/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-rfc6555
+version             0.0.0
+revision            0
+categories-append   devel
+platforms           darwin
+license             Apache-2
+supported_archs     noarch
+
+maintainers         nomaintainer
+
+description         Python implementation of RFC 6555.
+long_description    Python implementation of the Happy Eyeballs Algorithm described in RFC 6555. \
+    Provided with a single file and dead-simple API \
+    to allow easy vendoring and integration into other projects.
+
+homepage            https://www.github.com/SethMichaelLarson/rfc6555
+
+checksums           rmd160  7bd0464b9353f10892fca2cca5943962ec5f9cfa \
+                    sha256  191cbba0315b53654155321e56a93466f42cd0a474b4f341df4d03264dcb5217 \
+                    size    11218
+
+python.versions     27 38 39
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools
+
+    livecheck.type      none
+}


### PR DESCRIPTION
#### Description

Python implementation of the Happy Eyeballs Algorithm described in RFC 6555.

###### Type(s)


- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.0.1 20B50
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
