### PR TITLE
ngircd: update to 26.1

### DIFF
--- a/irc/ngircd/Portfile
+++ b/irc/ngircd/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                ngircd
-version             26
+version             26.1
 revision            0
 
 categories          irc
@@ -20,9 +20,9 @@ homepage            http://ngircd.barton.de/
 master_sites        http://arthur.barton.de/pub/ngircd/
 use_xz              yes
 
-checksums           rmd160  666eb04b8e3889473957b8ab3cb508416adc54af \
-                    sha256  56dcc6483058699fcdd8e54f5010eecee09824b93bad7ed5f18818e550d855c6 \
-                    size    371716
+checksums           rmd160  097809c717fdb296bd783556324de33ccfd8fdee \
+                    sha256  55c16fd26009f6fc6a007df4efac87a02e122f680612cda1ce26e17a18d86254 \
+                    size    375812
 
 depends_lib         port:libiconv \
                     port:libident \


### PR DESCRIPTION
#### Description

Update `ngircd` to 26.1.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
CLT 12.3.0.0.1.1607026830
Xcode N/A

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
