### PR TITLE
bootstrap.sh: Use MacPorts 2.6.4, asciidoc: Update to 9.0.4, htop: Update to 3.0.3

### DIFF
--- a/_ci/bootstrap.sh
+++ b/_ci/bootstrap.sh
@@ -16,7 +16,7 @@ done
 OS_MAJOR=$(uname -r | cut -f 1 -d .)
 
 # Download resources in background ASAP but use later
-curl -fsSLO "https://dl.bintray.com/macports-ci-bot/macports-base/2.6r0/MacPorts-${OS_MAJOR}.tar.bz2" &
+curl -fsSLO "https://dl.bintray.com/macports-ci-bot/macports-base/2.6.4/MacPorts-${OS_MAJOR}.tar.bz2" &
 curl_mpbase_pid=$!
 curl -fsSLO "https://dl.bintray.com/macports-ci-bot/getopt/getopt-v1.1.6.tar.bz2" &
 curl_getopt_pid=$!

--- a/sysutils/htop/Portfile
+++ b/sysutils/htop/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        htop-dev htop 3.0.2
+github.setup        htop-dev htop 3.0.3
 revision            0
 epoch               1
 
@@ -17,9 +17,9 @@ long_description    ${name} is {*}${description} systems. It aims to be a better
 
 homepage            https://htop.dev
 
-checksums           rmd160  c4bd777dc6ae096b3f1e18c1b42f09bacfec71a5 \
-                    sha256  ec3a80f8772a3e156bc9d7d4ffca6bff342c04b78c52edff3621b6e83ac37b6a \
-                    size    176174
+checksums           rmd160  c1e2045d92e4a7f4da15d2ae44c6964db16352e7 \
+                    sha256  594bf2c9833dca97a84184a199ae77c4144d679c043d9db38ba6578e18727876 \
+                    size    292990
 
 depends_build       port:autoconf \
                     port:automake \

--- a/textproc/asciidoc/Portfile
+++ b/textproc/asciidoc/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 
 PortGroup           github 1.0
 
-github.setup        asciidoc asciidoc-py3 9.0.3
+github.setup        asciidoc asciidoc-py3 9.0.4
 revision            0
-checksums           rmd160  6a3e444927b754dd0424344433932ec1bda10a53 \
-                    sha256  7003b0dbe62f9f274663994d3fe466c00ca2ddc2d9b1390bde12fa8472b1e048 \
-                    size    1110672
+checksums           rmd160  5b3bc91137e294a21d065bd89f1aa42abe7450b2 \
+                    sha256  04daa8b89b82388ee0fc95650b9b49605a6b20984fca96d4b5db4385eaac03d7 \
+                    size    1111301
 name                asciidoc
 
 categories          textproc


### PR DESCRIPTION
#### Description

Update the CI environment to use MacPorts 2.6.4.
Update asciidoc to 9.0.4, htop to 3.0.3 in the same PR so that we can test the new build environment.

Closes: https://trac.macports.org/ticket/61533

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G6042
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?