### PR TITLE
wavpack: disable asm on arm64

### DIFF
--- a/audio/wavpack/Portfile
+++ b/audio/wavpack/Portfile
@@ -6,7 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                wavpack
 version             5.3.0
-revision            0
+revision            1
 checksums           rmd160  ab0ad42eb7587adb334554eba7983b7264fd43ef \
                     sha256  b6f00b3a2185a1d2df6cf8d893ec60fd645d2eb90db7428a617fd27c9e8a6a01 \
                     size    851092
@@ -32,7 +32,7 @@ platform darwin {
     # handrolled asm has issues on older platforms.  Disable it if we don't have access to newer compilers.
     # Note that "libc++" is really a proxy here for "configuration that supports newer compilers"; the C++
     # runtime actually isn't relevant other than being a requirement of clang-3.5+.
-    if {${configure.cxx_stdlib} eq "libc++"} {
+    if {${configure.cxx_stdlib} eq "libc++" && ${build_arch} ne "arm64"} {
         compiler.blacklist {macports-clang-3.[34]} {clang < 500} *gcc*
     } else {
         configure.args-append --disable-asm


### PR DESCRIPTION
#### Description

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0.1 20B50
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
