### PR TITLE
openmpi: force use of macports libevent, to eliminate implicit use when already installed

### DIFF
--- a/science/openmpi/Portfile
+++ b/science/openmpi/Portfile
@@ -9,6 +9,7 @@ PortGroup           legacysupport 1.0
 
 name                openmpi
 version             4.1.0
+revision            0
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          science parallel net
 platforms           darwin
@@ -151,7 +152,8 @@ if {${subport} != ${name}} {
     archive_sites
 
     depends_build-append        port:pkgconfig
-    depends_lib-append          port:hwloc
+    depends_lib-append          port:hwloc \
+                                port:libevent
     depends_run                 port:mpi_select port:mpi-doc
     select.group                mpi
     select.file                 ${filespath}/${name}-${cname}
@@ -173,7 +175,8 @@ if {${subport} != ${name}} {
         --datadir=${prefix}/share/${name}-${cname} \
         --docdir=${prefix}/share/docdelete \
         --mandir=${prefix}/share/mandelete \
-        --with-hwloc=${prefix}
+        --with-hwloc=${prefix} \
+        --with-libevent=${prefix}
 
     post-destroot {
         if {[string first "-devel" $subport] > 0} {


### PR DESCRIPTION
#### Description

Force use of macports libevent, to ensure it is not used implicitly. Necessary for OpenMPI 4.x, as the configure script behavior changed to favor an external version (when available).

Fixes: https://trac.macports.org/ticket/59626

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.8.5 12F2560
Xcode 5.1.1 5B1008

macOS 10.12.6 16G2136
Xcode 9.2 9C40b

macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
