### PR TITLE
compilers-pg: -fallow-argument-mismatch should also be added to gcc-devel

### DIFF
--- a/_resources/port1.0/group/compilers-1.0.tcl
+++ b/_resources/port1.0/group/compilers-1.0.tcl
@@ -728,7 +728,7 @@ proc compilers::add_fortran_legacy_support {} {
         } else {
             set fortran_compiler    [fortran_variant_name]
         }
-        if {${fortran_compiler} eq "gcc10"} {
+        if {${fortran_compiler} in "gcc10 gccdevel"} {
             configure.fflags-delete     -fallow-argument-mismatch
             configure.fcflags-delete    -fallow-argument-mismatch
             configure.f90flags-delete   -fallow-argument-mismatch


### PR DESCRIPTION
#### Description
If `compilers.allow_arguments_mismatch` is set to `yes`, the flag `-fallow-argument-mismatch` should also be added to `gcc-devel`, now this only happens for `gcc10`. For example, I think that `pgplot` fails due to this ; see [Trac ticket 61711](https://trac.macports.org/ticket/61711). I've made the change in the PG where I think it should be made and added a commit increasing the `revision` for `pgplot` here as well to test if that indeed works. However, I don't claim that I fully understand all the details of that PG so it would be good if someone could review this...

**!!! There is no reason to increase the revision for `pgplot`, except for CI reasons, so this should NOT be merged as is !!!**


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H114
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->