### PR TITLE
edgectl: new port

### DIFF
--- a/sysutils/edgectl/Portfile
+++ b/sysutils/edgectl/Portfile
@@ -1,0 +1,52 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/datawire/ambassador 1.10.0 v
+name                edgectl
+revision            0
+
+homepage            https://www.getambassador.io
+
+description         CLI for installing and managing Ambassador
+
+long_description    Edge Control is the command-line tool for installing and \
+                    managing the Ambassador Edge Stack. And Edge Control's \
+                    outbound and intercept features allow developers to \
+                    preview changes to their services while sharing a single \
+                    development cluster. If you are a developer working on a \
+                    service that depends on other in-cluster services, use \
+                    \`edgectl connect\` to set up connectivity from your \
+                    laptop to the cluster. This allows software on your \
+                    laptop, such as your work-in-progress service running in \
+                    your debugger, to connect to other services in the \
+                    cluster.  When you want to test your service with traffic \
+                    from the cluster, use \`edgectl intercept\` to designate \
+                    a subset of requests for this service to be redirected to \
+                    your laptop. You can use those requests to test and debug \
+                    your local copy of the service. All other requests will \
+                    go to the existing service running in the cluster \
+                    without disruption.
+
+categories          sysutils net
+license             Apache-2
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+build.pre_args      -ldflags \"-X main.Version=${version}\"
+build.args          ./cmd/edgectl
+
+installs_libs       no
+
+# Allow Go to download dependencies at build time
+build.env-delete    GOPROXY=off GO111MODULE=off
+
+checksums           rmd160  6884c9c11ce4a536ce2b1004880589f6c0a4b5db \
+                    sha256  031c2e05ad8113cf272a0ccdb1fdb7be501cd7b56166ee8870dc5154ec68f90e \
+                    size    8727154
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

New port for [Ambassador's edgectl](https://www.getambassador.io/)

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
