### PR TITLE
libmad: configure stage on Big Sur

### DIFF
--- a/audio/libmad/Portfile
+++ b/audio/libmad/Portfile
@@ -5,7 +5,7 @@ PortGroup       muniversal 1.0
 
 name            libmad
 version         0.15.1b
-revision        3
+revision        4
 categories      audio
 license         GPL-2+
 maintainers     nomaintainer
@@ -27,13 +27,14 @@ checksums           rmd160  0f3415ee10b188681e282ca69dec74c46ca73b0f \
 depends_build   port:pkgconfig
 
 use_autoreconf  yes
+autoreconf.args -fvi
 
 post-extract {
     copy ${filespath}/mad.pc.in ${worksrcpath}/mad.pc
     touch ${worksrcpath}/AUTHORS ${worksrcpath}/ChangeLog ${worksrcpath}/NEWS
 }
 
-patchfiles      patch-configure.ac.diff automake.patch
+patchfiles      patch-configure.ac.diff automake.patch remove-optimizations.patch
 
 post-patch {
     reinplace "s|%PREFIX%|${prefix}|g" ${worksrcpath}/mad.pc

--- a/audio/libmad/files/remove-optimizations.patch
+++ b/audio/libmad/files/remove-optimizations.patch
@@ -1,0 +1,21 @@
+--- configure.ac.orig  2004-01-23 04:41:32.000000000 -0500
++++ configure.ac       2020-12-06 10:22:19.000000000 -0500
+@@ -139,18 +139,13 @@
+     case "$optimize" in
+ 	-O|"-O "*)
+ 	    optimize="-O"
+-	    optimize="$optimize -fforce-mem"
+ 	    optimize="$optimize -fforce-addr"
+ 	    : #x optimize="$optimize -finline-functions"
+ 	    : #- optimize="$optimize -fstrength-reduce"
+-	    optimize="$optimize -fthread-jumps"
+-	    optimize="$optimize -fcse-follow-jumps"
+-	    optimize="$optimize -fcse-skip-blocks"
+ 	    : #x optimize="$optimize -frerun-cse-after-loop"
+ 	    : #x optimize="$optimize -frerun-loop-opt"
+ 	    : #x optimize="$optimize -fgcse"
+ 	    optimize="$optimize -fexpensive-optimizations"
+-	    optimize="$optimize -fregmove"
+ 	    : #* optimize="$optimize -fdelayed-branch"
+ 	    : #x optimize="$optimize -fschedule-insns"
+ 	    optimize="$optimize -fschedule-insns2"


### PR DESCRIPTION
#### Description

- A number of optimizations are no longer supported flags under clang
- The generated automake files are so out of date that `config.sub`
  rejects the requested build triple

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0.1 20B50
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
