### PR TITLE
whitebox-tools: update to version 1.4.0

### DIFF
--- a/gis/whitebox-tools/Portfile
+++ b/gis/whitebox-tools/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        jblindsay whitebox-tools 1.3.0 v
+github.setup        jblindsay whitebox-tools 1.4.0
 categories          gis
 platforms           darwin
 maintainers         {@mholling gmail.com:mdholling} openmaintainer
@@ -15,9 +15,9 @@ homepage            https://jblindsay.github.io/ghrg/WhiteboxTools/index.html
 license             MIT
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  67cc18a34fd4bd4edd81705da9e7f581488a8c13 \
-                    sha256  14ae2fb344d4dddac9ba44d359283dc3c63462a7ab62a9fd5ab781b9f3f8ad0e \
-                    size    7975126
+                    rmd160  af2546a2f34f317211970874b319b0cabf20ba32 \
+                    sha256  15abf0c972a5eb6cac90265b9357864da722281ee8508b8875099fd57d91f236 \
+                    size    15797799
 
 # When updating Portfile version, see instructions in cargo_fetch
 # PortGroup file for updating crate versions and checksums:
@@ -34,9 +34,14 @@ cargo.crates \
                     bzip2-sys 0.1.8+1.0.8 05305b41c5034ff0e93937ac64133d109b5a2660114ec45e9760bc6816d83038 \
                     cc 1.0.52 c3d87b23d6a92cd03af510a5ade527033f6aa6fa92161e2d5863a907d4c5e31d \
                     cfg-if 0.1.10 4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
-                    chrono 0.4.11 80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2 \
+                    chrono 0.4.15 942f72db697d8767c22d46a598e01f2d3b475501ea43d0db4f16d90259182d0b \
                     cloudabi 0.0.3 ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
                     crc32fast 1.2.0 ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1 \
+                    crossbeam-deque 0.7.3 9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285 \
+                    crossbeam-epoch 0.8.2 058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace \
+                    crossbeam-queue 0.2.3 774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570 \
+                    crossbeam-utils 0.7.2 c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8 \
+                    either 1.5.3 bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3 \
                     flate2 1.0.14 2cfff41391129e0a856d6d822600b8d71179d46879e310417eb9c762eb178b42 \
                     fuchsia-cprng 0.1.1 a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba \
                     generic-array 0.12.3 c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec \
@@ -45,10 +50,13 @@ cargo.crates \
                     itoa 0.4.5 b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e \
                     kdtree 0.6.0 80ee359328fc9087e9e3fc0a4567c4dd27ec69a127d6a70e8d9dd22845b8b1a2 \
                     late-static 0.3.0 fa0fc01ae4c505cff39f8bf927b37a4799ef3309bb865f8cffad2fa3250439c2 \
+                    lazy_static 1.4.0 e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
                     libc 0.2.69 99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005 \
                     libm 0.2.1 c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a \
                     lzw 0.10.0 7d947cbb889ed21c2a84be6ffbaebf5b4e0f4340638cba0444907e38b56be084 \
                     matrixmultiply 0.2.3 d4f7ec66360130972f34830bfad9ef05c6610a43938a467bcc9ab9369ab3478f \
+                    maybe-uninit 2.0.0 60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00 \
+                    memoffset 0.5.5 c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f \
                     miniz_oxide 0.3.6 aa679ff6578b1cddee93d7e82e263b94a575e0bfced07284eb0c037c1d2416a5 \
                     msdos_time 0.1.6 aad9dfe950c057b1bfe9c1f2aa51583a8468ef2a5baba2ebbe06d775efeb7729 \
                     nalgebra 0.18.1 aaa9fddbc34c8c35dd2108515587b8ce0cab396f17977b8c738568e4edb521a2 \
@@ -81,9 +89,12 @@ cargo.crates \
                     rand_pcg 0.2.1 16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429 \
                     rand_xorshift 0.1.1 cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c \
                     rawpointer 0.2.1 60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3 \
+                    rayon 1.3.1 62f02856753d04e03e26929f820d0a0a337ebe71f849801eea335d464b349080 \
+                    rayon-core 1.7.1 e92e15d89083484e11353891f1af602cc661426deb9564c298b270c726973280 \
                     rdrand 0.4.0 678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2 \
                     rstar 0.7.1 0650eaaa56cbd1726fd671150fce8ac6ed9d9a25d1624430d7ee9d196052f6b6 \
                     ryu 1.0.4 ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1 \
+                    scopeguard 1.1.0 d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
                     serde 1.0.110 99e7b308464d16b56eba9964e4972a3eee817760ab60d88c3f86e1fecb08204c \
                     serde_derive 1.0.110 818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984 \
                     serde_json 1.0.53 993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2 \


### PR DESCRIPTION
#### Description

Update whitebox-tools to version 1.4.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
