### PR TITLE
openjdk11-openj9*: update to 11.0.9+11.2

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -128,28 +128,28 @@ subport openjdk11-graalvm {
 
 subport openjdk11-openj9 {
     version      11.0.9
-    revision     1
+    revision     2
 
     set build    11
     set openj9_version 0.23.0
     set major    11
 
-    checksums    rmd160  459d97290f1a84e53811fc60cd4f3a02008be4b0 \
-                 sha256  382238443d4495d976f9e1a66b0f6e3bc250d3d009b64d2c29d44022afd7e418 \
-                 size    195535925
+    checksums    rmd160  e86e9e2f6cfea7715633e6e096f8fbbaf9cfd8b5 \
+                 sha256  ba97e4f2ffc5f9a673e00596aa3fc684242522e043ef8f0ddd71479782c2412a \
+                 size    196396470
 }
 
 subport openjdk11-openj9-large-heap {
     version      11.0.9
-    revision     1
+    revision     2
 
     set build    11
     set openj9_version 0.23.0
     set major    11
 
-    checksums    rmd160  1c87a3ffe4fe32e8482f35ecf59cbb6aa6f5d74d \
-                 sha256  dc6987f495c7c16c8f7ad7eee50c6e62afcd3c4279e5c223e302bd529d06fb8d \
-                 size    196321048
+    checksums    rmd160  7babb4d116f8420178b7f27d0ee77ee7c856aa75 \
+                 sha256  17de92b88fe593d48fa8c74dbb9a92b586248021dfdcbbdcc045fa3bcc5704ec \
+                 size    195626456
 }
 
 subport openjdk12 {
@@ -372,13 +372,13 @@ if {${subport} eq "openjdk8"} {
 
 # Temporary overrides for stealth updates
 if {${subport} eq "openjdk11-openj9"} {
-    # Stealth update for 11.1, remove this for the next release
-    dist_subdir  ${name}/${version}_1
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.1_openj9-${openj9_version}/
+    # Stealth update for 11.2, remove this for the next release
+    dist_subdir  ${name}/${version}_2
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.2_openj9-${openj9_version}/
 } elseif {${subport} eq "openjdk11-openj9-large-heap"} {
-    # Stealth update for 11.1, remove this for the next release
-    dist_subdir  ${name}/${version}_1
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.1_openj9-${openj9_version}/
+    # Stealth update for 11.2, remove this for the next release
+    dist_subdir  ${name}/${version}_2
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.2_openj9-${openj9_version}/
 }
 
 if [string match *-graalvm ${subport}] {


### PR DESCRIPTION
#### Description

Update OpenJ9-based AdoptOpenJDK 11 ports to 11.0.9+11.2.

###### Tested on

macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?