### PR TITLE
gnuplot: update to 5.4.1, retire cxx11 PG

### DIFF
--- a/math/gnuplot/Portfile
+++ b/math/gnuplot/Portfile
@@ -6,7 +6,7 @@ PortGroup           xcodeversion    1.0
 PortGroup           wxWidgets       1.0
 
 name                gnuplot
-version             5.2.8
+version             5.4.1
 categories          math science
 # the license has some inconvenient requirements that we're not meeting
 # to be allowed to distribute binaries
@@ -29,9 +29,9 @@ homepage            http://gnuplot.sourceforge.net/
 master_sites        sourceforge:project/gnuplot/gnuplot/${version}
 dist_subdir         ${name}/${version}
 
-checksums           rmd160  1048f333f14be3f27bd8a6fa866371c6308f4f5d \
-                    sha256  60a6764ccf404a1668c140f11cc1f699290ab70daa1151bb58fed6139a28ac37 \
-                    size    5340677
+checksums           rmd160  0ccca1f34480fd3bcae3012c200e8f534010c5e4 \
+                    sha256  6b690485567eaeb938c26936e5e0681cf70c856d273cc2c45fabf64d8bc6590e \
+                    size    5608076
 
 depends_build       port:pkgconfig
 
@@ -102,15 +102,15 @@ variant wxwidgets description "Enable wxt terminal" {
 
 variant qt conflicts qt5 description "Enable qt terminal with Qt 4" {
     PortGroup qt4 1.0
+
     configure.args-replace      --without-qt --with-qt=qt4
 }
 
 variant qt5 conflicts qt description "Enable qt terminal with Qt 5" {
     # Latest versions of Qt require C++11
     PortGroup qt5   1.0
-    PortGroup cxx11 1.1
 
-    configure.cxxflags-append   -std=c++11
+    compiler.cxx_standard       2011
 
     qt5.depends_component       qtbase   \
                                 qtsvg    \


### PR DESCRIPTION
#### Description
- update to latest version
- use `compiler.cxx_standard       2011` instead of the `cxx11` PG

###### Tested on
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
PR #6917 discusses the option to use the `qt5` variant by default; it seems there is no consensus yet. That discussion can be continued once the version has been update.
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

I only installed and did some basic testing with the default variants.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
