### PR TITLE
Add global description for +zsh_completion

### DIFF
--- a/_resources/port1.0/variant_descriptions.conf
+++ b/_resources/port1.0/variant_descriptions.conf
@@ -3,3 +3,4 @@ nls                     {Enable national language support}
 quartz                  {Enable native macOS graphics support}
 universal               {Build for multiple architectures}
 x11                     {Enable X11 support}
+zsh_completion          {Enable completion support for Zsh}

--- a/sysutils/podman/Portfile
+++ b/sysutils/podman/Portfile
@@ -46,7 +46,7 @@ variant bash_completion {
     }
 }
 
-variant zsh_completion description {Enable completion support for zsh} {
+variant zsh_completion {
     depends_run-append path:${prefix}/bin/zsh:zsh
 
     post-destroot {


### PR DESCRIPTION
#### Description

This should help to keep shell completion messaging more consistent, and assist in simplifying portfiles since this variant's description will no longer be required.

It should also help prevent ` port lint --nitpick` errors such as https://github.com/macports/macports-ports/pull/9746#issuecomment-761822929, where you presume that because bash_completion has a global description, zsh should have one too.

I thought about fish_completion, but currently I don't think that there are enough ports with this variant to warrant a global description.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
N/A

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
