### PR TITLE
bed: new port

### DIFF
--- a/sysutils/bed/Portfile
+++ b/sysutils/bed/Portfile
@@ -1,0 +1,63 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/itchyny/bed 0.2.1 v
+revision            0
+
+description         Binary editor written in Go
+
+long_description    {*}${description}. Binary editor with Vim-like user \
+                    interface, which runs in terminals, portable, fast and \
+                    with window splitting feature.
+
+categories          sysutils
+license             MIT
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+build.args-append   -ldflags \"-s -w -X main.revision=${version}\" ./cmd/bed
+
+installs_libs       no
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  ddecc12fa679a9f3f4a70c19d3523fe879dfe6f5 \
+                        sha256  70008e7679c18770e1aa978ffed9ac5569254c00db86760e1da48ac053ce11be \
+                        size    51195
+
+go.vendors          golang.org/x/text \
+                        lock    v0.3.4 \
+                        rmd160  2b9cc1c618efac6184ba3cc497945bfe8299878b \
+                        sha256  4f7508324739fdddcc1bf653a755608aa8ed0119d297ba7460d812e67d661e6a \
+                        size    8347767 \
+                    golang.org/x/sys \
+                        lock    0d417f636930 \
+                        rmd160  ead4b38281effb38bd8804cefe838a9b0bf89382 \
+                        sha256  bfd9a073d4bf0d052fb5d3c03fac05c59aaaa0d19ec2d050e364fc9caaccbd34 \
+                        size    1090915 \
+                    github.com/mattn/go-runewidth \
+                        lock    v0.0.9 \
+                        rmd160  412c0e508e55f4fe437be0f71d7d22eca2b4366f \
+                        sha256  4f0f4a22257ccecfb6beae88052d850380ecc0e806d6bcc92d3656ebcac3b638 \
+                        size    16716 \
+                    github.com/lucasb-eyer/go-colorful \
+                        lock    v1.0.3 \
+                        rmd160  0d0a283ba00c871d123c951efea0605a869951aa \
+                        sha256  ecd902ddda5d05cc8a857873bf8b984a5cd2d7b75f1185edcfc2c472707958b3 \
+                        size    430208 \
+                    github.com/gdamore/tcell \
+                        lock    v1.4.0 \
+                        rmd160  479ce3d189ac02a4de5219054f537cc173c28b43 \
+                        sha256  ee8948a76a4cc5ba8285f03840473cf41e80e476a1317239414ee54396db82c9 \
+                        size    152003 \
+                    github.com/gdamore/encoding \
+                        lock    v1.0.0 \
+                        rmd160  3ed8916f763a5b51db1bcc8bd3ad06cf3d12ec07 \
+                        sha256  4f470c7308790bea8a526ea26cecbaa22345aad8dc566821cda6175b3d241ee1 \
+                        size    10900


### PR DESCRIPTION
#### Description

New port for the **[bed](https://github.com/itchyny/bed)** command line hex-editor.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
