### PR TITLE
libcerf: update to 1.14, use gitlab PG

### DIFF
--- a/math/gnuplot/Portfile
+++ b/math/gnuplot/Portfile
@@ -7,6 +7,8 @@ PortGroup           wxWidgets       1.0
 
 name                gnuplot
 version             5.4.1
+revision            1
+
 categories          math science
 # the license has some inconvenient requirements that we're not meeting
 # to be allowed to distribute binaries

--- a/math/libcerf/Portfile
+++ b/math/libcerf/Portfile
@@ -1,31 +1,27 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           gitlab 1.0
 PortGroup           cmake 1.1
 
-name                libcerf
-version             1.13
-set upload_tag      924b8d245ad3461107ec630734dfc781
+gitlab.instance     https://jugit.fz-juelich.de
+gitlab.setup        mlz libcerf 1.14 v
+revision            0
+
 categories          math
 platforms           darwin
 license             MIT
 maintainers         {mojca @mojca} openmaintainer
+
 description         Library for complex error functions
 long_description    The libcerf library is a self-contained numeric library that provides \
                     an efficient and accurate implementation of complex error functions, \
                     along with Dawson, Faddeeva, and Voigt functions.
-homepage            https://jugit.fz-juelich.de/mlz/libcerf
-master_sites        https://jugit.fz-juelich.de/mlz/libcerf/uploads/${upload_tag}/
 
-extract.suffix      .tgz
-checksums           rmd160  6bf9e6dea553fbd961f4ca02e3f047b7ea7f1c6f \
-                    sha256  011303e59ac63b280d3d8b10c66b07eb02140fcb75954d13ec26bf830e0ea2f9 \
-                    size    61589
+checksums           rmd160  85fb3c31f80ff47962bfeee435d4fc1eca54ce61 \
+                    sha256  98ba08736ca455400e388d2830266607d14a13bcb1ee41f2f2975250cb879cb6 \
+                    size    66056
 
 test.run            yes
 test.cmd            ctest
 test.target
-
-livecheck.type      regex
-livecheck.url       https://jugit.fz-juelich.de/mlz/libcerf/-/tags
-livecheck.regex     "${name}-(\\d+(?:\\.\\d+)*)${extract.suffix}"


### PR DESCRIPTION
#### Description
- update to latest version (of note, 2.0 is present as tag but withdrawn so not actually available)
- use the gitlab PG (this fixes the previously broken livecheck as well)

###### Tested on
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
