### PR TITLE
task: update to 2.5.3

### DIFF
--- a/office/task/Portfile
+++ b/office/task/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.0
 
-github.setup        GothenburgBitFactory taskwarrior 2.5.2 v
+github.setup        GothenburgBitFactory taskwarrior 2.5.3 v
 github.tarball_from releases
 name                task
 maintainers         nomaintainer
@@ -22,9 +22,9 @@ license             MIT
 homepage            https://taskwarrior.org/
 
 distname            task-${github.version}
-checksums           rmd160  6b8fc81545fbbf208c00774437efb8fd8c1a0210\
-                    sha256  63fe45caf2b9bd4a6f00bb817d61500c19eedc762d12b30fd074274a66a2ee46\
-                    size    790210
+checksums           rmd160  d59dcb1644dccafb0ff35c5ea3e704e88b5d9f71\
+                    sha256  7243d75e0911d9e2c9119ad94a61a87f041e4053e197f7280c42410aa1ee963b\
+                    size    788760
 
 depends_lib         port:gnutls
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance
macOS 10.15.7 19H2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
