### PR TITLE
postgresql13: add support for llvm > 10

### DIFF
--- a/databases/postgresql13/Portfile
+++ b/databases/postgresql13/Portfile
@@ -9,7 +9,7 @@ PortGroup muniversal 1.0
 #remember to update the -doc and -server as well
 name                postgresql13
 version             13.1
-revision            0
+revision            1
 
 categories          databases
 platforms           darwin
@@ -149,11 +149,17 @@ variant tcl description {add Tcl support} {
 }
 
 variant llvm description {add support for JIT compilation} {
-    set llvm_ver 9.0
+    set llvm_ver 11
 
     foreach clang ${compilers.clang_variants} {
         if { [variant_exists ${clang}] && [variant_isset ${clang}] } {
-            set llvm_ver [string index ${clang} end-1].[string index ${clang} end]
+            set clang_port_ver [string range ${clang} 5 6]
+
+            if { ${clang_port_ver} >= 50 } {
+                set llvm_ver [string index ${clang} end-1].[string index ${clang} end]
+            } else {
+                set llvm_ver ${clang_port_ver}
+            }
         }
     }
 


### PR DESCRIPTION
#### Description

Bump the default version to 11 and add support for clang versions 10 and 11

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
