### PR TITLE
poetry: install bash and zsh completion in post-destroot

### DIFF
--- a/python/poetry/Portfile
+++ b/python/poetry/Portfile
@@ -5,7 +5,7 @@ PortGroup               python 1.0
 
 name                    poetry
 version                 1.1.4
-revision                0
+revision                1
 categories-append       devel
 platforms               darwin
 license                 MIT
@@ -60,6 +60,17 @@ depends_lib-append \
     port:py${python.version}-packaging \
     port:py${python.version}-virtualenv \
     port:py${python.version}-keyring
+
+# Shell completion
+post-destroot {
+    xinstall -d "${destroot}${prefix}/etc/bash_completion.d"
+    xinstall -d "${destroot}${prefix}/share/zsh/site-functions"
+    system "PYTHONPATH=${destroot}${python.pkgd} ${destroot}${python.prefix}/bin/poetry completions bash > ${destroot}${prefix}/etc/bash_completion.d/poetry"
+    system "PYTHONPATH=${destroot}${python.pkgd} ${destroot}${python.prefix}/bin/poetry completions zsh > ${destroot}${prefix}/share/zsh/site-functions/_poetry"
+    reinplace "s|${destroot}||g" \
+        ${destroot}${prefix}/etc/bash_completion.d/poetry \
+        ${destroot}${prefix}/share/zsh/site-functions/_poetry
+}
 
 test.run                yes
 test.cmd                ${python.bin}


### PR DESCRIPTION
#### Description

Have poetry install its bash completion script in the post-activate phase.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
