### PR TITLE
libjpeg-turbo: update to 2.0.6

### DIFF
--- a/graphics/libjpeg-turbo/Portfile
+++ b/graphics/libjpeg-turbo/Portfile
@@ -1,9 +1,9 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 PortSystem          1.0
 PortGroup           cmake 1.1
-PortGroup           github 1.0
 
-github.setup        libjpeg-turbo libjpeg-turbo 2.0.4
+name                libjpeg-turbo
+version             2.0.6
 categories          graphics
 platforms           darwin
 license             BSD
@@ -25,18 +25,22 @@ long_description    libjpeg-turbo is a JPEG image codec that uses SIMD \
                     cases, the performance of libjpeg-turbo rivals \
                     that of proprietary high-speed JPEG codecs.
 homepage            https://www.${name}.org
+master_sites        sourceforge:project/${name}/${version}
 
-checksums           rmd160  83f073615a13198f6fedf0a1cdfb4b1713c858d1 \
-                    sha256  63366c34a89e0739a87d4aa36a473b5a5d98f8c8ab77cc027e5f1181f4997a7e \
-                    size    2161945
+checksums           sha1    5406c7676d7df89fb4da791ad5af51202910fb25 \
+                    rmd160  efc242b0c43fd245093939f45bc6cc2fb951ba6e \
+                    sha256  d74b92ac33b0e3657123ddcf6728788c90dc84dcb6a52013d758af3c4af481bb \
+                    size    2192315
 
+if {${build_arch} in {i386 x86_64} || ([variant_isset universal] &&
+    ("x86_64" in ${universal_archs} || "i386" in ${universal_archs}))} {
 depends_build-append port:nasm
 
 configure.env       ASM_NASM=${prefix}/bin/nasm
+}
 configure.args      -DWITH_JPEG8=1
 
-# disabled because tests fail with linking problems and MD5 failure
-test.run            no
+test.run            yes
 test.env            CTEST_OUTPUT_ON_FAILURE=1
 
 pre-activate {

--- a/graphics/libjpeg-turbo/Portfile
+++ b/graphics/libjpeg-turbo/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 PortSystem          1.0
 PortGroup           cmake 1.1
+PortGroup           muniversal 1.0
 
 name                libjpeg-turbo
 version             2.0.6
@@ -32,11 +33,18 @@ checksums           sha1    5406c7676d7df89fb4da791ad5af51202910fb25 \
                     sha256  d74b92ac33b0e3657123ddcf6728788c90dc84dcb6a52013d758af3c4af481bb \
                     size    2192315
 
-if {${build_arch} in {i386 x86_64} || ([variant_isset universal] &&
-    ("x86_64" in ${universal_archs} || "i386" in ${universal_archs}))} {
-depends_build-append port:nasm
-
-configure.env       ASM_NASM=${prefix}/bin/nasm
+if {[variant_isset universal]} {
+    if {"x86_64" in ${configure.universal_archs} || "i386" in ${configure.universal_archs}} {
+        depends_build-append port:nasm
+    }
+    set merger_configure_env(i386)  ASM_NASM=${prefix}/bin/nasm
+    set merger_configure_env(x86_64)    ASM_NASM=${prefix}/bin/nasm
+    foreach uarch {arm64 i386 ppc ppc64 x86_64} {
+        set merger_configure_args(${uarch}) -DCMAKE_SYSTEM_PROCESSOR=${uarch}
+    }
+} elseif {${configure.build_arch} in {i386 x86_64}} {
+    depends_build-append port:nasm
+    configure.env       ASM_NASM=${prefix}/bin/nasm
 }
 configure.args      -DWITH_JPEG8=1
 


### PR DESCRIPTION
Use official release tarball instead of github auto-generated snapshot,
re-enable tests, only add nasm dep if building for Intel archs.

###### Tested on
macOS 10.15.7 19H114
Xcode 12.3 12C33
