### PR TITLE
supertuxkart: patch to fix SDL-related build failure in file src/input/gamepad_config.cpp

### DIFF
--- a/games/supertuxkart/Portfile
+++ b/games/supertuxkart/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 
 name                supertuxkart
 version             1.2
-revision            1
+revision            2
 categories          games
 license             GPL-3+
 platforms           darwin
@@ -19,6 +19,11 @@ worksrcdir          ${name}-${version}
 use_xz              yes
 
 homepage            http://supertuxkart.sourceforge.net/
+
+# Patch for v1.2: static_assert build failure in src/input/gamepad_config.cpp
+# Already included in upstream master; remove after next release.
+# https://trac.macports.org/ticket/62024
+patchfiles          patch-1.2-sdl-gamepad_config.diff
 
 checksums           rmd160  266b0ee1bca4726dd87104dc568baa632f84461a \
                     sha256  052edf0afdbeb99583fe8676fb0ab80ecb6103fb88b7540f858d1b5fa1297d37 \

--- a/games/supertuxkart/files/patch-1.2-sdl-gamepad_config.diff
+++ b/games/supertuxkart/files/patch-1.2-sdl-gamepad_config.diff
@@ -1,0 +1,95 @@
+--- src/input/gamepad_config.cpp
++++ src/input/gamepad_config.cpp
+@@ -32,8 +32,7 @@
+ #include "input/sdl_controller.hpp"
+ #include <array>
+ 
+-static_assert(SDL_CONTROLLER_BUTTON_MAX - 1 == SDL_CONTROLLER_BUTTON_DPAD_RIGHT, "non continous name");
+-enum AxisWithDirection
++enum AxisWithDirection : unsigned
+ {
+     SDL_CONTROLLER_AXIS_LEFTX_RIGHT = SDL_CONTROLLER_BUTTON_MAX,
+     SDL_CONTROLLER_AXIS_LEFTX_LEFT,
+@@ -140,56 +139,56 @@ void GamepadConfig::setDefaultBinds ()
+ core::stringw GamepadConfig::getBindingAsString(const PlayerAction action) const
+ {
+ #ifndef SERVER_ONLY
+-    std::array<core::stringw, SDL_CONTROLLER_AXIS_WITH_DIRECTION_AND_BUTTON_MAX> readable =
++    std::map<unsigned, core::stringw> readable =
+     {{
+-        "A", // SDL_CONTROLLER_BUTTON_A
+-        "B", // SDL_CONTROLLER_BUTTON_B
+-        "X", // SDL_CONTROLLER_BUTTON_X
+-        "Y", // SDL_CONTROLLER_BUTTON_Y
++        { SDL_CONTROLLER_BUTTON_A, "A" },
++        { SDL_CONTROLLER_BUTTON_B, "B" },
++        { SDL_CONTROLLER_BUTTON_X, "X" },
++        { SDL_CONTROLLER_BUTTON_Y, "Y" },
+         // I18N: name of buttons on gamepads
+-        _("Back"), // SDL_CONTROLLER_BUTTON_BACK
++        { SDL_CONTROLLER_BUTTON_BACK, _("Back") },
+         // I18N: name of buttons on gamepads
+-        _("Guide"), // SDL_CONTROLLER_BUTTON_GUIDE
++        { SDL_CONTROLLER_BUTTON_GUIDE, _("Guide") },
+         // I18N: name of buttons on gamepads
+-        _("Start"), // SDL_CONTROLLER_BUTTON_START
++        { SDL_CONTROLLER_BUTTON_START, _("Start") },
+         // I18N: name of buttons on gamepads
+-        _("Left thumbstick press"), // SDL_CONTROLLER_BUTTON_LEFTSTICK
++        { SDL_CONTROLLER_BUTTON_LEFTSTICK, _("Left thumbstick press") },
+         // I18N: name of buttons on gamepads
+-        _("Right thumbstick press"), // SDL_CONTROLLER_BUTTON_RIGHTSTICK
++        { SDL_CONTROLLER_BUTTON_RIGHTSTICK, _("Right thumbstick press") },
+         // I18N: name of buttons on gamepads
+-        _("Left shoulder"), // SDL_CONTROLLER_BUTTON_LEFTSHOULDER
++        { SDL_CONTROLLER_BUTTON_LEFTSHOULDER, _("Left shoulder") },
+         // I18N: name of buttons on gamepads
+-        _("Right shoulder"), // SDL_CONTROLLER_BUTTON_RIGHTSHOULDER
++        { SDL_CONTROLLER_BUTTON_RIGHTSHOULDER, _("Right shoulder") },
+         // I18N: name of buttons on gamepads
+-        _("DPad up"), // SDL_CONTROLLER_BUTTON_DPAD_UP
++        { SDL_CONTROLLER_BUTTON_DPAD_UP, _("DPad up") },
+         // I18N: name of buttons on gamepads
+-        _("DPad down"), // SDL_CONTROLLER_BUTTON_DPAD_DOWN
++        { SDL_CONTROLLER_BUTTON_DPAD_DOWN, _("DPad down") },
+         // I18N: name of buttons on gamepads
+-        _("DPad left"), // SDL_CONTROLLER_BUTTON_DPAD_LEFT
++        { SDL_CONTROLLER_BUTTON_DPAD_LEFT, _("DPad left") },
+         // I18N: name of buttons on gamepads
+-        _("DPad right"), // SDL_CONTROLLER_BUTTON_DPAD_RIGHT
++        { SDL_CONTROLLER_BUTTON_DPAD_RIGHT, _("DPad right") },
+ 
+         // Below are extensions after SDL2 header SDL_CONTROLLER_BUTTON_MAX
+         // I18N: name of buttons on gamepads
+-        _("Left thumbstick right"), // SDL_CONTROLLER_AXIS_LEFTX_RIGHT
++        { SDL_CONTROLLER_AXIS_LEFTX_RIGHT, _("Left thumbstick right") },
+         // I18N: name of buttons on gamepads
+-        _("Left thumbstick left"), // SDL_CONTROLLER_AXIS_LEFTX_LEFT
++        { SDL_CONTROLLER_AXIS_LEFTX_LEFT, _("Left thumbstick left") },
+         // I18N: name of buttons on gamepads
+-        _("Left thumbstick down"), // SDL_CONTROLLER_AXIS_LEFTY_DOWN
++        { SDL_CONTROLLER_AXIS_LEFTY_DOWN, _("Left thumbstick down") },
+         // I18N: name of buttons on gamepads
+-        _("Left thumbstick up"), // SDL_CONTROLLER_AXIS_LEFTY_UP
++        { SDL_CONTROLLER_AXIS_LEFTY_UP, _("Left thumbstick up") },
+         // I18N: name of buttons on gamepads
+-        _("Right thumbstick right"), // SDL_CONTROLLER_AXIS_RIGHTX_RIGHT
++        { SDL_CONTROLLER_AXIS_RIGHTX_RIGHT, _("Right thumbstick right") },
+         // I18N: name of buttons on gamepads
+-        _("Right thumbstick left"), // SDL_CONTROLLER_AXIS_RIGHTX_LEFT
++        { SDL_CONTROLLER_AXIS_RIGHTX_LEFT, _("Right thumbstick left") },
+         // I18N: name of buttons on gamepads
+-        _("Right thumbstick down"), // SDL_CONTROLLER_AXIS_RIGHTY_DOWN
++        { SDL_CONTROLLER_AXIS_RIGHTY_DOWN, _("Right thumbstick down") },
+         // I18N: name of buttons on gamepads
+-        _("Right thumbstick up"), // SDL_CONTROLLER_AXIS_RIGHTY_UP
++        { SDL_CONTROLLER_AXIS_RIGHTY_UP, _("Right thumbstick up") },
+         // I18N: name of buttons on gamepads
+-        _("Left trigger"), // SDL_CONTROLLER_AXIS_TRIGGERLEFT_UP
++        { SDL_CONTROLLER_AXIS_TRIGGERLEFT_UP, _("Left trigger") },
+         // I18N: name of buttons on gamepads
+-        _("Right trigger") // SDL_CONTROLLER_AXIS_TRIGGERRIGHT_UP
++        { SDL_CONTROLLER_AXIS_TRIGGERRIGHT_UP, _("Right trigger") }
+     }};
+ 
+     const Binding &b = getBinding(action);


### PR DESCRIPTION
#### Description

Fix for SDL-related build failure for v1.2. Patch already present in upstream's master.

Fixes: [supertuxkart: @1.2_1 build failure: static_assert failure, re: SDL_CONTROLLER_BUTTON](https://trac.macports.org/ticket/62024)

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G2136
Xcode 9.2 9C40b

macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
