### PR TITLE
OmegaT: Updated to accept Java 1.8 or later

### DIFF
--- a/aqua/OmegaT/Portfile
+++ b/aqua/OmegaT/Portfile
@@ -6,7 +6,7 @@ PortGroup           java 1.0
 name                OmegaT
 set name_lower      [string tolower ${name}]
 version             4.3.2
-revision            1
+revision            2
 categories          aqua textproc java
 license             GPL-3
 maintainers         {amake @amake} openmaintainer
@@ -22,7 +22,7 @@ platforms           darwin
 supported_archs     noarch
 universal_variant   no
 
-java.version        1.8
+java.version        1.8+
 
 set flavor          Standard
 set version_suff    {}


### PR DESCRIPTION
Failed to build with Java 11, reporting "Error: OmegaT requires Java
1.8 but no such installation could be found."

The `openjdk8` port is marked as obsolete.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7
Xcode 12.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
