### PR TITLE
grass7: update to 7.8.5

### DIFF
--- a/gis/grass7/Portfile
+++ b/gis/grass7/Portfile
@@ -5,7 +5,7 @@ PortGroup           wxWidgets 1.0
 PortGroup           github 1.0
 PortGroup           debug 1.0
 
-github.setup        OSGeo grass 7.8.4
+github.setup        OSGeo grass 7.8.5
 name                grass7
 set main_version    [join [lrange [split ${version} "."] 0 1] ""]
 revision            0
@@ -24,9 +24,9 @@ long_description    GRASS is a Geographic Information System (GIS) used for \
 homepage            http://grass.osgeo.org/
 master_sites        ${homepage}grass[join [lrange [split ${realVersion} .] 0 1] {}]/source/
 
-checksums           rmd160  849a59adbebf9c5901fc851b963cb1a28369edf1 \
-                    sha256  d9535afb5e43ecdcf9a6233f5a1fa83908b66456bdd06107e7320a51ee86cff9 \
-                    size    61791074
+checksums           rmd160  44502e643db9b79b427429b6b0f5b604e465bce0 \
+                    sha256  a359bb665524ecccb643335d70f5436b1c84ffb6a0e428b78dffebacd983ff37 \
+                    size    61801712
 
 depends_build       port:pkgconfig
 depends_lib         port:bzip2 \


### PR DESCRIPTION
#### Description

Update GRASS GIS to version 7.8.5.

<!-- Note:
 it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
