### PR TITLE
sbt: bump to 1.4.6

### DIFF
--- a/devel/sbt/Portfile
+++ b/devel/sbt/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            sbt
-version         0.13.18
+version         1.4.6
 revision        0
 categories      devel java
 license         BSD
@@ -20,17 +20,15 @@ long_description \
     and testing with triggered execution in mixed Scala/Java projects.
 
 homepage        https://www.scala-sbt.org/
-master_sites    https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/${version}
-distname        ${name}-launch
-dist_subdir     ${name}/${version}
+master_sites    https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/${version}
+distname        sbt-launch
+dist_subdir     sbt/${version}
 
-checksums       md5     c660658ea9b1300d31aaa713f214b1b4 \
-                sha1    db44e7b60ed5c82ea00315ad223e3a8cc3d086e5 \
-                rmd160  a61cd251a1593dafa0d1452dbb615b4fb1fd5a19 \
-                sha256  add170a6e07d3ecf2a5add54565a0b5f729524083f0b05f9e1d4df90adb9257b \
-                size    1210278
+checksums       rmd160  99cc4c86e79a5e5c29e798a641f4391004c73e90 \
+                sha256  0d389f794664a49684fdcdb2cbc8bbcacdb4fc72dd4e6b8a654b69a3b50278ca \
+                size    1394954
 
-java.version    1.6+
+java.version    1.8+
 java.fallback   openjdk8
 
 # Name the wrapper shell script.
@@ -65,5 +63,5 @@ destroot {
 }
 
 livecheck.type  regex
-livecheck.url   https://dl.bintray.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/
-livecheck.regex {>([0-9.]+)/<}
+livecheck.url   https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/maven-metadata.xml
+livecheck.regex {\<latest\>([0-9.]+)\</latest\>}


### PR DESCRIPTION
#### Description

old port migrated to sbt-0.13

###### Type(s)

- [x] update
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
