### PR TITLE
syncthing: update to 1.12.1

### DIFF
--- a/net/syncthing/Portfile
+++ b/net/syncthing/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/syncthing/syncthing 1.12.0 v
+go.setup            github.com/syncthing/syncthing 1.12.1 v
 categories          net
 platforms           darwin
 license             MPL-2
@@ -18,9 +18,9 @@ long_description    Syncthing replaces proprietary sync and cloud services \
 homepage            https://syncthing.net
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  174051bb18728ed6a47aabd75129ca96b8f6ddad \
-                        sha256  8288a94a8a0ed62d3b7b07607cff7540f30ee9d016db39a658384c6bce6d2385 \
-                        size    5002452
+                        rmd160  a158f05e366e6711d53c91f71557823b6e5b7d8a \
+                        sha256  65c578b90ba5b53193e23274e753a829e20216c7fcb17b6765e691e33c9f5a29 \
+                        size    5033543
 
 go.vendors          gopkg.in/yaml.v3 \
                         lock    9f266ea9e77c \
@@ -224,20 +224,20 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  903a5fd94d31df7ec39c3482926ff69182e0fd9ae5891850d7fb26570eb73f41 \
                         size    1219072 \
                     github.com/marten-seemann/qtls-go1-15 \
-                        lock    v0.1.0 \
-                        rmd160  d14038cf74ece3ff410b88f61a21c818e8b1e8aa \
-                        sha256  20a60b2f7f1f1c75dfcce4c784ed02c92a9a0698695c9be2ca3b9b1b6c4b6667 \
-                        size    413553 \
+                        lock    v0.1.1 \
+                        rmd160  a292bd4cc78e1f395ec65180d3e47e85b6aa55a1 \
+                        sha256  dca45a0ba054751a908de41055d292b0020e9ccbc959b52231b1f8027fe17da1 \
+                        size    413727 \
                     github.com/marten-seemann/qtls \
                         lock    v0.10.0 \
                         rmd160  560c030e5cd2045dc65345b67ce0257ec709ac65 \
                         sha256  9db255f013988eee87447b47a3510b56cfb3e0acb1e4f0af13215b971a82f6b4 \
                         size    403908 \
                     github.com/lucas-clemente/quic-go \
-                        lock    v0.18.1 \
-                        rmd160  fa742ed3bfd5b74e7c8d8b86eb18a1313a9685e3 \
-                        sha256  de1608164707258a25fc9f7293068cb1b6f975b593834e71fa1327ed8d3086e6 \
-                        size    488876 \
+                        lock    v0.19.3 \
+                        rmd160  d34abe8d7dc661b7deaf5e39fbbe88747314d662 \
+                        sha256  2589e82385f612cc4b45ab0bad5ae105d36d823a137245520d71e90009f4f17f \
+                        size    495534 \
                     github.com/lib/pq \
                         lock    v1.8.0 \
                         rmd160  3bdbb0bd8abc244e2a17318be93ca6e9ba11d982 \


### PR DESCRIPTION
#### Description

Updates syncthing to 1.12.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
