### PR TITLE
qwt-qt5: update to 6.1.6

### DIFF
--- a/graphics/qwt-qt5/Portfile
+++ b/graphics/qwt-qt5/Portfile
@@ -16,11 +16,11 @@ use_bzip2               yes
 
 platforms               darwin
 
-version                 6.1.5
+version                 6.1.6
 distname                qwt-${version}
-checksums               rmd160  37bf5b741cbf9c760879b88cdfae741c0c6dc9ce \
-                        sha256  4076de63ec2b5e84379ddfebf27c7b29b8dc9074f3db7e2ca61d11a1d8adc041 \
-                        size    4408268
+checksums               rmd160  d85320b3fbe2df75d0c8eee993d101fa18ba300e \
+                        sha256  99460d31c115ee4117b0175d885f47c2c590d784206f09815dc058fbe5ede1f6 \
+                        size    4306402
 
 description             Qt Widgets for Technical Applications
 


### PR DESCRIPTION
#### Description

update qwt-qt5 from 6.1.5 to 6.1.6; nice and simple!

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2 20D5029f
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
