### PR TITLE
GPXSee: update to 8.0

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 7.36
+github.setup        tumic0 GPXSee 8.0
 categories          gis graphics
 platforms           darwin
 license             GPL-3
@@ -16,9 +16,9 @@ long_description    GPXSee is a Qt-based GPS log file viewer and analyzer \
 
 homepage            https://www.gpxsee.org/
 
-checksums           rmd160  6c4650c76d023228b50c21b387202734d52cd950 \
-                    sha256  c6edd213c42b020b3fb9961ac8ebac2d93cd9ae86e1f14577e0eea8bf9d36651 \
-                    size    5404955
+checksums           rmd160  c00ee6907ccb7475010e1dd58eaa3ec812375927 \
+                    sha256  c496cda4408cfd474515c77ff125a0bd0133f06b4da6e62ece8ef92be6507cb5 \
+                    size    7714526
 
 patchfiles          patch-src_GUI_app_cpp.diff
 

--- a/gis/GPXSee/files/patch-src_GUI_app_cpp.diff
+++ b/gis/GPXSee/files/patch-src_GUI_app_cpp.diff
@@ -1,11 +1,11 @@
---- src/GUI/app.cpp.orig	2018-12-08 04:27:27.000000000 +0300
-+++ src/GUI/app.cpp	2018-12-08 23:42:52.000000000 +0300
-@@ -34,7 +34,7 @@
- 	installTranslator(gpxsee);
+--- src/GUI/app.cpp.orig	2020-12-29 04:24:02.000000000 +0300
++++ src/GUI/app.cpp	2020-12-29 04:24:21.000000000 +0300
+@@ -35,7 +35,7 @@
+ 		installTranslator(gpxsee);
  
  	QTranslator *qt = new QTranslator(this);
 -#if defined(Q_OS_WIN32) || defined(Q_OS_MAC)
 +#if defined(Q_OS_WIN32)
- 	qt->load(QLocale::system(), "qt", "_", ProgramPaths::translationsDir());
+ 	if (qt->load(QLocale::system(), "qt", "_", ProgramPaths::translationsDir()))
  #else // Q_OS_WIN32 || Q_OS_MAC
- 	qt->load(QLocale::system(), "qt", "_", QLibraryInfo::location(
+ 	if (qt->load(QLocale::system(), "qt", "_", QLibraryInfo::location(


### PR DESCRIPTION
#### Description
[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
