### PR TITLE
watson: new port

### DIFF
--- a/office/watson/Portfile
+++ b/office/watson/Portfile
@@ -1,0 +1,42 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                watson
+python.rootname     td-watson
+version             1.10.0
+revision            0
+
+homepage            http://tailordev.github.io/Watson
+
+description         A wonderful CLI to track your time!
+
+long_description    Watson is here to help you manage your time. You want to \
+                    know how much time you are spending on your projects? You \
+                    want to generate a nice report for your client? Watson is \
+                    here for you.
+
+platforms           darwin
+license             MIT
+categories          office python
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  a7cecfd5aed7e85220fc30a7438128b27d2435b6 \
+                    sha256  f223bc0cd03a4baeb0b149032731edda9c6fc0c04ff61d819c6f542f01957369 \
+                    size    8894805
+
+test.run            yes
+test.env            PYTHONPATH=${worksrcpath}/build/lib
+test.cmd            ${python.bin} -m watson --version
+
+python.default_version  39
+
+depends_lib-append      port:py${python.version}-arrow              \
+                        port:py${python.version}-click              \
+                        port:py${python.version}-click-didyoumean   \
+                        port:py${python.version}-colorama           \
+                        port:py${python.version}-requests           \
+                        port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

New port for the **[Watson](https://github.com/TailorDev/Watson)** time tracker.
<img src="https://camo.githubusercontent.com/ee99dc0fe65634533c3096bec7a3244f5b4d01b9290f0076ccdcd654ddec8f55/68747470733a2f2f7461696c6f726465762e6769746875622e696f2f576174736f6e2f696d672f776174736f6e2d64656d6f2e676966" />

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
