### PR TITLE
amp: new port

### DIFF
--- a/editors/amp/Portfile
+++ b/editors/amp/Portfile
@@ -1,0 +1,193 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo 1.0
+
+github.setup        jmacdonald amp 0.6.2
+revision            0
+
+description         A complete text editor for your terminal.
+
+long_description    Heavily inspired by Vi/Vim. Amp aims to take the core \
+                    interaction model of Vim, simplify it, and bundle in the \
+                    essential features required for a modern text editor.
+
+categories          editors
+platforms           darwin
+license             GPL-3
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  4a36cb027ef854090916abc21359e1b472552266 \
+                    sha256  83746e07a10c6bbf49930a9d32a85d15dca634ae6a7a9517a14bc523626c68b2 \
+                    size    453880
+
+destroot {
+    xinstall -m 755 \
+        ${worksrcpath}/target/[cargo.rust_platform]/release/${name} \
+        ${destroot}${prefix}/bin/
+}
+
+cargo.crates \
+    aho-corasick                     0.5.3  ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66 \
+    aho-corasick                     0.6.4  d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4 \
+    aho-corasick                     0.7.8  743ad5a418686aad3b87fd14c43badd828cf26e214a00f92a384291cf22e1811 \
+    ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
+    app_dirs                         1.2.1  e73a24bad9bd6a94d6395382a6c69fe071708ae4409f763c5475e14ee896313d \
+    arc-swap                        0.3.11  bc4662175ead9cd84451d5c35070517777949a2ed84551764129cedb88384841 \
+    atty                            0.2.10  2fc4a1aa4c24c0718a250f0681885c1af91419d242f29eb8f2ab28502d80dbd1 \
+    backtrace                        0.3.8  dbdd17cd962b570302f5297aea8648d5923e22e555c2ed2d8b2e34eca646bf6d \
+    backtrace-sys                   0.1.23  bff67d0c06556c0b8e6b5f090f0eac52d950d9dfd1d35ba04e4ca3543eaf6a7e \
+    base64                           0.8.0  7c4a342b450b268e1be8036311e2c613d7f8a7ed31214dff1cc3b60852a3168d \
+    bincode                          1.0.1  9f2fb9e29e72fd6bc12071533d5dc7664cb01480c59406f656d7ac25c7bd8ff7 \
+    bitflags                         1.1.0  3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd \
+    block                            0.1.6  0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a \
+    bloodhound                       0.5.4  c3adde3a05c6955eb3bbf6134a06d863d0e1ac23b3f46de258839dc1d8f813cb \
+    byteorder                        1.2.3  74c0b906e9446b0a2e4f760cdb3fa4b2c48cdc6db8766a845c54b6ff063fd2e9 \
+    bytes                            0.4.8  7dd32989a66957d3f0cba6588f15d4281a733f4e9ffc43fcd2385f57d3bf99ff \
+    cast                             0.2.2  926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427 \
+    cc                              1.0.45  4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be \
+    cfg-if                           0.1.3  405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18 \
+    chrono                           0.4.2  1cce36c92cb605414e9b824f866f5babe0a0368e39ea07393b9b63cf3844c0e6 \
+    clap                            2.31.2  f0f16b89cbb9ee36d87483dc939fe9f1e13c05898d56d7b230a0d4dff033a536 \
+    clipboard                        0.4.6  b9b4623b47d8637fc9d47564583d4cc01eb8c8e34e26b2bf348bf4b036acb657 \
+    clipboard-win                    2.1.2  289da2fc09ab964a4948a63287c94fcb4698fa823c46da84c3792928c9d36110 \
+    cmake                           0.1.31  95470235c31c726d72bf2e1f421adc1e65b9d561bf5529612cbe1a72da1467b3 \
+    criterion                        0.2.3  4f11151e2961d0483e5eb7a2ede5ed8071a460d04d2b7c89e8257aa5502b0e0b \
+    criterion-plot                   0.2.3  9f7f7c88a8d341dd9fd9e31a72ca2ca24428db79afb491852873b2c784e037e6 \
+    criterion-stats                  0.2.3  dd48feb0253b2968ff3085e7f3fba6738c9ff859f420a2fb81a48986eb66da36 \
+    dtoa                             0.4.2  09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab \
+    duct                            0.10.0  166298c17c5b4fe5997b962c2f22e887c7c5adc44308eb9103ce5b66af45a423 \
+    either                           1.5.0  3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0 \
+    error-chain                     0.10.0  d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8 \
+    error-chain                     0.11.0  ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3 \
+    error-chain                     0.12.0  07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02 \
+    failure                          0.1.1  934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82 \
+    failure_derive                   0.1.1  c7cdda555bb90c9bb67a3b670a0f42de8e73f5981524123ad8578aafec8ddb8b \
+    flate2                           1.0.1  9fac2277e84e5e858483756647a9d0aa8d9a2b7cba517fd84325a0aaa69a0909 \
+    fnv                              1.0.6  2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3 \
+    fragment                         0.3.1  90ed2593535a2bf81d7d008c153027c08fdfce2dcca920ba6f345a59d8754cb3 \
+    fuchsia-zircon                   0.3.3  2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
+    fuchsia-zircon-sys               0.3.3  3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
+    gcc                             0.3.54  5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb \
+    getrandom                       0.1.12  473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571 \
+    git2                            0.10.1  39f27186fbb5ec67ece9a56990292bc5aed3c3fc51b9b07b0b52446b1dfb4a82 \
+    glob                            0.2.11  8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb \
+    handlebars                      0.31.0  e7bdb08e879b8c78ee90f5022d121897c31ea022cb0cc6d13f2158c7a9fbabb1 \
+    idna                             0.2.0  02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9 \
+    iovec                            0.1.2  dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08 \
+    itertools                        0.7.8  f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450 \
+    itertools-num                    0.1.1  4d78fa608383e6e608ba36f962ac991d5d6878d7203eb93b4711b14fa6717813 \
+    itoa                             0.4.1  c069bbec61e1ca5a596166e55dfe4773ff745c3d16b700013bcaff9a6df2c682 \
+    jobserver                       0.1.17  f2b1d42ef453b30b7387e113da1c83ab1605d90c5b4e0eb8e96d016ed3b8c160 \
+    kernel32-sys                     0.2.2  7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d \
+    lazy_static                      1.2.0  a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1 \
+    lazycell                         0.6.0  a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef \
+    lazycell                         1.2.1  b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f \
+    libc                            0.2.62  34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba \
+    libgit2-sys                      0.9.1  a30f8637eb59616ee3b8a00f6adff781ee4ddd8343a615b8238de756060cc1b3 \
+    libz-sys                        1.0.25  2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe \
+    linked-hash-map                  0.5.1  70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e \
+    log                              0.4.8  14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7 \
+    luthor                           0.1.7  07d562e61c90471939bec3e4aa518826b2002190c35279df82e87ee73faf665e \
+    malloc_buf                       0.0.6  62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb \
+    matches                          0.1.6  100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376 \
+    memchr                          0.1.11  d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20 \
+    memchr                           2.3.0  3197e20c7edb283f87c071ddfc7a2cca8f8e0b888c242959846a6fce03c72223 \
+    miniz-sys                       0.1.10  609ce024854aeb19a0ef7567d348aaa5a746b32fb72e336df7fcc16869d7e2b4 \
+    mio                             0.6.16  71646331f2619b1026cc302f87a2b8b648d5c6dd6937846a16cc8ce0f347f432 \
+    mio-uds                          0.6.7  966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125 \
+    miow                             0.2.1  8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919 \
+    net2                            0.2.33  42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88 \
+    nix                             0.10.0  b7fd5681d13fda646462cfbd4e5f2051279a89a544d50eb98c365b507246839f \
+    num-integer                     0.1.38  6ac0ea58d64a89d9d6b7688031b3be9358d6c919badcf7fbb0527ccfd891ee45 \
+    num-traits                      0.1.43  92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31 \
+    num-traits                       0.2.4  775393e285254d2f5004596d69bb8bc1149754570dcc08cf30cabeba67955e28 \
+    num_cpus                        1.10.1  bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273 \
+    objc                             0.2.2  877f30f37acef6749b1841cceab289707f211aecfc756553cd63976190e6cc2e \
+    objc-foundation                  0.1.1  1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9 \
+    objc_id                          0.1.0  e4730aa1c64d722db45f7ccc4113a3e2c465d018de6db4d3e7dfe031e8c8a297 \
+    ole32-sys                        0.2.0  5d2c49021782e5233cd243168edfa8037574afed4eba4bbaf538b3d8d1789d8c \
+    onig                             3.2.2  f5eeb268a4620c74ea5768c6d2ccd492d60a47a8754666b91a46bfc35cd4d1ba \
+    onig_sys                        68.0.1  5c6be7c4f985508684e54f18dd37f71e66f3e1ad9318336a520d7e42f0d3ea8e \
+    os_pipe                          0.6.1  934868c3f86ed7a39ef63d88edeac5bd49a0c843192651900e9ce1178cbbf157 \
+    pad                              0.1.5  9c9b8de33465981073e32e1d75bb89ade49062bb853e7c97ec2c13439095563a \
+    percent-encoding                 2.1.0  d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
+    pest                             1.0.6  0fce5d8b5cc33983fc74f78ad552b5522ab41442c4ca91606e4236eb4b5ceefc \
+    pest_derive                      1.0.7  ab94faafeb93f4c5e3ce81ca0e5a779529a602ad5d09ae6d21996bfb8b6a52bf \
+    pkg-config                      0.3.11  110d5ee3593dbb73f56294327fe5668bcc997897097cbc76b51e7aed3f52452f \
+    plist                            0.2.4  c61ac2afed2856590ae79d6f358a24b85ece246d2aa134741a66d589519b7503 \
+    proc-macro2                      0.4.6  effdb53b25cdad54f8f48843d67398f7ef2e14f12c1b4cb4effc549a6462a4d6 \
+    quick-error                      1.2.2  9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0 \
+    quote                           0.3.15  7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a \
+    quote                            0.6.3  e44651a0dc4cdd99f71c83b561e221f714912d11af1a4dff0631f923d53af035 \
+    rand                             0.4.2  eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5 \
+    redox_syscall                   0.1.40  c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1 \
+    redox_termios                    0.1.1  7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76 \
+    regex                           0.1.80  4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f \
+    regex                           0.2.11  9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384 \
+    regex                            1.3.4  322cf97724bea3ee221b78fe25ac9c46114ebb51747ad5babd51a2fc6a8235a8 \
+    regex-syntax                     0.3.9  f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957 \
+    regex-syntax                     0.4.2  8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e \
+    regex-syntax                     0.5.6  7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7 \
+    regex-syntax                    0.6.14  b28dfe3fe9badec5dbf0a79a9cccad2cfc2ab5484bdb3e44cbd1ae8b3ba2be06 \
+    rustc-demangle                   0.1.8  76d7ba1feafada44f2d38eed812bd2489a03c0f5abb975799251518b68848649 \
+    safemem                          0.2.0  e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f \
+    same-file                        1.0.2  cfb6eded0b06a0b512c8ddbcf04089138c9b4362c2f696f3c3d76039d68f3637 \
+    scribe                           0.7.2  cb99ef1fd77b50de934186933961ce2ee4d88c0a533a7ad0cd0cf7fc90600943 \
+    serde                           1.0.66  e9a2d9a9ac5120e0f768801ca2b58ad6eec929dc9d1d616c162f208869c2ce95 \
+    serde_derive                    1.0.66  0a90213fa7e0f5eac3f7afe2d5ff6b088af515052cc7303bd68c7e3b91a3fb79 \
+    serde_json                      1.0.19  93aee34bb692dde91e602871bc792dd319e489c7308cdbbe5f27cf27c64280f5 \
+    shared_child                     0.3.2  bcd5e483b3475af9bc2a35311c2f3bbf0bd98fde91410ab15a0d4ba3c3127b4e \
+    shell32-sys                      0.1.2  9ee04b46101f57121c9da2b151988283b6beb79b34f5bb29a58ee48cb695122c \
+    signal-hook                      0.1.9  72ab58f1fda436857e6337dcb6a5aaa34f16c5ddc87b3a8b6ef7a212f90b9c5a \
+    signal-hook-registry             1.0.1  cded4ffa32146722ec54ab1f16320568465aa922aa9ab4708129599740da85d7 \
+    simplelog                        0.5.2  9cc12b39fdf4c9a07f88bffac2d628f0118ed5ac077a4b0feece61fadf1429e5 \
+    slab                             0.4.1  5f9776d6b986f77b35c6cf846c11ad986ff128fe0b2b63a3628e3755e8d3102d \
+    smallvec                         0.4.5  f90c5e5fe535e48807ab94fc611d323935f39d4660c52b26b96446a7b33aef10 \
+    strsim                           0.7.0  bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550 \
+    syn                            0.11.11  d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad \
+    syn                             0.14.2  c67da57e61ebc7b7b6fff56bb34440ca3a83db037320b0507af4c10368deda7d \
+    synom                           0.11.3  a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6 \
+    synstructure                     0.6.1  3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd \
+    syntect                          2.1.0  dc8a6f0db88d4afc340522c20d260411e746b2225b257c6b238a75de9d7cec78 \
+    term                             0.5.1  5e6b677dd1e8214ea1ef4297f85dbcbed8e8cdddb561040cc998ca2551c37561 \
+    termion                          1.5.1  689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096 \
+    textwrap                         0.9.0  c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693 \
+    thread-id                        2.0.0  a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03 \
+    thread-scoped                    1.0.2  bcbb6aa301e5d3b0b5ef639c9a9c7e2f1c944f177b460c04dc24c69b1fa2bd99 \
+    thread_local                     0.2.7  8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5 \
+    thread_local                     0.3.5  279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963 \
+    thread_local                     1.0.1  d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14 \
+    time                            0.1.40  d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b \
+    ucd-util                         0.1.1  fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d \
+    unicode-bidi                     0.3.4  49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5 \
+    unicode-normalization            0.1.7  6a0180bc61fc5a987082bfa111f4cc95c4caff7f9799f3e46df09163a937aa25 \
+    unicode-segmentation             1.0.3  3c5336c5173d8a77ae0b36151c706e32ae10f4985e29d704ad5b5f9565d6d4b6 \
+    unicode-width                    0.1.5  882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526 \
+    unicode-xid                      0.0.4  8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc \
+    unicode-xid                      0.1.0  fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc \
+    unreachable                      1.0.0  382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56 \
+    url                              2.1.0  75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61 \
+    utf8-ranges                      0.1.3  a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f \
+    utf8-ranges                      1.0.0  662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122 \
+    vcpkg                            0.2.3  7ed0f6789c8a85ca41bbc1c9d175422116a9869bd1cf31bb08e1493ecce60380 \
+    vec_map                          0.8.1  05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a \
+    void                             1.0.2  6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d \
+    walkdir                          2.1.4  63636bd0eb3d00ccb8b9036381b526efac53caf112b7783b730ab3f8e44da369 \
+    wasi                             0.7.0  b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d \
+    winapi                           0.2.8  167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
+    winapi                           0.3.5  773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd \
+    winapi-build                     0.1.1  2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    ws2_32-sys                       0.2.1  d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e \
+    x11-clipboard                    0.2.2  2e7374c7699210cca7084ca61d57e09640fc744d1391808cb9ae2fe4ca9bd1df \
+    xcb                              0.8.2  5e917a3f24142e9ff8be2414e36c649d47d6cc2ba81f16201cdef96e533e02de \
+    xdg                              2.1.0  a66b7c2281ebde13cf4391d70d4c7e5946c3c25e72a7b859ca8f677dcd0b0c61 \
+    xml-rs                           0.7.0  3c1cb601d29fe2c2ac60a2b2e5e293994d87a1f6fa9687a31a15270f909be9c2 \
+    yaml-rust                        0.3.5  e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992 \
+    yaml-rust                        0.4.0  57ab38ee1a4a266ed033496cf9af1828d8d6e6c1cfa5f643a2809effcae4d628


### PR DESCRIPTION
#### Description

New port for the [amp](https://github.com/jmacdonald/amp) terminal editor

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
