### PR TITLE
shmux: Add patch to fix missinc time.h include.

### DIFF
--- a/sysutils/shmux/Portfile
+++ b/sysutils/shmux/Portfile
@@ -26,3 +26,5 @@ checksums           md5     4ab5c46b4154cbeab54bdc0036bd9140 \
                     sha1    6fe39602c497331e448c4331b8cddbb2abb71b79 \
                     rmd160  31937f39483e8ab54848f84830489bf45dff5783
 
+patchfiles          patch-time_h.diff
+

--- a/sysutils/shmux/files/patch-time_h.diff
+++ b/sysutils/shmux/files/patch-time_h.diff
@@ -1,0 +1,10 @@
+--- src/target.c.orig	2020-12-30 14:32:11.000000000 -0500
++++ src/target.c	2020-12-30 14:32:37.000000000 -0500
+@@ -11,6 +11,7 @@
+ 
+ #include "target.h"
+ #include "term.h"
++#include "time.h"
+ 
+ #include "status.h"
+ #include "units.h"


### PR DESCRIPTION
* fixes a build problem with Big Sur.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.1 20C69
Xcode 12.3 12C33


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
