### PR TITLE
mame: update for 0.227; update launch script to improve user experience

### DIFF
--- a/emulators/mame/Portfile
+++ b/emulators/mame/Portfile
@@ -14,52 +14,83 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
-github.setup        mamedev mame 0226 mame
-revision            2
-
-version             [string index ${github.version} 0].[string range ${github.version} 1 end]
+name                mame
 categories          emulators
-maintainers         {@mascguy} \
-                    openmaintainer
 platforms           darwin
 license             GPL-2+
-homepage            https://www.mamedev.org
+
+maintainers         {@mascguy} \
+                    openmaintainer
 
 description         Multiple Arcade Machine Emulator
-long_description    The purpose of MAME is to preserve decades of software history. As \
-    electronic technology continues to rush forward, MAME prevents this important \
-    "vintage" software from being lost and forgotten. This is achieved by documenting \
-    the hardware and how it functions. The source code to MAME serves as this \
+long_description    \
+    The purpose of MAME is to preserve decades of software history. As electronic \
+    technology continues to rush forward, MAME prevents this important "vintage" \
+    software from being lost and forgotten. This is achieved by documenting the \
+    hardware and how it functions. The source code to MAME serves as this \
     documentation.
-
-github.tarball_from archive
+homepage            https://www.mamedev.org
 
 #------------------------------------------------------------------------------
-# Patches and Checksums
+# Versions, Patches, and Checksums
 #------------------------------------------------------------------------------
 
-# Patch 'language-portuguese_brazil' applies to release 0.226; fixes
-# errors during translation build phase.
-# Fix submitted, and merged, by Mame maintainers; will be part of Mame
-# releases from 0.227 onward. Tracked by Mame issue:
-# https://github.com/mamedev/mame/issues/7510
-#
-# Patch 'src-posixfile-build-error' applies to release 0.226; fixes
-# compilation errors for MacOS 10.8 and Xcode 5.x.
-# Fix submitted, and merged, by Mame maintainers; will be part of Mame
-# releases from 0.227 onward. Tracked by Mame issue:
-# https://github.com/mamedev/mame/issues/7536
-#
-# Patch 'scripts-genie-compile-warnings' applies to all releases; greatly
-# reduces compilation warnings.
+# Mame versions > 0.226 require C++ 2017, and specifically aligned allocation
+# support. That's only supported by MacOS system libc++ from 10.13 onward.
+# However, once MacPorts provides a custom libc++ for all ports, Mame will
+# support older MacOS releases.
+if {${os.major} >= 17} {
+    set g_mame_latest yes
+} else {
+    set g_mame_latest no
+}
 
-patchfiles          mame-patch-0226-language-portuguese_brazil.diff \
-                    mame-patch-0226-src-posixfile-build-error.diff \
-                    mame-patch-0226-scripts-genie-compile-warnings.diff
+if {${g_mame_latest}} {
+    set g_mame_release \
+                    "0227"
 
-checksums           rmd160  b9e4ae321b7673790d374c63bbe966d1502d6738 \
+    revision        0
+
+    checksums       \
+                    rmd160  862df6a449329fe5b16e6d46a030fe157c3a8eb3 \
+                    sha256  95dbce00a4f05a35f66ef966fe9efad1e4e78ce62e0eba3f7031dfa6737829a5 \
+                    size    195226157
+} else {
+    set g_mame_release \
+                    "0226"
+
+    revision        3
+
+    # Patch 'language-portuguese_brazil' applies to release 0.226; fixes
+    # errors during translation build phase.
+    # Merged into Mame releases from 0.227 onward. Tracked by issue:
+    # https://github.com/mamedev/mame/issues/7510
+    #
+    # Patch 'src-posixfile-build-error' applies to release 0.226; fixes
+    # compilation errors for MacOS 10.8 and Xcode 5.x.
+    # Merged into Mame releases from 0.227 onward. Tracked by issue:
+    # https://github.com/mamedev/mame/issues/7536
+    patchfiles      \
+                    mame-patch-0226-language-portuguese_brazil.diff \
+                    mame-patch-0226-src-posixfile-build-error.diff
+
+    checksums       \
+                    rmd160  b9e4ae321b7673790d374c63bbe966d1502d6738 \
                     sha256  7c4c9ec232ba988e65fd29665c9b8e40b5ac3aa9f561eeb107cebbf08ba94baf \
                     size    196379874
+}
+
+# Note: For user-presentable version string, we add a period between the first
+# two characters of release. So '0227', for example, becomes '0.227'.
+set g_mame_version_string \
+                    [string index ${g_mame_release} 0].[string range ${g_mame_release} 1 end]
+
+github.setup        mamedev mame ${g_mame_release} mame
+github.tarball_from archive
+
+# Note: Version declaration must occur after 'github.setup', as the latter
+# sets our version whether we want it or not.
+version             ${g_mame_version_string}
 
 #------------------------------------------------------------------------------
 # Port-Specific Globals
@@ -170,7 +201,8 @@ use_configure       no
 build.cmd           ${prefix}/bin/gmake
 
 # https://github.com/mamedev/mame/issues/6004
-compiler.blacklist  {clang < 1000}
+compiler.blacklist  \
+                    {clang < 1000}
 
 # https://github.com/mamedev/mame/issues/3788
 # As long as we're blacklisting clangs from the affected Xcode versions,
