### PR TITLE
zathura-plugin-pdf-mupdf: update to 0.3.6

### DIFF
--- a/office/zathura-plugin-pdf-mupdf/Portfile
+++ b/office/zathura-plugin-pdf-mupdf/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           meson 1.0
 
 name                zathura-plugin-pdf-mupdf
-version             0.3.5
+version             0.3.6
 categories          office
 platforms           darwin
 license             zlib
@@ -19,9 +19,9 @@ homepage            https://git.pwmt.org/pwmt/zathura-pdf-mupdf
 master_sites        ${homepage}/-/archive/${version}
 distname            zathura-pdf-mupdf-${version}
 
-checksums           rmd160  34998a3d958037ecf8aff78374afe3f1a4bb4997 \
-                    sha256  6344acda225ca637fc72788cacce7448cd2e69ac13f19429726786a0b62cd7e3 \
-                    size    8901
+checksums           rmd160  84fc8cbf54f47a473223003a9b27cb6aa436bbd1 \
+                    sha256  94ab90b367c04e3a9dda52e3587e257e4c825b375bde13032f81b1f84becb4f1 \
+                    size    8925
 
 configure.args-append \
                     -Dlink-external=true


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/57691

#### Description

Fixes a build failure

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.1 20C69
Xcode 12.3 12C33


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
