### PR TITLE
hamlib: use legacysupport

### DIFF
--- a/science/hamlib/Portfile
+++ b/science/hamlib/Portfile
@@ -2,6 +2,10 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           legacysupport 1.0
+
+# clock_gettime
+legacysupport.newest_darwin_requires_legacy 15
 
 name                hamlib
 categories          science
@@ -19,10 +23,6 @@ homepage            https://hamlib.github.io
 
 subport hamlib-devel {}
 if {[string first "-devel" $subport] > 0} {
-    PortGroup       legacysupport 1.0
-
-    # clock_gettime
-    legacysupport.newest_darwin_requires_legacy 15
 
     github.setup    Hamlib Hamlib dbb06f9e7ba96d2f74d5adaba54b5718b5271f3f
     version         20201229-[string range ${github.version} 0 7]


### PR DESCRIPTION
all builds now need legacysupport

