### PR TITLE
google-cloud-sdk: add variants for gcloud components

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                google-cloud-sdk
 version             324.0.0
+revision            1
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -44,8 +45,66 @@ post-patch {
 use_configure       no
 build               {}
 
+# MacPorts variants are not allowed to contain '-' and gcloud component names use both '-' and '_',
+# so each variant adds an explicit mapping from variant name to gcloud component name.
+# See https://cloud.google.com/sdk/docs/components for more info about gcloud components.
+# Current list of available components is not documented, but can be found via: docker run -it --rm google/cloud-sdk gcloud components list
+# 'gcloud', 'bq', 'gsutil' and 'core' components are installed by default, so not offered as variants.
+set variant_to_component [dict create]
+variant alpha description {Add gcloud CLI Alpha Commands} { dict set variant_to_component alpha alpha }
+variant anthos_auth description {Add Anthos auth} { dict set variant_to_component anthos_auth anthos-auth }
+variant app_engine_go description {Add App Engine Go Extensions} { dict set variant_to_component app_engine_go app-engine-go }
+variant app_engine_java description {Add gcloud app Java Extensions} { dict set variant_to_component app_engine_java app-engine-java }
+variant app_engine_python description {Add gcloud app Python Extensions} { dict set variant_to_component app_engine_python app-engine-python }
+variant app_engine_python_extras description {Add gcloud app Python Extensions (Extra Libraries)} { dict set variant_to_component app_engine_python_extras app-engine-python-extras }
+variant appctl description {Add Appctl} { dict set variant_to_component appctl appctl }
+variant beta description {Add gcloud CLI Beta Commands } { dict set variant_to_component beta beta }
+variant bigtable description {Add Cloud Bigtable Emulator} { dict set variant_to_component bigtable bigtable }
+variant cbt description {Add Cloud Bigtable Command Line Tool} { dict set variant_to_component cbt cbt }
+variant cloud_build_local description {Add Google Cloud Build Local Builder} { dict set variant_to_component cloud_build_local cloud-build-local }
+variant cloud_datastore_emulator description {Add Cloud Datastore Emulator} { dict set variant_to_component cloud_datastore_emulator cloud-datastore-emulator }
+variant cloud_firestore_emulator description {Add Cloud Firestore Emulator} { dict set variant_to_component cloud_firestore_emulator cloud-firestore-emulator }
+variant cloud_spanner_emulator description {Add Cloud Spanner Emulator} { dict set variant_to_component cloud_spanner_emulator cloud-spanner-emulator }
+variant cloud_sql_proxy description {Add Cloud SQL Proxy} { dict set variant_to_component cloud_sql_proxy cloud_sql_proxy }
+variant config_connector description {Add config connector} { dict set variant_to_component config_connector config-connector }
+variant datalab description {Add Cloud Datalab Command Line Tool} { dict set variant_to_component datalab datalab }
+variant docker_credential_gcr description {Add Google Container Registry's Docker credential helper} { dict set variant_to_component docker_credential_gcr docker-credential-gcr }
+variant emulator_reverse_proxy description {Add Emulator Reverse Proxy} { dict set variant_to_component emulator_reverse_proxy emulator-reverse-proxy }
+variant kpt description {Add kpt} { dict set variant_to_component kpt kpt }
+variant kubectl description {Add kubectl} { dict set variant_to_component kubectl kubectl }
+variant kubectl_oidc description {Add kubectl-oidc} { dict set variant_to_component kubectl_oidc kubectl-oidc }
+variant kustomize description {Add Kustomize} { dict set variant_to_component kustomize kustomize }
+variant minikube description {Add Minikube} { dict set variant_to_component minikube minikube }
+variant nomos description {Add Nomos CLI} { dict set variant_to_component nomos nomos }
+variant pkg description {Add pkg} { dict set variant_to_component pkg pkg }
+variant pubsub_emulator description {Add Cloud Pub/Sub Emulator} { dict set variant_to_component pubsub_emulator pubsub-emulator }
+variant skaffold description {Add Skaffold} { dict set variant_to_component skaffold skaffold }
+
+patch {
+    set install_command "CLOUDSDK_CONFIG=${worksrcpath}/.config ./install.sh \
+        --usage-reporting false \
+        --command-completion false \
+        --path-update false \
+        --quiet"
+
+    set additional_components {}
+    foreach component_variant [dict keys ${variant_to_component}] {
+        if {[variant_isset ${component_variant}]} {
+            lappend additional_components [dict get ${variant_to_component} ${component_variant}]
+        }
+    }
+
+    if { [llength ${additional_components}] > 0 } {
+        append install_command " --additional-components"
+        foreach additional_component ${additional_components} {
+            append install_command " " ${additional_component}
+        }
+    }
+
+    system -W ${worksrcpath} ${install_command}
+}
+
 destroot {
-    system -W ${worksrcpath} "CLOUDSDK_CONFIG=${worksrcpath}/.config ./install.sh --usage-reporting false --command-completion false --path-update false --quiet"
     set libexecdir ${destroot}${prefix}/libexec/${name}
     xinstall -d ${libexecdir}
     copy \


### PR DESCRIPTION
#### Description

Add variants for additional gcloud components.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?