### PR TITLE
gcc-devel for ARM64: update to 11-20201227

### DIFF
--- a/lang/gcc-devel/Portfile
+++ b/lang/gcc-devel/Portfile
@@ -20,7 +20,8 @@ license             {GPL-3+ Permissive}
 description         The GNU compiler collection, prerelease BETA snapshot.
 long_description    The GNU compiler collection, including front ends for \
                     C, C++, Objective-C, Objective-C++ and Fortran. \
-                    This is a prerelease BETA version! built from GCC snapshots.
+                    This is an !experimental!, !BETA! version \
+                    built from GCC snapshots.
 
 if { ${build_arch} eq "arm64" } {
     # Use lead Darwin developer branch for now
@@ -28,16 +29,16 @@ if { ${build_arch} eq "arm64" } {
     # Arm machines can use same snapshots as Intel.
     PortGroup github 1.0
 
-    github.setup    iains gcc-darwin-arm64 f335f738078a35dd48a0aaacbe58a0b7b11c86ce
+    github.setup    iains gcc-darwin-arm64 6be7a45e8ace6a06e80c135e6682b46230c7a884
 
     # Version must follow same scheme as with GCC snapshots below <version>-<commit-date>
-    version         11-20201205
+    version         11-20201227
     revision        0
     subport         libgcc-devel { revision 0 }
 
-    checksums       rmd160  6eedae12588172d517797c6640809c741485cbdb \
-                    sha256  6a9aced13da950bfc8f8c8c58d5ca15d07c374df70a7dc1f41cd3c4194140eb0 \
-                    size    121303649
+    checksums       rmd160  45b881864c25b2440406017ab1788135a6800694 \
+                    sha256  7bf8929a5f84ebaef409b5e73b284fa3af0e093303441f490ba9315710666144 \
+                    size    123992922
 
 } else {
     # Use regular GCC releases and snapshsots
@@ -93,7 +94,11 @@ license_noconflict  gmp mpfr ppl libmpc zlib
 set major           [lindex [split ${version} .-] 0]
 
 platform darwin {
-    configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    if { ${build_arch} eq "arm64" } {
+        configure.pre_args-append --build=aarch64-apple-darwin${os.major}
+    } else {
+        configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    }
 }
 
 set gcc_configure_langs {c c++ objc obj-c++ lto fortran}


### PR DESCRIPTION
#### Description

update gcc-devel for ARM64 to 11-20201227

+ use "aarch64", not "arm64" for the first entry of the build triplet, per discussion with the GCC Darwin lead

+ tweak "long_description" to be a little more explicit in the status of this port

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2 20D5029f
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
