### PR TITLE
jpeginfo: use autoconf

### DIFF
--- a/multimedia/jpeginfo/Portfile
+++ b/multimedia/jpeginfo/Portfile
@@ -17,8 +17,11 @@ homepage            http://www.kokkonen.net/tjko/projects.html
 master_sites        http://www.kokkonen.net/tjko/src/
 
 checksums           rmd160  d145384f4bfc002eb93da6ab9053965164394492 \
-                    sha256  629e31cf1da0fa1efe4a7cc54c67123a68f5024f3d8e864a30457aeaed1d7653
+                    sha256  629e31cf1da0fa1efe4a7cc54c67123a68f5024f3d8e864a30457aeaed1d7653 \
+                    size    64856
 
 depends_lib         port:jpeg
 
 destroot.destdir    INSTALL_ROOT=${destroot}
+
+use_autoconf        yes

--- a/multimedia/jpeginfo/Portfile
+++ b/multimedia/jpeginfo/Portfile
@@ -6,7 +6,7 @@ name                jpeginfo
 version             1.6.1
 categories          multimedia
 platforms           darwin
-maintainers         yandex.com:bstj openmaintainer
+maintainers         {yandex.com:bstj @toy} openmaintainer
 license             GPL-2+
 
 description         Prints information and tests integrity of JPEG/JFIF files.
@@ -22,6 +22,7 @@ checksums           rmd160  d145384f4bfc002eb93da6ab9053965164394492 \
 
 depends_lib         port:jpeg
 
-destroot.destdir    INSTALL_ROOT=${destroot}
-
+# Fix implicit declaration of function errors in configure tests.
 use_autoconf        yes
+
+destroot.destdir    INSTALL_ROOT=${destroot}


### PR DESCRIPTION
#### Description

Hopefully this will fix wrong 0 sizes of int/long on arm64. Look for "checking size of" in:
https://build.macports.org/builders/ports-11_arm64-builder/builds/7148/steps/install-port/logs/stdio

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.7 19H15
Xcode 12.3 12C33

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
