### PR TITLE
wget: use std=c99

### DIFF
--- a/net/wget/Portfile
+++ b/net/wget/Portfile
@@ -90,6 +90,9 @@ configure.env-append    POD2MAN=${prefix}/bin/pod2man-${perl_version}
 # Ensure libuuid doesn't get used even if the ossp-uuid port is installed.
 configure.args-append       ac_cv_header_uuid_uuid_h=no
 
+# tempname.c:290: error: 'for' loop initial declaration used outside C99 mode
+configure.cflags-append -std=c99
+
 test.run                yes
 test.target             check
 


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/62134

10.5:
```
$ port -v installed wget
The following ports are currently installed:
  wget @1.21.1_0+gnutls (active) platform='darwin 9' archs='i386' date='2021-01-24T15:05:05-0800'
```