### PR TITLE
cairo(-devel): fix crash on Big Sur

### DIFF
--- a/graphics/cairo-devel/Portfile
+++ b/graphics/cairo-devel/Portfile
@@ -49,6 +49,11 @@ minimum_xcodeversions       {8 2.4.1}
 # Prevent cairo from using librsvg, libspectre, poppler.
 patchfiles-append           patch-configure.diff
 
+# Fix crash on macOS Big Sur and newer.
+# https://gitlab.freedesktop.org/cairo/cairo/-/issues/420
+# https://gitlab.freedesktop.org/cairo/cairo/-/merge_requests/52
+patchfiles-append           patch-cairo-quartz-surfaces.diff
+
 # https://trac.macports.org/ticket/34137
 compiler.blacklist-append   {clang < 318.0.61}
 
@@ -101,14 +106,6 @@ platform macosx {
     # Don't allow Quartz support to be disabled. Keep the variant for awhile in
     # case any dependents are using the active_variants portgroup to check for it.
     variant_set             quartz
-
-    # Apply changes from https://gitlab.freedesktop.org/cairo/cairo/-/merge_requests/52
-    # on macOS Big Sur and newer. Fixes:
-    # https://gitlab.freedesktop.org/cairo/cairo/-/issues/420
-    # https://trac.macports.org/ticket/61586
-    if {${os.major} > 19} {
-        patchfiles-append   patch-cairo-quartz-surfaces.diff
-    }
 }
 
 variant x11 {

--- a/graphics/cairo-devel/Portfile
+++ b/graphics/cairo-devel/Portfile
@@ -11,7 +11,7 @@ name                        cairo-devel
 conflicts                   cairo
 set my_name                 cairo
 version                     1.17.4
-revision                    0
+revision                    1
 checksums                   rmd160  7a440359be60f8cb971e9d538973ac29613e143e \
                             sha256  74b24c1ed436bbe87499179a3b27c43f4143b8676d8ad237a6fa787401959705 \
                             size    41834076
@@ -101,6 +101,14 @@ platform macosx {
     # Don't allow Quartz support to be disabled. Keep the variant for awhile in
     # case any dependents are using the active_variants portgroup to check for it.
     variant_set             quartz
+
+    # Apply changes from https://gitlab.freedesktop.org/cairo/cairo/-/merge_requests/52
+    # on macOS Big Sur and newer. Fixes:
+    # https://gitlab.freedesktop.org/cairo/cairo/-/issues/420
+    # https://trac.macports.org/ticket/61586
+    if {${os.major} > 19} {
+        patchfiles-append   patch-cairo-quartz-surfaces.diff
+    }
 }
 
 variant x11 {

--- a/graphics/cairo-devel/files/patch-cairo-quartz-surfaces.diff
+++ b/graphics/cairo-devel/files/patch-cairo-quartz-surfaces.diff
@@ -1,0 +1,276 @@
+--- src/cairo-quartz-image-surface.c
++++ src/cairo-quartz-image-surface.c
+@@ -50,10 +50,9 @@
+ #define SURFACE_ERROR_INVALID_FORMAT (_cairo_surface_create_in_error(_cairo_error(CAIRO_STATUS_INVALID_FORMAT)))
+ 
+ static void
+-DataProviderReleaseCallback (void *info, const void *data, size_t size)
++DataProviderReleaseCallback (void *image_info, const void *data, size_t size)
+ {
+-    cairo_surface_t *surface = (cairo_surface_t *) info;
+-    cairo_surface_destroy (surface);
++    free (image_info);
+ }
+ 
+ static cairo_surface_t *
+@@ -88,9 +87,8 @@ _cairo_quartz_image_surface_finish (void *asurface)
+ {
+     cairo_quartz_image_surface_t *surface = (cairo_quartz_image_surface_t *) asurface;
+ 
+-    /* the imageSurface will be destroyed by the data provider's release callback */
+     CGImageRelease (surface->image);
+-
++    cairo_surface_destroy (surface->imageSurface);
+     return CAIRO_STATUS_SUCCESS;
+ }
+ 
+@@ -147,24 +145,29 @@ _cairo_quartz_image_surface_flush (void *asurface,
+     cairo_quartz_image_surface_t *surface = (cairo_quartz_image_surface_t *) asurface;
+     CGImageRef oldImage = surface->image;
+     CGImageRef newImage = NULL;
+-
++    void *image_data;
++    const unsigned int size = surface->imageSurface->height * surface->imageSurface->stride;
+     if (flags)
+ 	return CAIRO_STATUS_SUCCESS;
+ 
+     /* XXX only flush if the image has been modified. */
+ 
+-    /* To be released by the ReleaseCallback */
+-    cairo_surface_reference ((cairo_surface_t*) surface->imageSurface);
++    image_data = _cairo_malloc_ab ( surface->imageSurface->height,
++				    surface->imageSurface->stride);
++    if (unlikely (!image_data))
++	return _cairo_error (CAIRO_STATUS_NO_MEMORY);
+ 
++    memcpy (image_data, surface->imageSurface->data,
++	    surface->imageSurface->height * surface->imageSurface->stride);
+     newImage = CairoQuartzCreateCGImage (surface->imageSurface->format,
+ 					 surface->imageSurface->width,
+ 					 surface->imageSurface->height,
+ 					 surface->imageSurface->stride,
+-					 surface->imageSurface->data,
++					 image_data,
+ 					 TRUE,
+ 					 NULL,
+ 					 DataProviderReleaseCallback,
+-					 surface->imageSurface);
++					 image_data);
+ 
+     surface->image = newImage;
+     CGImageRelease (oldImage);
+@@ -308,7 +311,7 @@ cairo_quartz_image_surface_create (cairo_surface_t *surface)
+     cairo_image_surface_t *image_surface;
+     int width, height, stride;
+     cairo_format_t format;
+-    unsigned char *data;
++    void *image_data;
+ 
+     if (surface->status)
+ 	return surface;
+@@ -321,7 +324,6 @@ cairo_quartz_image_surface_create (cairo_surface_t *surface)
+     height = image_surface->height;
+     stride = image_surface->stride;
+     format = image_surface->format;
+-    data = image_surface->data;
+ 
+     if (!_cairo_quartz_verify_surface_size(width, height))
+ 	return SURFACE_ERROR_INVALID_SIZE;
+@@ -338,20 +340,19 @@ cairo_quartz_image_surface_create (cairo_surface_t *surface)
+ 
+     memset (qisurf, 0, sizeof(cairo_quartz_image_surface_t));
+ 
+-    /* In case the create_cgimage fails, this ref will
+-     * be released via the callback (which will be called in
+-     * case of failure.)
+-     */
+-    cairo_surface_reference (surface);
++    image_data = _cairo_malloc_ab (height, stride);
++    if (unlikely (!image_data))
++	return _cairo_error (CAIRO_STATUS_NO_MEMORY);
+ 
++    memcpy (image_data, image_surface->data, height * stride);
+     image = CairoQuartzCreateCGImage (format,
+ 				      width, height,
+ 				      stride,
+-				      data,
++				      image_data,
+ 				      TRUE,
+ 				      NULL,
+ 				      DataProviderReleaseCallback,
+-				      image_surface);
++				      image_data);
+ 
+     if (!image) {
+ 	free (qisurf);
+
+--- src/cairo-quartz-surface.c
++++ src/cairo-quartz-surface.c
+@@ -778,20 +778,10 @@ CairoQuartzCreateGradientFunction (const cairo_gradient_pattern_t *gradient,
+ 			     &gradient_callbacks);
+ }
+ 
+-/* Obtain a CGImageRef from a #cairo_surface_t * */
+-
+-typedef struct {
+-    cairo_surface_t *surface;
+-    cairo_image_surface_t *image_out;
+-    void *image_extra;
+-} quartz_source_image_t;
+-
+ static void
+ DataProviderReleaseCallback (void *info, const void *data, size_t size)
+ {
+-    quartz_source_image_t *source_img = info;
+-    _cairo_surface_release_source_image (source_img->surface, source_img->image_out, source_img->image_extra);
+-    free (source_img);
++    free (info);
+ }
+ 
+ static cairo_status_t
+@@ -803,8 +793,9 @@ _cairo_surface_to_cgimage (cairo_surface_t       *source,
+ 			   CGImageRef            *image_out)
+ {
+     cairo_status_t status;
+-    quartz_source_image_t *source_img;
+     cairo_image_surface_t *image_surface;
++    void *image_data, *image_extra;
++    cairo_bool_t acquired = FALSE;
+ 
+     if (source->backend && source->backend->type == CAIRO_SURFACE_TYPE_QUARTZ_IMAGE) {
+ 	cairo_quartz_image_surface_t *surface = (cairo_quartz_image_surface_t *) source;
+@@ -826,19 +817,12 @@ _cairo_surface_to_cgimage (cairo_surface_t       *source,
+ 	}
+     }
+ 
+-    source_img = _cairo_malloc (sizeof (quartz_source_image_t));
+-    if (unlikely (source_img == NULL))
+-	return _cairo_error (CAIRO_STATUS_NO_MEMORY);
+-
+-    source_img->surface = source;
+-
+     if (source->type == CAIRO_SURFACE_TYPE_RECORDING) {
+ 	image_surface = (cairo_image_surface_t *)
+ 	    cairo_image_surface_create (format, extents->width, extents->height);
+ 	if (unlikely (image_surface->base.status)) {
+ 	    status = image_surface->base.status;
+ 	    cairo_surface_destroy (&image_surface->base);
+-	    free (source_img);
+ 	    return status;
+ 	}
+ 
+@@ -848,46 +832,61 @@ _cairo_surface_to_cgimage (cairo_surface_t       *source,
+ 							    NULL);
+ 	if (unlikely (status)) {
+ 	    cairo_surface_destroy (&image_surface->base);
+-	    free (source_img);
+ 	    return status;
+ 	}
+ 
+-	source_img->image_out = image_surface;
+-	source_img->image_extra = NULL;
+-
+ 	cairo_matrix_init_identity (matrix);
+     }
+     else {
+-	status = _cairo_surface_acquire_source_image (source_img->surface,
+-						      &source_img->image_out,
+-						      &source_img->image_extra);
+-	if (unlikely (status)) {
+-	    free (source_img);
++	status = _cairo_surface_acquire_source_image (source, &image_surface,
++						      &image_extra);
++	if (unlikely (status))
+ 	    return status;
+-	}
++	acquired = TRUE;
+     }
+ 
+-    if (source_img->image_out->width == 0 || source_img->image_out->height == 0) {
++    if (image_surface->width == 0 || image_surface->height == 0) {
+ 	*image_out = NULL;
+-	DataProviderReleaseCallback (source_img,
+-				     source_img->image_out->data,
+-				     source_img->image_out->height * source_img->image_out->stride);
+-    } else {
+-	*image_out = CairoQuartzCreateCGImage (source_img->image_out->format,
+-					       source_img->image_out->width,
+-					       source_img->image_out->height,
+-					       source_img->image_out->stride,
+-					       source_img->image_out->data,
+-					       TRUE,
+-					       NULL,
+-					       DataProviderReleaseCallback,
+-					       source_img);
+-
+-	/* TODO: differentiate memory error and unsupported surface type */
+-	if (unlikely (*image_out == NULL))
+-	    status = CAIRO_INT_STATUS_UNSUPPORTED;
++	if (acquired)
++	    _cairo_surface_release_source_image (source, image_surface, image_extra);
++	else
++	    cairo_surface_destroy (&image_surface->base);
++
++	return status;
+     }
+ 
++    image_data = _cairo_malloc_ab (image_surface->height, image_surface->stride);
++    if (unlikely (!image_data))
++    {
++	if (acquired)
++	    _cairo_surface_release_source_image (source, image_surface, image_extra);
++	else
++	    cairo_surface_destroy (&image_surface->base);
++
++	return _cairo_error (CAIRO_STATUS_NO_MEMORY);
++    }
++
++    memcpy (image_data, image_surface->data,
++	    image_surface->height * image_surface->stride);
++    *image_out = CairoQuartzCreateCGImage (image_surface->format,
++					   image_surface->width,
++					   image_surface->height,
++					   image_surface->stride,
++					   image_data,
++					   TRUE,
++					   NULL,
++					   DataProviderReleaseCallback,
++					   image_data);
++
++    /* TODO: differentiate memory error and unsupported surface type */
++    if (unlikely (*image_out == NULL))
++	status = CAIRO_INT_STATUS_UNSUPPORTED;
++
++    if (acquired)
++	_cairo_surface_release_source_image (source, image_surface, image_extra);
++    else
++	cairo_surface_destroy (&image_surface->base);
++
+     return status;
+ }
+ 
+@@ -2273,11 +2272,13 @@ _cairo_quartz_surface_create_internal (CGContextRef cgContext,
+     surface->extents.width = width;
+     surface->extents.height = height;
+     surface->virtual_extents = surface->extents;
++    surface->imageData = NULL;
++    surface->imageSurfaceEquiv = NULL;
++
+ 
+     if (IS_EMPTY (surface)) {
+ 	surface->cgContext = NULL;
+ 	surface->cgContextBaseCTM = CGAffineTransformIdentity;
+-	surface->imageData = NULL;
+ 	surface->base.is_clear = TRUE;
+ 	return surface;
+     }
+@@ -2290,9 +2291,6 @@ _cairo_quartz_surface_create_internal (CGContextRef cgContext,
+     surface->cgContext = cgContext;
+     surface->cgContextBaseCTM = CGContextGetCTM (cgContext);
+ 
+-    surface->imageData = NULL;
+-    surface->imageSurfaceEquiv = NULL;
+-
+     return surface;
+ }
+ 

--- a/graphics/cairo/Portfile
+++ b/graphics/cairo/Portfile
@@ -11,6 +11,7 @@ name                        cairo
 conflicts                   cairo-devel
 set my_name                 cairo
 version                     1.16.0
+revision                    1
 checksums                   rmd160  cfd2ef6ec55b267e04600f6b1e36bb07f2566b35 \
                             sha256  5e7b29b3f113ef870d1e3ecf8adf21f923396401604bda16d44be45e66052331 \
                             size    41997432
@@ -100,6 +101,14 @@ platform macosx {
     # Don't allow Quartz support to be disabled. Keep the variant for awhile in
     # case any dependents are using the active_variants portgroup to check for it.
     variant_set             quartz
+
+    # Apply changes from https://gitlab.freedesktop.org/cairo/cairo/-/merge_requests/52
+    # on macOS Big Sur and newer. Fixes:
+    # https://gitlab.freedesktop.org/cairo/cairo/-/issues/420
+    # https://trac.macports.org/ticket/61586
+    if {${os.major} > 19} {
+        patchfiles-append   patch-cairo-quartz-surfaces.diff
+    }
 }
 
 variant x11 {

--- a/graphics/cairo/Portfile
+++ b/graphics/cairo/Portfile
@@ -49,6 +49,11 @@ minimum_xcodeversions       {8 2.4.1}
 # Prevent cairo from using librsvg, libspectre, poppler.
 patchfiles-append           patch-configure.diff
 
+# Fix crash on macOS Big Sur and newer.
+# https://gitlab.freedesktop.org/cairo/cairo/-/issues/420
+# https://gitlab.freedesktop.org/cairo/cairo/-/merge_requests/52
+patchfiles-append           patch-cairo-quartz-surfaces.diff
+
 # https://trac.macports.org/ticket/34137
 compiler.blacklist-append   {clang < 318.0.61}
 
@@ -101,14 +106,6 @@ platform macosx {
     # Don't allow Quartz support to be disabled. Keep the variant for awhile in
     # case any dependents are using the active_variants portgroup to check for it.
     variant_set             quartz
-
-    # Apply changes from https://gitlab.freedesktop.org/cairo/cairo/-/merge_requests/52
-    # on macOS Big Sur and newer. Fixes:
-    # https://gitlab.freedesktop.org/cairo/cairo/-/issues/420
-    # https://trac.macports.org/ticket/61586
-    if {${os.major} > 19} {
-        patchfiles-append   patch-cairo-quartz-surfaces.diff
-    }
 }
 
 variant x11 {

--- a/graphics/cairo/files/patch-cairo-quartz-surfaces.diff
+++ b/graphics/cairo/files/patch-cairo-quartz-surfaces.diff
@@ -1,0 +1,276 @@
+--- src/cairo-quartz-image-surface.c
++++ src/cairo-quartz-image-surface.c
+@@ -50,10 +50,9 @@
+ #define SURFACE_ERROR_INVALID_FORMAT (_cairo_surface_create_in_error(_cairo_error(CAIRO_STATUS_INVALID_FORMAT)))
+ 
+ static void
+-DataProviderReleaseCallback (void *info, const void *data, size_t size)
++DataProviderReleaseCallback (void *image_info, const void *data, size_t size)
+ {
+-    cairo_surface_t *surface = (cairo_surface_t *) info;
+-    cairo_surface_destroy (surface);
++    free (image_info);
+ }
+ 
+ static cairo_surface_t *
+@@ -88,9 +87,8 @@ _cairo_quartz_image_surface_finish (void *asurface)
+ {
+     cairo_quartz_image_surface_t *surface = (cairo_quartz_image_surface_t *) asurface;
+ 
+-    /* the imageSurface will be destroyed by the data provider's release callback */
+     CGImageRelease (surface->image);
+-
++    cairo_surface_destroy (surface->imageSurface);
+     return CAIRO_STATUS_SUCCESS;
+ }
+ 
+@@ -147,24 +145,29 @@ _cairo_quartz_image_surface_flush (void *asurface,
+     cairo_quartz_image_surface_t *surface = (cairo_quartz_image_surface_t *) asurface;
+     CGImageRef oldImage = surface->image;
+     CGImageRef newImage = NULL;
+-
++    void *image_data;
++    const unsigned int size = surface->imageSurface->height * surface->imageSurface->stride;
+     if (flags)
+ 	return CAIRO_STATUS_SUCCESS;
+ 
+     /* XXX only flush if the image has been modified. */
+ 
+-    /* To be released by the ReleaseCallback */
+-    cairo_surface_reference ((cairo_surface_t*) surface->imageSurface);
++    image_data = _cairo_malloc_ab ( surface->imageSurface->height,
++				    surface->imageSurface->stride);
++    if (unlikely (!image_data))
++	return _cairo_error (CAIRO_STATUS_NO_MEMORY);
+ 
++    memcpy (image_data, surface->imageSurface->data,
++	    surface->imageSurface->height * surface->imageSurface->stride);
+     newImage = CairoQuartzCreateCGImage (surface->imageSurface->format,
+ 					 surface->imageSurface->width,
+ 					 surface->imageSurface->height,
+ 					 surface->imageSurface->stride,
+-					 surface->imageSurface->data,
++					 image_data,
+ 					 TRUE,
+ 					 NULL,
+ 					 DataProviderReleaseCallback,
+-					 surface->imageSurface);
++					 image_data);
+ 
+     surface->image = newImage;
+     CGImageRelease (oldImage);
+@@ -308,7 +311,7 @@ cairo_quartz_image_surface_create (cairo_surface_t *surface)
+     cairo_image_surface_t *image_surface;
+     int width, height, stride;
+     cairo_format_t format;
+-    unsigned char *data;
++    void *image_data;
+ 
+     if (surface->status)
+ 	return surface;
+@@ -321,7 +324,6 @@ cairo_quartz_image_surface_create (cairo_surface_t *surface)
+     height = image_surface->height;
+     stride = image_surface->stride;
+     format = image_surface->format;
+-    data = image_surface->data;
+ 
+     if (!_cairo_quartz_verify_surface_size(width, height))
+ 	return SURFACE_ERROR_INVALID_SIZE;
+@@ -338,20 +340,19 @@ cairo_quartz_image_surface_create (cairo_surface_t *surface)
+ 
+     memset (qisurf, 0, sizeof(cairo_quartz_image_surface_t));
+ 
+-    /* In case the create_cgimage fails, this ref will
+-     * be released via the callback (which will be called in
+-     * case of failure.)
+-     */
+-    cairo_surface_reference (surface);
++    image_data = _cairo_malloc_ab (height, stride);
++    if (unlikely (!image_data))
++	return _cairo_error (CAIRO_STATUS_NO_MEMORY);
+ 
++    memcpy (image_data, image_surface->data, height * stride);
+     image = CairoQuartzCreateCGImage (format,
+ 				      width, height,
+ 				      stride,
+-				      data,
++				      image_data,
+ 				      TRUE,
+ 				      NULL,
+ 				      DataProviderReleaseCallback,
+-				      image_surface);
++				      image_data);
+ 
+     if (!image) {
+ 	free (qisurf);
+
+--- src/cairo-quartz-surface.c
++++ src/cairo-quartz-surface.c
+@@ -778,20 +778,10 @@ CairoQuartzCreateGradientFunction (const cairo_gradient_pattern_t *gradient,
+ 			     &gradient_callbacks);
+ }
+ 
+-/* Obtain a CGImageRef from a #cairo_surface_t * */
+-
+-typedef struct {
+-    cairo_surface_t *surface;
+-    cairo_image_surface_t *image_out;
+-    void *image_extra;
+-} quartz_source_image_t;
+-
+ static void
+ DataProviderReleaseCallback (void *info, const void *data, size_t size)
+ {
+-    quartz_source_image_t *source_img = info;
+-    _cairo_surface_release_source_image (source_img->surface, source_img->image_out, source_img->image_extra);
+-    free (source_img);
++    free (info);
+ }
+ 
+ static cairo_status_t
+@@ -803,8 +793,9 @@ _cairo_surface_to_cgimage (cairo_surface_t       *source,
+ 			   CGImageRef            *image_out)
+ {
+     cairo_status_t status;
+-    quartz_source_image_t *source_img;
+     cairo_image_surface_t *image_surface;
++    void *image_data, *image_extra;
++    cairo_bool_t acquired = FALSE;
+ 
+     if (source->backend && source->backend->type == CAIRO_SURFACE_TYPE_QUARTZ_IMAGE) {
+ 	cairo_quartz_image_surface_t *surface = (cairo_quartz_image_surface_t *) source;
+@@ -826,19 +817,12 @@ _cairo_surface_to_cgimage (cairo_surface_t       *source,
+ 	}
+     }
+ 
+-    source_img = _cairo_malloc (sizeof (quartz_source_image_t));
+-    if (unlikely (source_img == NULL))
+-	return _cairo_error (CAIRO_STATUS_NO_MEMORY);
+-
+-    source_img->surface = source;
+-
+     if (source->type == CAIRO_SURFACE_TYPE_RECORDING) {
+ 	image_surface = (cairo_image_surface_t *)
+ 	    cairo_image_surface_create (format, extents->width, extents->height);
+ 	if (unlikely (image_surface->base.status)) {
+ 	    status = image_surface->base.status;
+ 	    cairo_surface_destroy (&image_surface->base);
+-	    free (source_img);
+ 	    return status;
+ 	}
+ 
+@@ -848,46 +832,61 @@ _cairo_surface_to_cgimage (cairo_surface_t       *source,
+ 							    NULL);
+ 	if (unlikely (status)) {
+ 	    cairo_surface_destroy (&image_surface->base);
+-	    free (source_img);
+ 	    return status;
+ 	}
+ 
+-	source_img->image_out = image_surface;
+-	source_img->image_extra = NULL;
+-
+ 	cairo_matrix_init_identity (matrix);
+     }
+     else {
+-	status = _cairo_surface_acquire_source_image (source_img->surface,
+-						      &source_img->image_out,
+-						      &source_img->image_extra);
+-	if (unlikely (status)) {
+-	    free (source_img);
++	status = _cairo_surface_acquire_source_image (source, &image_surface,
++						      &image_extra);
++	if (unlikely (status))
+ 	    return status;
+-	}
++	acquired = TRUE;
+     }
+ 
+-    if (source_img->image_out->width == 0 || source_img->image_out->height == 0) {
++    if (image_surface->width == 0 || image_surface->height == 0) {
+ 	*image_out = NULL;
+-	DataProviderReleaseCallback (source_img,
+-				     source_img->image_out->data,
+-				     source_img->image_out->height * source_img->image_out->stride);
+-    } else {
+-	*image_out = CairoQuartzCreateCGImage (source_img->image_out->format,
+-					       source_img->image_out->width,
+-					       source_img->image_out->height,
+-					       source_img->image_out->stride,
+-					       source_img->image_out->data,
+-					       TRUE,
+-					       NULL,
+-					       DataProviderReleaseCallback,
+-					       source_img);
+-
+-	/* TODO: differentiate memory error and unsupported surface type */
+-	if (unlikely (*image_out == NULL))
+-	    status = CAIRO_INT_STATUS_UNSUPPORTED;
++	if (acquired)
++	    _cairo_surface_release_source_image (source, image_surface, image_extra);
++	else
++	    cairo_surface_destroy (&image_surface->base);
++
++	return status;
+     }
+ 
++    image_data = _cairo_malloc_ab (image_surface->height, image_surface->stride);
++    if (unlikely (!image_data))
++    {
++	if (acquired)
++	    _cairo_surface_release_source_image (source, image_surface, image_extra);
++	else
++	    cairo_surface_destroy (&image_surface->base);
++
++	return _cairo_error (CAIRO_STATUS_NO_MEMORY);
++    }
++
++    memcpy (image_data, image_surface->data,
++	    image_surface->height * image_surface->stride);
++    *image_out = CairoQuartzCreateCGImage (image_surface->format,
++					   image_surface->width,
++					   image_surface->height,
++					   image_surface->stride,
++					   image_data,
++					   TRUE,
++					   NULL,
++					   DataProviderReleaseCallback,
++					   image_data);
++
++    /* TODO: differentiate memory error and unsupported surface type */
++    if (unlikely (*image_out == NULL))
++	status = CAIRO_INT_STATUS_UNSUPPORTED;
++
++    if (acquired)
++	_cairo_surface_release_source_image (source, image_surface, image_extra);
++    else
++	cairo_surface_destroy (&image_surface->base);
++
+     return status;
+ }
+ 
+@@ -2273,11 +2272,13 @@ _cairo_quartz_surface_create_internal (CGContextRef cgContext,
+     surface->extents.width = width;
+     surface->extents.height = height;
+     surface->virtual_extents = surface->extents;
++    surface->imageData = NULL;
++    surface->imageSurfaceEquiv = NULL;
++
+ 
+     if (IS_EMPTY (surface)) {
+ 	surface->cgContext = NULL;
+ 	surface->cgContextBaseCTM = CGAffineTransformIdentity;
+-	surface->imageData = NULL;
+ 	surface->base.is_clear = TRUE;
+ 	return surface;
+     }
+@@ -2290,9 +2291,6 @@ _cairo_quartz_surface_create_internal (CGContextRef cgContext,
+     surface->cgContext = cgContext;
+     surface->cgContextBaseCTM = CGContextGetCTM (cgContext);
+ 
+-    surface->imageData = NULL;
+-    surface->imageSurfaceEquiv = NULL;
+-
+     return surface;
+ }
+ 


### PR DESCRIPTION
#### Description

Apply changes from https://gitlab.freedesktop.org/cairo/cairo/-/merge_requests/52 to fix crashes of several applications (gimp2, inkscape, meld, etc.) on macOS Big Sur.

See: https://gitlab.freedesktop.org/cairo/cairo/-/issues/420

Fixes: https://trac.macports.org/ticket/61586

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3 12C33

For me, this fixes crashes of gimp2 and meld that made those programs unusable before on Big Sur. According to the bug report, inkscape is affected as well by the same bug. However, I have not tested if the issue is resolved for inkscape.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? (cairo-test-suite hangs with 100% CPU for cairo. haven't tried for cairo-devel after that...)
- [ ] tried a full install with `sudo port -vst install`? (only without trace mode)
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
