### PR TITLE
logrotate: attempt to fix build on macOS 10.6

### DIFF
--- a/sysutils/logrotate/Portfile
+++ b/sysutils/logrotate/Portfile
@@ -3,6 +3,10 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
+# Need O_CLOEXEC
+PortGroup           legacysupport 1.0
+legacysupport.newest_darwin_requires_legacy 10
+
 github.setup        logrotate logrotate 3.18.0
 
 github.tarball_from releases


### PR DESCRIPTION
#### Description
[Build fails on macOS 10.6](https://build.macports.org/builders/ports-10.6_i386-builder/builds/24103/steps/install-port/logs/stdio) which doesn't have `O_CLOEXEC` (but which is available from legacysupport):
```
/opt/local/bin/clang-mp-9.0 -DHAVE_CONFIG_H -I.  -include config.h -I/opt/local/include -Wall -Wconversion -Wdeclaration-after-statement -Wextra -Wmissing-format-attribute -Wmissing-noreturn -Wmissing-prototypes -Wpointer-arith -Wshadow -Wstrict-prototypes -Wundef -Wunused -Wwrite-strings -pipe -Os -arch i386 -MT logrotate.o -MD -MP -MF .deps/logrotate.Tpo -c -o logrotate.o logrotate.c
logrotate.c:2900:47: error: use of undeclared identifier 'O_CLOEXEC'
    int lockFd = open(stateFilename, O_RDWR | O_CLOEXEC);
                                              ^
1 error generated.
```

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### ~~Tested on~~
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
Untested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
