### PR TITLE
cargo portgroup: use [cargo.rust_platform] for the executable's destroot path

### DIFF
--- a/_resources/port1.0/group/cargo-1.0.tcl
+++ b/_resources/port1.0/group/cargo-1.0.tcl
@@ -29,7 +29,7 @@ destroot {
     ui_msg "Here is an example destroot phase:"
     ui_msg
     ui_msg "destroot {"
-    ui_msg {    xinstall -m 0755 ${worksrcpath}/target/release/${name} ${destroot}${prefix}/bin/}
+    ui_msg {    xinstall -m 0755 ${worksrcpath}/target/[cargo.rust_platform]/release/${name} ${destroot}${prefix}/bin/}
     ui_msg {    xinstall -m 0444 ${worksrcpath}/doc/${name}.1 ${destroot}${prefix}/share/man/man1/}
     ui_msg "}"
     ui_msg


### PR DESCRIPTION
Cargo will build executables into the ./target directory under a subdir
that matches the host's current OS and architecture.  This can be
retrieved using [cargo.rust_platform].  We update the destroot example
provided by the Cargo portgroup that is shown when a Portfile author
forgets to include a destroot block to include this so that the correct
thing happens regardless of the build platform.