### PR TITLE
google-cloud-sdk: update to 320.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             319.0.0
+version             320.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  3123da5e34f2ac1dde6ede18a4e34708cdc44944 \
-                    sha256  cbc88f1ac96504343b6f349b9289c22273f4803c64444d2161b015ff6a5c9fd6 \
-                    size    85701008
+    checksums       rmd160  0899b6259c82a6dd050ffc20df8abc2908ae5e4d \
+                    sha256  6547b2b7d2819e8870d3f20ddfd943fda349ec2d15a228858419134b536c4070 \
+                    size    85975911
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  2bf06c333dbc3fd29c4487128bf42209def4354f \
-                    sha256  5c37fc7199141c63b6e5b1dfc55ed88ae681077fcf2e5fbd9945ad378cdf8d4e \
-                    size    86713228
+    checksums       rmd160  181cbbda2089903751edd434c63d624021f35ffc \
+                    sha256  4e9f98a7361fab73ea6b1e2e3d6f045914fefdf1798880cac59741464a2e11b3 \
+                    size    107893233
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 320.0.0.

###### Tested on

macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?