### PR TITLE
google-cloud-sdk: update to 324.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             323.0.0
+version             324.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,14 +20,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  fef40eeab167fc88c6efc6b30959f41049268ca9 \
-                    sha256  d8f11372d7b69e19c6e320cdbd4f3b86fad44bbd72406a7bb5eca85389b9f4d3 \
-                    size    86395433
+    checksums       rmd160  33296497e1be495ef9feeee906b9d12ca5e8597a \
+                    sha256  1578a2d4d5fb810cc981d84037d99078e3f1eb625488f4d86a7f2053e89a274d \
+                    size    86690663
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  3931fba11b5807d47257b25b73432bbb93652897 \
-                    sha256  17db4d373eb2607fc1e6d6c49881d0370b9e02415f52a35654a48e78233b3f7e \
-                    size    108978062
+    checksums       rmd160  1b71e263e9514a639cd0d9526ba7b12566f89f1e \
+                    sha256  a0c278171a736dcd2fb4fc3f6819299e27a3e05fedad05f1be8ff56f26460ad4 \
+                    size    87698261
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 324.0.0.

###### Tested on

macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?