### PR TITLE
p5-io-compress-zstd: update to version 2.100

### DIFF
--- a/perl/p5-io-compress-zstd/Portfile
+++ b/perl/p5-io-compress-zstd/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28 5.30
-perl5.setup         IO-Compress-Zstd 2.099
+perl5.setup         IO-Compress-Zstd 2.100
 license             {Artistic-1 GPL}
 maintainers         {devans @dbevans} openmaintainer
 description         IO::Compress::Zstd - Read/Write zstd files/buffers
@@ -12,9 +12,9 @@ long_description    ${description}
 
 platforms           darwin
 
-checksums           rmd160  44c6c94c0b38d284e0188cc536cca3e56ae20f9a \
-                    sha256  e1b05d7227495f3fb8bf8294c637f1765501386f8717f9d48f2ed90cfc6af0ac \
-                    size    76665
+checksums           rmd160  f8dc416887aecf6c2faf85eb0d4283615709ba76 \
+                    sha256  e8031a309e74e2557afd024e7c57e90cf15088a7d6a2b7bb8f4c74f8c504a2d0 \
+                    size    76554
 
 if {${perl5.major} != ""} {
     depends_lib-append \


### PR DESCRIPTION
#### Description

p5-io-compress-zstd: update to version 2.100

###### Tested on
macOS 10.14.6 18G6020
Xcode 11.3.1 11C504

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
