### PR TITLE
python34: fix building on big sur

### DIFF
--- a/lang/python34/Portfile
+++ b/lang/python34/Portfile
@@ -37,6 +37,8 @@ patchfiles          patch-setup.py.diff \
                     patch-Lib-cgi.py.diff \
                     patch-configure.diff \
                     patch-Lib-ctypes-macholib-dyld.py.diff \
+                    patch-pyconfig.h.in.diff \
+                    patch-Python-random.c.diff \
                     patch-libedit.diff \
                     patch-openssl11.diff \
                     omit-local-site-packages.patch \

--- a/lang/python34/files/patch-Python-random.c.diff
+++ b/lang/python34/files/patch-Python-random.c.diff
@@ -1,0 +1,12 @@
+--- Python/random.c
++++ Python/random.c
+@@ -6,6 +6,9 @@
+ #ifdef HAVE_SYS_STAT_H
+ #include <sys/stat.h>
+ #endif
++#ifdef HAVE_SYS_RANDOM_H
++#include <sys/random.h>
++#endif
+ #endif
+ 
+ #ifdef Py_DEBUG

--- a/lang/python34/files/patch-configure.diff
+++ b/lang/python34/files/patch-configure.diff
@@ -9,3 +9,12 @@
  		prefix=$PYTHONFRAMEWORKINSTALLDIR/Versions/$VERSION
  
  		# Add files for Mac specific code to the list of output
+@@ -7013,7 +7013,7 @@
+ sys/times.h sys/types.h sys/uio.h sys/un.h sys/utsname.h sys/wait.h pty.h \
+ libutil.h sys/resource.h netpacket/packet.h sysexits.h bluetooth.h \
+ bluetooth/bluetooth.h linux/tipc.h spawn.h util.h alloca.h endian.h \
+-sys/endian.h
++sys/random.h sys/endian.h
+ do :
+   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
+ ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"

--- a/lang/python34/files/patch-configure.diff
+++ b/lang/python34/files/patch-configure.diff
@@ -18,3 +18,67 @@
  do :
    as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
  ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
+--- configure.orig	2021-01-02 20:14:31.000000000 +1100
++++ configure	2021-01-02 20:29:17.000000000 +1100
+@@ -10037,10 +10037,10 @@
+       main() {
+         pthread_attr_t attr;
+         pthread_t id;
+-        if (pthread_attr_init(&attr)) exit(-1);
+-        if (pthread_attr_setscope(&attr, PTHREAD_SCOPE_SYSTEM)) exit(-1);
+-        if (pthread_create(&id, &attr, foo, NULL)) exit(-1);
+-        exit(0);
++        if (pthread_attr_init(&attr)) return (-1);
++        if (pthread_attr_setscope(&attr, PTHREAD_SCOPE_SYSTEM)) return (-1);
++        if (pthread_create(&id, &attr, foo, NULL)) return (-1);
++        return (0);
+       }
+ _ACEOF
+ if ac_fn_c_try_run "$LINENO"; then :
+@@ -13733,7 +13733,7 @@
+   int main()
+   {
+ 	/* Success: exit code 0 */
+-        exit((((wchar_t) -1) < ((wchar_t) 0)) ? 0 : 1);
++        return ((((wchar_t) -1) < ((wchar_t) 0)) ? 0 : 1);
+   }
+ 
+ _ACEOF
+@@ -14051,7 +14051,7 @@
+ 
+ int main()
+ {
+-	exit(((-1)>>3 == -1) ? 0 : 1);
++	return (((-1)>>3 == -1) ? 0 : 1);
+ }
+ 
+ _ACEOF
+@@ -14434,13 +14434,16 @@
+ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
++#if HAVE_UNISTD_H
++#include <unistd.h>
++#endif
+ 
+ int main()
+ {
+ 	int val1 = nice(1);
+ 	if (val1 != -1 && val1 == nice(2))
+-		exit(0);
+-	exit(1);
++		return (0);
++	return (1);
+ }
+ 
+ _ACEOF
+@@ -14476,6 +14479,9 @@
+ /* end confdefs.h.  */
+ 
+ #include <poll.h>
++#if HAVE_UNISTD_H
++#include <unistd.h>
++#endif
+ 
+ int main()
+ {

--- a/lang/python34/files/patch-pyconfig.h.in.diff
+++ b/lang/python34/files/patch-pyconfig.h.in.diff
@@ -1,0 +1,12 @@
+--- pyconfig.h.in
++++ pyconfig.h.in
+@@ -982,6 +982,9 @@
+ /* Define to 1 if you have the <sys/poll.h> header file. */
+ #undef HAVE_SYS_POLL_H
+ 
++/* Define to 1 if you have the <sys/random.h> header file. */
++#undef HAVE_SYS_RANDOM_H
++
+ /* Define to 1 if you have the <sys/resource.h> header file. */
+ #undef HAVE_SYS_RESOURCE_H
+ 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Python 3.4 failed to build on Big Sur due to a missing `#include <sys/random.h>` for `getentropy()`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
