### PR TITLE
go-mmv: new port

### DIFF
--- a/sysutils/go-mmv/Portfile
+++ b/sysutils/go-mmv/Portfile
@@ -1,0 +1,60 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/itchyny/mmv 0.1.2 v
+name                go-mmv
+revision            0
+
+description         rename multiple files with editor
+
+long_description    Rename multiple files using your \$EDITOR. The command \
+                    name is named after multi-mv.
+
+conflicts           mmv
+
+categories          sysutils
+license             MIT
+platforms           darwin
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+build.cmd           make
+build.pre_args      CURRENT_REVISION=v${version}
+build.args          build
+
+patch {
+    reinplace {/GO111MODULE/ d} ${worksrcpath}/Makefile
+}
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/mmv ${destroot}${prefix}/bin/
+}
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  25798d8266395eb94208761382d885aea336d850 \
+                        sha256  d9f9764c93e3755fe8fa7e23b87bd00700a79190e5888734d90b4a61a8ad5b2f \
+                        size    7522
+
+go.vendors          golang.org/x/sys \
+                        lock    af09f7315aff \
+                        rmd160  2e2294bcbcefb80f8ad5a51d474a18f08f8ffcdb \
+                        sha256  9ee36a2c435fda5e5b9d80c764d9972d5110a232418ec1f4f0fb9e5307e0cd51 \
+                        size    1063406 \
+                    github.com/mattn/go-tty \
+                        lock    v0.0.3 \
+                        rmd160  a9e55e7400c71fbcee463f9bc0e649763b0c3d80 \
+                        sha256  7654b2a00f82d1828a6045bcc1f6f516e3f41cd3c73c4e38451d55f56672c247 \
+                        size    7799 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.12 \
+                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
+                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
+                        size    4549 \
+                    github.com/mattn/getwild \
+                        lock    c2e221927ad6 \
+                        rmd160  8a1673876afb454ecd9ba9a44f44b9e86e51b492 \
+                        sha256  ee8a3788be7f4e94670c1091c26bb91ef8c48f3fc853d71c80f697aa70feb04b \
+                        size    1540


### PR DESCRIPTION
#### Description

New port for [mmv](https://github.com/itchyny/mmv) (the Go version, since there's already a historic `mmv` port)

<img src="https://user-images.githubusercontent.com/375258/72040421-d4f8cd00-32eb-11ea-828f-d9f14f3261ac.gif" />

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
