### PR TITLE
openmpi: add subport clang11

### DIFF
--- a/science/openmpi/Portfile
+++ b/science/openmpi/Portfile
@@ -9,12 +9,14 @@ PortGroup           legacysupport 1.0
 
 name                openmpi
 version             4.0.1
-revision            1
+revision            2
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          science parallel net
 platforms           darwin
 license             BSD
-maintainers         nomaintainer
+maintainers         \
+                    {@mascguy} \
+                    openmaintainer
 description         A High Performance Message Passing Library
 long_description    Open MPI is a project combining technologies and resources \
                     from several other projects (FT-MPI, LA-MPI, LAM/MPI, and \
@@ -73,6 +75,7 @@ array set clist {
     clang80 {macports-clang-8.0}
     clang90 {macports-clang-9.0}
     clang10 {macports-clang-10}
+    clang11 {macports-clang-11}
     gcc5    {macports-gcc-5}
     gcc6    {macports-gcc-6}
     gcc7    {macports-gcc-7}

--- a/science/openmpi/files/openmpi-clang11
+++ b/science/openmpi/files/openmpi-clang11
@@ -1,0 +1,11 @@
+bin/mpicc-openmpi-clang11
+-
+bin/mpicxx-openmpi-clang11
+bin/mpiexec-openmpi-clang11
+bin/mpirun-openmpi-clang11
+-
+-
+-
+lib/openmpi-clang11/pkgconfig/ompi.pc
+lib/openmpi-clang11/pkgconfig/orte.pc
+-

--- a/science/openmpi/files/openmpi-clang11-fortran
+++ b/science/openmpi/files/openmpi-clang11-fortran
@@ -1,0 +1,11 @@
+bin/mpicc-openmpi-clang11
+-
+bin/mpicxx-openmpi-clang11
+bin/mpiexec-openmpi-clang11
+bin/mpirun-openmpi-clang11
+bin/mpif77-openmpi-clang11
+bin/mpif90-openmpi-clang11
+-
+lib/openmpi-clang11/pkgconfig/ompi.pc
+lib/openmpi-clang11/pkgconfig/orte.pc
+bin/mpifort-openmpi-clang11


### PR DESCRIPTION
#### Description

Add new subport `clang11`, for `openmpi`.

Resolves issue [61879 - Add clang11 sub-port to openmpi](https://trac.macports.org/ticket/61879)

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.8.5 12F2560
Xcode 5.1.1 5B1008

macOS 10.12.6 16G2136
Xcode 9.2 9C40b

macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
