### PR TITLE
libgdiplus: enable pango support

### DIFF
--- a/devel/libgdiplus/Portfile
+++ b/devel/libgdiplus/Portfile
@@ -5,7 +5,7 @@ PortGroup               active_variants 1.1
 
 name                    libgdiplus
 version                 6.0.5
-revision                1
+revision                2
 categories              devel
 platforms               darwin
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
@@ -37,7 +37,8 @@ depends_lib             path:include/turbojpeg.h:libjpeg-turbo \
 patchfiles              patch-no_zlib.diff \
                         patch-fix_flags.diff
 
-configure.args-append   --without-x11
+configure.args-append   --without-x11 \
+                        --with-pango
 
 test.run                yes
 test.target             check


### PR DESCRIPTION
#### Description

Without pango support, libgdiplus offers basic text rendering and lacks
advanced typography features like emphasis.

While the `depends_lib` had `pango` listed, `--with-pango` was missing
from the args.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G4032
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
