### PR TITLE
submission: Portfile for Munt's library for emulation of Roland MT-32, CM-32L and…

### DIFF
--- a/audio/munt-mt32emu/Portfile
+++ b/audio/munt-mt32emu/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+
+name                munt-mt32emu
+version             2.4.0
+revision            0
+
+homepage            http://munt.sourceforge.net/
+description         Munt library
+long_description    mt32emu is a C/C++ library which allows to emulate (approximately) the Roland MT-32, CM-32L and LAPC-I synthesiser modules.
+
+categories          audio emulators
+platforms           darwin
+license             LGPL-2.1
+
+maintainers         nomaintainer
+
+master_sites        sourceforge:project/munt/munt/${version}
+
+distname            munt-${version}
+
+checksums           rmd160  9f3c76daf60294613e4e2646eba9e76d506c85ff \
+                    sha256  b4f7054df1d3f89e2cc683ff6182c4d0a272daceffc4d27fd968b6eaebcdc9ed \
+                    size    474789
+
+configure.args-append \
+                    -Dmunt_WITH_MT32EMU_SMF2WAV=FALSE \
+                    -Dmunt_WITH_MT32EMU_QT=FALSE


### PR DESCRIPTION
#### Description

mt32emu is a C/C++ library which allows to emulate (approximately) the Roland MT-32, CM-32L and LAPC-I synthesiser modules.
The Munt project also provides a GUI (QT4/5) app, as well as terminal program. These usually go into a sperate package ("munt") because of the many dependencies (QT, glib2, JACK, Portaudio), the library has no dependencies (other than CMake).

This builds just the shared library for other projects to make use of.

I've made port request the other day:  https://trac.macports.org/ticket/62166


###### Type(s)

- [x] submission


###### Tested on

macOS 11.1 20C69
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

