### PR TITLE
fzf: update to 0.25.0

### DIFF
--- a/sysutils/fzf/Portfile
+++ b/sysutils/fzf/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/junegunn/fzf 0.24.4
+go.setup            github.com/junegunn/fzf 0.25.0
 revision            0
 
 categories          sysutils
@@ -14,20 +14,25 @@ description         A command-line fuzzy finder written in Go
 long_description    ${description}
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  260efd240405352c89c9668572c6c26255dac736 \
-                        sha256  7adf3f2dd2d1f960f2d93d91f7c3fa2836724158804b935d56b312794829d3cf \
-                        size    175469
+                        rmd160  bb7b266ce23c014d095ed94ea3f73547583e9a79 \
+                        sha256  5dba419e2081e80d91afd7547481b52e156c6b7fce69e1c2ccc7419d9452ee68 \
+                        size    176961
 
-go.vendors          golang.org/x/sys \
-                        lock    119d4633e4d1 \
-                        rmd160  ff96c15036f10cb4c2e209003e8c0368eaba3197 \
-                        sha256  442977a4c5259a8f9b2327d127f8da6eaaa02cdcbcbfe7b573e9f57570f208bc \
-                        size    1072778 \
-                    golang.org/x/text \
+go.vendors          golang.org/x/text \
                         lock    v0.3.3 \
                         rmd160  babfa547ba9a9dab7fe08fa5543f1d8e7ae00301 \
                         sha256  1c4a8c12295d484e0360d8e010ebc4b8a9a05aa2a07c10c3d3e5b17aa063f0db \
                         size    7745597 \
+                    golang.org/x/sys \
+                        lock    119d4633e4d1 \
+                        rmd160  ff96c15036f10cb4c2e209003e8c0368eaba3197 \
+                        sha256  442977a4c5259a8f9b2327d127f8da6eaaa02cdcbcbfe7b573e9f57570f208bc \
+                        size    1072778 \
+                    golang.org/x/sync \
+                        lock    67f06af15bc9 \
+                        rmd160  1975599ab89b8c6a6b7fbca131efb1b705f7f022 \
+                        sha256  78883bdc5e24128ee3700bfe03eddb759dbaabdeb99eeda2826bf95a2784d18e \
+                        size    18695 \
                     golang.org/x/crypto \
                         lock    9e8e0b390897 \
                         rmd160  bd4738a1bbf4d94ec5f840e7425ffa473c6b97bd \
@@ -38,41 +43,39 @@ go.vendors          golang.org/x/sys \
                         rmd160  e67c5be594fe7f19d8ad45b89675095604b51888 \
                         sha256  c6d2759f59c616980eb6afe86cbc1adb615b8ab56bf52cf428afcffb0a718910 \
                         size    10718 \
-                    github.com/gdamore/tcell \
-                        lock    v1.4.0 \
-                        rmd160  479ce3d189ac02a4de5219054f537cc173c28b43 \
-                        sha256  ee8948a76a4cc5ba8285f03840473cf41e80e476a1317239414ee54396db82c9 \
-                        size    152003 \
-                    github.com/lucasb-eyer/go-colorful \
-                        lock    v1.0.3 \
-                        rmd160  0d0a283ba00c871d123c951efea0605a869951aa \
-                        sha256  ecd902ddda5d05cc8a857873bf8b984a5cd2d7b75f1185edcfc2c472707958b3 \
-                        size    430208 \
-                    github.com/mattn/go-isatty \
-                        lock    v0.0.12 \
-                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
-                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
-                        size    4549 \
-                    github.com/mattn/go-runewidth \
-                        lock    v0.0.9 \
-                        rmd160  412c0e508e55f4fe437be0f71d7d22eca2b4366f \
-                        sha256  4f0f4a22257ccecfb6beae88052d850380ecc0e806d6bcc92d3656ebcac3b638 \
-                        size    16716 \
                     github.com/mattn/go-shellwords \
                         lock    v1.0.10 \
                         rmd160  5cd8df0280d795cc159d4be9039b193418375f4c \
                         sha256  3691f606a48a973e02cb57e1ce724500a29cff5cad229dae24179ee3094561ae \
                         size    5149 \
-                    golang.org/x/sync \
-                        lock    67f06af15bc9 \
-                        rmd160  1975599ab89b8c6a6b7fbca131efb1b705f7f022 \
-                        sha256  78883bdc5e24128ee3700bfe03eddb759dbaabdeb99eeda2826bf95a2784d18e \
-                        size    18695 \
+                    github.com/mattn/go-runewidth \
+                        lock    v0.0.9 \
+                        rmd160  412c0e508e55f4fe437be0f71d7d22eca2b4366f \
+                        sha256  4f0f4a22257ccecfb6beae88052d850380ecc0e806d6bcc92d3656ebcac3b638 \
+                        size    16716 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.12 \
+                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
+                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
+                        size    4549 \
+                    github.com/lucasb-eyer/go-colorful \
+                        lock    v1.0.3 \
+                        rmd160  0d0a283ba00c871d123c951efea0605a869951aa \
+                        sha256  ecd902ddda5d05cc8a857873bf8b984a5cd2d7b75f1185edcfc2c472707958b3 \
+                        size    430208 \
+                    github.com/gdamore/tcell \
+                        lock    v1.4.0 \
+                        rmd160  479ce3d189ac02a4de5219054f537cc173c28b43 \
+                        sha256  ee8948a76a4cc5ba8285f03840473cf41e80e476a1317239414ee54396db82c9 \
+                        size    152003 \
                     github.com/gdamore/encoding \
                         lock    v1.0.0 \
                         rmd160  3ed8916f763a5b51db1bcc8bd3ad06cf3d12ec07 \
                         sha256  4f470c7308790bea8a526ea26cecbaa22345aad8dc566821cda6175b3d241ee1 \
                         size    10900
+
+# adds specific major.minor.patch version information
+build.args-append   "-ldflags \"-X main.version=${version} -X main.revision=MacPorts\""
 
 destroot {
     # install fzf


### PR DESCRIPTION
#### Description

fzf: update to 0.25.0
* sort vendors (using `go2port`) for easier updates
* adds version information during build

###### Tested on
macOS 10.14.6 18G6020
Xcode 11.3.1 11C504

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
