### PR TITLE
py-importlib-resources: update to 4.1.0

### DIFF
--- a/python/py-importlib-resources/Portfile
+++ b/python/py-importlib-resources/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-importlib-resources
-version             1.4.0
+python.rootname     importlib_resources
+version             4.1.0
 revision            0
 
 platforms           darwin
@@ -17,13 +18,12 @@ description         A backport of Python standard library importlib.resources mo
 long_description    ${description}
 
 homepage            https://importlib-resources.readthedocs.io
-distfiles           importlib_resources-${version}${extract.suffix}
 
-checksums           rmd160  751df6e4184cfafcfbd6f0cb5a113e88965edbc9 \
-                    sha256  4019b6a9082d8ada9def02bece4a76b131518866790d58fdda0b5f8c603b36c2 \
-                    size    23220
+checksums           rmd160  373ae070ad4aaaac8a61719bc2ba1bb5ec0ca5af \
+                    sha256  01fe9f1f2000677b2cdc7838473143341401d010eee276d2fcb64c219f624a25 \
+                    size    30814
 
-# keep version for PY27 and PY34, these are (indirect) dependencies of py-virtualenv
+# keep version for PY27/PY34/PY35, these are (indirect) dependencies of py-virtualenv
 python.versions     27 34 35 36 37 38
 
 if {${name} ne ${subport}} {
@@ -33,20 +33,39 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-toml
 
     if {${python.version} == 27} {
+        version     3.3.1
+        revision    0
+        checksums   rmd160  6b0e6b482a5cb45430243e78317731efcf7eb84b \
+                    sha256  0ed250dbd291947d1a298e89f39afcc477d5a6624770503034b72588601bcc05 \
+                    size    29012
+
         depends_lib-append \
                     port:py${python.version}-contextlib2 \
                     port:py${python.version}-pathlib2 \
-                    port:py${python.version}-singledispatch
-    }
-
-    if {${python.version} < 35} {
-        depends_lib-append \
+                    port:py${python.version}-singledispatch \
                     port:py${python.version}-typing
+    } elseif {${python.version} == 34} {
+        version     1.0.2
+        epoch       1
+        revision    0
+        checksums   rmd160  ccbed771125ab62eda228842bc87339dd9aa21a8 \
+                    sha256  d3279fd0f6f847cced9f7acc19bd3e5df54d34f93a2e7bb5f238f81545787078 \
+                    size    23602
+        depends_build-append \
+                    port:py${python.version}-wheel
+        depends_lib-append \
+                    port:py${python.version}-pathlib2 \
+                    port:py${python.version}-typing
+    } elseif {${python.version} == 35} {
+        version     3.2.1
+        revision    0
+        checksums   rmd160  5abb9e9bbae805089609dca64868d2ea7a8629fd \
+                    sha256  a9fe213ab6452708ec1b3f4ec6f2881b8ab3645cb4e5efb7fea2bbf05a91db3b \
+                    size    28884
     }
 
     if {${python.version} < 38} {
         depends_lib-append \
-                    port:py${python.version}-importlib-metadata \
                     port:py${python.version}-zipp
     }
 

--- a/python/py-wheel/Portfile
+++ b/python/py-wheel/Portfile
@@ -4,7 +4,6 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-wheel
-set real_name       wheel
 version             0.36.2
 revision            0
 platforms           darwin
@@ -15,8 +14,6 @@ description         A built package format for Python.
 long_description    ${description}
 
 homepage            https://github.com/pypa/wheel/
-master_sites        pypi:w/${real_name}
-distname            wheel-${version}
 
 checksums           rmd160  8aef0f39508d9326e767115346e115b7fbf58c9b \
                     sha256  e11eefd162658ea59a60a0f6c7d493a7190ea4b9a85e335b33489d9f17e0245e \
@@ -24,10 +21,24 @@ checksums           rmd160  8aef0f39508d9326e767115346e115b7fbf58c9b \
 
 supported_archs     noarch
 
-python.versions     27 35 36 37 38 39
+# leave the EOL PY34 subport here as it is an indirect dependency of py34-virtualenv
+python.versions     27 34 35 36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_build-append \
-                        port:py${python.version}-setuptools \
-                        port:py${python.version}-setuptools_scm
+                    port:py${python.version}-setuptools \
+                    port:py${python.version}-setuptools_scm
+
+    if {${python.version} == 34} {
+        version     0.33.6
+        revision    0
+        checksums   rmd160  9c84bfce4d05e61aed7898a212f37eb9d7351543 \
+                    sha256  10c9da68765315ed98850f8e048347c3eb06dd81822dc2ab1d4fde9dc9702646 \
+                    size    48130
+
+        depends_run-append \
+                    port:py${python.version}-setuptools
+    }
+
+    livecheck.type  none
 }


### PR DESCRIPTION
#### Description
- update `py-importlib-resources` to 4.1.0, pin to latest versions for PY27/PY34/PY35
- add py24 subport to `py-wheel` since it's a requirement for `py34-importlib-resources`

###### Tested on
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
