### PR TITLE
KeePassXC: update to version 2.6.3

### DIFF
--- a/security/KeePassXC/Portfile
+++ b/security/KeePassXC/Portfile
@@ -20,8 +20,8 @@ platforms               darwin
 license                 GPL-2+
 license_noconflict      openssl
 
-github.setup            keepassxreboot keepassxc 2.6.2
-revision                1
+github.setup            keepassxreboot keepassxc 2.6.3
+revision                0
 github.tarball_from     releases
 distname                keepassxc-${version}-src
 use_xz                  yes
@@ -29,13 +29,13 @@ distfiles-append        ${distname}${extract.suffix}.sig
 
 # See keepassxc-${version}-src.tar.xz.DIGEST on upstream GitHub releases page for SHA256 sums
 checksums               ${distname}${extract.suffix} \
-                        rmd160  a0d5a8aa6cae87adb8104b5c666f1009f9614209 \
-                        sha256  101bfade0a760d6ec6b8c4f3556e7f1201f1edd29ceabc73ad5846f9a57d7e38 \
-                        size    5720788 \
+                        rmd160  19905c6bbe4cb2aa8f049944a3a820d2328ff287 \
+                        sha256  e7e0b6ed8f3881c5b9579074bc3cde3991b28c1a3d1c852c46f2b7930a10f7d1 \
+                        size    7562816 \
                         ${distname}${extract.suffix}.sig \
-                        rmd160  3e7a7dafedd0825152c886b02ef667a2da6ca1b4 \
-                        sha256  d7c803e7f262e7f99fc3ef920b12f526290be9a08ca9541b5bcafe31121cd4f9 \
-                        size    488
+                        rmd160  e9fae371c739f35467d44ada579a9681b15f369f \
+                        sha256  2df21e996386e34d1a305070159d9b9abd33e5b5b72461a6ff768ee09df7ffd3 \
+                        size    499
 
 gpg_verify.use_gpg_verification \
                         yes


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Update KeePassXC to newest minor version

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G7016
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
