### PR TITLE
p5-extutils-makemaker: don't suppress errors

### DIFF
--- a/perl/p5-extutils-makemaker/Portfile
+++ b/perl/p5-extutils-makemaker/Portfile
@@ -5,6 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28 5.30
 perl5.setup         ExtUtils-MakeMaker 7.58
+revision            1
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
 description         Create a module Makefile
@@ -19,6 +20,10 @@ checksums           rmd160  52ff38101b7c53a2323598885300f6541eaf36c9 \
 
 perl5.link_binaries no
 if {${perl5.major} != ""} {
+    # See https://trac.macports.org/ticket/61630
+    patchfiles-append \
+                    patch-want-implicit-errors.diff
+
     depends_lib-append \
                     port:p${perl5.major}-cpan-meta-requirements \
                     port:p${perl5.major}-extutils-manifest

--- a/perl/p5-extutils-makemaker/files/patch-want-implicit-errors.diff
+++ b/perl/p5-extutils-makemaker/files/patch-want-implicit-errors.diff
@@ -1,0 +1,14 @@
+Do not suppress errors for implicit function declarations
+(which was done for https://rt.cpan.org/Ticket/Display.html?id=133493)
+See: https://trac.macports.org/ticket/61630
+
+--- lib/ExtUtils/MM_Darwin.pm.orig
++++ lib/ExtUtils/MM_Darwin.pm
+@@ -62,6 +62,5 @@
+     foreach (split /\n/, $base) {
+         /^(\S*)\s*=\s*(\S*)$/ and $self->{$1} = $2;
+     };
+-    $self->{CCFLAGS} .= " -Wno-error=implicit-function-declaration";
+ 
+     return $self->{CFLAGS} = qq{
+ CCFLAGS = $self->{CCFLAGS}


### PR DESCRIPTION
…regarding implicit function declarations in modules
Closes: https://trac.macports.org/ticket/61630

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7
Xcode 12.3 command line tools
Perl 5.32.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
