### PR TITLE
kaf: new port

### DIFF
--- a/sysutils/kaf/Portfile
+++ b/sysutils/kaf/Portfile
@@ -1,0 +1,46 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/birdayz/kaf 0.1.40 v
+revision            0
+
+description         Modern CLI for Apache Kafka, written in Go
+long_description    {*}${description}
+
+categories          sysutils
+license             Apache-2
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+installs_libs       no
+
+# All dependencies are already vendored into the code's source tree (./vendor)
+# Turn on G111MODULE so that we can build with -mod=vendor
+build.env-delete    GO111MODULE=off
+build.pre_args      -mod=vendor -ldflags \"-w -s\"
+build.args          ./cmd/kaf
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}
+
+checksums          rmd160  10637dee9b6049c5218269e5bef10c7c18186362 \
+                   sha256  6742a0eaa934043669e8921aabc854a6fa09e489b873d67c3568e0735ab1048d \
+                   size    4397595
+
+notes "
+
+To add shell completions for kaf, source the completion script in your shell
+commands file:
+
+Bash
+
+    $ echo 'source <(kaf completion bash)' >> ~/.bashrc
+
+Zsh
+
+    $ echo 'source <(kaf completion zsh)' >> ~/.zshrc
+"


### PR DESCRIPTION
#### Description

New port for the **[kaf](https://github.com/birdayz/kaf)** Go Kafka client.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
