### PR TITLE
hyper: new port

### DIFF
--- a/aqua/hyper/Portfile
+++ b/aqua/hyper/Portfile
@@ -1,0 +1,54 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        vercel hyper 3.0.2
+revision            0
+
+homepage            https://hyper.is
+
+description         A terminal built on web technologies
+
+long_description    {*}${description}. The goal of the project is to create a \
+                    beautiful and extensible experience for command-line \
+                    interface users, built on open web standards. In the \
+                    beginning, our focus will be primarily around speed, \
+                    stability and the development of the correct API for \
+                    extension authors.
+
+categories          aqua shells
+license             MIT
+platforms           darwin
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  d0d44d2e4163f9ef3b3ffbcb31d9c8af6111ed0f \
+                    sha256  ef9b9883fe25a003243030b9d7ff09ce3b67512daff3495e85669e85e99fffd2 \
+                    size    1665558
+
+patchfiles          patch-package-json.diff
+
+depends_build       port:python27 \
+                    port:yarn
+
+build.env-append    CSC_IDENTITY_AUTO_DISCOVERY=false
+
+use_configure       no
+use_xcode           yes
+
+build {
+    # Set up all JS dependencies
+    system -W ${worksrcpath} "yarn --frozen-lockfile"
+
+    # Build electron app
+    system -W ${worksrcpath} "${build.env} yarn run dist"
+}
+
+destroot {
+    copy ${worksrcpath}/dist/mac/Hyper.app ${destroot}${applications_dir}
+}
+
+github.livecheck.regex {([0-9.]+)}

--- a/aqua/hyper/files/patch-package-json.diff
+++ b/aqua/hyper/files/patch-package-json.diff
@@ -1,0 +1,16 @@
+--- package.json	2020-12-13 01:59:24.000000000 -0500
++++ package.json	2020-12-13 02:00:43.000000000 -0500
+@@ -158,7 +158,12 @@
+     },
+     "mac": {
+       "category": "public.app-category.developer-tools",
+-      "extendInfo": "build/Info.plist"
++      "extendInfo": "build/Info.plist",
++      "target": [
++        {
++          "target": "dir"
++        }
++      ]
+     },
+     "deb": {
+       "afterInstall": "./build/linux/after-install.tpl"


### PR DESCRIPTION
#### Description

New port for the **[Hyper](https://hyper.is/)** web-based terminal app

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
