### PR TITLE
webkit2-gtk: fix build with Xcode 12

### DIFF
--- a/www/webkit2-gtk/Portfile
+++ b/www/webkit2-gtk/Portfile
@@ -98,6 +98,10 @@ patchfiles-append    patch-enable-plugin-architecture-unix.diff
 # runs without this patch.
 patchfiles-append    patch-bundle-link-webcore.diff
 
+# Fix incompatibility with XCode 12:
+# https://bugs.webkit.org/show_bug.cgi?id=207871
+patchfiles-append    patch-WTF-wtf-getVTablePointer.diff
+
 # it is preferred to use the WebKit built in bmalloc if it builds on a given os.
 # it has improved security features, but not all systems can build it at present.
 

--- a/www/webkit2-gtk/files/patch-WTF-wtf-getVTablePointer.diff
+++ b/www/webkit2-gtk/files/patch-WTF-wtf-getVTablePointer.diff
@@ -1,0 +1,37 @@
+diff --git Source/WTF/wtf/PointerPreparations.h Source/WTF/wtf/PointerPreparations.h
+index ef20a5e48512..ef9495169ff4 100644
+--- Source/WTF/wtf/PointerPreparations.h
++++ Source/WTF/wtf/PointerPreparations.h
+@@ -34,16 +34,16 @@ namespace WTF {
+ #if COMPILER_HAS_CLANG_BUILTIN(__builtin_get_vtable_pointer)
+
+ template<typename T>
+-ALWAYS_INLINE void* getVTablePointer(T* o) { return __builtin_get_vtable_pointer(o); }
++ALWAYS_INLINE const void* getVTablePointer(T* o) { return __builtin_get_vtable_pointer(o); }
+
+ #else // not COMPILER_HAS_CLANG_BUILTIN(__builtin_get_vtable_pointer)
+
+ #if CPU(ARM64E)
+ template<typename T>
+-ALWAYS_INLINE void* getVTablePointer(T* o) { return __builtin_ptrauth_auth(*(reinterpret_cast<void**>(o)), ptrauth_key_cxx_vtable_pointer, 0); }
++ALWAYS_INLINE const void* getVTablePointer(T* o) { return __builtin_ptrauth_auth(*(reinterpret_cast<void**>(o)), ptrauth_key_cxx_vtable_pointer, 0); }
+ #else // not CPU(ARM64E)
+ template<typename T>
+-ALWAYS_INLINE void* getVTablePointer(T* o) { return (*(reinterpret_cast<void**>(o))); }
++ALWAYS_INLINE const void* getVTablePointer(T* o) { return (*(reinterpret_cast<void**>(o))); }
+ #endif // not CPU(ARM64E)
+
+ #endif // not COMPILER_HAS_CLANG_BUILTIN(__builtin_get_vtable_pointer)
+diff --git Source/WebCore/bindings/scripts/CodeGeneratorJS.pm Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+index 35db4d28ccd6..03dd9c161a83 100644
+--- Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
++++ Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+@@ -4881,7 +4881,7 @@ END
+         push(@implContent, <<END) if $vtableNameGnu;
+
+ #if ENABLE(BINDING_INTEGRITY)
+-    void* actualVTablePointer = getVTablePointer(impl.ptr());
++    const void* actualVTablePointer = getVTablePointer(impl.ptr());
+ #if PLATFORM(WIN)
+     void* expectedVTablePointer = ${vtableRefWin};
+ #else


### PR DESCRIPTION
#### Description
Compilation fails with the following error:

```
DerivedSources/ForwardingHeaders/wtf/PointerPreparations.h:37:53: error: cannot initialize return object of type 'void *' with an rvalue of type 'const void *'
ALWAYS_INLINE void* getVTablePointer(T* o) { return __builtin_get_vtable_pointer(o); }
                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This issue has been fixed in version 2.30.0. Until the package is updated, it can be fixed with a simple patch obtained from
https://bugs.webkit.org/show_bug.cgi?id=207871

Fixes https://trac.macports.org/ticket/61650
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? (no tests available)
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->