### PR TITLE
libreoffice: accept macOS 11.1 SDK

### DIFF
--- a/office/libreoffice/Portfile
+++ b/office/libreoffice/Portfile
@@ -215,7 +215,8 @@ if {${os.major} < 14} {
 
 patchfiles \
     configure.patch \
-    unpack-sources-fix-for-bsd-find.patch
+    unpack-sources-fix-for-bsd-find.patch \
+    accept-macos-11.1.patch
 
 set product_name LibreOffice
 

--- a/office/libreoffice/files/accept-macos-11.1.patch
+++ b/office/libreoffice/files/accept-macos-11.1.patch
@@ -1,0 +1,52 @@
+diff --git configure.ac configure.ac
+index ad35a32c752e..5836bbb58d4a 100644
+--- configure.ac
++++ configure.ac
+@@ -3105,7 +3105,7 @@ if test $_os = Darwin; then
+     # higher than or equal to the minimum required should be found.
+ 
+     AC_MSG_CHECKING([what macOS SDK to use])
+-    for _macosx_sdk in ${with_macosx_sdk-11.0 10.15 10.14 10.13}; do
++    for _macosx_sdk in ${with_macosx_sdk-11.1 11.0 10.15 10.14 10.13}; do
+         MACOSX_SDK_PATH=`xcrun --sdk macosx${_macosx_sdk} --show-sdk-path 2> /dev/null`
+         if test -d "$MACOSX_SDK_PATH"; then
+             with_macosx_sdk="${_macosx_sdk}"
+@@ -3137,8 +3137,11 @@ if test $_os = Darwin; then
+     11.0)
+         MACOSX_SDK_VERSION=110000
+         ;;
++    11.1)
++        MACOSX_SDK_VERSION=110100
++        ;;
+     *)
+-        AC_MSG_ERROR([with-macosx-sdk $with_macosx_sdk is not a supported value, supported values are 10.13--11.0])
++        AC_MSG_ERROR([with-macosx-sdk $with_macosx_sdk is not a supported value, supported values are 10.13--11.1])
+         ;;
+     esac
+ 
+@@ -3200,8 +3203,11 @@ if test $_os = Darwin; then
+     11.0)
+         MAC_OS_X_VERSION_MIN_REQUIRED="110000"
+         ;;
++    11.1)
++        MAC_OS_X_VERSION_MIN_REQUIRED="110100"
++        ;;
+     *)
+-        AC_MSG_ERROR([with-macosx-version-min-required $with_macosx_version_min_required is not a supported value, supported values are 10.10--11.0])
++        AC_MSG_ERROR([with-macosx-version-min-required $with_macosx_version_min_required is not a supported value, supported values are 10.10--11.1])
+         ;;
+     esac
+ 
+@@ -3262,8 +3268,11 @@ if test $_os = Darwin; then
+     11.0)
+         MAC_OS_X_VERSION_MAX_ALLOWED="110000"
+         ;;
++    11.1)
++        MAC_OS_X_VERSION_MAX_ALLOWED="110100"
++        ;;
+     *)
+-        AC_MSG_ERROR([with-macosx-version-max-allowed $with_macosx_version_max_allowed is not a supported value, supported values are 10.10--11.0])
++        AC_MSG_ERROR([with-macosx-version-max-allowed $with_macosx_version_max_allowed is not a supported value, supported values are 10.10--11.1])
+         ;;
+     esac
+ 


### PR DESCRIPTION
Patch is from upstream: libreoffice/core@378f96019fff0d2e4db318187c3c143bdc0c3982

Should be removed when next version of LibreOffice is released.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
