### PR TITLE
kubectx: update default kubectl dependency to kubectl-1.19

### DIFF
--- a/sysutils/kubectx/Portfile
+++ b/sysutils/kubectx/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        ahmetb kubectx 0.9.1 v
-revision            0
+revision            1
 categories          sysutils
 platforms           darwin
 supported_archs     noarch
@@ -19,7 +19,7 @@ checksums           rmd160  dc6a1b33555b13c07970f53a08ad3ca7bf85552e \
                     sha256  6c1f140b5e02988b13aa87be6e788af98ba93c947aaa48c9a015209c49a00dc9 \
                     size    512930
 
-depends_run         path:${prefix}/bin/kubectl:kubectl-1.17
+depends_run         path:${prefix}/bin/kubectl:kubectl-1.19
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

Update default kubectl dependency for kubectx to kubectl 1.19.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?