### PR TITLE
qt5-qtcreator: bump to 4.12.4

### DIFF
--- a/devel/qt5-qtcreator/Portfile
+++ b/devel/qt5-qtcreator/Portfile
@@ -5,7 +5,7 @@ PortGroup           qmake5 1.0
 
 name                qt5-qtcreator
 
-version             4.12.1
+version             4.12.4
 revision            0
 categories          devel aqua
 platforms           darwin
@@ -20,9 +20,9 @@ homepage            http://qt-project.org/wiki/Category:Tools::QtCreator
 distname            qt-creator-opensource-src-${version}
 master_sites        https://download.qt.io/official_releases/qtcreator/[join [lrange [split ${version} .] 0 1] .]/${version}/
 
-checksums           rmd160  c2a27b4323e331fdebde23a88458f5325b50e16f \
-                    sha256  4022738235c549808ef807bfdb8e96da6c44ce8c408c03be4a91b0395997f766 \
-                    size    43456155
+checksums           rmd160  ce792f9da383f72da77b16e5efc15ed519966f5c \
+                    sha256  26c484412bf3ac6ce6f97e1147fcdd29d7ddc396826acf6d4a90afd03610708b \
+                    size    43455579
 
 compiler.cxx_standard \
                     2014
@@ -45,7 +45,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 16} {
 license_noconflict  openssl
 
 # avoid make[4]: write error
-use_parallel_build  no
+#use_parallel_build  no
 
 if { ${subport} eq ${name}  } {
 
@@ -57,12 +57,22 @@ if { ${subport} eq ${name}  } {
     depends_lib-append     port:qbs
     configure.args-append  "QBS_INSTALL_DIR=${prefix}"
 
-    depends_lib-append     port:llvm-9.0 \
-                           port:clang-9.0
-    configure.args-append  "LLVM_INSTALL_DIR=${prefix}/libexec/llvm-9.0"
 
-    depends_build-append port:python27
-    set python_framework ${frameworks_dir}/Python.framework/Versions/2.7
+# llvm-11 does not work
+#clangformatbaseindenter.cpp:346:67: error: no viable conversion from 'llvm::StringRef' to 'const std::string' (aka 'const basic_string<char, char_traits<char>, allocator<char> >')
+#                                           QString::fromStdString(replacement.getReplacementText()));
+#                                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/string:799:5: note: candidate constructor not viable: no known conversion from 'llvm::StringRef' to 'const std::__1::basic_string<char> &' for 1st argument
+#    basic_string(const basic_string& __str);
+#    ^
+
+
+    depends_lib-append     port:llvm-10 \
+                           port:clang-10
+    configure.args-append  "LLVM_INSTALL_DIR=${prefix}/libexec/llvm-10"
+
+    depends_build-append port:python39
+    set python_framework ${frameworks_dir}/Python.framework/Versions/3.9
     configure.env-append PATH=${python_framework}/bin:$env(PATH)
     build.env-append     PATH=${python_framework}/bin:$env(PATH)
 


### PR DESCRIPTION
use llvm-10 (llvm-11 not working at present)
use python39
re-enable parallel build

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
