### PR TITLE
portaudio: add missing definition

### DIFF
--- a/audio/portaudio/Portfile
+++ b/audio/portaudio/Portfile
@@ -48,6 +48,9 @@ patchfiles          patch-configure.diff \
                     patch-src__common__pa_types.h.diff \
                     patch-audacity-portmixer.diff
 
+# add missing definition to fix build on older systems
+patchfiles-append   patch-portaudio-coreaudio-tigerdef.diff
+
 variant jack description {Enable JACK support} {
     depends_lib-append \
                     port:jack

--- a/audio/portaudio/files/patch-portaudio-coreaudio-tigerdef.diff
+++ b/audio/portaudio/files/patch-portaudio-coreaudio-tigerdef.diff
@@ -1,0 +1,13 @@
+--- src/hostapi/coreaudio/pa_mac_core.c.orig	2021-01-27 22:51:12.000000000 -0800
++++ src/hostapi/coreaudio/pa_mac_core.c	2021-01-27 22:54:02.000000000 -0800
+@@ -71,6 +71,10 @@
+ #include "pa_mac_core_utilities.h"
+ #include "pa_mac_core_blocking.h"
+ 
++#ifndef MAC_OS_X_VERSION_10_6
++#define MAC_OS_X_VERSION_10_6 1060
++#endif
++
+ 
+ #ifdef __cplusplus
+ extern "C"


### PR DESCRIPTION
fixes build on some older systems

this software has excellent older systems support
just needs one small missing definition to build

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.4
Xcode 2.5
