### PR TITLE
mlt: add patches for missing includes found by buildbot

### DIFF
--- a/multimedia/mlt/Portfile
+++ b/multimedia/mlt/Portfile
@@ -30,6 +30,9 @@ checksums           rmd160  44be9a15f7516a25dedc79162e8403a1cccac643 \
                     sha256  3b977c5632329fca7634d0034162df6d5b79cde3256bac43e7ba8353acced61e \
                     size    1351427
 
+patchfiles          patch-filter_rbpitch.cpp.diff \
+                    patch-RtAudio.cpp.diff
+
 subport ${name}-qt5 {
     replaced_by     ${name}
     PortGroup obsolete 1.0

--- a/multimedia/mlt/files/patch-RtAudio.cpp.diff
+++ b/multimedia/mlt/files/patch-RtAudio.cpp.diff
@@ -1,0 +1,15 @@
+--- src/modules/rtaudio/RtAudio.cpp.orig	2020-12-31 11:47:28.000000000 -0800
++++ src/modules/rtaudio/RtAudio.cpp	2020-12-31 11:48:08.000000000 -0800
+@@ -46,6 +46,7 @@
+ #include <cstring>
+ #include <climits>
+ #include <algorithm>
++#include <unistd.h>
+ 
+ // Static variable definitions.
+ const unsigned int RtApi::MAX_SAMPLE_RATES = 14;
+@@ -10227,4 +10228,3 @@
+   // End:
+   //
+   // vim: et sts=2 sw=2
+-

--- a/multimedia/mlt/files/patch-filter_rbpitch.cpp.diff
+++ b/multimedia/mlt/files/patch-filter_rbpitch.cpp.diff
@@ -1,0 +1,10 @@
+--- src/modules/rubberband/filter_rbpitch.cpp.orig	2020-12-31 11:47:05.000000000 -0800
++++ src/modules/rubberband/filter_rbpitch.cpp	2020-12-31 11:47:55.000000000 -0800
+@@ -25,6 +25,7 @@
+ #include <algorithm>
+ #include <cstring>
+ #include <math.h>
++#include <cstdlib>
+ 
+ using namespace RubberBand;
+ 


### PR DESCRIPTION
#### Description

buildbot failure logs shows these missing includes, but I do not have all these macOS versions to verify these will fix everything. However, it should improve coverage. I will commit these changes upstream as well for the next release.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G7016
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. --> **N/A**
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? **N/A**
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
