### PR TITLE
OpenBLAS: update to version 0.3.13, update -devel version to latest c…

### DIFF
--- a/math/OpenBLAS/Portfile
+++ b/math/OpenBLAS/Portfile
@@ -41,11 +41,11 @@ if {![info exists blas_arch]} {
 subport OpenBLAS-devel {}
 if {[string first "-devel" $subport] > 0} {
 
-    github.setup    xianyi OpenBLAS 7e9cb39a2598124eac0b27186e32de10cce09a04
-    version         20201116-[string range ${github.version} 0 7]
-    checksums       rmd160  2d5624acb9c8b7695036c346b9baa67c1848afa9 \
-                    sha256  494769dc612c846b7ab30e5b9d34d9fdbf7084ce46c15bed98f42c2896be557a \
-                    size    12363979
+    github.setup    xianyi OpenBLAS 3559c5d7a2250d9d89105d0ff411348c035e33be
+    version         20201221-[string range ${github.version} 0 7]
+    checksums       rmd160  1e7fefbf999b91e8487fe2dce28cbfd1df94e354 \
+                    sha256  6dbc6252226b700cb8362602f496d9b7f8503bedd9a70b2a58ef9460f986d1ef \
+                    size    12442927
     revision        0
 
     name            ${github.project}-devel
@@ -61,10 +61,10 @@ if {[string first "-devel" $subport] > 0} {
 
 } else {
 
-    github.setup    xianyi OpenBLAS 0.3.12 v
-    checksums       rmd160  cbdef2d6ca019cec74dd211ebe14689d12dc8a09 \
-                    sha256  5cfa5c8a993ff8813849e95317e9b1820dfb0ac63e0adc6e95d43030ca5e9a1f \
-                    size    12329032
+    github.setup    xianyi OpenBLAS 0.3.13 v
+    checksums       rmd160  ac0847547d4d1ca21c1e8bb1a681a3680826907c \
+                    sha256  9223b504b90ddf854339f6fdd9e89755feeb9efbdbfbd09ae61411a5fc183d27 \
+                    size    12442494
     revision        0
 
     conflicts       OpenBLAS-devel


### PR DESCRIPTION
#### Description

Update OpenBLAS to version 0.13, which contains certain fixes for memory leaks.
I don't have the ability to test on the new Apple chips, but based on reports on OpenBLAS website, CPU detection should work.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

