### PR TITLE
py-nbconvert: add missing dependency to pandoc

### DIFF
--- a/python/py-nbconvert/Portfile
+++ b/python/py-nbconvert/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-nbconvert
 version             6.0.7
-revision            0
+revision            1
 categories-append   textproc
 platforms           darwin
 license             BSD
@@ -38,7 +38,8 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-pandocfilters \
                         port:py${python.version}-testpath \
                         port:py${python.version}-defusedxml \
-                        port:py${python.version}-nbclient
+                        port:py${python.version}-nbclient \
+                        port:pandoc
 
     if {${python.version} eq 27} {
         version             5.5.0


### PR DESCRIPTION
#### Description

When using jupyter-nbconvert to convert some .ipynb notebook to pdf, pandoc needs to be installed --- otherwise, jupyter-nbconvert stops and complains it can't find pandoc. Thus py-nbconvert's Portfile might indicate pandoc as a dependency.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H114
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
