### PR TITLE
dpkg: update to 1.20.7.1

### DIFF
--- a/sysutils/dpkg/Portfile
+++ b/sysutils/dpkg/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 name                dpkg
-version             1.20.5
+version             1.20.7.1
 revision            0
 
 platforms           darwin
@@ -21,12 +21,12 @@ worksrcdir          ${name}-${version}
 
 use_xz              yes
 
-checksums           rmd160  3d1f1981775fe058cfa8e34851e447965a60bdab \
-                    sha256  f2f23f3197957d89e54b87cf8fc42ab00e1b74f3a32090efe9acd08443f3e0dd \
-                    size    4715684
+checksums           rmd160  72c1867a8bf5378011bc80f0800664a14cfaab63 \
+                    sha256  0aad2de687f797ef8ebdabc7bafd16dc1497f1ce23bd9146f9aa73f396a5636f \
+                    size    4952736
 
-perl5.branches          5.28 5.30
-perl5.default_branch    5.30
+perl5.branches          5.28 5.30 5.32
+perl5.default_branch    5.32
 perl5.create_variants   ${perl5.branches}
 
 depends_build-append \


### PR DESCRIPTION
#### Description

Update `dpkg` to `1.20.7.1`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
CLT 12.3.0.0.1.1607026830
Xcode N/A

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->