### PR TITLE
py-segno: add setuptools as a library dependency

### DIFF
--- a/python/py-segno/Portfile
+++ b/python/py-segno/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                py-segno
 version             1.3.1
+revision            1
 platforms           darwin
 license             BSD
 supported_archs     noarch
@@ -28,7 +29,7 @@ python.versions     38 39
 
 if {${name} ne ${subport}} {
 
-    depends_build-append \
+    depends_lib-append \
                         port:py${python.version}-setuptools
 
     livecheck.type      none


### PR DESCRIPTION
#### Description

segno makes use of entry_points, and so setuptools is required at both build-time and run-time.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.6 19G73
xcode-select version 2373

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
