### PR TITLE
mbedtls: Use github portgroup

### DIFF
--- a/devel/mbedtls/Portfile
+++ b/devel/mbedtls/Portfile
@@ -2,9 +2,9 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.1
+PortGroup           github 1.0
 
-name                mbedtls
-version             2.25.0
+github.setup        ARMmbed mbedtls 2.25.0 mbedtls-
 revision            0
 
 categories          devel
@@ -16,8 +16,7 @@ long_description    {*}${description}
 platforms           darwin
 
 homepage            https://tls.mbed.org
-master_sites        https://github.com/ARMmbed/mbedtls/archive
-distfiles           ${name}-${version}${extract.suffix}
+github.tarball_from archive
 
 checksums           rmd160  05a42409bafee4bfe1397a98878abdaab7d85c2c \
                     sha256  ea2049c2dd4868693998d5a9780e198194be5aea1706ff4a9d4f882f18c0a101 \
@@ -59,7 +58,3 @@ if {${os.platform} eq "darwin" && ${os.major} < 13} {
 }
 
 test.run            yes
-
-livecheck.type      regex
-livecheck.url       https://github.com/ARMmbed/mbedtls/releases
-livecheck.regex     ${name}-(\\d+(?:\\.\\d+)*)${extract.suffix}


### PR DESCRIPTION
#### Description

mbedtls: Use github portgroup

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14019
Xcode 9.4.1 9F2000
