### PR TITLE
chafa: new port

### DIFF
--- a/graphics/chafa/Portfile
+++ b/graphics/chafa/Portfile
@@ -1,0 +1,49 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        hpjansson chafa 1.4.1
+revision            0
+
+homepage            https://hpjansson.org/chafa
+
+description         Terminal graphics for the 21st century
+
+long_description    {*}${description}. Chafa is a command-line utility that \
+                    converts all kinds of images, including animated GIFs, \
+                    into sixel or ANSI/Unicode character output that can be \
+                    displayed in a terminal. It is highly configurable, with \
+                    support for alpha transparency and multiple color modes \
+                    and color spaces, combining selectable ranges of Unicode \
+                    characters to produce the desired output.
+
+categories          graphics
+license             LGPL-3
+platforms           darwin linux
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  35a406ed8f4988caea800309cdd369cbe8325cf2 \
+                    sha256  f2a2a937a9687fc46a23c12b235aa847bf1c1e9d062c0d97f865b4b8504382ec \
+                    size    1212010
+
+depends_build-append \
+                    port:autoconf   \
+                    port:automake   \
+                    port:libtool    \
+                    port:pkgconfig
+
+depends_lib-append  port:glib2 \
+                    port:ImageMagick
+
+configure.cmd       ./autogen.sh
+configure.args      --disable-gtk-doc \
+                    --disable-man
+
+platform darwin {
+    post-extract {
+        reinplace "s|libtoolize|glibtoolize|g" ${worksrcpath}/autogen.sh
+    }
+}


### PR DESCRIPTION
#### Description

New port for the [chafa](https://github.com/hpjansson/chafa) terminal graphics viewer

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
