### PR TITLE
libqalculate: use legacysupport

### DIFF
--- a/math/libqalculate/Portfile
+++ b/math/libqalculate/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           compiler_blacklist_versions 1.0
+PortGroup           legacysupport 1.1
 
 github.setup        qalculate libqalculate 3.15.0 v
 revision            0


### PR DESCRIPTION
fixes:
qalc.cc:5691:52: error: use of undeclared identifier 'CLOCK_MONOTONIC'
