### PR TITLE
freac, BoCA, smooth: new port

### DIFF
--- a/aqua/smooth/Portfile
+++ b/aqua/smooth/Portfile
@@ -1,0 +1,43 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           makefile 1.0
+
+github.setup        enzo1982 smooth 0.9.6 v
+github.tarball_from releases
+
+categories          aqua
+platforms           darwin
+license             Artistic-2
+maintainers         {@janosch mailbox.org:janosch1} openmaintainer
+description         ${name} is a class library for user interfaces written in C++
+long_description    ${name} is an object oriented C++ class library for Windows, \
+                    macOS, Linux and most Unix-like operating systems. \
+                    It provides basic functionality and platform support for \
+                    applications and libraries. \
+                    \n \
+                    \nFeatures provided by smooth include:\
+                    \n* user interface API with various widgets\
+                    \n* simple to use multithreading API\
+                    \n* file and network IO interface\
+                    \n* completely transparent Unicode and software \
+                    internationalization support\
+                    \n* a libxml2 based XML parser\
+homepage            http://www.smooth-project.org/
+
+checksums           rmd160  b53e8720b3e3e8fad48e7c1f6f1dd55a910758f8 \
+                    sha256  e678880e59c8cf7c53c4b4d72df0d11b07a650f288b55f2d44e95b02495c0e8c \
+                    size    8040291
+
+depends_lib         port:bzip2 \
+                    port:curl \
+                    port:fribidi \
+                    port:gtk3 \
+                    path:include/turbojpeg.h:libjpeg-turbo \
+                    port:libxml2
+
+patchfiles          patch-fix-libxml2-includes.diff \
+                    patch-fix-dylib-install-path.diff
+
+makefile.prefix_name    prefix

--- a/aqua/smooth/files/patch-fix-dylib-install-path.diff
+++ b/aqua/smooth/files/patch-fix-dylib-install-path.diff
@@ -1,0 +1,11 @@
+--- Makefile.orig	2020-12-25 17:02:53.000000000 +0100
++++ Makefile	2021-01-27 12:17:23.000000000 +0100
+@@ -246,7 +246,7 @@
+ ifeq ($(BUILD_WIN32),True)
+ 	LINKER_OPTS += --shared -mwindows -Wl,--dynamicbase,--nxcompat,--kill-at,--out-implib,$(LIBNAME)
+ else ifeq ($(BUILD_OSX),True)
+-	LINKER_OPTS += -dynamiclib -framework Carbon -framework Cocoa -Wl,-dylib_install_name,libsmooth-$(VERSION).$(REVISION)$(SHARED)
++	LINKER_OPTS += -dynamiclib -framework Carbon -framework Cocoa -Wl,-dylib_install_name,$(prefix)/lib/libsmooth-$(VERSION).$(REVISION)$(SHARED)
+ else
+ 	LINKER_OPTS += --shared -Wl,-soname,libsmooth-$(VERSION)$(SHARED).$(REVISION)
+ 

--- a/aqua/smooth/files/patch-fix-libxml2-includes.diff
+++ b/aqua/smooth/files/patch-fix-libxml2-includes.diff
@@ -1,0 +1,11 @@
+--- classes/xml/Makefile.orig	2020-12-22 20:25:35.000000000 +0100
++++ classes/xml/Makefile	2020-12-29 15:28:02.000000000 +0100
+@@ -9,7 +9,7 @@
+ ifeq ($(USE_BUNDLED_LIBXML2),True)
+ 	MYCCOPTS += -I"$(SRCDIR)"/$(SMOOTH_PATH)/include/support/libxml2
+ else ifeq ($(BUILD_OSX),True)
+-	MYCCOPTS += -I$(shell xcodebuild -sdk macosx -version | grep "^Path: " | head -n 1 | tail -c +7)/usr/include/libxml2
++	MYCCOPTS += -I$(prefix)/include/libxml2
+ else
+ 	MYCCOPTS += $(shell pkg-config --cflags libxml-2.0)
+ endif

--- a/audio/boca/Portfile
+++ b/audio/boca/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           makefile 1.0
+
+github.setup        enzo1982 boca 1.0.3 v
+github.tarball_from releases
+
+categories          audio
+platforms           darwin
+license             GPL-2
+maintainers         {@janosch mailbox.org:janosch1} openmaintainer
+description         The component framework behind the fre:ac audio converter.
+long_description    ${name} provides unified interfaces for components like \
+                    encoders, decoders, taggers and extensions as well as code \
+                    to support communication between the application \
+                    and its components.
+homepage            https://www.freac.org/
+
+checksums           rmd160  f694b410a87acc81afc1a53b2046be500712cebd \
+                    sha256  314467893f3472a8354b60566877b064a0f37279990c70d93005bca265b2c926 \
+                    size    2548107
+
+depends_lib         port:expat \
+                    port:libcdio \
+                    port:libcdio-paranoia \
+                    port:smooth \
+                    port:uriparser
+
+patchfiles          patch-set-install-path-runtime.diff \
+                    patch-set-install-path-components.diff
+
+makefile.prefix_name    prefix

