### PR TITLE
ccls: include clang-11 support

### DIFF
--- a/devel/ccls/Portfile
+++ b/devel/ccls/Portfile
@@ -20,7 +20,7 @@ long_description            {*}${description}
 
 compiler.cxx_standard       2017
 
-foreach clang_v {7.0 8.0 9.0 10} {
+foreach clang_v {7.0 8.0 9.0 10 11} {
     subport ccls-clang-${clang_v} {
         compiler.whitelist    macports-clang-${clang_v}
         configure.args-append -DCMAKE_PREFIX_PATH=${prefix}/libexec/llvm-${clang_v}


### PR DESCRIPTION
Add clang-11 support as this enables ccls on the arm64 arch.

#### Description

Add clang 11 support to ccls.  This allows ccls to be built on arm64 Macs.

###### Type(s)


- [ ] bugfix
- [ x] enhancement
- [ ] security fix

###### Tested on
macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ x] tried existing tests with `sudo port test`?
- [ x] tried a full install with `sudo port -vst install`?
- [ x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
