### PR TITLE
submission libcbor

### DIFF
--- a/devel/libcbor/Portfile
+++ b/devel/libcbor/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                libcbor
+license             MIT License
+version             0.8.0
+revision            0
+categories          devel
+platforms           darwin
+maintainers         @trodemaster \
+                    openmaintainer
+description         library for parsing and generating CBOR
+PortGroup           cmake 1.1
+
+long_description    libcbor is a C library for parsing and generating CBOR, the general-purpose schema-less binary data format.
+homepage            https://github.com/PJK/libcbor
+master_sites        https://github.com/PJK/libcbor/archive/
+distfiles           v${version}.tar.gz
+checksums               rmd160  ddd307e64b50f2a777a88e89e10e3891571226a2 \
+                        sha256  618097166ea4a54499646998ccaa949a5816e6a665cf1d6df383690895217c8b \
+                        size    267044
+configure.args      --mandir=${prefix}/share/man
+
+depends_lib        port:cmake

--- a/devel/libcbor/Portfile
+++ b/devel/libcbor/Portfile
@@ -1,25 +1,24 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 
-name                libcbor
-license             MIT License
-version             0.8.0
+Github.setup        PJK libcbor 0.8.0
 revision            0
 categories          devel
 platforms           darwin
-maintainers         @trodemaster \
+maintainers         @trodemaster netjibbing.com:blake \
                     openmaintainer
-description         library for parsing and generating CBOR
-PortGroup           cmake 1.1
+license             MIT
 
+description         library for parsing and generating CBOR
 long_description    libcbor is a C library for parsing and generating CBOR, the general-purpose schema-less binary data format.
+
 homepage            https://github.com/PJK/libcbor
-master_sites        https://github.com/PJK/libcbor/archive/
-distfiles           v${version}.tar.gz
+github.tarball_from releases
+
 checksums               rmd160  ddd307e64b50f2a777a88e89e10e3891571226a2 \
                         sha256  618097166ea4a54499646998ccaa949a5816e6a665cf1d6df383690895217c8b \
                         size    267044
 configure.args      --mandir=${prefix}/share/man
 
-depends_lib        port:cmake

--- a/devel/libcbor/Portfile
+++ b/devel/libcbor/Portfile
@@ -7,7 +7,8 @@ Github.setup        PJK libcbor 0.8.0
 revision            0
 categories          devel
 platforms           darwin
-maintainers         @trodemaster netjibbing.com:blake \
+maintainers         @trodemaster \
+                    netjibbing.com:blake \
                     openmaintainer
 license             MIT
 


### PR DESCRIPTION
#### Description
Libcbor is a dependency for libfido2

###### Type(s)

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification 
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

