### PR TITLE
libmpeg2: fix arm64 build by dropping old ARM asm code

### DIFF
--- a/multimedia/libmpeg2/Portfile
+++ b/multimedia/libmpeg2/Portfile
@@ -19,9 +19,10 @@ platforms           darwin
 master_sites        ${homepage}files/
 
 checksums           rmd160  00b2d669655ed3f7a176f5eecc925045159a0301 \
-                    sha256  dee22e893cb5fc2b2b6ebd60b88478ab8556cb3b93f9a0d7ce8f3b61851871d4
+                    sha256  dee22e893cb5fc2b2b6ebd60b88478ab8556cb3b93f9a0d7ce8f3b61851871d4 \
+                    size    524776
 
-patchfiles          universal.patch
+patchfiles          universal.patch patch-arm64.diff
 
 configure.args      --enable-shared \
                     --disable-sdl \

--- a/multimedia/libmpeg2/files/patch-arm64.diff
+++ b/multimedia/libmpeg2/files/patch-arm64.diff
@@ -1,0 +1,11 @@
+--- configure.orig	2008-07-18 16:41:54.000000000 +0200
++++ configure	2020-12-13 11:36:32.000000000 +0100
+@@ -5144,7 +5144,7 @@
+ #define ARCH_ALPHA
+ _ACEOF
+ ;;
+-    arm*)
++    brokenarm*)
+ 	arm_conditional=:
+ 
+ cat >>confdefs.h <<\_ACEOF


### PR DESCRIPTION
#### Description

libmpeg2 currenly fails to build on arm64, because `./configure` enables old ARM assembly code on all `arm*` systems. This assembly code can't work on arm64 systems. Other ports tree such as [OpenBSD's](https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/graphics/libmpeg2/patches/patch-configure_ac) just disable this configure check, so I suggest doing the same.

Not bumping `revision` since it fixes a build failure, and doesn't change anything on other architectures.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?