### PR TITLE
Mame: Fix compilation error on older MacOS/Xcode releases, for file 'src/osd/modules/file/posixfile.cpp'

### DIFF
--- a/emulators/mame/Portfile
+++ b/emulators/mame/Portfile
@@ -18,7 +18,7 @@ PortGroup           github 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        mamedev mame 0226 mame
-revision            0
+revision            1
 
 version             [string index ${github.version} 0].[string range ${github.version} 1 end]
 categories          emulators
@@ -46,12 +46,16 @@ github.tarball_from archive
 # be removed starting with 0.227. Tracked by Mame issue:
 # https://github.com/mamedev/mame/issues/7510
 #
+# Patch 'src-posixfile-build-error' applies to release 0.226. It fixes a
+# compilation error on older MacOS/Xcode releases, particularly 10.8.
+#
 # Conversely, patch 'scripts-genie-compile-warnings' is not specific to any
 # particular Mame release. Indeed, it is technically not required at all.
 # However, it eliminates spurious warnings due to use of deprecated types
 # and/or calls... and reduces pollution in the build log.
 
 patchfiles          mame-patch-0226-language-portuguese_brazil.diff \
+                    mame-patch-0226-src-posixfile-build-error.diff \
                     mame-patch-0226-scripts-genie-compile-warnings.diff
 
 checksums           rmd160  b9e4ae321b7673790d374c63bbe966d1502d6738 \

--- a/emulators/mame/files/mame-patch-0226-src-posixfile-build-error.diff
+++ b/emulators/mame/files/mame-patch-0226-src-posixfile-build-error.diff
@@ -1,0 +1,15 @@
+--- src/osd/modules/file/posixfile.cpp	2020-12-08 16:14:00.000000000 -0500
++++ src/osd/modules/file/posixfile.cpp	2020-12-08 16:15:00.000000000 -0500
+@@ -37,6 +37,11 @@
+ #endif
+ #endif
+ 
++// Fix for MacOS compilation errors
++#if defined(__APPLE__) && !defined(_DARWIN_C_SOURCE)
++#define _DARWIN_C_SOURCE
++#endif
++
+ // MAME headers
+ #include "posixfile.h"
+ #include "unicode.h"
+


### PR DESCRIPTION
###### Description

Mame compilation error fix:
* Added patch for compilation errors on older MacOS/Xcode releases, which occur in source file 'src/osd/modules/file/posixfile.cpp'. Patch defines '_DARWIN_C_SOURCE', to enable additional C stdio functions.
* Incremented portfile revision.
* Tracked by issue: https://trac.macports.org/ticket/61775
 
###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.8.5 12F2560
Xcode 5.1.1 5B1008

macOS 10.12.6 16G2136
Xcode 9.2 9C40b

macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
