### PR TITLE
mame: user-experience improvements: add tutorial link to port notes; update launcher to enable additional core functionality

### DIFF
--- a/emulators/mame/Portfile
+++ b/emulators/mame/Portfile
@@ -64,7 +64,7 @@ if {${g_mame_latest}} {
     set g_mame_release \
                     "0227"
 
-    revision        1
+    revision        2
 
     checksums       \
                     rmd160  862df6a449329fe5b16e6d46a030fe157c3a8eb3 \
@@ -74,19 +74,18 @@ if {${g_mame_latest}} {
     set g_mame_release \
                     "0226"
 
-    revision        4
+    revision        5
 
-    # Patch 'language-portuguese_brazil' applies to release 0.226; fixes
-    # errors during translation build phase.
+    # Mame 0.226: Fix errors during translation build phase.
     # Merged into Mame releases from 0.227 onward. Tracked by issue:
     # https://github.com/mamedev/mame/issues/7510
-    #
-    # Patch 'src-posixfile-build-error' applies to release 0.226; fixes
-    # compilation errors for MacOS 10.8 and Xcode 5.x.
+    patchfiles-append \
+                    mame-patch-0226-language-portuguese_brazil.diff
+
+    # Mame 0.226: Fix compilation errors for MacOS 10.8 and Xcode 5.x.
     # Merged into Mame releases from 0.227 onward. Tracked by issue:
     # https://github.com/mamedev/mame/issues/7536
-    patchfiles      \
-                    mame-patch-0226-language-portuguese_brazil.diff \
+    patchfiles-append \
                     mame-patch-0226-src-posixfile-build-error.diff
 
     checksums       \
@@ -732,16 +731,19 @@ post-build {
     ui_debug "Phase post-build: mame_release_doc_dir: ${mame_release_doc_dir}"
 
     # Rename Tools-related man pages, to include defined prefix
-    set man_page_rename_list \
-        [glob -nocomplain -type f \
-            -directory ${mame_release_doc_dir} \
-            *.1]
-    ui_debug "Phase post-build: man_page_rename_list: ${man_page_rename_list}"
-    foreach tgt ${man_page_rename_list} {
-        set fn [file tail ${tgt}]
-        set fn_new "${g_mame_tools_prefix}${fn}"
-        ui_debug "Phase post-build: renaming man page: ${fn} -> ${fn_new}"
-        move ${tgt} "${mame_release_doc_dir}/${fn_new}"
+    if {[variant_isset tools]} {
+        set man_page_rename_list \
+            [glob -nocomplain -type f \
+                -directory ${mame_release_doc_dir} \
+                *.1]
+        ui_debug "Phase post-build: man_page_rename_list: ${man_page_rename_list}"
+        foreach tgt ${man_page_rename_list} {
+            set fn [file tail ${tgt}]
+            set fn_new "${g_mame_tools_prefix}${fn}"
+            ui_debug "Phase post-build: renaming man page: ${fn} -> ${fn_new}"
+            move ${tgt} "${mame_release_doc_dir}/${fn_new}"
+        }
+        unset man_page_rename_list
     }
 
     # Copy generated Mame man page, joining pre-generated files for Tools
@@ -760,9 +762,8 @@ post-build {
         delete ${tgt}
     }
     unset tgt
-
-    unset man_page_rename_list
     unset man_page_delete_list
+
     unset mame_release_doc_dir
     unset mame_release_dir
 }
@@ -861,6 +862,7 @@ post-destroot {
             ln -s "${prefix}/libexec/mame/${fn}" \
                 "${destroot}${prefix}/bin/${fn}"
         }
+        unset mame_tools_list
     }
 
     set man_page_files \
@@ -878,8 +880,8 @@ post-destroot {
             "${mp_man_dest_dir}/${fn}"
     }
     unset f
-
     unset man_page_files
+
     unset mame_launch_link
     unset mame_launch_script
     unset mame_share_dir
@@ -900,6 +902,11 @@ notes {
     Examples:
         mame -video accel
         mame -video opengl
+
+    If you're new to Mame, our tutorial will quickly walk you through the\
+    process of setting up a new game:
+
+    https://trac.macports.org/wiki/howto/Mame
 }
 
 if {[variant_isset tools]} {

--- a/emulators/mame/files/mame-script-template-launcher.sh
+++ b/emulators/mame/files/mame-script-template-launcher.sh
@@ -12,11 +12,19 @@ script_dir=$(dirname "${script_file}")
 cmd="${script_dir}/@@MACPORTS_MAME_EXECUTABLE@@"
 bgfx_path="${script_dir}/bgfx"
 languagepath="${script_dir}/language"
+pluginspath="${script_dir}/plugins"
+artpath="${script_dir}/artwork"
+hashpath="${script_dir}/hash"
+ctrlrpath="${script_dir}/ctrlr"
 
 cmdline=()
 cmdline+=( "${cmd}" )
 cmdline+=( -bgfx_path "${bgfx_path}" )
 cmdline+=( -languagepath "${languagepath}" )
+cmdline+=( -pluginspath "${pluginspath}" )
+cmdline+=( -artpath "${artpath}" )
+cmdline+=( -hashpath "${hashpath}" )
+cmdline+=( -ctrlrpath "${ctrlrpath}" )
 
 # Note that Mame handles duplicate arguments, using the last one found.
 # Net-Net, there's no need to check whether the user specified the same


### PR DESCRIPTION
#### Description

Mame user-experience enhancements:
* Port notes now provide link to our Mame tutorial, written by Ruben Di Battista.
* Launcher script now specifies several additional paths, enabling further Mame core functionality.
* Minor portfile cleanup.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14019
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
