### PR TITLE
mc: add sftp variant

### DIFF
--- a/sysutils/mc/Portfile
+++ b/sysutils/mc/Portfile
@@ -62,6 +62,10 @@ variant ncurses conflicts slang2 description {use ncurses screen library} {
     configure.args-append   --with-screen=ncurses
 }
 
+variant sftp description {adds remote access to sftp servers} {
+    depends_build-append port:libssh2
+}
+
 if { ![variant_isset ncurses] } {
     default_variants        +slang2
 }


### PR DESCRIPTION
adds a new variant to mc (midnight commander) that allows connections to
sftp servers. This is automatically detected by ./configure.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance
macOS 10.15.7 19H2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
