### PR TITLE
qt5*-qtbase: fix build for Xcode 11.4 and later

### DIFF
--- a/aqua/phantomjs-qt/Portfile
+++ b/aqua/phantomjs-qt/Portfile
@@ -267,11 +267,21 @@ foreach {module module_info} [array get modules] {
                     mkspecs/features/mac/rez.prf
             }
 
-            # Qt assumes _bit_scan_reverse is not provided by Clang
-            # this assumption is incorrect for recent versions of Clang
-            #     see https://github.com/llvm/llvm-project/commit/e54093fcc0a651df14040a61fc8efdd338389afa
+            # Qt assumes Clang's x86intrin.h does not provide _bit_scan_reverse
+            # this assumption is incorrect for Clang 9.0 and later
+            #     see https://github.com/llvm/llvm-project/commit/88f4054f48c5
             # see https://trac.macports.org/ticket/59364
             patchfiles-append patch-qtbase-intel_intrinsics.diff
+            if {${os.major} >= 19} {
+                # Xcode 11.4 is also based on Clang 9.0, but
+                # patch-qtbase-intel_intrinsics.diff does not work
+                # for Xcode clang; use an alternative approach
+                # (not tested on older macOS but may work)
+                # See https://trac.macports.org/ticket/62051
+                patchfiles-replace \
+                    patch-qtbase-intel_intrinsics.diff \
+                    patch-qtbase-intel_intrinsics-xcode11.4.diff
+            }
 
             # ICU now requires C++11
             # see https://trac.macports.org/ticket/59434

--- a/aqua/phantomjs-qt/files/patch-qtbase-intel_intrinsics-xcode11.4.diff
+++ b/aqua/phantomjs-qt/files/patch-qtbase-intel_intrinsics-xcode11.4.diff
@@ -1,0 +1,11 @@
+--- src/corelib/tools/qsimd_p.h.orig	2017-09-06 05:13:54.000000000 -0700
++++ src/corelib/tools/qsimd_p.h	2021-01-12 23:42:29.000000000 -0600
+@@ -329,7 +329,7 @@
+     _BitScanForward(&result, val);
+     return result;
+ }
+-#  elif (defined(Q_CC_CLANG) || (defined(Q_CC_GNU) && Q_CC_GNU < 405)) \
++#  elif ((defined(Q_CC_CLANG) && !defined(_bit_scan_reverse)) || (!defined(Q_CC_CLANG) && defined(Q_CC_GNU) && Q_CC_GNU < 405)) \
+     && !defined(Q_CC_INTEL)
+ // Clang is missing the intrinsic for _bit_scan_reverse
+ // GCC only added it in version 4.5

