### PR TITLE
py-outcome: update to 1.1.0, remove py27, py35

### DIFF
--- a/python/py-outcome/Portfile
+++ b/python/py-outcome/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-outcome
-version             1.0.0
+version             1.1.0
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
 license             {Apache-2 MIT}
 
-python.versions     27 35 36 37 38
+python.versions     36 37 38 39
 
 maintainers         {@jandemter demter.de:jan} openmaintainer
 
@@ -23,9 +23,9 @@ master_sites        pypi:o/outcome
 
 distname            outcome-${version}
 
-checksums           rmd160  6b31076292a1a6ef4ee93bffb0d3cc109a63d515 \
-                    sha256  9d58c05db36a900ce60c6da0167d76e28869f64b338d60fa3a61841cfa54ac71 \
-                    size    17307
+checksums           rmd160  4913b8bb101cb26474607864d8d44343c9410daf \
+                    sha256  e862f01d4e626e63e8f92c38d1f8d5546d3f9cce989263c521b2e7990d186967 \
+                    size    18164
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

- add Python 3.9 subport
- fixes trac [61832](https://trac.macports.org/ticket/61832) by removing Python 2.7 subport

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
