### PR TITLE
godot: fix building for apple silicon

### DIFF
--- a/games/godot/Portfile
+++ b/games/godot/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        godotengine godot 3.2.3 "" -stable
-revision            0
+revision            1
 categories          games graphics multimedia
 platforms           darwin
 license             MIT
@@ -43,13 +43,13 @@ use_xcode           yes
 
 build.cmd           ${prefix}/bin/scons
 build.env-append    BUILD_NAME=macports_build
-build.target        platform=osx target=release_debug
+build.target        platform=osx arch=${build_arch} target=release_debug
 
 destroot {
     copy ${worksrcpath}/misc/dist/osx_tools.app \
          ${destroot}${applications_dir}/Godot.app
     xinstall -d ${destroot}${applications_dir}/Godot.app/Contents/MacOS
-    move ${worksrcpath}/bin/godot.osx.opt.tools.64 \
+    move ${worksrcpath}/bin/godot.osx.opt.tools.${build_arch} \
          ${destroot}${applications_dir}/Godot.app/Contents/MacOS/Godot
     ln -s ${applications_dir}/Godot.app/Contents/MacOS/Godot \
        ${destroot}${prefix}/bin/godot


### PR DESCRIPTION
#### Description

Godot 3.2.3 supports Apple Silicon, but `arch` was not set in MacPorts template, so [Godot build script default to x86_64](https://github.com/godotengine/godot/blob/31d0f8ad8d5cf50a310ee7e8ada4dcdb4510690b/platform/osx/detect.py#L85-L92) resulting in Intel binary being built for `darwin_20.arm64`. This patch fixes this by utilizing `build_arch` and pack the proper arch into the final Godot.app bundle (per [documentation](https://docs.godotengine.org/en/stable/development/compiling/compiling_for_osx.html))

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?