### PR TITLE
gnss-sdr: update to 0.0.14

### DIFF
--- a/science/gnss-sdr/Portfile
+++ b/science/gnss-sdr/Portfile
@@ -23,11 +23,11 @@ if {${subport} eq "gnss-sdr"} {
     long_description    ${description}: \
         This port is kept up with the GNSS-SDR release, which is typically updated every few months.
 
-    github.setup        gnss-sdr gnss-sdr 0.0.13 v
-    revision            3
-    checksums           rmd160 ba3bb492b9c60ae644e8b439dd94973148dba1a5 \
-                        sha256 fdfbc641424014555b15beec9eadecc6c7c54fc23b35722bad559288c4dc4c1b \
-                        size   3930919
+    github.setup        gnss-sdr gnss-sdr 0.0.14 v
+    revision            0
+    checksums           rmd160 71e9bbb7e125396be06d97b26f333e9e2bb4a9be \
+                        sha256 48ba64073a995aa6f835c7a0cb775a741db9475359b036ca4245a65a6c1135fd \
+                        size   4269976
 
     conflicts           gnss-sdr-devel
 
@@ -40,11 +40,11 @@ subport gnss-sdr-devel {
     long_description    ${description}: \
         This port is kept up with the GNSS-SDR GIT next branch, which is typically updated daily to weekly. This version of GNSS-SDR generally contains fixes and new features that will be incorporated in an upcoming release.
     name      gnss-sdr-devel
-    github.setup gnss-sdr gnss-sdr 25787deca7bf3863c3fc1af8bccbbda111b8d033
-    version   20210107-[string range ${github.version} 0 7]
-    checksums rmd160 76cddf5dd3c22677097b0a3f361011ade28ff4dd \
-              sha256 667537aab9c697b14c2fdecec5263d900b3a26171ad3eaf7a940c88ad1fcba4c \
-              size   4269851
+    github.setup gnss-sdr gnss-sdr 87882d3d23d4d3d0e7381bb4f076e4e0383392d0
+    version   20210108-[string range ${github.version} 0 7]
+    checksums rmd160 f7caa6aa3b164dc002993c935341f36cdafe9514 \
+              sha256 71f8fe704978c86ed8e97ee35ceca0b5f218ff668a095637fdbc35d4a401a026 \
+              size   4269904
     revision  0
 
     conflicts gnss-sdr
@@ -61,16 +61,6 @@ subport gnss-sdr-devel {
 
     github.livecheck.branch next
 
-}
-
-# This port can be removed on Dec 4, 2020.
-subport gnss-sdr-next {
-    replaced_by gnss-sdr-devel
-    PortGroup obsolete 1.0
-
-    name      gnss-sdr-next
-    version   20191204
-    revision  3
 }
 
 # override github PortGroup homepage setting

--- a/science/volk-gnss-sdr/Portfile
+++ b/science/volk-gnss-sdr/Portfile
@@ -22,11 +22,11 @@ if {${subport} eq "volk-gnss-sdr"} {
     long_description    ${description}: \
         This port is kept up with the VOLK-GNSS-SDR release, which is typically updated every few months.
 
-    github.setup        gnss-sdr gnss-sdr 0.0.13 v
-    revision            1
-    checksums           rmd160 ba3bb492b9c60ae644e8b439dd94973148dba1a5 \
-                        sha256 fdfbc641424014555b15beec9eadecc6c7c54fc23b35722bad559288c4dc4c1b \
-                        size   3930919
+    github.setup        gnss-sdr gnss-sdr 0.0.14 v
+    revision            0
+    checksums           rmd160 71e9bbb7e125396be06d97b26f333e9e2bb4a9be \
+                        sha256 48ba64073a995aa6f835c7a0cb775a741db9475359b036ca4245a65a6c1135fd \
+                        size   4269976
 
     conflicts           volk-gnss-sdr-devel
 
@@ -37,12 +37,12 @@ subport volk-gnss-sdr-devel {
         This port is kept up with the VOLK-GNSS-SDR GIT next branch, which is typically updated daily to weekly. This version of VOLK-GNSS-SDR generally contains fixes and new features that will be incorporated in an upcoming release.
 
     name      volk-gnss-sdr-devel
-    github.setup gnss-sdr gnss-sdr 4e0391f4947aabc8e83561e46e1b010bc12affae
-    version   20200729-[string range ${github.version} 0 7]
-    checksums rmd160 d45c1bb6992a824729af9dddab707581d6f08189 \
-              sha256 2e29dcc5d23ac988e22d43757498f06a2021ac716ce4af1819810ef0cf8cbe20 \
-              size   3930962
-    revision  1
+    github.setup gnss-sdr gnss-sdr 87882d3d23d4d3d0e7381bb4f076e4e0383392d0
+    version   20210108-[string range ${github.version} 0 7]
+    checksums rmd160 f7caa6aa3b164dc002993c935341f36cdafe9514 \
+              sha256 71f8fe704978c86ed8e97ee35ceca0b5f218ff668a095637fdbc35d4a401a026 \
+              size   4269904
+    revision  0
 
     conflicts volk-gnss-sdr
 
@@ -50,16 +50,6 @@ subport volk-gnss-sdr-devel {
 
     github.livecheck.branch next
 
-}
-
-# This port can be removed on Dec 4, 2020.
-subport volk-gnss-sdr-next {
-    replaced_by volk-gnss-sdr-devel
-    PortGroup obsolete 1.0
-
-    name      volk-gnss-sdr-next
-    version   20191204
-    revision  0
 }
 
 # override github PortGroup homepage setting


### PR DESCRIPTION
#### Description

Upgrade gnss-sdr and volk-gnss-sdr ports (and their -devel counterparts) to new upstream version 0.0.14.

Remove obsolete notice about the disappeared gnss-sdr-next port.
 
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1
Xcode 12.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
