### PR TITLE
libid3tag: update to version 0.15.1c

### DIFF
--- a/audio/libid3tag/Portfile
+++ b/audio/libid3tag/Portfile
@@ -1,22 +1,22 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
+PortSystem	1.0
+PortGroup       github 1.0
+github.setup    azakkerman libid3tag 0.15.1c
 
-name		libid3tag
-version		0.15.1b
 revision	2
 categories	audio
 license		GPL-2+
 maintainers	nomaintainer
 description	id3 tag manipulation library
-long_description	libid3tag is a library for reading and \
-	writing ID3 tags, bothID3v1 \
-	and the various versions of ID3v2.
+long_description	libid3tag is a library for reading and writing ID3 tags, bothID3v1 and the various versions of ID3v2.
 platforms	darwin freebsd
 homepage	http://www.underbit.com/products/mad/
-master_sites	ftp://ftp.mars.org/pub/mpeg/ sourceforge:mad
-checksums	sha1    4d867e8a8436e73cd7762fe0e85958e35f1e4306 \
-		rmd160  31a69b8ad7684aefdb675acc8ebf89bd6f432095
+
+checksums           rmd160  e273ddf0a7e7dfea0428663995d56e4c72d5d407 \
+                    sha256  7c151ee7f97a277316c327934babf54cc4b851cdc33eef56e870f0c0aff9a03c \
+                    size    390078
+
 depends_lib	port:zlib
 
 patchfiles	patch-id3tag.diff
@@ -33,7 +33,3 @@ post-destroot {
 	xinstall -m 0644 ${worksrcpath}/id3tag.pc \
  		${destroot}${prefix}/lib/pkgconfig
 }
-
-livecheck.type  regex
-livecheck.url   ftp://ftp.mars.org/pub/mpeg/
-livecheck.regex "${name}-(\\d+(?:\\.\\d+)*\[a-z\])${extract.suffix}"


### PR DESCRIPTION
#### Description

Fix libid3tag build on arm64 Macs (issue #61609)

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
