### PR TITLE
py-blosc: do not build bundled Blosc/zlib/zstd/lz4/etc.

### DIFF
--- a/python/py-blosc/Portfile
+++ b/python/py-blosc/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-blosc
 version             1.8.1
-revision            0
+revision            1
 categories-append   devel
 platforms           darwin
 license             MIT
@@ -44,8 +44,12 @@ if {${name} ne ${subport}} {
     depends_build-append \
                         port:py${python.version}-setuptools
     depends_lib-append  port:blosc
+    depends_test-append \
+                        port:py${python.version}-numpy
 
     build.args-append   --blosc=${prefix}
+    destroot.args-append \
+                        --blosc=${prefix}
 
     pre-test {
         test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]


### PR DESCRIPTION
Add numpy test dependency

#### Description

(This port is outdated; I am not interested in updating it myself at the moment.)

This port failed to build with recent Xcode because of implicit function declarations in the outdated versions of bundled libraries (specifically zlib), which this port shouldn't be building anyway, as it should use MacPorts' Blosc/zlib/zstd/lz4/etc. instead.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7
Xcode 12.3 command line tools
Python 3.8.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
