### PR TITLE
openmpi: update to 4.1.0

### DIFF
--- a/science/openmpi/Portfile
+++ b/science/openmpi/Portfile
@@ -8,8 +8,7 @@ PortGroup           muniversal 1.0
 PortGroup           legacysupport 1.0
 
 name                openmpi
-version             4.0.1
-revision            2
+version             4.1.0
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          science parallel net
 platforms           darwin
@@ -29,9 +28,10 @@ homepage            https://www.open-mpi.org/
 set subdir          ompi/v${branch}/downloads/
 master_sites        https://www.open-mpi.org/software/${subdir}
 
-checksums           rmd160  a9b7730d31e77e8d8d49204f9945d24f2dd54072 \
-                    sha256  cce7b6d20522849301727f81282201d609553103ac0b09162cf28d102efb9709 \
-                    size    9838152
+checksums           rmd160  15e3b5429e74f0f39a46ca0cc35de92b68ea21d0 \
+                    sha256  73866fb77090819b6a8c85cb8539638d37d6877455825b74e289d647a39fd5b5 \
+                    size    10022171
+
 use_bzip2           yes
 
 livecheck.type      regex


### PR DESCRIPTION
#### Description

Straight forward update of openmpi to version 4.1.0 which contains a fix for Big Sur.

Partially fixes https://trac.macports.org/ticket/61492 (only the openmpi part of it of course).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? (no tests available)
- [ ] tried a full install with `sudo port -vst install`? (only for openmpi-gcc10 and without trace mode. trace mode hangs during configure)
- [ ] tested basic functionality of all binary files? (only for openmpi-gcc10 and only mpicc and a local mpirun)

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
