### PR TITLE
openmpi: rev bump for recent libevent changes

### DIFF
--- a/science/openmpi/Portfile
+++ b/science/openmpi/Portfile
@@ -9,7 +9,7 @@ PortGroup           legacysupport 1.0
 
 name                openmpi
 version             4.1.0
-revision            0
+revision            1
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          science parallel net
 platforms           darwin
@@ -46,7 +46,7 @@ if {[string first "-devel" $subport] > 0} {
 
     name                openmpi-devel
     version             ${branch}.999-${base}
-    revision            1
+    revision            2
 
     distname            openmpi-v${branch}.x-${base}-${tag}
 


### PR DESCRIPTION
#### Description

Ensure all subports are rebuilt, for both our infrastructure and end-users; related to the previous `libevent` change:

[openmpi: force use of macports libevent, to eliminate implicit use when already installed](https://github.com/macports/macports-ports/pull/9684)

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
N/A - rev bump only

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
