### PR TITLE
Update to openssh adds fido2 support

### DIFF
--- a/net/openssh/Portfile
+++ b/net/openssh/Portfile
@@ -188,6 +188,12 @@ if {${name} eq ${subport}} {
         depends_lib-append      port:ldns
     }
 
+    variant fido2 description "Enable fido2 support" {
+        configure.args-delete  --without-security-key-builtin
+        configure.args-append  --with-security-key-builtin
+        depends_lib-append      port:libfido2
+    }
+
     default_variants            +kerberos5 +xauth
 
     platform darwin {


### PR DESCRIPTION
#### Description

The addition of the variant fido2 enables ssh auth via fido2 compliant devices like yubikey. Fido2 is described here https://www.openssh.com/txt/release-8.2 . This variant depends on libfido and it's dependancy libcbor. Pull requests adding those ports have been submitted.

libfido2 - https://github.com/macports/macports-ports/pull/9480
libcbor - https://github.com/macports/macports-ports/pull/9487

###### Type(s)
- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification 

- [X ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
