### PR TITLE
freeimage: fix build failure due to C99 implicit declaration

### DIFF
--- a/graphics/freeimage/Portfile
+++ b/graphics/freeimage/Portfile
@@ -30,6 +30,8 @@ distname            FreeImage[strsed ${version} {g/\.//}]
 use_zip             yes
 worksrcdir          FreeImage
 
+patchfiles          patch-c99-fixes.diff
+
 post-patch {
     set makefiles   "${worksrcpath}/Makefile.fip ${worksrcpath}/Makefile.gnu"
 
@@ -47,6 +49,9 @@ post-patch {
 
     # Darwin requires different arguments to build dynamic libraries
     reinplace {s|-shared -Wl,-soname,$(VERLIBNAME)|-dynamiclib -install_name $(PREFIX)/lib/$(VERLIBNAME) -compatibility_version $(VER_MAJOR) -current_version $(VER_MAJOR).$(VER_MINOR)|} {*}${makefiles}
+
+    # Introduce HAVE_UNISTD_H to avoid C99 issues in zlib.
+    reinplace {s/-D__ANSI__/-D__ANSI__ -DHAVE_UNISTD_H/} {*}${makefiles}
 
     # Use CXX not CC to link the library, since it is made up of C++ code.
     reinplace {/\$(LIBRARIES)/s/$(CC)/$(CXX)/} {*}${makefiles}

--- a/graphics/freeimage/files/patch-c99-fixes.diff
+++ b/graphics/freeimage/files/patch-c99-fixes.diff
@@ -1,0 +1,73 @@
+--- Source/LibJXR/image/sys/strcodec.c.orig	2015-02-21 04:36:26.000000000 +0000
++++ Source/LibJXR/image/sys/strcodec.c	2020-12-09 12:11:53.000000000 +0000
+@@ -664,24 +664,6 @@
+ //================================================================
+ // Memory access functions
+ //================================================================
+-#if (defined(WIN32) && !defined(UNDER_CE) && (!defined(__MINGW32__) || defined(__MINGW64_TOOLCHAIN__))) || (defined(UNDER_CE) && defined(_ARM_))
+-// WinCE ARM and Desktop x86
+-#else
+-// other platform
+-#ifdef _BIG__ENDIAN_
+-#define _byteswap_ulong(x)  (x)
+-#else // _BIG__ENDIAN_
+-U32 _byteswap_ulong(U32 bits)
+-{
+-    U32 r = (bits & 0xffu) << 24;
+-    r |= (bits << 8) & 0xff0000u;
+-    r |= ((bits >> 8) & 0xff00u);
+-    r |= ((bits >> 24) & 0xffu);
+-
+-    return r;
+-}
+-#endif // _BIG__ENDIAN_
+-#endif
+ 
+ U32 load4BE(void* pv)
+ {
+--- Source/LibJXR/image/sys/strcodec.h.orig	2015-02-21 04:35:46.000000000 +0000
++++ Source/LibJXR/image/sys/strcodec.h	2020-12-09 12:28:41.000000000 +0000
+@@ -28,6 +28,7 @@
+ #pragma once
+ 
+ #include <stddef.h>
++#include <stdlib.h>
+ #if defined(__MINGW32__)
+ #include <stdint.h>
+ #endif
+@@ -117,6 +118,25 @@
+ 
+ #define TraceResult(a)
+ 
++#if (defined(WIN32) && !defined(UNDER_CE) && (!defined(__MINGW32__) || defined(__MINGW64_TOOLCHAIN__))) || (defined(UNDER_CE) && defined(_ARM_))
++// WinCE ARM and Desktop x86
++#else
++// other platform
++#ifdef _BIG__ENDIAN_
++#define _byteswap_ulong(x)  (x)
++#else // _BIG__ENDIAN_
++static inline U32 _byteswap_ulong(U32 bits)
++{
++    U32 r = (bits & 0xffu) << 24;
++    r |= (bits << 8) & 0xff0000u;
++    r |= ((bits >> 8) & 0xff00u);
++    r |= ((bits >> 24) & 0xffu);
++
++    return r;
++}
++#endif // _BIG__ENDIAN_
++#endif
++
+ //================================================================
+ typedef enum tagPacketType
+ {
+--- Source/LibJXR/jxrgluelib/JXRGlueJxr.c.orig	2013-12-06 23:04:54.000000000 +0000
++++ Source/LibJXR/jxrgluelib/JXRGlueJxr.c	2020-12-09 12:14:48.000000000 +0000
+@@ -27,5 +27,6 @@
+ //
+ //*@@@---@@@@******************************************************************
+ #include <limits.h>
++#include <wchar.h>
+ #include <JXRGlue.h>
+ 
+ 


### PR DESCRIPTION
#### Description

This PR fixes build issues with freeimage owing to C99 implicit declarations in macOS 11. Issue on trac here: https://trac.macports.org/ticket/61790

Some notes:

- The patch here affects four files, mostly to add a couple of headers; however I also discovered that I needed to inline a function `_byteorder_swap` - this seemed like something MSVC specific, but perhaps clang had some kind of support for this.
- `port test` fails, but it's unclear this is due to this patch, since on a machine where I'm running 10.15, I also get the same failure with the current Portfile from master.
- With this patched I can compile e.g. OpenCASCADE, which seems to work okay, but I'm no expert in these libraries to tell whether this would be something critical or not.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->