### PR TITLE
OpenBLAS: on ARM64 build as +native for now

### DIFF
--- a/math/OpenBLAS/Portfile
+++ b/math/OpenBLAS/Portfile
@@ -37,6 +37,10 @@ if {![info exists blas_arch]} {
     #For older versions, we force native variant as there is no PPCG3 target in OpenBLAS
     default_variants-append +native
 }
+if {${build_arch} eq "arm64" } {
+    #currently require native builds for Apple Silicon
+    default_variants-append +native
+}
 
 subport OpenBLAS-devel {}
 if {[string first "-devel" $subport] > 0} {


### PR DESCRIPTION
Based on personal testing on my ARM64 macOS box, it seems like we need to be building as +native there. That's all this PR does. Easy to add, easy to remove in the future once MacPorts and OpenBLAS get to that point.