### PR TITLE
gpsd: Update to 3.22

### DIFF
--- a/net/gpsd/Portfile
+++ b/net/gpsd/Portfile
@@ -3,8 +3,8 @@
 PortSystem              1.0
 
 name                    gpsd
-version                 3.21
-revision                1
+version                 3.22
+revision                0
 categories              net
 license                 BSD
 maintainers             {michaelld @michaelld} \
@@ -23,9 +23,9 @@ long_description        GPSD is a service daemon that handles GPSes and other \
 homepage                https://gpsd.io
 
 master_sites            savannah
-checksums               rmd160  3c521009854e2ae19bcd4f7fb0f0c33c334bcbc5 \
-                        sha256  65504c3af8d3b0cce3c07405b8815d7730d2d2be2da7d28d275f1a9c57c6fe91 \
-                        size    3984157
+checksums               rmd160  916829bad167ef8313ea348cfaac71201ab77cc1 \
+                        sha256  783fdf2a5f78a593230c7bfa8b409956545765563224c6c56ad69cc6c2a637a3 \
+                        size    4758761
 
 livecheck.type          regex
 livecheck.url           https://download.savannah.gnu.org/releases/gpsd/
@@ -42,9 +42,13 @@ foreach s ${pythons_suffixes} {
     lappend pythons_ports python${s}
 }
 
+proc dotted_ver {nodot} {
+    return [string index ${nodot} 0].[string range ${nodot} 1 99]
+}
+
 foreach s ${pythons_suffixes} {
     set p python${s}
-    set v [string index ${s} 0].[string index ${s} 1]
+    set v [dotted_ver ${s}]
     set i [lsearch -exact ${pythons_ports} ${p}]
     set c [lreplace ${pythons_ports} ${i} ${i}]
     variant ${p} description "Build ${name} to use Python ${v}" conflicts {*}${c} ""
@@ -71,7 +75,7 @@ if {${pyver_no_dot} eq ""} {
 return -code error "Invalid Python variant selection"
 }
 
-set pyver_dotted [join [split ${pyver_no_dot} ""] .]
+set pyver_dotted [dotted_ver ${pyver_no_dot}]
 
 # NOTE:  All Python dependencies which are conceptually depends_run actually
 # need to be depends_lib, since the build procedure references them, usually
@@ -87,7 +91,7 @@ depends_lib-append      port:python${pyver_no_dot} \
 configure.python        ${prefix}/bin/python${pyver_dotted}
 
 depends_lib-append      port:ncurses
-depends_build-append    port:scons port:pkgconfig
+depends_build-append    port:scons port:pkgconfig port:docbook-xml-4.1.2
 
 use_configure           no
 use_xcode               yes
@@ -123,6 +127,9 @@ build.env-append        "CC=${configure.cc} [get_canonical_archflags cc]" \
 # extra_env in macports.conf.  In all cases, the WRITE_PAD value in use is
 # reported by the test framework and is visible with -v.
 #
+# UPDATE: The default 1ms WRITE_PAD currently seems to be marginal, so we
+# default it to 3ms.
+#
 # The test phase duplicates the arguments and environment (except WRITE_PAD)
 # from the build phase, mainly to avoid gratuitous rebuilds between the phases.
 #
@@ -137,7 +144,10 @@ test.args               {*}${build.args}
 test.env-append         {*}${build.env}
 if { [info exists ::env(WRITE_PAD)] } {
     test.env-append     WRITE_PAD=$::env(WRITE_PAD)
+} else {
+    test.env-append     WRITE_PAD=0.003
 }
+
 
 destroot.args           {*}${build.args}
 destroot.env-append     {*}${destroot.destdir} {*}${build.env}
@@ -171,6 +181,8 @@ variant dbus description {Include support for DBUS} {
     destroot.args-replace   dbus_export=no  dbus_export=yes
 }
 
+# The xgps programs recusively require a massive set of dependencies,
+# so we make them optional.
 variant xgps \
 description {Include xgps/xgpsspeed X11 clients (dependency-intensive)} {
     depends_lib-append      port:py${pyver_no_dot}-cairo \
@@ -182,10 +194,33 @@ description {Include xgps/xgpsspeed X11 clients (dependency-intensive)} {
     destroot.args-replace   xgps=no         xgps=yes
 }
 
+# The upstream build script installs xgps* even with xgps=no.
+# Although the files aren't large, installing programs which either fail
+# or opportunistically work is undesirable, so we remove them.
+# Similarly, we exclude the manpages for the nonexistent programs.
 if {![variant_isset xgps]} {
-    notes "The xgps variant is now needed to get the xgps and xgpsspeed programs."
+    post-destroot {
+        delete "${destroot}${prefix}/bin/xgps"
+        delete "${destroot}${prefix}/bin/xgpsspeed"
+        delete "${destroot}${prefix}/share/man/man1/xgps.1"
+        delete "${destroot}${prefix}/share/man/man1/xgpsspeed.1"
+    }
 }
 
+# The gpsplot program recusively requires a massive set of dependencies,
+# so we make it optional.  This currently has no upstream equivalent.
+variant plot \
+description {Include gpsplot client (dependency-intensive)} {
+    depends_lib-append      port:py${pyver_no_dot}-matplotlib
+}
+
+# In the absence of the 'plot' variant, we remove the program and manpage.
+if {![variant_isset plot]} {
+    post-destroot {
+        delete "${destroot}${prefix}/bin/gpsplot"
+        delete "${destroot}${prefix}/share/man/man1/gpsplot.1"
+    }
+}
 
 # The gpsd-devel subport is obsolete as of 04-Jan-2020.
 # Handle it last so that it can override the dependencies.


### PR DESCRIPTION
Adds a missing docbook build dependency.

Removes the note related to xgps variant.  At the time this variant
was added, the note was included to avoid surprising users who'd
expected xgps* to be included by default.  Since that was more than
three years ago, it's reasonable to suppose that users either know
about the variant by now or don't care.

Explicitly deletes xgps* in the -xgps case.  Although the upstream
code has an option for xgps, it installs the xgps* programs even with
xgps=no, though they may or may not work based on the opportunistic
availability of the dependencies.  Now they (and the related manpages)
are excluded in that case.

Adds a new 'plot' variant.  The new 'gpsplot' program requires
pyXX-matplotlib, which is another heavyweight dependency.  The variant
makes that dependency optional.  Since 'gpsplot' is not optional
upstream, it's explicitly removed (along with its manpage) in the
-plot case.  This variant defaults off, for consistency with the
behavior of earlier versions.

Changes the default WRITE_PAD to 3ms for the tests.  The upstream
default 1ms value has become somewhat marginal.

Fixes Python version handling for a future python310 variant.

TESTED:
Tested (including building the usual set of variant combinations and
running the tests) on 10.5 ppc, 10.5-10.6 i386, and 10.6-10.15 x86_64.
The 'plot' and 'xgps' variants were excluded in some cases due to
issues with the dependencies, though it's expected that they'd work
if the broken dependencies were fixed.
Not tested on 10.16/11.0.
Known not to build on 10.4.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G7016, x86_64, Xcode 11.3.1 11C505
macOS 10.15.6 19G2021, x86_64, Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
