### PR TITLE
pandoc: install binary for BigSur

### DIFF
--- a/textproc/pandoc/Portfile
+++ b/textproc/pandoc/Portfile
@@ -1,15 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
-PortGroup           haskell_stack 1.0
 
-github.setup        jgm pandoc 2.10.1
-revision            0
 categories          textproc haskell
 platforms           darwin
 license             GPL-3
 maintainers         nomaintainer
+homepage            https://pandoc.org
 
 description         Conversion between markup formats
 long_description    \
@@ -21,25 +18,73 @@ long_description    \
     Textile, groff man pages, plain text, Emacs Org-Mode, AsciiDoc, EPUB (v2 \
     and v3), FictionBook2, and S5, Slidy and Slideous HTML slide shows.
 
-checksums           rmd160  e5a6e7e6f4b2062d9d0afed78f428a11bdb6d664 \
-                    sha256  06e257fb318670501c88abc83fff1f9484c5f1981b6c855640f170a451dcd6d0 \
-                    size    12709912
 
-test.run            yes
-test.args           --test-arguments='-p markdown'
+# use a downloaded binary for systems that can't build pandoc through MacPorts at present
+if { ${os.platform} eq "darwin" && ${os.major} >= 20 } {
 
-post-destroot {
-    xinstall -d ${destroot}${prefix}/share/doc
-    copy ${worksrcpath}/doc ${destroot}${prefix}/share/doc/${subport}
-    xinstall -m 0644 -W ${worksrcpath} \
-        AUTHORS.md \
-        BUGS \
-        CONTRIBUTING.md \
-        COPYING.md \
-        COPYRIGHT \
-        MANUAL.txt \
-        README.md \
-        ${destroot}${prefix}/share/doc/${subport}
-    xinstall -m 0644 ${worksrcpath}/man/pandoc.1 \
-        ${destroot}${prefix}/share/man/man1
+    # BigSur can't presently build ghc/stack/cabal ports so use Catalina binary on
+    # both Intel and arm64
+    name                pandoc
+    version             2.10.1
+    revision            0
+    master_sites        https://packages.macports.org/pandoc/
+    use_bzip2           yes
+    distfiles           pandoc-${version}_${revision}.darwin_19.x86_64.tbz2
+    checksums           rmd160  66a0c26a1a3797c434bcb0e0ee1e28d49ccd5acc \
+                        sha256  0cff6477cc54b4d75dcf7d288a0ecb8adb23c427e60106e9f13c386a9eb67108 \
+                        size    16436020
+    use_configure no
+    build {}
+    destroot {
+        move ${worksrcpath}/local/bin/pandoc ${destroot}${prefix}/bin
+        move ${worksrcpath}/local/share/doc/pandoc/ ${destroot}${prefix}/share/doc
+        move ${worksrcpath}/local/share/man ${destroot}${prefix}/share/man
+    }
+
+    notes-append {
+    This port installs a Catalina Intel binary for use on BigSur, both Intel and arm64.
+
+    once ghc / stack / cabal all properly function on these systems then a full building \
+    version of this port can be re-enabled.
+
+    }
+
+# this is a placeholder for a binary install version that will work on older systems
+# not yet completed
+# } elseif { ${os.platform} eq "darwin" && ${os.major} < 14 } {
+# these systems can't presently build a working pandoc binary via MacPorts
+
+
+} else {
+
+    # these systems can build a working pandoc using MacPorts standard mechanisms
+
+    PortGroup           github 1.0
+    PortGroup           haskell_stack 1.0
+
+    github.setup        jgm pandoc 2.10.1
+    revision            0
+    checksums           rmd160  e5a6e7e6f4b2062d9d0afed78f428a11bdb6d664 \
+                        sha256  06e257fb318670501c88abc83fff1f9484c5f1981b6c855640f170a451dcd6d0 \
+                        size    12709912
+
+    test.run            yes
+    test.args           --test-arguments='-p markdown'
+
+    post-destroot {
+        xinstall -d ${destroot}${prefix}/share/doc
+        copy ${worksrcpath}/doc ${destroot}${prefix}/share/doc/${subport}
+        xinstall -m 0644 -W ${worksrcpath} \
+            AUTHORS.md \
+            BUGS \
+            CONTRIBUTING.md \
+            COPYING.md \
+            COPYRIGHT \
+            MANUAL.txt \
+            README.md \
+            ${destroot}${prefix}/share/doc/${subport}
+        xinstall -m 0644 ${worksrcpath}/man/pandoc.1 \
+            ${destroot}${prefix}/share/man/man1
+    }
+
 }


### PR DESCRIPTION
this port installs the x86_64 binary from
Catalina on BigSur Intel and arm64

ghc/stack/cabal will work on BigSur Intel
at some point. Just when they might work on arm64
is less clear.

see: https://trac.macports.org/ticket/61422
