### PR TITLE
p5-compress-raw-bzip2: update to version 2.100

### DIFF
--- a/perl/p5-compress-raw-bzip2/Portfile
+++ b/perl/p5-compress-raw-bzip2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28 5.30
-perl5.setup         Compress-Raw-Bzip2 2.096 ../../authors/id/P/PM/PMQS
+perl5.setup         Compress-Raw-Bzip2 2.100 ../../authors/id/P/PM/PMQS
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
 description         Perl low-level interface to bzip2 compression library
@@ -14,8 +14,8 @@ long_description    Compress::Raw::Bzip2 provides an interface to the \
                     IO::Compress::Bzip2 and IO::Compress::Bunzip2.
 platforms           darwin
 
-checksums           rmd160  d559382a2a602d4dc2590c4efe8a9b2c85af1141 \
-                    sha256  a564e7634eca7740c5487d01effe1461e9e51b8909e69b3d8f5be98997958cbe \
-                    size    138744
+checksums           rmd160  b287233934a718419acd0494a4f6302fe449d965 \
+                    sha256  2f1fe7ef2bf7cf87c8dbc82a605fd4a1411997858d802d0b1ead4745955cda04 \
+                    size    138698
 
 # builds using embedded bzip2 source, no external dependency required


### PR DESCRIPTION
#### Description

p5-compress-raw-bzip2: update to version 2.100

###### Tested on
macOS 10.14.6 18G6020
Xcode 11.3.1 11C504

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?