### PR TITLE
shellcheck: install binary for BigSur

### DIFF
--- a/devel/shellcheck/Portfile
+++ b/devel/shellcheck/Portfile
@@ -1,12 +1,8 @@
-PortSystem          1.0
-PortGroup           haskell_stack 1.0
-PortGroup           github 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-github.setup        koalaman shellcheck 0.7.1 v
+PortSystem          1.0
+
 categories          devel haskell
-checksums           rmd160  92eb70521e96c0a546500f589f5b8c02e986ae7f \
-                    sha256  732a9c54ce6cc719ef5f402ef5b3705410aefdf6c3c3df3d0f7f017bd42b05d8 \
-                    size    211867
 
 license             GPL-3+
 maintainers         {cal @neverpanic} openmaintainer
@@ -18,3 +14,41 @@ long_description    \
     \n - To point out and clarify typical beginner's syntax issues, that causes a shell to give cryptic error messages. \
     \n - To point out and clarify typical intermediate level semantic problems, that causes a shell to behave strangely and counter-intuitively. \
     \n - To point out subtle caveats, corner cases and pitfalls, that may cause an advanced user's otherwise working script to fail under future circumstances.
+
+# use a downloaded binary for systems that can't build pandoc through MacPorts at present
+if { ${os.platform} eq "darwin" && ${os.major} >= 20 } {
+
+    # BigSur can't presently build ghc/stack/cabal ports so use Catalina binary on
+    # both Intel and arm64
+    name            shellcheck
+    version         0.7.1
+    master_sites    https://github.com/koalaman/shellcheck/releases/download/v${version}
+    distfiles       ${name}-v${version}.darwin.x86_64.tar.xz
+    checksums           rmd160  edce5cdbb0de2ec12c2fa037fb82612e9eedb133 \
+                        sha256  b080c3b659f7286e27004aa33759664d91e15ef2498ac709a452445d47e3ac23 \
+                        size    1348272
+    use_configure   no
+    build {}
+    destroot {
+        move ${worksrcpath}/${name} ${destroot}${prefix}/bin
+    }
+
+    notes-append {
+    This port installs a Catalina Intel binary for use on BigSur, both Intel and arm64.
+
+    once ghc / stack / cabal all properly function on these systems then a full building \
+    version of this port can be re-enabled.
+
+    }
+} else {
+
+    # these systems can build a working pandoc using MacPorts standard mechanisms
+
+    PortGroup           haskell_stack 1.0
+    PortGroup           github 1.0
+
+    github.setup        koalaman shellcheck 0.7.1 v
+    checksums           rmd160  92eb70521e96c0a546500f589f5b8c02e986ae7f \
+                        sha256  732a9c54ce6cc719ef5f402ef5b3705410aefdf6c3c3df3d0f7f017bd42b05d8 \
+                        size    211867
+}


### PR DESCRIPTION
this port installs the x86_64 binary on Intel and
arm64

ghc/stack/cabal will work on BigSur Intel
at some point. Just when they might work on arm64
is less clear.

see: https://trac.macports.org/ticket/61422

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3 12C33


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

cc @kencu 