### PR TITLE
cdparanoia: Fix compilation problems on macOS 11

### DIFF
--- a/audio/cdparanoia/Portfile
+++ b/audio/cdparanoia/Portfile
@@ -5,7 +5,7 @@ PortSystem 1.0
 name			cdparanoia
 epoch			20050508
 version			10.2
-revision                1
+revision                2
 categories		audio
 maintainers		{jeremyhu @jeremyhu} openmaintainer
 license			GPL-2+ LGPL-2.1+
@@ -42,7 +42,10 @@ checksums           md5     b304bbe8ab63373924a744eac9ebc652 \
                     sha1    1901e20d3a370ca6afa4c76a9ef30d3f03044320 \
                     rmd160  d6c4ea9cc4aa4d5bcca4985e668ea6142d53cc55
 
-patchfiles	    osx_interface.patch
+patchfiles	    osx_interface.patch \
+                fixing-include.patch \
+                fixing-labs.patch \
+                fixing-fprintf.patch
 patch.args -p1
 
 use_autoconf	yes

--- a/audio/cdparanoia/files/fixing-fprintf.patch
+++ b/audio/cdparanoia/files/fixing-fprintf.patch
@@ -1,0 +1,16 @@
+diff -ur cdparanoia-III-10.2/main.c cdparanoia-III-10.2/main.c
+--- cdparanoia-III-10.2/main.c	2021-01-04 20:15:32.000000000 +0800
++++ cdparanoia-III-10.2/main.c	2021-01-04 20:14:09.000000000 +0800
+@@ -588,10 +588,10 @@
+ 	    buffer[aheadposition+19]='>';
+ 	}
+    
+-	fprintf(stderr,buffer);
++	fprintf(stderr,"%s",buffer);
+        
+ 	if (logfile != NULL && function==-1) {
+-	  fprintf(logfile,buffer+1);
++	  fprintf(logfile,"%s",buffer+1);
+ 	  fprintf(logfile,"\n\n");
+ 	  fflush(logfile);
+ 	}

--- a/audio/cdparanoia/files/fixing-include.patch
+++ b/audio/cdparanoia/files/fixing-include.patch
@@ -1,0 +1,22 @@
+diff -ur cdparanoia-III-10.2/interface/common_interface.c cdparanoia-III-10.2/interface/common_interface.c
+--- cdparanoia-III-10.2/interface/common_interface.c	2021-01-04 20:15:31.000000000 +0800
++++ cdparanoia-III-10.2/interface/common_interface.c	2021-01-04 20:06:17.000000000 +0800
+@@ -19,6 +19,7 @@
+ #ifdef __APPLE__
+ #include "cdda_interface.h"
+ #include "utils.h"
++#include "smallft.h"
+ #else
+ #include "low_interface.h"
+ #include <linux/hdreg.h>
+diff -ur cdparanoia-III-10.2/interface/interface.c cdparanoia-III-10.2/interface/interface.c
+--- cdparanoia-III-10.2/interface/interface.c	2021-01-04 20:15:31.000000000 +0800
++++ cdparanoia-III-10.2/interface/interface.c	2021-01-04 20:09:46.000000000 +0800
+@@ -13,6 +13,7 @@
+ #include "low_interface.h"
+ #endif
+ #include "common_interface.h"
++#include "osx_interface.h"
+ #include "utils.h"
+ #include "../version.h"
+ 

--- a/audio/cdparanoia/files/fixing-labs.patch
+++ b/audio/cdparanoia/files/fixing-labs.patch
@@ -1,0 +1,21 @@
+diff -ur cdparanoia-III-10.2/paranoia/overlap.c cdparanoia-III-10.2/paranoia/overlap.c
+--- cdparanoia-III-10.2/paranoia/overlap.c	2008-08-07 02:27:41.000000000 +0800
++++ cdparanoia-III-10.2/paranoia/overlap.c	2021-01-04 20:12:11.000000000 +0800
+@@ -107,7 +107,7 @@
+        sector, frob it.  We just want a little hysteresis [sp?]*/
+     long av=(p->stage2.offpoints?p->stage2.offaccum/p->stage2.offpoints:0);
+     
+-    if(abs(av)>p->dynoverlap/4){
++    if(labs(av)>p->dynoverlap/4){
+       av=(av/MIN_SECTOR_EPSILON)*MIN_SECTOR_EPSILON;
+       
+       if(callback)(*callback)(ce(p->root.vector),PARANOIA_CB_DRIFT);
+@@ -207,7 +207,7 @@
+   if(o->offpoints!=-1){
+ 
+     /* Track the average magnitude of jitter (in either direction) */
+-    o->offdiff+=abs(value);
++    o->offdiff+=labs(value);
+     o->offpoints++;
+     o->newpoints++;
+ 


### PR DESCRIPTION
#### Description

Fix compiling problem for cdparanoia on macOS 11
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1
Xcode 12.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
