### PR TITLE
mos: update to 2.19.0

### DIFF
--- a/devel/mos/Portfile
+++ b/devel/mos/Portfile
@@ -3,9 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/mongoose-os/mos 2.18.0
+go.setup            github.com/mongoose-os/mos 2.19.0
 conflicts           ${name}-devel
-revision            1
+revision            0
 categories          devel
 license             Apache-2
 
@@ -52,22 +52,24 @@ post-patch {
 configure.env       PYTHON3=${prefix}/bin/python${python_branch}
 build.cmd           make
 
+# Test all packages in directory tree
+test.run            yes
+test.target         ./...
+
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
 }
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  9ad2092f04bae9e21d26999e38699c5d3ceba7e3 \
-                        sha256  555df9fc6a629f6b79e61245cb4802544193e14528b110c13de015e2098954be \
-                        size    673863
+                        rmd160  66d697552c9ea2c1c443eb236598f317f9293325 \
+                        sha256  f05df7ee2176e3ffb53fe2ab248b24463cbb9a189884bad10a4052bf477698ae \
+                        size    674562
 
-# NOTES FOR UPDATING 
+# NOTES FOR UPDATING
 # See mos-devel for help in updating
 # github.com/docker/docker is now github.com/moby/moby
 # v17.12.0-ce-rc1.0.20181016164535-5271c7cb484d+incompatible of docker/docker should be v17.12.0-ce-rc1
 # github.com/go-ini/ini hash should be used, and placed above gopkg.in/ini.v1
-# github.com/theckman/go-flock is now github.com/gofrs/flock
-# github.com/theckman/go-flock and github.com/gofrs/flock both used. github.com/gofrs/flock hash placed above theckman
 # jtolds should be jtolio
 # Microsoft needs to be lowercase
 
@@ -79,10 +81,10 @@ go.vendors          k8s.io/klog \
                         size    39993 \
                     gotest.tools \
                         repo    github.com/gotestyourself/gotest.tools \
-                        lock    v2.1.0 \
-                        rmd160  4c6ab0e0c39c930e23b840ad44d28f440ce3a18d \
-                        sha256  1626806815e917a551a1fc846995cffad016e5751d961532323212f0ddc2198e \
-                        size    56487 \
+                        lock    v2.2.0 \
+                        rmd160  cb0575d175c0eab986da6c2778312c95b506216c \
+                        sha256  d38e94ad87cf05274b1606ba10a489b88199fd373d9943ac256b463bc1542e57 \
+                        size    56869 \
                     gopkg.in/yaml.v2 \
                         lock    v2.2.4 \
                         rmd160  e7d6084770eadd1aea75e3e6ad70962436c22989 \
@@ -115,10 +117,10 @@ go.vendors          k8s.io/klog \
                         size    31616 \
                     google.golang.org/grpc \
                         repo    github.com/grpc/grpc-go \
-                        lock    v1.17.0 \
-                        rmd160  cfe04e0438b61ebeb2d41af1cb67eaa867edef9a \
-                        sha256  b20a487022207a29f1ccbbddc10562434354a7f0a147b997a32f20a4237898a4 \
-                        size    563589 \
+                        lock    v1.22.0 \
+                        rmd160  998cd31c7f25aef682f9a5ecf23f4f263abd77a3 \
+                        sha256  1cba8de8897802041a9403ccacd01a784dfba69b94bd4bf158799568f7512e7b \
+                        size    742509 \
                     google.golang.org/genproto \
                         repo    github.com/googleapis/go-genproto \
                         lock    8819c946db44 \
@@ -194,27 +196,6 @@ go.vendors          k8s.io/klog \
                         rmd160  356547460413381067ab37d9a8ce904dc91e5d9b \
                         sha256  0e439b2a0962200a2e7872fb8cfe8f9be6942aa66a89230c805aac3ddc456664 \
                         size    7623 \
-                    github.com/vishvananda/netns \
-                        lock    13995c7128cc \
-                        rmd160  235dbd7bd26335c9321796e1afad96c86a22fd01 \
-                        sha256  74d93513da4d3016cd34bf302e34251da1facd701014fdc299be36730e472afd \
-                        size    7865 \
-                    github.com/vishvananda/netlink \
-                        lock    v1.0.0 \
-                        rmd160  876a6a0e1ee5c41ce87838c8099afa3c8dffb0e6 \
-                        sha256  727c5750c781e67f1cce6200b6b29103d3efee72e5d18a5a98a484a4557173ab \
-                        size    119963 \
-                    github.com/gofrs/flock \
-                        lock    392e7fae8f1b0bdbd67dad7237d23f618feb6dbb \
-                        rmd160  11ff63d56f27c7c99593e5a9f654f7a9690eca47 \
-                        sha256  f4c610afd9f8681ceb049bc27b16329de58e40693d0eba13b1809633ae8a172e \
-                        size    7289 \
-                    github.com/theckman/go-flock \
-                        repo    github.com/gofrs/flock \
-                        lock    v0.7.0 \
-                        rmd160  a18c8f5a96e7b7e3aaf574a46cf68ebb085f1fed \
-                        sha256  e21a652f3042352d78a76134290a7436c82b36511b34d180a9fd368fbe4a14bf \
-                        size    7268 \
                     github.com/stretchr/testify \
                         lock    v1.4.0 \
                         rmd160  86bd663e13ea7266334c47689074df16252db5ff \
