### PR TITLE
py-pytest-asyncio: update to 0.14.0, maintainer

### DIFF
--- a/python/py-pytest-asyncio/Portfile
+++ b/python/py-pytest-asyncio/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        pytest-dev pytest-asyncio 0.10.0 v
+github.setup        pytest-dev pytest-asyncio 0.14.0 v
 name                py-pytest-asyncio
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
 license             Apache-2
-maintainers         nomaintainer
+maintainers         {@jandemter demter.de:jan} openmaintainer
 
 description         pytest support for asyncio
 long_description    \
@@ -20,15 +20,16 @@ long_description    \
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  17544d7f44bf1160881409e306622bb7ec971489 \
-                    sha256  082aca0ee895e33460aa4c32bd2922ab7f7dcdbe5417b40d4700457ab3680b65 \
-                    size    13983
+checksums           rmd160  552d2e17a62eee56168fef73d67f8219660cffe5 \
+                    sha256  504d4179e83d532b11fa0a51bfa0737abaf1aac315b6f033e4dfc918ef27bc65 \
+                    size    14803
 
-python.versions     36 37 38
+python.versions     36 37 38 39
 
 if {${name} ne ${subport}} {
-    depends_build-append    port:py${python.version}-setuptools \
-                            port:py${python.version}-async_generator \
+    depends_build-append    port:py${python.version}-setuptools
+
+    depends_test-append     port:py${python.version}-async_generator \
                             port:py${python.version}-hypothesis
 
     depends_lib-append      port:py${python.version}-pytest


### PR DESCRIPTION
#### Description
- update to 0.14.0
- add maintainer
- added Python 3.9 subport
- changed some dependencies to test-only as well

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3 12C33


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
