### PR TITLE
pastel: new port

### DIFF
--- a/graphics/pastel/Portfile
+++ b/graphics/pastel/Portfile
@@ -1,0 +1,132 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo 1.0
+
+github.setup        sharkdp pastel 0.8.0 v
+revision            0
+
+description         A command-line tool to generate, analyze, convert and \
+                    manipulate colors
+
+long_description    pastel is a command-line tool to generate, analyze, \
+                    convert and manipulate colors. It supports many different \
+                    color formats and color spaces like RGB (sRGB), HSL, \
+                    CIELAB, CIELCh as well as ANSI 8-bit and 24-bit \
+                    representations.
+
+categories          graphics
+platforms           darwin
+license             MIT
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  b27d868fff2a6f14298f10706b2e57a321849ae9 \
+                    sha256  524357f9d05f02249c02d916aed635dfaa0ee6786877eb0ed9c1773b3363b865 \
+                    size    3226850
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+destroot {
+    xinstall -m 755 \
+        ${worksrcpath}/target/[cargo.rust_platform]/release/${name} \
+        ${destroot}${prefix}/bin/
+}
+
+cargo.crates \
+    aho-corasick                    0.7.10  8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada \
+    ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
+    approx                           0.3.2  f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3 \
+    arrayvec                        0.4.12  cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9 \
+    assert_cmd                      0.12.2  936fcf2c692b37c696cd0002c57752b2d9478402450c9ca4a463f6afae16d6f5 \
+    atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+    autocfg                          1.0.0  f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d \
+    bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
+    bstr                            0.2.13  31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931 \
+    bumpalo                          3.3.0  5356f1d23ee24a1f785a56d1d1a5f0fd5b0f6a0c0fb2412ce11da71649ab78f6 \
+    byteorder                        1.3.4  08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de \
+    cast                             0.2.3  4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0 \
+    cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
+    clap                            2.33.1  bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129 \
+    criterion                        0.3.2  63f696897c88b57f4ffe3c69d8e1a0613c7d0e6c4833363c8560fbde9c47b966 \
+    criterion-plot                   0.4.2  ddeaf7989f00f2e1d871a26a110f3ed713632feac17f65f03ca938c542618b60 \
+    crossbeam-deque                  0.7.3  9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285 \
+    crossbeam-epoch                  0.8.2  058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace \
+    crossbeam-queue                  0.2.1  c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db \
+    crossbeam-utils                  0.7.2  c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8 \
+    csv                              1.1.3  00affe7f6ab566df61b4be3ce8cf16bc2576bca0963ceb0955e45d514bf9a279 \
+    csv-core                        0.1.10  2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90 \
+    difference                       2.0.0  524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198 \
+    doc-comment                      0.3.3  fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10 \
+    either                           1.5.3  bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3 \
+    escargot                         0.5.0  74cf96bec282dcdb07099f7e31d9fed323bca9435a09aba7b6d99b7617bca96d \
+    getrandom                       0.1.14  7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb \
+    hermit-abi                      0.1.13  91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71 \
+    itertools                        0.9.0  284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b \
+    itoa                             0.4.5  b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e \
+    js-sys                          0.3.39  fa5a448de267e7358beaf4a5d849518fe9a0c13fce7afd44b06e68550e5562a7 \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    lexical-core                     0.6.2  d7043aa5c05dd34fb73b47acb8c3708eac428de4545ea3682ed2f11293ebd890 \
+    libc                            0.2.70  3baa92041a6fec78c687fa0cc2b3fae8884f743d672cf551bed1d6dac6988d0f \
+    log                              0.4.8  14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7 \
+    maybe-uninit                     2.0.0  60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00 \
+    memchr                           2.3.3  3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400 \
+    memoffset                        0.5.4  b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8 \
+    nodrop                          0.1.14  72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb \
+    nom                              5.1.1  0b471253da97532da4b61552249c521e01e736071f71c1a4f7ebbfbf0a06aad6 \
+    num-traits                      0.2.11  c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096 \
+    num_cpus                        1.13.0  05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3 \
+    oorandom                        11.1.1  94af325bc33c7f60191be4e2c984d48aaa21e2854f473b85398344b60c9b6358 \
+    output_vt100                     0.1.2  53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9 \
+    plotters                        0.2.14  f9b1d9ca091d370ea3a78d5619145d1b59426ab0c9eedbad2514a4cee08bf389 \
+    ppv-lite86                       0.2.8  237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea \
+    predicates                       1.0.4  347a1b6f0b21e636bc9872fb60b83b8e185f6f5516298b8238699f7f9a531030 \
+    predicates-core                  1.0.0  06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178 \
+    predicates-tree                  1.0.0  8e63c4859013b38a76eca2414c64911fba30def9e3202ac461a2d22831220124 \
+    proc-macro2                     1.0.17  1502d12e458c49a4c9cbff560d0fe0060c252bc29799ed94ca2ed4bb665a0101 \
+    quote                            1.0.6  54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea \
+    rand                             0.7.3  6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
+    rand_chacha                      0.2.2  f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402 \
+    rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
+    rand_hc                          0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
+    rand_xoshiro                     0.4.0  a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004 \
+    rayon                            1.3.0  db6ce3297f9c85e16621bb8cca38a06779ffc31bb8184e1be4bed2be4678a098 \
+    rayon-core                       1.7.0  08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9 \
+    regex                            1.3.7  a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692 \
+    regex-automata                   0.1.9  ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4 \
+    regex-syntax                    0.6.17  7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae \
+    rustc_version                    0.2.3  138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a \
+    ryu                              1.0.4  ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1 \
+    same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
+    scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
+    semver                           0.9.0  1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403 \
+    semver-parser                    0.7.0  388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
+    serde                          1.0.110  99e7b308464d16b56eba9964e4972a3eee817760ab60d88c3f86e1fecb08204c \
+    serde_derive                   1.0.110  818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984 \
+    serde_json                      1.0.53  993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2 \
+    static_assertions                0.3.4  7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3 \
+    strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
+    syn                             1.0.24  f87bc5b2815ebb664de0392fdf1b95b6d10e160f86d9f64ff65e5679841ca06a \
+    term_size                        0.3.2  1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9 \
+    textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
+    thread_local                     1.0.1  d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14 \
+    tinytemplate                     1.0.4  45e4bc5ac99433e0dcb8b9f309dd271a165ae37dde129b9e0ce1bfdd8bfe4891 \
+    treeline                         0.1.0  a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41 \
+    unicode-width                    0.1.7  caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479 \
+    unicode-xid                      0.2.0  826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c \
+    vec_map                          0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
+    version_check                    0.9.2  b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed \
+    wait-timeout                     0.2.0  9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6 \
+    walkdir                          2.3.1  777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d \
+    wasi      0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
+    wasm-bindgen                    0.2.62  e3c7d40d09cdbf0f4895ae58cf57d92e1e57a9dd8ed2e8390514b54a47cc5551 \
+    wasm-bindgen-backend            0.2.62  c3972e137ebf830900db522d6c8fd74d1900dcfc733462e9a12e942b00b4ac94 \
+    wasm-bindgen-macro              0.2.62  2cd85aa2c579e8892442954685f0d801f9129de24fa2136b2c6a539c76b65776 \
+    wasm-bindgen-macro-support      0.2.62  8eb197bd3a47553334907ffd2f16507b4f4f01bbec3ac921a7719e0decdfe72a \
+    wasm-bindgen-shared             0.2.62  a91c2916119c17a8e316507afaaa2dd94b47646048014bbdf6bef098c1bb58ad \
+    web-sys                         0.3.39  8bc359e5dd3b46cb9687a051d50a2fdd228e4ba7cf6fcf861a5365c3d671a642 \
+    winapi                           0.3.8  8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6 \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                      0.1.5  70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f


### PR DESCRIPTION
#### Description

New port for [pastel](https://github.com/sharkdp/pastel), a CLI utility for working with color.

<img src="https://raw.githubusercontent.com/sharkdp/pastel/master/doc/pastel.gif" />


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