--- a/aqua/qt53/Portfile
+++ b/aqua/qt53/Portfile
@@ -742,9 +742,9 @@ foreach {module module_info} [array get modules] {
             # so we instead have to disable adding the SDK tool prefix in configure to allow MacPorts-installed compilers to be used
             patchfiles-append patch-qt53-disable-macsdkify.diff
 
-            # Qt assumes _bit_scan_reverse is not provided by Clang
-            # this assumption is incorrect for recent versions of Clang
-            #     see https://github.com/llvm/llvm-project/commit/e54093fcc0a651df14040a61fc8efdd338389afa
+            # Qt assumes Clang's x86intrin.h does not provide _bit_scan_reverse
+            # this assumption is incorrect for Clang 9.0 and later
+            #     see https://github.com/llvm/llvm-project/commit/88f4054f48c5
             # see https://trac.macports.org/ticket/59364
             patchfiles-append patch-qtbase-intel_intrinsics.diff
 

--- a/aqua/qt55/Portfile
+++ b/aqua/qt55/Portfile
@@ -762,11 +762,21 @@ foreach {module module_info} [array get modules] {
                     mkspecs/features/mac/rez.prf
             }
 
-            # Qt assumes _bit_scan_reverse is not provided by Clang
-            # this assumption is incorrect for recent versions of Clang
-            #     see https://github.com/llvm/llvm-project/commit/e54093fcc0a651df14040a61fc8efdd338389afa
+            # Qt assumes Clang's x86intrin.h does not provide _bit_scan_reverse
+            # this assumption is incorrect for Clang 9.0 and later
+            #     see https://github.com/llvm/llvm-project/commit/88f4054f48c5
             # see https://trac.macports.org/ticket/59364
             patchfiles-append patch-qtbase-intel_intrinsics.diff
+            if {${os.major} >= 19} {
+                # Xcode 11.4 is also based on Clang 9.0, but
+                # patch-qtbase-intel_intrinsics.diff does not work
+                # for Xcode clang; use an alternative approach
+                # (not tested on older macOS but may work)
+                # See https://trac.macports.org/ticket/62051
+                patchfiles-replace \
+                    patch-qtbase-intel_intrinsics.diff \
+                    patch-qtbase-intel_intrinsics-xcode11.4.diff
+            }
 
             # ICU now requires C++11
             # see https://trac.macports.org/ticket/59434

--- a/aqua/qt55/files/patch-qtbase-intel_intrinsics-xcode11.4.diff
+++ b/aqua/qt55/files/patch-qtbase-intel_intrinsics-xcode11.4.diff
@@ -1,0 +1,11 @@
+--- src/corelib/tools/qsimd_p.h.orig	2017-09-06 05:13:54.000000000 -0700
++++ src/corelib/tools/qsimd_p.h	2021-01-12 23:42:29.000000000 -0600
+@@ -329,7 +329,7 @@
+     _BitScanForward(&result, val);
+     return result;
+ }
+-#  elif (defined(Q_CC_CLANG) || (defined(Q_CC_GNU) && Q_CC_GNU < 405)) \
++#  elif ((defined(Q_CC_CLANG) && !defined(_bit_scan_reverse)) || (!defined(Q_CC_CLANG) && defined(Q_CC_GNU) && Q_CC_GNU < 405)) \
+     && !defined(Q_CC_INTEL)
+ // Clang is missing the intrinsic for _bit_scan_reverse
+ // GCC only added it in version 4.5

--- a/aqua/qt56/Portfile
+++ b/aqua/qt56/Portfile
@@ -806,11 +806,21 @@ foreach {module module_info} [array get modules] {
                     mkspecs/features/mac/rez.prf
             }
 
-            # Qt assumes _bit_scan_reverse is not provided by Clang
-            # this assumption is incorrect for recent versions of Clang
-            #     see https://github.com/llvm/llvm-project/commit/e54093fcc0a651df14040a61fc8efdd338389afa
+            # Qt assumes Clang's x86intrin.h does not provide _bit_scan_reverse
+            # this assumption is incorrect for Clang 9.0 and later
+            #     see https://github.com/llvm/llvm-project/commit/88f4054f48c5
             # see https://trac.macports.org/ticket/59364
             patchfiles-append patch-qtbase-intel_intrinsics.diff
+            if {${os.major} >= 19} {
+                # Xcode 11.4 is also based on Clang 9.0, but
+                # patch-qtbase-intel_intrinsics.diff does not work
+                # for Xcode clang; use an alternative approach
+                # (not tested on older macOS but may work)
+                # See https://trac.macports.org/ticket/62051
+                patchfiles-replace \
+                    patch-qtbase-intel_intrinsics.diff \
+                    patch-qtbase-intel_intrinsics-xcode11.4.diff
+            }
 
             # ICU now requires C++11
             # see https://trac.macports.org/ticket/59434

--- a/aqua/qt56/files/patch-qtbase-intel_intrinsics-xcode11.4.diff
+++ b/aqua/qt56/files/patch-qtbase-intel_intrinsics-xcode11.4.diff
@@ -1,0 +1,11 @@
+--- src/corelib/tools/qsimd_p.h.orig	2017-09-06 05:13:54.000000000 -0700
++++ src/corelib/tools/qsimd_p.h	2021-01-12 23:42:29.000000000 -0600
+@@ -452,7 +452,7 @@
+     _BitScanForward(&result, val);
+     return result;
+ }
+-#  elif (defined(Q_CC_CLANG) || (defined(Q_CC_GNU) && Q_CC_GNU < 405)) \
++#  elif ((defined(Q_CC_CLANG) && !defined(_bit_scan_reverse)) || (!defined(Q_CC_CLANG) && defined(Q_CC_GNU) && Q_CC_GNU < 405)) \
+     && !defined(Q_CC_INTEL)
+ // Clang is missing the intrinsic for _bit_scan_reverse
+ // GCC only added it in version 4.5

