### PR TITLE
submission libfido2

### DIFF
--- a/security/libfido2/Portfile
+++ b/security/libfido2/Portfile
@@ -1,29 +1,27 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-
-name                libfido2
-version             1.5.0
-revision            0
-categories          security crypto
-platforms           darwin
-license             BSD 2-Clause "Simplified" License
-maintainers         @trodemaster \
-                    openmaintainer
-description         FIDO library
+PortGroup           github 1.0
 PortGroup           cmake 1.1
 
-long_description    library functionality and command-line tools to communicate with a FIDO device over USB
-homepage            https://github.com/Yubico/libfido2
-master_sites        https://github.com/Yubico/libfido2/archive/
-distfiles           ${version}.tar.gz
-checksums               rmd160  f7f714ed5899c6bf764e172f3c62d0a7f0134059 \
-                        sha256  5990f923c9390fe1e6a00ba5d1d1f74030e7344b855e971d9fb7223e70ff3122 \
-                        size    407259
-configure.args      --mandir=${prefix}/share/man
+github.setup        Yubico libfido2 1.6.0
+revision            0
 
-depends_lib        port:cmake \
-                   port:mandoc \
+categories          security crypto
+platforms           darwin
+maintainers         {@trodemaster netjibbing.com:blake} \
+                    openmaintainer
+license             BSD-2-Clause
+description         library to communicate with a FIDO device over USB
+long_description    provides library functionality and command-line tools to communicate with a FIDO device over USB, and to verify attestation and assertion signatures.
+
+checksums               rmd160  8f58ba379c26d550531a5fa5b949cbdd8370809f \
+                        sha256  5969bfbdd3f5c5e3252c927c15ab28b1c4c4f60a51d1408b3d15cc556ec78835 \
+                        size    413939
+
+configure.args-append    -DBUILD_SHARED_LIBS=ON
+
+depends_lib        port:mandoc \
                    port:libcbor \
                    port:pkgconfig \
                    port:openssl

--- a/security/libfido2/Portfile
+++ b/security/libfido2/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                libfido2
+version             1.5.0
+revision            0
+categories          security crypto
+platforms           darwin
+license             BSD 2-Clause "Simplified" License
+maintainers         @trodemaster \
+                    openmaintainer
+description         FIDO library
+PortGroup           cmake 1.1
+
+long_description    library functionality and command-line tools to communicate with a FIDO device over USB
+homepage            https://github.com/Yubico/libfido2
+master_sites        https://github.com/Yubico/libfido2/archive/
+distfiles           ${version}.tar.gz
+checksums               rmd160  f7f714ed5899c6bf764e172f3c62d0a7f0134059 \
+                        sha256  5990f923c9390fe1e6a00ba5d1d1f74030e7344b855e971d9fb7223e70ff3122 \
+                        size    407259
+configure.args      --mandir=${prefix}/share/man
+
+depends_lib        port:cmake \
+                   port:mandoc \
+                   port:libcbor \
+                   port:pkgconfig \
+                   port:openssl


### PR DESCRIPTION
#### Description

Adding libfido2 port. This library adds fido2 support in openssh and likely other tools. 

###### Type(s)
- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification 
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

