### PR TITLE
openjdk8*: update to 8u282

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -47,15 +47,15 @@ set long_description_oracle_openjdk \
     are the HotSpot virtual machine, the Java class library and the Java compiler."
 
 subport openjdk8 {
-    version      8u275
+    version      8u282
     revision     0
 
-    set build    01
+    set build    08
     set major    8
 
-    checksums    rmd160  c59602c9c079d368f06ac8beea51c230f1e09e63 \
-                 sha256  4afd2b3d21b625392fe4501e9445d1125498e6e7fb78042495c04e7cfc1b5e69 \
-                 size    101776105
+    checksums    rmd160  3187d760b3cbeaaf01d47481f069a3e2d1011cfd \
+                 sha256  1766d756f6e4a5d41b539f2ecf83e5a33e9336bd75f1602e8f4b4afbb8f47aaa \
+                 size    101808251
 
     configure.cxx_stdlib libstdc++
 }
@@ -72,29 +72,29 @@ subport openjdk8-graalvm {
 }
 
 subport openjdk8-openj9 {
-    version      8u275
+    version      8u282
     revision     0
 
-    set build    01
+    set build    08
     set major    8
-    set openj9_version 0.23.0
+    set openj9_version 0.24.0
 
-    checksums    rmd160  87dbdf04bdb95f872b6a15374c61dc1d5f35837f \
-                 sha256  0e19282fe1dae272f1383f726cc6fc70d77816bebe07e0959ac2c9b9b711f709 \
-                 size    114196051
+    checksums    rmd160  b66caafe41d50052fa438dfcef5fdf58430f42c8 \
+                 sha256  265d4fb01b61ed7a3a9fae6a50bcf6322687b5f08de8598d8e42263cbd8b5772 \
+                 size    115586057
 }
 
 subport openjdk8-openj9-large-heap {
-    version      8u275
+    version      8u282
     revision     0
 
-    set build    01
+    set build    08
     set major    8
-    set openj9_version 0.23.0
+    set openj9_version 0.24.0
 
-    checksums    rmd160  11c8c8add75504e72ce7183fe1007216f96c3d2d \
-                 sha256  5f2375de68ec0d0ff4d42670aa54416948fcdd62a1cc035023c27d5d090522ab \
-                 size    114907169
+    checksums    rmd160  e4797c143ca666baa428a252bb130251af25a1b2 \
+                 sha256  64f2b106bc5c65ed963a72893e3d676df58704718dd86fc0fcbbb61e615e4742 \
+                 size    116297701
 }
 
 # Remove after 2021-11-28


### PR DESCRIPTION
#### Description

Update to AdoptOpenJDK 8u282, for both HotSpot VM and OpenJ9 VM ports.

###### Tested on

macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?