--- a/aqua/qt57/Portfile
+++ b/aqua/qt57/Portfile
@@ -877,11 +877,21 @@ foreach {module module_info} [array get modules] {
                     mkspecs/features/mac/rez.prf
             }
 
-            # Qt assumes _bit_scan_reverse is not provided by Clang
-            # this assumption is incorrect for recent versions of Clang
-            #     see https://github.com/llvm/llvm-project/commit/e54093fcc0a651df14040a61fc8efdd338389afa
+            # Qt assumes Clang's x86intrin.h does not provide _bit_scan_reverse
+            # this assumption is incorrect for Clang 9.0 and later
+            #     see https://github.com/llvm/llvm-project/commit/88f4054f48c5
             # see https://trac.macports.org/ticket/59364
             patchfiles-append patch-qtbase-intel_intrinsics.diff
+            if {${os.major} >= 19} {
+                # Xcode 11.4 is also based on Clang 9.0, but
+                # patch-qtbase-intel_intrinsics.diff does not work
+                # for Xcode clang; use an alternative approach
+                # (not tested on older macOS but may work)
+                # See https://trac.macports.org/ticket/62051
+                patchfiles-replace \
+                    patch-qtbase-intel_intrinsics.diff \
+                    patch-qtbase-intel_intrinsics-xcode11.4.diff
+            }
 
             # ICU now requires C++11
             # see https://trac.macports.org/ticket/59434

--- a/aqua/qt57/files/patch-qtbase-intel_intrinsics-xcode11.4.diff
+++ b/aqua/qt57/files/patch-qtbase-intel_intrinsics-xcode11.4.diff
@@ -1,0 +1,20 @@
+--- src/corelib/tools/qsimd_p.h.orig	2016-12-01 01:17:04.000000000 -0700
++++ src/corelib/tools/qsimd_p.h	2021-01-12 23:42:29.000000000 -0600
+@@ -465,7 +465,7 @@
+ #define qCpuHasFeature(feature)     ((qCompilerCpuFeatures & (Q_UINT64_C(1) << CpuFeature ## feature)) \
+                                      || (qCpuFeatures() & (Q_UINT64_C(1) << CpuFeature ## feature)))
+ 
+-#if QT_HAS_BUILTIN(__builtin_clz) && QT_HAS_BUILTIN(__builtin_ctz) && defined(Q_CC_CLANG) && !defined(Q_CC_INTEL)
++#if QT_HAS_BUILTIN(__builtin_clz) && QT_HAS_BUILTIN(__builtin_ctz) && (defined(Q_CC_CLANG) && !defined(_bit_scan_reverse)) && !defined(Q_CC_INTEL)
+ static Q_ALWAYS_INLINE unsigned _bit_scan_reverse(unsigned val)
+ {
+     Q_ASSERT(val != 0); // if val==0, the result is undefined.
+@@ -503,7 +503,7 @@
+     _BitScanForward(&result, val);
+     return result;
+ }
+-#  elif (defined(Q_CC_CLANG) || (defined(Q_CC_GNU) && Q_CC_GNU < 405)) \
++#  elif ((defined(Q_CC_CLANG) && !defined(_bit_scan_reverse)) || (!defined(Q_CC_CLANG) && defined(Q_CC_GNU) && Q_CC_GNU < 405)) \
+     && !defined(Q_CC_INTEL)
+ // Clang is missing the intrinsic for _bit_scan_reverse
+ // GCC only added it in version 4.5


### PR DESCRIPTION
Outdated Xcode-LLVM clang version mapping in qcompilerdetection.h defines `Q_CC_CLANG` too low; check for `_bit_scan_reverse()` macro instead.
~~(`qt53-qtbase` not affected but updated for consistency.)~~

Revise comment and reference to upstream clang commit to better reflect why this problem appeared with clang 9.0 and not sooner.
Fixes: https://trac.macports.org/ticket/62051

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
Only patch phase is tested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
