### PR TITLE
pv: Fix detection of stat64 in Apple Silicon.

### DIFF
--- a/sysutils/pv/Portfile
+++ b/sysutils/pv/Portfile
@@ -33,7 +33,11 @@ configure.args      --mandir=${prefix}/share/man \
 
 depends_lib         port:gettext
 
-if {${os.platform} eq "darwin" && ${os.major} != 9} {
+if {${build_arch} eq "arm64"} {
+    # For further information on why we redefine these symbols, see the trac ticket
+    # https://trac.macports.org/ticket/61784#comment:4
+    configure.cppflags-append -Dfstat64=fstat -Dlstat64=lstat -Dstat64=stat
+} elseif {${os.platform} eq "darwin" && ${os.major} != 9} {
     # Leopard is the only release where stat64 exists and is not deprecated.
     # Rather than updating a patch to replace each instance, use the deprecated
     # interface as long as it exists, just don't complain about it. (configure


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/61784

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
