### PR TITLE
nonpareil: fixes for newer scons.

### DIFF
--- a/emulators/nonpareil/Portfile
+++ b/emulators/nonpareil/Portfile
@@ -5,11 +5,11 @@ PortSystem          1.0
 
 name                nonpareil
 version             0.79
-revision            7
+revision            8
 platforms           darwin
 categories          emulators
 license             GPL-2
-maintainers         nomaintainer
+maintainers         {krischik @krischik} openmaintainer
 description         a high-fidelity simulator for calculators.
 long_description    Nonpareil is a high-fidelity simulator for calculators. \
                     It currently supports many HP calculators models        \
@@ -34,13 +34,17 @@ distfiles           ${prog}:prog            \
                     ${appbundles}:appbundles
 
 checksums           ${prog} \
-                    md5		4274dee70d9633304194a904b2573489 \
-                    sha1	83bc2f57e6ece9ce19e3449cce075ef246a9f4c2 \
-                    rmd160	0bbf88e7c4614ac757bebbc1089804bea088d181 \
+                    md5     4274dee70d9633304194a904b2573489 \
+                    sha1    83bc2f57e6ece9ce19e3449cce075ef246a9f4c2 \
+                    rmd160  0bbf88e7c4614ac757bebbc1089804bea088d181 \
+                    sha256  3bcb2f9a829a4cad003f84a42c6f0e31a7bf527e634aea9cf13e370b6c175841 \
+                    size    4761552 \
                     ${appbundles} \
-                    md5		b71f77851f4204b984b80e57c4ad7e65 \
-                    sha1	4798b1ae8a56275a4c2eb4df54f352c457f1ff0a \
-                    rmd160	f0aa0eea748297f652f08c239fe1922b9f61e31d
+                    md5     b71f77851f4204b984b80e57c4ad7e65 \
+                    sha1    4798b1ae8a56275a4c2eb4df54f352c457f1ff0a \
+                    rmd160  f0aa0eea748297f652f08c239fe1922b9f61e31d \
+                    sha256  7242663b7debb30e8acd04657ee177d69508144d841b0b118932227f3e2f52f8 \
+                    size    4301000
 
 extract.only        ${prog}                                 \
                     ${appbundles}
@@ -60,7 +64,8 @@ depends_build       port:bison                              \
 patchfiles          osx.patch                               \
                     patch-src-printer.c.diff                \
                     patch-src-util.diff                     \
-                    patch-sconstruct.diff
+                    patch-sconstruct.diff                   \
+                    patch-src-sconscript.diff
 
 use_parallel_build  yes
 use_configure       no
@@ -69,7 +74,6 @@ build.args          prefix=${prefix}
 build.target
 
 destroot.args       prefix=${prefix} destdir=${destroot}
