### PR TITLE
yarn: use latest NodeJS

### DIFF
--- a/devel/yarn/Portfile
+++ b/devel/yarn/Portfile
@@ -32,11 +32,11 @@ checksums           rmd160  93f551f2f987a454a7f5295eb62bcc26a0e01eb2 \
                     sha256  7e433d4a77e2c79e6a7ae4866782608a8e8bcad3ec6783580577c59538381a6e \
                     size    1244965
 
-depends_run         path:bin/node:nodejs12
+depends_run         path:bin/node:nodejs15
 
 platform darwin {
     if {${os.major} < 13} {
-        depends_run-replace path:bin/node:nodejs12 path:bin/node:nodejs6
+        depends_run-replace path:bin/node:nodejs15 path:bin/node:nodejs8
     }
 }
 


### PR DESCRIPTION
#### Description

Yarn should use the same version of NodeJS as the latest version of npm in Ports.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
  printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
