### PR TITLE
bupstash: new port

### DIFF
--- a/sysutils/bupstash/Portfile
+++ b/sysutils/bupstash/Portfile
@@ -1,0 +1,136 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo 1.0
+
+github.setup        andrewchambers bupstash 0.6.4 v
+revision            0
+
+homepage            https://bupstash.io
+
+description         Easy and efficient encrypted backups
+
+long_description    Bupstash is a tool for encrypted backups - if you need \
+                    secure backups, Bupstash is the tool for you.  Bupstash \
+                    was designed to have: Efficient deduplication, Offline \
+                    decryption keys, Key/value tagging with search, Great \
+                    performance on slow networks, Secure remote access \
+                    controls, Efficient incremental backups, Fantastic \
+                    performance with low RAM usage, Safety against malicious \
+                    attacks.
+
+categories          sysutils
+platforms           darwin
+license             MIT
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  01417e673865bebb744c71af26ce07e2c9b297a3 \
+                    sha256  1cfeae63cab2a2e6bb45b0f260b12a4f89acb64b51a43b36e4573c7a46289cab \
+                    size    119320
+
+depends_build-append        port:pkgconfig
+
+depends_lib-append          port:libsodium
+
+destroot {
+    xinstall -m 755 \
+        ${worksrcpath}/target/[cargo.rust_platform]/release/${name} \
+        ${destroot}${prefix}/bin/
+}
+
+cargo.crates \
+    aho-corasick                    0.7.15  7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5 \
+    anyhow                          1.0.34  bf8dcb5b4bbaa28653b647d8c77bd4ed40183b48882e130c1f1ffb73de069fd7 \
+    arrayref                         0.3.6  a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544 \
+    arrayvec                         0.5.2  23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b \
+    atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+    autocfg                          1.0.1  cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a \
+    bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
+    blake3                           0.3.7  e9ff35b701f3914bdb8fad3368d822c766ef2858b2583198e41639b936f09d3f \
+    cc                              1.0.65  95752358c8f7552394baf48cd82695b345628ad3f170d607de3ca03b8dacca15 \
+    cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
+    cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
+    chrono                          0.4.19  670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73 \
+    codemap                          0.1.3  b9e769b5c8c8283982a987c6e948e540254f1058d5a74b8794914d4ef5fc2a24 \
+    codemap-diagnostic               0.1.1  4ba0e6be8e2774e750f9e90625b490249715bece38a12f9d09e82477caba5028 \
+    console                         0.13.0  a50aab2529019abfabfa93f1e6c41ef392f91fbf179b347a7e96abb524884a08 \
+    constant_time_eq                 0.1.5  245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc \
+    crossbeam-channel                0.5.0  dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775 \
+    crossbeam-utils                  0.8.1  02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d \
+    crypto-mac                       0.8.0  b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab \
+    digest                           0.9.0  d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066 \
+    encode_unicode                   0.3.6  a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f \
+    fallible-iterator                0.2.0  4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7 \
+    fallible-streaming-iterator      0.1.9  7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a \
+    filetime                        0.2.13  0c122a393ea57648015bf06fbd3d372378992e86b9ff5a7a497b076a28c79efe \
+    fs2                              0.4.3  9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213 \
+    generic-array                   0.14.4  501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817 \
+    getopts                         0.2.21  14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5 \
+    getrandom                       0.1.15  fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6 \
+    glob                             0.3.0  9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574 \
+    hermit-abi                      0.1.17  5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8 \
+    humantime                        2.0.1  3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a \
+    indicatif                       0.15.0  7baab56125e25686df467fe470785512329883aab42696d661247aca2a2896e4 \
+    itoa                             0.4.6  dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6 \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    libc                            0.2.80  4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614 \
+    libsqlite3-sys                  0.18.0  1e704a02bcaecd4a08b93a23f6be59d0bd79cd161e0963e9499165a0a35df7bd \
+    linked-hash-map                  0.5.3  8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a \
+    lru-cache                        0.1.2  31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c \
+    lz4                             1.23.2  aac20ed6991e01bf6a2e68cc73df2b389707403662a8ba89f68511fb340f724c \
+    lz4-sys                          1.9.2  dca79aa95d8b3226213ad454d328369853be3a1382d89532a854f4d69640acae \
+    memchr                           2.3.4  0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525 \
+    nix                             0.17.0  50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363 \
+    num-integer                     0.1.44  d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db \
+    num-traits                      0.2.14  9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290 \
+    number_prefix                    0.3.0  17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a \
+    once_cell                        1.5.2  13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0 \
+    path-clean                       0.1.0  ecba01bf2678719532c5e3059e0b5f0811273d94b397088b82e3bd0a78c78fdd \
+    pkg-config                      0.3.19  3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c \
+    ppv-lite86                      0.2.10  ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857 \
+    proc-macro2                     1.0.24  1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71 \
+    quote                            1.0.7  aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37 \
+    rand                             0.7.3  6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
+    rand_chacha                      0.2.2  f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402 \
+    rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
+    rand_hc                          0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
+    rangemap                         0.1.8  4174335dcaeee48b7d5b97969c9935f81c5f67ce25548e9b00b4d68a0da9e35f \
+    redox_syscall                   0.1.57  41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce \
+    regex                            1.4.2  38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c \
+    regex-syntax                    0.6.21  3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189 \
+    remove_dir_all                   0.5.3  3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7 \
+    rusqlite                        0.23.1  45d0fd62e1df63d254714e6cb40d0a0e82e7a1623e7a27f679d851af092ae58b \
+    ryu                              1.0.5  71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e \
+    serde                          1.0.117  b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a \
+    serde_bare                       0.3.0  01db2255aa98fb93ad74272d8b2e6fd4851860e733e944b9439cf148127164b2 \
+    serde_derive                   1.0.117  cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e \
+    serde_json                      1.0.59  dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95 \
+    shlex                            0.1.1  7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2 \
+    smallvec                         1.5.0  7acad6f34eb9e8a259d3283d1e8c1d34d7415943d4895f65cc73813c7396fc85 \
+    subtle                           2.3.0  343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd \
+    syn                             1.0.51  3b4f34193997d92804d359ed09953e25d5138df6bcc055a71bf68ee89fdf9223 \
+    tar                             0.4.30  489997b7557e9a43e192c527face4feacc78bfbe6eed67fd55c4c9e381cba290 \
+    tempfile                         3.1.0  7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9 \
+    termcolor                        1.1.2  2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4 \
+    terminal_size                   0.1.15  4bd2d183bd3fac5f5fe38ddbeb4dc9aec4a39a9d7d59e7491d900302da01cbe1 \
+    thiserror                       1.0.22  0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e \
+    thiserror-impl                  1.0.22  9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56 \
+    thread_local                     1.0.1  d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14 \
+    time                            0.1.44  6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255 \
+    typenum                         1.12.0  373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33 \
+    unicode-width                    0.1.8  9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3 \
+    unicode-xid                      0.2.1  f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564 \
+    vcpkg                           0.2.10  6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c \
+    version_check                    0.9.2  b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed \
+    void                             1.0.2  6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d \
+    wasi      0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
+    wasi     0.10.0+wasi-snapshot-preview1  1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f \
+    winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                      0.1.5  70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    xattr                            0.2.2  244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c


### PR DESCRIPTION
#### Description

New port for the **[bupstash](https://bupstash.io/)** backup utility.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
