### PR TITLE
frei0r-plugins: update to 1.7.0

### DIFF
--- a/multimedia/frei0r-plugins/Portfile
+++ b/multimedia/frei0r-plugins/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 
 name                frei0r-plugins
-version             1.4
-revision            1
+version             1.7.0
+revision            0
 categories          multimedia
 maintainers         {dennedy.org:dan @ddennedy}
 license             GPL-2+
@@ -16,19 +16,21 @@ long_description    frei0r is a minimalistic plugin API for video sources and fi
                     adaptation issue of standard effects. It is not meant as a generic API for \
                     all kinds of video applications.
 
-homepage            http://frei0r.dyne.org/
+homepage            https://frei0r.dyne.org/
 master_sites        https://releases.dyne.org/frei0r/releases/
 
 platforms           darwin
 
-checksums           sha1    7995d06c5412b14fa3b05647084ca9d7a0c84faa \
-                    rmd160  b49a341474facc633feed5007ebe1e8f01a1199e
+checksums           sha1    f56840b3d8235810ec1ce5f036c20f88ece6ddca \
+                    rmd160  5f53940b12737c9d0f7b868305396f26a34b4649 \
+                    sha256  1b1ff8f0f9bc23eed724e94e9a7c1d8f0244bfe33424bb4fe68e6460c088523a
 
 depends_build       port:pkgconfig
 
 depends_lib         path:lib/pkgconfig/cairo.pc:cairo
 
-patchfiles          patch-configure.ac.diff
+patchfiles          patch-configure.ac.diff \
+                    patch-Makefile.am.diff
 
 use_autoreconf      yes
 

--- a/multimedia/frei0r-plugins/files/patch-Makefile.am.diff
+++ b/multimedia/frei0r-plugins/files/patch-Makefile.am.diff
@@ -1,0 +1,8 @@
+--- Makefile.am.orig	2020-12-26 11:31:35.000000000 -0800
++++ Makefile.am	2020-12-26 11:31:25.000000000 -0800
+@@ -16,4 +16,4 @@
+ pkgconfig_DATA = frei0r.pc
+ 
+ docsdir = ${prefix}/share/doc/${PACKAGE}
+-docs_DATA = README.md ChangeLog TODO AUTHORS 
++docs_DATA = README.txt ChangeLog.txt TODO.txt AUTHORS.txt 


### PR DESCRIPTION
#### Description

Upgrade to version 1.7.0 and fixes https://trac.macports.org/ticket/61916 

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.1 20C69
Xcode 12.3 12C33
arm64 (M1!)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? 
This port only installs dynamic libraries that must be `dlopen()`-ed and has no test harness. I tested several of them using ffplay.
  > Failed to test frei0r-plugins: frei0r-plugins has no tests turned on. see 'test.run' in portfile(7)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
