### PR TITLE
opencv and opencv4: eliminate conflict, add new variants, bring parity between both

### DIFF
--- a/graphics/opencv/Portfile
+++ b/graphics/opencv/Portfile
@@ -7,12 +7,14 @@ PortGroup           legacysupport 1.0
 
 name                opencv
 version             3.4.13
-revision            0
+revision            1
 categories          graphics science
 platforms           darwin
 license             BSD
 
-maintainers         nomaintainer
+maintainers         \
+                    {@mascguy} \
+                    openmaintainer
 
 description         Intel(R) Open Source Computer Vision Library
 
@@ -53,24 +55,29 @@ platform macosx {
 
 worksrcdir          opencv-${version}
 
-conflicts           opencv4
-
 compiler.cxx_standard   2011
-compiler.blacklist-append cc *gcc* {clang < 800} {macports-clang-3.[0-9]} macports-clang-4.0
+
+compiler.blacklist-append \
+                    cc \
+                    *gcc* \
+                    {clang < 800} \
+                    {macports-clang-3.[0-9]} \
+                    macports-clang-4.0
 
 depends_build-append \
                     port:pkgconfig
 
-depends_lib-append  port:zlib \
+depends_lib-append  \
+                    port:ffmpeg \
+                    port:zlib \
                     port:bzip2 \
                     port:libpng \
                     port:jpeg \
-                    port:jasper \
+                    port:openjpeg \
                     port:tiff \
                     port:webp \
                     port:ilmbase \
-                    port:openexr \
-                    path:lib/libavcodec.dylib:ffmpeg
+                    port:openexr
 
 # only search for openexr in ${prefix}
 patchfiles-append   patch-find-openexr.diff
@@ -107,8 +114,9 @@ configure.args-append \
                     -DWITH_GSTREAMER=OFF \
                     -DWITH_GTK=OFF \
                     -DWITH_IPP=OFF \
-                    -DWITH_JASPER=ON \
+                    -DWITH_JASPER=OFF \
                     -DWITH_JPEG=ON \
+                    -DWITH_OPENJPEG=ON \
                     -DWITH_WEBP=ON \
                     -DWITH_OPENEXR=ON \
                     -DWITH_OPENGL=ON \
@@ -142,6 +150,7 @@ configure.args-append \
                     -DWITH_GDAL=OFF \
                     -DWITH_GPHOTO2=OFF \
                     \
+                    -DBUILD_WITH_DEBUG_INFO=OFF \
                     -DBUILD_SHARED_LIBS=ON \
                     -DBUILD_opencv_apps=ON \
                     -DBUILD_DOCS=OFF \
@@ -155,10 +164,12 @@ configure.args-append \
                     -DBUILD_TIFF=OFF \
                     -DBUILD_JASPER=OFF \
                     -DBUILD_JPEG=OFF \
+                    -DBUILD_OPENJPEG=OFF \
                     -DBUILD_WEBP=OFF \
                     -DBUILD_PNG=OFF \
                     -DBUILD_OPENEXR=OFF \
                     -DBUILD_TBB=OFF \
+                    -DBUILD_FFMPEG=OFF \
                     \
                     -DBUILD_opencv_java=OFF \
                     \
@@ -168,6 +179,7 @@ configure.args-append \
                     -DINSTALL_C_EXAMPLES=OFF \
                     -DINSTALL_PYTHON_EXAMPLES=OFF \
                     -DENABLE_PRECOMPILED_HEADERS=ON \
+                    -DOPENCV_ENABLE_NONFREE=OFF \
                     -DENABLE_CXX11=ON
 
 platform darwin {
@@ -231,6 +243,12 @@ if {[variant_isset universal]} {
                             -DENABLE_PRECOMPILED_HEADERS=OFF
 }
 
+variant debug description {Build with debugging info} {
+    configure.args-replace \
+                            -DBUILD_WITH_DEBUG_INFO=OFF \
+                            -DBUILD_WITH_DEBUG_INFO=ON
+}
+
 variant avx conflicts avx2 description {Enable AVX (and SSE4*) support} {
     configure.args-append   -DENABLE_AVX=ON \
                             -DENABLE_SSE41=ON -DENABLE_SSE42=ON
@@ -241,14 +259,14 @@ variant avx2 conflicts avx description {Enable AVX, AVX2 (and SSE4*) support} {
                             -DENABLE_SSE41=ON -DENABLE_SSE42=ON
 }
 
-variant eigen description {Enable eigen support.} {
+variant eigen description {Enable eigen support} {
     depends_lib-append      port:eigen3
     configure.args-replace  -DWITH_EIGEN=OFF \
                             -DWITH_EIGEN=ON
     configure.args-append   -DEIGEN_INCLUDE_PATH=${prefix}/include/eigen3
 }
 
-variant opencl description {Enable OpenCL support.} {
+variant opencl description {Enable OpenCL support} {
     pre-configure {
         if {${os.platform} eq "darwin" && ${os.major} < 11} {
             ui_error "The OpenCL variant only works with OS X 10.7 Lion or later."
@@ -259,7 +277,7 @@ variant opencl description {Enable OpenCL support.} {
                             -DWITH_OPENCL=ON
 }
 
-variant openni description {Enable OpenNI support.} {
+variant openni description {Enable OpenNI support} {
     depends_lib-append      port:openni
     patchfiles-append       patch-cmake_OpenCVFindOpenNI.cmake.diff
     configure.args-replace  -DWITH_OPENNI=OFF \
@@ -270,26 +288,26 @@ variant openni description {Enable OpenNI support.} {
     }
 }
 
-variant dc1394 description {Use libdc1394 for FireWire camera. Breaks compatibility with Apple iSight FireWire camera.} {
+variant dc1394 description {Use libdc1394 for FireWire camera; breaks compatibility with Apple iSight FireWire camera} {
     depends_lib-append      port:libdc1394
     configure.args-replace  -DWITH_1394=OFF \
                             -DWITH_1394=ON
     configure.args-append   -DHAVE_DC1394_2=ON
 }
 
-variant qt4 conflicts qt5 description {Build with Qt4 Backend support.} {
+variant qt4 conflicts qt5 description {Build with Qt4 Backend support} {
     PortGroup               qt4 1.0
     configure.args-replace  -DWITH_QT=OFF \
                             -DWITH_QT=4
 }
 
-variant qt5 conflicts qt4 description {Build with Qt5 Backend support.} {
+variant qt5 conflicts qt4 description {Build with Qt5 Backend support} {
     PortGroup               qt5 1.0
     configure.args-replace  -DWITH_QT=OFF \
                             -DWITH_QT=5
 }
 
-variant java description {Add Java bindings.} {
+variant java description {Add Java bindings} {
     PortGroup               java 1.0
     # OpenCV appears to support older Java versions,
     # and MacPorts users have requested Java 8 support:
@@ -308,7 +326,7 @@ if {[variant_isset java] && ![variant_isset python27]} {
     configure.args-delete   -DBUILD_opencv_python2=OFF
 }
 
-variant python27 description {Add Python 2.7 bindings.} {
+variant python27 description {Add Python 2.7 bindings} {
     depends_lib-append      port:python27 \
                             port:py27-numpy
     configure.args-delete   -DINSTALL_PYTHON_EXAMPLES=OFF \
@@ -358,7 +376,7 @@ foreach pdv ${pythonversions} {
     }
 }
 
-variant tbb description {Use Intel TBB.} {
+variant tbb description {Use Intel TBB} {
     depends_lib-append      port:tbb
     configure.args-replace  -DWITH_TBB=OFF \
                             -DWITH_TBB=ON
@@ -366,19 +384,19 @@ variant tbb description {Use Intel TBB.} {
                             -DTBB_INCLUDE_DIRS=${prefix}/include
 }
 
-variant vtk description {Include VTK support.} {
+variant vtk description {Include VTK support} {
     depends_lib-append      port:vtk
     configure.args-replace  -DWITH_VTK=OFF \
                             -DWITH_VTK=ON
 }
 
-variant gdal description {Include GDAL support.} {
+variant gdal description {Include GDAL support} {
     depends_lib-append      port:gdal
     configure.args-replace  -DWITH_GDAL=OFF \
                             -DWITH_GDAL=ON
 }
 
-variant contrib description {Build OpenCV with extra modules.} {
+variant contrib description {Build OpenCV with extra modules} {
     master_sites-append     https://github.com/opencv/opencv_contrib/archive:opencv_contrib
     distfiles-append        ${version}.zip:opencv_contrib
     checksums-append        ${version}.zip \
@@ -387,7 +405,11 @@ variant contrib description {Build OpenCV with extra modules.} {
                             size    56393041
     configure.args-append   -DOPENCV_EXTRA_MODULES_PATH=${workpath}/opencv_contrib-${version}/modules \
                             -DBUILD_PROTOBUF=YES
-    depends_lib-append      port:protobuf3-cpp
+    depends_lib-append      \
+                            port:protobuf3-cpp \
+                            port:google-glog \
+                            port:gflags \
+                            port:ceres-solver
 
     post-extract {
         # gunzip cannot handle multi-member .zip archives
@@ -494,6 +516,25 @@ variant contrib description {Build OpenCV with extra modules.} {
     configure.args-append  -DOPENCV_FACE_ALIGNMENT_URL=file://${distpath}/
 }
 
+variant nonfree description {Include nonfree algorithms} {
+    configure.args-replace \
+                            -DOPENCV_ENABLE_NONFREE=OFF \
+                            -DOPENCV_ENABLE_NONFREE=ON
+}
+
+variant tests description {Enable tests} {
+    configure.args-replace \
+                            -DBUILD_TESTS=OFF \
+                            -DBUILD_TESTS=ON
+
+    configure.args-replace \
+                            -DBUILD_PERF_TESTS=OFF \
+                            -DBUILD_PERF_TESTS=ON
+
+    test.run     yes
+    test.target  test
+}
+
 platform darwin {
     post-patch {
         if {${os.major} < 10} {
@@ -503,7 +544,8 @@ platform darwin {
 }
 
 pre-configure {
-    configure.args-append   -DOPENCV_LINKER_LIBS=\"[join ${opencv_linker_libs} " "]\"
+    configure.args-append \
+                        -DOPENCV_LINKER_LIBS=\"[join ${opencv_linker_libs} " "]\"
 }
 
 post-destroot {

--- a/graphics/opencv4/Portfile
+++ b/graphics/opencv4/Portfile
@@ -5,14 +5,17 @@ PortGroup           cmake 1.1
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 
-github.setup        opencv opencv 4.3.0
+github.setup        opencv opencv 4.5.0
 name                opencv4
 revision            0
 categories          graphics science
 platforms           darwin
 license             BSD
 
-maintainers         {stromnov @stromnov} openmaintainer
+maintainers         \
+                    {stromnov @stromnov} \
+                    {@mascguy} \
+                    openmaintainer
 
 description         Open Source Computer Vision Library
 
@@ -27,16 +30,17 @@ long_description    OpenCV (Open Source Computer Vision Library) is an\
 
 homepage            https://opencv.org
 
-conflicts           opencv
-
 master_sites        ${github.master_sites}:${github.project}
 
 distfiles           [lindex ${distfiles} 0]:${github.project}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  6a01059dd1bf57a21f8663bec5e856607c342e84 \
-                    sha256  e11293aef34048f6c283c844c5260b8914e511586bc0ed30852ce18cefebbc0d \
-                    size    87942711
+                    rmd160  fadb405b7d38f829775da60a62d29368b2159ce4 \
+                    sha256  03d9f7d777d8a62a5481934dbba2fd692b6cb43f1690a8546e45f9bdb1ee0863 \
+                    size    90119002
+
+# recognize dylib as a valid library suffix
+patchfiles-append   patch-dylib_suffix.diff
 
 # modify from _resources/port1.0/group/github-1.0.tcl to avoid file tag issue
 proc move_gh_repo {repo_dir_patt new_name} {
@@ -61,15 +65,21 @@ post-extract {
 
 compiler.cxx_standard 2011
 
-compiler.blacklist-append *gcc* {clang < 900} {macports-clang-3.[0-9]} {macports-clang-[4-6].0}
+compiler.blacklist-append \
+                    *gcc* \
+                    {clang < 900} \
+                    {macports-clang-3.[0-9]} \
+                    {macports-clang-[4-6].0}
 
 depends_build-append \
                     port:pkgconfig
 
-depends_lib-append  port:zlib \
+depends_lib-append  \
+                    port:ffmpeg \
+                    port:zlib \
                     port:libpng \
                     port:jpeg \
-                    port:jasper \
+                    port:openjpeg \
                     port:tiff \
                     port:webp \
                     port:openexr \
@@ -77,34 +87,58 @@ depends_lib-append  port:zlib \
                     port:ade
 
 configure.args-append \
-                    -DCMAKE_RULE_MESSAGES:BOOL=OFF -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+                    -DCMAKE_RULE_MESSAGES:BOOL=OFF \
+                    -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+                    \
+                    -DENABLE_CONFIG_VERIFICATION:BOOL=OFF \
+                    \
+                    -DOPENCV_BIN_INSTALL_PATH=${prefix}/libexec/opencv4/bin \
+                    -DOPENCV_SBIN_INSTALL_PATH=${prefix}/libexec/opencv4/sbin \
+                    -DOPENCV_TEST_INSTALL_PATH=${prefix}/libexec/opencv4/test \
+                    -DOPENCV_SAMPLES_BIN_INSTALL_PATH=${prefix}/libexec/opencv4/samples \
+                    -DOPENCV_SETUPVARS_INSTALL_PATH=${prefix}/libexec/opencv4/scripts \
+                    -DCMAKE_BINARY_DIR=${prefix}/libexec/opencv4/bin \
+                    -DCMAKE_INSTALL_BINDIR=libexec/opencv4/bin \
+                    -DCMAKE_INSTALL_SBINDIR=libexec/opencv4/sbin \
+                    -DCMAKE_INSTALL_LIBEXECDIR=libexec/opencv4 \
+                    -DCMAKE_INSTALL_LIBDIR=lib/opencv4 \
+                    -DCMAKE_INSTALL_NAME_DIR=${prefix}/lib/opencv4 \
+                    -DCMAKE_INSTALL_RPATH=${prefix}/lib/opencv4 \
                     \
                     -DWITH_ADE:BOOL=ON \
                     -Dade_DIR:PATH=${prefix}/share/ade/ \
                     \
+                    -DBUILD_WITH_DEBUG_INFO:BOOL=OFF \
                     -DHAVE_CXX11:BOOL=ON \
+                    -DENABLE_CXX11:BOOL=ON \
                     -DENABLE_PIC:BOOL=OFF \
-                    -DBUILD_SHARED_LIBS:BOOL=OFF \
+                    -DBUILD_SHARED_LIBS:BOOL=ON \
                     -DBUILD_opencv_apps:BOOL=ON \
                     -DBUILD_DOCS:BOOL=OFF \
                     -DBUILD_EXAMPLES:BOOL=OFF \
+                    -DINSTALL_C_EXAMPLES:BOOL=OFF \
+                    -DBUILD_TESTS:BOOL=OFF \
+                    -DBUILD_PERF_TESTS:BOOL=OFF \
                     \
                     -DENABLE_CCACHE:BOOL=OFF \
                     -DBUILD_JAVA:BOOL=OFF \
                     -DENABLE_LTO:BOOL=OFF \
                     -DENABLE_THIN_LTO:BOOL=OFF \
+                    -DENABLE_PRECOMPILED_HEADERS:BOOL=ON \
                     \
                     -DOPENCV_ENABLE_NONFREE:BOOL=OFF \
                     -DOPENCV_FORCE_3RDPARTY_BUILD:BOOL=OFF \
                     \
                     -DBUILD_ZLIB:BOOL=OFF \
                     -DBUILD_TIFF:BOOL=OFF -DWITH_TIFF:BOOL=ON \
-                    -DBUILD_JASPER:BOOL=OFF -DWITH_JASPER:BOOL=ON \
+                    -DBUILD_JASPER:BOOL=OFF -DWITH_JASPER:BOOL=OFF \
                     -DBUILD_JPEG:BOOL=OFF -DWITH_JPEG:BOOL=ON \
+                    -DBUILD_OPENJPEG:BOOL=OFF -DWITH_OPENJPEG:BOOL=ON \
                     -DBUILD_PNG:BOOL=OFF -DWITH_PNG:BOOL=ON \
                     -DBUILD_OPENEXR:BOOL=OFF -DWITH_OPENEXR:BOOL=ON \
                     -DBUILD_WEBP:BOOL=OFF -DWITH_WEBP:BOOL=ON \
                     -DBUILD_TBB:BOOL=OFF -DWITH_TBB:BOOL=OFF \
+                    -DBUILD_FFMPEG:BOOL=OFF -DWITH_FFMPEG:BOOL=ON \
                     \
                     -DWITH_OPENCL:BOOL=OFF \
                     -DWITH_OPENCL_SVM:BOOL=OFF \
@@ -119,7 +153,6 @@ configure.args-append \
                     -DWITH_AVFOUNDATION:BOOL=ON \
                     -DWITH_VTK:BOOL=OFF \
                     -DWITH_EIGEN:BOOL=OFF \
-                    -DWITH_FFMPEG:BOOL=OFF \
                     -DWITH_GSTREAMER:BOOL=OFF \
                     -DWITH_GTK:BOOL=OFF \
                     -DWITH_IPP:BOOL=OFF \
@@ -157,11 +190,20 @@ configure.args-append \
                     \
                     -DBUILD_opencv_python2:BOOL=OFF \
                     -DBUILD_opencv_python3:BOOL=OFF \
+                    -DBUILD_opencv_aruco:BOOL=ON \
                     -DOPENCV_PYTHON_SKIP_DETECTION:BOOL=OFF \
                     -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/python \
                     -DPYTHON_DEFAULT_EXECUTABLE:FILEPATH=/usr/bin/python
 
 universal_variant   no
+
+# PCH broken when universal
+# Keep around, for when universal support is fixed/enabled
+if {[variant_isset universal]} {
+    configure.args-replace \
+                        -DENABLE_PRECOMPILED_HEADERS:BOOL=ON \
+                        -DENABLE_PRECOMPILED_HEADERS:BOOL=OFF
+}
 
 if { ${configure.ccache} } {
     configure.args-replace \
@@ -180,6 +222,31 @@ platform darwin {
                         -DLAPACK_LIBRARIES="-framework Accelerate" \
                         -DLAPACK_CBLAS_H=Accelerate/Accelerate.h \
                         -DLAPACK_LAPACKE_H=Accelerate/Accelerate.h
+
+    # the AVFoundation backend is failing to build up to 10.8
+    # it might be possible to work around or repair this on 10.7 and 10.8
+    # there as a qtkit video implementation prior to the AVFoundation version
+    # that is about 2016 vintage. This could possibly be resuscitated if there
+    # is motivation or interest in so doing
+    if {${os.major} < 13} {
+        ui_debug "AVFoundation not supported on this MacOS release; disabling"
+        configure.args-replace \
+                        -DWITH_AVFOUNDATION:BOOL=ON \
+                        -DWITH_AVFOUNDATION:BOOL=OFF
+    }
+}
+
+notes {
+    opencv4 binaries are now prefixed with 'opencv4_', to prevent conflicts\
+    with opencv.
+
+    opencv4 libraries have changed from static to dynamic.
+}
+
+variant debug description {Build with debugging info} {
+    configure.args-replace \
+                        -DBUILD_WITH_DEBUG_INFO:BOOL=OFF \
+                        -DBUILD_WITH_DEBUG_INFO:BOOL=ON
 }
 
 variant opencl description {Enable OpenCL support} {
@@ -216,16 +283,30 @@ variant nonfree description {Include nonfree algorithms} {
                         -DOPENCV_ENABLE_NONFREE:BOOL=ON
 }
 
-variant opencv_contrib description {Build OpenCV with extra modules (untested)} {
+# Respect legacy variant name 'opencv_contrib', and replace with 'contrib'
+if {[variant_isset opencv_contrib]} {
+    ui_debug "Legacy variant 'opencv_contrib' set; enabling 'contrib'"
+
+    default_variants-append \
+                        +contrib
+}
+
+variant contrib description {Build OpenCV with extra modules (untested)} {
     master_sites-append \
-                    https://github.com/${github.author}/${github.project}_contrib/tarball/${version}:${github.project}_contrib
+                        https://github.com/${github.author}/${github.project}_contrib/tarball/${version}:${github.project}_contrib
     distfiles-append \
-                    ${github.project}_contrib-${version}${extract.suffix}:${github.project}_contrib
+                        ${github.project}_contrib-${version}${extract.suffix}:${github.project}_contrib
     checksums-append \
-                    ${github.project}_contrib-${version}${extract.suffix} \
-                    rmd160  edee305f9361720ae48043fa7d7325d0b2416af1 \
-                    sha256  83904a2feca4e6f48f43909fbf5e9bfe0985d408cdb9dc7c9e82d70bde71555d \
-                    size    60882932
+                        ${github.project}_contrib-${version}${extract.suffix} \
+                        rmd160  179e9842172a67db96c976e6ab4944b826835970 \
+                        sha256  f16aa7c7960e6a0d855b681d19437d4e05bc8abd6af5adf5ab86f37d1019d663 \
+                        size    60120338
+
+    depends_lib-append \
+                        port:protobuf3-cpp \
+                        port:google-glog \
+                        port:gflags \
+                        port:ceres-solver
 
     post-extract {
         move_gh_repo ${github.author}-${github.project}-* ${distname}
@@ -233,14 +314,171 @@ variant opencv_contrib description {Build OpenCV with extra modules (untested)} 
     }
 
     pre-patch {
-        delete      ${worksrcpath}/${github.project}_contrib
+        delete ${worksrcpath}/${github.project}_contrib
         ln -s ${workpath}/${github.project}_contrib-${version} ${worksrcpath}/${github.project}_contrib
     }
 
     configure.args-append \
-                    -DOPENCV_EXTRA_MODULES_PATH=${worksrcpath}/${github.project}_contrib/modules
+                        -DOPENCV_EXTRA_MODULES_PATH=${worksrcpath}/${github.project}_contrib/modules
+}
+
+variant qt4 conflicts qt5 description {Build with Qt4 Backend support} {
+    PortGroup           qt4 1.0
+    configure.args-replace \
+                        -DWITH_QT:BOOL=OFF \
+                        -DWITH_QT=4
+}
+
+variant qt5 conflicts qt4 description {Build with Qt5 Backend support} {
+    PortGroup           qt5 1.0
+    configure.args-replace \
+                        -DWITH_QT:BOOL=OFF \
+                        -DWITH_QT=5
+}
+
+variant java description {Add Java bindings} {
+    PortGroup           java 1.0
+    # OpenCV appears to support older Java versions,
+    # and MacPorts users have requested Java 8 support:
+    # see https://trac.macports.org/ticket/60193
+    java.version        1.6+
+    # Use latest LTS Java version as fallback
+    java.fallback       openjdk11
+    depends_build-append \
+                        port:apache-ant
+    configure.args-replace \
+                        -DBUILD_JAVA:BOOL=OFF \
+                        -DBUILD_JAVA:BOOL=ON
+}
+
+set pythonversions {3.5 3.6 3.7 3.8 3.9}
+foreach pdv ${pythonversions} {
+    set pv [join [lrange [split ${pdv} .] 0 1] ""]
+    set conflist ""
+    foreach v ${pythonversions} {
+        if {${v} ne ${pdv}} {
+            set vv [join [lrange [split ${v} .] 0 1] ""]
+            set conflist "${conflist} python${vv}"
+        }
+    }
+    variant python${pv} conflicts {*}${conflist} description "Add bindings for Python ${pdv}" {
+        configure.args-delete \
+                        -DINSTALL_PYTHON_EXAMPLES:BOOL=OFF \
+                        -DBUILD_opencv_python3:BOOL=OFF
+    }
+    # settings that depend on loop variables must be set in an appropriate if, not in the
+    # variant declaration scope.
+    if {[variant_isset python${pv}]} {
+        depends_lib-append \
+                        port:python${pv} \
+                        port:py${pv}-numpy
+        configure.args-append \
+                        -DINSTALL_PYTHON_EXAMPLES:BOOL=ON \
+                        -DPYTHON3_EXECUTABLE=${prefix}/bin/python${pdv} \
+                        -DPYTHON3_LIBRARY=${frameworks_dir}/Python.framework/Versions/${pdv}/lib/libpython${pdv}.dylib \
+                        -DPYTHON3_INCLUDE_DIR=${frameworks_dir}/Python.framework/Versions/${pdv}/Headers \
+                        -DPYTHON3_PACKAGES_PATH=${frameworks_dir}/Python.framework/Versions/${pdv}/lib/python${pdv}/site-packages
+    }
+}
+
+variant tbb description {Use Intel TBB} {
+    depends_lib-append \
+                         port:tbb
+    configure.args-replace \
+                        -DWITH_TBB:BOOL=OFF \
+                        -DWITH_TBB:BOOL=ON
+    configure.args-append \
+                        -DHAVE_TBB:BOOL=ON \
+                        -DTBB_INCLUDE_DIRS=${prefix}/include
+}
+
+variant vtk description {Include VTK support} {
+    depends_lib-append \
+                        port:vtk
+    configure.args-replace \
+                        -DWITH_VTK:BOOL=OFF \
+                        -DWITH_VTK:BOOL=ON
+}
+
+variant tests description {Enable tests} {
+    configure.args-replace \
+                        -DBUILD_TESTS:BOOL=OFF \
+                        -DBUILD_TESTS:BOOL=ON
+
+    configure.args-replace \
+                        -DBUILD_PERF_TESTS:BOOL=OFF \
+                        -DBUILD_PERF_TESTS:BOOL=ON
+
+    test.run     yes
+    test.target  test
 }
 
 livecheck.type      regex
 livecheck.url       https://opencv.org/releases.html
 livecheck.regex     {/archive/([0-9.]+)[a-z]?\.[tz]}
+
+proc opencv4_move_binaries {p_bin_main_dir p_bin_port_dir} {
+    set bin_main_files \
+        [glob -nocomplain -type f \
+            -directory ${p_bin_main_dir} \
+            *]
+    ui_debug "opencv4_move_binaries: bin_main_files: ${bin_main_files}"
+
+    foreach f ${bin_main_files} {
+        set fn [file tail ${f}]
+        set f_dest "${p_bin_port_dir}/${fn}"
+        ui_debug "opencv4_move_binaries: moving file: ${f} -> ${f_dest}"
+        move ${f} ${f_dest}
+    }
+
+    return 0
+}
+
+proc opencv4_soft_link_binaries {p_bin_main_dir p_bin_port_dir p_destroot p_prefix} {
+    set bin_prefix_old "opencv_"
+    set bin_prefix_new "opencv4_"
+    set bin_port_files \
+        [glob -nocomplain -type f \
+            -directory ${p_bin_port_dir} \
+            *]
+    ui_debug "opencv4_soft_link_binaries: bin_port_files: ${bin_port_files}"
+
+    # Links: Remove prefix 'opencv_', if any; add prefix 'opencv4_'.
+    foreach f ${bin_port_files} {
+        set fn [file tail ${f}]
+        set fn_new \
+            [regsub ***=${bin_prefix_old} ${fn} ""]
+        set f_dest \
+            [regsub ***=${p_destroot} ${f} ""]
+        set f_link \
+            "${p_bin_main_dir}/${bin_prefix_new}${fn_new}"
+        ui_debug "opencv4_soft_link_binaries: soft-linking file: ${f_link} -> ${f_dest}"
+        ln -s ${f_dest} ${f_link}
+    }
+
+    return 0
+}
+
+post-destroot {
+    set bin_main_dir \
+        "${destroot}${prefix}/bin"
+    set bin_port_dir \
+        "${destroot}${prefix}/libexec/opencv4/bin"
+
+    # While the various configure-related options should catch everything, one or more
+    # files may be missed. If so, ensure they're moved to the opencv4 bin area.
+    opencv4_move_binaries \
+        ${bin_main_dir} \
+        ${bin_port_dir}
+
+    # Create soft links for binaries, each prefixed with 'opencv4_'.
+    opencv4_soft_link_binaries \
+        ${bin_main_dir} \
+        ${bin_port_dir} \
+        ${destroot} \
+        ${prefix}
+
+    unset bin_port_dir
+    unset bin_main_dir
+}
+

--- a/graphics/opencv4/files/patch-dylib_suffix.diff
+++ b/graphics/opencv4/files/patch-dylib_suffix.diff
@@ -1,0 +1,11 @@
+--- cmake/OpenCVUtils.cmake.orig	2018-02-23 01:38:33.000000000 -0700
++++ cmake/OpenCVUtils.cmake	2018-04-20 06:20:44.000000000 -0700
+@@ -1335,7 +1335,7 @@
+ macro(ocv_get_libname var_name)
+   get_filename_component(__libname "${ARGN}" NAME)
+   # libopencv_core.so.3.3 -> opencv_core
+-  string(REGEX REPLACE "^lib(.+)\\.(a|so|dll)(\\.[.0-9]+)?$" "\\1" __libname "${__libname}")
++  string(REGEX REPLACE "^lib(.+)\\.(a|so|dll|dylib)(\\.[.0-9]+)?$" "\\1" __libname "${__libname}")
+   # MacOSX: libopencv_core.3.3.1.dylib -> opencv_core
+   string(REGEX REPLACE "^lib(.+[^.0-9])\\.([.0-9]+\\.)?dylib$" "\\1" __libname "${__libname}")
+   set(${var_name} "${__libname}")

--- a/python/py-pytorch/Portfile
+++ b/python/py-pytorch/Portfile
@@ -8,7 +8,7 @@ PortGroup           python 1.0
 
 name                py-pytorch
 version             1.6.0
-revision            0
+revision            1
 github.setup        pytorch pytorch ${version} v
 fetch.type          git
 
@@ -110,6 +110,7 @@ if {${name} ne ${subport}} {
     build.env-append \
         CMAKE_LIBRARY_PATH=${prefix}/lib:${prefix}/lib/libomp \
         LIBRARY_PATH=${prefix}/lib:${prefix}/lib/libomp \
+        OpenCV_DIR=${prefix}/lib/opencv4/cmake/opencv4 \
         USE_CUDA=OFF \
         USE_GFLAGS=ON \
         USE_GLOG=ON \

--- a/science/gerbil/Portfile
+++ b/science/gerbil/Portfile
@@ -7,6 +7,7 @@ PortGroup           qt5 1.0
 
 github.setup        gerbilvis gerbil 5a7705fe1170f812a6cd0e79a1a853f4d8aec2cf
 version             2020-05-06-5a7705f
+revision            1
 checksums           rmd160  9b3f9ac2589a4f3b2ae12db6b02fdcd924886ec4 \
                     sha256  1eb67522c0629a885f940ce333880982528c0ef23ee5a3b27aaddf9facf72d6f \
                     size    2301204
@@ -31,7 +32,7 @@ depends_lib         port:opencv4 \
 
 cmake.out_of_source yes
 configure.args-append \
-                    -DOpenCV_DIR="${prefix}/lib/cmake" \
+                    -DOpenCV_DIR="${prefix}/lib/opencv4/cmake/opencv4" \
                     -DCMAKE_BUILD_TYPE=Release \
                     -DBoost_DIR="${prefix}"
 


### PR DESCRIPTION
#### Description
Goals:
* Eliminate conflict between opencv and opencv4.
* Ensure parity and consistency between them, as much as possible.
* Upgrade opencv4 to v4.5.0.

Detailed Changes:
* opencv: eliminate conflict with opencv4; add variants debug, nonfree, tests
* opencv4: eliminate conflict with opencv; switch to shared libs; rename variant opencv_contrib to contrib, to match opencv; add variants debug, java, python35..39, qt4, qt5, tbb, tests, vtk; add patch for dylibs
* gerbil: bump revision to rebuild against updated opencv4; update for opencv4 library move
* py-pytorch: bump revision to rebuild against updated opencv4; update for opencv4 library move

Fixed Issues:
* [61912 - opencv @3.4.13: only 17% of test suite passes](https://trac.macports.org/ticket/61912)
* [61801 - opencv4: update to 4.5.0](https://trac.macports.org/ticket/61801)
* [60118 - opencv and opencv4 conflict](https://trac.macports.org/ticket/60118)
* [58845 - python support for opencv4](https://trac.macports.org/ticket/58845)
* [57640 - opencv @3.4.3: +contrib not configured correctly](https://trac.macports.org/ticket/57640)
* [51734 - OpenCV needs patch to build with +vtk](https://trac.macports.org/ticket/51734)
* [48218 - opencv @3.0.0_0: debug variant not producing debug symbols](https://trac.macports.org/ticket/48218)
* [32528 - opencv @2.3.1a fixes and improvements: eigen, ffmpeg, docs, opengl, python, shared+static, tbb](https://trac.macports.org/ticket/32528)

Dependencies:
* Pull Request [9502 - vtk: Fix QPainterPath include](https://github.com/macports/macports-ports/pull/9502) needs to be merged first, to support variant `vtk`.

###### Type(s)
- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.6.8 10K549
Xcode 3.2.2 10M2148

macOS 10.8.5 12F2560
Xcode 5.1.1 5B1008

macOS 10.12.6 16G2136
Xcode 9.2 9C40b

macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] ensured the port does not create any faulty symbolic links?