### PR TITLE
fpc: Update to fix build on 11.x

### DIFF
--- a/lang/fpc/Portfile
+++ b/lang/fpc/Portfile
@@ -7,7 +7,7 @@ version             3.2.0
 categories          lang
 platforms           darwin
 license             GPL-2 LGPL-2
-maintainers         nomaintainer
+maintainers         {@kamischi web.de:karl-michael.schindler} openmaintainer
 description         Free Pascal, an open source Pascal and Object Pascal compiler.
 long_description    Free Pascal is a 32, 64 and 16 bit professional Pascal compiler. \
                     It can target many processor architectures: Intel x86 (including 8086), \
@@ -145,6 +145,7 @@ if {${subport} eq "${name}"} {
     worksrcdir          ${name}build-${version}/fpcsrc
     build.env           PP=${workpath}/${b} \
                         PREFIX=${destroot}${fpcbasepath}
+    build.args          OPT="-ap -v0 -XR/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
     build.target        all
 
     destroot.env        {*}${build.env}
@@ -152,8 +153,10 @@ if {${subport} eq "${name}"} {
     # build the compiler utilities msgdif and msg2inc
     post-build {
         system -W ${worksrcpath}/compiler/utils \
-               "../ppcx64 -WM10.9 -Fu../../rtl/units/${build_arch}-darwin msgdif.pp && \
-                ../ppcx64 -WM10.9 -Fu../../rtl/units/${build_arch}-darwin msg2inc.pp"
+               "../ppcx64 -WM10.9 -Fu../../rtl/units/${build_arch}-darwin -ap -v0 \
+                  -XR/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk msgdif.pp && \
+                ../ppcx64 -WM10.9 -Fu../../rtl/units/${build_arch}-darwin -ap -v0 \
+                  -XR/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk msg2inc.pp"
     }
 
     post-destroot {


### PR DESCRIPTION
#### Description

On 11.x, the path /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk needs to be added to prevent the error: ld: library not found for -lc

###### Type(s)

- [x] bugfix
- [x] enhancement

###### Tested on

macOS 11.1
Xcode 12.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? https://trac.macports.org/ticket/61621
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
