### PR TITLE
py-slack-sdk: new port

### DIFF
--- a/python/py-slack-sdk/Portfile
+++ b/python/py-slack-sdk/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 supported_archs     noarch
 license             MIT
 
-python.versions     36 37 38 39
+python.versions     38 39
 
 maintainers         {gmail.com:giovanni.bussi @GiovanniBussi} openmaintainer
 

--- a/python/py-slack-sdk/Portfile
+++ b/python/py-slack-sdk/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim: fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
+
+github.setup        slackapi python-slack-sdk 3.1.1 v
+name                py-slack-sdk
+categories-append   irc
+platforms           darwin
+supported_archs     noarch
+license             MIT
+
+python.versions     36 37 38 39
+
+maintainers         {gmail.com:giovanni.bussi @GiovanniBussi} openmaintainer
+
+description         Python Slack SDK.
+long_description    The Slack platform offers several APIs to build apps. Each Slack API \
+                    delivers part of the capabilities from the platform, so that you can \
+                    pick just those that fit for your needs. This SDK offers a \
+                    corresponding package for each of Slack’s APIs. They are small and  \
+                    powerful when used independently, and work seamlessly when used \
+                    together, too. This package replaces py-slackclient.
+
+homepage            https://slack.dev/python-slackclient/
+
+checksums           rmd160  888f11df7d65660a5ce1cb3d7325b553cc273589 \
+                    sha256  858a8545c684ca5395a716dff7e9e379c242971242eb3e5161ebc154a300c37f \
+                    size    2996184
+
+if {${name} ne ${subport}} {
+    conflicts               py${python.version}-slackclient
+    depends_build-append    port:py${python.version}-setuptools
+
+    livecheck.type none
+}


### PR DESCRIPTION
#### Description

This is a new package. Slack users are expected to migrate from the old py-slackclient (v2) to this new package (v3). The two packages cannot be installed simultaneously, so I added a conflict. This package is not a straightforward replacement of the v2 package, and users should explicitly look at the migration guide for API changes. Thus, I would keep the port py-slackclient v2 as well.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
