### PR TITLE
google-cloud-sdk: update to 322.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             321.0.0
+version             322.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  c8139a7e87702ab9933979d99093454288f2fb3e \
-                    sha256  2895762c646e3a8decc95a92cf9b09a426318d59efb19a8100cc3bd5444592fe \
-                    size    86065585
+    checksums       rmd160  466d78daa3e190f475bdbe353099fd7eb6bc0e15 \
+                    sha256  b48cf3292472122dd264ba1b41fd571aa02bbd319812bdb4414388d671f47cac \
+                    size    86278176
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  40b7e494f3560c465faea32c95f9b3196c529092 \
-                    sha256  3bca7104f35cd0eacab475b2828cf979dc4a488ac5213c4cceb9d7b104dc38d6 \
-                    size    108128649
+    checksums       rmd160  eab098f4022d5a9b9f3c56442b0642f9db6efe79 \
+                    sha256  6b22e0b37741f0f513ea3ea21f741ee88749affc5be9143ba63256321651cae5 \
+                    size    108847955
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 322.0.0.

###### Tested on

macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?