--- a/audio/boca/files/patch-set-install-path-components.diff
+++ b/audio/boca/files/patch-set-install-path-components.diff
@@ -1,0 +1,11 @@
+--- Makefile-commands.orig	2021-01-27 13:17:25.000000000 +0100
++++ Makefile-commands	2021-01-27 13:18:49.000000000 +0100
+@@ -31,7 +31,7 @@
+ 	LDOPTS += -L$(prefix)/lib -lsmooth-$(SMOOTHVER) -lboca-$(VERSION)
+ 
+ 	ifeq ($(BUILD_OSX),True)
+-		LDOPTS += -Wl,-headerpad,80
++		LDOPTS += -Wl,-headerpad,80,-dylib_install_name,$(prefix)/lib/boca/boca_$(TYPE)_$(TARGET).$(VERSION)$(SHARED)
+ 	else ifeq ($(BUILD_NETBSD),True)
+ 		LDOPTS += -Wl,-rpath,/usr/pkg/lib -L/usr/pkg/lib
+ 	else

--- a/audio/boca/files/patch-set-install-path-runtime.diff
+++ b/audio/boca/files/patch-set-install-path-runtime.diff
@@ -1,0 +1,11 @@
+--- runtime/Makefile.orig	2021-01-27 13:22:09.000000000 +0100
++++ runtime/Makefile	2021-01-27 13:22:20.000000000 +0100
+@@ -61,7 +61,7 @@
+ 	LDOPTS += -L$(prefix)/lib -lsmooth-$(SMOOTHVER)
+ 
+ 	ifeq ($(BUILD_OSX),True)
+-		LDOPTS += -Wl,-dylib_install_name,libboca-$(VERSION).$(REVISION)$(SHARED)
++		LDOPTS += -Wl,-dylib_install_name,$(prefix)/lib/libboca-$(VERSION).$(REVISION)$(SHARED)
+ 	else
+ 		LDOPTS += -Wl,-soname,libboca-$(VERSION)$(SHARED).$(REVISION)
+ 	endif

--- a/audio/freac/Portfile
+++ b/audio/freac/Portfile
@@ -1,0 +1,43 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           makefile 1.0
+
+github.setup        enzo1982 freac 1.1.3 v
+github.tarball_from releases
+
+categories          audio
+platforms           darwin
+license             GPL-2
+maintainers         {@janosch mailbox.org:janosch1} openmaintainer
+description         An open source audio converter.
+long_description    ${name} is a free audio converter and CD ripper with support \
+                    for various popular formats and encoders. It converts freely \
+                    between MP3, M4A/AAC, FLAC, WMA, Opus, Ogg Vorbis, Speex, \
+                    Monkey's Audio (APE), WavPack, WAV and other formats.
+homepage            https://www.freac.org/
+
+checksums           rmd160  2f1f9ea871793cec1a8fe02a96fb9c03b1fa0c49 \
+                    sha256  eb8e362457614b0e256c9c641ed1f0408b6a56e0eb6af11b5993f2ef30403332 \
+                    size    3299064
+
+depends_lib         port:boca \
+                    port:smooth
+
+makefile.prefix_name    prefix
+
+post-destroot {
+    # Copy the the application bundle shipped by the upstream project
+    copy -- ${worksrcpath}/packaging/macosx/freac.app ${destroot}${applications_dir}
+
+    # Create MacOS folders where the symlinks to the freac binaries will be created
+    xinstall -d ${destroot}${applications_dir}/freac.app/Contents/MacOS
+    xinstall -d ${destroot}${applications_dir}/freac.app/Contents/Resources/translator.app/Contents/MacOS
+
+    # Create symlinks for freac binaries in ${prefix}/bin
+    ln -s ${prefix}/bin/freac ${destroot}${applications_dir}/freac.app/Contents/MacOS/freac
+    ln -s ${prefix}/bin/freaccmd ${destroot}${applications_dir}/freac.app/Contents/MacOS/freaccmd
+    ln -s ${prefix}/bin/smooth-translator \
+    ${destroot}${applications_dir}/freac.app/Contents/Resources/translator.app/Contents/MacOS/translator
+}


### PR DESCRIPTION
#### Description
New port for [fre:ac](https://www.freac.org/) audio converter and its dependencies [BoCA](https://github.com/enzo1982/BoCA) and [smooth](https://github.com/enzo1982/smooth).

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3.0.0.1.1607026830

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on Trac with full URL? 
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
