### PR TITLE
v2ray: remove execute bit from dat files

### DIFF
--- a/net/v2ray/Portfile
+++ b/net/v2ray/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           golang 1.0
 
 go.setup            github.com/v2fly/v2ray-core 4.34.0 v
+revision            1
 name                v2ray
 categories          net security
 platforms           darwin
@@ -244,8 +245,8 @@ build {
 destroot {
     xinstall -m 755 ${worksrcpath}/main/v2ray ${destroot}${prefix}/bin
     xinstall -m 755 ${worksrcpath}/infra/control/main/v2ctl ${destroot}${prefix}/bin
-    xinstall -m 755 ${worksrcpath}/release/config/geosite.dat ${destroot}${prefix}/bin
-    xinstall -m 755 ${worksrcpath}/release/config/geoip.dat ${destroot}${prefix}/bin
+    xinstall -m 644 ${worksrcpath}/release/config/geosite.dat ${destroot}${prefix}/bin
+    xinstall -m 644 ${worksrcpath}/release/config/geoip.dat ${destroot}${prefix}/bin
     xinstall -d ${destroot}${prefix}/etc/v2ray
     xinstall -m 640 ${worksrcpath}/release/config/config.json ${destroot}${prefix}/etc/v2ray
 }


### PR DESCRIPTION
#### Description
*.dat are not excutable files.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
