### PR TITLE
mindforger: new port

### DIFF
--- a/editors/mindforger/Portfile
+++ b/editors/mindforger/Portfile
@@ -1,0 +1,70 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github  1.0
+PortGroup               cmake   1.1
+
+github.setup            dvorka mindforger 1.52.0
+revision                0
+
+homepage                https://www.mindforger.com
+
+description             Thinking notebook and Markdown editor
+
+long_description        MindForger is an open, free, well-performing Markdown \
+                        editor which respects your privacy and enables \
+                        security.  It is actually more than an editor or IDE \
+                        - it's a human mind -inspired personal knowledge \
+                        management tool.
+
+categories              editors office
+license                 GPL-2
+platforms               darwin
+
+maintainers             {gmail.com:herby.gillot @herbygillot} \
+                        openmaintainer
+
+fetch.type              git
+
+set qmake_bin           ${prefix}/libexec/qt5/bin/qmake
+
+depends_build-append    port:pkgconfig
+
+# mindforger is a Qt5 project, but one of its dependencies, cmark-gfm, uses
+# CMake.  The qmake5/qt5 portgroups do not mix very well with the cmake
+# portgroup, so we use only cmake-1.1 and specify Qt5 dependencies directly:
+depends_lib-append      port:qt5-qtbase \
+                        port:qt5-qtwebengine \
+                        port:zlib
+
+# Since cmark-gfm is built with CMake, set CMake's source dir to where
+# cmark-gfm lives.
+cmake.source_dir        ${worksrcpath}/deps/cmark-gfm
+
+configure.args-append   -DCMARK_TESTS=OFF \
+                        -DCMARK_SHARED=OFF
+
+post-extract {
+    # mindforger's dependencies are provided as git submodules
+    system -W ${worksrcpath} "git submodule update --init --recursive"
+}
+
+pre-configure {
+    # Prepare the mindforger make process from its Qt5 project file.
+    system -W ${worksrcpath} \
+        "${qmake_bin} CONFIG+=mfnoccache -r ./mindforger.pro"
+}
+
+post-build {
+    # CMake builds cmark-gfm out of source.  We symlink the external build
+    # directory back into the cfmark-gfm dir so that the main mindforger 
+    # Makefile can find resources within it when building mindforger itself.
+    ln -s ${cmake.build_dir} ${cmake.source_dir}/build
+
+    # Build mindforger itself
+    system -W ${worksrcpath} "make"
+}
+
+destroot {
+    copy ${worksrcpath}/app/mindforger.app ${destroot}${applications_dir}/
+}


### PR DESCRIPTION
#### Description

New port for the **[MindForger](https://www.mindforger.com)** GPLv2 personal knowledge base.

<img src="https://camo.githubusercontent.com/cd77f72c4b01a64406b867f78e9be6a42ebbce7233bc6d6b82e74db56cffae4c/687474703a2f2f7777772e6d696e64666f726765722e636f6d2f6769746875622f6769746875622d7468696e6b696e672d6e6f7465626f6f6b2e706e67" />

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
