### PR TITLE
p5-io-compress: update to version 2.100

### DIFF
--- a/perl/p5-io-compress/Portfile
+++ b/perl/p5-io-compress/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28 5.30
-perl5.setup         IO-Compress 2.096 ../../authors/id/P/PM/PMQS
+perl5.setup         IO-Compress 2.100 ../../authors/id/P/PM/PMQS
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
 description         Perl interface to allow reading and writing of \
@@ -16,9 +16,9 @@ homepage            https://metacpan.org/release/${perl5.module}/
 
 platforms           darwin
 
-checksums           rmd160  d3548e502373b3e8d11447b9ded018c859613015 \
-                    sha256  9d219fd5df4b490b5d2f847921e3cb1c3392758fa0bae9b05a8992b3620ba572 \
-                    size    291399
+checksums           rmd160  dcc07cd7ff0c0c57ad6cb44aebdbc3aa9828c69f \
+                    sha256  2d23b0be2e2967c604c407d415588920a69083587d0f65f355137592989c6c36 \
+                    size    291283
 
 if {${perl5.major} != ""} {
     depends_lib-append \


### PR DESCRIPTION
#### Description

p5-io-compress: update to version 2.100

###### Tested on
macOS 10.14.6 18G6020
Xcode 11.3.1 11C504

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
