### PR TITLE
qt5 PortGroup: support arm64

### DIFF
--- a/_resources/port1.0/group/qt5-1.0.tcl
+++ b/_resources/port1.0/group/qt5-1.0.tcl
@@ -7,7 +7,7 @@
 
 global available_qt_versions
 array set available_qt_versions {
-    qt5   {qt5-qtbase   5.14}
+    qt5   {qt5-qtbase   5.15}
     qt513 {qt513-qtbase 5.13}
     qt511 {qt511-qtbase 5.11}
     qt59  {qt59-qtbase  5.9}
@@ -660,7 +660,10 @@ global qt_qmake_spec_32
 global qt_qmake_spec_64
 compiler.blacklist-append *gcc*
 
-if {[vercmp ${qt5.version} 5.10]>=0} {
+if {[vercmp ${qt5.version} 5.15]>=0} {
+    # only qt5 5.15.x has so far been built as arm64 on MacPorts
+    default supported_archs "x86_64 arm64"
+} elseif {[vercmp ${qt5.version} 5.10]>=0} {
     # see https://bugreports.qt.io/browse/QTBUG-58401
     default supported_archs x86_64
 } else {

--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -162,7 +162,7 @@ array set modules {
         {"Qt Core" "Qt GUI" "Qt Network" "Qt SQL" "Qt Test" "Qt Widgets" "Qt Concurrent" "Qt D-Bus" "Qt OpenGL" "Qt Platform Headers" "Qt Print Support" "Qt XML"}
         ""
         "variant overrides: "
-        "revision 0"
+        "revision 1"
         "License: "
     }
     qtcharts {
@@ -935,6 +935,13 @@ foreach {module module_info} [array get modules] {
             # this patch is specific to version 5.15
             patchfiles-append patch-qt515-highsierra1.diff
 
+            # upstream patch to allow for non-x86_64 builds
+            # https://github.com/qt/qtbase/commit/9082cc8e8d5a6441dabe5e7a95bc0cd9085b95fe
+            patchfiles-append patch-qmake-dont-hard-code-x86_64-as-the-architecture-when-using-qmake.diff
+
+            # and also patch the mkspecs we are going to install as well
+            patchfiles-append patch-qmake-dont-hard-code-x86_64-as-the-architecture-when-using-qmake-installed.diff
+
             # find the Rez program
             patchfiles-append patch-find_rez.diff
             post-patch {
@@ -1065,16 +1072,16 @@ foreach {module module_info} [array get modules] {
             }
 
             # respect configure.universal_archs or build_arch
-            post-patch {
-                if {[variant_exists universal] && [variant_isset universal]} {
-                    set arch_replace ${configure.universal_archs}
-                } else {
-                    set arch_replace ${build_arch}
-                }
-                reinplace \
-                    "s|__MACPORTS_DEVICE_ARCHS__|${arch_replace}|g" \
-                    ${worksrcpath}/mkspecs/common/macx.conf
-            }
+            #post-patch {
+            #    if {[variant_exists universal] && [variant_isset universal]} {
+            #        set arch_replace ${configure.universal_archs}
+            #    } else {
+            #        set arch_replace ${build_arch}
+            #    }
+            #    reinplace \
+            #        "s|__MACPORTS_DEVICE_ARCHS__|${arch_replace}|g" \
+            #        ${worksrcpath}/mkspecs/common/macx.conf
+            #}
 
             # use MacPorts X11
             post-patch {

--- a/aqua/qt5/files/patch-mkspecs.diff
+++ b/aqua/qt5/files/patch-mkspecs.diff
@@ -1,5 +1,22 @@
---- mkspecs/common/clang.conf.orig	2017-06-28 02:54:29.000000000 -0700
-+++ mkspecs/common/clang.conf	2017-08-27 07:20:26.000000000 -0700
+diff --git mkspecs/common/clang-mac.conf mkspecs/common/clang-mac.conf
+index 14340630..a98aa869 100644
+--- mkspecs/common/clang-mac.conf
++++ mkspecs/common/clang-mac.conf
+@@ -7,8 +7,8 @@ QMAKE_OBJCXXFLAGS_USE_PRECOMPILE = $$QMAKE_CFLAGS_USE_PRECOMPILE
+ QMAKE_XCODE_GCC_VERSION = com.apple.compilers.llvm.clang.1_0
+ QMAKE_LFLAGS_LTCG_SEPARATE_DEBUG_INFO = -Wl,-object_path_lto,${OBJECTS_DIR}/${TARGET}_lto.o
+ 
+-QMAKE_CXXFLAGS += -stdlib=libc++
+-QMAKE_LFLAGS   += -stdlib=libc++
++QMAKE_CXXFLAGS += -stdlib=__MACPORTS_CXX_STDLIB__
++QMAKE_LFLAGS   += -stdlib=__MACPORTS_CXX_STDLIB__
+ QMAKE_AR_LTCG  = libtool -static -o
+ 
+ QMAKE_CFLAGS_APPLICATION_EXTENSION  = -fapplication-extension
+diff --git mkspecs/common/clang.conf mkspecs/common/clang.conf
+index dad15a22..8a30113e 100644
+--- mkspecs/common/clang.conf
++++ mkspecs/common/clang.conf
 @@ -4,8 +4,8 @@
  
  QMAKE_COMPILER          = gcc clang llvm   # clang pretends to be gcc
@@ -11,9 +28,24 @@
  
  QMAKE_LINK_C            = $$QMAKE_CC
  QMAKE_LINK_C_SHLIB      = $$QMAKE_CC
---- mkspecs/common/macx.conf.orig	2017-06-28 02:54:29.000000000 -0700
-+++ mkspecs/common/macx.conf	2017-08-27 07:11:49.000000000 -0700
-@@ -3,10 +3,10 @@
+diff --git mkspecs/common/gcc-base.conf mkspecs/common/gcc-base.conf
+index 99d77156..2e124369 100644
+--- mkspecs/common/gcc-base.conf
++++ mkspecs/common/gcc-base.conf
+@@ -34,7 +34,7 @@
+ QMAKE_CFLAGS_OPTIMIZE      = -O2
+ QMAKE_CFLAGS_OPTIMIZE_FULL = -O3
+ QMAKE_CFLAGS_OPTIMIZE_DEBUG = -Og
+-QMAKE_CFLAGS_OPTIMIZE_SIZE = -Os
++QMAKE_CFLAGS_OPTIMIZE_SIZE = __MACPORTS_OPTFLAGS__
+ 
+ !equals(QMAKE_HOST.os, Windows): QMAKE_CFLAGS += -pipe
+ QMAKE_CFLAGS_DEPS          += -M
+diff --git mkspecs/common/macx.conf mkspecs/common/macx.conf
+index 4ba0a8ea..5f75283f 100644
+--- mkspecs/common/macx.conf
++++ mkspecs/common/macx.conf
+@@ -3,9 +3,9 @@
  #
  
  QMAKE_PLATFORM         += macos osx macx
@@ -21,14 +53,14 @@
 +QMAKE_MAC_SDK           = __MACPORTS_MAC_SDK__
  
 -QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.13
--QMAKE_APPLE_DEVICE_ARCHS = x86_64
 +QMAKE_MACOSX_DEPLOYMENT_TARGET = __MACPORTS_DEPLOYMENT_TARGET__
-+QMAKE_APPLE_DEVICE_ARCHS = __MACPORTS_DEVICE_ARCHS__
  
  # Should be 10.15, but as long as the CI builds with
  # older SDKs we have to keep this.
---- mkspecs/macx-clang/qmake.conf.orig	2017-06-28 02:54:29.000000000 -0700
-+++ mkspecs/macx-clang/qmake.conf	2017-08-27 07:13:38.000000000 -0700
+diff --git mkspecs/macx-clang/qmake.conf mkspecs/macx-clang/qmake.conf
+index 0cf1f31b..73752938 100644
+--- mkspecs/macx-clang/qmake.conf
++++ mkspecs/macx-clang/qmake.conf
 @@ -21,8 +21,8 @@
  # and X11, OpenGL is currently not supported.
  
@@ -40,27 +72,3 @@
  
  include(../common/macx.conf)
  include(../common/gcc-base-mac.conf)
---- mkspecs/common/clang-mac.conf.orig	2017-06-28 02:54:29.000000000 -0700
-+++ mkspecs/common/clang-mac.conf	2017-08-27 07:17:44.000000000 -0700
-@@ -7,8 +7,8 @@ 
- QMAKE_XCODE_GCC_VERSION = com.apple.compilers.llvm.clang.1_0
- QMAKE_LFLAGS_LTCG_SEPARATE_DEBUG_INFO = -Wl,-object_path_lto,${OBJECTS_DIR}/${TARGET}_lto.o
- 
--QMAKE_CXXFLAGS += -stdlib=libc++
--QMAKE_LFLAGS   += -stdlib=libc++
-+QMAKE_CXXFLAGS += -stdlib=__MACPORTS_CXX_STDLIB__
-+QMAKE_LFLAGS   += -stdlib=__MACPORTS_CXX_STDLIB__
- QMAKE_AR_LTCG  = libtool -static -o
- 
- QMAKE_CFLAGS_APPLICATION_EXTENSION  = -fapplication-extension
---- mkspecs/common/gcc-base.conf.orig	2017-06-28 02:54:29.000000000 -0700
-+++ mkspecs/common/gcc-base.conf	2017-10-12 09:42:06.000000000 -0700
-@@ -34,7 +34,7 @@
- QMAKE_CFLAGS_OPTIMIZE      = -O2
- QMAKE_CFLAGS_OPTIMIZE_FULL = -O3
- QMAKE_CFLAGS_OPTIMIZE_DEBUG = -Og
--QMAKE_CFLAGS_OPTIMIZE_SIZE = -Os
-+QMAKE_CFLAGS_OPTIMIZE_SIZE = __MACPORTS_OPTFLAGS__
- 
- !equals(QMAKE_HOST.os, Windows): QMAKE_CFLAGS += -pipe
- QMAKE_CFLAGS_DEPS          += -M

--- a/aqua/qt5/files/patch-qmake-dont-hard-code-x86_64-as-the-architecture-when-using-qmake-installed.diff
+++ b/aqua/qt5/files/patch-qmake-dont-hard-code-x86_64-as-the-architecture-when-using-qmake-installed.diff
@@ -1,0 +1,67 @@
+From <https://github.com/qt/qtbase/commit/9082cc8e8d5a6441dabe5e7a95bc0cd9085b95fe>
+
+This patch is for the mkspecs that we are going to install with qt5-qtbase
+
+
+
+
+diff --git mkspecs-save/common/macx.conf mkspecs-save/common/macx.conf
+index 1f99c8ff5ab..1b8bbbe047c 100644
+--- mkspecs-save/common/macx.conf
++++ mkspecs-save/common/macx.conf
+@@ -6,7 +6,6 @@ QMAKE_PLATFORM         += macos osx macx
+ QMAKE_MAC_SDK           = macosx
+ 
+ QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.13
+-QMAKE_APPLE_DEVICE_ARCHS = x86_64
+ 
+ # Should be 10.15, but as long as the CI builds with
+ # older SDKs we have to keep this.
+diff --git mkspecs-save/features/mac/default_post.prf mkspecs-save/features/mac/default_post.prf
+index 92a9112bca6..d888731ec8d 100644
+--- mkspecs-save/features/mac/default_post.prf
++++ mkspecs-save/features/mac/default_post.prf
+@@ -90,6 +90,11 @@ app_extension_api_only {
+     QMAKE_LFLAGS              += $$QMAKE_CFLAGS_APPLICATION_EXTENSION
+ }
+ 
++# Non-universal builds do not set QMAKE_APPLE_DEVICE_ARCHS,
++# so we pick it up from what the arch test resolved instead.
++isEmpty(QMAKE_APPLE_DEVICE_ARCHS): \
++    QMAKE_APPLE_DEVICE_ARCHS = $$QT_ARCH
++
+ macx-xcode {
+     qmake_pkginfo_typeinfo.name = QMAKE_PKGINFO_TYPEINFO
+     !isEmpty(QMAKE_PKGINFO_TYPEINFO): \
+@@ -145,9 +150,6 @@ macx-xcode {
+     simulator: VALID_SIMULATOR_ARCHS = $$QMAKE_APPLE_SIMULATOR_ARCHS
+     VALID_ARCHS = $$VALID_DEVICE_ARCHS $$VALID_SIMULATOR_ARCHS
+ 
+-    isEmpty(VALID_ARCHS): \
+-        error("QMAKE_APPLE_DEVICE_ARCHS or QMAKE_APPLE_SIMULATOR_ARCHS must contain at least one architecture")
+-
+     single_arch: VALID_ARCHS = $$first(VALID_ARCHS)
+ 
+     ACTIVE_ARCHS = $(filter $(EXPORT_VALID_ARCHS), $(ARCHS))
+diff --git mkspecs/features/toolchain.prf mkspecs/features/toolchain.prf
+index 2a1f7cba3dd..0040b6c4b9f 100644
+--- mkspecs-save/features/toolchain.prf
++++ mkspecs-save/features/toolchain.prf
+@@ -182,9 +182,14 @@ isEmpty($${target_prefix}.INCDIRS) {
+         # UIKit simulator platforms will see the device SDK's sysroot in
+         # QMAKE_DEFAULT_*DIRS, because they're handled in a single build pass.
+         darwin {
+-            # Clang doesn't pick up the architecture from the sysroot, and will
+-            # default to the host architecture, so we need to manually set it.
+-            cxx_flags += -arch $$QMAKE_APPLE_DEVICE_ARCHS
++            uikit {
++                # Clang doesn't automatically pick up the architecture, just because
++                # we're passing the iOS sysroot below, and we will end up building the
++                # test for the host architecture, resulting in linker errors when
++                # linking against the iOS libraries. We work around this by passing
++                # the architecture explicitly.
++                cxx_flags += -arch $$first(QMAKE_APPLE_DEVICE_ARCHS)
++            }
+ 
+             uikit:macx-xcode: \
+                 cxx_flags += -isysroot $$sdk_path_device.value

--- a/aqua/qt5/files/patch-qmake-dont-hard-code-x86_64-as-the-architecture-when-using-qmake.diff
+++ b/aqua/qt5/files/patch-qmake-dont-hard-code-x86_64-as-the-architecture-when-using-qmake.diff
@@ -1,0 +1,159 @@
+From <https://github.com/qt/qtbase/commit/9082cc8e8d5a6441dabe5e7a95bc0cd9085b95fe>
+
+From 9082cc8e8d5a6441dabe5e7a95bc0cd9085b95fe Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tor=20Arne=20Vestb=C3=B8?= <tor.arne.vestbo@qt.io>
+Date: Fri, 4 Dec 2020 17:29:06 +0100
+Subject: [PATCH] macOS: Don't hard-code x86_64 as the architecture when using
+ qmake
+
+The qmake variable QMAKE_APPLE_DEVICE_ARCHS was added for iOS,
+to support universal builds, as the QT_ARCH is a single value.
+
+Since the qmake macOS builds are non-universal (at the moment),
+we remove the hard-coded value for QMAKE_APPLE_DEVICE_ARCHS on
+macOS, and let the normal architecture test resolve the arch,
+like on other platforms.
+
+To ensure that the following configuration tests are run with
+an -arch argument, we trigger a commit of the preliminary Qt
+configuration after running the architecture test. This is not
+strictly necessary, but makes it clearer what's going on during
+configure.
+
+The device_and_simulator configuration option was used by the
+iOS toolchain, and needed to be moved up in the configuration
+test order to not break later tests.
+
+The logic in mac/default_post.prf for both Xcode and Makefiles
+to add -arch flags was kept as is, based on the existing
+variable, to avoid too many changes to this logic.
+
+The logic in toolchain.prf was amended to make it clear and
+ensure that it only applies to iOS builds. macOS builds do
+not have this issue.
+
+Pick-to: 6.0
+Pick-to: 5.15
+Pick-to: 5.12
+Change-Id: I70db7e4c27f0d3da5d0af33cb491d72c312d3fa8
+Reviewed-by: Alexandru Croitor <alexandru.croitor@qt.io>
+---
+ configure.json                        | 13 ++++++++++---
+ configure.pri                         |  7 +++++++
+ mkspecs/common/macx.conf              |  1 -
+ mkspecs/features/mac/default_post.prf |  8 +++++---
+ mkspecs/features/toolchain.prf        | 11 ++++++++---
+ 5 files changed, 30 insertions(+), 10 deletions(-)
+
+diff --git configure.json configure.json
+index 29afbac43d5..a9249e1ed29 100644
+--- configure.json
++++ configure.json
+@@ -241,11 +241,18 @@
+ 
+     "testTypeDependencies": {
+         "linkerSupportsFlag": [ "use_bfd_linker", "use_gold_linker", "use_lld_linker" ],
+-        "verifySpec": [ "shared", "use_bfd_linker", "use_gold_linker", "use_lld_linker", "compiler-flags", "qmakeargs", "commit" ],
++        "verifySpec": [
++            "shared",
++            "use_bfd_linker", "use_gold_linker", "use_lld_linker",
++            "compiler-flags", "qmakeargs",
++            "simulator_and_device",
++            "thread",
++            "commit" ],
+         "compile": [ "verifyspec" ],
+         "detectPkgConfig": [ "cross_compile", "machineTuple" ],
+         "library": [ "pkg-config", "compiler-flags" ],
+-        "getPkgConfigVariable": [ "pkg-config" ]
++        "getPkgConfigVariable": [ "pkg-config" ],
++        "architecture" : [ "verifyspec" ]
+     },
+ 
+     "testTypeAliases": {
+@@ -749,7 +756,7 @@
+         },
+         "architecture": {
+             "label": "Architecture",
+-            "output": [ "architecture" ]
++            "output": [ "architecture", "commitConfig" ]
+         },
+         "pkg-config": {
+             "label": "Using pkg-config",
+diff --git configure.pri configure.pri
+index a04aa172366..f55b7cb448d 100644
+--- configure.pri
++++ configure.pri
+@@ -660,6 +660,13 @@ defineTest(qtConfOutput_commitOptions) {
+     write_file($$QT_BUILD_TREE/mkspecs/qdevice.pri, $${currentConfig}.output.devicePro)|error()
+ }
+ 
++# Output is written after configuring each Qt module,
++# but some tests within a module might depend on the
++# configuration output of previous tests.
++defineTest(qtConfOutput_commitConfig) {
++    qtConfProcessOutput()
++}
++
+ # type (empty or 'host'), option name, default value
+ defineTest(processQtPath) {
+     out_var = config.rel_input.$${2}
+diff --git mkspecs/common/macx.conf mkspecs/common/macx.conf
+index 1f99c8ff5ab..1b8bbbe047c 100644
+--- mkspecs/common/macx.conf
++++ mkspecs/common/macx.conf
+@@ -6,7 +6,6 @@ QMAKE_PLATFORM         += macos osx macx
+ QMAKE_MAC_SDK           = macosx
+ 
+ QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.13
+-QMAKE_APPLE_DEVICE_ARCHS = x86_64
+ 
+ # Should be 10.15, but as long as the CI builds with
+ # older SDKs we have to keep this.
+diff --git mkspecs/features/mac/default_post.prf mkspecs/features/mac/default_post.prf
+index 92a9112bca6..d888731ec8d 100644
+--- mkspecs/features/mac/default_post.prf
++++ mkspecs/features/mac/default_post.prf
+@@ -90,6 +90,11 @@ app_extension_api_only {
+     QMAKE_LFLAGS              += $$QMAKE_CFLAGS_APPLICATION_EXTENSION
+ }
+ 
++# Non-universal builds do not set QMAKE_APPLE_DEVICE_ARCHS,
++# so we pick it up from what the arch test resolved instead.
++isEmpty(QMAKE_APPLE_DEVICE_ARCHS): \
++    QMAKE_APPLE_DEVICE_ARCHS = $$QT_ARCH
++
+ macx-xcode {
+     qmake_pkginfo_typeinfo.name = QMAKE_PKGINFO_TYPEINFO
+     !isEmpty(QMAKE_PKGINFO_TYPEINFO): \
+@@ -145,9 +150,6 @@ macx-xcode {
+     simulator: VALID_SIMULATOR_ARCHS = $$QMAKE_APPLE_SIMULATOR_ARCHS
+     VALID_ARCHS = $$VALID_DEVICE_ARCHS $$VALID_SIMULATOR_ARCHS
+ 
+-    isEmpty(VALID_ARCHS): \
+-        error("QMAKE_APPLE_DEVICE_ARCHS or QMAKE_APPLE_SIMULATOR_ARCHS must contain at least one architecture")
+-
+     single_arch: VALID_ARCHS = $$first(VALID_ARCHS)
+ 
+     ACTIVE_ARCHS = $(filter $(EXPORT_VALID_ARCHS), $(ARCHS))
+diff --git mkspecs/features/toolchain.prf mkspecs/features/toolchain.prf
+index 2a1f7cba3dd..0040b6c4b9f 100644
+--- mkspecs/features/toolchain.prf
++++ mkspecs/features/toolchain.prf
+@@ -182,9 +182,14 @@ isEmpty($${target_prefix}.INCDIRS) {
+         # UIKit simulator platforms will see the device SDK's sysroot in
+         # QMAKE_DEFAULT_*DIRS, because they're handled in a single build pass.
+         darwin {
+-            # Clang doesn't pick up the architecture from the sysroot, and will
+-            # default to the host architecture, so we need to manually set it.
+-            cxx_flags += -arch $$QMAKE_APPLE_DEVICE_ARCHS
++            uikit {
++                # Clang doesn't automatically pick up the architecture, just because
++                # we're passing the iOS sysroot below, and we will end up building the
++                # test for the host architecture, resulting in linker errors when
++                # linking against the iOS libraries. We work around this by passing
++                # the architecture explicitly.
++                cxx_flags += -arch $$first(QMAKE_APPLE_DEVICE_ARCHS)
++            }
+ 
+             uikit:macx-xcode: \
+                 cxx_flags += -isysroot $$sdk_path_device.value


### PR DESCRIPTION
at present only on qt5.15.x and above
universal builds not tested as yet

closes: https://trac.macports.org/ticket/60944

