### PR TITLE
plumed: fix for arm build

### DIFF
--- a/science/plumed/Portfile
+++ b/science/plumed/Portfile
@@ -8,6 +8,7 @@ PortGroup           debug 1.0
 
 github.setup        plumed plumed2 2.7.0 v
 name                plumed
+revision            1
 
 categories          science
 
@@ -43,12 +44,15 @@ checksums           rmd160  607a3908f8548f88ac14c990e38a6fe99b40c3ea \
 # --disable-mpi:          Do not search for MPI compiler (replaced when enabling mpi, see below)
 # --disable-python:       Python wrappers will be installed with a separate python port
 configure.args-append \
-                    --enable-asmjit \
                     --disable-doc \
                     --disable-libsearch \
                     --disable-static-patch \
                     --disable-mpi \
                     --disable-python
+
+if {${configure.build_arch} eq "x86_64"} {
+    configure.args-append --enable-asmjit
+}
 
 # install bash completions
 configure.args-append BASH_COMPLETION_DIR=${prefix}/share/bash-completion/completions


### PR DESCRIPTION
#### Description

This is an attempt to fix the build on arm64, that is currently failing.

The failing build is [this one](https://build.macports.org/builders/ports-11_arm64-builder/builds/8060).

It looks like the embedded asmjit library does not support arm64, so I tried to disable it when building on arm64. **I have no way to test this though**.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
