### PR TITLE
libmed: added patch for compilation with hdf 1.12

### DIFF
--- a/science/libmed/Portfile
+++ b/science/libmed/Portfile
@@ -8,6 +8,7 @@ name                    libmed
 version                 4.0.0
 # Must rebuild afer upgrading HDF5. Keep revision number even if 0.
 revision                1
+patchfiles              patch-hdf5-1.12.diff
 categories              science devel
 platforms               darwin
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer

--- a/science/libmed/files/patch-hdf5-1.12.diff
+++ b/science/libmed/files/patch-hdf5-1.12.diff
@@ -1,0 +1,91 @@
+diff --git c/config/cmake_files/medMacros.cmake w/config/cmake_files/medMacros.cmake
+index b79f387..7c82cec 100644
+--- config/cmake_files/medMacros.cmake
++++ config/cmake_files/medMacros.cmake
+@@ -398,7 +398,7 @@ MACRO(MED_FIND_HDF5)
+     ##
+     ## Requires 1.10.x version
+     ##
+-    IF (NOT HDF_VERSION_MAJOR_REF EQUAL 1 OR NOT HDF_VERSION_MINOR_REF EQUAL 10 OR NOT HDF_VERSION_RELEASE_REF GREATER 1)
++    IF (HDF5_VERSION VERSION_LESS 1.10.2)
+         MESSAGE(FATAL_ERROR "HDF5 version is ${HDF_VERSION_REF}. Only versions >= 1.10.2 are supported.")
+     ENDIF()
+     ##
+diff --git c/src/ci/MEDfileCompatibility.c w/src/ci/MEDfileCompatibility.c
+index b5c42d1..d94e6a8 100644
+--- src/ci/MEDfileCompatibility.c
++++ src/ci/MEDfileCompatibility.c
+@@ -71,7 +71,7 @@ MEDfileCompatibility(const char* const filename,
+   _hversionMMR=10000*_hmajeur+100*_hmineur+_hrelease;
+   /* ISCRUTE(_hversionMMR); */
+   /* ISCRUTE(HDF_VERSION_NUM_REF); */
+-  if ( (_hversionMMR >= HDF_VERSION_NUM_REF) && (_hmineur == HDF_VERSION_MINOR_REF) ) *hdfok = MED_TRUE;
++  if (_hversionMMR >= HDF_VERSION_NUM_REF) *hdfok = MED_TRUE;
+ 
+   /* TODO : Vérifier si la version mineure HDF du fichier est supérieur 
+      à la version mineure de la bibliothèque HDF utilisée  */
+diff --git c/src/hdfi/_MEDfileCreate.c w/src/hdfi/_MEDfileCreate.c
+index 34c75cc..66073c1 100644
+--- src/hdfi/_MEDfileCreate.c
++++ src/hdfi/_MEDfileCreate.c
+@@ -84,7 +84,7 @@ med_idt _MEDfileCreate(const char * const filename, const med_access_mode access
+    * En HDF5-1.10.0p1 cela n'a aucun effet ! 
+    * Un test autoconf permet de fixer un intervalle de version HDF à MED.
+    */
+-#if H5_VERS_MINOR > 10
++#if H5_VERS_MINOR > 12
+ #error "Don't forget to change the compatibility version of the library !"
+ #endif
+    
+diff --git c/src/hdfi/_MEDfileOpen.c w/src/hdfi/_MEDfileOpen.c
+index 7d0b798..6a7de9a 100644
+--- src/hdfi/_MEDfileOpen.c
++++ src/hdfi/_MEDfileOpen.c
+@@ -72,7 +72,7 @@ med_idt _MEDfileOpen(const char * const filename,const med_access_mode accessmod
+ 
+    •   The creation order tracking property, H5P_CRT_ORDER_TRACKED, has been set in the group creation property list (see H5Pset_link_creation_order). 
+   */
+-#if H5_VERS_MINOR > 10
++#if H5_VERS_MINOR > 12
+ #error "Don't forget to change the compatibility version of the library !"
+ #endif
+ /* L'avantage de bloquer le modèle interne HDF5 
+diff --git c/src/hdfi/_MEDmemFileOpen.c w/src/hdfi/_MEDmemFileOpen.c
+index 9449cda..a3f4adc 100644
+--- src/hdfi/_MEDmemFileOpen.c
++++ src/hdfi/_MEDmemFileOpen.c
+@@ -434,7 +434,7 @@ med_idt _MEDmemFileOpen(const char * const filename, med_memfile * const memfile
+     goto ERROR;
+   }
+ 
+-#if H5_VERS_MINOR > 10
++#if H5_VERS_MINOR > 12
+ #error "Don't forget to change the compatibility version of the library !"
+ #endif
+   if ( H5Pset_libver_bounds( _fapl, H5F_LIBVER_18, H5F_LIBVER_18) ) {
+diff --git c/src/hdfi/_MEDparFileCreate.c w/src/hdfi/_MEDparFileCreate.c
+index c6d9f44..b3b2a41 100644
+--- src/hdfi/_MEDparFileCreate.c
++++ src/hdfi/_MEDparFileCreate.c
+@@ -64,7 +64,7 @@ med_idt _MEDparFileCreate(const char * const filename, const med_access_mode acc
+    * En HDF5-1.10.0p1 cela n'a aucun effet ! 
+    * Un test autoconf permet de fixer un intervalle de version HDF à MED.
+    */
+-#if H5_VERS_MINOR > 10
++#if H5_VERS_MINOR > 12
+ #error "Don't forget to change the compatibility version of the library !"
+ #endif
+    
+diff --git c/src/hdfi/_MEDparFileOpen.c w/src/hdfi/_MEDparFileOpen.c
+index 0100729..dfad95c 100644
+--- src/hdfi/_MEDparFileOpen.c
++++ src/hdfi/_MEDparFileOpen.c
+@@ -55,7 +55,7 @@ med_idt _MEDparFileOpen(const char * const filename,const med_access_mode access
+     MED_ERR_(_fid,MED_ERR_INIT,MED_ERR_PROPERTY,MED_ERR_PARALLEL_MSG);
+     goto ERROR;
+   }
+-#if H5_VERS_MINOR > 10
++#if H5_VERS_MINOR > 12
+ #error "Don't forget to change the compatibility version of the library !"
+ #endif
+   if ( H5Pset_libver_bounds( _fapl, H5F_LIBVER_18, H5F_LIBVER_18 ) ) {


### PR DESCRIPTION
patch adapted from https://gist.github.com/jedbrown/527ef81ff59a0dccf833da40fdd15a47

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G3020
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
I didn't find any.
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
there are none.
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
I tested `gmsh` which depends on this port - however, I'm not sure which features actually need libmed.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
