### PR TITLE
ncarg: Fix duplicate symbol errors with gcc10

### DIFF
--- a/science/ncarg/Portfile
+++ b/science/ncarg/Portfile
@@ -85,6 +85,7 @@ patchfiles                  patch-Configure.diff \
                             patch-ncarg2d-src-bin-ezmapdemo-yMakefile.diff \
                             patch-ncarg2d-src-bin-tdpackdemo-yMakefile.diff \
                             patch-ngmath-src-bin-nnalg-yMakefile.diff \
+                            patch-ni-src-ncl-global-vars.diff \
                             patch-ncarg2d-src-libncarg_gks-bwi-argb2ci.f.diff
 if {$build_arch eq "x86_64"} {
     patchfiles-append       patch-config-ymake.diff

--- a/science/ncarg/files/patch-ni-src-ncl-global-vars.diff
+++ b/science/ncarg/files/patch-ni-src-ncl-global-vars.diff
@@ -1,0 +1,38 @@
+--- ni/src/ncl/NclApi.c.orig	2019-02-27 16:44:39.000000000 -0700
++++ ni/src/ncl/NclApi.c	2020-12-10 17:35:44.000000000 -0700
+@@ -140,9 +140,10 @@
+ extern char *the_input_buffer_ptr;
+ extern int the_input_buffer_size;
+ 
+-FILE *thefptr;
+-FILE *theoptr;
+-int cmd_line;
++extern FILE *thefptr;
++extern FILE *theoptr;
++extern int cmd_line;
++
+ extern int cur_line_number;
+ extern char *cur_line_text;
+ extern int cur_line_maxsize;
+--- ni/src/ncl/NclHDF5.c.orig	2019-02-27 16:44:39.000000000 -0700
++++ ni/src/ncl/NclHDF5.c	2020-12-09 21:12:16.000000000 -0700
+@@ -240,7 +240,7 @@
+ 
+ #define NUMPOSDIMNAMES	6
+ 
+-NclQuark possibleDimNames[NUMPOSDIMNAMES];
++static NclQuark possibleDimNames[NUMPOSDIMNAMES];
+ 
+ static int _H5_initializeOptions 
+ #if    NhlNeedProto
+--- ni/src/ncl/NclNewHDF5.c.orig	2019-02-27 16:44:39.000000000 -0700
++++ ni/src/ncl/NclNewHDF5.c	2020-12-09 21:13:25.000000000 -0700
+@@ -82,7 +82,7 @@
+ 
+ #define NUMPOSDIMNAMES	6
+ 
+-NclQuark possibleDimNames[NUMPOSDIMNAMES];
++static NclQuark possibleDimNames[NUMPOSDIMNAMES];
+ 
+ #ifndef FALSE
+ #define FALSE           0


### PR DESCRIPTION
* Patched 3 source files in ni/src/ncl.
* Fixed improper use of global variables. Fixed 4 symbol conflicts, total.

Gcc10 changed option default from -fcommon to -fno-common. See gcc10 release notes and porting notes.  Use this patch, do not use -fcommon.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.14.6 build 18G6032
Xcode 11.5 build 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
   -- Tested only the main NCL executable.

Reported upstream:  https://github.com/NCAR/ncl/issues/148

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->