### PR TITLE
py-torchvision: add subport for Python 3.9

### DIFF
--- a/python/py-torchvision/Portfile
+++ b/python/py-torchvision/Portfile
@@ -28,7 +28,7 @@ homepage            https://github.com/pytorch/vision
 github.livecheck.regex  {([0-9.]+)}
 
 # Support python versions
-python.versions        36 37 38
+python.versions        36 37 38 39
 python.default_version 37
 
 compiler.cxx_standard 2011
@@ -45,6 +45,5 @@ if {${name} ne ${subport}} {
     build.cmd    "${python.bin} setup.py"
     destroot.cmd "${python.bin} setup.py install"
 
-    livecheck.type none 
-
+    livecheck.type none
 }


### PR DESCRIPTION
#### Description

Add Python 3.9 subport for py-torchvision.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G7016
Xcode 11.3.1 11C505

macOS 10.15.7 19H114
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
