### PR TITLE
qt5-mysql-plugin: Add variants for mariadb10.1-10.5 and mysql8

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -813,6 +813,54 @@ array set sql_plugins {
             ""
         }
         {
+            "mariadb10_5"
+            "port:mariadb-10.5"
+            "${prefix}/include/mariadb-10.5/mysql"
+            "${prefix}/lib/mariadb-10.5/mysql"
+            "-lmysqlclient_r"
+            ""
+        }
+        {
+            "mariadb10_4"
+            "port:mariadb-10.4"
+            "${prefix}/include/mariadb-10.4/mysql"
+            "${prefix}/lib/mariadb-10.4/mysql"
+            "-lmysqlclient_r"
+            ""
+        }
+        {
+            "mariadb10_3"
+            "port:mariadb-10.3"
+            "${prefix}/include/mariadb-10.3/mysql"
+            "${prefix}/lib/mariadb-10.3/mysql"
+            "-lmysqlclient_r"
+            ""
+        }
+        {
+            "mariadb10_2"
+            "port:mariadb-10.2"
+            "${prefix}/include/mariadb-10.2/mysql"
+            "${prefix}/lib/mariadb-10.2/mysql"
+            "-lmysqlclient_r"
+            ""
+        }
+        {
+            "mariadb10_1"
+            "port:mariadb-10.1"
+            "${prefix}/include/mariadb-10.1/mysql"
+            "${prefix}/lib/mariadb-10.1/mysql"
+            "-lmysqlclient_r"
+            ""
+        }
+        {
+            "mysql8"
+            "port:mysql8"
+            "${prefix}/include/mysql8/mysql"
+            "${prefix}/lib/mysql8/mysql"
+            "-lmysqlclient"
+            ""
+        }
+        {
             "mysql57"
             "port:mysql57"
             "${prefix}/include/mysql57/mysql"


### PR DESCRIPTION
#### Description

Add variants to qt5-mysql-plugin allowing the use of mariadb-10.1, mariadb-10.2, mariadb-10.3, mariadb-10.4, mariadb-10.5, and mysql8

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

Reference enhancement ticket: https://trac.macports.org/ticket/62129#ticket