### PR TITLE
ghc: Update to version 10.8.3

### DIFF
--- a/lang/ghc/Portfile
+++ b/lang/ghc/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           gpg_verify 1.0
 
 name                ghc
-version             8.10.2
-revision            1
+version             8.10.3
+revision            0
 categories          lang haskell
 maintainers         {ieee.org:s.t.smith @essandess} openmaintainer
 license             BSD
@@ -41,13 +41,13 @@ distfiles           ${distname}-x86_64-apple-darwin${extract.suffix} \
                     ${distname}-testsuite${extract.suffix}
 
 checksums           ${distname}-x86_64-apple-darwin${extract.suffix} \
-                    rmd160  eb97c90addf98984fbd07a358b8a03d471199f31 \
-                    sha256  edb772b00c0d7f18bb56ad27765162ee09c508104d40f82128c9114a02f6cfc2 \
-                    size    193710384 \
+                    rmd160  2b111b7272c133225fc0ab0196a5fd3a1305afb7 \
+                    sha256  2635f35d76e44e69afdfd37cae89d211975cc20f71f784363b72003e59f22015 \
+                    size    193854504 \
                     ${distname}-testsuite${extract.suffix} \
-                    rmd160  55e9ddfa3490463695d8e34e62542abb675aa2c1 \
-                    sha256  3a4aac2f2fba635499bb8c946c19410a37740e5d26c3e6816304b29cfa426a29 \
-                    size    2101788
+                    rmd160  a56666b34b679c3927c66859a5ba8468e745347d \
+                    sha256  8f82e69067fe69a1fd0916325d8c76c90b050393e9c37a70274d60f9b34cfe00 \
+                    size    2261376
 
 gpg_verify.use_gpg_verification \
                     yes
@@ -109,9 +109,9 @@ if { [variant_isset "prebuilt"] } {
                     ${distname}-src${extract.suffix}
     checksums-append \
                     ${distname}-src${extract.suffix} \
-                    rmd160  370e1f509bcfa913300b218b4397411efc317522 \
-                    sha256  9c573a4621a78723950617c223559bdc325ea6a3409264aedf68f05510b0880b \
-                    size    21880680
+                    rmd160  2cbd70a2d0e20fa19f9e00b755015bb28e1ac268 \
+                    sha256  ccdc8319549028a708d7163e2967382677b1a5a379ff94d948195b5cf46eb931 \
+                    size    19872356
 
     depends_build-append \
                     port:alex \


### PR DESCRIPTION
ghc: Update to version 10.8.3

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
