### PR TITLE
qemu: update to 5.2.0

### DIFF
--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -7,8 +7,8 @@ PortGroup compiler_blacklist_versions 1.0
 PortGroup legacysupport 1.0
 
 name                    qemu
-version                 5.0.0
-revision                1
+version                 5.2.0
+revision                0
 categories              emulators
 license                 GPL-2+
 platforms               darwin
@@ -25,20 +25,24 @@ homepage                https://www.qemu.org
 master_sites            https://download.qemu.org/
 use_xz                  yes
 
-checksums               rmd160  58a704960cd712cf6c218216e8426a05948f6526 \
-                        sha256  2f13a92a0fa5c8b69ff0796b59b86b080bbb92ebad5d301a7724dd06b5e78cb6 \
-                        size    62426192
+checksums               rmd160  2c33e773f012e333f99237e3d4ff1653ea0bc88f \
+                        sha256  cb18d889b628fbe637672b0326789d9b0e3b8027e0445b936537c78549df17bc \
+                        size    106902800
 
 patchfiles              patch-configure.diff
 patch.pre_args          -p1
 
 depends_build           port:texinfo \
                         port:libtool \
+                        port:ninja \
                         port:pkgconfig
 
-# python is only used for build scripts, no linking
-depends_build-append    port:python38
-license_noconflict      python38
+# python/perl5 is only used for build scripts, no linking
+depends_build-append    port:python38 \
+                        port:perl5
+
+license_noconflict      python38 \
+                        perl5
 
 depends_lib             path:lib/pkgconfig/glib-2.0.pc:glib2 \
                         port:zlib \
@@ -59,6 +63,9 @@ configure.args          --cpu=${configure.build_arch} \
                         --objcc=${configure.objc} \
                         --host-cc=${configure.cc} \
                         --python=${prefix}/bin/python3.8
+
+# Use internal meson
+configure.args-append   --meson=internal
 
 # Do not use iasl, even if it is installed, #43911
 configure.args-append   --iasl=/usr/bin/false

--- a/emulators/qemu/files/patch-configure.diff
+++ b/emulators/qemu/files/patch-configure.diff
@@ -1,13 +1,13 @@
---- a/configure	2020-04-28 18:49:25.000000000 +0200
-+++ b/configure	2020-05-06 23:14:55.000000000 +0200
-@@ -858,10 +858,6 @@
-   hax="yes"
-   hvf="yes"
-   LDFLAGS_SHARED="-bundle -undefined dynamic_lookup"
+--- a/configure	2020-12-20 15:49:00.000000000 +0900
++++ b/configure	2020-12-20 15:49:17.000000000 +0900
+@@ -764,10 +764,6 @@
+ Darwin)
+   bsd="yes"
+   darwin="yes"
 -  if [ "$cpu" = "x86_64" ] ; then
 -    QEMU_CFLAGS="-arch x86_64 $QEMU_CFLAGS"
 -    QEMU_LDFLAGS="-arch x86_64 $QEMU_LDFLAGS"
 -  fi
-   cocoa="yes"
+   cocoa="enabled"
    audio_drv_list="coreaudio try-sdl"
    audio_possible_drivers="coreaudio sdl"


### PR DESCRIPTION
#### Description

Update QEMU; now requires ninja/perl5 to build. May have error with "too many open files" on system with low maxfiles limit.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.0.1 20B29
Xcode 12.2 12B45b

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
