### PR TITLE
ports-p5-dbd-mariadb: add mysql8 variant

### DIFF
--- a/perl/p5-dbd-mariadb/Portfile
+++ b/perl/p5-dbd-mariadb/Portfile
@@ -34,40 +34,46 @@ if {${perl5.major} != ""} {
     depends_lib-append \
                     port:p${perl5.major}-dbi
 
-    variant mariadb10_1 conflicts mariadb10_2 mariadb10_3 mariadb10_4 mariadb10_5 \
+    variant mariadb10_1 conflicts mariadb10_2 mariadb10_3 mariadb10_4 mariadb10_5 mysql8 \
                         description {Build with mariadb-10.1 port} {
         depends_lib-append      port:mariadb-10.1
         # There's no mariadb_config in mentioned in 10.1, use mysql_config
         configure.args-append   --mariadb_config=${prefix}/lib/mariadb-10.1/bin/mysql_config
     }
 
-    variant mariadb10_2 conflicts mariadb10_1 mariadb10_3 mariadb10_4 mariadb10_5 \
+    variant mariadb10_2 conflicts mariadb10_1 mariadb10_3 mariadb10_4 mariadb10_5 mysql8 \
                         description {Build with mariadb-10.2 port} {
         depends_lib-append      port:mariadb-10.2
         configure.args-append   --mariadb_config=${prefix}/lib/mariadb-10.2/bin/mariadb_config
     }
 
-    variant mariadb10_3 conflicts mariadb10_1 mariadb10_2 mariadb10_4 mariadb10_5 \
+    variant mariadb10_3 conflicts mariadb10_1 mariadb10_2 mariadb10_4 mariadb10_5 mysql8 \
                         description {Build with mariadb-10.3 port} {
         depends_lib-append      port:mariadb-10.3
         configure.args-append   --mariadb_config=${prefix}/lib/mariadb-10.3/bin/mariadb_config
     }
 
-    variant mariadb10_4 conflicts mariadb10_1 mariadb10_2 mariadb10_3 mariadb10_5 \
+    variant mariadb10_4 conflicts mariadb10_1 mariadb10_2 mariadb10_3 mariadb10_5 mysql8 \
                         description {Build with mariadb-10.4 port} {
         depends_lib-append      port:mariadb-10.4
         configure.args-append   --mariadb_config=${prefix}/lib/mariadb-10.4/bin/mariadb_config
     }
 
-    variant mariadb10_5 conflicts mariadb10_1 mariadb10_2 mariadb10_3 mariadb10_4 \
+    variant mariadb10_5 conflicts mariadb10_1 mariadb10_2 mariadb10_3 mariadb10_4 mysql8 \
                         description {Build with mariadb-10.5 port} {
         depends_lib-append      port:mariadb-10.5
         configure.args-append   --mariadb_config=${prefix}/lib/mariadb-10.5/bin/mariadb_config
     }
 
+    variant mysql8 conflicts mariadb10_1 mariadb10_2 mariadb10_3 mariadb10_4 mariadb10_5 \
+                        description {Build with mariadb-10.5 port} {
+        depends_lib-append      port:mysql8
+        configure.args-append   --mysql_config=${prefix}/lib/mysql8/bin/mysql_config
+    }
+
     if {![variant_isset mariadb10_1] && ![variant_isset mariadb10_2] &&
         ![variant_isset mariadb10_3] && ![variant_isset mariadb10_4] &&
-        ![variant_isset mariadb10_5]} {
+        ![variant_isset mariadb10_5] && ![variant_isset mysql8]} {
         default_variants +mariadb10_5
     }
 }


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

Reference p5-dbd-mysql ticket: https://trac.macports.org/ticket/62086

Adds a new variant for mysql8
