### PR TITLE
phpmyadmin: Add php80 variant and make default

### DIFF
--- a/www/phpmyadmin/Portfile
+++ b/www/phpmyadmin/Portfile
@@ -32,7 +32,7 @@ use_xz              yes
 
 # The php variants deliberately do not conflict
 
-foreach php {php71 php72 php73 php74} {
+foreach php {php71 php72 php73 php74 php80} {
     variant ${php} description "Use ${php}" "
         depends_run-append  port:${php}-gd \
                             port:${php}-mbstring \
@@ -42,8 +42,8 @@ foreach php {php71 php72 php73 php74} {
     "
 }
 
-if {![variant_isset php71] && ![variant_isset php72] && ![variant_isset php73] && ![variant_isset php74]} {
-    default_variants +php74
+if {![variant_isset php71] && ![variant_isset php72] && ![variant_isset php73] && ![variant_isset php74] && ![variant_isset php80]} {
+    default_variants +php80
 }
 
 set docroot         ${destroot}${prefix}/www/${name}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
