### PR TITLE
folderify: fix dependency categories

### DIFF
--- a/sysutils/folderify/Portfile
+++ b/sysutils/folderify/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                folderify
 version             2.1.1
+revision            1
 categories-prepend  sysutils amusements
 platforms           darwin
 license             MIT
@@ -25,10 +26,10 @@ checksums           rmd160  1bfec4e0ef2f16cb29a7bfb8aaa9c06cde3d18a8 \
                     sha256  4167dcd86878fa0115101959d5437531954a6707dbe207f8cb45425a4547d730 \
                     size    4579099
 
-depends_build-append \
+depends_lib-append \
                     port:py${python.version}-setuptools
 
-depends_lib-append \
+depends_run-append \
                     port:ImageMagick
 
 livecheck.type      pypi


### PR DESCRIPTION
#### Description

folderify makes use of entry_points, and so setuptools is required at both build-time and run-time.

ImageMagick is only required at run-time.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.6 19G73
xcode-select version 2373

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
