### PR TITLE
pkger: new port

### DIFF
--- a/devel/pkger/Portfile
+++ b/devel/pkger/Portfile
@@ -1,0 +1,77 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/markbates/pkger 0.17.1 v
+revision            0
+
+description         Embed static files in Go binaries (replacement for packr)
+
+long_description    {*}${description}. Pkger is powered by the dark magic of \
+                    Go Modules, so they're like, totally required.
+
+categories          devel
+license             MIT
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+build.target        ./cmd/pkger
+
+installs_libs       no
+
+destroot {
+    copy ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  cefada3f5511c2d616c8d81f9cb857fb0cd20557 \
+                        sha256  8b97110407d1da2f93d5a153040df73c7f69e191e5128e61c42950954f69d822 \
+                        size    442121
+
+go.vendors          gopkg.in/yaml.v2 \
+                        lock    v2.2.7 \
+                        rmd160  8a2eb51b49235820619e4703f557b266d5941645 \
+                        sha256  15d29283f38f1213445158c16dad11f84ab72aa0256af555c2392492315760ba \
+                        size    72665 \
+                    gopkg.in/check.v1 \
+                        lock    788fd7840127 \
+                        rmd160  b63165c8909a27edc15dda210df66a1b49efb49e \
+                        sha256  7e5547c6471cc48da89a7c87f965b20ca5311f43fc4d883ca62f9fccf7551630 \
+                        size    31597 \
+                    github.com/stretchr/testify \
+                        lock    v1.4.0 \
+                        rmd160  86bd663e13ea7266334c47689074df16252db5ff \
+                        sha256  8ed95078bfd318ea477da509e6b16e6cf8d0d1b6b8d93b1f6097c6ba2a6df788 \
+                        size    110114 \
+                    github.com/stretchr/objx \
+                        lock    v0.1.0 \
+                        rmd160  fa58b6a0f55fce44b3d4e246b07574f016a1dabf \
+                        sha256  e80eb3ee16d44676befb5b8044459492f73e6f153ad3f28b13949c9f9cfaf558 \
+                        size    109497 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/kr/text \
+                        lock    v0.1.0 \
+                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
+                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
+                        size    8691 \
+                    github.com/kr/pretty \
+                        lock    v0.1.0 \
+                        rmd160  9aa7a5aad4c48840eecfd0f80186d1fb5ded0fd6 \
+                        sha256  f6c3f89667c63e5b7f1fc6ee2c06b6a6bfdce88f3a965ccd395b64c6f95c9a47 \
+                        size    8553 \
+                    github.com/gobuffalo/here \
+                        lock    v0.6.0 \
+                        rmd160  101a878fe2ac69eac11e8e9124c5464af56a263c \
+                        sha256  95540b835f78717eaf92efdf24cd168c4d2c43d4a0a1c366c7ad5dbc615477c8 \
+                        size    8996 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171


### PR DESCRIPTION
#### Description

New port for [pkger](https://github.com/markbates/pkger)

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
