### PR TITLE
libde265: Update to 1.0.8, fix building on Apple Silicon

### DIFF
--- a/multimedia/libde265/Portfile
+++ b/multimedia/libde265/Portfile
@@ -4,7 +4,7 @@ PortSystem                  1.0
 PortGroup                   github 1.0
 PortGroup                   legacysupport 1.1
 
-github.setup                strukturag libde265 1.0.6 v
+github.setup                strukturag libde265 1.0.8 v
 revision                    0
 categories                  multimedia
 license                     LGPL-3+
@@ -15,9 +15,9 @@ platforms                   darwin
 
 github.tarball_from         releases
 
-checksums                   rmd160  0b9d2858c3c3383efb153b3275b3f33295aeb4d1 \
-                            sha256  e2a34ca3934a826d0893e966ee93bc2d207f505253be94ad38fb40ca98cceb5f \
-                            size    837596
+checksums                   rmd160  5dc4fef504d7c0afe88e62a9580e72fe897b8758 \
+                            sha256  24c791dd334fa521762320ff54f0febfd3c09fc978880a8c5fbc40a88f21d905 \
+                            size    837878
 
 compiler.cxx_standard       2011
 # see https://trac.macports.org/ticket/59866
@@ -27,7 +27,8 @@ legacysupport.newest_darwin_requires_legacy \
 # dec265, a simple player for raw h.265 bitstreams.
 # sherlock265, a Qt-based video player.
 configure.args-append       --disable-dec265 \
-                            --disable-sherlock265
+                            --disable-sherlock265 \
+                            --disable-arm
 
 variant players description {install example video players} {
     PortGroup               qt5 1.0


### PR DESCRIPTION
Upstream issue: https://github.com/strukturag/libde265/issues/284

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
