### PR TITLE
openjdk11*: update to 11.0.10

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -104,15 +104,15 @@ subport openjdk10 {
 }
 
 subport openjdk11 {
-    version      11.0.9.1
+    version      11.0.10
     revision     0
 
-    set build    1
+    set build    9
     set major    11
 
-    checksums    rmd160  26c0fdcd8f7785759b6503ddf79d11bb942f31b4 \
-                 sha256  96bc469f9b02a3b84382a0685b0bd7935e1ad1bd82a0aab9befb5b42a17cbd77 \
-                 size    185368626
+    checksums    rmd160  3c1f62a95095aee9f0ee3d02ba4a4a67f5425ba1 \
+                 sha256  ee7c98c9d79689aca6e717965747b8bf4eec5413e89d5444cc2bd6dbd59e3811 \
+                 size    186160219
 }
 
 subport openjdk11-graalvm {
@@ -127,29 +127,29 @@ subport openjdk11-graalvm {
 }
 
 subport openjdk11-openj9 {
-    version      11.0.9
-    revision     2
+    version      11.0.10
+    revision     0
 
-    set build    11
-    set openj9_version 0.23.0
+    set build    9
+    set openj9_version 0.24.0
     set major    11
 
-    checksums    rmd160  e86e9e2f6cfea7715633e6e096f8fbbaf9cfd8b5 \
-                 sha256  ba97e4f2ffc5f9a673e00596aa3fc684242522e043ef8f0ddd71479782c2412a \
-                 size    196396470
+    checksums    rmd160  68da07a92466f0ce17d814e29f20985b95689853 \
+                 sha256  58f931dc30160b04da2d94af32e0dfa384f4b2cf92b7217c0937fd057e668d54 \
+                 size    196594593
 }
 
 subport openjdk11-openj9-large-heap {
-    version      11.0.9
-    revision     2
+    version      11.0.10
+    revision     0
 
-    set build    11
-    set openj9_version 0.23.0
+    set build    9
+    set openj9_version 0.24.0
     set major    11
 
-    checksums    rmd160  7babb4d116f8420178b7f27d0ee77ee7c856aa75 \
-                 sha256  17de92b88fe593d48fa8c74dbb9a92b586248021dfdcbbdcc045fa3bcc5704ec \
-                 size    195626456
+    checksums    rmd160  66e4e36eb013a66d7970c3874046b80e771cd36d \
+                 sha256  ac6998c1a7945dab9d008e3702a69ed86488321aea197961f72375e8bc8bc114 \
+                 size    195829115
 }
 
 subport openjdk12 {
@@ -371,15 +371,7 @@ if {${subport} eq "openjdk8"} {
 }
 
 # Temporary overrides for stealth updates
-if {${subport} eq "openjdk11-openj9"} {
-    # Stealth update for 11.2, remove this for the next release
-    dist_subdir  ${name}/${version}_2
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.2_openj9-${openj9_version}/
-} elseif {${subport} eq "openjdk11-openj9-large-heap"} {
-    # Stealth update for 11.2, remove this for the next release
-    dist_subdir  ${name}/${version}_2
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.2_openj9-${openj9_version}/
-} elseif {${subport} eq "openjdk15"} {
+if {${subport} eq "openjdk15"} {
     # Stealth update for 9.1, remove this for the next release
     dist_subdir  ${name}/${version}_1
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.1/


### PR DESCRIPTION
#### Description

Update to AdoptOpenJDK 11.0.10.

###### Tested on

macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?