### PR TITLE
xournalpp: update to version 1.0.20-hotfix

### DIFF
--- a/x11/xournalpp/Portfile
+++ b/x11/xournalpp/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.0
 
-github.setup        xournalpp xournalpp 1.0.18
+github.setup        xournalpp xournalpp 1.0.20-hotfix
 categories          x11
 platforms           darwin
 maintainers         nomaintainer
@@ -15,9 +15,9 @@ description         A hand note taking software
 long_description    Xournal++ is a hand note taking software written in C++ \
                     with the target of flexibility, functionality and speed.
 
-checksums           rmd160  f407a8391a3683d87c15d3762c9ecacc13d4dbf5 \
-                    sha256  13e37aef0bc8178d78301c2405e5e463f70069600512a7b61dedec46cf860844 \
-                    size    14892459
+checksums           rmd160  58010bdc60112f2f6f693163a7d997c329814ed8 \
+                    sha256  1f6a297665ba9200d35bef9e03c480c0fe69036e71502674134d0a59b404d671 \
+                    size    14896961
 
 depends_build       port:pkgconfig \
                     port:gtk-mac-bundler


### PR DESCRIPTION
#### Description

Update the port xournalpp to version 1.0.20-hotfix

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6 17G14042
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? -> There's no ticket
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? -> no tests are enabled
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

