### PR TITLE
dmux: new port

### DIFF
--- a/sysutils/dmux/Portfile
+++ b/sysutils/dmux/Portfile
@@ -1,0 +1,123 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo 1.0
+
+github.setup        zdcthomas dmux 0.6.2 v
+revision            0
+
+description         A tmux workspace manager
+
+long_description    Development tMUX - {*}${description} written in Rust that \
+                    manages tmux sessions, opening them with specified \
+                    commands, layout and more.  Integrates with fzf, and \
+                    optionally fd.
+
+categories          sysutils
+platforms           darwin
+license             MIT
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  c7e3c0f4f7c160c059edfc97b24c80cf060b2665 \
+                    sha256  66bd0bc4c180b7dff6e631e153ffdc188547a916d28977b7a73a3f0db0b7dcec \
+                    size    17710
+
+depends_run-append  port:fzf
+
+installs_libs       no
+
+destroot {
+    xinstall -m 755 \
+        ${worksrcpath}/target/[cargo.rust_platform]/release/${name} \
+        ${destroot}${prefix}/bin/
+}
+
+cargo.crates \
+    aho-corasick                    0.7.10  8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada \
+    ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
+    anyhow                          1.0.32  6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b \
+    arrayref                         0.3.6  a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544 \
+    arrayvec                        0.4.12  cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9 \
+    arrayvec                         0.5.1  cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8 \
+    atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+    autocfg                          1.0.0  f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d \
+    base64                          0.11.0  b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7 \
+    bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
+    blake2b_simd                    0.5.10  d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a \
+    bstr                            0.2.13  31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931 \
+    byteorder                        1.3.4  08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de \
+    cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
+    clap                            2.33.1  bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129 \
+    colored                          2.0.0  b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd \
+    config                          0.10.1  19b076e143e1d9538dde65da30f8481c2a6c44040edb8e02b9bf1351edb92ce3 \
+    constant_time_eq                 0.1.5  245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc \
+    crossbeam-utils                  0.7.2  c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8 \
+    dirs                             2.0.2  13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3 \
+    dirs-sys                         0.3.4  afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b \
+    fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
+    getrandom                       0.1.14  7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb \
+    globset                          0.4.5  7ad1da430bd7281dde2576f44c84cc3f0f7b475e7202cd503042dff01a8c8120 \
+    grep-cli                         0.1.4  ed5e5eb2190c17996aabc6d35abfc3a0c16659a92488261d13ede46748d9ab38 \
+    hermit-abi                       0.1.8  1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8 \
+    idna                             0.2.0  02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9 \
+    itoa                             0.4.5  b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    lexical-core                     0.6.2  d7043aa5c05dd34fb73b47acb8c3708eac428de4545ea3682ed2f11293ebd890 \
+    libc                            0.2.70  3baa92041a6fec78c687fa0cc2b3fae8884f743d672cf551bed1d6dac6988d0f \
+    linked-hash-map                  0.3.0  6d262045c5b87c0861b3f004610afd0e2c851e2908d08b6c870cbb9d5f494ecd \
+    linked-hash-map                  0.5.2  ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83 \
+    log                              0.4.8  14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7 \
+    matches                          0.1.8  7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
+    memchr                           2.3.3  3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400 \
+    nodrop                          0.1.14  72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb \
+    nom                              5.1.1  0b471253da97532da4b61552249c521e01e736071f71c1a4f7ebbfbf0a06aad6 \
+    num-traits                      0.1.43  92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31 \
+    num-traits                      0.2.11  c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096 \
+    percent-encoding                 2.1.0  d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
+    proc-macro2                      1.0.9  6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435 \
+    quote                            1.0.3  2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f \
+    redox_syscall                   0.1.56  2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84 \
+    redox_users                      0.3.4  09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431 \
+    regex                            1.3.7  a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692 \
+    regex-automata                   0.1.9  ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4 \
+    regex-syntax                    0.6.17  7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae \
+    rust-argon2                      0.7.0  2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017 \
+    rust-ini                        0.13.0  3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2 \
+    rustc_version                    0.2.3  138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a \
+    ryu                              1.0.4  ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1 \
+    same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
+    semver                           0.9.0  1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403 \
+    semver-parser                    0.7.0  388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
+    serde                           0.8.23  9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8 \
+    serde                          1.0.106  36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399 \
+    serde-hjson                      0.9.1  6a3a4e0ea8a88553209f6cc6cfe8724ecad22e1acf372793c27d995290fe74f8 \
+    serde_derive                   1.0.106  9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c \
+    serde_json                      1.0.51  da07b57ee2623368351e9a0488bb0b261322a15a6e0ae53e243cbdc0f4208da9 \
+    serde_test                      0.8.23  110b3dbdf8607ec493c22d5d947753282f3bae73c0f56d322af1e8c78e4c23d5 \
+    smallvec                         1.4.0  c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4 \
+    static_assertions                0.3.4  7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3 \
+    strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
+    syn                             1.0.16  123bd9499cfb380418d509322d7a6d52e5315f064fe4b3ad18a53d6b92c07859 \
+    termcolor                        1.1.0  bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f \
+    textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
+    thread_local                     1.0.1  d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14 \
+    tmux_interface                   0.0.6  da8c7dd072ba7aee9fda883fc0a313ed1f2e65e30815667cbc9c7dafe1d63387 \
+    toml                             0.5.6  ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a \
+    unicode-bidi                     0.3.4  49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5 \
+    unicode-normalization           0.1.12  5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4 \
+    unicode-width                    0.1.7  caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479 \
+    unicode-xid                      0.2.0  826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c \
+    url                              2.1.1  829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb \
+    vec_map                          0.8.1  05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a \
+    version_check                    0.9.1  078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce \
+    walkdir                          2.3.1  777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d \
+    wasi      0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
+    winapi                           0.3.8  8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6 \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                      0.1.3  4ccfbf554c6ad11084fb7517daca16cfdcaccbdadba4fc336f032a8b12c2ad80 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    yaml-rust                        0.4.3  65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d


### PR DESCRIPTION
#### Description

New port for **[dmux](https://github.com/zdcthomas/dmux)**, a `tmux` session manager.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->