### PR TITLE
py-py2app: update to 0.23

### DIFF
--- a/python/py-py2app/Portfile
+++ b/python/py-py2app/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-py2app
-version             0.22
+version             0.23
 categories-append   devel
 license             {MIT PSF}
 maintainers         {jmr @jmroot} openmaintainer
@@ -18,9 +18,10 @@ platforms           darwin
 
 homepage            https://wiki.python.org/moin/MacPython/py2app
 
-checksums           md5 80f27c88c07a0e4526c98656bba61703 \
-                    rmd160 8e8fc2737cb4efdf230a04483028c212e5e71262 \
-                    sha256 0ec29109338cb7c5340457aa6df972904d0d00533e8ab4107b9e00fe1da5d300
+checksums           md5 6cfa83ca979ee28b35b8a0478ed76221 \
+                    rmd160 af07b4829b5100a69abf750e9e95e6902b0a081b \
+                    sha256 772f7b30cac260537ecfada2801d1e9833010caf6d0439e80e64e1a558718d39 \
+                    size 20178302
 
 python.versions     27 34 35 36 37 38 39
 


### PR DESCRIPTION
#### Description

Updated py2app to 0.23

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
    - There are no existing Trac tickets
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
    - Error: Failed to test py-py2app: py-py2app has no tests turned on.
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
    - The 'prebuilt' directories contains files for a variety of architectures. I have realised that it is currently missing arm64 architecture. I think there is still value in updating the port regardless, but let me know if this is considered a blocker.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->