### PR TITLE
tilt: new port

### DIFF
--- a/devel/tilt/Portfile
+++ b/devel/tilt/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/tilt-dev/tilt 0.18.6 v
+revision            0
+
+categories          devel
+maintainers         nomaintainer
+platforms           darwin
+license             Apache-2
+
+description         Run Kubernetes environments locally, for local development
+
+long_description    Tilt powers multi-service development and makes sure they \
+                    behave! Run tilt up to work in a complete dev environment \
+                    configured for your team. \
+                    \
+                    Tilt automates all the steps from a code change to a new \
+                    process: watching files, building container images, and \
+                    bringing your environment up-to-date. Think docker build \
+                    && kubectl apply or docker-compose up.
+
+homepage            https://tilt.dev/
+
+checksums           rmd160  17ff0a5a8b343760d4b719aa01337cdb0ca488cd \
+                    sha256  f4f51a362b326f3df4c315bb3c932a87b2d7a5a29e6b72bb85beb0f0d82c42df \
+                    size    23480949
+
+depends_build-append \
+                    port:yarn port:nodejs12
+use_parallel_build  no
+build.cmd           "make build-js && ${go.bin} build -mod vendor ./cmd/tilt"
+build.env-replace   GO111MODULE=off GO111MODULE=on
+
+destroot {
+    xinstall -m 0755 ${build.dir}/${name} ${destroot}${prefix}/bin/
+}
+


### PR DESCRIPTION
#### Description
Unfortunately the yarn stuff requires network i/o to build, but at least it has a lockfile. The go dependencies are all vendored.

###### Type(s)

- [x] enhancement

###### Tested on
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
