### PR TITLE
micronaut: update to 2.2.2

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       java 1.0
 
-github.setup    micronaut-projects micronaut-starter 2.2.1 v
+github.setup    micronaut-projects micronaut-starter 2.2.2 v
 revision        0
 name            micronaut
 categories      java
@@ -53,9 +53,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  ccaabbb1a754c21940b67ea431328ea5a097433f \
-                sha256  7419a6bb0210b582eb1ca0fdc4dd9dc142a41720a59f1be98beee1443ee76e10 \
-                size    19935790
+checksums       rmd160  5109ff68cc9eeca81c50260262523b9ec8db0c18 \
+                sha256  67f3f89c6319db10d677483eb130de234e2f0c816f22f7b9e157de552ee6238a \
+                size    19946248
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 2.2.2.

###### Tested on

macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?