### PR TITLE
mlt: add qpainterpath header

### DIFF
--- a/multimedia/mlt/Portfile
+++ b/multimedia/mlt/Portfile
@@ -50,6 +50,10 @@ variant qt5 conflicts qt4 description "build Qt5 version of ${name}" {
     compiler.cxx_standard 2011
     configure.cxxflags-append \
                     -std=c++11
+
+    # qt 5.15.2 changed the headers a bit
+    # https://trac.macports.org/ticket/61946
+    patchfiles-append patch-mlt-qpainterpath.diff
 }
 
 # somewhat arbitrary boundary for Qt versions

--- a/multimedia/mlt/files/patch-mlt-qpainterpath.diff
+++ b/multimedia/mlt/files/patch-mlt-qpainterpath.diff
@@ -1,0 +1,36 @@
+diff --git src/modules/qt/graph.cpp src/modules/qt/graph.cpp
+index 6a97011..54f7582 100644
+--- src/modules/qt/graph.cpp
++++ src/modules/qt/graph.cpp
+@@ -19,6 +19,7 @@
+ 
+ #include "graph.h"
+ #include <QVector>
++#include <QtGui/QPainterPath>
+ #include <math.h>
+ 
+ /*
+diff --git src/modules/qt/kdenlivetitle_wrapper.cpp src/modules/qt/kdenlivetitle_wrapper.cpp
+index af65519..bd06277 100755
+--- src/modules/qt/kdenlivetitle_wrapper.cpp
++++ src/modules/qt/kdenlivetitle_wrapper.cpp
+@@ -45,6 +45,7 @@
+ #include <QGraphicsEffect>
+ #include <QGraphicsBlurEffect>
+ #include <QGraphicsDropShadowEffect>
++#include <QtGui/QPainterPath>
+ #endif
+ 
+ Q_DECLARE_METATYPE(QTextCursor);
+diff --git src/modules/qt/producer_qtext.cpp src/modules/qt/producer_qtext.cpp
+index f3b0915..a7339fd 100644
+--- src/modules/qt/producer_qtext.cpp
++++ src/modules/qt/producer_qtext.cpp
+@@ -30,6 +30,7 @@
+ #include <QString>
+ #include <QTextCodec>
+ #include <QTextDecoder>
++#include <QtGui/QPainterPath>
+ 
+ static void close_qimg( void* qimg )
+ {


### PR DESCRIPTION
qt5.15.2 shifted the headers a touch
closes: https://trac.macports.org/ticket/61946

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G7016
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
