### PR TITLE
cfssl: new port

### DIFF
--- a/security/cfssl/Portfile
+++ b/security/cfssl/Portfile
@@ -1,0 +1,265 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/cloudflare/cfssl 1.5.0 v
+revision            0
+
+homepage            https://cfssl.org
+
+description         Cloudflare's PKI and TLS toolkit
+
+long_description    CFSSL is CloudFlare's PKI/TLS swiss army knife. It is \
+                    both a command line tool and an HTTP API server for \
+                    signing, verifying, and bundling TLS certificates. \
+                    CFSSL consists of: a set of packages useful for \
+                    building custom TLS PKI tools, the cfssl program - the \
+                    canonical command line utility using the CFSSL \
+                    packages, the multirootca program - a certificate \
+                    authority server that can use multiple signing keys, \
+                    the mkbundle program - used to build certificate pool \
+                    bundles, the cfssljson program - which takes the JSON \
+                    output from the cfssl and multirootca programs and writes \
+                    certificates, keys, CSRs, and bundles to disk.
+
+categories          security
+license             BSD
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+set work_dist_path  ${worksrcpath}/dist
+
+build.pre_args      -o ${work_dist_path} -ldflags \
+                        \"-X ${go.package}/cli/version.version=${version}\"
+build.args          ./cmd/...
+
+installs_libs       no
+
+post-extract {
+    file mkdir ${work_dist_path}
+}
+
+destroot {
+    foreach _cfssl_bin [glob ${work_dist_path}/*] {
+        xinstall -m 755 ${_cfssl_bin} ${destroot}${prefix}/bin/
+    }
+}
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  c920538845eacaf417024878a3c1aef5aec35e5c \
+                        sha256  55840d537d7ba6dea8fe4fa9a4cda2fc2f6f9a92de00e710b02438d0689dd7cf \
+                        size    6168575
+
+go.vendors          gopkg.in/yaml.v2 \
+                        lock    v2.2.2 \
+                        rmd160  03aea7b7e847179b29044d5a928b9f8a889fe87b \
+                        sha256  da1e31b7beb9a6907947caa794134bdc2501d1a3474568b61cc2562a398d3d87 \
+                        size    70676 \
+                    gopkg.in/check.v1 \
+                        lock    788fd7840127 \
+                        rmd160  b63165c8909a27edc15dda210df66a1b49efb49e \
+                        sha256  7e5547c6471cc48da89a7c87f965b20ca5311f43fc4d883ca62f9fccf7551630 \
+                        size    31597 \
+                    google.golang.org/appengine \
+                        repo    github.com/golang/appengine \
+                        lock    v1.6.6 \
+                        rmd160  ee3e5a6d2742607fd310e18634c1268156f39ad4 \
+                        sha256  084ba3a248eccd0c7606dc6cff3918326a0adb2e8d30babcbaf6f1c00e1d28f9 \
+                        size    333013 \
+                    golang.org/x/tools \
+                        lock    11955173bddd \
+                        rmd160  3f018974cbd88912e85ad015d33a5bf3c02cf100 \
+                        sha256  beda28740d4fc61c10f191f7dfb51dcaa6ac5a9c20ec16ab3e1096e987161740 \
+                        size    2651713 \
+                    golang.org/x/text \
+                        lock    v0.3.3 \
+                        rmd160  babfa547ba9a9dab7fe08fa5543f1d8e7ae00301 \
+                        sha256  1c4a8c12295d484e0360d8e010ebc4b8a9a05aa2a07c10c3d3e5b17aa063f0db \
+                        size    7745597 \
+                    golang.org/x/net \
+                        lock    4f7140c49acb \
+                        rmd160  bcdf3dbb29069a17f27f97ac1f270176ef877f20 \
+                        sha256  be7a3da1644be68d841f20f466c879bdeab8c3e70556b42c0e147ade4df53999 \
+                        size    1177560 \
+                    golang.org/x/lint \
+                        lock    16217165b5de \
+                        rmd160  6ecf457d183d152054cca90b7dff0d2f5dc875b4 \
+                        sha256  36bd7b7dca98c2695b9f19a8e2401a2b4d8f8dabc0282bddde40c1eb5cf27b11 \
+                        size    31434 \
+                    golang.org/x/crypto \
+                        lock    84dcc777aaee \
+                        rmd160  0b887dd69368f7879b3b640567514550dcdcb394 \
+                        sha256  6804d15ce3aae1f3d2a817d0b4ad0419e15ace9c43f5a9f5bd5c147e0abbeef0 \
+                        size    1732591 \
+                    github.com/zmap/zlint \
+                        lock    v2.2.1 \
+                        rmd160  e04c7c1286f5a67bbd885084aecdcc7af6641192 \
+                        sha256  42dd226035256bf93b20240492373445558287ee07f7b92baee47f4b58d6388a \
+                        size    1174252 \
+                    github.com/zmap/zcrypto \
+                        lock    43ff0ea04f21 \
+                        rmd160  a6d2471c73616f2727a8f19a7d746a22d6260b95 \
+                        sha256  6a9822261aebc79bf46b4c1fe30604fffcd6aaeb11233cb7f5c1cfde13de9490 \
+                        size    2109526 \
+                    github.com/ziutek/mymysql \
+                        lock    v1.5.4 \
+                        rmd160  855c3211173a49e70324c0b5962bc761a92ee4b5 \
+                        sha256  eaaf2694adb8916feabe2fda4946c272ffd753b79e82e274ccc9c60f8a19a0bc \
+                        size    61577 \
+                    github.com/weppos/publicsuffix-go \
+                        lock    v0.13.0 \
+                        rmd160  116081b672269c572c62ccca201ac99f75248d84 \
+                        sha256  bb19d269b7929c6d4c983cbcbbd63accc4b79ef5f3346960ec6c78ffbd1fa56d \
+                        size    59260 \
+                    github.com/valyala/fasttemplate \
+                        lock    v1.0.1 \
+                        rmd160  a36c2d8c29fb1dca783a0a72756c2a79e0d23309 \
+                        sha256  d8cdde0b980e2c72cb30f12033634bcf21dc543a6f3cee7154a70bf06cd31a65 \
+                        size    11818 \
+                    github.com/valyala/bytebufferpool \
+                        lock    v1.0.0 \
+                        rmd160  32bddf2031e54e583df580e989cfd9be2f51bda8 \
+                        sha256  849a2f097cc06fb40219bd350225e99bfdeb1e9105b428d72f07953f44808531 \
+                        size    5031 \
+                    github.com/stretchr/testify \
+                        lock    v1.4.0 \
+                        rmd160  86bd663e13ea7266334c47689074df16252db5ff \
+                        sha256  8ed95078bfd318ea477da509e6b16e6cf8d0d1b6b8d93b1f6097c6ba2a6df788 \
+                        size    110114 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/pkg/errors \
+                        lock    v0.8.0 \
+                        rmd160  762fc7077449a4f2467de5398bd50501ea2d7be4 \
+                        sha256  3bb85e407ab7aaf2b1e3f23b7242ded175345000b55642dc286c481e8d32d970 \
+                        size    11350 \
+                    github.com/nkovacs/streamquote \
+                        lock    49af9bddb229 \
+                        rmd160  d12c1125ca2a89640d40d5303785e3317e6ec220 \
+                        sha256  bcad13edc4d3d831437d72a4ceb76f7d017487dc3792f0408ecd82a9b2f23774 \
+                        size    3939 \
+                    github.com/mattn/go-sqlite3 \
+                        lock    v1.10.0 \
+                        rmd160  3ba2a5c3c3f99fe3bd9d9970623d8473d541707c \
+                        sha256  6cfaf1635a14ecc5ef9c61b72dfa83984d0aaf8060c107fa5b55ca3798d7a59b \
+                        size    2231312 \
+                    github.com/lib/pq \
+                        lock    v1.3.0 \
+                        rmd160  86d8b9bde83708e2bb9b13a62af8e343dcf903ea \
+                        sha256  034e6ab8ce1fb06a2de31774939d33319d2240c19211b185ef90013ccf71b8db \
+                        size    96287 \
+                    github.com/kylelemons/go-gypsy \
+                        lock    08cad365cd28 \
+                        rmd160  c7f9b7c9c9926daab231934e197001096878a9f9 \
+                        sha256  7ec1e0c28bf9070c96a108c050b3eb39257faf877f854032f1be470b2648ab3e \
+                        size    13625 \
+                    github.com/kr/text \
+                        lock    v0.1.0 \
+                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
+                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
+                        size    8691 \
+                    github.com/kr/pretty \
+                        lock    v0.1.0 \
+                        rmd160  9aa7a5aad4c48840eecfd0f80186d1fb5ded0fd6 \
+                        sha256  f6c3f89667c63e5b7f1fc6ee2c06b6a6bfdce88f3a965ccd395b64c6f95c9a47 \
+                        size    8553 \
+                    github.com/kisom/goutils \
+                        lock    v1.1.0 \
+                        rmd160  9e82745985fe5a06dc7b76009c934e0fb363d0cb \
+                        sha256  89ffac42468e833c96765243ccd13f8a66cfda65201918b12e54389c6ddba4e2 \
+                        size    71806 \
+                    github.com/kisielk/sqlstruct \
+                        lock    648daed35d49 \
+                        rmd160  6a37ee084d2408ba3175a5e67d92285e48b29a65 \
+                        sha256  9dc7cd01b375f04be6c7a8609938e177d6b419a76719e2e6d8933b7e4ad6b7db \
+                        size    5084 \
+                    github.com/jmoiron/sqlx \
+                        lock    v1.2.0 \
+                        rmd160  ec7ec0610aa5095570ec8337fb5b98cd7fb6cabb \
+                        sha256  910a22494076f7dcdc3954d0278d62cd4455eea298c7da08111b3675014b6282 \
+                        size    49555 \
+                    github.com/jmhodges/clock \
+                        lock    880ee4c33548 \
+                        rmd160  a7f9e32938f5cdcedacb93cdd4d77206ff065082 \
+                        sha256  63d7afde7e945287224920e8f23805554d3f3cd5e48d41a28aa90c83d80179db \
+                        size    5767 \
+                    github.com/jessevdk/go-flags \
+                        lock    v1.4.0 \
+                        rmd160  b0c73c434cdc6019a10f27b5ab9bbb2134ae063d \
+                        sha256  407533a2bca7c9b49b2ef5860350f0533227335191dc90995ca880091e35b503 \
+                        size    55476 \
+                    github.com/google/certificate-transparency-go \
+                        lock    v1.0.21 \
+                        rmd160  a39bfbc91beb2078a0fafbe64bba919a145498d2 \
+                        sha256  5a81e4a977b860cce7d1bed53db762be625f3d141ebfb5a698aaf03d89e87298 \
+                        size    4401580 \
+                    github.com/golang/protobuf \
+                        lock    v1.3.1 \
+                        rmd160  801150957b99de8eef10cb8d5ea2a08b240f2cb5 \
+                        sha256  a53c2c8c5c02311d2fa3bc6656614e20f9e5568b87c9f07702f083457e69f7d2 \
+                        size    310935 \
+                    github.com/go-sql-driver/mysql \
+                        lock    v1.4.0 \
+                        rmd160  e74cc9a744e6c1efd459ebd7356447c77750ccf8 \
+                        sha256  aa5a61a6ccf76481fba7558ce526c43d857f3eacdcec6a9e2b2d0d27e394c76a \
+                        size    82923 \
+                    github.com/getsentry/raven-go \
+                        lock    563b81fc02b7 \
+                        rmd160  933626e472f060a8ce3c9fdfef5162f27d243f45 \
+                        sha256  87caadd5e42d81684c35a26dd6ef7a045fbfa2bff51826747ccf76b61efff065 \
+                        size    24430 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/daaku/go.zipexe \
+                        lock    v1.0.0 \
+                        rmd160  f5efd1ab849873c73e87a3522b20b7b7df54c019 \
+                        sha256  35b91f82785376cc89a635f276c4ea35d596e0353818430c948264e3af477838 \
+                        size    2106 \
+                    github.com/cloudflare/redoctober \
+                        lock    746a508df14c \
+                        rmd160  5d5d985b02b55f6a2c0332320e6d712461508a52 \
+                        sha256  ef9311ad4e13e8a5324eb098a5422867cc4d2d630ba1d1c7d45cb7fd046de2a0 \
+                        size    536362 \
+                    github.com/cloudflare/go-metrics \
+                        lock    6a9aea36fb41 \
+                        rmd160  c179d357946e32f2e113197710feec3c75faedea \
+                        sha256  17c8a3db351bd697df49e2c3fa8855fef389df76223c48153416d145c647b3c5 \
+                        size    31845 \
+                    github.com/cloudflare/backoff \
+                        lock    647f3cdfc87a \
+                        rmd160  9b1bed36145abafbfa87e9f3a9fe33087d1acf2e \
+                        sha256  d32546e42117b6b6707db96ad8661575ee5ed50aefb6c39def49d0b1dcca0e33 \
+                        size    4751 \
+                    github.com/certifi/gocertifi \
+                        lock    deb3ae2ef261 \
+                        rmd160  603b6012b77cedc16a40e2e4ccc6fbe5d5bf5df9 \
+                        sha256  8368aa8cf2de473677fa77c1ef01f8d456d294c2d7cbe6bba7a46a4c54ee9123 \
+                        size    147884 \
+                    github.com/akavel/rsrc \
+                        lock    v0.8.0 \
+                        rmd160  924eb95cf5a06705771e75b1537e97c5856b6674 \
+                        sha256  688c181f9b36b22b3650eb31eabfed15aa13cf9939b705f7e51d8cd085d820bd \
+                        size    11155 \
+                    github.com/GeertJohan/go.rice \
+                        lock    v1.0.0 \
+                        rmd160  bf1a707bc65990bddd03145512181a2e2fb09e2b \
+                        sha256  1dfa0c320e0a946acf25e2bbc4a3680b10bda8a6b1bc6d119db9ce1caa85b5af \
+                        size    69285 \
+                    github.com/GeertJohan/go.incremental \
+                        lock    v1.0.0 \
+                        rmd160  884301b8a38638d6f1ba2e23ab6b39484218bb32 \
+                        sha256  d667969b1d35318191da8a3e918fd57a828c0a4595830d4cd9e94dd8d4a980bc \
+                        size    4130 \
+                    bitbucket.org/liamstask/goose \
+                        lock    8488cc47d90c \
+                        rmd160  0390fc7b429091d2affaa0d0cdacfbb912c96bc2 \
+                        sha256  de23d03b1f2c04c18bfd75462af496547d335e5ef7813bc72dbc8285ccfd1b70 \
+                        size    15324


### PR DESCRIPTION
#### Description

New port for the **[Cloudflare PKI/TLS toolkit](https://github.com/cloudflare/cfssl/)**

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
