### PR TITLE
urlscan: new port

### DIFF
--- a/mail/urlscan/Portfile
+++ b/mail/urlscan/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           python 1.0
+
+github.setup        firecat53 urlscan 0.9.5
+categories          mail python
+platforms           darwin
+license             GPL-2
+maintainers         {@ryanakca debian.org:rak} \
+                    openmaintainer
+description         extract and browse the URLs in an email
+long_description    ${name} lets you easily browse URLs contained in an email\
+                    and launch a web browser to view them. It is a replacement\
+                    for the "urlview" program and integrates with the mutt MUA.
+
+github.tarball_from archive
+
+python.default_version 39
+
+checksums           rmd160  439e24ccb82619affe45c22bbca2272d466b875a \
+                    sha256  db76f61966431a8938adc998aaa2b30be54f9b1ff2a4c0064e9915df2fb6b996 \
+                    size    32010
+
+depends_build-append \
+                    port:py${python.version}-setuptools
+
+depends_lib-append  port:py${python.version}-urwid

--- a/python/py-urwid/Portfile
+++ b/python/py-urwid/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  35600850053629027be799fa0297a0a3b162063a \
                     sha256  870fa60cb4cc7403be2e5e0d99e04dbe71183a036a6df630146827e64114c951 \
                     size    588040
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

```
long_description    ${name} lets you easily browse URLs contained in an email\
                    and launch a web browser to view them. It is a replacement\
                    for the "urlview" program and integrates with the mutt MUA.
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
