### PR TITLE
openrct2: add -Wno-range-loop-analysis cxx flag

### DIFF
--- a/games/openrct2/Portfile
+++ b/games/openrct2/Portfile
@@ -115,6 +115,7 @@ configure.args-append \
 configure.cppflags-append -DNCURSES_UNCTRL_H_incl
 
 configure.cppflags-append -Wno-deprecated-declarations
+configure.cppflags-append -Wno-range-loop-analysis
 
 notes "
 OpenRCT2 requires files from the original RollerCoaster Tycoon 2 in order to work.


### PR DESCRIPTION
#### Description

Got this issue recently and not sure exactly why. It may be because `-Wrange-loop-analysis` is now enabled by default with newer Clang or something similar.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
