### PR TITLE
libgrcypt: fix kdf selftest

### DIFF
--- a/devel/libgcrypt/Portfile
+++ b/devel/libgcrypt/Portfile
@@ -5,7 +5,7 @@ PortGroup       muniversal 1.0
 
 name            libgcrypt
 version         1.9.0
-revision        0
+revision        1
 categories      devel security
 # libs are LGPL, executables and docs are GPL
 license         {GPL-2+ LGPL-2.1+}
@@ -30,7 +30,8 @@ checksums       rmd160  f4a12a634e96a656a8ab8ab44a2dce96fd864f34 \
 depends_lib     port:libgpg-error
 
 patchfiles      patch-configure.diff \
-                patch-random-rndlinux.c.diff
+                patch-random-rndlinux.c.diff \
+                patch-kdf-selftest.diff
 
 configure.args  --disable-asm
 

--- a/devel/libgcrypt/files/patch-kdf-selftest.diff
+++ b/devel/libgcrypt/files/patch-kdf-selftest.diff
@@ -1,0 +1,14 @@
+diff --git a/cipher/kdf.c b/cipher/kdf.c
+index 3d707bd0..b916a3f8 100644
+--- cipher/kdf.c
++++ cipher/kdf.c
+@@ -452,7 +452,8 @@ selftest_pbkdf2 (int extended, selftest_report_func_t report)
+       "\x34\x8c\x89\xdb\xcb\xd3\x2b\x2f\x32\xd8\x14\xb8\x11\x6e\x84\xcf"
+       "\x2b\x17\x34\x7e\xbc\x18\x00\x18\x1c\x4e\x2a\x1f\xb8\xdd\x53\xe1"
+       "\xc6\x35\x51\x8c\x7d\xac\x47\xe9"
+-    }
++    },
++    { NULL }
+   };
+   const char *what;
+   const char *errtxt;


### PR DESCRIPTION
#### Description

libgcrypt 1.9.0 contains an error that leads to a failing selftest.
This lets ports like KeePassXC fail on startup with the following
error:

libgcrypt selftest: kdf  (34): gcry_kdf_derive failed (1.2.643.2.2.30.0)
libgcrypt selftest: kdf  (34): Selftest failed

Upstream report: https://dev.gnupg.org/T5254

Patch source: https://dev.gnupg.org/rCc6425a5537294dfe2beaafc9105f7af4ceac677f

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