@@ -241,10 +222,10 @@ go.vendors          k8s.io/klog \
                         sha256  43650db3719bb888dc000c9316c69fff549822d0374a57b2d59ce5e86a9e76cf \
                         size    7019 \
                     github.com/sirupsen/logrus \
-                        lock    680f584d621d \
-                        rmd160  7c277f23c7f895c8978146f65bc7cd786ca0c8e1 \
-                        sha256  04b0da35bf185e7c9978ce253a90778a1822a0987accb04bb02cb2db46bae42b \
-                        size    33669 \
+                        lock    v1.4.1 \
+                        rmd160  ebde5e9141f9618aab63ac2448e1125ce5944776 \
+                        sha256  3da9149cdc4b1500b0c055c9aba699e3c074cdb44de0cbcb8f769eaff8e02e03 \
+                        size    40818 \
                     github.com/sergi/go-diff \
                         lock    v1.1.0 \
                         rmd160  6449feb5884c316206f256e55b81aba3e6a78a9f \
@@ -316,10 +297,10 @@ go.vendors          k8s.io/klog \
                         sha256  f6c3f89667c63e5b7f1fc6ee2c06b6a6bfdce88f3a965ccd395b64c6f95c9a47 \
                         size    8553 \
                     github.com/konsorten/go-windows-terminal-sequences \
-                        lock    b729f2633dfe \
-                        rmd160  6eefc01e840a12399e567480dd29018455b01ba5 \
-                        sha256  4d5a1c9235aa6609029bf358c306d659958aab21c3afea165dbd8a7b8ab33ca4 \
-                        size    1859 \
+                        lock    v1.0.1 \
+                        rmd160  180a26856df70cac3359c725a12955cc4899cfb8 \
+                        sha256  493c09f694c8496f1eac50a50ab76e9c492a8b288924329a433a29435447bca5 \
+                        size    1906 \
                     github.com/kevinburke/ssh_config \
                         lock    01f96b0aa0cd \
                         rmd160  c962defaa545cfeafa69e015b409607091fa81ee \
@@ -382,25 +363,30 @@ go.vendors          k8s.io/klog \
                         sha256  362d13c754f3d96223c013c22eda3a9ebfc6179b9dda486bc9293ff167258e47 \
                         size    249524 \
                     github.com/google/go-cmp \
-                        lock    v0.3.0 \
-                        rmd160  023b52ba78fcaa734cfa0f54111e6ee8aba4777b \
-                        sha256  0672ceb4418adc04c39047892ec8f6322165c099ac3755c491ff722c47897cae \
-                        size    76135 \
+                        lock    v0.3.1 \
+                        rmd160  66e42f672a5a40561c388b78b3644abd926e7bef \
+                        sha256  86ee7c90714e7eb5c60d1a8a515235daef806df454c767043b593540e958167f \
+                        size    76416 \
                     github.com/golang/protobuf \
-                        lock    347cf4a86c1c \
-                        rmd160  4cdb4dfcd5336d258e581dd2f524af3549a1b4a1 \
-                        sha256  76a08ba3ffabc9786c200a817dfc11fa410abc1d681e67c7f980693170b9e801 \
-                        size    329195 \
+                        lock    v1.3.0 \
+                        rmd160  2bc16a2820ff31cd8299d35f03295af9fb521315 \
+                        sha256  3dce948004a81c947ab830a734eae83a9559f38ad9dab25417fa495d16f880d3 \
+                        size    329176 \
                     github.com/golang/glog \
                         lock    23def4e6c14b \
                         rmd160  b5bd9166cd1e073a035b5bbd3c4d9febf2c917a7 \
                         sha256  2826d20759090e909ba0f8771def236ad6433fc3e44bdc28374b309efe3e57cf \
                         size    19662 \
                     github.com/gogo/protobuf \
-                        lock    v1.1.1 \
-                        rmd160  71086a467a47129a1932d8502170ad5d58b83a84 \
-                        sha256  ff99aac8091263f4053491ccd874ca4d6ef0aa7e90b3120b1875cd4dcc2c2e4b \
-                        size    1868511 \
+                        lock    v1.2.1 \
+                        rmd160  494337d5b5a44ef41ab2d8af5273c33e37e5f3ff \
+                        sha256  aada5eeede08e90c3ec1141a4913d344cfa17fa14d37db17b7a87137c83c8644 \
+                        size    2017659 \
+                    github.com/gofrs/flock \
+                        lock    v0.7.1 \
+                        rmd160  13e11a2c3709abc110893e99ed0ddebd6738216f \
+                        sha256  419157453801b3875873bdffa2f6dfbc7b03f42fa7e69dab60da688841c7d16a \
+                        size    7297 \
                     github.com/go-logr/logr \
                         lock    v0.2.0 \
                         rmd160  40a88db949dfa2a245a79414fea435b6734830be \
