### PR TITLE
Poppler upgrade 20.12.0 to 20.12.1

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -621,7 +621,7 @@ array set modules {
         {"Qt WebEngine"}
         "very large and relatively new"
         "variant overrides: "
-        "revision 1"
+        "revision 2"
         "License: "
     }
     qtwebglplugin {

--- a/aqua/qt513/Portfile
+++ b/aqua/qt513/Portfile
@@ -599,7 +599,7 @@ array set modules {
         {"Qt WebEngine"}
         "very large and relatively new"
         "variant overrides: "
-        "revision 2"
+        "revision 3"
         "License: "
     }
     qtwebglplugin {

--- a/devel/olena/Portfile
+++ b/devel/olena/Portfile
@@ -5,7 +5,7 @@ PortGroup               qt4   1.0
 
 name                    olena
 version                 2.1
-revision                0
+revision                1
 categories              devel framework graphics science
 platforms               darwin
 license                 GPL-2

--- a/editors/frescobaldi/Portfile
+++ b/editors/frescobaldi/Portfile
@@ -38,7 +38,7 @@ subport ${name}-devel {
 
 subport ${name}2 {
     github.setup        wbsoft frescobaldi 2.20.0 v
-    revision            1
+    revision            2
     conflicts           ${name} ${name}-devel
 
     checksums           rmd160  27f121545cc7efe6a2b10fa69490a5714655f729 \

--- a/editors/texstudio/Portfile
+++ b/editors/texstudio/Portfile
@@ -5,7 +5,7 @@ PortGroup               qmake5 1.0
 PortGroup               github 1.0
 
 github.setup            texstudio-org texstudio 2.12.16
-revision                1
+revision                2
 categories              editors
 platforms               darwin
 license                 GPL-2+

--- a/editors/texworks/Portfile
+++ b/editors/texworks/Portfile
@@ -18,6 +18,7 @@ long_description    TeXworks is an environment for authoring TeX (LaTeX, ConTeXt
 checksums           rmd160  dc56df2c97b4bc408fbfeb9c2b30d4024ed8c5f5 \
                     sha256  eb7426b9296aa92da06183690f542c2dcf0f2236215de5843f4585dd544d28be \
                     size    12082392
+revision            1
 
 depends_build-append \
                     port:pkgconfig

--- a/gnome/evince/Portfile
+++ b/gnome/evince/Portfile
@@ -11,7 +11,7 @@ legacysupport.newest_darwin_requires_legacy 10
 
 name                evince
 version             3.36.7
-revision            1
+revision            2
 license             GPL-2+
 set branch          [join [lrange [split ${version} .] 0 1] .]
 description         Evince is a document viewer for multiple document formats like pdf, and many others.

--- a/gnome/gourmet/Portfile
+++ b/gnome/gourmet/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           python 1.0
 
 github.setup        thinkle gourmet 0.17.4
-revision            2
+revision            3
 categories          gnome python
 platforms           darwin
 supported_archs     noarch

--- a/gnome/tracker/Portfile
+++ b/gnome/tracker/Portfile
@@ -6,7 +6,7 @@ PortGroup           gobject_introspection 1.0
 
 name                tracker
 version             1.12.4
-revision            7
+revision            8
 license             GPL-2+ LGPL-2.1+ BSD
 set branch          [join [lrange [split ${version} .] 0 1] .]
 description         Metadata database, indexer and search tool.

--- a/gnustep/Etoile-devel/Portfile
+++ b/gnustep/Etoile-devel/Portfile
@@ -3,7 +3,7 @@ PortGroup   gnustep 1.0
 
 name            Etoile-devel
 version         0.1.9
-revision        8
+revision        9
 platforms       darwin
 maintainers     nomaintainer
 homepage        http://www.etoile-project.org/

--- a/gnustep/Etoile/Portfile
+++ b/gnustep/Etoile/Portfile
@@ -3,7 +3,7 @@ PortGroup   gnustep 1.0
 
 name            Etoile
 version         0.1.9
-revision        11
+revision        12
 platforms       darwin
 license         GPL-2+ LGPL BSD
 maintainers     nomaintainer

--- a/graphics/DiffPDF/Portfile
+++ b/graphics/DiffPDF/Portfile
@@ -23,6 +23,7 @@ checksums           sha1    663ecb7666a4b7d6fbd1a37327fd1f895fae69b8 \
                     rmd160  12a5f6921b8a53d98d9786af25e408e27611f56f \
                     sha256  c6142ee038a78108397f45b0c456dca7a4fe1d75250f21a514a134101d322433 \
                     size    91856
+revision            1
 
 depends_lib-append  port:poppler-qt4-mac
 configure.pkg_config_path-append \

--- a/graphics/OpenSceneGraph-devel/Portfile
+++ b/graphics/OpenSceneGraph-devel/Portfile
@@ -9,7 +9,7 @@ set git_date            20200529
 github.setup            openscenegraph OpenSceneGraph ${git_commit}
 name                    OpenSceneGraph-devel
 version                 3.7.0-${git_date}
-revision                0
+revision                1
 conflicts               OpenSceneGraph
 platforms               darwin
 categories              graphics

--- a/graphics/OpenSceneGraph/Portfile
+++ b/graphics/OpenSceneGraph/Portfile
@@ -5,7 +5,7 @@ PortGroup               github 1.0
 PortGroup               cmake 1.1
 
 github.setup            openscenegraph OpenSceneGraph 3.6.5 OpenSceneGraph-
-revision                1
+revision                2
 conflicts               OpenSceneGraph-devel
 platforms               darwin
 categories              graphics

--- a/graphics/diff-pdf/Portfile
+++ b/graphics/diff-pdf/Portfile
@@ -7,7 +7,7 @@ PortGroup           wxWidgets 1.0
 
 github.setup        vslavik diff-pdf 0.4.1 v
 github.tarball_from releases
-revision            9
+revision            10
 
 wxWidgets.use       wxWidgets-3.0
 

--- a/graphics/gegl-devel/Portfile
+++ b/graphics/gegl-devel/Portfile
@@ -11,7 +11,7 @@ conflicts           gegl
 set git_commit      123e846bed6c74696f25e150f425030d5b886ed2
 set git_date        20201101
 version             0.4.27-${git_date}
-revision            0
+revision            1
 license             {GPL-3+ LGPL-3+}
 categories          graphics
 maintainers         {devans @dbevans}

--- a/graphics/gegl/Portfile
+++ b/graphics/gegl/Portfile
@@ -8,7 +8,7 @@ PortGroup           legacysupport 1.0
 
 name                gegl
 version             0.4.26
-revision            0
+revision            1
 set branch          [join [lrange [split ${version} .] 0 1] .]
 conflicts           gegl-devel
 license             {GPL-3+ LGPL-3+}

--- a/graphics/gimp2-devel/Portfile
+++ b/graphics/gimp2-devel/Portfile
@@ -10,7 +10,7 @@ set git_name        gimp
 set git_commit      3525e0d19a5cd64bcabb2e8975ba04643cc82b6e
 set git_date        20201102
 version             2.10.23-${git_date}
-revision            0
+revision            1
 license             GPL-3+
 categories          graphics
 maintainers         {devans @dbevans}

--- a/graphics/gimp2/Portfile
+++ b/graphics/gimp2/Portfile
@@ -8,7 +8,7 @@ name                gimp2
 conflicts           gimp2-devel gimp3-devel
 # please remember to update the gimp metapackage to match
 version             2.10.22
-revision            1
+revision            2
 set branch          [join [lrange [split ${version} .] 0 1] .]
 license             GPL-3+
 categories          graphics

--- a/graphics/gimp3-devel/Portfile
+++ b/graphics/gimp3-devel/Portfile
@@ -9,7 +9,7 @@ conflicts           gimp2 gimp2-devel
 set git_commit      9046c758e7b82ffe39b1acb93160a0c9c15743ff
 set git_date        20200223
 version             2.99.1-${git_date}
-revision            4
+revision            5
 license             GPL-3+
 categories          graphics
 maintainers         {devans @dbevans}

--- a/graphics/gle-graphics/Portfile
+++ b/graphics/gle-graphics/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                gle-graphics
 version             4.2.5
-revision            2
+revision            3
 set major           [lindex [split ${version} .] 0]
 categories          graphics
 platforms           darwin

--- a/graphics/inkscape-devel/Portfile
+++ b/graphics/inkscape-devel/Portfile
@@ -12,7 +12,7 @@ epoch               1
 set git_commit      0ad1ac96
 set git_date        20200806
 version             0.92.5-${git_date}
-revision            0
+revision            1
 license             GPL-3+
 maintainers         {devans @dbevans}
 categories          graphics gnome

--- a/graphics/inkscape-gtk3-devel/Portfile
+++ b/graphics/inkscape-gtk3-devel/Portfile
@@ -11,7 +11,7 @@ name                inkscape-gtk3-devel
 conflicts           inkscape inkscape-devel
 set git_commit      42f2371f
 set git_date        20190429
-revision            3
+revision            4
 version             1.0alpha-${git_date}
 license             GPL-2 LGPL-2.1
 maintainers         {devans @dbevans}

--- a/graphics/inkscape/Portfile
+++ b/graphics/inkscape/Portfile
@@ -9,7 +9,7 @@ cmake.generator     Ninja
 name                inkscape
 conflicts           inkscape-devel inkscape-gtk3-devel
 version             0.92.5
-revision            5
+revision            6
 license             GPL-3+
 maintainers         {devans @dbevans}
 categories          graphics gnome

--- a/graphics/ipe-tools/Portfile
+++ b/graphics/ipe-tools/Portfile
@@ -5,7 +5,7 @@ PortGroup               github 1.0
 
 github.setup            otfried ipe-tools e5b23399a83d69fd5bb5d4645ef7325b4b57435b
 version                 20151202
-revision                11
+revision                12
 categories              graphics
 maintainers             {gmx.de:Torsten.Maehne @maehne} \
                         openmaintainer

--- a/graphics/pdf2djvu/Portfile
+++ b/graphics/pdf2djvu/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        jwilk pdf2djvu 0.9.17.1
-revision            4
+revision            5
 categories          graphics textproc
 platforms           darwin
 license             GPL-2

--- a/graphics/pdf2svg/Portfile
+++ b/graphics/pdf2svg/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        dawbarton pdf2svg 0.2.3 v
-revision            2
+revision            3
 license             GPL-2
 categories          graphics
 maintainers         nomaintainer

--- a/graphics/pdfpc/Portfile
+++ b/graphics/pdfpc/Portfile
@@ -6,7 +6,7 @@ PortGroup               active_variants 1.1
 PortGroup               cmake 1.1
 
 github.setup            pdfpc pdfpc 4.4.0 v
-revision                1
+revision                2
 
 maintainers             {gmx.de:Torsten.Maehne @maehne} openmaintainer
 

--- a/graphics/poppler-qt4-mac/Portfile
+++ b/graphics/poppler-qt4-mac/Portfile
@@ -25,6 +25,7 @@ use_xz              yes
 checksums           rmd160  62fa0f917e31e0c733228ea9289b4493a0fc29a8 \
                     sha256  1266096343f5163c1a585124e9a6d44474e1345de5cdfe55dc7b47357bcfcda9 \
                     size    1433696
+revision            1
 
 depends_lib-append  port:bzip2 \
                     port:curl \

--- a/graphics/poppler/Portfile
+++ b/graphics/poppler/Portfile
@@ -7,7 +7,7 @@ PortGroup           cmake 1.1
 PortGroup           legacysupport 1.0
 
 name                poppler
-version             20.12.0
+version             20.12.1
 revision            0
 
 conflicts           xpdf-tools
@@ -25,9 +25,9 @@ master_sites        ${homepage} \
 
 use_xz              yes
 
-checksums           rmd160  d7115178560f6bda4e5d17004bb8f9615270a3b5 \
-                    sha256  a3907525c32e7ff395eaf8cf83efa8d4f522b911281b80828586fa832feef824 \
-                    size    1659844
+checksums           rmd160  83955e916df329edc3ccbc394778ca80ccacaa2a \
+                    sha256  d0aa2586c0a4296c775f0d2045f28bb95a694113fc995f95350faa12930f7b35 \
+                    size    1660164
 
 depends_build-append \
                     port:pkgconfig

--- a/graphics/poppler/files/patch-check-boost.diff
+++ b/graphics/poppler/files/patch-check-boost.diff
@@ -1,5 +1,5 @@
---- CMakeLists.txt.orig	2020-10-01 21:44:58.000000000 +0200
-+++ CMakeLists.txt	2020-10-08 14:15:20.000000000 +0200
+--- CMakeLists.txt.orig
++++ CMakeLists.txt
 @@ -178,7 +178,7 @@
  set(HAVE_SPLASH ${ENABLE_SPLASH})
  macro_optional_find_package(Cairo ${CAIRO_VERSION})
@@ -8,4 +8,4 @@
 +if(ENABLE_SPLASH AND USE_BOOST_HEADERS)
    find_package(Boost 1.58.0)
    if(Boost_FOUND)
-     include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
+     set(USE_BOOST_HEADERS ON)

--- a/graphics/poppler/files/patch-cmake_modules_PopplerMacros.cmake.diff
+++ b/graphics/poppler/files/patch-cmake_modules_PopplerMacros.cmake.diff
@@ -1,6 +1,6 @@
 --- cmake/modules/PopplerMacros.cmake.orig
 +++ cmake/modules/PopplerMacros.cmake
-@@ -128,7 +128,7 @@
+@@ -126,7 +126,7 @@
    endif(GCC_HAS_AS_NEEDED)
  endif (CMAKE_COMPILER_IS_GNUCXX)
  

--- a/graphics/vips/Portfile
+++ b/graphics/vips/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           gobject_introspection 1.0
 
 github.setup        libvips libvips 8.10.2 v
-revision            0
+revision            1
 name                vips
 distname            vips-${version}
 description         VIPS is an image processing library.

--- a/kde/tellico/Portfile
+++ b/kde/tellico/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4 1.1
 
 name                tellico
 version             2.3.12
-revision            3
+revision            4
 categories          kde kde4
 platforms           darwin
 maintainers         nomaintainer

--- a/mail/claws-mail/Portfile
+++ b/mail/claws-mail/Portfile
@@ -5,7 +5,7 @@ PortGroup       active_variants 1.1
 
 name            claws-mail
 version         3.17.6
-revision        2
+revision        3
 categories      mail news
 platforms       darwin
 license         GPL-3+

--- a/office/zathura-plugin-pdf-poppler/Portfile
+++ b/office/zathura-plugin-pdf-poppler/Portfile
@@ -6,7 +6,7 @@ PortGroup           meson 1.0
 
 name                zathura-plugin-pdf-poppler
 version             0.2.9
-revision            0
+revision            1
 categories          office
 platforms           darwin
 license             zlib

--- a/perl/p5-poppler/Portfile
+++ b/perl/p5-poppler/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28 5.30
 perl5.setup         Poppler 1.0101 ../../authors/id/V/VO/VOLKENING
-revision            3
+revision            4
 platforms           darwin
 maintainers         {devans @dbevans} openmaintainer
 license             {Artistic-1 GPL}

--- a/print/latex2html/Portfile
+++ b/print/latex2html/Portfile
@@ -23,6 +23,7 @@ homepage                https://www.ctan.org/pkg/${name}
 checksums               rmd160  7eacda067f7804497b62b26e3915df3b005e4c28 \
                         sha256  414194e7c5164b447b72e1f70b9cfe3e2aeb0c60d81a84def6a8a08bf47c3771 \
                         size    1120645
+revision                1
 
 depends_lib             bin:latex:texlive-latex \
                         port:dvipng \

--- a/print/scribus-devel/Portfile
+++ b/print/scribus-devel/Portfile
@@ -13,7 +13,7 @@ set git_date        20201101
 github.setup        scribusproject scribus ${git_commit}
 name                scribus-devel
 version             1.5.6.svn-${git_date}
-revision            0
+revision            1
 categories          print
 license             LGPL-2+ BSD MIT
 platforms           darwin

--- a/python/impressive/Portfile
+++ b/python/impressive/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                impressive
 version             0.12.1
-revision            0
+revision            1
 
 categories-append   graphics
 license             GPL-2

--- a/python/py-poppler-qt4/Portfile
+++ b/python/py-poppler-qt4/Portfile
@@ -7,7 +7,7 @@ name                py-poppler-qt4
 python.rootname     python-poppler-qt4
 set _n              [string index ${python.rootname} 0]
 version             0.24.0
-revision            3
+revision            4
 platforms           darwin
 license             LGPL-2.1+
 maintainers         {gmail.com:davide.liessi @dliessi} openmaintainer

--- a/python/py-poppler-qt5/Portfile
+++ b/python/py-poppler-qt5/Portfile
@@ -29,6 +29,7 @@ checksums           md5     e411d6c8bb25faa9208387b1075895ad \
                     rmd160  ac42b3a4fbcd63e79fbfa42537f75087f06b170b \
                     sha256  ea0ec9ebe995705ab19a301290365652e62bab5c9b05db5697c7bf2173335107 \
                     size    23608
+revision            1
 
 python.versions     27 35 36 37 38
 

--- a/python/py-poppler/Portfile
+++ b/python/py-poppler/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 name                py-poppler
 set rname           pypoppler
 version             0.12.1
-revision            6
+revision            7
 
 platforms           darwin
 license             GPL-2

--- a/python/py-qpageview/Portfile
+++ b/python/py-qpageview/Portfile
@@ -22,6 +22,7 @@ checksums           md5     a322c628eba13992992c378d241eeb9d \
                     rmd160  b4485bb13efa885ffc4fa64bcca320874c2b6dfa \
                     sha256  3961e0b93a4f5e56c03ea547d5ba1094272a12ecb32ea09c9cf947bbc2d50dd6 \
                     size    158235
+revision            1
 
 python.versions     36 37 38
 

--- a/ruby/rb-gnome/Portfile
+++ b/ruby/rb-gnome/Portfile
@@ -4,7 +4,7 @@ PortGroup		ruby 1.0
 ruby.setup		{gnome ruby-gnome2} 1.1.3 fetch \
 				{ README NEWS } \
 				sourceforge:ruby-gnome2
-revision		2
+revision		3
 
 maintainers		{kimuraw @kimuraw}
 platforms		darwin

--- a/ruby/rb-poppler/Portfile
+++ b/ruby/rb-poppler/Portfile
@@ -5,7 +5,7 @@ PortGroup		ruby 1.0
 ruby.setup		{poppler ruby-gnome2} 1.1.3 extconf.rb \
 				{ poppler/README poppler/sample } \
 				sourceforge:ruby-gnome2
-revision		3
+revision		4
 maintainers		{kimuraw @kimuraw}
 platforms		darwin
 description		Ruby/Poppler is a Ruby binding of poppler-glib.

--- a/sysutils/cfiles/Portfile
+++ b/sysutils/cfiles/Portfile
@@ -17,6 +17,7 @@ long_description    ${name} is a terminal file manager with vim like keybindings
 checksums           rmd160  263993e1f7f9813753a208e4a86d9fb0dda65013 \
                     sha256  10d3ca8d167c0c74c41d9213933e85519d75a302fba54614682c13381a9d93ad \
                     size    237807
+revision            1
 
 patchfiles          patch-config.h.diff \
                     patch-Makefile.diff

--- a/sysutils/littleutils/Portfile
+++ b/sysutils/littleutils/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                littleutils
 version             1.2.3
-revision            0
+revision            1
 categories          sysutils
 maintainers         {mps @Schamschula} openmaintainer
 platforms           darwin

--- a/textproc/extractpdfmark/Portfile
+++ b/textproc/extractpdfmark/Portfile
@@ -25,6 +25,7 @@ github.tarball_from releases
 checksums           rmd160  8d6dd90de6f4f555012bd6edd8ac4e00dfc356fc \
                     sha256  0935045084211fcf68a9faaba2b65c037d0adfd7fa27224d2b6c7ae0fd7964cb \
                     size    308226
+revision            1
 
 compiler.cxx_standard 2011
 

--- a/textproc/pdf2htmlex/Portfile
+++ b/textproc/pdf2htmlex/Portfile
@@ -8,7 +8,7 @@ PortGroup           compiler_blacklist_versions 1.0
 github.setup        coolwanglu pdf2htmlEX 43e3174cbc
 name                pdf2htmlex
 version             0.11
-revision            23
+revision            24
 categories          textproc
 maintainers         iapa.in:iapain {mojca @mojca} openmaintainer
 platforms           darwin

--- a/textproc/pdfgrep-legacy/Portfile
+++ b/textproc/pdfgrep-legacy/Portfile
@@ -3,7 +3,7 @@ PortSystem          1.0
 name                pdfgrep-legacy
 set realname        pdfgrep
 version             1.3.2
-revision            2
+revision            3
 conflicts           pdfgrep
 categories          textproc
 platforms           darwin

--- a/textproc/pdfgrep/Portfile
+++ b/textproc/pdfgrep/Portfile
@@ -2,7 +2,7 @@ PortSystem          1.0
 
 name                pdfgrep
 version             2.1.1
-revision            1
+revision            2
 conflicts           pdfgrep-legacy
 categories          textproc
 platforms           darwin

--- a/textproc/recoll/Portfile
+++ b/textproc/recoll/Portfile
@@ -23,6 +23,7 @@ master_sites        ${homepage}
 checksums           rmd160  88aebac6074f3e6242770348ac30e405975effa6 \
                     sha256  500d114952aa03c222847df8ecd0f9c58fc1d03b940df72de81e02e52ca905bc \
                     size 2849390
+revision            1
 
 depends_lib         port:xapian-core \
                     port:aspell \

--- a/x11/auto-multiple-choice/Portfile
+++ b/x11/auto-multiple-choice/Portfile
@@ -31,7 +31,7 @@ if {${subport} eq ${name}} {
     set gitlab.commit       "c6041a162202380b065b1b1abbdb016bb6d4b6a8"
     set amc_revision        "201812291614"
     set amc_date            "201812291614"
-    revision                1
+    revision                2
     version                 1.4.0-${amc_revision}
     checksums               rmd160  205d1907927c3e3b230e19f3460d151dfa3dfa7d \
                             sha256  8362dd01bd902556940a1415f23d00278b36c27e1e3d62e2190e32d78864b0fe \
@@ -43,6 +43,7 @@ if {${subport} eq ${name}} {
     set gitlab.commit       "fd2136db5241e33dec5d920535d23000525b6b6d"
     set amc_revision        "202004101300"
     set amc_date            "202004101300"
+    revision                1
     version                 1.4.0-${amc_revision}
     checksums               rmd160  bb6b8faefbca2ba5293a6ba2861fffcdc26844c2 \
                             sha256  ce77a35e6c72d32645921cdf327e2fc9569f4146823c6d1d98d54ecdcb2edf31 \

--- a/x11/xournal/Portfile
+++ b/x11/xournal/Portfile
@@ -5,7 +5,7 @@ PortGroup               active_variants 1.1
 
 name                    xournal
 version                 0.4.8.2016
-revision                1
+revision                2
 categories              x11
 platforms               darwin
 maintainers             {ryandesign @ryandesign} openmaintainer

--- a/x11/xournalpp/Portfile
+++ b/x11/xournalpp/Portfile
@@ -18,6 +18,7 @@ long_description    Xournal++ is a hand note taking software written in C++ \
 checksums           rmd160  f407a8391a3683d87c15d3762c9ecacc13d4dbf5 \
                     sha256  13e37aef0bc8178d78301c2405e5e463f70069600512a7b61dedec46cf860844 \
                     size    14892459
+revision            1
 
 depends_build       port:pkgconfig \
                     port:gtk-mac-bundler

--- a/xfce/tumbler/Portfile
+++ b/xfce/tumbler/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 
 name                    tumbler
 version                 0.2.3
-revision                0
+revision                1
 set branch              [join [lrange [split ${version} .] 0 1] .]
 categories              xfce
 platforms               darwin


### PR DESCRIPTION
#### Description

Poppler upgrade 20.12.0 to 20.12.1 ; then rev-bump all ports that depend on poppler due to an ABI name change.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C5061b
Xcode 12.2 12B5035g

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
