### PR TITLE
gitlab-runner: update to 13.7.0

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 13.6.0 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 13.7.0 v
 
 categories          devel
 platforms           darwin
@@ -23,9 +23,9 @@ homepage            https://docs.gitlab.com/runner/
 master_sites        https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v${version}/
 distname            gitlab-runner-v${version}
 
-checksums           rmd160  8cabc91c48a339e22f3915a0681bcd5c8a5c3fc9 \
-                    sha256  ae40744bb94f59ef91ec81ca79d79cd126daab865f8a342d1116075f263d7f29 \
-                    size    8030709
+checksums           rmd160  2b26dc9898dd031717c8bbb19e7cbe46e6294f31 \
+                    sha256  543d7849d887fcfdabb22ef768e720d34d558fbc0c73860849ceb042b3927b50 \
+                    size    8050256
 
 # Reproduce the "build_simple" target from the upstream Makefile
 set go_ldflags      "-X ${go.package}/common.NAME=${go.package} \


### PR DESCRIPTION
#### Description

Update to GitLab Runner 13.7.0.

###### Tested on

macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?