### PR TITLE
offlineimap: update version to 7.3.3

### DIFF
--- a/mail/offlineimap/Portfile
+++ b/mail/offlineimap/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        OfflineIMAP offlineimap 7.2.1 v
+github.setup        OfflineIMAP offlineimap 7.3.3 v
 categories          mail python
 platforms           darwin
 license             {GPL-2+ OpenSSLException}
@@ -36,9 +36,9 @@ long_description    OfflineIMAP is a tool to simplify your e-mail reading. \
 
 homepage            http://offlineimap.org/
 
-checksums           rmd160  ae800a7f9b817b76ec36f18622d880b278e11ad0 \
-                    sha256  3f3f142392456b38b02fcf505e737bfe5057ccc9e3f31c7d674e65be05faea1b \
-                    size    720398
+checksums           rmd160  f726544ff07a73aa8a9d7721159bc2b56392abbc \
+                    sha256  46a0e304e5019a7d64fe5224987871d283890a7da09ab2aba267922a2e9cb1b7 \
+                    size    724303
 
 python.default_version 27
 
@@ -47,7 +47,9 @@ depends_build       port:py${python.version}-docutils \
                     port:asciidoc \
                     port:docbook-xsl-nons
 
-depends_lib         port:py${python.version}-six
+depends_lib         port:py${python.version}-rfc6555 \
+                    port:py${python.version}-selectors2 \
+                    port:py${python.version}-six
 
 post-build {
     system -W ${worksrcpath} "PATH='${python.prefix}/bin:$env(PATH)' make docs"


### PR DESCRIPTION
#### Description

This port depends on https://github.com/macports/macports-ports/pull/9351

###### Type(s)

- [x] update
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 11.0.1 20B50
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
