### PR TITLE
poetry: Depend on py-lockfile; py-lockfile: Support 3.9; py-pkginfo: Update to 1.7.0

### DIFF
--- a/python/poetry/Portfile
+++ b/python/poetry/Portfile
@@ -5,7 +5,7 @@ PortGroup               python 1.0
 
 name                    poetry
 version                 1.1.4
-revision                1
+revision                2
 categories-append       devel
 platforms               darwin
 license                 MIT
@@ -60,6 +60,10 @@ depends_lib-append \
     port:py${python.version}-packaging \
     port:py${python.version}-virtualenv \
     port:py${python.version}-keyring
+
+# Needed for the filecache extra of the cachecontrol dependency
+depends_lib-append \
+    port:py${python.version}-lockfile
 
 # Shell completion
 post-destroot {

--- a/python/py-lockfile/Portfile
+++ b/python/py-lockfile/Portfile
@@ -28,7 +28,7 @@ checksums           rmd160  6aaa40fb1a1bd4322f26182fca631a6c4c1f8d24 \
                     sha256  6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799 \
                     size    20874
 
-python.versions     27 37 38
+python.versions     27 37 38 39
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-pkginfo/Portfile
+++ b/python/py-pkginfo/Portfile
@@ -4,10 +4,11 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pkginfo
-version             1.4.2
+version             1.7.0
 platforms           darwin
 license             MIT
 maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
+supported_archs     noarch
 
 description         Query metadatdata from sdists and bdists installed packages.
 long_description \
@@ -16,15 +17,14 @@ long_description \
     distribution (e.g., created by running bdist_egg).
 
 homepage            https://pypi.python.org/pypi/pkginfo
-master_sites        pypi:p/pkginfo/
-distname            ${python.rootname}-${version}
 
-checksums           rmd160  65db4ba7d508330ae31741d6fc61e8b26c32b70e \
-                    sha256  5878d542a4b3f237e359926384f1dde4e099c9f5525d236b1840cf704fa8d474 \
-                    size    33539
+checksums           rmd160  9065991656247be33e4e01478bcbd222e6261646 \
+                    sha256  029a70cb45c6171c329dfc890cde0879f8c52d6f3922794796e06f577bb03db4 \
+                    size    37209
 
 python.versions     27 36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
+    livecheck.type          none
 }


### PR DESCRIPTION
#### Description

py-cachecontrol: Add missing dependency py-lockfile. poetry uses py-cachecontrol and fails without the py-lockfile dependency.

py-pkginfo: Update to 1.7.0. Fixes an issue with poetry because the previous version could not parse installed wheels, i.e., dist-info folders. See also https://github.com/python-poetry/poetry/issues/3362

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G7016
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?