### PR TITLE
oidn: update to version 1.2.1

### DIFF
--- a/graphics/oidn/Portfile
+++ b/graphics/oidn/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 PortGroup           legacysupport 1.0
 
-github.setup        OpenImageDenoise oidn 1.2.0 v
+github.setup        OpenImageDenoise oidn 1.2.1 v
 github.tarball_from releases
 extract.suffix      .src${extract.suffix}
 categories          graphics
@@ -21,9 +21,9 @@ long_description    Open Image Denoise is a library of ${description}, \
                     ray-tracing-based rendering applications to \
                     significantly reduce rendering times.
 
-checksums           rmd160  0048ae6a28a6466d81d8b62ad2382326d4e8fb6f \
-                    sha256  041f59758e79f4ea29a9b7a952f2c096426820678a5a713880b6d8a6519a75d0 \
-                    size    45522650
+checksums           rmd160  dab6cc697730a139ddeb4371ed3f1ca8ee5d818b \
+                    sha256  bc75d28f472628c80768435e800a28fdb18a5d058c16dac98c00f9aae8c536e6 \
+                    size    45859598
 
 depends_build-append \
                     port:ispc
@@ -43,41 +43,4 @@ compiler.cxx_standard 2011
 #     * https://reviews.llvm.org/D31417)
 compiler.blacklist-append clang
 
-post-patch {
-    # Patch needed in order to compile using ISPC 1.13+
-    # (Reference: https://github.com/OpenImageDenoise/oidn/issues/60)
-    set core_math_ih ${worksrcpath}/core/math.ih
-    set status 0
-    if {[catch {system "grep -q ISPC_UINT_IS_DEFINED $core_math_ih"} results options]} {
-        set details [dict get $options -errorcode]
-        if {[lindex $details 0] eq "CHILDSTATUS"} {
-            set status [lindex $details 2]
-            if {$status == 1} {
-                reinplace "/typedef.*uint8/i\\
-#ifndef ISPC_UINT_IS_DEFINED\\
-" \
-                    $core_math_ih
-                reinplace "/typedef.*uint64/a\\
-#endif\\
-" \
-                    $core_math_ih
-            }
-        }
-    }
-}
-
 configure.args-append -DOIDN_APPS_OPENIMAGEIO=ON
-
-post-destroot {
-    # Prevent conflicts with libde265's tests command
-    # This issue has been reported upstream:
-    # https://github.com/OpenImageDenoise/oidn/issues/64
-    if {[file exists ${destroot}${prefix}/bin/tests]} {
-        move ${destroot}${prefix}/bin/tests \
-             ${destroot}${prefix}/bin/oidnTest
-    }
-    if {[file exists ${destroot}${prefix}/bin/denoise]} {
-        move ${destroot}${prefix}/bin/denoise \
-             ${destroot}${prefix}/bin/oidnDenoise
-    }
-}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Backported patches for OpenImageDenoise/oidn#60 and OpenImageDenoise/oidn#64 were incorporated into OIDN 1.2.1, and have been removed from the portfile.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->