### PR TITLE
openjdk*-graalvm: update to GraalVM 21.0.0

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -61,14 +61,14 @@ subport openjdk8 {
 }
 
 subport openjdk8-graalvm {
-    version      20.3.0
+    version      21.0.0
     revision     0
 
     set major    8
     
-    checksums    rmd160  5dfe16a90a2c6cc893d169029c77f891dda023fd \
-                 sha256  01e84c44032f8932ed04b2b829e0454973145bf55ddeeeed0ce71220c2213ae7 \
-                 size    347626453
+    checksums    rmd160  81a22898316b657c8a8c9320d1b208959354ee23 \
+                 sha256  9192d8370b544c0efd36ef744f5933bd2d694d0cc9cb5e7f53d3b7e58f433b3e \
+                 size    349292989
 }
 
 subport openjdk8-openj9 {
@@ -116,14 +116,14 @@ subport openjdk11 {
 }
 
 subport openjdk11-graalvm {
-    version      20.3.0
+    version      21.0.0
     revision     0
 
     set major    11
     
-    checksums    rmd160  897ea6614ee32d4a52cf0cc97dd0ad26e2a26fb3 \
-                 sha256  22b869fbf590c461278efae5e06fdd5ba32b4d5b302da838d9f50cb71aa20d01 \
-                 size    445970375
+    checksums    rmd160  4496162ca0f7eead7fcc70d1c1349e051b211695 \
+                 sha256  0e6b9af45d0ba40d8e61b16708361f794e17430f5098760bd03584ebcc950fa9 \
+                 size    446431096
 }
 
 subport openjdk11-openj9 {


### PR DESCRIPTION
#### Description

Update to GraalVM 21.0.0.

###### Tested on

macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?