### PR TITLE
Ngspice update and fix openmp

### DIFF
--- a/science/ngspice/Portfile
+++ b/science/ngspice/Portfile
@@ -3,7 +3,8 @@
 PortSystem      1.0
 
 name            ngspice
-version         30
+version         33
+revision        0
 license         BSD
 categories      science cad
 maintainers     {@mguthaus ucsc.edu:mrg+openram} openmaintainer
@@ -18,14 +19,19 @@ long_description \
 homepage        http://ngspice.sourceforge.net/
 master_sites    sourceforge:project/ngspice/ng-spice-rework/${version}
 
-checksums       rmd160  965684c859955a42218c3d9f6deb2ed7cbe0cf6a \
-                sha256  08fe0e2f3768059411328a33e736df441d7e6e7304f8dad0ed5f28e15d936097 \
-                size    7147044
+checksums       rmd160  b9a5183c85c017b2746fd4eae5a7f6b3fda23881 \
+                sha256  b99db66cc1c57c44e9af1ef6ccb1dcbc8ae1df3e35acf570af578f606f8541f1 \
+                size    7760956
 
 set docdir      ${prefix}/share/doc/${name}
 
 if {${name} eq ${subport}} {
-    depends_lib         port:ncurses \
+
+    # freetype2 headers are not found by default
+    # we could fix the header path in configure.ac, but then need autorecconf, etc
+	configure.cppflags-prepend -I${prefix}/include/freetype2
+
+    depends_lib-append  port:ncurses \
                         port:libedit \
                         port:xorg-libX11 \
                         port:xorg-libXaw \
@@ -38,7 +44,8 @@ if {${name} eq ${subport}} {
                         --enable-pss \
                         --with-editline \
                         --with-x \
-                        --enable-debug=no
+                        --enable-debug=no \
+                        --disable-silent-rules
     
     post-destroot {
         xinstall -d ${destroot}${docdir}
@@ -70,6 +77,13 @@ if {${name} eq ${subport}} {
     default_variants    +openmp +manual
     
     livecheck.regex     ${name}-(\[0-9.\]+)${extract.suffix}
+
+    # running the tests from MacPorts errors early, probably due to a permissions
+    # issue when calling the X11 display subsystem. Running the tests manually from the
+    # worksrcdir works fine, however
+    # test.run            yes
+    # test.target         check
+
 } else {
     livecheck.type      none
 }
@@ -83,9 +97,9 @@ subport ngspice-docs {
     extract.suffix
     extract.only
  
-    checksums           rmd160  a9848930d0789c0e73b12dcea7d0548c11dd9f0e \
-                        sha256  d9658d5e52f27822ef852063599d81a7f647fa03db993fca5b90f4677e0a8257 \
-                        size    2131163
+    checksums           rmd160  edcf2718e69e04d5c29748dfb83756ad9a41faf7 \
+                        sha256  0c97dee66db3207b2f5578fbfd4227765dc04d2a43d60753f88223394c3eef3e \
+                        size    2205893
     
     use_configure       no
 

--- a/science/ngspice/Portfile
+++ b/science/ngspice/Portfile
@@ -61,16 +61,10 @@ if {${name} eq ${subport}} {
     }
     
     variant openmp description {Add OpenMP support variant} {
-        depends_lib-append       port:libomp 
-        
+        # ngspice does not specify what openmp version they require
+        # version 2.5 is the least strict, and works
+        compiler.openmp_version  2.5
         configure.args-append    --enable-openmp
-
-        compiler.whitelist       macports-clang-7.0 macports-clang-6.0 macports-clang-5.0 \
-                                 macports-clang-3.7 \
-                                 macports-gcc-8 macports-gcc-7 macports-gcc-6 macports-gcc-5 \
-                                 macports-gcc-4.8 macports-gcc-4.7 macports-gcc-4.6 macports-gcc-4.5 \
-                                 macports-gcc-4.4 macports-gcc-4.3
-        compiler.fallback        macports-clang-7.0
     }
 
     default_variants    +openmp +manual


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
