### PR TITLE
openal-soft: fix build errors for older macOS releases

### DIFF
--- a/audio/openal-soft/Portfile
+++ b/audio/openal-soft/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem              1.0
 PortGroup               cmake 1.1
+PortGroup               compiler_blacklist_versions 1.0
 if {${subport} eq "openal-soft" && [variant_isset gui]} {
 PortGroup               qt5 1.0
 }
@@ -51,6 +52,13 @@ patch.pre_args          -p1
 
 compiler.cxx_standard   2014
 compiler.thread_local_storage   yes
+
+# Fix for incorrect MacPorts compiler selection, tracked by:
+# https://trac.macports.org/ticket/61418
+# Ticket specific to openal-soft build errors, caused by the former:
+# https://trac.macports.org/ticket/61431
+compiler.blacklist      \
+                        {clang < 800.0.38}
 
 configure.args-append   -DALSOFT_EXAMPLES=OFF \
                         -DALSOFT_UTILS=ON \


### PR DESCRIPTION
#### Description

Additional change to fix build errors for older macOS releases.

Fixes: [openal-soft @1.21.0: error: inline declaration of 'PopCount<unsigned long long>' follows non-inline definition](https://trac.macports.org/ticket/61431)

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.8.5 12F2560
Xcode 5.1.1 5B1008

macOS 10.10.5 14F2511
Xcode 6.4 6E35b

macOS 10.11.6 15G22010
Xcode 7.3.1 7D1014

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
