### PR TITLE
pinentry-mac: fix building for apple silicon

### DIFF
--- a/aqua/pinentry-mac/Portfile
+++ b/aqua/pinentry-mac/Portfile
@@ -6,7 +6,7 @@ PortGroup               xcode 1.0
 PortGroup               xcodeversion 1.0
 
 github.setup            GPGTools pinentry-mac 0.9.4 v
-revision                0
+revision                1
 categories              aqua security
 license                 GPL-3+
 maintainers             {ionic @Ionic}
@@ -19,14 +19,17 @@ long_description        ${description} \
 homepage                https://github.com/GPGTools/pinentry-mac
 
 checksums               rmd160 b4023708d1320bd1b0ad5ce0dc35ec71fc68b33c \
-                        sha256 73e649213e17dd46340f202453ed835166245b63f0cf2a78203d51d620b2742c
+                        sha256 73e649213e17dd46340f202453ed835166245b63f0cf2a78203d51d620b2742c \
+                        size   284942
 
-# Utilizes ARC which is x86_64-only. #45949
-supported_archs         x86_64
+# Utilizes ARC which is x86_64/arm64-only. #45949
+supported_archs         x86_64 arm64
 installs_libs           no
 
 patchfiles              patch-includes-quotes.diff \
-                        patch-includes-quotes-2.diff
+                        patch-includes-quotes-2.diff \
+                        patch-apple-silicon.diff
+
 patch.pre_args          -p1
 
 # This is a temporary kludge. The new Xcode build system fails to

--- a/aqua/pinentry-mac/files/patch-apple-silicon.diff
+++ b/aqua/pinentry-mac/files/patch-apple-silicon.diff
@@ -1,0 +1,35 @@
+From cc38341adc179a26ac3ea3754a4013afb9681930 Mon Sep 17 00:00:00 2001
+From: Kridsada Thanabulpong <sirn@ogsite.net>
+Date: Wed, 30 Dec 2020 19:10:46 +0900
+Subject: [PATCH] Add arm64 to build targets
+
+This allows pinentry-mac to be built on Apple Silicon with macOS 11
+---
+ pinentry-mac.xcodeproj/project.pbxproj | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/pinentry-mac.xcodeproj/project.pbxproj b/pinentry-mac.xcodeproj/project.pbxproj
+index f8f55b3..861fe43 100755
+--- a/pinentry-mac.xcodeproj/project.pbxproj
++++ b/pinentry-mac.xcodeproj/project.pbxproj
+@@ -421,7 +421,7 @@
+ 				);
+ 				PREBINDING = NO;
+ 				SDKROOT = macosx;
+-				VALID_ARCHS = "i386 x86_64 ppc";
++				VALID_ARCHS = "i386 x86_64 ppc arm64";
+ 			};
+ 			name = Debug;
+ 		};
+@@ -444,7 +444,7 @@
+ 				);
+ 				PREBINDING = NO;
+ 				SDKROOT = macosx;
+-				VALID_ARCHS = "i386 x86_64 ppc";
++				VALID_ARCHS = "i386 x86_64 ppc arm64";
+ 			};
+ 			name = Release;
+ 		};
+-- 
+2.29.2
+


### PR DESCRIPTION
#### Description

pinentry-mac compiles and runs on Apple Silicon, but require adding `arm64` to its build target (https://github.com/GPGTools/pinentry-mac/pull/9). 

https://trac.macports.org/ticket/61575

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
