### PR TITLE
vf1: submission

### DIFF
--- a/net/vf-1/Portfile
+++ b/net/vf-1/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           python 1.0
+
+name                vf-1
+github.setup        solderpunk vf-1 0.0.11 v
+categories          net python
+platforms           darwin
+license             BSD
+maintainers         {@ryanakca debian.org:rak}
+description         command-line gopher client
+long_description    A full-featured gopher client. VF-1's features include:\
+                    \n* Bookmarking\
+                    \n* Configurable MIME-type handlers\
+                    \n* Line wrapping\
+                    \n* TLS support\
+                    \n* visiting a queue of links (the "tour" feature)\
+                    \n* Veronica search
+
+github.tarball_from archive
+
+python.default_version     38
+
+checksums           rmd160  2f569ef10cc28a21a18b099fdecd3f1ec774cff4 \
+                    sha256  021d2020cddb5ef83e9c26038df95bbb4a6ad9c4cdc7303cbda9c4129856db0e \
+                    size    19400
+
+depends_build-append port:py${python.version}-setuptools
+
+# We need gnureadline due to https://trac.macports.org/ticket/47827
+depends_lib         port:py${python.version}-gnureadline


### PR DESCRIPTION
#### Description

```
long_description    A full-featured gopher client. VF-1's features include:\
                    \n* Bookmarking\
                    \n* Configurable MIME-type handlers\
                    \n* Line wrapping\
                    \n* TLS support\
                    \n* visiting a queue of links (the "tour" feature)\
                    \n* Veronica search
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.0.1 20B29
Xcode 12.2 12B45b


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
