### PR TITLE
igraph: update to 0.8.5

### DIFF
--- a/math/igraph/Portfile
+++ b/math/igraph/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        igraph igraph 0.8.4
+github.setup        igraph igraph 0.8.5
 github.tarball_from releases
 
 categories          math science devel
@@ -18,14 +18,14 @@ platforms           darwin
 depends_lib         port:gmp \
                     port:libxml2
 
-checksums           rmd160  2e47ea898e34945ffb3076bf7f850d24274e3443 \
-                    sha256  ceef4e169777bdfb94673a068d128e189c311d6de62fe88569bbae090836f888 \
-                    size    3302695
+checksums           rmd160  ad4364f3c4d8d8608f34a7023c0117a840ccd97b \
+                    sha256  2e5da63a2b8e9bb497893a17cf77c691df1739c298664f8adb1310a01218f95b \
+                    size    3303252
 
 test.run            yes
 test.target         check
 
-# igraph 0.8.4 embeds GLPK 4.45. Currently GLPK is at version 4.65.
+# igraph 0.8.5 embeds GLPK 4.45. Currently GLPK is at version 4.65.
 # Some igraph functions perform better with this new GLPK version.
 
 variant external_glpk description {Build with external GLPK} {


### PR DESCRIPTION
#### Description

 * update to 0.8.5

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G6042
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
