### PR TITLE
google-cloud-sdk: update to 325.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             324.0.0
-revision            1
+version             325.0.0
+revision            0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -21,14 +21,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  33296497e1be495ef9feeee906b9d12ca5e8597a \
-                    sha256  1578a2d4d5fb810cc981d84037d99078e3f1eb625488f4d86a7f2053e89a274d \
-                    size    86690663
+    checksums       rmd160  98e31e2129003f7ce5e59fa766cb0f01e6ab4176 \
+                    sha256  ca31b437868284fd1b03748e4f3707ad3c796379a1646775b073c4fd8255e529 \
+                    size    87274051
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  1b71e263e9514a639cd0d9526ba7b12566f89f1e \
-                    sha256  a0c278171a736dcd2fb4fc3f6819299e27a3e05fedad05f1be8ff56f26460ad4 \
-                    size    87698261
+    checksums       rmd160  894b32b9a9eeb6464840ab28f46886ff9977a039 \
+                    sha256  da3cbb3157b98b1a5923e0866e3a1b8d35eadfd36b9a1f4a88ca3de6770ffb26 \
+                    size    110085875
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 325.0.0.

###### Tested on

macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?