### PR TITLE
skaffold: update to 1.17.2

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 1.17.1 v
+github.setup        GoogleContainerTools skaffold 1.17.2 v
 revision            0
 
 categories          devel
@@ -23,9 +23,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  f4f72df880752f1d4041f7b488fca9d7648b22d0 \
-                    sha256  df9a4153c5d508bc2e315b6f224d52ec31548c3355e70b4663abf4ad508c89ee \
-                    size    27692956
+checksums           rmd160  e50c36b640318c18116a69a5dd8f6e190d61ffa9 \
+                    sha256  1d23795bc92d77fbfd92ff1068013c35cd0f4fbde24f06f46cff8caa8b7a4972 \
+                    size    27691567
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 1.17.2.

###### Tested on

macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?