### PR TITLE
gcc-devel for ARM64: update to 11-20201205

### DIFF
--- a/lang/gcc-devel/Portfile
+++ b/lang/gcc-devel/Portfile
@@ -27,21 +27,21 @@ if { ${build_arch} eq "arm64" } {
     # Eventually Darwin Arm support will be merged with upstream at which point
     # Arm machines can use same snapshots as Intel.
     PortGroup github 1.0
-    
-    github.setup    iains gcc-darwin-arm64 6b589e6cb14fb74eaac99411a64083ff32fada85
+
+    github.setup    iains gcc-darwin-arm64 f335f738078a35dd48a0aaacbe58a0b7b11c86ce
 
     # Version must follow same scheme as with GCC snapshots below <version>-<commit-date>
-    version         11-20201122
+    version         11-20201205
     revision        0
-    subport         libgcc-devel { revision 1 }
-    
-    checksums       rmd160  005cdb1c71ee78234d3db08853e873cbae320854 \
-                    sha256  fe70b2caedf6f23b1caa9bf478b195be7d6801bd10836fb2419c85446034bbe9 \
-                    size    121028082
-    
+    subport         libgcc-devel { revision 0 }
+
+    checksums       rmd160  6eedae12588172d517797c6640809c741485cbdb \
+                    sha256  6a9aced13da950bfc8f8c8c58d5ca15d07c374df70a7dc1f41cd3c4194140eb0 \
+                    size    121303649
+
 } else {
     # Use regular GCC releases and snapshsots
-    
+
     version         11-20201129
     revision        0
     subport         libgcc-devel { revision 0 }


### PR DESCRIPTION
#### Description

Looks like Iain rebased his ARM64 GCC repo to GCC master. This creates a new commit series. I'm thinking we're using the branch "master-wip-apple-si" ... yes? Pretty cool how GitHub finds the correct branch from a commit.

Here's a link to the current commit for this port: < https://github.com/iains/gcc-darwin-arm64/commit/6b589e6cb14fb74eaac99411a64083ff32fada85 > ... GitHub notes "This commit does not belong to any branch on this repository, and may belong to a fork outside of the repository." ... which is a sign that Iain rebased and force pushed the changes over his dev branch. The commit message reads "Darwin, Arm64 : Initial changes to libitm. Just add Arm64 as a target and adjust the SjLj code to allow mach-o assembler."

The current commit is < https://github.com/iains/gcc-darwin-arm64/commit/f335f738078a35dd48a0aaacbe58a0b7b11c86ce >, which has the exact same commit message. Hence, this PR.

Builds cleanly on ARM64 macOS 11.0.1 20B28 && Xcode 12.2 12B45b.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C5061b
Xcode 12.2 12B5035g

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
