### PR TITLE
p5-compress-raw-lzma: update to version 2.100

### DIFF
--- a/perl/p5-compress-raw-lzma/Portfile
+++ b/perl/p5-compress-raw-lzma/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28 5.30
-perl5.setup         Compress-Raw-Lzma 2.096 ../../authors/id/P/PM/PMQS
+perl5.setup         Compress-Raw-Lzma 2.100 ../../authors/id/P/PM/PMQS
 revision            0
-checksums           rmd160  b794d7c6ef996e16e635fc0456f3b589d4d5ff61 \
-                    sha256  f3afb267b1303b0f125976e9e4a70c6a4a205e35e7c99b408911f5e5c6578217 \
-                    size    116451
+checksums           rmd160  5b8af69812d8a4705e4ca46729fbc1b72ef2079d \
+                    sha256  5cef2d8ff53ab0361b5afb827b9d7e00d230bdbad577955622c43f933294f42b \
+                    size    117490
 
 platforms           darwin
 


### PR DESCRIPTION
#### Description

p5-compress-raw-lzma: update to version 2.100

###### Tested on
macOS 10.14.6 18G6020
Xcode 11.3.1 11C504

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?