### PR TITLE
re2: change to cmake build  to support gprc, which currently needs a cmake version of re2 to build. Try to make it work like the previous autotools build worked.

### DIFF
--- a/devel/re2/Portfile
+++ b/devel/re2/Portfile
@@ -1,11 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           cmake 1.1
 PortGroup           github 1.0
 
 epoch               1
 github.setup        google re2 2021-02-02
-revision            0
+revision            1
 categories          devel textproc
 maintainers         nomaintainer
 
@@ -22,23 +23,34 @@ checksums           rmd160  47471514269abd3b815358fa2e8934d4489985e3 \
                     sha256  3fe6eecd1bc4a254a0eac1f63c4af2002da6ec157986307a364fe4647bae9792 \
                     size    402998
 
-use_configure       no
-
 variant universal   {}
 
 compiler.cxx_standard   2011
-if {[string match *clang* ${configure.cxx}]} {
-    configure.ldflags-append -stdlib=${configure.cxx_stdlib}
+
+configure.args-append \
+                    -DBUILD_SHARED_LIBS:BOOL=ON
+
+# Fix pkgconfig and shared library versioning; see:
+# https://bugs.archlinux.org/task/67739
+# https://gist.github.com/mtorromeo/1d48de16534dc8ee29cd872f94b070e5
+
+pre-configure {
+    reinplace s|@includedir@|${prefix}/include/${name}|g \
+        ${worksrcpath}/re2.pc
+    reinplace s|@libdir@|${prefix}/lib|g \
+        ${worksrcpath}/re2.pc
+    set somajor [exec /bin/sh -c "grep '^SONAME=' ${worksrcpath}/Makefile | cut -d= -f2"]
+    # append this line to CMakeLists.txt
+    reinplace "\$ a\\
+set_target_properties(re2 PROPERTIES VERSION ${somajor}.0.0 SOVERSION ${somajor})" \
+        ${worksrcpath}/CMakeLists.txt
 }
 
-build.args          CXX="${configure.cxx}" \
-                    CXXFLAGS="${configure.cxxflags} [get_canonical_archflags cxx]" \
-                    LDFLAGS="${configure.ldflags} [get_canonical_archflags cxx]" \
-                    prefix=${prefix}
-
-destroot.args       {*}${build.args}
-
 post-destroot {
+    xinstall -d ${destroot}${prefix}/lib/pkgconfig
+    xinstall -m 644 -W ${worksrcpath} \
+        re2.pc \
+        ${destroot}${prefix}/lib/pkgconfig
     # install additional documents.
     set docdir ${prefix}/share/doc/re2
     xinstall -d ${destroot}${docdir}


### PR DESCRIPTION
re2: Add cmake build and .cmake files
* Fixes: https://trac.macports.org/ticket/62168#ticket
* Related: https://github.com/macports/macports-ports/pull/7791

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
