### PR TITLE
kotlin: update to 1.4.21

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           java 1.0
 
-github.setup        JetBrains kotlin 1.4.20 v
+github.setup        JetBrains kotlin 1.4.21 v
 revision            0
 github.tarball_from releases
 distname            ${name}-compiler-${version}
@@ -23,9 +23,9 @@ long_description    Kotlin is a pragmatic programming language for JVM \
 
 homepage            https://kotlinlang.org/
 
-checksums           rmd160  cdbd160863e708be85b4a8f32619724ab0cd0fd5 \
-                    sha256  11db93a4d6789e3406c7f60b9f267eba26d6483dcd771eff9f85bb7e9837011f \
-                    size    60773121
+checksums           rmd160  1a45dab95fa84a2fa307a7df724033fcfa514682 \
+                    sha256  46720991a716e90bfc0cf3f2c81b2bd735c14f4ea6a5064c488e04fd76e6b6c7 \
+                    size    60776740
 
 java.version        1.8+
 java.fallback       openjdk8


### PR DESCRIPTION
#### Description

Update to Kotlin 1.4.21.

###### Tested on

macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?