### PR TITLE
shellcheck: add livecheck for Darwin >= 20

### DIFF
--- a/devel/shellcheck/Portfile
+++ b/devel/shellcheck/Portfile
@@ -27,6 +27,10 @@ if { ${os.platform} eq "darwin" && ${os.major} >= 20 } {
     checksums           rmd160  edce5cdbb0de2ec12c2fa037fb82612e9eedb133 \
                         sha256  b080c3b659f7286e27004aa33759664d91e15ef2498ac709a452445d47e3ac23 \
                         size    1348272
+    homepage        https://github.com/koalaman/shellcheck
+    livecheck.type  regex
+    livecheck.url   https://github.com/koalaman/shellcheck/tags
+    livecheck.regex "archive/v(\[^\"]+)\\.tar\\.gz"
     use_configure   no
     build {}
     destroot {


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
