### PR TITLE
getdns: update to 1.6.0

### DIFF
--- a/devel/getdns/Portfile
+++ b/devel/getdns/Portfile
@@ -1,10 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           cmake   1.1
 
 name                getdns
-version             1.5.2
+version             1.6.0
 revision            0
+
 categories          devel
 platforms           darwin
 maintainers         {l2dy @l2dy} openmaintainer
@@ -19,20 +21,23 @@ long_description    getdns is a modern asynchronous DNS API. It implements DNS \
                     maintained in collaboration by NLnet Labs, Sinodun and No \
                     Mountain Software.
 
-homepage            https://getdnsapi.net/
+homepage            https://getdnsapi.net
 
-master_sites        ${homepage}dist/
+master_sites        ${homepage}/dist/
 
-checksums           rmd160  85ce46a88273dbe6c38f73acc5a4d15a7c4a6392 \
-                    sha256  1826a6a221ea9e9301f2c1f5d25f6f5588e841f08b967645bf50c53b970694c0 \
-                    size    1091088
+checksums           rmd160  58ad868301b78a0b6ac4770324e1d0bc6c3f9b61 \
+                    sha256  40e5737471a3902ba8304b0fd63aa7c95802f66ebbc6eae53c487c8e8a380f4a \
+                    size    673593
 
-depends_lib         path:lib/libssl.dylib:openssl \
-                    port:libevent \
-                    port:libidn2
+depends_build-append        port:pkgconfig
 
-configure.args      --enable-stub-only \
-                    --with-libevent \
-                    --without-libidn
+depends_lib                 path:lib/libssl.dylib:openssl \
+                            port:libevent \
+                            port:libidn2
+
+configure.args-append       -DBUILD_TESTING=OFF \
+                            -DENABLE_STUB_ONLY=ON \
+                            -DUSE_LIBIDN2=ON \
+                            -DUSE_LIBEVENT2=ON
 
 livecheck.regex     ${name}-(\\d+(?:\\.\\d+)*)[quotemeta ${extract.suffix}]


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
