### PR TITLE
py-nbconvert: add notes for optional dependencies

### DIFF
--- a/python/py-nbconvert/Portfile
+++ b/python/py-nbconvert/Portfile
@@ -60,5 +60,16 @@ if {${name} ne ${subport}} {
                             port:py${python.version}-nbclient
     }
 
+    notes "
+To convert markdown to formats other than HTML, nbconvert uses pandoc.\
+Install it by running
+
+sudo port install pandoc
+
+To convert notebooks to PDF, nbconvert makes use of LaTeX and the XeTeX\
+as the rendering engine. Install it by running
+
+sudo port install texlive-xetex
+"
     livecheck.type      none
 }


### PR DESCRIPTION
#### Description

Add notes to `py-nbconvert` to tell user about optional dependencies. This PR
should replace #9700.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
