### PR TITLE
python39: tweak copyfile patch

### DIFF
--- a/lang/python39/files/patch-no-copyfile-on-Tiger.diff
+++ b/lang/python39/files/patch-no-copyfile-on-Tiger.diff
@@ -41,14 +41,26 @@ diff --git Modules/posixmodule.c Modules/posixmodule.c
 index 01e8bcb..ff7fb30 100644
 --- Modules/posixmodule.c
 +++ Modules/posixmodule.c
-@@ -8,6 +8,7 @@
-    test macro, e.g. '_MSC_VER'. */
+@@ -56,7 +56,10 @@
+  */
+ #if defined(__APPLE__)
  
- #ifdef __APPLE__
+-#if defined(__has_builtin) && __has_builtin(__builtin_available)
 +#include <AvailabilityMacros.h>
-    /*
-     * Step 1 of support for weak-linking a number of symbols existing on
-     * OSX 10.4 and later, see the comment in the #ifdef __APPLE__ block
++
++#if defined(__has_builtin)  
++#if __has_builtin(__builtin_available)
+ #  define HAVE_FSTATAT_RUNTIME __builtin_available(macOS 10.10, iOS 8.0, *)
+ #  define HAVE_FACCESSAT_RUNTIME __builtin_available(macOS 10.10, iOS 8.0, *)
+ #  define HAVE_FCHMODAT_RUNTIME __builtin_available(macOS 10.10, iOS 8.0, *)
+@@ -74,6 +77,7 @@
+ #  define HAVE_PWRITEV_RUNTIME __builtin_available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+ 
+ #  define HAVE_POSIX_SPAWN_SETSID_RUNTIME __builtin_available(macOS 10.15, *)
++#endif
+ 
+ #else /* Xcode 8 or earlier */
+ 
 @@ -109,7 +110,7 @@ corresponding Unix manual entries for more information on calls.");
  #  include <sys/sendfile.h>
  #endif


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/61848

Note @jmroot -- there is one bit of this that should be upstreamed.

You can't do this on one line:
```
#if defined(__has_builtin) && __has_builtin(__builtin_available)
```
You have to do it on two lines:
```
#if defined(__has_builtin)
#if  __has_builtin(__builtin_available)
```
otherwise you get an error parsing this, at least with gcc-4.2.

tested on 10.5 PPC, does quite well compared to previous.

```

389 tests OK.

13 tests failed:
    test_asyncio test_c_locale_coercion test_concurrent_futures
    test_gdb test_multiprocessing_forkserver
    test_multiprocessing_main_handling test_multiprocessing_spawn
    test_os test_pkgutil test_readline test_socket test_subprocess
    test_zoneinfo

1 test altered the execution environment:
    test_posix

22 tests skipped:
    test_ctypes test_dbm_gnu test_devpoll test_epoll test_idle
    test_ioctl test_msilib test_multiprocessing_fork test_ossaudiodev
    test_poll test_spwd test_startfile test_tcl test_tix test_tk
    test_ttk_guionly test_ttk_textonly test_turtle test_winconsoleio
    test_winreg test_winsound test_zipfile64

13 re-run tests:
    test_asyncio test_c_locale_coercion test_concurrent_futures
    test_gdb test_multiprocessing_forkserver
    test_multiprocessing_main_handling test_multiprocessing_spawn
    test_os test_pkgutil test_readline test_socket test_subprocess
    test_zoneinfo

Total duration: 43 min 33 sec
Tests result: FAILURE then FAILURE
make: *** [test] Error 2
```