### PR TITLE
mame: enable arm64 build

### DIFF
--- a/emulators/mame/Portfile
+++ b/emulators/mame/Portfile
@@ -209,9 +209,7 @@ depends_run-append  \
 # Build Options
 #------------------------------------------------------------------------------
 
-# Note: ARM64 support untested
-#supported_archs     ppc ppc64 i386 x86_64 arm64
-supported_archs     ppc ppc64 i386 x86_64
+supported_archs     ppc ppc64 i386 x86_64 arm64
 
 use_configure       no
 


### PR DESCRIPTION
#### Description

Now that `portmidi` has been fixed, Mame builds successfully for Big Sur x86_64. So we're ready to enable the arm64 build.

Fixes: [mame: validate and certify build for Big Sur, both x86_64 and arm64](https://trac.macports.org/ticket/61795)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
N/A - Apart from local sanity testing of the portfile change, I don't have a Mac with Apple Silicon to test with.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
