### PR TITLE
kakoune: new port

### DIFF
--- a/editors/kakoune/Portfile
+++ b/editors/kakoune/Portfile
@@ -1,0 +1,55 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           makefile 1.0
+
+github.setup        mawww kakoune 2020.09.01 v
+revision            0
+
+homepage            https://kakoune.org
+
+description         Modal editor — Faster as in fewer keystrokes — \
+                    Multiple selections — Orthogonal design
+
+long_description    Kakoune is a code editor that implements Vi’s \
+                    \"keystrokes as a text editing language\" model. As it’s \
+                    also a modal editor, it is somewhat similar to the Vim \
+                    editor (after which Kakoune was originally inspired). \
+                    Kakoune can operate in two modes, normal and insertion. \
+                    In insertion mode, keys are directly inserted into the \
+                    current buffer. In normal mode, keys are used to \
+                    manipulate the current selection and to enter insertion \
+                    mode.  Kakoune has a strong focus on interactivity, most \
+                    commands provide immediate and incremental results, while \
+                    still being competitive (as in keystroke count) with Vim. \
+                    Kakoune works on selections, which are oriented, \
+                    inclusive ranges of characters. Selections have an anchor \
+                    and a cursor. Most commands move both of them except when \
+                    extending selections, where the anchor character stays \
+                    fixed and the cursor moves around.
+
+# kakoune is licensed via The Unlicense, making it public domain.
+license             public-domain
+
+categories          editors
+platforms           darwin linux freebsd
+
+checksums           rmd160  793126df59847c8663be08688b32ded3f47c9314 \
+                    sha256  106adf110d1a4c17853b4783a4f4240270ca2b515f2cce5e04345d76767d97d9 \
+                    size    612988
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+pre-build {
+    set _version_file [open ${worksrcpath}/src/.version "w"]
+    puts -nonewline ${_version_file} "${version}"
+    close ${_version_file}
+}
+
+compiler.cxx_standard   2017
+
+depends_lib-append      port:ncurses
+
+makefile.has_destdir    yes


### PR DESCRIPTION
#### Description

New port for the **[kakoune](https://kakoune.org)** vim-style modal editor.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
