### PR TITLE
google-cloud-sdk: update to 321.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             320.0.0
+version             321.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  0899b6259c82a6dd050ffc20df8abc2908ae5e4d \
-                    sha256  6547b2b7d2819e8870d3f20ddfd943fda349ec2d15a228858419134b536c4070 \
-                    size    85975911
+    checksums       rmd160  c8139a7e87702ab9933979d99093454288f2fb3e \
+                    sha256  2895762c646e3a8decc95a92cf9b09a426318d59efb19a8100cc3bd5444592fe \
+                    size    86065585
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  181cbbda2089903751edd434c63d624021f35ffc \
-                    sha256  4e9f98a7361fab73ea6b1e2e3d6f045914fefdf1798880cac59741464a2e11b3 \
-                    size    107893233
+    checksums       rmd160  40b7e494f3560c465faea32c95f9b3196c529092 \
+                    sha256  3bca7104f35cd0eacab475b2828cf979dc4a488ac5213c4cceb9d7b104dc38d6 \
+                    size    108128649
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 321.0.0.

###### Tested on

macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?