### PR TITLE
pass: fix bash, fish and zsh completion installation

### DIFF
--- a/security/pass/Portfile
+++ b/security/pass/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                pass
 version             1.7.3
+revision            1
 maintainers         nomaintainer
 categories          security
 description         ${name} is the standard unix password manager
@@ -44,7 +45,7 @@ default_variants    +bash
 
 variant bash description {Include Bash completion support} {
     depends_run-append port:bash
-    destroot.env-append FORCE_BASHCOMP=1
+    destroot.env-append WITH_BASHCOMP=yes
 
     notes-append {
         To use pass bash completion, add the following lines at the end of your .bash_profile:
@@ -54,12 +55,12 @@ variant bash description {Include Bash completion support} {
 
 variant fish description {Include fish completion support} {
     depends_run-append port:fish
-    destroot.env-append FORCE_FISHCOMP=1
+    destroot.env-append WITH_FISHCOMP=yes
 }
 
 variant zsh description {Include Zsh completion support} {
     depends_run-append port:zsh
-    destroot.env-append FORCE_ZSHCOMP=1
+    destroot.env-append WITH_ZSHCOMP=yes
 }
 
 livecheck.type    regex


### PR DESCRIPTION
#### Description

Currently, makefile variables are used that aren't referenced in pass'
Makefile.  The name of the variables that control completion install
must have changed from FORCE_<shellname> to WITH_<shellname>.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
