### PR TITLE
gimp2: fix file export plugin dialogs, for GIF and PNG

### DIFF
--- a/graphics/gimp2/Portfile
+++ b/graphics/gimp2/Portfile
@@ -8,7 +8,7 @@ name                gimp2
 conflicts           gimp2-devel gimp3-devel
 # please remember to update the gimp metapackage to match
 version             2.10.22
-revision            1
+revision            2
 set branch          [join [lrange [split ${version} .] 0 1] .]
 license             GPL-3+
 categories          graphics
@@ -97,6 +97,14 @@ patchfiles          patch-etc-gimprc.in.diff \
                     patch-mach-task-info.diff \
                     patch-quartz-32bit.diff \
                     MYPAINT_BRUSHES_DIR.patch
+
+# Fix for 2.10.22 file export plugin dialogs GIF and PNG.
+# Credit to @pietvo, who contributed this both to upstream, as well as MacPorts.
+# Remove once upstream has merged patch into official release:
+# https://gitlab.gnome.org/GNOME/gimp/-/merge_requests/392
+# Tracked by MacPorts issue:
+# https://trac.macports.org/ticket/61799
+patchfiles-append   patch-2.10-gimpenv-plugin-subdir.diff
 
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
     # avoid Cursor type conflict between X11 and Quickdraw

--- a/graphics/gimp2/files/patch-2.10-gimpenv-plugin-subdir.diff
+++ b/graphics/gimp2/files/patch-2.10-gimpenv-plugin-subdir.diff
@@ -1,0 +1,23 @@
+--- libgimpbase/gimpenv.c.old	2020-11-22 00:48:03.000000000 +0100
++++ libgimpbase/gimpenv.c	2020-11-28 16:40:34.000000000 +0100
+@@ -435,6 +435,20 @@
+         g_free (tmp);
+         g_free (tmp2);
+       }
++    else if (! strcmp (g_path_get_basename (dirname), "plug-ins"))
++      {
++        /*  same for plug-ins in subdirectory, go three levels up from prefix/lib/gimp/x.y  */
++
++        gchar *tmp  = g_path_get_dirname (dirname);
++        gchar *tmp2 = g_path_get_dirname (tmp);
++        gchar *tmp3 = g_path_get_dirname (tmp2);
++
++        toplevel = g_path_get_dirname (tmp3);
++
++        g_free (tmp);
++        g_free (tmp2);
++        g_free (tmp3);
++      }
+     else
+       {
+         /*  if none of the above match, we assume that we are really in a bundle  */


### PR DESCRIPTION
#### Description

Patch to fix GIMP file export UI issue: full export dialogs aren't displayed for GIF or PNG, blocking basic functionality

Credit goes to @pietvo, who was kind enough to provide this patch to MacPorts.

Note: Patch submitted to upstream. As of 1/18/2021, it has been reviewed, and officially approved:
[gimp: macOS: fix for file export dialogs GIF and PNG](https://gitlab.gnome.org/GNOME/gimp/-/merge_requests/392)

Fixes: [gimp2 @2.10.22: export as gif or png does not display dialog](https://trac.macports.org/ticket/61799)

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.8.5 12F2560
Xcode 5.1.1 5B1008

macOS 10.12.6 16G2136
Xcode 9.2 9C40b

macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
