### PR TITLE
npm6: fix broken replace for older versions of macOS

### DIFF
--- a/devel/npm6/Portfile
+++ b/devel/npm6/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                npm6
 version             6.14.11
-revision            0
+revision            1
 categories          devel
 platforms           darwin
 supported_archs     noarch
@@ -37,7 +37,7 @@ depends_lib         path:bin/node:nodejs15
 
 platform darwin {
     if {${os.major} < 13} {
-        depends_lib-replace path:bin/node:nodejs14 path:bin/node:nodejs8
+        depends_lib-replace path:bin/node:nodejs15 path:bin/node:nodejs8
     }
 }
 


### PR DESCRIPTION
#### Description

For older versions of macOS, the Portfile aims to use `nodejs8` instead of `nodejs15`, but this is broken since the replacement pattern is actually looking for `nodejs14` instead of `nodejs15`.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
