### PR TITLE
ipcalc: support perl 5.32. Default perl to 5.28.

### DIFF
--- a/net/ipcalc/Portfile
+++ b/net/ipcalc/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                ipcalc
 version             0.41
-revision            5
+revision            6
 
 categories          net
 license             GPL-2+
@@ -27,8 +27,8 @@ checksums           rmd160  aaa21c1804d7498e2604c907a336c20dc9b4511d \
                     sha256  dda9c571ce3369e5b6b06e92790434b54bec1f2b03f1c9df054c0988aa4e2e8a \
                     size    21599
 
-perl5.branches          5.28 5.30
-perl5.default_branch    5.30
+perl5.branches          5.28 5.30 5.32
+perl5.default_branch    5.28
 perl5.create_variants   ${perl5.branches}
 
 configure {


### PR DESCRIPTION
#### Description

Support perl 5.32 and default perl to 5.28 for `ipcalc`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
CLT 12.3.0.0.1.1607026830
Xcode N/A

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
