### PR TITLE
libarchive: update to 3.5.1

### DIFF
--- a/archivers/libarchive/Portfile
+++ b/archivers/libarchive/Portfile
@@ -16,16 +16,15 @@ long_description \
 	also write shar archives.
 platforms        darwin
 
-version          3.5.0
-revision         1
+version          3.5.1
+revision         0
 
-checksums        rmd160  9bbd61e676c7b51f5a66fa80c58dd440bb9d9ccb \
-                 sha256  fc4bc301188376adc18780d35602454cc8df6396e1b040fbcbb0d4c0469faf54 \
-                 size    7017726
+checksums        rmd160  80fef1fe33c2a9a86f5ec0cac109a29cf2fcd50e \
+                 sha256  9015d109ec00bb9ae1a384b172bf2fc1dff41e2c66e5a9eeddf933af9db37f5a \
+                 size    7008338
 
 homepage         https://libarchive.org/
 master_sites     ${homepage}downloads/
-
 
 depends_lib      port:bzip2 port:zlib port:libxml2 port:xz \
                  port:lzo2 port:libiconv \


### PR DESCRIPTION
#### Description

libarchive: update to 3.5.1 ; nice and simple!

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2 20D5029f
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
