### PR TITLE
dstask: new port

### DIFF
--- a/office/dstask/Portfile
+++ b/office/dstask/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/naggie/dstask 0.23.2 v
+revision            0
+
+description         Single binary terminal-based TODO manager with git-based \
+                    sync + markdown notes per task
+
+long_description    {*}${description}. Dstask is a personal task tracker \
+                    designed to help you focus. It is similar to taskwarrior \
+                    but uses git to synchronise instead of a special protocol.
+
+categories          office
+license             MIT
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  b77d01474ea405fe3021f42bc8c701210bc29462 \
+                    sha256  26520fa0d0b89b416b569aa486e7442bb3e9e039493742a7e5291228aad83b04 \
+                    size    2538050
+
+build.pre_args      -o _dist/dstask
+build.args          ./cmd/dstask
+
+installs_libs       no
+use_parallel_build  no
+
+# Allow Go to fetch dependencies at build time.
+# When dependencies are vendored, build fails due to an unsafeheader issue.
+build.env-delete    GO111MODULE=off GOPROXY=off
+
+destroot {
+    foreach dstask_bin [glob ${worksrcpath}/_dist/*] {
+        xinstall -m 755 ${dstask_bin} ${destroot}${prefix}/bin/
+    }
+}


### PR DESCRIPTION
#### Description

New port for [dstask](https://github.com/naggie/dstask), a git-based todo and task management CLI.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
