### PR TITLE
[volk]-gnss-sdr-devel: fix collision of cpu_features files

### DIFF
--- a/science/gnss-sdr/Portfile
+++ b/science/gnss-sdr/Portfile
@@ -40,11 +40,11 @@ subport gnss-sdr-devel {
     long_description    ${description}: \
         This port is kept up with the GNSS-SDR GIT next branch, which is typically updated daily to weekly. This version of GNSS-SDR generally contains fixes and new features that will be incorporated in an upcoming release.
     name      gnss-sdr-devel
-    github.setup gnss-sdr gnss-sdr 87882d3d23d4d3d0e7381bb4f076e4e0383392d0
-    version   20210108-[string range ${github.version} 0 7]
-    checksums rmd160 f7caa6aa3b164dc002993c935341f36cdafe9514 \
-              sha256 71f8fe704978c86ed8e97ee35ceca0b5f218ff668a095637fdbc35d4a401a026 \
-              size   4269904
+    github.setup gnss-sdr gnss-sdr f75017e5206a2803f8dcd9dc6d1385bb939586c7
+    version   20210111-[string range ${github.version} 0 7]
+    checksums rmd160 6c5c60d95184c23a302c2f6867ec1ac619cd7cdc \
+              sha256 29e715beb64877486ea9b09302ac3b4587dd85098a178ae4f98bb7d61fdbc95a \
+              size   4271026
     revision  0
 
     conflicts gnss-sdr

--- a/science/volk-gnss-sdr/Portfile
+++ b/science/volk-gnss-sdr/Portfile
@@ -37,11 +37,11 @@ subport volk-gnss-sdr-devel {
         This port is kept up with the VOLK-GNSS-SDR GIT next branch, which is typically updated daily to weekly. This version of VOLK-GNSS-SDR generally contains fixes and new features that will be incorporated in an upcoming release.
 
     name      volk-gnss-sdr-devel
-    github.setup gnss-sdr gnss-sdr 87882d3d23d4d3d0e7381bb4f076e4e0383392d0
-    version   20210108-[string range ${github.version} 0 7]
-    checksums rmd160 f7caa6aa3b164dc002993c935341f36cdafe9514 \
-              sha256 71f8fe704978c86ed8e97ee35ceca0b5f218ff668a095637fdbc35d4a401a026 \
-              size   4269904
+    github.setup gnss-sdr gnss-sdr f75017e5206a2803f8dcd9dc6d1385bb939586c7
+    version   20210111-[string range ${github.version} 0 7]
+    checksums rmd160 6c5c60d95184c23a302c2f6867ec1ac619cd7cdc \
+              sha256 29e715beb64877486ea9b09302ac3b4587dd85098a178ae4f98bb7d61fdbc95a \
+              size   4271026
     revision  0
 
     conflicts volk-gnss-sdr
@@ -137,9 +137,11 @@ configure.args-append \
 test.run yes
 
 # temporary fix to remove same-named files from 'volk' install
-post-destroot {
-    file delete ${destroot}${prefix}/bin/list_cpu_features
-    file delete ${destroot}${prefix}/lib/libcpu_features.a
-    file delete -force ${destroot}${prefix}/include/cpu_features
-    file delete -force ${destroot}${prefix}/lib/cmake/CpuFeatures
+if {${subport} eq "volk-gnss-sdr"} {
+    post-destroot {
+        file delete ${destroot}${prefix}/bin/list_cpu_features
+        file delete ${destroot}${prefix}/lib/libcpu_features.a
+        file delete -force ${destroot}${prefix}/include/cpu_features
+        file delete -force ${destroot}${prefix}/lib/cmake/CpuFeatures
+    }
 }


### PR DESCRIPTION
#### Description

This PR  updates the volk-gnss-sdr-devel subport, so now it makes use of the cpu_features files installed by the volk port, thus avoiding the collision when trying to install files with the same name.

See [this comment](https://github.com/macports/macports-ports/pull/9660#issuecomment-756850505) in PR #9660

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1
Xcode 12.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
