### PR TITLE
haproxy: update to 2.2.6

### DIFF
--- a/net/haproxy/Portfile
+++ b/net/haproxy/Portfile
@@ -4,9 +4,11 @@ PortSystem          1.0
 PortGroup           legacysupport 1.1
 
 name                haproxy
-version             2.2.4
+version             2.2.6
 revision            0
+
 set branch          [join [lrange [split ${version} .] 0 1] .]
+
 categories          net
 platforms           darwin
 maintainers         {gmail.com:jeremy.mcmillan @aphor} openmaintainer
@@ -27,9 +29,9 @@ homepage            https://www.haproxy.org/
 master_sites        ${homepage}download/${branch}/src/ \
                     https://sources.openwrt.org/
 
-checksums           rmd160  202b897893f94a27967972a756fcf83a471b0027 \
-                    sha256  87a4d9d4ff8dc3094cb61bbed4a8eed2c40b5ac47b9604daebaf036d7b541be2 \
-                    size    2874180
+checksums           rmd160  b25ae5caf161dbfa63b670fa91a0356e4c9d751a \
+                    sha256  be1c6754cbaceafc4837e0c6036c7f81027a3992516435cbbbc5dc749bf5a087 \
+                    size    2890554
 
 depends_lib         path:lib/libssl.dylib:openssl \
                     port:pcre \


### PR DESCRIPTION
This updates `haproxy` to the latest **LTS** version, though there is also the **stable** line:

Branch | Release date | End of life | Latest version 
-- | -- | -- | -- 
2.3 | 2020-11-05 | 2022-Q1 **(stable)** | 2.3.2
2.2 | 2020-07-07 | 2025-Q2 **(LTS)** | 2.2.6

...from http://www.haproxy.org

Wondering if it makes sense to move the current `haproxy` port into a `haproxy-lts` subport, and make `haproxy` point to the stable version...

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
