### PR TITLE
shmux: update to version 1.0.3

### DIFF
--- a/sysutils/shmux/Portfile
+++ b/sysutils/shmux/Portfile
@@ -3,17 +3,17 @@
 PortSystem          1.0
 
 name                shmux
-version             1.0.2
-revision            1
+version             1.0.3
+revision            0
 categories          sysutils
 maintainers         nomaintainer
 description         utility for executing the command on many hosts in parallel
 long_description    shmux is program for executing the same command on \
                     many hosts in parallel. For each target, a child \
                     process is spawned by shmux, and a shell on the target \
-                    obtained one of the supported methods: rsh, ssh, or sh. 
-homepage            http://web.taranis.org/shmux/
-
+                    obtained one of the supported methods: rsh, ssh, or sh.
+homepage            https://github.com/shmux/shmux
+license             BSD
 platforms           darwin
 
 depends_build       port:pcre
@@ -21,8 +21,8 @@ depends_run         port:fping
 
 master_sites        http://web.taranis.org/shmux/dist/
 extract.suffix      .tgz
-build.target        
-checksums           md5     4ab5c46b4154cbeab54bdc0036bd9140 \
-                    sha1    6fe39602c497331e448c4331b8cddbb2abb71b79 \
-                    rmd160  31937f39483e8ab54848f84830489bf45dff5783
+build.target
+checksums           sha256  c9f8863e2550e23e633cf5fc7a9c4c52d287059f424ef78aba6ecd98390fb9ab \
+                    rmd160  8cff1bdfa3f9d02096e514e58802c63ad07481cd \
+                    size    116613
 


### PR DESCRIPTION
* update to version 1.0.3
* drectly point to the homepage on github
* mention the license (https://github.com/shmux/shmux/blob/master/LICENSE)

#### Description

Update to version 1.0.3

1.0.2 was no longer compiling, and checksums were mismatched due to the main repo moving to github.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.1 20C69
Xcode 12.3 12C33


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
