### PR TITLE
py-trio: update to 0.17.0

### DIFF
--- a/python/py-trio/Portfile
+++ b/python/py-trio/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-trio
-version             0.13.0
+version             0.17.0
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
@@ -27,9 +27,9 @@ master_sites        pypi:t/trio
 
 distname            trio-${version}
 
-checksums           rmd160  d25652aca7570946ec30a8c38cbfbc8651ffa2de \
-                    sha256  f1cf00054ad974c86d9b7afa187a65d79fd5995340abe01e8e4784d86f4acb30 \
-                    size    390017
+checksums           rmd160  96713c61a7200c147359d6acd2127fb45719f66d \
+                    sha256  e85cf9858e445465dfbb0e3fdf36efe92082d2df87bfe9d62585eedd6e8e9d7d \
+                    size    439265
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
@@ -41,7 +41,7 @@ if {${name} ne ${subport}} {
                             port:py${python.version}-sniffio
     depends_test-append     port:py${python.version}-astor \
                             port:py${python.version}-openssl \
-                            port:py${python.version}-yapf \
+                            port:py${python.version}-black \
                             port:py${python.version}-trustme \
                             port:py${python.version}-jedi \
                             port:py${python.version}-pylint \
@@ -52,7 +52,8 @@ if {${name} ne ${subport}} {
     }
 
     test.run            yes
-    test.cmd            py.test-${python.branch}
+    test.cmd            py.test-${python.branch} -m 'not redistributors_should_skip' \
+                        --deselect trio/_core/tests/test_asyncgen.py::test_fallback_when_no_hook_claims_it
     test.target
     test.env            PYTHONPATH=${worksrcpath}/build/lib
 


### PR DESCRIPTION
#### Description

py-trio: update to 0.17.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
