### PR TITLE
enscript: add patch to add missing strings.h include.

### DIFF
--- a/print/enscript/Portfile
+++ b/print/enscript/Portfile
@@ -20,7 +20,8 @@ homepage            https://www.gnu.org/software/enscript/
 master_sites        gnu
 
 checksums           rmd160  eae37efdd916fbd2520834c2e2428e7b729621f1 \
-                    sha256  6d56bada6934d055b34b6c90399aa85975e66457ac5bf513427ae7fc77f5c0bb
+                    sha256  6d56bada6934d055b34b6c90399aa85975e66457ac5bf513427ae7fc77f5c0bb \
+                    size     1330493
 
 depends_lib         port:gettext
 
@@ -28,6 +29,7 @@ depends_lib         port:gettext
 # http://www.freebsd.org/cgi/cvsweb.cgi/ports/print/enscript-letter/
 # and from http://support.rubyforge.org/svn/trunk/support/ruby.st
 patchfiles-append   patch-ruby_syntax.diff
+patchfiles-append   patch-string_h.diff
 
 test.run            yes
 test.target         check

--- a/print/enscript/files/patch-string_h.diff
+++ b/print/enscript/files/patch-string_h.diff
@@ -1,0 +1,10 @@
+--- compat/getopt.c.orig	2020-12-30 05:06:26.000000000 -0500
++++ compat/getopt.c	2020-12-30 05:11:31.000000000 -0500
+@@ -43,6 +43,7 @@
+ #endif
+ 
+ #include <stdio.h>
++#include <string.h>
+ 
+ /* Comment out all this code if we are using the GNU C Library, and are not
+    actually compiling the library itself.  This code is part of the GNU C


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/61730

#### Description

Fixes a missing include that prevents building on Big Sur.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