@@ -437,10 +423,10 @@ go.vendors          k8s.io/klog \
                         sha256  fab13a77bd8c2ec9e8f441b81515016f2783fa348405676d9952f2ad78412ca2 \
                         size    21484 \
                     github.com/fsouza/go-dockerclient \
-                        lock    66e134a27bd8 \
-                        rmd160  7c7c9d505d47d0f71246c9ecbcd80c3289fbe1a7 \
-                        sha256  a3dbdf9d44d2b96549ca43d85c366884c713b7fc897d4e845584d1b78dbb7b15 \
-                        size    152085 \
+                        lock    v1.5.0 \
+                        rmd160  8ed84177c0d7c0798841d35f60d111954ccfc589 \
+                        sha256  9b42b751813feb078d5cb17c0e6204411f133e44a66a66fcea31ef811c5ef3ec \
+                        size    145427 \
                     github.com/flynn/go-shlex \
                         lock    3f9db97f8568 \
                         rmd160  ec42eaffe2cf17a46e12c7c2a7d436c0f68ba655 \
@@ -466,16 +452,11 @@ go.vendors          k8s.io/klog \
                         rmd160  a045d7c4db0d62285dae151826607c2c5bac51e4 \
                         sha256  c1deebf18f0c43d1a19ca15f170c0823895087c2471713ffd3dbc6e1e0acdcd3 \
                         size    70106 \
-                    github.com/docker/libnetwork \
-                        lock    19279f049241 \
-                        rmd160  eb1ff27f8b3403c7fe0e6eaaf57c47b7a2d1fa9e \
-                        sha256  fc45b4ef565317a0bf6ecabac8c4a5b6aa0172deb11639883fda593b41f0fb06 \
-                        size    2695951 \
                     github.com/docker/go-units \
-                        lock    v0.3.3 \
-                        rmd160  8438067ab4930245c5354bb35491b02c429ba79b \
-                        sha256  e7d0de26ad2a6fe849521563eb05f9a22f3ddf6daf428ce6546ae4dd615f0801 \
-                        size    11227 \
+                        lock    v0.4.0 \
+                        rmd160  601c61f9c14069da8dd0b87c06615c9f0b7f5895 \
+                        sha256  35ff0b87bbe66d7cadbbe26140f7504df76ccef6654bbe43534afc7f30eff25f \
+                        size    11520 \
                     github.com/docker/go-connections \
                         lock    v0.4.0 \
                         rmd160  ca292c68d7b491dab7afc866d62723ee50c27f4e \
@@ -493,10 +474,10 @@ go.vendors          k8s.io/klog \
                         sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
                         size    42171 \
                     github.com/containerd/continuity \
-                        lock    bd77b46c8352 \
-                        rmd160  eaed47014196dd18d0715c615c487969898699a5 \
-                        sha256  742abe20a424addf90c5d92ccd9619ea5dd18a7a095028c5dcdec34748695eae \
-                        size    1074026 \
+                        lock    004b46473808 \
+                        rmd160  8752c0d15b3ad22376aee689a6277892a486761b \
+                        sha256  0ca94576becb3df881cc0271493e858af37992e8d3aa472e0e2922cf2c86447b \
+                        size    1075168 \
                     github.com/cesanta/hid \
                         lock    79d86877855b \
                         rmd160  e0457035039a1a491b41c1aad3969e5b6869af56 \
@@ -534,10 +515,10 @@ go.vendors          k8s.io/klog \
                         size    10512 \
                     github.com/Microsoft/go-winio \
                         repo    github.com/microsoft/go-winio \
-                        lock    v0.4.11 \
-                        rmd160  6f8b5805e0169faf827413aa4cff3826a960af78 \
-                        sha256  76da26e81706f7bb4cc0a8264b7d93276c47ba9de4d27ddc8c2d0b5c6b8a0948 \
-                        size    79261 \
+                        lock    v0.4.14 \
+                        rmd160  cf17d0ba1074e056a848ee5b8f769352e67df555 \
+                        sha256  30767823a41f098aeeda440afa3439fe93b97d152a7ccee9b955215ba5e2f1ea \
+                        size    118038 \
                     github.com/Azure/go-ansiterm \
                         lock    d6e3b3328b78 \
                         rmd160  e9dc43a29fa14a2df0161868862c7fbab793b25a \


### PR DESCRIPTION
#### Description

As well as bumping the version number, I merged some changes from mos-devel, such as the tests.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.6 19G73
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
