### PR TITLE
lnav: update to 0.9.0

### DIFF
--- a/sysutils/lnav/Portfile
+++ b/sysutils/lnav/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           legacysupport 1.0
 
-github.setup        tstack lnav 0.8.5 v
+github.setup        tstack lnav 0.9.0 v
 revision            0
 
 maintainers         {g5pw @g5pw} openmaintainer
@@ -28,9 +28,9 @@ depends_lib         port:curl \
                     port:bzip2 \
                     path:lib/libssl.dylib:openssl
 
-checksums           rmd160  611d29fe11c79a8f253b6c775eb4c3ade01ee4dc \
-                    sha256  bb809bc8198d8f7395f3de76efdc1a08a5c2c97dc693040faee38802c38945de \
-                    size    908012
+checksums           rmd160  88827fcfd89b726f36d1abd20f343f1bd22b3526 \
+                    sha256  03e15449a87fa511cd19c6bb5e95de4fffe17612520ff7683f2528d3b2a7238f \
+                    size    1094734
 
 configure.args      --disable-silent-rules \
                     --disable-static \
@@ -43,3 +43,5 @@ configure.args      --disable-silent-rules \
 use_autoreconf      yes
 
 github.tarball_from releases
+
+github.livecheck.regex {([0-9.]+)}


### PR DESCRIPTION
- add livecheck regex

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
