### PR TITLE
mlt: update to 6.24.0

### DIFF
--- a/multimedia/mlt/Portfile
+++ b/multimedia/mlt/Portfile
@@ -5,7 +5,7 @@ PortGroup           muniversal 1.0
 PortGroup           github 1.0
 PortGroup           active_variants 1.1
 
-github.setup        mltframework mlt 6.10.0 v
+github.setup        mltframework mlt 6.24.0 v
 github.tarball_from releases
 
 epoch               3
@@ -26,9 +26,9 @@ long_description    MLT is an open source multimedia framework, designed and dev
 homepage            https://www.mltframework.org/
 platforms           darwin
 
-checksums           rmd160  fcb78f4250effd63e1097cabb737adcd840da6ee \
-                    sha256  10642a80f81e12c6cc5405e60ced640b3dd325c793fe73207ae07de321ad6810 \
-                    size    1384632
+checksums           rmd160  44be9a15f7516a25dedc79162e8403a1cccac643 \
+                    sha256  3b977c5632329fca7634d0034162df6d5b79cde3256bac43e7ba8353acced61e \
+                    size    1351427
 
 subport ${name}-qt5 {
     replaced_by     ${name}
@@ -74,7 +74,8 @@ depends_lib-append  port:atk \
                     port:libxml2 \
                     port:libexif \
                     port:fftw-3 \
-                    port:libebur128
+                    port:libebur128 \
+                    port:rubberband
 
 configure.args-append \
                     --enable-gpl \


### PR DESCRIPTION
#### Description

Fixes compile error again Qt 5 reported in https://trac.macports.org/ticket/61946 by upgrading MLT to latest version.

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G7016
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
(N/A no tests defined)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

[skip notification]
