### PR TITLE
commitizen: add setuptools as a library dependency

### DIFF
--- a/devel/commitizen/Portfile
+++ b/devel/commitizen/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                commitizen
 version             2.10.0
+revision            1
 categories-prepend  devel
 platforms           darwin
 license             MIT
@@ -29,7 +30,7 @@ checksums           rmd160  59ed92de84ef7d097c9eeb6a8d80cab278ea8388 \
                     sha256  33e515940e49355381d29f41081124c0203d92dfce399b82ea4b04a74fc16cba \
                     size    29807
 
-depends_build-append \
+depends_lib-append \
     port:py${python.version}-setuptools
 
 depends_run-append \


### PR DESCRIPTION
#### Description

commitizen makes use of `entry_points`, and so setuptools is required at both build-time and run-time.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.6 19G73
xcode-select version 2373

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
