### PR TITLE
qt5pas: new port

### DIFF
--- a/devel/qt5pas/Portfile
+++ b/devel/qt5pas/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           qmake5 1.0
+
+name                qt5pas
+version             2.0.10-2
+revision            0
+categories          devel
+platforms           darwin
+license             GPL-2 LGPL-2
+maintainers         {@kamischi web.de:karl-michael.schindler} openmaintainer
+description         Pascal wrapper for Qt5
+
+long_description    The Free Pascal Qt5 binding allows Free Pascal to interface with the \
+                    C++ Library Qt. \
+                    \
+                    This binding may not cover the whole Qt5 framework but only the classes \
+                    needed by the Cross Platform Lazarus IDE to use Qt as a Widget set.
+
+homepage            https://wiki.freepascal.org/Qt5_Interface
+master_sites        sourceforge:lazarus
+distname            lazarus-${version}
+checksums           rmd160  1e9c89a34bbdf90bf4010e73424b53be117e8e74 \
+                    sha256  64d5626468dd24a3332b205f3abd0a581ab7de1b060a2d57e21864066cfd43b7 \
+                    size    69626076
+
+worksrcdir          lazarus/lcl/interfaces/qt5/cbindings
+
+post-destroot {
+    xinstall -m 755 -d ${destroot}${prefix}/share/doc/qt5pas
+    xinstall -m 644 {*}[glob ${worksrcpath}/*.TXT] ${destroot}${prefix}/share/doc/qt5pas
+}


### PR DESCRIPTION
qt5pas contains Free Pascal Qt5 bindings as interface with the C++ Library Qt.
The bindings do not cover everything, only what is needed for Qt based Lazarus.

#### Description

###### Type(s)
- [x] enhancement

###### Tested on
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [*] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [*] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [*] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [*] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [*] checked your Portfile with `port lint`?
- [*] tried existing tests with `sudo port test`?
- [*] tried a full install with `sudo port -vst install`?
- [*] tested basic functionality of all binary files?
