### PR TITLE
p5-io-compress-lzma: update to version 2.100

### DIFF
--- a/perl/p5-io-compress-lzma/Portfile
+++ b/perl/p5-io-compress-lzma/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28 5.30
-perl5.setup         IO-Compress-Lzma 2.096 ../../authors/id/P/PM/PMQS
+perl5.setup         IO-Compress-Lzma 2.100 ../../authors/id/P/PM/PMQS
 revision            0
-checksums           rmd160  140aad90a9e771239a7070548d52efca9b33bfe5 \
-                    sha256  2f29125f19bb41d29c4b5a2467e3560b7bce5d428176a046b7c8a51609dce6e8 \
-                    size    102815
+checksums           rmd160  2edd0f5a9d33a9f0c7bc99771fa16c7c1c2c1ec3 \
+                    sha256  25117139d6cb7c19ce645fa2a5e3b2b937187e581ec9544705fc505270c46556 \
+                    size    102359
 
 platforms           darwin
 


### PR DESCRIPTION
#### Description

p5-io-compress-lzma: update to version 2.100

###### Tested on
macOS 10.14.6 18G6020
Xcode 11.3.1 11C504

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
