### PR TITLE
openjdk15*: update to 15.0.2

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -267,41 +267,41 @@ subport openjdk14-openj9-large-heap {
 }
 
 subport openjdk15 {
-    version      15.0.1
-    revision     1
+    version      15.0.2
+    revision     0
 
-    set build    9
+    set build    7
     set major    15
 
-    checksums    rmd160  be222e8bdd8365555c279c4a033c9e992749e85a \
-                 sha256  b8c2e2ad31f3d6676ea665d9505b06df15e23741847556612b40e3ee329fc046 \
-                 size    195872839
+    checksums    rmd160  74950bb51052416c41fcc4e33db077919e504097 \
+                 sha256  d358a7ff03905282348c6c80562a4da2e04eb377b60ad2152be4c90f8d580b7f \
+                 size    195232978
 }
 
 subport openjdk15-openj9 {
-    version      15.0.1
-    revision     1
+    version      15.0.2
+    revision     0
 
-    set build    9
-    set openj9_version 0.23.0
+    set build    7
+    set openj9_version 0.24.0
     set major    15
 
-    checksums    rmd160  2f60777b953496b8b42c80ca07609afdf2816dd8 \
-                 sha256  57d1714db90eed5ee69c96b4e18e1ff5468580a299deef06d7f5a8a65e3bdc3b \
-                 size    195920750
+    checksums    rmd160  76b4e46152ba4ddca1274b20eb75fd22fdb1b34e \
+                 sha256  1336ae5529af3a0e35ae569e4188944831aeed7080a482f2490fc619380cbe53 \
+                 size    195257737
 }
 
 subport openjdk15-openj9-large-heap {
-    version      15.0.1
-    revision     1
+    version      15.0.2
+    revision     0
 
-    set build    9
-    set openj9_version 0.23.0
+    set build    7
+    set openj9_version 0.24.0
     set major    15
 
-    checksums    rmd160  58881640a668e44785e679b4f0ec58c1079946d7 \
-                 sha256  cd1edee27abc36879b288d67237078c1ea8898a495b5d66144f0d23988e27cdb \
-                 size    195168686
+    checksums    rmd160  ed1021fa9c1e6960d5b2fcbb7317d1fa7a4844d0 \
+                 sha256  b9192784a877b2066c7f60eea9901f1181d19b3a39260bc04f1a33febbdb342d \
+                 size    195261675
 }
 
 # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
@@ -368,21 +368,6 @@ if {${subport} eq "openjdk8"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}/
     distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}_${build}
     worksrcdir   jdk-${version}+${build}
-}
-
-# Temporary overrides for stealth updates
-if {${subport} eq "openjdk15"} {
-    # Stealth update for 9.1, remove this for the next release
-    dist_subdir  ${name}/${version}_1
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.1/
-} elseif {${subport} eq "openjdk15-openj9"} {
-    # Stealth update for 9.2, remove this for the next release
-    dist_subdir  ${name}/${version}_1
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.2_openj9-${openj9_version}/
-} elseif {${subport} eq "openjdk15-openj9-large-heap"} {
-    # Stealth update for 9.2, remove this for the next release
-    dist_subdir  ${name}/${version}_1
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}.2_openj9-${openj9_version}/
 }
 
 if [string match *-graalvm ${subport}] {


### PR DESCRIPTION
#### Description

Update to AdoptOpenJDK 15.0.2.

###### Tested on

macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?