### PR TITLE
argocd: new port

### DIFF
--- a/devel/argocd/Portfile
+++ b/devel/argocd/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/argoproj/argo-cd 1.8.2 v
+name                argocd
+revision            0
+
+homepage            https://argoproj.github.io/argo-cd
+
+description         Declarative continuous deployment for Kubernetes
+
+long_description    Argo CD is a declarative, GitOps continuous delivery tool \
+                    for Kubernetes. Argo CD follows the GitOps pattern of \
+                    using Git repositories as the source of truth for \
+                    defining the desired application state. This port \
+                    installs the Argo CD CLI.
+
+categories          devel sysutils
+license             Apache-2
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  92215699b8ae35175160651083fb31972cf7b21b \
+                    sha256  6065075ea757acdc0660506e77e5e421046b6806134b805c1795c8a32a817367 \
+                    size    11943839
+
+depends_build-append port:packr1
+
+# Allow fetching dependencies at build time
+build.env-delete    GOPROXY=off GO111MODULE=off
+
+build.cmd               make
+build.pre_args-append   GOPATH=${gopath} PACKR_CMD=${prefix}/bin/packr
+build.args-append       cli-local
+
+installs_libs       no
+use_parallel_build  no
+
+post-patch {
+    reinplace {s|build -v -i|build -v|g} ${worksrcpath}/Makefile
+}
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/dist/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

New port for **[Argo CD](https://argoproj.github.io/argo-cd/)**, a GitOps CD tool for Kubernetes.  This port delivers only the CLI.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
