### PR TITLE
py-qtconsole: update to 5.0.1

### DIFF
--- a/python/py-qtconsole/Portfile
+++ b/python/py-qtconsole/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-qtconsole
-version             4.7.7
+version             5.0.1
 revision            0
 
 categories-append   devel
@@ -21,11 +21,19 @@ long_description    ${description}
 
 homepage            https://jupyter.org
 
-checksums           rmd160  d1289312eb91b253a306aaae2644b0f4b3b4037b \
-                    sha256  f236ead8711dba0702507dd8fad473c7216a86eefa6098eff8ec4b54f57d7804 \
-                    size    425068
+checksums           rmd160  cc1bf77c510b9ce9e1bedb097eef471be8a71c4c \
+                    sha256  4d7dd4eae8a90d0b2b19b31794b30f137238463998989734a3acb8a53b506bab \
+                    size    424682
 
 if {${name} ne ${subport}} {
+    if {${python.version} in "27 35"} {
+        version     4.7.7
+        revision    1
+        checksums   rmd160  d1289312eb91b253a306aaae2644b0f4b3b4037b \
+                    sha256  f236ead8711dba0702507dd8fad473c7216a86eefa6098eff8ec4b54f57d7804 \
+                    size    425068
+    }
+
     depends_lib-append  port:py${python.version}-setuptools \
                         port:py${python.version}-traitlets \
                         port:py${python.version}-ipython_genutils \
@@ -33,7 +41,8 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-jupyter_client \
                         port:py${python.version}-pygments \
                         port:py${python.version}-ipykernel \
-                        port:py${python.version}-qtpy
+                        port:py${python.version}-qtpy \
+                        port:py${python.version}-zmq
 
     # Note: depends on one of py-pyqt4, py-pyqt5 or py-pyside (first available at runtime)
     notes-append        "Please do not forget to install one of Qt backends: py${python.version}-pyside, py${python.version}-pyqt5 or py${python.version}-pyqt4."


### PR DESCRIPTION
#### Description
This PR update py-qtconsole to its latest version: 5.0.1; additionally:
- pin to version 4.7.7 for PY27/PY35
- add missing py-zmq dependency

###### Tested on
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
