### PR TITLE
emacs{,-app}-devel: update to 20210105

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -103,11 +103,11 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
     legacysupport.newest_darwin_requires_legacy 13
 
     epoch           2
-    version         20201204
+    version         20210105
 
     fetch.type      git
     git.url         --depth=1000 https://github.com/emacs-mirror/emacs.git
-    git.branch      81fe928a769d9a63078aa1144335c204a2541595
+    git.branch      80e26472206cc44837521ba594cd50e724d9af5c
 
     pre-configure {
         system -W ${worksrcpath} "sh ./autogen.sh"
@@ -117,7 +117,7 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
 
     variant nativecomp description {Builds emacs with native compilation support} {
         git.url-prepend  --branch feature/native-comp
-        git.branch       981240078cddbd26b35a65e5311350196542b42b
+        git.branch       8ad983c4acef60a80e8d6b6ba891b1ef957f2d7c
 
         depends_build-append     port:coreutils
         depends_lib-append       port:gcc10


### PR DESCRIPTION
Interesting developments:

- [Improved macOS graphic performance](https://lists.gnu.org/archive/html/emacs-devel/2020-12/msg01806.html) (emacs-app-devel only)
- [gccemacs update 13](https://akrl.sdf.org/gccemacs.html#org335c0de) (+nativecomp only)

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->