### PR TITLE
npm6: depend upon nodejs15

### DIFF
--- a/devel/npm6/Portfile
+++ b/devel/npm6/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                npm6
 version             6.14.10
+revision            1
 categories          devel
 platforms           darwin
 supported_archs     noarch
@@ -32,7 +33,7 @@ checksums           sha1    f45c8e4244294ba793770f2ab0e9ce2d0b93fd29 \
 
 worksrcdir          "package"
 
-depends_lib         path:bin/node:nodejs14
+depends_lib         path:bin/node:nodejs15
 
 platform darwin {
     if {${os.major} < 13} {


### PR DESCRIPTION
#### Description

nodejs15 now builds on arm64. Re-target npm6 to work with nodejs15 so
that a usable node system can be installed on that platform.

Note: There may be a good reason that npm6 requires nodejs14, rather than 15.  If so, is there an alternative to getting a fully working node system on arm64?

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
