### PR TITLE
libxmi: fix missing includes of stdlib.h

### DIFF
--- a/graphics/libxmi/Portfile
+++ b/graphics/libxmi/Portfile
@@ -18,3 +18,5 @@ checksums        md5 4e6935484f0ad71b531920bf4c546b47 \
                  rmd160 6622ed9793605380c8f55f93bf953182fff07dd4
 
 configure.args   --infodir=${prefix}/share/info
+
+patchfiles       patch-missing-stdlib.diff

--- a/graphics/libxmi/files/patch-missing-stdlib.diff
+++ b/graphics/libxmi/files/patch-missing-stdlib.diff
@@ -1,0 +1,23 @@
+--- mi_alloc.c
++++ mi_alloc.c
+@@ -9,6 +9,8 @@
+ #include "mi_spans.h"
+ #include "mi_api.h"
+ 
++#include <stdlib.h>
++
+ /* wrapper for malloc() */
+ voidptr_t 
+ #ifdef _HAVE_PROTOS
+
+--- mi_arc.c
++++ mi_arc.c
+@@ -29,6 +29,8 @@
+ #include "mi_fply.h"		/* for miFillSppPoly() */
+ #include "mi_fllarc.h"		/* for MIWIDEARCSETUP, MIFILLINARCSTEP etc. */
+ 
++#include <stdlib.h>
++
+ /* undefine if cbrt(), a fast cube root function for non-negative
+    arguments, is available */
+ #define cbrt(x) pow((x), 1.0/3.0)


### PR DESCRIPTION
#### Description

Trying to build libxmi on Big Sur leads to the following two errors:

```
mi_alloc.c:31:7: error: implicitly declaring library function 'exit' with type 'void (int) __attribute__((noreturn))' [-Werror,-Wimplicit-function-declaration]
      exit (EXIT_FAILURE);
      ^
mi_alloc.c:31:7: note: include the header <stdlib.h> or explicitly provide a declaration for 'exit'

mi_arc.c:2302:11: error: implicitly declaring library function 'abs' with type 'int (int)' [-Werror,-Wimplicit-function-declaration]
  count = abs(count) + 1;
          ^
mi_arc.c:2302:11: note: include the header <stdlib.h> or explicitly provide a declaration for 'abs'
```

Adding those includes fixes the build.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. --> (no tickets available)
- [x] checked your Portfile with `port lint`? (two warnings on checksum type which are not caused by this PR)
- [ ] tried existing tests with `sudo port test`? (no tests available)
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
