### PR TITLE
restic: update to 0.11.0

### DIFF
--- a/sysutils/restic/Portfile
+++ b/sysutils/restic/Portfile
@@ -3,28 +3,32 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/restic/restic 0.10.0 v
-categories          sysutils
+go.setup            github.com/restic/restic 0.11.0 v
+revision            0
 
+categories          sysutils
 license             BSD
 maintainers         nomaintainer
 
 description         Fast, secure, efficient backup program.
-long_description    Restic is a program that does backups right. Its design goals are: Easy, Fast, Verifiable, Secure, Efficient and Free.
 
-homepage            https://restic.net/
+long_description    Restic is a program that does backups right. Its design \
+                    goals are: Easy, Fast, Verifiable, Secure, Efficient and \
+                    Free.
+
+homepage            https://restic.net
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  f5eb870195c8127742c10ed80575e2f3c16dd6b0 \
-                        sha256  8758130f7aa1639b1b2c24c327114657a819c81cdd229a41f56fe9a6550a2b05 \
-                        size    23683647
+                        rmd160  89c0647a53dcb1333371734ce8c57cb26d91ffb8 \
+                        sha256  3fee12f2bf405e28cc35e8fe8379d9d73345a79ee8347f4928701158495bb266 \
+                        size    23760697
 
 # FIXME: This port currently can't be built without allowing go mod to fetch
 # dependencies during the build phase. See
 # https://trac.macports.org/ticket/61192
 build.env-delete    GOPROXY=off GO111MODULE=off
 
-set pyver           3.7
+set pyver           3.9
 
 variant             docs description {Build the documentation} {
     set pyver_nodot [string map {. {}} ${pyver}]
@@ -72,7 +76,7 @@ destroot {
 
     set docdir ${prefix}/share/doc/${name}
     xinstall -m 755 -d ${destroot}${docdir}
-    xinstall -m 644 -W ${worksrcpath} LICENSE README.rst ${destroot}${docdir}
+    xinstall -m 644 -W ${worksrcpath} LICENSE README.md ${destroot}${docdir}
 
     if {[variant_isset docs]} {
         file copy ${worksrcpath}/doc/_build/html ${destroot}${docdir}


### PR DESCRIPTION
- switch Python deps to using Python 3.9

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
