### PR TITLE
valgrind: bump to 3.16.1, add valgrind-macos-devel

### DIFF
--- a/devel/valgrind/Portfile
+++ b/devel/valgrind/Portfile
@@ -131,7 +131,6 @@ subport valgrind-devel {
 }
 
 subport valgrind-macos-devel {
-    epoch           1
     set date        2020-12-17
     version         3.16.1-r${date}
     conflicts       valgrind valgrind-devel

--- a/devel/valgrind/Portfile
+++ b/devel/valgrind/Portfile
@@ -78,13 +78,13 @@ pre-configure {
 }
 
 if {$subport eq $name} {
-    version             3.14.0
+    version             3.16.1
     revision            0
-    conflicts           valgrind-devel
+    conflicts           valgrind-devel valgrind-macos-devel
 
-    checksums           rmd160  562359c6222acd8546eedf6f0b6db964e91bd434 \
-                        sha256  037c11bfefd477cc6e9ebe8f193bb237fe397f7ce791b4a4ce3fa1c6a520baa5 \
-                        size    16602858
+    checksums           rmd160  f06068b1f2aa9f6c2377816a0af809459da2c5a8 \
+                        sha256  c91f3a2f7b02db0f3bc99479861656154d241d2fdb265614ba918cc6720a33ca \
+                        size    16262776
 
     use_bzip2           yes
 
@@ -105,13 +105,13 @@ if {$subport eq $name} {
 
 subport valgrind-devel {
     epoch           1
-    set date        2017-11-21
-    version         3.14.0-r${date}
-    conflicts       valgrind
+    set date        2020-12-17
+    version         3.16.1-r${date}
+    conflicts       valgrind valgrind-macos-devel
 
     fetch.type      git
     git.url         http://repo.or.cz/valgrind.git
-    git.branch      0a5ff8c309d18778bb919a1a661a1976b04a6483
+    git.branch      04cdc29b007594a0e58ffef0c9dd87df3ea595ea
 
     pre-fetch {
         if {${os.platform} eq "darwin" && ${os.major} < 9 } {
@@ -124,6 +124,23 @@ subport valgrind-devel {
             return -code error "incompatible macOS version"
         }
     }
+
+    use_autoreconf      yes
+
+    livecheck.type none
+}
+
+subport valgrind-macos-devel {
+    epoch           1
+    set date        2020-12-17
+    version         3.16.1-r${date}
+    conflicts       valgrind valgrind-devel
+
+    fetch.type      git
+    git.url         https://github.com/LouisBrunner/valgrind-macos.git
+    git.branch      adaae87a41bccb91fef7bf834647d1874c3ba816
+
+    description     A powerful memory debugger with latest macOS support
 
     use_autoreconf      yes
 


### PR DESCRIPTION
#### Description

* bump valgrind to 3.16.1
* bump valgrind-devel to latest version ot 2020-12-17
* add a fork that can be used on latest macOS

###### Type(s)

- [x] update
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.1 20C69
Xcode 12.3 12C33
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
