### PR TITLE
optipng: fix arm64 linking error

### DIFF
--- a/graphics/optipng/Portfile
+++ b/graphics/optipng/Portfile
@@ -30,6 +30,8 @@ checksums       rmd160  bd6df4ef9f258474f352820eec545f482c7194cd \
 configure.cppflags
 configure.ldflags
 
+configure.cppflags-append -DPNG_ARM_NEON_OPT=0
+
 configure.args-append  --mandir=${prefix}/share/man
 
 configure.universal_args-delete --disable-dependency-tracking


### PR DESCRIPTION
Disable `PNG_ARM_NEON_OPT` to avoid a linking error in bundled libpng for `png_init_filter_functions_neon()`.

Otherwise, the build currently fails on arm64 with the following error:

```
:info:build /usr/bin/clang -Os -arch arm64 -Wl,-syslibroot,/Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk -arch arm64 -o optipng optipng.o optim.o bitset.o ioutil.o ratio.o wildargs.o ../opngreduc/libopngreduc.a ../pngxtern/libpngxtern.a ../libpng/libpng.a ../zlib/libz.a ../gifread/libgifread.a ../pnmio/libpnmio.a ../minitiff/libminitiff.a   -lm
:info:build Undefined symbols for architecture arm64:
:info:build   "_png_init_filter_functions_neon", referenced from:
:info:build       _png_read_filter_row in libpng.a(pngrutil.o)
:info:build ld: symbol(s) not found for architecture arm64
:info:build clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

OptiPNG already disables a good number of libpng features, so I'm not sure that a more complicated fix restoring NEON support in optipng's limited build system would be worth it.

(An alternative solution is to make optipng use the MacPorts version of libpng, instead of using the bundled copy.)

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?