@@ -179,20 +211,37 @@ compiler.blacklist  {clang < 1000}
 #    configure.cxxflags-append -DMAME_DEVCB_GNUC_BROKEN_FRIEND
 #}
 
-compiler.cxx_standard   2014
+if {${g_mame_latest}} {
+    compiler.cxx_standard 2017
+} else {
+    compiler.cxx_standard 2014
+}
 
 # Note: Compiler optimization level is controlled by makefile variable 'OPTIMIZE', below.
-configure.cxxflags-delete -O1 -O2 -O3 -Os
+configure.cxxflags-delete \
+                    -O1 -O2 -O3 -Os
 
 # Note: Linker flag '-no_deduplicate' is absolutely vital, ensuring that 'ld'
 # finishes quickly. Without it, the final link time increases by a factor of
 # 10x for a release build... and 50x for a debug build! (The latter can take
 # 50+ minutes without it.)
-configure.cxxflags-append \
+# Note: Linker dedupe support not present in version of MacPorts 'ld', for
+# macOS 10.6 and earlier.
+if {${os.major} >= 11} {
+    configure.cxxflags-append \
                     -Xlinker -no_deduplicate \
                     -Wno-unused-command-line-argument
+}
 
-build.args-append   ARCHOPTS="${configure.cxxflags}" \
+if {[tbool configure.ccache]} {
+    configure.cc    ccache \
+                    ${configure.cc}
+    configure.cxx   ccache \
+                    ${configure.cxx}
+}
+
+build.args-append   \
+                    ARCHOPTS="${configure.cxxflags}" \
                     CC="${configure.cc}" \
                     CXX="${configure.cxx}" \
                     OVERRIDE_CC="${configure.cc}" \
@@ -230,11 +279,6 @@ build.target
 
 build.post_args
 
-if {[tbool configure.ccache]} {
-    build.post_args-append \
-        "CCACHE=ccache"
-}
-
 # Ensure 'g_mame_build_arch_64' set early, as it's needed later
 if {$build_arch in [list arm64 x86_64 ppc64]} {
     set g_mame_build_arch_64  1
@@ -250,8 +294,8 @@ if {$build_arch in [list arm64 x86_64 ppc64]} {
 # sanity checks.
 #------------------------------------------------------------------------------
 
-test.run      yes
-test.target   tests
+test.run            yes
+test.target         tests
 
 #------------------------------------------------------------------------------
 # Developer-Only Command-Line Overrides
@@ -266,6 +310,13 @@ if {[info exists mame.override.build.bgfx]} {
 
     set g_mame_build_bgfx_enabled \
         [string is true ${mame.override.build.bgfx}]
+}
+
+if {[info exists mame.override.build.gmake.args]} {
+    ui_msg "mame.override.build.gmake.args specified: ${mame.override.build.gmake.args}"
+
+    build.pre_args-append \
+        ${mame.override.build.gmake.args}
 }
 
 #------------------------------------------------------------------------------
@@ -452,6 +503,9 @@ proc mame_build_run {p_work_path p_makefile p_target p_build_args_list} {
 # Variants
 #------------------------------------------------------------------------------
 
+# Universal variant is untested
+universal_variant no
+
 variant debug \
         description {Enable debug support} {
     mame_variant_debug_setup
@@ -480,14 +534,13 @@ variant python39 \
     mame_variant_python_setup 3 9
 }
 
-default_variants   +tools
-
-# Universal variant is untested
-universal_variant   no
+default_variants-append \
+    +tools
 
 # Ensure one python* variant is selected by default, if not specified by user
 if {![variant_isset python37] && ![variant_isset python38] && ![variant_isset python39]} {
-    default_variants +python38
+    default_variants-append \
+        +python38
 }
 
 #------------------------------------------------------------------------------

--- a/emulators/mame/files/mame-script-template-launcher.sh
+++ b/emulators/mame/files/mame-script-template-launcher.sh
@@ -9,7 +9,19 @@
 script_file=$(grealpath "${0}")
 script_dir=$(dirname "${script_file}")
 
-cd "${script_dir}"
+cmd="${script_dir}/@@MACPORTS_MAME_EXECUTABLE@@"
+bgfx_path="${script_dir}/bgfx"
+languagepath="${script_dir}/language"
 
-./@@MACPORTS_MAME_EXECUTABLE@@ "${@}"
+cmdline=()
+cmdline+=( "${cmd}" )
+cmdline+=( -bgfx_path "${bgfx_path}" )
+cmdline+=( -languagepath "${languagepath}" )
+
+# Note that Mame handles duplicate arguments, using the last one found.
+# Net-Net, there's no need to check whether the user specified the same
+# parameters, as theirs will take precedence.
+
+"${cmdline[@]}" \
+"${@}"
 


### PR DESCRIPTION
#### Description

Mame Changes:
* Update for Mame 0.227 release; includes seamless fallback to 0.226, for macOS releases prior to 10.13.
* Updated launch script to improve user experience.

Fixes: [61976 - mame: update to 0.227](https://trac.macports.org/ticket/61976)
Fixes: [61743 - mame: improve user experience when running](https://trac.macports.org/ticket/61743)

###### Type(s)
- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.6.8 10K549
Xcode 3.2.2 10M2148

macOS 10.8.5 12F2560
Xcode 5.1.1 5B1008

macOS 10.12.6 16G2136
Xcode 9.2 9C40b

macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
