### PR TITLE
mesa: fix build on macOS 10.11 and earlier

### DIFF
--- a/x11/mesa/Portfile
+++ b/x11/mesa/Portfile
@@ -3,6 +3,10 @@
 PortSystem          1.0
 PortGroup           compiler_blacklist_versions 1.0
 
+# May need clock_gettime()
+PortGroup           legacysupport 1.0
+legacysupport.newest_darwin_requires_legacy 15
+
 name                mesa
 epoch               1
 version             19.0.8


### PR DESCRIPTION
Recently added patch uses `clock_gettime()` on macOS 10.14 and earlier; `clock_gettime()` is unavailable on macOS 10.11 and earlier, but is available from legacysupport.

#### Description
(Alternatively, the maintainer can figure out an alternative approach to using `clock_gettime()`—as yet another alternative to `timespec_get()`—which upstream can incorporate.)

See recent build failures for macOS 10.7-10.11: https://ports.macports.org/port/mesa/builds
```
In file included from ../include/c11/threads.h:66:
../include/c11/threads_posix.h:391:9: warning: implicit declaration of function 'clock_gettime' is invalid in C99 [-Wimplicit-function-declaration]
        clock_gettime(CLOCK_REALTIME, ts);
        ^
../include/c11/threads_posix.h:391:23: error: use of undeclared identifier 'CLOCK_REALTIME'
        clock_gettime(CLOCK_REALTIME, ts);
                      ^
```
(10.6 fails during patching; static-strndup.patch appears to be outdated. See https://trac.macports.org/ticket/62063)
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### ~~Tested on~~
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
Untested; I do not have access to an affected macOS version.
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
