### PR TITLE
bazel: fix build for +bash_completion variant

### DIFF
--- a/devel/bazel/Portfile
+++ b/devel/bazel/Portfile
@@ -233,7 +233,7 @@ build {
         file delete -force /var/tmp/_${name}_root
 
         # Build the bash completion script
-        system -W ${worksrcpath} "./${name} --max_idle_secs=60 --output_user_root=${workpath} build -s --javabase //:jdk10 --host_javabase //:jdk10 //scripts:${name}-complete.bash"
+        system -W ${worksrcpath} "./${name} --max_idle_secs=60 --output_user_root=${workpath} build -s //scripts:${name}-complete.bash"
 
     }
 }


### PR DESCRIPTION
Removed --javabase //:jdk10 --host_javabase //:jdk10. Upstream bazel BUILD file does not seem to pass it. BUILD target (https://github.com/bazelbuild/bazel/blob/master/scripts/BUILD) is a genrule, which simply runs this shell script: https://github.com/bazelbuild/bazel/blob/master/scripts/generate_bash_completion.sh.

Tested: edited portfile locally and installed.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
