### PR TITLE
hexyl: new port

### DIFF
--- a/sysutils/hexyl/Portfile
+++ b/sysutils/hexyl/Portfile
@@ -1,0 +1,49 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo 1.0
+
+github.setup        sharkdp hexyl 0.8.0 v
+revision            0
+
+description         A command-line hex viewer.
+
+long_description    hexyl is a simple hex viewer for the terminal. It uses a \
+                    colored output to distinguish different categories of \
+                    bytes (NULL bytes, printable ASCII characters, ASCII \
+                    whitespace characters, other ASCII characters and \
+                    non-ASCII).
+
+categories          sysutils
+license             MIT
+platforms           darwin
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  1e399bae35d9075135e6f2614bfee79464355cc0 \
+                    sha256  547ac2f578b8ad8f9b3e0496470cdfa9f60c9e01633a4285e5ea19be5def3c38 \
+                    size    22584
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/${name} ${destroot}${prefix}/bin/
+}
+
+cargo.crates \
+    ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
+    ansi_term                       0.12.1  d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2 \
+    atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+    bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
+    clap                            2.33.1  bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129 \
+    hermit-abi                      0.1.13  91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71 \
+    libc                            0.2.71  9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49 \
+    strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
+    term_size                        0.3.2  1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9 \
+    textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
+    unicode-width                    0.1.7  caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479 \
+    vec_map                          0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
+    winapi                           0.3.8  8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6 \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f


### PR DESCRIPTION
#### Description

New port for the [hexyl hex viewer](https://github.com/sharkdp/hexyl)

###### Tested on
macOS 10.15.7 19H15
Xcode 12.2 12B45b


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
