### PR TITLE
cddlib: new port

### DIFF
--- a/math/cddlib/Portfile
+++ b/math/cddlib/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        cddlib cddlib 0.94m
+revision            0
+
+description         An efficient implementation of the Double Description \
+                    Method
+
+long_description    The C-library cddlib is a C implementation of the Double \
+                    Description Method of Motzkin et al.
+
+categories          math devel
+license             GPL-2
+platforms           darwin macosx linux freebsd
+
+checksums           rmd160  c7162e46e9179e6fb72584189c155c852a2059c9 \
+                    sha256  f60a8ef4e34d5589acc1d27b758998e9f686258a7a0cd704d9d4545b01405b2c \
+                    size    494338
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+use_autoreconf      yes
+autoreconf.cmd      ./bootstrap
+autoreconf.args
+
+depends_build-append    port:autoconf   \
+                        port:automake   \
+                        port:libtool    \
+                        port:pkgconfig  \
+                        port:texlive
+
+depends_lib-append      port:gmp


### PR DESCRIPTION
#### Description

New port for the [cddlib](https://github.com/cddlib/cddlib) math library.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
