### PR TITLE
wireshark3: update port to select 3.4.1 for older macOS releases, and add patch for clock_realtime build errors on those

### DIFF
--- a/net/wireshark3/Portfile
+++ b/net/wireshark3/Portfile
@@ -4,8 +4,6 @@ PortSystem          1.0
 PortGroup           cmake 1.0
 
 name                wireshark3
-version             3.4.2
-revision            0
 categories          net
 license             {GPL-2 GPL-3}
 maintainers         {darkart.com:opendarwin.org @ghosthound}
@@ -18,6 +16,40 @@ long_description    A network analyzer that lets you capture and \
                     Packet data can be read from a file, or live from a local \
                     network interface.
 
+# Include patch for CLOCK_REALTIME build errors, on macOS releases prior to 10.12.
+# While a fix has been included in upstream 3.4.2, that release also requires
+# QT59... and is a no-go for these older macOS releases.
+#
+# So for now, we're stuck with 3.4.1, for users running macOS 10.11 and earlier.
+#
+# MacPorts issue, with all of the juicy details:
+#   https://trac.macports.org/ticket/61511
+# GitHub issue:
+#   https://gitlab.com/wireshark/wireshark/-/issues/17101
+# Upstream fix committed:
+#   https://gitlab.com/wireshark/wireshark/-/merge_requests/1404
+
+if {${os.major} >= 16} {
+    version         3.4.2
+    revision        0
+
+    checksums       sha256  de9868729e426a469baabd8d444240d84fa5445020e92c842dd19afd0d47a4c4 \
+                    rmd160  53a02106b0f23e50b1108d93772464974b2b37be \
+                    sha1    b33276e4e6c3d6a057da3b569b58316330a5f3e3 \
+                    size    32465900
+} else {
+    version         3.4.1
+    revision        2
+
+    checksums       sha256  f8165211f5b4a4f6708df73ef9be51df917927f2da78348b32d3a6eb5fc458a3 \
+                    rmd160  1b5e1fee340c149b70dbe8e8cf935518b06656e8 \
+                    sha1    3c9a24b8954d712a189f997131e283fbd0b606bc \
+                    size    32470004
+
+    patchfiles-append \
+                    patch-wireshark3-3.4.1-fix-clock_realtime.diff
+}
+
 master_sites        https://www.wireshark.org/download/src/ \
                     https://www.wireshark.org/download/src/all-versions/
 
@@ -26,11 +58,6 @@ use_xz              yes
 distfiles           wireshark-${version}${extract.suffix}
 
 worksrcdir          wireshark-${version}
-
-checksums           sha256  de9868729e426a469baabd8d444240d84fa5445020e92c842dd19afd0d47a4c4 \
-                    rmd160  53a02106b0f23e50b1108d93772464974b2b37be \
-                    sha1    b33276e4e6c3d6a057da3b569b58316330a5f3e3 \
-                    size    32465900
 
 conflicts           wireshark-devel wireshark wireshark2 wireshark22 wireshark24 wireshark30
 

--- a/net/wireshark3/files/patch-wireshark3-3.4.1-fix-clock_realtime.diff
+++ b/net/wireshark3/files/patch-wireshark3-3.4.1-fix-clock_realtime.diff
@@ -1,0 +1,30 @@
+--- ui/qt/import_text_dialog.cpp	2020-12-20 11:02:56.000000000 -0500
++++ ui/qt/import_text_dialog.cpp	2020-12-15 16:53:01.000000000 -0500
+@@ -11,6 +11,11 @@
+ 
+ #include <time.h>
+ 
++#ifdef __MACH__
++#include <mach/clock.h>
++#include <mach/mach.h>
++#endif
++
+ #include "import_text_dialog.h"
+ 
+ #include "wiretap/wtap.h"
+@@ -384,6 +389,15 @@
+ 
+ #ifdef _WIN32
+             timespec_get(&timenow, TIME_UTC); /* supported by Linux and Windows */
++#elif defined(__MACH__)
++            // OS X does not have clock_gettime, use clock_get_time
++            clock_serv_t cclock;
++            mach_timespec_t mts;
++            host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
++            clock_get_time(cclock, &mts);
++            mach_port_deallocate(mach_task_self(), cclock);
++            timenow.tv_sec = mts.tv_sec;
++            timenow.tv_nsec = mts.tv_nsec;
+ #else
+             clock_gettime(CLOCK_REALTIME, &timenow); /* supported by Linux and MacOS */
+ #endif


### PR DESCRIPTION
#### Description

To ensure users of Wireshark3 on macOS releases prior to 10.12 are still supported, gracefully downgrade version to 3.4.1 for those cases. (Note that 3.4.2 requires QT 5.9, so until/unless we can get that working in older macOS releases... this is our only choice.) Also include a patch to fix build error related to CLOCK_REALTIME.

Fixes: [wireshark3 @3.4.0_0+cares+chmodbpf+geoip+gnutls+kerberos5+libsmi+python37+qt5+zlib: error: use of undeclared identifier 'CLOCK_REALTIME'](https://trac.macports.org/ticket/61511)

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.8.5 12F2560
Xcode 5.1.1 5B1008

macOS 10.10.5 14F2511
Xcode 6.4 6E35b

macOS 10.11.6 15G22010
Xcode 7.3.1 7D1014

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
