### PR TITLE
p5-io-compress-lzf: update to version 2.100

### DIFF
--- a/perl/p5-io-compress-lzf/Portfile
+++ b/perl/p5-io-compress-lzf/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28 5.30
-perl5.setup         IO-Compress-Lzf 2.096
+perl5.setup         IO-Compress-Lzf 2.100
 license             {Artistic-1 GPL}
 maintainers         {devans @dbevans} openmaintainer
 description         IO::Compress::Lzf - Write lzf files/buffers
@@ -12,9 +12,9 @@ long_description    ${description}
 
 platforms           darwin
 
-checksums           rmd160  ddf24f244daa93ff98b0f28ec2a3395b63849542 \
-                    sha256  06cd8c5ca885d61f9950d3d2cedef056fa1350c07d661a6eec758774ddda5358 \
-                    size    76197
+checksums           rmd160  12df9b72ff38ca9b58f4cdb6ee06bf9c8316ab13 \
+                    sha256  32fbaecd4910d0d4e38a1952a231d07a272b44ce31bf720cf9890ab0e8f40ad4 \
+                    size    75712
 
 if {${perl5.major} != ""} {
     depends_lib-append \


### PR DESCRIPTION
#### Description

p5-io-compress-lzf: update to version 2.100

###### Tested on
macOS 10.14.6 18G6020
Xcode 11.3.1 11C504

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
