### PR TITLE
skaffold: update to 1.18.0

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 1.17.2 v
+github.setup        GoogleContainerTools skaffold 1.18.0 v
 revision            0
 
 categories          devel
@@ -23,9 +23,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  e50c36b640318c18116a69a5dd8f6e190d61ffa9 \
-                    sha256  1d23795bc92d77fbfd92ff1068013c35cd0f4fbde24f06f46cff8caa8b7a4972 \
-                    size    27691567
+checksums           rmd160  0003a1ed0018dfb2c267cb0f17f8c5144117acfc \
+                    sha256  14c9640d32eb81e0b7a82159deab00f6e0f2d68a8d50a64ccea504cf3a2b19fe \
+                    size    18969547
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 1.18.0.

###### Tested on

macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?