### PR TITLE
net/nss: Import patch from pkgsrc to fix building on Apple Silicon

### DIFF
--- a/net/nss/Portfile
+++ b/net/nss/Portfile
@@ -43,6 +43,8 @@ depends_lib     port:nspr \
                 port:zlib \
                 port:sqlite3
 
+patchfiles      patch-nss_coreconf_Darwin.mk
+
 destroot.dir ${destroot.dir}/dist
 build.dir    ${build.dir}/nss
 

--- a/net/nss/files/patch-nss_coreconf_Darwin.mk
+++ b/net/nss/files/patch-nss_coreconf_Darwin.mk
@@ -1,0 +1,27 @@
+$NetBSD: patch-nss_coreconf_Darwin.mk $
+
+use uname -m (arm64), not uname -p (arm), convert arm64 to aarch64
+
+--- nss/coreconf/Darwin.mk.orig	2020-12-11 16:32:40.000000000 +0100
++++ nss/coreconf/Darwin.mk	2020-12-29 19:40:02.000000000 +0100
+@@ -15,7 +15,7 @@
+ ifndef CPU_ARCH
+ # When cross-compiling, CPU_ARCH should already be defined as the target
+ # architecture, set to powerpc or i386.
+-CPU_ARCH	:= $(shell uname -p)
++CPU_ARCH	:= $(shell uname -m)
+ endif
+ 
+ ifeq (,$(filter-out i%86,$(CPU_ARCH)))
+@@ -30,8 +30,9 @@
+ override CPU_ARCH	= x86
+ endif
+ else
+-ifeq (arm,$(CPU_ARCH))
+-# Nothing set for arm currently.
++ifeq (arm64,$(CPU_ARCH))
++override CPU_ARCH	= aarch64
++# Nothing else set for arm64/aarch64 currently.
+ else
+ OS_REL_CFLAGS	= -Dppc
+ CC              += -arch ppc


### PR DESCRIPTION
#### Description

Fixes build on aarch64 / Apple Silicon

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
