### PR TITLE
py-httpcore: update to 0.12.2

### DIFF
--- a/python/py-httpcore/Portfile
+++ b/python/py-httpcore/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-httpcore
-version             0.12.0
+version             0.12.2
 platforms           darwin
 license             BSD
 maintainers         nomaintainer
@@ -14,9 +14,9 @@ long_description    {*}${description}
 
 homepage            https://github.com/encode/httpcore
 
-checksums           rmd160  2243bd83a143ce17ed77ea02cd7df0f8ee93d0f5 \
-                    sha256  2526a38f31ac5967d38b7f593b5d8c4bd3fa82c21400402f866ba3312946acbf \
-                    size    40748
+checksums           rmd160  108fe8d58175a52fc9767e8b7034dff33db79389 \
+                    sha256  dd1d762d4f7c2702149d06be2597c35fb154c5eff9789a8c5823fbcf4d2978d6 \
+                    size    42392
 
 python.versions     38 39
 
@@ -27,4 +27,6 @@ if {${name} ne ${subport}} {
     depends_lib-append \
                     port:py${python.version}-h11      \
                     port:py${python.version}-sniffio
+                    
+    livecheck.type  none
 }


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
xcode-select version 2384.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
