### PR TITLE
kustomize: update to 3.9.1

### DIFF
--- a/devel/kustomize/Portfile
+++ b/devel/kustomize/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/kubernetes-sigs/kustomize 3.9.0 kustomize/v
+go.setup            github.com/kubernetes-sigs/kustomize 3.9.1 kustomize/v
 revision            0
 
 categories          devel
@@ -23,9 +23,9 @@ long_description    kustomize lets you customize raw, template-free YAML files f
 
 homepage            https://kustomize.io
 
-checksums           rmd160  9f096e50349af47af00923c5f76b154e24ebe2d4 \
-                    sha256  aa6fc6d0c16e164b20ed074ac0ab9717f9891a342c7d02e7cf02159face3305c \
-                    size    28107515
+checksums           rmd160  95476f2c6aaa4add86d6c69c5c4df40cc8d78fae \
+                    sha256  ca325ee330061b4f330fdf7da8717feb5158b7bc56f77a1e6fc53eba9b5337c8 \
+                    size    28091436
 
 build.dir           ${worksrcpath}/${name}
 


### PR DESCRIPTION
#### Description

Update to Kustomize 3.9.1.

###### Tested on

macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?