### PR TITLE
wireshark3: support and default to python39, remove python35

### DIFF
--- a/net/wireshark3/Portfile
+++ b/net/wireshark3/Portfile
@@ -128,20 +128,20 @@ variant chmodbpf description {Enable Wireshark to acces macOS capture devices} {
     depends_run             port:wireshark-chmodbpf
 }
 
-variant python35 conflicts python36 python37 python38 description {Use python35 during build} {
-    depends_build-append    port:python35
-}
-
-variant python36 conflicts python35 python37 python38 description {Use python36 during build} {
+variant python36 conflicts python37 python38 python39 description {Use python36 during build} {
     depends_build-append    port:python36
 }
 
-variant python37 conflicts python35 python36 python38 description {Use python37 during build} {
+variant python37 conflicts python36 python38 python39 description {Use python37 during build} {
     depends_build-append    port:python37
 }
 
-variant python38 conflicts python35 python36 python37 description {Use python38 during build} {
+variant python38 conflicts python36 python37 python39 description {Use python38 during build} {
     depends_build-append    port:python38
+}
+
+variant python39 conflicts python36 python37 python38 description {Use python39 during build} {
+    depends_build-append    port:python39
 }
 
 default_variants +zlib +libsmi +gnutls +geoip +kerberos5 +chmodbpf
@@ -156,9 +156,9 @@ if {![variant_isset adns] && ![variant_isset cares]} {
 
 ## if no python3* variant is specified, add +python38
 ## XYZZY: it would be better to detect which python3* is already installed and use that...
-if {![variant_isset python35] && ![variant_isset python36] && \
-    ![variant_isset python37] && ![variant_isset python38] } {
-    default_variants-append +python38
+if {![variant_isset python36] && ![variant_isset python37] && \
+    ![variant_isset python38] && ![variant_isset python39] } {
+    default_variants-append +python39
 }
 
 post-destroot {


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
