### PR TITLE
icu: repair multiarch universal build

### DIFF
--- a/devel/icu/Portfile
+++ b/devel/icu/Portfile
@@ -180,6 +180,17 @@ if { ${subport} ne "${name}-docs" } {
                     ${dir}/config/icu-config
                 reinplace -E {s| -arch +[^ ]+||g} \
                     ${dir}/config/pkgdata.inc
+
+                # remove architecture-specific host information
+                # calling icu-config for the host information is not mentioned in any
+                # icu man pages as an option, differs between architectures, and can't be merged
+                # https://trac.macports.org/ticket/45268
+                reinplace {s|host=\".*\"|host=\"\"|g} \
+                    ${dir}/config/icu-config
+                reinplace {s|host_alias=\".*\"|host_alias=\"\"|g} \
+                    ${dir}/config/icu-config
+                reinplace {s|host_cpu=\".*\"|host_cpu=\"\"|g} \
+                    ${dir}/config/icu-config
             }
         }
     }

--- a/devel/icu/Portfile
+++ b/devel/icu/Portfile
@@ -46,7 +46,7 @@ if {${os.major} >= 11 || ${subport} eq "${name}58"} {
 }
 
 subport ${name}58 {
-    revision                0
+    revision                1
     configure.pre_args      --prefix=${prefix}/libexec/${subport}
 
     patchfiles-append       CVE-2017-7867-CVE-2017-7868.patch \
@@ -122,7 +122,7 @@ subport ${name}-lx {
 }
 
 if {${subport} eq ${name}} {
-    revision                2
+    revision                3
 }
 
 if { ${subport} ne "${name}-docs" } {


### PR DESCRIPTION
icu-config embeds host information about the
host that configure ran on. This information is
different for each supported arch, and can't be merged.

icu-config --host
is not mentioned in the icu-config manpages anywhwere
and has no perceived useful purpose

so nullify the arch-specific differences between the
icu-config script to allow a universal icu to be
built once again

the other option would be to write a new icu-config
script that can handle multi-arch logic. What this
script would be expected to output, and how and why
it would be ever used, is not clear, however, so this
option is considered less desirable

closes: https://trac.macports.org/ticket/45268

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3 12C33

```
% port -v installed icu
The following ports are currently installed:
  icu @67.1_2 platform='darwin 20' archs='x86_64' date='2020-12-27T18:45:30-0800'
  icu @67.1_2+universal (active) platform='darwin 20' archs='arm64 x86_64' date='2021-01-16T10:24:45-0800'
```

```
% icu-config --cppflags --cxxflags --ldflags
-I/opt/local/include -std=c++11  -L/opt/local/lib -licui18n -licuuc -licudata  
```

```
 % icu-config --host                         

```