### PR TITLE
openal-soft: update port to use macports clang 9..11, to fix template compilation errors

### DIFF
--- a/audio/openal-soft/Portfile
+++ b/audio/openal-soft/Portfile
@@ -37,7 +37,7 @@ master_sites            ${homepage}/openal-releases/
 use_bzip2               yes
 
 if {${subport} eq ${name}} {
-revision                0
+revision                1
 
 depends_build-append    port:pkgconfig
 
@@ -50,6 +50,10 @@ patch.pre_args          -p1
 
 compiler.cxx_standard   2014
 compiler.thread_local_storage   yes
+
+compiler.whitelist      macports-clang-9.0 \
+                        macports-clang-10 \
+                        macports-clang-11
 
 configure.args-append   -DALSOFT_EXAMPLES=OFF \
                         -DALSOFT_UTILS=ON \


### PR DESCRIPTION
#### Description

Update port to use macports clang 9..11, to fix template compilation errors.

Fixes: [openal-soft @1.21.0: error: inline declaration of 'PopCount<unsigned long long>' follows non-inline definition](https://trac.macports.org/ticket/61431)

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.8.5 12F2560
Xcode 5.1.1 5B1008

macOS 10.10.5 14F2511
Xcode 6.4 6E35b

macOS 10.11.6 15G22010
Xcode 7.3.1 7D1014

macOS 10.12.6 16G2136
Xcode 9.2 9C40b

macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
