### PR TITLE
BlackHole: Add compiler blacklist

### DIFF
--- a/audio/BlackHole/Portfile
+++ b/audio/BlackHole/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           xcode 1.0
 PortGroup           xcode_workaround 1.0
+PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        ExistentialAudio BlackHole 0.2.8 v
 categories          audio
@@ -29,6 +30,8 @@ post-activate {
 # BlackHole violates the mtree layout by placing the driver in
 # /Library/Audio/Plug-Ins/HAL
 destroot.violate_mtree yes
+
+compiler.blacklist-append {clang < 600}
 
 checksums           rmd160  18ab212b098fa535fa24dc9a5b47d57de25919ad \
                     sha256  1e3774d11eec3d1fa471c89de79793eb40b8fc348c2e47ce2751bf0503665387 \


### PR DESCRIPTION
#### Description

This PR adds a compiler blacklist directive. From the BlackHole [README](https://github.com/ExistentialAudio/BlackHole/blob/master/README.md), they support macOS versions from 10.9 to 11.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
