### PR TITLE
py-Pillow: update to 8.1.0

### DIFF
--- a/python/py-Pillow/Portfile
+++ b/python/py-Pillow/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-Pillow
-version             8.0.1
+version             8.1.0
 revision            0
 categories-append   devel
 platforms           darwin
@@ -19,9 +19,9 @@ long_description    ${description}
 
 homepage            https://github.com/python-imaging/Pillow
 
-checksums           rmd160  e1ed47669f9593ce0c7401a94ea38371688e6c0b \
-                    sha256  11c5c6e9b02c9dac08af04f093eb5a2f84857df70a7d4a6a6ad461aca803fb9e \
-                    size    44620531
+checksums           rmd160  79ba951cd01ee56aba5a592034136539eb708f1d \
+                    sha256  887668e792b7edbfb1d3c9d8b5d8c859269a0f0eba4dda562adb95500f60dbba \
+                    size    44934336
 
 if {${name} ne ${subport}} {
     conflicts           py${python.version}-pil


### PR DESCRIPTION
#### Description

Updated Pillow to 8.1.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
- There are no existing Trac tickets
- 'Error: Failed to test py-Pillow: py-Pillow has no tests turned on.'