### PR TITLE
proxify: new port

### DIFF
--- a/net/proxify/Portfile
+++ b/net/proxify/Portfile
@@ -1,0 +1,158 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/projectdiscovery/proxify 0.0.3 v
+revision            0
+
+description         Swiss Army knife Proxy tool for HTTP/HTTPS traffic \
+                    capture, manipulation, and replay on the go.
+
+long_description    Swiss Army Knife Proxy for rapid deployments. Supports \
+                    multiple operations such as request/response dump, \
+                    filtering and manipulation via DSL language, upstream \
+                    HTTP/Socks5 proxy. Additionally a replay utility allows \
+                    to import the dumped traffic (request/responses with \
+                    correct domain name) into burp or any other proxy by \
+                    simply setting the upstream proxy to proxify.
+
+categories          net www
+license             MIT
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+set _dist_path      ${workpath}/dist
+
+build.pre_args      -o ${_dist_path}
+build.args          ./cmd/...
+
+installs_libs       no
+
+post-extract {
+    file mkdir ${_dist_path}
+}
+
+post-build {
+    move ${_dist_path}/replay ${_dist_path}/${name}-replay
+}
+
+destroot {
+    foreach _proxify_bin [glob ${_dist_path}/*] {
+        xinstall -m 755 ${_proxify_bin} ${destroot}${prefix}/bin/
+    }
+}
+
+notes "replay is installed as ${name}-replay"
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  53cd979aa44bf6dd6efeaa660d20c43b613ab0f6 \
+                        sha256  595c047e9ac14b2a609b19fcb5c98c9a84395f3049ed20e197873bcc4d3e9bea \
+                        size    518059
+
+go.vendors          golang.org/x/sys \
+                        lock    f84b799fce68 \
+                        rmd160  7c2bf3dcd2b38950447af1105a6417de5b0a51d2 \
+                        sha256  f1f9c7d245ab11f81ee400be9a33b5a85de6c81d3d40604e64262701748adbb0 \
+                        size    1087929 \
+                    golang.org/x/net \
+                        lock    ac852fbbde11 \
+                        rmd160  cb4a0aadd6a499c5dd51322c3dd0f884976e0f88 \
+                        sha256  bdf1767b52a5585e8b40da601d6d63c5c064d418d0f4f3679a1f21a44323efb9 \
+                        size    1248863 \
+                    golang.org/x/crypto \
+                        lock    5f87f3452ae9 \
+                        rmd160  ddee6847cbc4a909173d6b28587a7ff41cce94f9 \
+                        sha256  d04d022b76f99ec3a1cfa8d16ce5e3054290ed7e82742a276339d9aa314d1b29 \
+                        size    1721629 \
+                    github.com/syndtr/goleveldb \
+                        lock    v1.0.0 \
+                        rmd160  5dabbe69dffc7e8ce98a219e886526307c12631e \
+                        sha256  56ab18ab765fcc74122cf7329bd2d8ab697193b93fff1d723cb7c13ba4e1916a \
+                        size    142689 \
+                    github.com/spaolacci/murmur3 \
+                        lock    v1.1.0 \
+                        rmd160  53215abb0d59b6c64e926e90fb33da1906a1a525 \
+                        sha256  54d6a3300600dd2f5e444f6d19fe1f91e1174329cdfff1d50dae837689214a68 \
+                        size    7396 \
+                    github.com/rs/xid \
+                        lock    v1.2.1 \
+                        rmd160  2cff9628752a94fc62ab0e83436c61df7195eed1 \
+                        sha256  38881e009bacdbf91f6e586207b346eb9ec93f06335331c07a5e0b2ad41ee3f6 \
+                        size    9555 \
+                    github.com/projectdiscovery/tinydns \
+                        lock    v0.0.1 \
+                        rmd160  09f651b182667dff7510806d7952f3bf324c7813 \
+                        sha256  749a2b1577ef558f6e7ee7045772f1819980cf6565f6eb95936e61b099860671 \
+                        size    1050 \
+                    github.com/projectdiscovery/retryabledns \
+                        lock    v1.0.5 \
+                        rmd160  1bb84d1e0643fc1d527da97db615dab94003b807 \
+                        sha256  c627c329a1f53d711298a530c72a2983d5a417447940bc35b6998297b4a596e2 \
+                        size    4692 \
+                    github.com/projectdiscovery/mapsutil \
+                        lock    v0.0.1 \
+                        rmd160  8bf03c9f27b0d938d8f22da1e0488743bc2feed8 \
+                        sha256  2e05fa7293363f133a90955daf8aa269ca0013c5f0cb8a70f62b7a2a5a1ea421 \
+                        size    1316 \
+                    github.com/projectdiscovery/hmap \
+                        lock    v0.0.1 \
+                        rmd160  d4ccbd3a0f543417097c9853773c72deb7b0b478 \
+                        sha256  a3349ab272eb2183d3cc2803b4974743952bf01b4cf7ef38ce0b83328076683b \
+                        size    7778 \
+                    github.com/projectdiscovery/gologger \
+                        lock    v1.0.1 \
+                        rmd160  bde48e348f976a755628f8c15613d835d2114c5d \
+                        sha256  24537b4cc5b904f7c774bacf2100e00594e670437aa00b3a5a918e5f3909a7b4 \
+                        size    3545 \
+                    github.com/projectdiscovery/fastdialer \
+                        lock    v0.0.2 \
+                        rmd160  982be9301deb1d29faf9a949db1bf5bfad668d0d \
+                        sha256  15e6eb5ecfe18b3becf8b9ec2e30adfdea842d3988a198799858c484a2a51cc0 \
+                        size    5691 \
+                    github.com/projectdiscovery/dsl \
+                        lock    v0.0.2 \
+                        rmd160  ab6586ab5dd220b020c3bd2963cda9abeadd9101 \
+                        sha256  310dea650de71da6558226ccc81d4db4b6a94d35d8f44188c18832529145d172 \
+                        size    2695 \
+                    github.com/pkg/errors \
+                        lock    v0.9.1 \
+                        rmd160  dc065c655f8a24c6519b58f9d1202eb266ecda40 \
+                        sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
+                        size    13422 \
+                    github.com/miekg/dns \
+                        lock    v1.1.29 \
+                        rmd160  92809bac3d60dbe7b05b1be7e1d7b2a38c5251ff \
+                        sha256  5c60b4ae859c5cb14715ae29a8a5235212536a4ec60d9537b4a3557a516c09e7 \
+                        size    184263 \
+                    github.com/logrusorgru/aurora \
+                        lock    e9ef32dff381 \
+                        rmd160  27e9a9bf2789acb5da740ed564043f65101db1e2 \
+                        sha256  b430980e939900f71c8bf977b3abb9c57a6a1c62e40a4f5480cc9c236762bbcc \
+                        size    133632 \
+                    github.com/hashicorp/golang-lru \
+                        lock    v0.5.4 \
+                        rmd160  833d8d87b84f13bc545ecffff9358a19671d185a \
+                        sha256  c358bb5050adae91e443f59ff70b7c0ad6906fc4abe1b30066bf0c408fdf9b5c \
+                        size    13435 \
+                    github.com/golang/snappy \
+                        lock    2e65f85255db \
+                        rmd160  7e9517261dff8bee74bd76da85e10381a4631f5a \
+                        sha256  72fd623a76472d6139668b09552a75acd87b240d3d978b7d506e372c93420153 \
+                        size    62584 \
+                    github.com/elazarl/goproxy \
+                        lock    00ad82a08272 \
+                        rmd160  315060dfaac04f01be97d9b4d60752b7e05a86f1 \
+                        sha256  66c386c4986c9c373812dce00248cd18cf755dd276e1b3115ba6463aff18c637 \
+                        size    108530 \
+                    github.com/dimchansky/utfbom \
+                        lock    v1.1.1 \
+                        rmd160  182248653dc487311900d188180c74962909bd76 \
+                        sha256  203f7bd33e56dfc3d1764493615e3171f4fb3edf5ee234628123e464406e77b1 \
+                        size    8497 \
+                    github.com/Knetic/govaluate \
+                        lock    v3.0.0 \
+                        rmd160  60c7cfe26e7cd48a41ec07d19f2ea8cb42ea90a7 \
+                        sha256  83712df8e07f8ce8d89151d0778b57900ecb52fa98f2a17d6497f269e3a13e48 \
+                        size    39407


### PR DESCRIPTION
#### Description

New port for [proxify](https://github.com/projectdiscovery/proxify), an HTTP/HTTPS traffic capture utility

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
