### PR TITLE
cmake: disable universal on BigSur+

### DIFF
--- a/devel/cmake/Portfile
+++ b/devel/cmake/Portfile
@@ -1,7 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           muniversal 1.0
+
+# cmake does not build universal on BigSur Intel
+if { ${os.platform} eq "darwin" && ${os.major} >= 20 && ${build_arch} eq "x86_64"} {
+	universal_variant no
+} else {
+	PortGroup           muniversal 1.0
+}
+
 PortGroup           xcodeversion 1.0
 PortGroup           gitlab 1.0
 PortGroup           legacysupport 1.1


### PR DESCRIPTION
there is no real need for cmake to build universal
it is a tool that works well in native arch
and it sets installs_libs no

cmake has many deps, all of which need to be universal
if cmake is universal

cmake does not presently build universal on BigSur Intel
and there is no compelling reason for it to do so

disable the universal build on BigSur+  Intel

allows the many ports that build with cmake to build
universal without requiring cmake to be universal

This is a much better idea than the previous.