### PR TITLE
openjdk15*: stealth updates

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem       1.0
+PortGroup        obsolete 1.0
 
 name             openjdk
 categories       java devel
@@ -13,7 +14,6 @@ version          11
 
 if {${subport} eq "openjdk"} {
     # The openjdk port is not installable, but recommends users to install the latest Long Term Support (LTS) subport
-    PortGroup    obsolete 1.0
     replaced_by  openjdk${version}
 }
 
@@ -268,40 +268,40 @@ subport openjdk14-openj9-large-heap {
 
 subport openjdk15 {
     version      15.0.1
-    revision     0
+    revision     1
 
     set build    9
     set major    15
 
-    checksums    rmd160  ec9c5ee749c16ae2846e4f6e8ff63d4789ba80cb \
-                 sha256  d32f9429c4992cef7be559a15c542011503d6bc38c89379800cd209a9d7ec539 \
-                 size    195773522
+    checksums    rmd160  be222e8bdd8365555c279c4a033c9e992749e85a \
+                 sha256  b8c2e2ad31f3d6676ea665d9505b06df15e23741847556612b40e3ee329fc046 \
+                 size    195872839
 }
 
 subport openjdk15-openj9 {
     version      15.0.1
-    revision     0
+    revision     1
 
     set build    9
     set openj9_version 0.23.0
     set major    15
 
-    checksums    rmd160  9aeeaec14ed1d44f796c6f3f7e6cb5c545537c00 \
-                 sha256  688dea7aa7b077f10ed9af833d0d14fa1770961099f43933bb84724d1f068d6f \
-                 size    195840553
+    checksums    rmd160  2f60777b953496b8b42c80ca07609afdf2816dd8 \
+                 sha256  57d1714db90eed5ee69c96b4e18e1ff5468580a299deef06d7f5a8a65e3bdc3b \
+                 size    195920750
 }
 
 subport openjdk15-openj9-large-heap {
     version      15.0.1
-    revision     0
+    revision     1
 
     set build    9
     set openj9_version 0.23.0
     set major    15
 
-    checksums    rmd160  efbbf9c19429915a953d4df681199bd6d45c9058 \
-                 sha256  e48fd8ed4ef7386b59229cc86a1718e42b91209ba3b748a258850599ddeed8bb \
-                 size    195082957
+    checksums    rmd160  58881640a668e44785e679b4f0ec58c1079946d7 \
+                 sha256  cd1edee27abc36879b288d67237078c1ea8898a495b5d66144f0d23988e27cdb \
+                 size    195168686
 }
 
 # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
@@ -338,7 +338,6 @@ if {${subport} eq "openjdk8"} {
     worksrcdir   jdk${version}-b${build}
 } elseif {${subport} eq "openjdk10"} {
     # Remove after 2021-11-28
-    PortGroup    obsolete 1.0
     replaced_by  openjdk11
 } elseif [string match *-graalvm ${subport}] {
     description  GraalVM Community Edition based on OpenJDK ${major}
@@ -379,6 +378,18 @@ if {${subport} eq "openjdk11-openj9"} {
     # Stealth update for 11.1, remove this for the next release
     dist_subdir  ${name}/${version}_1
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.1_openj9-${openj9_version}/
+} elseif {${subport} eq "openjdk15"} {
+    # Stealth update for 9.1, remove this for the next release
+    dist_subdir  ${name}/${version}_1
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.1/
+} elseif {${subport} eq "openjdk15-openj9"} {
+    # Stealth update for 9.2, remove this for the next release
+    dist_subdir  ${name}/${version}_1
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.2_openj9-${openj9_version}/
+} elseif {${subport} eq "openjdk15-openj9-large-heap"} {
+    # Stealth update for 9.2, remove this for the next release
+    dist_subdir  ${name}/${version}_1
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.2_openj9-${openj9_version}/
 }
 
 if [string match *-graalvm ${subport}] {


### PR DESCRIPTION
#### Description

Update AdoptOpenJDK 15 to 15.0.1+9.1 (HotSpot VM) and 15.0.1+9.2 (OpenJ9 VM).

###### Tested on

macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?