### PR TITLE
py-serial: Update to v3.5.

### DIFF
--- a/python/py-serial/Portfile
+++ b/python/py-serial/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        pyserial pyserial 3.4 v
-revision            1
+github.setup        pyserial pyserial 3.5 v
+revision            0
 name                py-serial
 
 categories-append   comms
@@ -21,11 +21,11 @@ long_description    This module encapsulates the access for the serial port. \
                     The module named "serial" automatically selects the appropriate \
                     backend.
 
-checksums			rmd160  a307efb344e513f0f31efae1d0c3a1def3c68a9a \
-                    sha256  17279a02e2e14034f6366032b6e43db99ae6640b22b8fbac09cd47398a136173 \
-                    size 148412
+checksums           rmd160  ee56e22c15af484b72b65d445a4fe8a2aeee0cd0 \
+                    sha256  80125f950a620bd0a31cfa18f5eda0df77e0bed2accc2bb7a76ab650ff63afa9 \
+                    size    155864
 
-python.versions     27 35 36 37 38 39
+python.versions     27 34 35 36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
Also adds back py34 subport, since upstream supports it and it's
sometimes useful for testing.

TESTED:
Using gpsd's ubxtool, tested with Python 2.7 and 3.4-3.9, on 10.4-10.5
ppc, 10.4-10.6 i386, and 10.5-10.15 x86_64.

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G6042, x86_64, Xcode 11.3.1 11C505
macOS 10.15.6 19G2021, x86_64, Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [N/A] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
