### PR TITLE
spring-boot-cli: update to 2.4.2

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            spring-boot-cli
-version         2.4.1
+version         2.4.2
 revision        0
 
 categories      java
@@ -30,9 +30,9 @@ master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/
 
 distname        ${name}-${version}-bin
 
-checksums       rmd160  a40142a7fe45bf47e1dfa5e4eb96060630bd80e7 \
-                sha256  6d7f71f0472a71f8b35ef3759e1d0368b52c9e853e0d1cc2325a8faed45d58b8 \
-                size    11702996
+checksums       rmd160  d205503baaa0f8e298ae77e3597d0d3bfe7d8435 \
+                sha256  20317394ea38bba16385d1ed8e02eda73ae4dc88a1d5e2cb99798f6f8a803229 \
+                size    11704632
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
#### Description

Update to Spring Boot CLI 2.4.2.

###### Tested on

macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?