### PR TITLE
pdfpc: update to version 4.4.1

### DIFF
--- a/graphics/pdfpc/Portfile
+++ b/graphics/pdfpc/Portfile
@@ -5,8 +5,7 @@ PortGroup               github 1.0
 PortGroup               active_variants 1.1
 PortGroup               cmake 1.1
 
-github.setup            pdfpc pdfpc 4.4.0 v
-revision                1
+github.setup            pdfpc pdfpc 4.4.1 v
 
 maintainers             {gmx.de:Torsten.Maehne @maehne} openmaintainer
 
@@ -36,9 +35,9 @@ depends_lib-append      port:gtk3 \
 
 cmake.out_of_source     yes
 
-checksums               rmd160  ae78dbb12ec2f639705a09ecd67055b17599ea0e \
-                        sha256  04de35626c415ad4105dd9fb75e92b3f05c5e83a3728b1676ee1ef2e6581d03c \
-                        size 7733169
+checksums               rmd160  b1346ebfa595587ecc762696f1f060a43ac55c5c \
+                        sha256  c13e82599d2455583bd0bd8ac2744b343c25e8dd217b9eadedd529d0de2753ab \
+                        size    7734039
 
 configure.args          -DCMAKE_INSTALL_SYSCONFDIR=${prefix}/etc \
                         -DMOVIES=off


### PR DESCRIPTION
#### Description

* update port pdfpc to version 4.4.1
* The update to version 4.5.0 will require a new port discout (a.k.a. libmarkdown2) as additional dependency.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6 17G14042
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? -> no open ticket
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? -> no tests enabled
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