-
 
 post-patch {
     reinplace s|@PREFIX@|${prefix}|g ${worksrcpath}/src/SConscript
@@ -95,16 +99,18 @@ platform macosx {
 }
 
 variant voyager	                                                    \
-    description "Include Voyager Models (Not GPL licensed)!"        {
+    description "Include Voyager Models (Not GPL licensed)."        {
 
     set voyager     nonpareil-voyager-r${patchversion}.tar.gz
 
     distfiles-append        ${voyager}:voyager
 
     checksums-append        ${voyager} \
-                            md5		fbb227a28045c0bf8165bba86f199ec9 \
-                            sha1	8a51f656a523c5739d82a35ad933f8c448be58e6 \
-                            rmd160	4f7fec5af3b387fd6a7df44ce0a7b019eeb4a253
+                            md5     fbb227a28045c0bf8165bba86f199ec9 \
+                            sha1    8a51f656a523c5739d82a35ad933f8c448be58e6 \
+                            rmd160  4f7fec5af3b387fd6a7df44ce0a7b019eeb4a253 \
+                            sha256  fbdab9a62ffcf7027bc2936e0682768e45ffe3b48f1d2d02ab74b55fe33160a8 \
+                            size    152406
 
     extract.only-append     ${voyager}
 
@@ -133,13 +139,16 @@ variant voyager	                                                    \
 }
 
 variant debugger                        \
-    description "Include Debugger!"     {
+    description "Include Debugger for HP-41 and Voyager Models."     {
     build.args-append           debug=yes has_debugger_gui=yes
     destroot.args-append        debug=yes has_debugger_gui=yes
 }
 
 variant hpil                                                \
-    description "Include HP-Interface-Loop emulation (experimental) See http://pagesperso-orange.fr/kdntl/hp41/nonpareil-patch-doc.html" {
+    description "
+Include HP-Interface-Loop emulation.
+This features is experimental and last updated 2009.
+See http://pagesperso-orange.fr/kdntl/hp41/nonpareil-patch-doc.html" {
 
     global hpil
     set hpil nonpareil-wholepatch-20090714.diff.bz2

--- a/emulators/nonpareil/files/patch-image-voyager.diff
+++ b/emulators/nonpareil/files/patch-image-voyager.diff
@@ -31,7 +31,7 @@ diff -u -r image.orig/SConscript image/SConscript
 +# build Voyager PNG images from the PNM pieces (base image + segment image)
 +#-----------------------------------------------------------------------------
 +
-+vimg_env = env.Copy ()
++vimg_env = env.Clone ()
 +
 +def VPNM2PNG_Emitter (target, source, env):
 +    source.append (voyager_segment_pnm)

--- a/emulators/nonpareil/files/patch-sconstruct.diff
+++ b/emulators/nonpareil/files/patch-sconstruct.diff
@@ -80,3 +80,21 @@
  			     help = 'use Readline library for command editing and history (only when debugger CLI is enabled)',
  			     default = 1))  # only if has_debugger_cli
  
+@@ -235,7 +235,7 @@
+ # host platform code
+ #-----------------------------------------------------------------------------
+ 
+-native_env = env.Copy ()
++native_env = env.Clone ()
+ native_env ['build_target_only'] = 0
+ SConscript ('src/SConscript',
+             build_dir = 'build/' + env ['host'],
+@@ -256,7 +256,7 @@
+ #-----------------------------------------------------------------------------
+ 
+ if (env ['host'] != env ['target']):
+-	cross_build_env = env.Copy ()
++	cross_build_env = env.Clone ()
+ 	cross_build_env ['build_target_only'] = 1
+ 	SConscript ('src/SConscript',
+ 		    build_dir = 'build/' + env ['target'],

--- a/emulators/nonpareil/files/patch-src-sconscript.diff
+++ b/emulators/nonpareil/files/patch-src-sconscript.diff
@@ -1,0 +1,92 @@
+--- src/SConscript.orig	2021-01-26 14:07:26.279297036 +0100
++++ src/SConscript	2021-01-26 14:07:52.426086997 +0100
+@@ -79,7 +79,7 @@
+ state_io_objs = [build_env.Object(src) for src in state_io_srcs];
+ state_io_packages = "gtk+-2.0 gdk-2.0 gdk-pixbuf-2.0 glib-2.0 libxml-2.0"
+ 
+-release_env = build_env.Copy (CPPDEFINES = [('NONPAREIL_RELEASE', build_env ['RELEASE'])])
++release_env = build_env.Clone (CPPDEFINES = [('NONPAREIL_RELEASE', build_env ['RELEASE'])])
+ common_objs.append (release_env.Object ('release.c'))
+ 
+ build_env.ParseConfig(pkg_config_cmd + state_io_packages)
+@@ -89,7 +89,7 @@
+ #-----------------------------------------------------------------------------
+ 
+ if build_env ['build_target_only'] == 0:
+-    str2png_env = build_env.Copy ()
++    str2png_env = build_env.Clone ()
+ 
+     str2png_env.Append (CPPDEFINES = [('DEFAULT_PATH', 'image')])
+ 
+@@ -196,7 +196,7 @@
+ #-----------------------------------------------------------------------------
+ 
+ if not build_target_only:
+-    title_env = native_env.Copy (STR2PNG_STRING = 'NONPAREIL',
++    title_env = native_env.Clone (STR2PNG_STRING = 'NONPAREIL',
+                                  STR2PNG_OPTS = '-x 40 -y 44 -m 10')
+ 
+     title_env.STR2PNG (target = 'nonpareil_title',
+@@ -205,7 +205,7 @@
+     native_env.PNG2C (target = '#build/common/nonpareil_title_png.c',
+                       source = 'nonpareil_title.png')
+             
+-    rgoose_env = native_env.Copy (STR2PNG_STRING = '.',
++    rgoose_env = native_env.Clone (STR2PNG_STRING = '.',
+                                   STR2PNG_OPTS = '-x 40 -y 44')
+ 
+     rgoose_env.STR2PNG (target = 'rgoose',
+@@ -214,7 +214,7 @@
+     native_env.PNG2C (target = '#build/common/rgoose_png.c',
+                       source = 'rgoose.png')
+             
+-    lgoose_env = native_env.Copy (STR2PNG_STRING = ',',
++    lgoose_env = native_env.Clone (STR2PNG_STRING = ',',
+                                   STR2PNG_OPTS = '-x 40 -y 44')
+ 
+     lgoose_env.STR2PNG (target = 'lgoose',
+@@ -235,7 +235,7 @@
+ # nonpareil
+ #-----------------------------------------------------------------------------
+ 
+-nonpareil_env = build_env.Copy ()
++nonpareil_env = build_env.Clone ()
+ 
+ nonpareil_srcs = Split ("""proc.c glib_async_queue_source.c
+                            about.c goose.c pixbuf_util.c
+@@ -284,7 +284,7 @@
+ if (not ming) or (cross and not build_target_only):
+     nonpareil_env.ParseConfig (sdl_pkg_config_cmd)
+ 
+-csim_env = nonpareil_env.Copy ()
++csim_env = nonpareil_env.Clone ()
+ if not ming:
+     csim_env.Append (CPPDEFINES = [('DEFAULT_PATH', build_env ['libdir'])])
+ 
+@@ -296,7 +296,7 @@
+ 
+ if build_env ['has_debugger_cli']:
+     csim_env.Append (CPPDEFINES = [('HAS_DEBUGGER_CLI', 1)])
+-    debugger_cli_env = csim_env.Copy ()
++    debugger_cli_env = csim_env.Clone ()
+     if build_env ['use_tcl']:
+         debugger_cli_env.Append (CPPDEFINES = [('USE_TCL', 1)])
+         nonpareil_env.Append (LIBS = 'tcl')
+@@ -325,7 +325,7 @@
+ # udis
+ #-----------------------------------------------------------------------------
+ 
+-udis_env = build_env.Copy ()
++udis_env = build_env.Clone ()
+ 
+ udis_srcs = Split ("""dis.c""")
+ 
+@@ -336,7 +336,7 @@
+ # nsim_conv
+ #-----------------------------------------------------------------------------
+ 
+-nsim_conv_env = build_env.Copy ()
++nsim_conv_env = build_env.Clone ()
+ 
+ nsim_conv_srcs = Split ("""nsim_conv.c
+ 	                   state_read_nsim.c state_write_nsim.c""")


### PR DESCRIPTION
#### Description

1. Use Clone() instead of Copy() in scons scripts.
2. Update checksumms to satisfy a 'port lint' warning.
3. Update variant descriptions to be more expressive.
4. Update vim flags to better match current whitespace policy.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? 
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

There is also this Ticket here:

https://trac.macports.org/ticket/21150

But the voyager display is fine:

![image](https://user-images.githubusercontent.com/685853/105993400-aab8af80-60a6-11eb-98ed-36f18acf5f12.png)

Probably a GTK problem which fixed itself over time.