### PR TITLE
welly-ytang: new port

### DIFF
--- a/www/welly-ytang/Portfile
+++ b/www/welly-ytang/Portfile
@@ -1,0 +1,21 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           xcode 1.0
+
+name                welly-ytang
+github.setup        ytang welly 2020.12
+github.tarball_from archive
+categories          www aqua
+maintainers         @mecca831
+description         A powerful BBS client for macOS users, ytang's fork
+homepage            https://wellybbs.com
+long_description    Welly is a client for terminal BBS (Bulletin Board Systems), \
+                    such as MITBBS, NewSMTH, and PTT. It supports Telnet, SSH \
+                    (Version 1 & 2), and WebSocket.
+license             GPL-2
+
+checksums           rmd160  0c7db1f62e774842d1ad41a863240e98a099cbde \
+                    sha256  0bfe80c4ef869d8c3759add629434078c165cce248f4697c7153cf6ff9ef5ed9 \
+                    size    9865383


### PR DESCRIPTION
#### Description

New port for [Welly](https://wellybbs.com/).

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
