### PR TITLE
zettlr: update to 1.8.4

### DIFF
--- a/aqua/zettlr/Portfile
+++ b/aqua/zettlr/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        Zettlr Zettlr 1.8.3 v
+github.setup        Zettlr Zettlr 1.8.4 v
 name                zettlr
 revision            0
 
@@ -32,15 +32,18 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  9be10ebf2e23a8aceb0b3341202a38b0e511878d \
-                    sha256  7219465ae9db918ead76578de5b989ddf8476921a9ca72107b19d4740c516318 \
-                    size    25064201
+                    rmd160  7b644e9a5e2465f92dc5d1b9a4c78dbaf7b55f85 \
+                    sha256  a83f4dea8ead73ec2cb842f00cbf219af0488820a88da35f146b9e6e9f8752d4 \
+                    size    25067368
 
 depends_build       port:go \
+                    port:pandoc \
                     port:yarn
 
 build.env-append    CSC_IDENTITY_AUTO_DISCOVERY=false
+
 use_configure       no
+use_xcode           yes
 
 build {
     set gopath ${workpath}/go


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
