### PR TITLE
opencv3: variant openmp: implement fully, via compiler.openmp_version

### DIFF
--- a/graphics/opencv3/Portfile
+++ b/graphics/opencv3/Portfile
@@ -318,7 +318,8 @@ variant opencl description {Enable OpenCL support} {
                             -DWITH_OPENCL=ON
 }
 
-variant openmp description {Include OpenMP support (untested)} {
+variant openmp description {Include OpenMP support} {
+    compiler.openmp_version 4.0
     configure.args-replace \
                             -DWITH_OPENMP=OFF \
                             -DWITH_OPENMP=ON


### PR DESCRIPTION
#### Description

Update variant `openmp`, as done for ports opencv/opencv4 yesterday: [Merged PR 9777](https://github.com/macports/macports-ports/pull/9777)

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14019
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
