### PR TITLE
ruby: fix implicit function declarations

### DIFF
--- a/lang/ruby/Portfile
+++ b/lang/ruby/Portfile
@@ -76,7 +76,8 @@ patchfiles		patch-vendordir.diff \
 				patch-ext-tk-extconf.rb.diff \
 				patch-ext_openssl_extconf_rb.diff \
 				patch-ext_openssl_ossl_ssl_c.diff \
-				patch-ext_openssl_ossl.h.diff
+				patch-ext_openssl_ossl.h.diff \
+				implicit.patch
 
 # ignore getcontext() and setcontext()
 # on 10.5 or later, these functions have some problems (SEGV on ppc, slower than 1.8.6)
@@ -170,22 +171,6 @@ post-destroot {
 platform darwin {
 	# for proper rdoc/ri creation, make sure to link to destroot libruby.dylib
 	destroot.env	DYLD_LIBRARY_PATH=${destroot}${prefix}/lib
-
-	# ruby-1.8 cannot build with Xcode 12 (#61255)
-	# macOS 11
-    if {${os.major} >= 20} {
-		pre-fetch {
-			ui_error "${name} does not support macOS 11 or later."
-			return -code error "incompatible macOS version"
-		}
-    }
-	# macOS 10.15
-    if {${os.major} == 19 || [vercmp ${xcodeversion} 12.0] >= 0} {
-		pre-fetch {
-			ui_error "${name} does not support Xcode 12 or later."
-			return -code error "incompatible Xcode version"
-		}
-    }
 }
 
 variant tk conflicts mactk description "enable tk support" {

--- a/lang/ruby/files/implicit.patch
+++ b/lang/ruby/files/implicit.patch
@@ -1,0 +1,75 @@
+--- configure.orig	2021-01-01 19:59:14.000000000 +1100
++++ configure	2021-01-01 20:11:01.000000000 +1100
+@@ -9104,6 +9104,9 @@
+ /* end confdefs.h.  */
+ 
+ #include <time.h>
++#if HAVE_STDLIB_H
++#include <stdlib.h>
++#endif
+ 
+ void
+ check(tm, y, m, d, h, s)
+@@ -9911,6 +9914,12 @@
+ /* end confdefs.h.  */
+ 
+ #include <stdio.h>
++#if HAVE_STRING_H
++#include <string.h>
++#endif
++#if HAVE_UNISTD_H
++#include <unistd.h>
++#endif
+ #ifndef SEEK_SET
+ #define SEEK_SET 0
+ #endif
+@@ -10297,6 +10306,9 @@
+ /* Test for whether ELF binaries are produced */
+ #include <fcntl.h>
+ #include <stdlib.h>
++#if HAVE_UNISTD_H
++#include <unistd.h>
++#endif
+ main() {
+ 	char buffer[4];
+ 	int i=open("conftest",O_RDONLY);
+--- eval.c.orig	2012-06-29 22:31:25.000000000 +1000
++++ eval.c	2021-01-01 20:18:06.000000000 +1100
+@@ -7264,6 +7264,8 @@ rb_provide(feature)
+     rb_provide_feature(rb_str_new2(feature));
+ }
+ 
++int rb_thread_join _((VALUE, double));
++
+ static char *
+ load_lock(ftptr)
+     const char *ftptr;
+@@ -11524,7 +11526,6 @@ rb_thread_select(max, read, write, excep
+ }
+ 
+ static int rb_thread_join0 _((rb_thread_t, double));
+-int rb_thread_join _((VALUE, double));
+ 
+ static int
+ rb_thread_join0(th, limit)
+--- main.c.orig	2021-01-01 20:24:49.000000000 +1100
++++ main.c	2021-01-01 20:25:10.000000000 +1100
+@@ -26,6 +26,7 @@ int _CRT_glob = 0;
+ 
+ /* to link startup code with ObjC support */
+ #if (defined(__APPLE__) || defined(__NeXT__)) && defined(__MACH__)
++#include <objc/message.h>
+ static void objcdummyfunction( void ) { objc_msgSend(); }
+ #endif
+ 
+--- ext/pty/pty.c.orig	2008-04-15 13:35:55.000000000 +1000
++++ ext/pty/pty.c	2021-01-01 20:42:05.000000000 +1100
+@@ -21,6 +21,8 @@
+ #define WIFSTOPPED(status)    (((status) & 0xff) == 0x7f)
+ #endif
+ #include <ctype.h>
++int	openpty(int *, int *, char *, struct termios *,
++		     struct winsize *);
+ 
+ #include "ruby.h"
+ #include "rubyio.h"


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/61255

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7
Xcode 12.3

