### PR TITLE
tk: fix configure error with Xcode 12.3

### DIFF
--- a/x11/tk/Portfile
+++ b/x11/tk/Portfile
@@ -46,6 +46,9 @@ patchfiles-append   patch-dyld_fallback_library_path.diff
 # Remove when updating to 8.6.11
 patchfiles-append   patch-macosx-tkMacOSXInit.c.diff
 
+# Fix for impliclity defined error during configure under macOS 11.
+patchfiles-append   patch-implicitly-defined.diff
+
 configure.args      --mandir=${prefix}/share/man --with-tcl=${prefix}/lib
 # see https://trac.macports.org/ticket/58447
 configure.cppflags-replace -I${prefix}/include -isystem${prefix}/include

--- a/x11/tk/files/patch-implicitly-defined.diff
+++ b/x11/tk/files/patch-implicitly-defined.diff
@@ -1,0 +1,13 @@
+--- unix/configure.orig	2020-12-23 21:29:13.000000000 -0600
++++ unix/configure	2020-12-23 21:30:37.000000000 -0600
+@@ -3078,8 +3078,8 @@
+   for (i = 0; i < 256; i++)
+     if (XOR (islower (i), ISLOWER (i))
+ 	|| toupper (i) != TOUPPER (i))
+-      exit(2);
+-  exit (0);
++      return (2);
++  return (0);
+ }
+ _ACEOF
+ rm -f conftest$ac_exeext


### PR DESCRIPTION
#### Description

* add patch to fix a warning now elevated to an error in newer Xcode
releases, which causes a configure test to fail:

```
conftest.c:26:7: error: implicitly declaring library function 'exit'
  with type 'void (int) __attribute__((noreturn))'
  [-Werror,-Wimplicit-function-declaration]
        exit(2);
        ^
conftest.c:26:7: note: include the header <stdlib.h> or explicitly
  provide a declaration for 'exit'
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
