### PR TITLE
cmake: variant qt5: fix faulty symbolic link 'cmake-gui'

### DIFF
--- a/devel/cmake/Portfile
+++ b/devel/cmake/Portfile
@@ -42,7 +42,7 @@ if {${subport} eq ${name}} {
     checksums rmd160  934ee2e839f743e33ec609854c70fc46f25a5566 \
               sha256  8ddd992642e6050b302dfb66e70c17ab60063882d55421af070728638c194517 \
               size    7128815
-    revision  1
+    revision  2
 
     compiler.cxx_standard 2011
 

--- a/devel/cmake/files/patch-qt5gui.diff
+++ b/devel/cmake/files/patch-qt5gui.diff
@@ -20,7 +20,7 @@
 +  # installed. This one is created in the installation.
    install(CODE "
 -    execute_process(COMMAND ln -s \"../MacOS/CMake\" cmake-gui
-+    execute_process(COMMAND ln -s \"${CMAKE_BUNDLE_LOCATION}/CMake.app/MacOS/CMake\" cmake-gui
++    execute_process(COMMAND ln -s \"${CMAKE_BUNDLE_LOCATION}/CMake.app/Contents/MacOS/CMake\" cmake-gui
          WORKING_DIRECTORY \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/bin)
    " ${COMPONENT})
  endif()


### PR DESCRIPTION
#### Description

CMake: Fix faulty symbolic link `${prefix}/bin/cmake-gui`, for variant qt5.

Tracked by issue:
[61811](https://trac.macports.org/ticket/61811)

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14019
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] ensured the port does not create any faulty symbolic links?