### PR TITLE
sudo : Update to 1.9.5p2

### DIFF
--- a/sysutils/sudo/Portfile
+++ b/sysutils/sudo/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                sudo
 epoch               1
-version             1.9.5p1
+version             1.9.5p2
 revision            0
 categories          sysutils security
 license             ISC
@@ -23,9 +23,9 @@ homepage            http://www.sudo.ws/sudo/
 master_sites        ${homepage}dist/ \
                     ${homepage}dist/OLD/
 
-checksums           rmd160  4fdcb72761b7d3a7de6c98c11c5efc976a6b11e5 \
-                    sha256  4dddf37c22653defada299e5681e0daef54bb6f5fc950f63997bb8eb966b7882 \
-                    size    4008926
+checksums           rmd160  5952aafd4e777196eb8af81c4cdc420e3d688684 \
+                    sha256  539e2ef43c8a55026697fb0474ab6a925a11206b5aa58710cb42a0e1c81f0978 \
+                    size    4012277
 
 patchfiles          patch-configure.diff \
                     patch-sudoers.in.diff


### PR DESCRIPTION
#### Description

Fixes CVE-2021-3156

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
macOS 10.14.6 18G7016
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?