### PR TITLE
QtPBFImagePlugin: update to 2.3

### DIFF
--- a/graphics/QtPBFImagePlugin/Portfile
+++ b/graphics/QtPBFImagePlugin/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 QtPBFImagePlugin 2.2
+github.setup        tumic0 QtPBFImagePlugin 2.3
 revision            0
 categories          graphics
 platforms           darwin
@@ -14,9 +14,9 @@ maintainers         {@sikmir gmail.com:sikmir} openmaintainer
 description         PBF image plugin for Qt5
 long_description    Qt image plugin for displaying Mapbox vector tiles.
 
-checksums           rmd160  4428cac3e7af09bcddec16ad602bf07c17fd674b \
-                    sha256  5acd21390864473d8c86cdc28a448c8573b85d405b4b626898c435c0f703c414 \
-                    size    196198
+checksums           rmd160  3a44c686a724c8bad71dc277d35b3b9327674c66 \
+                    sha256  af8c772472c81d25119cdf1222d8fb75ddfeab4b774286215cfb7518d232e5f0 \
+                    size    196465
 
 configure.args-append \
                     PROTOBUF=${prefix} ZLIB=${prefix}


### PR DESCRIPTION
#### Description

[Changelog](https://build.opensuse.org/package/view_file/home:tumic:QtPBFImagePlugin/QtPBFImagePlugin/libqt5-qtpbfimageformat.changes)

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
