### PR TITLE
p5-compress-raw-zlib: update to version 2.100

### DIFF
--- a/perl/p5-compress-raw-zlib/Portfile
+++ b/perl/p5-compress-raw-zlib/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28 5.30
-perl5.setup         Compress-Raw-Zlib 2.096 ../../authors/id/P/PM/PMQS
+perl5.setup         Compress-Raw-Zlib 2.100 ../../authors/id/P/PM/PMQS
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
 description         The Compress::Raw::Zlib module provides a Perl \
@@ -13,8 +13,8 @@ long_description    ${description}
 
 platforms           darwin
 
-checksums           rmd160  48efb424dc3e8e3a08eff3b5b539425fc55f6423 \
-                    sha256  cd4cba20c159a7748b8bc91278524a7da70573d9531fde62298609a5f1c65912 \
-                    size    254784
+checksums           rmd160  badcc850b396b3611e661fdf5a09fd49b45ad152 \
+                    sha256  9fc6016cb2b07a1a41794f0c555e4449d16979716a8b4c704e86bbaaaa15992a \
+                    size    254557
 
 # builds using embedded zlib source, no external dependency required


### PR DESCRIPTION
#### Description

p5-compress-raw-zlib: update to version 2.100

###### Tested on
macOS 10.14.6 18G6020
Xcode 11.3.1 11C504

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
