### PR TITLE
Babllibrsvg

### DIFF
--- a/graphics/babl-devel/Portfile
+++ b/graphics/babl-devel/Portfile
@@ -31,8 +31,7 @@ configure.args-append \
                     -Dwith-docs=false
 
 depends_build-append \
-                    port:pkgconfig \
-                    port:librsvg
+                    port:pkgconfig
 
 depends_lib-append  port:lcms2 \
                     port:gobject-introspection
@@ -63,7 +62,8 @@ if {[variant_isset universal]} {
 }
 
 variant docs description {Generate optional docs} {
-    depends_build-append   port:w3m
+    depends_build-append   port:w3m \
+                           port:librsvg
 
     configure.args-delete  -Dwith-docs=false
     configure.args-append  -Dwith-docs=true

--- a/graphics/babl/Portfile
+++ b/graphics/babl/Portfile
@@ -30,8 +30,7 @@ configure.args-append \
                     -Dwith-docs=false
 
 depends_build-append \
-                    port:pkgconfig \
-                    port:librsvg
+                    port:pkgconfig
 
 depends_lib-append  port:lcms2 \
                     port:gobject-introspection \
@@ -63,7 +62,8 @@ if {[variant_isset universal]} {
 }
 
 variant docs description {Generate optional docs} {
-    depends_build-append   port:w3m
+    depends_build-append   port:w3m \
+                           port:librsvg
 
     configure.args-delete  -Dwith-docs=false
     configure.args-append  -Dwith-docs=true


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

librsvg is a big PITA due to rust, which is a heavy dependency.

As much as possible, we should get rid of it, but for now, we can at least move it into variants where it is actually needed, eg +docs variants where it is used to convert image formats, usually icons, around.