### PR TITLE
opencv/opencv4: add new variants: opencv +openmp, opencv4 +openni

### DIFF
--- a/graphics/opencv/Portfile
+++ b/graphics/opencv/Portfile
@@ -277,6 +277,12 @@ variant opencl description {Enable OpenCL support} {
                             -DWITH_OPENCL=ON
 }
 
+variant openmp description {Include OpenMP support (untested)} {
+    configure.args-replace \
+                            -DWITH_OPENMP=OFF \
+                            -DWITH_OPENMP=ON
+}
+
 variant openni description {Enable OpenNI support} {
     depends_lib-append      port:openni
     patchfiles-append       patch-cmake_OpenCVFindOpenNI.cmake.diff

--- a/graphics/opencv/Portfile
+++ b/graphics/opencv/Portfile
@@ -277,10 +277,12 @@ variant opencl description {Enable OpenCL support} {
                             -DWITH_OPENCL=ON
 }
 
-variant openmp description {Include OpenMP support (untested)} {
+variant openmp description {Include OpenMP support} {
+    compiler.openmp_version 4.0
     configure.args-replace \
                             -DWITH_OPENMP=OFF \
                             -DWITH_OPENMP=ON
+
 }
 
 variant openni description {Enable OpenNI support} {

--- a/graphics/opencv4/Portfile
+++ b/graphics/opencv4/Portfile
@@ -277,6 +277,16 @@ variant openmp description {Include OpenMP support (untested)} {
                         -DWITH_OPENMP:BOOL=ON
 }
 
+variant openni description {Enable OpenNI support} {
+    depends_lib-append  port:openni
+    configure.args-replace  \
+                        -DWITH_OPENNI:BOOL=OFF \
+                        -DWITH_OPENNI:BOOL=ON
+    configure.args-append \
+                        -DOPENNI_INCLUDE_DIR:PATH=${prefix}/include/ni \
+                        -DOPENNI_LIB_DIR:PATH=${prefix}/lib
+}
+
 variant nonfree description {Include nonfree algorithms} {
     configure.args-replace \
                         -DOPENCV_ENABLE_NONFREE:BOOL=OFF \

--- a/graphics/opencv4/Portfile
+++ b/graphics/opencv4/Portfile
@@ -271,7 +271,9 @@ variant gdal description {Include GDAL support} {
                         -DWITH_GDAL:BOOL=ON
 }
 
-variant openmp description {Include OpenMP support (untested)} {
+variant openmp description {Include OpenMP support} {
+    compiler.openmp_version \
+                        4.0
     configure.args-replace \
                         -DWITH_OPENMP:BOOL=OFF \
                         -DWITH_OPENMP:BOOL=ON


### PR DESCRIPTION
#### Description

Add variants, missed during the recent updates to opencv/opencv4:
* opencv: add variant openmp
* opencv4: add variant openni

This is phase one, of a five-phase rollout:
1. Add variants missed during opencv/opencv4 reconciliation (opencv +openmp, opencv4 +openni).
1. Add new port opencv3, segregated like opencv4. Also include initial changes, supporting later conversion to subport. [Merged PR 9789](https://github.com/macports/macports-ports/pull/9789)
1. Update ports presently dependent upon opencv, to use opencv3. And update port opencv to be a stub port, with replaced_by opencv3, etc.
1. Add new port opencv2, using same segregation strategy.
1. Reconcile all three into single opencv port, with three subports. This step may be combined with previous.

Details provided in tickets:
- [opencv/opencv4: eliminate portfile duplication, via subport](https://trac.macports.org/ticket/62011)
- [OpenCV 2.x (please re-instate or provide a new opencv2 port)](https://trac.macports.org/ticket/49670)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.8.5 12F2560
Xcode 5.1.1 5B1008

macOS 10.10.5 14F2511
Xcode 6.4 6E35b

macOS 10.12.6 16G2136
Xcode 9.2 9C40b

macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
