### PR TITLE
ruby-build: update to 20201225

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20201005 v
+github.setup        rbenv ruby-build 20201225 v
 categories          ruby
 license             MIT
 platforms           darwin
@@ -14,9 +14,9 @@ maintainers         {mojca @mojca} openmaintainer
 description         Compile and install Ruby
 long_description    ${description}
 
-checksums           rmd160  9da7101d0035fea4f3989c91038c5ca222bf0ef4 \
-                    sha256  7086ee466b4e1bd896c8d262bbf5b655fdad18641de1a70c9f642611afd4498d \
-                    size    69174
+checksums           rmd160  0ecc0202fe4cf904da34d77c3d65ed6cedad3908 \
+                    sha256  6ce7f8b4639dae70f646fc14d04feb8c1bb6a8a6d7cb24c3e6d1fad1e19c6ea4 \
+                    size    69799
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

Update ruby-build to 20201225

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->