### PR TITLE
timewarrior: new port

### DIFF
--- a/office/timewarrior/Portfile
+++ b/office/timewarrior/Portfile
@@ -1,0 +1,42 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+
+github.setup        GothenburgBitFactory timewarrior 1.4.2 v
+revision            0
+
+homepage            https://timewarrior.net
+
+description         Timewarrior is Free and Open Source Software that tracks \
+                    time from the command line.
+
+long_description    Timewarrior is a time tracking utility that offers simple \
+                    stopwatch features as well as sophisticated \
+                    calendar-based backfill, along with flexible reporting.
+
+categories          office
+platforms           darwin
+license             MIT
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+distname            timew-${version}
+
+checksums           rmd160  f20457b1c1503ee29f0f9e588483bf047cdccfb7\
+                    sha256  c3d3992aa8d2cc3cd86e59d00060fb4a3e16c15babce78451cc9d39a7f5bb2e1\
+                    size    1316841
+
+github.tarball_from releases
+
+post-destroot {
+    # Install bash completions
+    set bash_comp_path ${prefix}/share/bash-completion/completions
+
+    xinstall -d ${destroot}${bash_comp_path}
+
+    xinstall -m 0644 ${worksrcpath}/completion/timew-completion.bash \
+        ${destroot}${bash_comp_path}/timew
+}


### PR DESCRIPTION
#### Description

New port for **[TimeWarrior](https://timewarrior.net)**, a time tracking utility from the same [author](https://gothenburgbitfactory.org) as [TaskWarrior](https://taskwarrior.org).

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
