### PR TITLE
ixion: fix build on older Clang versions

### DIFF
--- a/devel/ixion/Portfile
+++ b/devel/ixion/Portfile
@@ -22,6 +22,9 @@ checksums           rmd160  eee46c42c638d5a5e48a88e728b59288b0d89ba5 \
                     sha256  1d01fcf56855334d6e0a75bd02339e08fd78359e09902660d4ad994f153d3167 \
                     size    173888
 
+patchfiles          patch-clang-fix.diff
+patch.pre_args      -p1
+
 use_autoreconf      yes
 configure.args      --disable-debug \
                     --disable-python \

--- a/devel/ixion/files/patch-clang-fix.diff
+++ b/devel/ixion/files/patch-clang-fix.diff
@@ -1,0 +1,25 @@
+From 1992b8ab9c7765b8da06b6054bb3c0ab990c62f7 Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Wed, 28 Oct 2020 08:13:31 -0700
+Subject: [PATCH] Fix build with clang.
+
+---
+ src/libixion/model_context.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/libixion/model_context.cpp b/src/libixion/model_context.cpp
+index 0fcbb31..f6eb3cf 100644
+--- a/src/libixion/model_context.cpp
++++ b/src/libixion/model_context.cpp
+@@ -17,7 +17,7 @@
+ 
+ namespace ixion {
+ 
+-model_context::input_cell::input_cell(nullptr_t) : type(celltype_t::empty) {}
++model_context::input_cell::input_cell(std::nullptr_t) : type(celltype_t::empty) {}
+ model_context::input_cell::input_cell(bool b) : type(celltype_t::boolean)
+ {
+     value.boolean = b;
+-- 
+GitLab
+


### PR DESCRIPTION
#### Description

Should fix error https://build.macports.org/builders/ports-10.10_x86_64-builder/builds/133754

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
