### PR TITLE
gnutls: simplify compiler selection

### DIFF
--- a/devel/gnutls/Portfile
+++ b/devel/gnutls/Portfile
@@ -86,6 +86,22 @@ configure.args  --disable-guile \
                 --with-default-trust-store-pkcs11=pkcs11: \
                 ac_cv_prog_AWK=/usr/bin/awk
 
+compiler.thread_local_storage yes
+
+# Undefined symbols for architecture x86_64: "___get_cpuid_count"
+compiler.blacklist-append {clang < 1000} {macports-clang-3.[0-9]} {macports-clang-[4-6].0}
+
+if {${os.platform} eq "darwin" && ${os.major} < 10 && [string match *clang* ${configure.compiler}] } {
+	depends_build-append  port:cctools
+	configure.env-append  NM=${prefix}/bin/nm
+	configure.args-append lt_cv_path_NM=${prefix}/bin/nm
+}
+
+platform darwin 8 {
+    depends_build-append   port:texinfo
+    configure.cppflags-append -D__WORDSIZE=32
+}
+
 variant dane description {Build libdane using unbound libraries} {
     depends_lib-append      port:unbound
     configure.args-append   --with-unbound-root-key-file="${prefix}/var/run/unbound/root.key"
@@ -148,50 +164,6 @@ test.target     check
 
 post-destroot {
     move ${destroot}${prefix}/bin/certtool ${destroot}${prefix}/bin/gnutls-certtool
-}
-
-platform darwin 8 {
-    depends_build-append   port:texinfo
-    configure.cppflags-append -D__WORDSIZE=32
-}
-
-if { ${build_arch} eq "i386" || ${build_arch} eq "x86_64" } {
-    compiler.blacklist-append *gcc-4.0
-    compiler.blacklist-append *gcc-4.2
-    # Undefined symbols for architecture x86_64:
-    # "___get_cpuid_count", referenced from:
-    #     _register_x86_crypto in libaccelerated.a(x86-common.o)
-    # ld: symbol(s) not found for architecture x86_64
-    compiler.blacklist-append {clang < 1000} {macports-clang-3.[0-9]} {macports-clang-[4-6].0}
-    compiler.fallback-append  macports-clang-8.0 macports-clang-7.0
-}
-
-# needs a TLS supporting compiler on older systems
-# most of this code can disappear once the new compilers selection logic comes into base
-platform darwin powerpc {
-    compiler.whitelist macports-gcc-6
-    universal_variant no
-}
-platform darwin i386 {
-    if {${os.major} < 9} {
-        compiler.whitelist macports-gcc-6
-        universal_variant no
-    } elseif {${os.major} < 11} {
-        compiler.whitelist macports-clang-5.0
-        if {[file exists ${prefix}/bin/clang-mp-5.0]} {
-            if {[active_variants clang-5.0 emulated_tls]} {
-                # needs to use a newer NM version to handle clang-5.0's objects on leopard
-                if {${os.major} < 10} {
-                    depends_build-append port:cctools
-                    configure.env-append NM=${prefix}/bin/nm
-                    configure.args-append lt_cv_path_NM=${prefix}/bin/nm
-                }
-            } else {
-                ui_error "Please install clang-5.0 first, with the emulated_tls variant enabled."
-                error "unsupported configuration"
-            }
-        }
-    }
 }
 
 livecheck.type  regex


### PR DESCRIPTION
use base TLS selection tools
blacklist compilers that don't support get_cpuid_count

closes: https://trac.macports.org/ticket/58804

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.5.8 9L34 Intel
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
