### PR TITLE
fix errors when compiling using Xcode 12

### DIFF
--- a/math/primegen/Portfile
+++ b/math/primegen/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                primegen
 version             0.97
+revision            1
 categories          math
 platforms           darwin
 maintainers         yandex.com:bstj openmaintainer
@@ -21,7 +22,8 @@ homepage            https://cr.yp.to/primegen.html
 master_sites        https://cr.yp.to/primegen/
 
 checksums           rmd160  6f18fb8819e5589b0d7701f2dd69a2d8be4138b3 \
-                    sha256  54285baf8eed9e421ff2220a2112d38cfb20c1ebef6014ef3f0004c22c95f40d
+                    sha256  54285baf8eed9e421ff2220a2112d38cfb20c1ebef6014ef3f0004c22c95f40d \
+                    size    31491
 
 configure {
     reinplace "s|gcc|${configure.cc} [get_canonical_archflags cc]|" ${worksrcpath}/conf-cc
@@ -29,6 +31,8 @@ configure {
 }
 
 build.target        it
+
+patchfiles          patch-modernise.diff
 
 destroot {
     xinstall -m 755 ${worksrcpath}/primegaps ${worksrcpath}/primes ${destroot}${prefix}/bin

--- a/math/primegen/Portfile
+++ b/math/primegen/Portfile
@@ -4,7 +4,6 @@ PortSystem          1.0
 
 name                primegen
 version             0.97
-revision            1
 categories          math
 platforms           darwin
 maintainers         yandex.com:bstj openmaintainer

--- a/math/primegen/files/patch-modernise.diff
+++ b/math/primegen/files/patch-modernise.diff
@@ -1,0 +1,89 @@
+diff --git eratspeed.c eratspeed.c
+index 3bad129..08fe934 100644
+--- eratspeed.c
++++ eratspeed.c
+@@ -1,6 +1,7 @@
+ #define B32 1001
+ #define B (B32 * 32)
+ 
++#include <stdio.h>
+ #include "timing.h"
+ #include "uint32.h"
+ 
+@@ -400,7 +401,7 @@ void countit()
+ timing t;
+ timing told;
+ 
+-main()
++int main()
+ {
+   int L = 1;
+ 
+@@ -432,5 +433,5 @@ main()
+   printf("Overall seconds: approximately %f.\n",0.000000001 * timing_basic_diff(&finishb,&startb));
+   printf("Tick counts may be underestimates on systems without hardware tick support.\n");
+ 
+-  exit(0);
++  return 0;
+ }
+diff --git primegaps.c primegaps.c
+index c040611..190d6b1 100644
+--- primegaps.c
++++ primegaps.c
+@@ -1,9 +1,10 @@
++#include <stdio.h>
+ #include <math.h>
+ #include "primegen.h"
+ 
+ primegen pg;
+ 
+-void main()
++int main()
+ {
+   uint64 p;
+   uint64 lastp;
+diff --git primes.c primes.c
+index b8b0461..a9cd8e5 100644
+--- primes.c
++++ primes.c
+@@ -36,7 +36,7 @@ primegen pg;
+ uint32 digits[40];
+ int len;
+ 
+-void main(argc,argv)
++int main(argc,argv)
+ int argc;
+ char **argv;
+ {
+@@ -88,5 +88,5 @@ char **argv;
+     putchar('\n');
+   }
+ 
+-  exit(0);
++  return 0;
+ }
+diff --git primespeed.c primespeed.c
+index 3d16c04..294f120 100644
+--- primespeed.c
++++ primespeed.c
+@@ -1,3 +1,4 @@
++#include <stdio.h>
+ #include "timing.h"
+ #include "primegen.h"
+ #include "primegen_impl.h"
+@@ -89,7 +90,7 @@ timing_basic startb;
+ timing finish;
+ timing_basic finishb;
+ 
+-void main(argc,argv)
++int main(argc,argv)
+ int argc;
+ char **argv;
+ {
+@@ -118,5 +119,5 @@ char **argv;
+   printf("Overall seconds: approximately %f.\n",0.000000001 * timing_basic_diff(&finishb,&startb));
+   printf("Tick counts may be underestimates on systems without hardware tick support.\n");
+ 
+-  exit(0);
++  return 0;
+ }


### PR DESCRIPTION
#### Description

Fix issues in code that are causing error in Xcode 12 and caused warnings in previous versions. Namely include missing stdio.h, use int as return type for main and use return instead of exit in main.

https://trac.macports.org/ticket/61870

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.7 19H15
Xcode 12.3 12C33

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
