### PR TITLE
wireshark3: patch for clock_realtime build error on older macos releases

### DIFF
--- a/net/wireshark3/Portfile
+++ b/net/wireshark3/Portfile
@@ -27,6 +27,16 @@ distfiles           wireshark-${version}${extract.suffix}
 
 worksrcdir          wireshark-${version}
 
+# Patch for CLOCK_REALTIME build errors, on older MacOS releases.
+# Merged into Wireshark3 master branch, and can be removed for next
+# major release.
+#
+# Tracked by issue:
+#   https://gitlab.com/wireshark/wireshark/-/issues/17101
+# Fix committed:
+#   https://gitlab.com/wireshark/wireshark/-/merge_requests/1404
+patchfiles          patch-wireshark3-3.4.2-fix-clock_realtime.diff
+
 checksums           sha256  de9868729e426a469baabd8d444240d84fa5445020e92c842dd19afd0d47a4c4 \
                     rmd160  53a02106b0f23e50b1108d93772464974b2b37be \
                     sha1    b33276e4e6c3d6a057da3b569b58316330a5f3e3 \

--- a/net/wireshark3/files/patch-wireshark3-3.4.2-fix-clock_realtime.diff
+++ b/net/wireshark3/files/patch-wireshark3-3.4.2-fix-clock_realtime.diff
@@ -1,0 +1,30 @@
+--- ui/qt/import_text_dialog.cpp	2020-12-20 11:02:56.000000000 -0500
++++ ui/qt/import_text_dialog.cpp	2020-12-15 16:53:01.000000000 -0500
+@@ -11,6 +11,11 @@
+ 
+ #include <time.h>
+ 
++#ifdef __MACH__
++#include <mach/clock.h>
++#include <mach/mach.h>
++#endif
++
+ #include "import_text_dialog.h"
+ 
+ #include "wiretap/wtap.h"
+@@ -384,6 +389,15 @@
+ 
+ #ifdef _WIN32
+             timespec_get(&timenow, TIME_UTC); /* supported by Linux and Windows */
++#elif defined(__MACH__)
++            // OS X does not have clock_gettime, use clock_get_time
++            clock_serv_t cclock;
++            mach_timespec_t mts;
++            host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
++            clock_get_time(cclock, &mts);
++            mach_port_deallocate(mach_task_self(), cclock);
++            timenow.tv_sec = mts.tv_sec;
++            timenow.tv_nsec = mts.tv_nsec;
+ #else
+             clock_gettime(CLOCK_REALTIME, &timenow); /* supported by Linux and MacOS */
+ #endif


### PR DESCRIPTION
### Description

Fixes: [wireshark3 @3.4.0_0+cares+chmodbpf+geoip+gnutls+kerberos5+libsmi+python37+qt5+zlib: error: use of undeclared identifier 'CLOCK_REALTIME'](https://trac.macports.org/ticket/61511)

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.8.5 12F2560
Xcode 5.1.1 5B1008

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
