### PR TITLE
erlang: fix for faulty symbolic links; issue: 61665

### DIFF
--- a/lang/erlang/Portfile
+++ b/lang/erlang/Portfile
@@ -6,7 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                erlang
 version             23.1
-revision            0
+revision            1
 
 categories          lang erlang
 maintainers         {ciserlohn @ci42}
@@ -90,8 +90,8 @@ post-destroot   {
     system "tar -C ${destroot}${prefix}/lib/erlang -zxvf [shellescape ${distpath}/otp_doc_html_${version}${extract.suffix}]"
     system "tar -C ${destroot}${prefix}/lib/erlang -zxvf [shellescape ${distpath}/otp_doc_man_${version}${extract.suffix}]"
  
-    set erts_dir            erts-11.0
-    set erl_interface_dir   erl_interface-4.0
+    set erts_dir            erts-11.1
+    set erl_interface_dir   erl_interface-4.0.1
     set wx_dir              wx-1.9.1
 
     foreach x {dialyzer ear ecc elink epmd erl erlc escript run_erl start to_erl typer} {


### PR DESCRIPTION
#### Description

Update erlang portfile, to fix broken functionality caused by faulty soft links.

Tracked by MacPorts issue:
[61665](https://trac.macports.org/ticket/61665)

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.8.5 12F2560
Xcode 5.1.1 5B1008

macOS 10.12.6 16G2136
Xcode 9.2 9C40b

macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] ensured the port does not create any faulty symbolic links?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
