### PR TITLE
auto-multiple-choice-devel: update to revision 3b5fec09

### DIFF
--- a/x11/auto-multiple-choice/Portfile
+++ b/x11/auto-multiple-choice/Portfile
@@ -40,13 +40,13 @@ if {${subport} eq ${name}} {
     conflicts               auto-multiple-choice-devel
 } else {
     # devel
-    set gitlab.commit       "fd2136db5241e33dec5d920535d23000525b6b6d"
-    set amc_revision        "202004101300"
-    set amc_date            "202004101300"
+    set gitlab.commit       "3bfa3245ddf9fba8200b87f978061ed256c95210"
+    set amc_revision        "202101081229"
+    set amc_date            "202101081229"
     version                 1.4.0-${amc_revision}
-    checksums               rmd160  bb6b8faefbca2ba5293a6ba2861fffcdc26844c2 \
-                            sha256  ce77a35e6c72d32645921cdf327e2fc9569f4146823c6d1d98d54ecdcb2edf31 \
-                            size    6522121
+    checksums               rmd160  3b5fec09dbcd8520be431723503815a882408ec8 \
+                            sha256  f6bfa2bf3eabc291d7c9ce137d71ed91d51ea141d62239cf546d22f12ba1a63a \
+                            size    7568646
     build.cmd               ${prefix}/bin/gmake
     conflicts               auto-multiple-choice
 }
@@ -57,6 +57,8 @@ distname                ${gitlab.project}-${gitlab.commit}-${gitlab.commit}
 depends_build-append    \
                         port:dblatex \
                         port:gmake \
+                        port:gettext \
+                        port:libxslt \
                         port:p${perl5.major}-xml-libxml
 
 depends_lib-append      port:opencv
@@ -74,8 +76,10 @@ depends_run             \
                         port:p${perl5.major}-email-sender \
                         port:p${perl5.major}-file-basedir \
                         port:p${perl5.major}-file-mimeinfo \
+                        port:p${perl5.major}-filesys-dfportable \
                         port:p${perl5.major}-glib-object-introspection \
                         port:p${perl5.major}-gtk3 \
+                        port:p${perl5.major}-io-compress \
                         port:p${perl5.major}-locale-codes \
                         port:p${perl5.major}-locale-gettext \
                         port:p${perl5.major}-module-load-conditional \
@@ -90,7 +94,8 @@ depends_run             \
                         port:texlive \
                         port:texlive-fonts-extra \
                         port:texlive-lang-japanese \
-                        port:texlive-latex-extra
+                        port:texlive-latex-extra \
+                        port:unzip
 
 configure {
     if {![variant_isset mactex]} {


### PR DESCRIPTION
auto-multiple-choice-devel: update to revision 3bfa3245 of jan 8, 2021

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3 12C33 

+mactex
macOS 10.15.7 19H114
Xcode 12.3 12C33 

macOS 10.14.6 18G7016 **
Xcode 11.3.1 11C504 

macOS 10.13.6 17G14033 **
Xcode 10.1 10B61 

macOS 10.12.6 16G2136 **
Xcode 9.2 9C40b 

macOS 10.11.6 15G22010 **
Xcode 8.2.1 8C1002 

** Need to force reinstall gobject-introspection atk gdk-pixbuf2 with `sudo port -sn upgrade --force gobject-introspection atk gdk-pixbuf2` to correct error with image not shown in the gtk interface. See [https://trac.macports.org/ticket/61699].
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
