### PR TITLE
keybase: Update to 5.5.2

### DIFF
--- a/security/keybase/Portfile
+++ b/security/keybase/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/keybase/client 2.7.3 v
+go.setup            github.com/keybase/client 5.5.2 v
 name                keybase
 categories          security
 license             BSD
@@ -13,9 +13,9 @@ long_description    ${description}
 
 depends_run         path:bin/gpg:gnupg2
 
-checksums           rmd160  311ed59796fd7f04468521e425c67eda39401c5c \
-                    sha256  8cf1e16862db06a73a39cdd032a3eb367c6716444b80c30af6cc6830c04cd13c \
-                    size    34646709
+checksums           rmd160  0f21d5dfa3f4e4ab0a9f6220aa209a96076effda \
+                    sha256  b502fbdedefc3f85af72c695e66dfb38faf6f8a28f921096263c9023cc454cff \
+                    size    79438696
 
 build.args          -tags production ${go.package}/go/keybase
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Update keybase.io client version to 5.5.2.

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
