### PR TITLE
gitlab-runner: update to 13.8.0

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 13.7.0 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 13.8.0 v
 
 categories          devel
 platforms           darwin
@@ -23,9 +23,9 @@ homepage            https://docs.gitlab.com/runner/
 master_sites        https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v${version}/
 distname            gitlab-runner-v${version}
 
-checksums           rmd160  2b26dc9898dd031717c8bbb19e7cbe46e6294f31 \
-                    sha256  543d7849d887fcfdabb22ef768e720d34d558fbc0c73860849ceb042b3927b50 \
-                    size    8050256
+checksums           rmd160  9568da84a2058ac381b8312bdb7fc398c28f13af \
+                    sha256  0b573176b26a025a6ac0bbb91cbeb77ce544597b76a5ee53cadae717b66100c9 \
+                    size    8288705
 
 # Reproduce the "build_simple" target from the upstream Makefile
 set go_ldflags      "-X ${go.package}/common.NAME=${go.package} \


### PR DESCRIPTION
#### Description

Update to GitLab Runner 13.8.0.

###### Tested on

macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?