### PR TITLE
java-pg: Better workaround for Big Sur JVM detection

### DIFF
--- a/_resources/port1.0/group/java-1.0.tcl
+++ b/_resources/port1.0/group/java-1.0.tcl
@@ -50,6 +50,7 @@ proc find_java_home {} {
 
     global java.version java.fallback
     if { ${java.version} ne "" } {
+        ui_debug "java-portgroup: Trying to find JVM version: ${java.version}"
 
         # If on arm automatically adjust to the *-zulu fallback versions
         # as required, as currently these are the only ones supporting arm.
@@ -80,7 +81,7 @@ proc find_java_home {} {
             set java_version_not_found yes
         } else {
             set home_value $val
-            ui_debug "Discovered JAVA_HOME via /usr/libexec/java_home: $home_value"
+            ui_debug "java-portgroup: Discovered matching JAVA_HOME: $home_value"
         }
     }
 
@@ -141,7 +142,7 @@ proc get_jvm_bigsur { version_requested } {
     set version_requested [regsub {^1\.} $version_requested ""]
     # Sort the JVMs we found on the system descending
     set versions_found [sort_dict [find_jvm_versions]]
-    ui_debug "Big Sur Workaround - Detected JVMs: $versions_found"
+    ui_debug "java-portgroup: Detected JVMs: $versions_found"
     # Match the systems JVMs with the one requested by MacPorts
     # Higher JVM Versions win
     return [match_jvm_version $version_requested $versions_found]

--- a/_resources/port1.0/group/java-1.0.tcl
+++ b/_resources/port1.0/group/java-1.0.tcl
@@ -148,7 +148,9 @@ proc get_jvm_bigsur { version_requested } {
 }
 
 # Find JVM versions by using /usr/libexec/java_home -V (not -v!)
-# Returns a dict of unique(!) major versions [major_version path]
+# Returns a dict with unique major versions as key and the corresponding
+# java_home as value:
+#  dict[major_version]=java_home
 proc find_jvm_versions {} {
     if {[catch {exec /usr/libexec/java_home -V} result options]} {
         # Extract JVM versions and corresponding JAVA_HOMEs
@@ -183,33 +185,51 @@ proc match_jvm_version { version_requested versions_found } {
     }
 }
 
-proc match_equal { version version_list } {
-    foreach vl_item [dict keys $version_list] {
-        if {$version == $vl_item} {
-            set java_home [dict get $version_list $vl_item]
-            return $java_home
+# Returns the value of the first dictionary entry
+# whose key is equal to search_key.
+#
+# @param search_key The key that is to be found in the dictionary
+# @param target_dict The dictionary which should be searched for search_key
+# @return The value of the first entry that matched.
+# Returns an error, if no such entry is found.
+proc match_equal { search_key target_dict } {
+    foreach td_key [dict keys $target_dict] {
+        if {$search_key == $td_key} {
+            set ret_value [dict get $target_dict $td_key]
+            return $ret_value
         }
     }
     return -code error
 }
 
-proc match_less_equal { version version_list } {
-    foreach vl_item [dict keys $version_list] {
-        if {$version <= $vl_item} {
-            set java_home [dict get $version_list $vl_item]
-            return $java_home
+# Returns the value of the first dictionary entry
+# whose key is less or equal to search_key.
+#
+# @param search_key The key that is to be found in the dictionary
+# @param target_dict The dictionary which should be searched for search_key
+# @return The value of the first entry that matched.
+# Returns an error, if no such entry is found.
+proc match_less_equal { search_key target_dict } {
+    foreach td_key [dict keys $target_dict] {
+        if {$search_key <= $td_key} {
+            set ret_value [dict get $target_dict $td_key]
+            return $ret_value
         }
     }
     return -code error
 }
 
+# Sorts a dictionary decreasing by its keys
+#
+# @param The dictionary that is to be sorted decreasing by its keys
+# @return A sorted dictionary
 proc sort_dict { unsorted_dict } {
-    set dkeys [dict keys $unsorted_dict]
-    set dkeys_sorted [lsort -decreasing $dkeys]
+    set keys_unsorted [dict keys $unsorted_dict]
+    set keys_sorted [lsort -decreasing $keys_unsorted]
 
-    foreach place $dkeys_sorted {
-        set jvm_path [dict get $unsorted_dict $place]
-        dict append version_path_dict $place $jvm_path
+    foreach key $keys_sorted {
+        set value [dict get $unsorted_dict $key]
+        dict append sorted_dict $key $value
     }
-    return $version_path_dict
+    return $sorted_dict
 }

--- a/_resources/port1.0/group/java-1.0.tcl
+++ b/_resources/port1.0/group/java-1.0.tcl
@@ -34,19 +34,11 @@ pre-fetch {
         java_set_env
         # If still not present, error out
         if { ${java_version_not_found} } {
-            global os.platform os.major
-            if {${os.platform} eq "darwin" && ${os.major} >= 20} {
-                # The following check is broken on macOS 11 Big Sur so we
-                # temporarily give up on ensuring an exact Java version. See
-                # https://trac.macports.org/ticket/61445
-                ui_warn "Failed to confirm that required Java was installed; see https://trac.macports.org/ticket/61445"
-            } else {
                 ui_error "${name} requires Java ${java.version} but no such installation could be found."
                 return -code error "missing required Java version"
             }
         }
     }
-}
 
 # Search for a good value for JAVA_HOME
 proc find_java_home {} {
@@ -69,39 +61,26 @@ proc find_java_home {} {
             ui_debug "Redefining java fallback ${java.fallback} to ${newjdk} for arm compatibility"
             java.fallback ${newjdk}
         }
-        
-        # /usr/libexec/java_home on Big Sur appears to have a bug where it won't
-        # honor the -f flag if the JAVA_HOME envar is set. See
-        # https://stackoverflow.com/a/64917842/448068
-        #
-        # Temporarily unset and stash the value here.
-        #
-        # Also it seems that wildcard syntax does not work, so we remove them.
+
+        # For macOS >= Big Sur, the JDK discovery was re-implemented because
+        # the previous approach relied on '/usr/libexec/java_home -v' whose
+        # behaviour changed with Big Sur. The new implementation can
+        # handle wildcards on the major version, but not on the minor version:
+        # 1.8+, 9* works, 1.7.35+ won't.
         #
         # See https://trac.macports.org/ticket/61445
         global os.platform os.major
-        set big_sur_workaround [expr {${os.platform} eq "darwin" && ${os.major} == 20}]
-        if {${big_sur_workaround}} {
-            set java.version [string map {+ "" * ""} ${java.version}]
-            if {[info exists ::env(JAVA_HOME)]} {
-                set env_java_home $::env(JAVA_HOME)
-                unset ::env(JAVA_HOME)
-            }
-        }
 
-        if { [catch {set val [exec "/usr/libexec/java_home" "-f" "-v" ${java.version}]}] } {
+        set big_sur_workaround [expr {${os.platform} eq "darwin" && ${os.major} >= 20}]
+        if { ${big_sur_workaround} && [catch {set val [get_jvm_bigsur ${java.version}] } ]
+        || !${big_sur_workaround} && [catch {set val [exec "/usr/libexec/java_home" "-f" "-v" ${java.version}] } ] } {
             # Don't return an error because that would prevent the port from
             # even being indexed when the required Java is missing. Instead, set
             # a flag to be checked at pre-fetch.
             set java_version_not_found yes
         } else {
             set home_value $val
-            ui_debug "Discovered JAVA_HOME via /usr/libexec/java_home -f -v: $home_value"
-        }
-
-        # Restore original JAVA_HOME value stashed above
-        if {${big_sur_workaround} && [info exists env_java_home]} {
-            set ::env(JAVA_HOME) ${env_java_home}
+            ui_debug "Discovered JAVA_HOME via /usr/libexec/java_home: $home_value"
         }
     }
 
@@ -154,4 +133,83 @@ proc java_set_env {} {
     destroot.env-append    JAVA_HOME=${java_home}
     java.home ${java_home}
 }
+
 port::register_callback java_set_env
+
+proc get_jvm_bigsur { version_requested } {
+    # Normalize version numbers 1.x -> x
+    set version_requested [regsub {^1\.} $version_requested ""]
+    # Sort the JVMs we found on the system descending
+    set versions_found [sort_dict [find_jvm_versions]]
+    ui_debug "Big Sur Workaround - Detected JVMs: $versions_found"
+    # Match the systems JVMs with the one requested by MacPorts
+    # Higher JVM Versions win
+    return [match_jvm_version $version_requested $versions_found]
+}
+
+# Find JVM versions by using /usr/libexec/java_home -V (not -v!)
+# Returns a dict of unique(!) major versions [major_version path]
+proc find_jvm_versions {} {
+    if {[catch {exec /usr/libexec/java_home -V} result options]} {
+        # Extract JVM versions and corresponding JAVA_HOMEs
+        set vm_versions [regexp -all -inline -- { +(\d+(?:\.\d+)+)[^/]+(\/[^\0\n]+)} $result]
+        # %3=0 -> Regex match, ignored.
+        # %3=1 -> Version
+        # %3=2 -> JAVA_HOME.
+        for {set idx 0} {$idx < [llength $vm_versions]} {incr idx 3} {
+            set vers [lindex $vm_versions $idx+1]
+            # Normalize version 1.x -> x
+            set vers [regsub {^1\.} $vers ""]
+            # Extract major version
+            set vers [regsub {(\.\d+)+} $vers ""]
+            set path [lindex $vm_versions $idx+2]
+            dict append version_path_dict $vers $path
+        }
+    } else {
+        set details [dict get $options -errorcode]
+        ui_debug "Error executing /usr/libexec/java_home -V"
+    }
+    set version_path_dict
+}
+
+# Match a normalized major version string like 7, 8*, 9+
+proc match_jvm_version { version_requested versions_found } {
+    if {[string first "+" $version_requested] != -1} {
+        set version_requested [regsub {\+} $version_requested ""]
+        match_less_equal $version_requested $versions_found
+    } else {
+        set version_requested [regsub {\*} $version_requested ""]
+        match_equal $version_requested $versions_found
+    }
+}
+
+proc match_equal { version version_list } {
+    foreach vl_item [dict keys $version_list] {
+        if {$version == $vl_item} {
+            set java_home [dict get $version_list $vl_item]
+            return $java_home
+        }
+    }
+    return -code error
+}
+
+proc match_less_equal { version version_list } {
+    foreach vl_item [dict keys $version_list] {
+        if {$version <= $vl_item} {
+            set java_home [dict get $version_list $vl_item]
+            return $java_home
+        }
+    }
+    return -code error
+}
+
+proc sort_dict { unsorted_dict } {
+    set dkeys [dict keys $unsorted_dict]
+    set dkeys_sorted [lsort -decreasing $dkeys]
+
+    foreach place $dkeys_sorted {
+        set jvm_path [dict get $unsorted_dict $place]
+        dict append version_path_dict $place $jvm_path
+    }
+    return $version_path_dict
+}

--- a/_resources/port1.0/group/java-1.0.tcl
+++ b/_resources/port1.0/group/java-1.0.tcl
@@ -31,206 +31,208 @@ set java_version_not_found no
 pre-fetch {
     if { ${java_version_not_found} } {
         # Check again, incase java became available, .e.g openjdk installed as a dependency
-        java_set_env
+        java::java_set_env
         # If still not present, error out
         if { ${java_version_not_found} } {
-                ui_error "${name} requires Java ${java.version} but no such installation could be found."
-                return -code error "missing required Java version"
-            }
+            ui_error "${name} requires Java ${java.version} but no such installation could be found."
+            return -code error "missing required Java version"
         }
     }
+}
 
-# Search for a good value for JAVA_HOME
-proc find_java_home {} {
-    set home_value ""
+port::register_callback java::java_set_env
 
-    # Default setting to found, until proved otherwise below
-    global java_version_not_found
-    set java_version_not_found no
+namespace eval java {
+    # Search for a good value for JAVA_HOME
+    proc find_java_home {} {
+        set home_value ""
 
-    global java.version java.fallback
-    if { ${java.version} ne "" } {
-        ui_debug "java-portgroup: Trying to find JVM version: ${java.version}"
+        # Default setting to found, until proved otherwise below
+        global java_version_not_found
+        set java_version_not_found no
 
-        # If on arm automatically adjust to the *-zulu fallback versions
-        # as required, as currently these are the only ones supporting arm.
-        # To be reviewed as support for arm comes for the other versions.
-        # Following regex matches openjdk<version> only.
-        if { [option configure.build_arch] eq "arm64" &&
-             [regexp {openjdk(\d{1,2}$)} ${java.fallback}] } {
-            set newjdk ${java.fallback}-zulu
-            ui_debug "Redefining java fallback ${java.fallback} to ${newjdk} for arm compatibility"
-            java.fallback ${newjdk}
+        global java.version java.fallback
+        if { ${java.version} ne "" } {
+            ui_debug "java-portgroup: Trying to find JVM version: ${java.version}"
+
+            # If on arm automatically adjust to the *-zulu fallback versions
+            # as required, as currently these are the only ones supporting arm.
+            # To be reviewed as support for arm comes for the other versions.
+            # Following regex matches openjdk<version> only.
+            if { [option configure.build_arch] eq "arm64" &&
+                 [regexp {openjdk(\d{1,2}$)} ${java.fallback}] } {
+                set newjdk ${java.fallback}-zulu
+                ui_debug "Redefining java fallback ${java.fallback} to ${newjdk} for arm compatibility"
+                java.fallback ${newjdk}
+            }
+
+            # For macOS >= Big Sur, the JDK discovery was re-implemented because
+            # the previous approach relied on '/usr/libexec/java_home -v' whose
+            # behaviour changed with Big Sur. The new implementation can
+            # handle wildcards on the major version, but not on the minor version:
+            # 1.8+, 9* works, 1.7.35+ won't.
+            #
+            # See https://trac.macports.org/ticket/61445
+            global os.platform os.major
+
+            set big_sur_workaround [expr {${os.platform} eq "darwin" && ${os.major} >= 20}]
+            if { ${big_sur_workaround} && [catch {set val [get_jvm_bigsur ${java.version}] } ]
+            || !${big_sur_workaround} && [catch {set val [exec "/usr/libexec/java_home" "-f" "-v" ${java.version}] } ] } {
+                # Don't return an error because that would prevent the port from
+                # even being indexed when the required Java is missing. Instead, set
+                # a flag to be checked at pre-fetch.
+                set java_version_not_found yes
+            } else {
+                set home_value $val
+                ui_debug "java-portgroup: Discovered matching JAVA_HOME: $home_value"
+            }
         }
 
-        # For macOS >= Big Sur, the JDK discovery was re-implemented because
-        # the previous approach relied on '/usr/libexec/java_home -v' whose
-        # behaviour changed with Big Sur. The new implementation can
-        # handle wildcards on the major version, but not on the minor version:
-        # 1.8+, 9* works, 1.7.35+ won't.
-        #
-        # See https://trac.macports.org/ticket/61445
-        global os.platform os.major
+        # Default to any valid value that made it through the environment
+        if { ![file isdirectory $home_value] && \
+                 [info exists ::env(JAVA_HOME)] } {
+            set val $::env(JAVA_HOME)
+            if { [file isdirectory $val] } {
+                set home_value $val
+                ui_debug "Discovered JAVA_HOME via env: $home_value"
+            }
+        }
 
-        set big_sur_workaround [expr {${os.platform} eq "darwin" && ${os.major} >= 20}]
-        if { ${big_sur_workaround} && [catch {set val [get_jvm_bigsur ${java.version}] } ]
-        || !${big_sur_workaround} && [catch {set val [exec "/usr/libexec/java_home" "-f" "-v" ${java.version}] } ] } {
-            # Don't return an error because that would prevent the port from
-            # even being indexed when the required Java is missing. Instead, set
-            # a flag to be checked at pre-fetch.
-            set java_version_not_found yes
+        # First, ask the system where java home is
+        if { ![file isdirectory $home_value] && ![catch {set val [exec "/usr/libexec/java_home"]}] } {
+            set home_value $val
+            ui_debug "Discovered JAVA_HOME via /usr/libexec/java_home: $home_value"
+        }
+
+        # Fall back to more conventional way to find java home
+        if { ![file isdirectory $home_value] } {
+            foreach loc { "/System/Library/Frameworks/JavaVM.framework/Home" } {
+                if { [file isdirectory $loc] } {
+                    set home_value $loc
+                    ui_debug "Discovered JAVA_HOME via search path: $home_value"
+                    break
+                }
+            }
+        }
+
+        # Warn user if we couldn't find a likely JAVA_HOME
+        if { ![file isdirectory $home_value]} {
+            ui_debug "No value for java JAVA_HOME was automatically discovered"
+        }
+
+        # Add dependency if required
+        if { ${java_version_not_found} && ${java.fallback} ne "" } {
+            ui_debug "Adding dependency on JDK fallback ${java.fallback}"
+            depends_lib-append port:${java.fallback}
+        }
+
+        return $home_value
+    }
+
+    proc java_set_env {} {
+        # Set the best value we can find for JAVA_HOME
+        set java_home [find_java_home]
+        configure.env-append   JAVA_HOME=${java_home}
+        build.env-append       JAVA_HOME=${java_home}
+        destroot.env-append    JAVA_HOME=${java_home}
+        java.home ${java_home}
+    }
+
+    proc get_jvm_bigsur { version_requested } {
+        # Normalize version numbers 1.x -> x
+        set version_requested [regsub {^1\.} $version_requested ""]
+        # Sort the JVMs we found on the system descending
+        set versions_found [sort_dict [find_jvm_versions]]
+        ui_debug "java-portgroup: Detected JVMs: $versions_found"
+        # Match the systems JVMs with the one requested by MacPorts
+        # Higher JVM Versions win
+        return [match_jvm_version $version_requested $versions_found]
+    }
+
+    # Find JVM versions by using /usr/libexec/java_home -V (not -v!)
+    # Returns a dict with unique major versions as key and the corresponding
+    # java_home as value:
+    #  dict[major_version]=java_home
+    proc find_jvm_versions {} {
+        if {[catch {exec /usr/libexec/java_home -V} result options]} {
+            # Extract JVM versions and corresponding JAVA_HOMEs
+            set vm_versions [regexp -all -inline -- { +(\d+(?:\.\d+)+)[^/]+(\/[^\0\n]+)} $result]
+            # %3=0 -> Regex match, ignored.
+            # %3=1 -> Version
+            # %3=2 -> JAVA_HOME.
+            for {set idx 0} {$idx < [llength $vm_versions]} {incr idx 3} {
+                set vers [lindex $vm_versions $idx+1]
+                # Normalize version 1.x -> x
+                set vers [regsub {^1\.} $vers ""]
+                # Extract major version
+                set vers [regsub {(\.\d+)+} $vers ""]
+                set path [lindex $vm_versions $idx+2]
+                dict append version_path_dict $vers $path
+            }
         } else {
-            set home_value $val
-            ui_debug "java-portgroup: Discovered matching JAVA_HOME: $home_value"
+            set details [dict get $options -errorcode]
+            ui_debug "Error executing /usr/libexec/java_home -V"
+        }
+        set version_path_dict
+    }
+
+    # Match a normalized major version string like 7, 8*, 9+
+    proc match_jvm_version { version_requested versions_found } {
+        if {[string first "+" $version_requested] != -1} {
+            set version_requested [regsub {\+} $version_requested ""]
+            match_less_equal $version_requested $versions_found
+        } else {
+            set version_requested [regsub {\*} $version_requested ""]
+            match_equal $version_requested $versions_found
         }
     }
 
-    # Default to any valid value that made it through the environment
-    if { ![file isdirectory $home_value] && \
-             [info exists ::env(JAVA_HOME)] } {
-        set val $::env(JAVA_HOME)
-        if { [file isdirectory $val] } {
-            set home_value $val
-            ui_debug "Discovered JAVA_HOME via env: $home_value"
-        }
-    }
-
-    # First, ask the system where java home is
-    if { ![file isdirectory $home_value] && ![catch {set val [exec "/usr/libexec/java_home"]}] } {
-        set home_value $val
-        ui_debug "Discovered JAVA_HOME via /usr/libexec/java_home: $home_value"
-    }
-
-    # Fall back to more conventional way to find java home
-    if { ![file isdirectory $home_value] } {
-        foreach loc { "/System/Library/Frameworks/JavaVM.framework/Home" } {
-            if { [file isdirectory $loc] } {
-                set home_value $loc
-                ui_debug "Discovered JAVA_HOME via search path: $home_value"
-                break
+    # Returns the value of the first dictionary entry
+    # whose key is equal to search_key.
+    #
+    # @param search_key The key that is to be found in the dictionary
+    # @param target_dict The dictionary which should be searched for search_key
+    # @return The value of the first entry that matched.
+    # Returns an error, if no such entry is found.
+    proc match_equal { search_key target_dict } {
+        foreach td_key [dict keys $target_dict] {
+            if {$search_key == $td_key} {
+                set ret_value [dict get $target_dict $td_key]
+                return $ret_value
             }
         }
+        return -code error
     }
 
-    # Warn user if we couldn't find a likely JAVA_HOME
-    if { ![file isdirectory $home_value]} {
-        ui_debug "No value for java JAVA_HOME was automatically discovered"
-    }
-
-    # Add dependency if required
-    if { ${java_version_not_found} && ${java.fallback} ne "" } {
-        ui_debug "Adding dependency on JDK fallback ${java.fallback}"
-        depends_lib-append port:${java.fallback}
-    }
-
-    return $home_value
-}
-
-proc java_set_env {} {
-    # Set the best value we can find for JAVA_HOME
-    set java_home [find_java_home]
-    configure.env-append   JAVA_HOME=${java_home}
-    build.env-append       JAVA_HOME=${java_home}
-    destroot.env-append    JAVA_HOME=${java_home}
-    java.home ${java_home}
-}
-
-port::register_callback java_set_env
-
-proc get_jvm_bigsur { version_requested } {
-    # Normalize version numbers 1.x -> x
-    set version_requested [regsub {^1\.} $version_requested ""]
-    # Sort the JVMs we found on the system descending
-    set versions_found [sort_dict [find_jvm_versions]]
-    ui_debug "java-portgroup: Detected JVMs: $versions_found"
-    # Match the systems JVMs with the one requested by MacPorts
-    # Higher JVM Versions win
-    return [match_jvm_version $version_requested $versions_found]
-}
-
-# Find JVM versions by using /usr/libexec/java_home -V (not -v!)
-# Returns a dict with unique major versions as key and the corresponding
-# java_home as value:
-#  dict[major_version]=java_home
-proc find_jvm_versions {} {
-    if {[catch {exec /usr/libexec/java_home -V} result options]} {
-        # Extract JVM versions and corresponding JAVA_HOMEs
-        set vm_versions [regexp -all -inline -- { +(\d+(?:\.\d+)+)[^/]+(\/[^\0\n]+)} $result]
-        # %3=0 -> Regex match, ignored.
-        # %3=1 -> Version
-        # %3=2 -> JAVA_HOME.
-        for {set idx 0} {$idx < [llength $vm_versions]} {incr idx 3} {
-            set vers [lindex $vm_versions $idx+1]
-            # Normalize version 1.x -> x
-            set vers [regsub {^1\.} $vers ""]
-            # Extract major version
-            set vers [regsub {(\.\d+)+} $vers ""]
-            set path [lindex $vm_versions $idx+2]
-            dict append version_path_dict $vers $path
+    # Returns the value of the first dictionary entry
+    # whose key is less or equal to search_key.
+    #
+    # @param search_key The key that is to be found in the dictionary
+    # @param target_dict The dictionary which should be searched for search_key
+    # @return The value of the first entry that matched.
+    # Returns an error, if no such entry is found.
+    proc match_less_equal { search_key target_dict } {
+        foreach td_key [dict keys $target_dict] {
+            if {$search_key <= $td_key} {
+                set ret_value [dict get $target_dict $td_key]
+                return $ret_value
+            }
         }
-    } else {
-        set details [dict get $options -errorcode]
-        ui_debug "Error executing /usr/libexec/java_home -V"
+        return -code error
     }
-    set version_path_dict
-}
 
-# Match a normalized major version string like 7, 8*, 9+
-proc match_jvm_version { version_requested versions_found } {
-    if {[string first "+" $version_requested] != -1} {
-        set version_requested [regsub {\+} $version_requested ""]
-        match_less_equal $version_requested $versions_found
-    } else {
-        set version_requested [regsub {\*} $version_requested ""]
-        match_equal $version_requested $versions_found
-    }
-}
+    # Sorts a dictionary decreasing by its keys
+    #
+    # @param The dictionary that is to be sorted decreasing by its keys
+    # @return A sorted dictionary
+    proc sort_dict { unsorted_dict } {
+        set keys_unsorted [dict keys $unsorted_dict]
+        set keys_sorted [lsort -decreasing $keys_unsorted]
 
-# Returns the value of the first dictionary entry
-# whose key is equal to search_key.
-#
-# @param search_key The key that is to be found in the dictionary
-# @param target_dict The dictionary which should be searched for search_key
-# @return The value of the first entry that matched.
-# Returns an error, if no such entry is found.
-proc match_equal { search_key target_dict } {
-    foreach td_key [dict keys $target_dict] {
-        if {$search_key == $td_key} {
-            set ret_value [dict get $target_dict $td_key]
-            return $ret_value
+        foreach key $keys_sorted {
+            set value [dict get $unsorted_dict $key]
+            dict append sorted_dict $key $value
         }
+        return $sorted_dict
     }
-    return -code error
-}
-
-# Returns the value of the first dictionary entry
-# whose key is less or equal to search_key.
-#
-# @param search_key The key that is to be found in the dictionary
-# @param target_dict The dictionary which should be searched for search_key
-# @return The value of the first entry that matched.
-# Returns an error, if no such entry is found.
-proc match_less_equal { search_key target_dict } {
-    foreach td_key [dict keys $target_dict] {
-        if {$search_key <= $td_key} {
-            set ret_value [dict get $target_dict $td_key]
-            return $ret_value
-        }
-    }
-    return -code error
-}
-
-# Sorts a dictionary decreasing by its keys
-#
-# @param The dictionary that is to be sorted decreasing by its keys
-# @return A sorted dictionary
-proc sort_dict { unsorted_dict } {
-    set keys_unsorted [dict keys $unsorted_dict]
-    set keys_sorted [lsort -decreasing $keys_unsorted]
-
-    foreach key $keys_sorted {
-        set value [dict get $unsorted_dict $key]
-        dict append sorted_dict $key $value
-    }
-    return $sorted_dict
 }


### PR DESCRIPTION
#### Description
This fixes the java version detection of the java port group on Big Sur. 
https://trac.macports.org/ticket/61445

#### Details
Instead of using `/usr/libexec/java_home -f -v` this piece of code uses `/usr/libexec/java_home -V`and does the parsing of existing JVMs and the matching with `${java.version} `on its own. The code only compares major versions (1.**7**, 1.**8**, **9**, **15**). Asterisk and plus notation is support, but only attached to the major version. 1.8+, 9* will work, 1.7.35+ won't.

If the plus suffix is used and more than one candidate is a match, the highest JVM version wins. If there are multiple JVMs with the same major version, it just picks any one of those.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3.0.0.1.1607026830

I tested the changes with following outputs from `/usr/libexec/java_home -V`
```
Matching Java Virtual Machines (2):
    15.0.1 (x86_64) "AdoptOpenJDK" - "OpenJDK 15.0.1" /Library/Java/JavaVirtualMachines/openjdk15/Contents/Home
    15 (x86_64) "Azul Systems, Inc." - "Zulu 15.27.17" /Library/Java/JavaVirtualMachines/zulu-15.jdk/Contents/Home
/Library/Java/JavaVirtualMachines/zulu-15.jdk/Contents/Home

Matching Java Virtual Machines (2):
    13.0.1, x86_64:    "Java SE 13.0.1"    /Library/Java/JavaVirtualMachines/jdk-13.0.1.jdk/Contents/Home
    1.8.0_231, x86_64:    "Java SE 8"    /Library/Java/JavaVirtualMachines/jdk1.8.0_231.jdk/Contents/Home
/Library/Java/JavaVirtualMachines/jdk-13.0.1.jdk/Contents/Home

Matching Java Virtual Machines (3):
    1.7.0_05, x86_64:	"Java SE 7"	/Library/Java/JavaVirtualMachines/1.7.0.jdk/Contents/Home
    1.6.0_41-b02-445, x86_64:	"Java SE 6"	/System/Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home
    1.6.0_41-b02-445, i386:	"Java SE 6"	/System/Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
