### PR TITLE
edex-ui: new port

### DIFF
--- a/sysutils/edex-ui/Portfile
+++ b/sysutils/edex-ui/Portfile
@@ -1,0 +1,54 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        GitSquared edex-ui 2.2.5 v
+revision            0
+
+description         Science fiction terminal emulator with advanced monitoring
+
+long_description    eDEX-UI is a fullscreen, cross-platform terminal emulator \
+                    and system monitor that looks and feels like a sci-fi \
+                    computer interface.  Heavily inspired from the TRON \
+                    Legacy movie effects (especially the Board Room \
+                    sequence), the eDEX-UI project was originally meant to be \
+                    a \"DEX-UI with less « art » and more « distributable \
+                    software »\". While keeping a futuristic look and feel, it \
+                    strives to maintain a certain level of functionality and \
+                    to be usable in real-life scenarios, with the larger goal \
+                    of bringing science-fiction UXs to the mainstream.
+
+categories          sysutils shells
+license             GPL-3
+platforms           darwin
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  df968e5358ed9bf99a52749a002dd0f82e043b1c \
+                    sha256  6f1aad983711fb2e5dfc51043f7a64fb2c3594931060c0c1c063a1ad74291f2a \
+                    size    5564104
+
+depends_build       port:npm6 \
+                    port:yarn
+
+build.env-append    CSC_IDENTITY_AUTO_DISCOVERY=false
+
+use_configure       no
+use_xcode           yes
+
+build {
+    # Set up all JS dependencies
+    system -W ${worksrcpath} "yarn --frozen-lockfile"
+
+    # Build electron app
+    system -W ${worksrcpath} "${build.env} yarn run build-darwin --dir"
+}
+
+destroot {
+    copy ${worksrcpath}/dist/mac/eDEX-UI.app ${destroot}${applications_dir}
+}
+
+github.livecheck.regex {([0-9.]+)}


### PR DESCRIPTION
#### Description

New port for the awesome [edex-ui](https://github.com/GitSquared/edex-ui) sci-fi -style terminal emulator.

<p align="center">
<img src="https://raw.githubusercontent.com/GitSquared/edex-ui/master/media/screenshot_default.png" />
</p>

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
