### PR TITLE
py-twisted and dependencies: add py39 subport

### DIFF
--- a/python/py-automat/Portfile
+++ b/python/py-automat/Portfile
@@ -18,14 +18,12 @@ description         A library for concise, idiomatic Python expression of finite
 long_description    Automat is a library for concise, idiomatic Python expression of finite-state automata (particularly deterministic finite-state transducers).
 
 homepage            https://github.com/glyph/automat
-master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
-distname            ${python.rootname}-${version}
 
 checksums           rmd160  389126c3183fdd8ad34333d86490e2ba448ced94 \
                     sha256  7979803c74610e11ef0c0d68a2942b152df52da55336e0c9d58daf1831cbdf33 \
                     size    61679
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -57,7 +55,7 @@ Please install py${python.version}-twisted and py${python.version}-graphviz manu
 "
     }
 
-    depends_run-append \
+    depends_test-append \
                     port:py${python.version}-pytest
 
     test.run        yes

--- a/python/py-constantly/Portfile
+++ b/python/py-constantly/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  7a9d1776bb3b44b1982ba01ce50f269d67c1e4a7 \
                     sha256  be63c40ef853ee785045a1d20327d8153db9291f9aaff552796bed5272f9dd60 \
                     size    40635
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-hyperlink/Portfile
+++ b/python/py-hyperlink/Portfile
@@ -20,7 +20,7 @@ checksums           rmd160  d6372062ea8a7721c96a9f519d2bdff587b8ec26 \
                     sha256  658cba1f39b2802ab80a394c582e420aab1ff5ece8e83804a4790c6f5cf835a3 \
                     size    101141
 
-python.versions 27 35 36 37 38
+python.versions 27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
 
@@ -30,10 +30,13 @@ if {${name} ne ${subport}} {
     depends_run-append    \
         port:py${python.version}-idna
 
-    test.run        yes
-
     depends_test-append  \
         port:py${python.version}-pytest
+
+    test.run        yes
+    test.cmd        py.test-${python.branch}
+    test.target
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     livecheck.type  none
 }

--- a/python/py-incremental/Portfile
+++ b/python/py-incremental/Portfile
@@ -20,7 +20,7 @@ checksums           rmd160  d43e1e373acf42abcaaef8ffde8f77bf5a48abb5 \
                     sha256  7be9a13ebb2ad1dd1ed3ecf547c3fa6e1154bb793418c6cc504b9b6039b0045a \
                     size    14674
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
     # see https://pypi.python.org/pypi/incremental/

--- a/python/py-m2r/Portfile
+++ b/python/py-m2r/Portfile
@@ -19,7 +19,7 @@ checksums           rmd160  a71cedf33366b78544c1f5488d57d879e16b87cd \
                     sha256  5864619db80a3470f2f535bd374d6bdf025806815b203e7e0c809b544106f249 \
                     size    24466
 
-python.versions 27 35 36 37 38
+python.versions 27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
 

--- a/python/py-pyhamcrest/Portfile
+++ b/python/py-pyhamcrest/Portfile
@@ -4,10 +4,10 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pyhamcrest
+python.rootname     PyHamcrest
 version             2.0.2
-if {${subport} eq "py27-pyhamcrest"} {
-    version         1.10.1
-}
+revision            0
+
 platforms           darwin
 license             BSD
 maintainers         {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
@@ -16,25 +16,24 @@ description         Hamcrest framework for matcher objects
 long_description    ${description}
 
 homepage            https://github.com/hamcrest/PyHamcrest
-master_sites        pypi:P/PyHamcrest
-distname            PyHamcrest-${version}
 
 checksums           rmd160  0a0710b31bbdc3c6984d789f6d4b3188af16ec51 \
                     sha256  412e00137858f04bde0729913874a48485665f2d36fe9ee449f26be864af9316 \
                     size    44329
-if {${subport} eq "py27-pyhamcrest"} {
-    checksums       rmd160  a6cbdb42ba7340e932a94ec120d6c77b1eec86f9 \
-                    sha256  f7ae19ddfd71f11a421bcec9608d708c0fab816db98b51fdbc672a6d99a30874 \
-                    size    43021
-}
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-                        port:py${python.version}-setuptools
+    if {${python.version} == 27} {
+        version     1.10.1
+        checksums   rmd160  a6cbdb42ba7340e932a94ec120d6c77b1eec86f9 \
+                    sha256  f7ae19ddfd71f11a421bcec9608d708c0fab816db98b51fdbc672a6d99a30874 \
+                    size    43021
+        distname    ${python.rootname}-${version}
+    }
 
-    livecheck.type      none
-} else {
-    livecheck.type      pypi
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    livecheck.type  none
 }

--- a/python/py-twisted/Portfile
+++ b/python/py-twisted/Portfile
@@ -1,4 +1,4 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
 PortGroup           python 1.0
@@ -27,7 +27,7 @@ checksums           rmd160  d30b3dd66222e4dd3ad4ce668f1c556690e8b554 \
                     sha256  d72c55b5d56e176563b91d11952d13b01af8725c623e498db5507b6614fc1e10 \
                     size    3127793
 
-python.versions 27 35 36 37 38
+python.versions 27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
     # uses "from pkg_resources import load_entry_point"


### PR DESCRIPTION
#### Description
This PR adds a py39 subport to py-twisted and its dependencies; required for `py39-structlog` that I (prematurely) committed in 6fabdc8c2ee4bd32e5f6ef59bb55035db8fd72ea. Additionally some minor clean-up of the Portfiles where appropriate.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
