### PR TITLE
zathura: install manual pages

### DIFF
--- a/office/zathura/Portfile
+++ b/office/zathura/Portfile
@@ -54,6 +54,29 @@ For handling additional file types, consider installing the various
 zathura-plugin-* ports (port search zathura-plugin).
 "
 
+subport ${name}-docs {
+    set python.version 39
+    set python.dot_version "[string index ${python.version} 0].[string range ${python.version} 1 end]"
+
+    post-patch {
+        reinplace "s|sphinx-build|${prefix}/Library/Frameworks/Python.framework/Versions/${python.dot_version}/bin/sphinx-build|g" ${worksrcpath}/doc/meson.build
+    }
+
+    depends_build-append \
+                        port:py${python.version}-sphinx
+
+    depends_run-append  port:${name}
+
+    build.target        doc/zathura.1 doc/zathurarc.5
+
+    destroot {
+        xinstall -m 640 ${build_dir}/doc/zathura.1   ${destroot}${prefix}/share/man/man1
+        xinstall -m 640 ${build_dir}/doc/zathurarc.5 ${destroot}${prefix}/share/man/man5
+    }
+
+    unset notes
+}
+
 livecheck.type      regex
 livecheck.url       ${homepage}/tags
 livecheck.regex     [quotemeta ${name}]-(\\d\\.\\d\\.\\d)[quotemeta ${extract.suffix}]


### PR DESCRIPTION
Requires the addition of several variants to support different versions
of py-sphinx

#### Description

Install man pages

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
