### PR TITLE
py-cffi: fix build on older systems

### DIFF
--- a/python/py-cffi/Portfile
+++ b/python/py-cffi/Portfile
@@ -29,6 +29,9 @@ checksums           rmd160  585002edbc970ac5ec7f592bb873cc7c415b9b31 \
 if {${name} ne ${subport}} {
     patchfiles-append   patch-setup.py.diff
 
+    # ticket 61804
+    compiler.blacklist-append *gcc-3.* *gcc-4.*
+
     depends_build-append \
                         port:py${python.version}-setuptools
     depends_lib-append  port:libffi \

--- a/python/py-cffi/files/patch-setup.py.diff
+++ b/python/py-cffi/files/patch-setup.py.diff
@@ -1,7 +1,7 @@
---- setup.py.orig	2015-12-18 16:51:35.000000000 +0300
-+++ setup.py	2015-12-18 16:52:01.000000000 +0300
-@@ -67,9 +67,6 @@
-         sys.stderr.write("The above error message can be safely ignored\n")
+--- setup.py.orig	2020-11-24 06:08:38.000000000 -0800
++++ setup.py	2020-12-10 22:04:28.000000000 -0800
+@@ -109,9 +109,6 @@
+     return config.try_compile('#ifndef _MSC_VER\n#error "not MSVC"\n#endif')
  
  def use_pkg_config():
 -    if sys.platform == 'darwin' and os.path.exists('/usr/local/bin/brew'):
@@ -10,3 +10,14 @@
      _ask_pkg_config(include_dirs,       '--cflags-only-I', '-I', sysroot=True)
      _ask_pkg_config(extra_compile_args, '--cflags-only-other')
      _ask_pkg_config(library_dirs,       '--libs-only-L', '-L', sysroot=True)
+@@ -153,10 +150,6 @@
+     ask_supports_thread()
+     ask_supports_sync_synchronize()
+ 
+-if 'darwin' in sys.platform:
+-    # priority is given to `pkg_config`, but always fall back on SDK's libffi.
+-    extra_compile_args += ['-iwithsysroot/usr/include/ffi']
+-
+ if 'freebsd' in sys.platform:
+     include_dirs.append('/usr/local/include')
+     library_dirs.append('/usr/local/lib')


### PR DESCRIPTION
blacklist older gcc versions that don't allow
  pragmas inside functions
remove a -iwithisysroot command that points to
  /usr/include/libffi, which we never want,
  and which is not accepted by gcc

closes: https://trac.macports.org/ticket/61804

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.5.8 9L31a
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
