### PR TITLE
xsane: fix implicit declarations for building on Big Sur

### DIFF
--- a/graphics/xsane/Portfile
+++ b/graphics/xsane/Portfile
@@ -46,9 +46,11 @@ depends_lib     path:lib/pkgconfig/gimp-2.0.pc:gimp2 \
 
 patchfiles      patch-sane-options-handling-fix.diff \
                 patch-gtk_adjustment_new.diff \
-                patch-src__xsane-save.c-libpng15-compat.diff
+                patch-src__xsane-save.c-libpng15-compat.diff \
+                patch-configure.diff \
+                patch-getopt.c.diff
 
-# gimp2 is not universal (#29165)
+# gimp2 is not universal (https://trac.macports.org/ticket/29165)
 
 if {![variant_isset disable_gimp]} {
     universal_variant no

--- a/graphics/xsane/files/patch-configure.diff
+++ b/graphics/xsane/files/patch-configure.diff
@@ -1,0 +1,18 @@
+--- configure.orig	2013-05-23 06:50:40.000000000 +0900
++++ configure	2020-12-23 23:30:41.000000000 +0900
+@@ -5876,6 +5876,7 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <libintl.h>
+ int
+ main ()
+ {
+@@ -6629,6 +6629,7 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ #include <sane/sane.h>
+ #include <stdio.h>
+ 

--- a/graphics/xsane/files/patch-getopt.c.diff
+++ b/graphics/xsane/files/patch-getopt.c.diff
@@ -1,0 +1,11 @@
+--- lib/getopt.c.orig	2020-12-23 23:39:20.000000000 +0900
++++ lib/getopt.c	2020-12-23 23:38:31.000000000 +0900
+@@ -38,6 +38,8 @@
+ #endif
+ #endif
+ 
++#include <unistd.h>
++#include <string.h>
+ #include <stdio.h>
+ 
+ /* Comment out all this code if we are using the GNU C Library, and are not


### PR DESCRIPTION
#### Description

This fixes some implicit declarations that caused configure- and build-time errors on Big Sur.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->