### PR TITLE
py-slackclient: update to 2.9.3, added python39 support

### DIFF
--- a/python/py-slackclient/Portfile
+++ b/python/py-slackclient/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        slackapi python-slackclient 2.9.1 v
+github.setup        slackapi python-slackclient 2.9.3 v
 name                py-slackclient
 categories-append   irc
 platforms           darwin
 supported_archs     noarch
 license             MIT
 
-python.versions     36 37 38
+python.versions     36 37 38 39
 
 maintainers         {gmail.com:giovanni.bussi @GiovanniBussi} openmaintainer
 
@@ -21,13 +21,14 @@ long_description    The Python slackclient is a developer kit for interfacing wi
 
 homepage            https://slack.dev/python-slackclient/
 
-checksums           rmd160  c2dfadfae285fe2cbdf4a11b0b2a1068ef6ed625 \
-                    sha256  cec492d6ca264c2b56d2746fd971f17f56f36ee84b2dfdf736d42ddfe20fe6e0 \
-                    size    2576869
+checksums           rmd160  1e8335d8498cfbea3eb77c360a581e301ca18f78 \
+                    sha256  505aad133ecc0563a75e1c7d7b1d3cc27f291fb155e03553ac06fcc01eaeed6a \
+                    size    2580387
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
     depends_lib-append      port:py${python.version}-aiohttp
+    depends_lib-append      port:py${python.version}-typing_extensions
 
     livecheck.type none
 }


### PR DESCRIPTION
#### Description

Updated, and added python 3.9 support as requested [here](https://github.com/macports/macports-ports/pull/9664#discussion_r558186697).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
