### PR TITLE
trdsql: new port

### DIFF
--- a/textproc/trdsql/Portfile
+++ b/textproc/trdsql/Portfile
@@ -1,0 +1,318 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/noborus/trdsql 0.8.0 v
+revision            0
+
+description         CLI tool that can execute SQL queries on CSV, LTSV, JSON \
+                    and TBLN files. Can output to various formats.
+
+long_description    {*}${description} Can use PostgreSQL or MySQL syntax.
+
+categories          textproc databases
+platforms           darwin
+license             MIT
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+build.cmd           make
+build.target        trdsql
+
+patch {
+    reinplace "s|^VERSION=.*|VERSION=v${version}|" ${worksrcpath}/Makefile
+}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  dc166a040b7d7e4bfd513f3b2836e22c240acb56 \
+                        sha256  5a9bb29f2ed76ec6a2f507508030241c1ff71ef17008020e9a561bb91d5098e4 \
+                        size    2455165
+
+go.vendors          gopkg.in/yaml.v2 \
+                        lock    v2.2.2 \
+                        rmd160  03aea7b7e847179b29044d5a928b9f8a889fe87b \
+                        sha256  da1e31b7beb9a6907947caa794134bdc2501d1a3474568b61cc2562a398d3d87 \
+                        size    70676 \
+                    gopkg.in/check.v1 \
+                        lock    20d25e280405 \
+                        rmd160  412aa0d109919182ff84259e9b5bbc9f24d78117 \
+                        sha256  233f8faf427ce6701ac3427f85c28bc6b6ae7cdc97a303a52873c69999223325 \
+                        size    30360 \
+                    google.golang.org/appengine \
+                        repo    github.com/golang/appengine \
+                        lock    v1.6.1 \
+                        rmd160  1aaf527f44d1b4eb210ab52cf3d1a5c1c70310bf \
+                        sha256  9420cc82dd8b0d0825356b17844bf836fd0a0af468b1394c70b498e4a0e471c2 \
+                        size    333388 \
+                    golang.org/x/tools \
+                        lock    d0a3d012864b \
+                        rmd160  a51bf2480e206dd6a4d2a8e9ccb03b636a1a2e72 \
+                        sha256  ef396f179249cb9f397f6d94e2b73338bdd301404af4639288e75310f9094142 \
+                        size    2124534 \
+                    golang.org/x/text \
+                        lock    v0.3.2 \
+                        rmd160  3b9523084f6a8b2e6a6987e49c56f05e22ad69eb \
+                        sha256  d624899dfd390d9d4a77e5c8e5abd8c45f0b6163e0dc7176aee39f25c5f1bed0 \
+                        size    7168458 \
+                    golang.org/x/term \
+                        lock    2321bbc49cbf \
+                        rmd160  94c32506cb76cee410574c49d6b4cfe294a8159d \
+                        sha256  3bf7b61de210c621fb70e697c0020789bfbe426754d0f743978e77f84a7472f1 \
+                        size    15286 \
+                    golang.org/x/sys \
+                        lock    22da62e12c0c \
+                        rmd160  15c235353d480b46af88f988d1cb58ee77194ea6 \
+                        sha256  2ef3888e228c2e10bd71add7c893d88260477cad9c5d529d95e899e62b57916b \
+                        size    1106946 \
+                    golang.org/x/sync \
+                        lock    112230192c58 \
+                        rmd160  37a8b11def31e2ad355002a8671245962be359f6 \
+                        sha256  951a6df1dadb061510f1c646197dd8f8a7c7842729d02c6a68a86bce66349f79 \
+                        size    16832 \
+                    golang.org/x/net \
+                        lock    60506f45cf65 \
+                        rmd160  4c5cb80ad56f1d9c3bdefb1ebcd6bf18340ccb62 \
+                        sha256  1459548aafe9233361185e82ead4b4e2b68d6435c3e6caffba37042bec8acab8 \
+                        size    1096626 \
+                    golang.org/x/crypto \
+                        lock    eec23a3978ad \
+                        rmd160  098b29e5fb0c1a0fa7a118e433eb5d952053391b \
+                        sha256  da658dad4a60a368edea1cbb28651cf44b46b06fdd726462c5696aa5283f12c2 \
+                        size    1725759 \
+                    github.com/xordataexchange/crypt \
+                        lock    b2862e3d0a77 \
+                        rmd160  d5214a59a959d2f1e6400e52ee268121decf321d \
+                        sha256  c0f7651d6a56e0323e1181b4e829795062d52bbdf2dc659525c46b8a280f60e1 \
+                        size    10748 \
+                    github.com/xo/dburl \
+                        lock    98997a05b24f \
+                        rmd160  b6c802b43398ebf2743d420668438f674a5c11b7 \
+                        sha256  5d1dfb7982983969ba2579fc9fadc6787d043fcfa6e571f3509070f47acb637a \
+                        size    15322 \
+                    github.com/ulikunitz/xz \
+                        lock    v0.5.9 \
+                        rmd160  6df470100684d9c1ed3021e183b4b0d50a4c4920 \
+                        sha256  c67593500935231d98bfab45278f1df8e58bfbed093094d3d3c6ecefd448ac02 \
+                        size    478035 \
+                    github.com/ugorji/go/codec \
+                        lock    d75b2dcb6bc8 \
+                        rmd160  9b31a64b6d929f8b583af9dd5d0f877257ad1246 \
+                        sha256  e4f9e90a141cbdd5745305947e74a4b122156d6c90cf19ebe2120ebb0e17ce12 \
+                        size    330036 \
+                    github.com/stretchr/testify \
+                        lock    v1.2.2 \
+                        rmd160  45703d5a082af570664fb80e99918077596349aa \
+                        sha256  ea0e76528dc47d7d84739cd8a8c7560e3f12d4ff490bdd2641a9990a168e6f2f \
+                        size    101747 \
+                    github.com/spf13/viper \
+                        lock    v1.3.2 \
+                        rmd160  d76c79ae5976d9c29f155fa9c19632f574c39b03 \
+                        sha256  4133e63136f66f5e2e121f943d88299251fd826d5aa9a3df4dffd413552e930b \
+                        size    36932 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.3 \
+                        rmd160  32abdd77a987af95ce5b647846bfdbb2d8db91a0 \
+                        sha256  046b6b81e3925ffe60e2213e9a239303ff98a51e76764590b807b591fedf2d1e \
+                        size    46029 \
+                    github.com/spf13/jwalterweatherman \
+                        lock    v1.0.0 \
+                        rmd160  364fd0d61e94bd3651b5506d61f0e9652d6e33a3 \
+                        sha256  e70eb4dbab0603ad35c32bf89cefd595b2d6d56d66695866bfad2350db939404 \
+                        size    6405 \
+                    github.com/spf13/cobra \
+                        lock    v0.0.5 \
+                        rmd160  53e9a05596343a23f3a42bb6bf0d1a740591345d \
+                        sha256  9987c8c42db1f7b6e17abb000d23457463bc3f8884c815777f7fbf5e48e6a498 \
+                        size    111150 \
+                    github.com/spf13/cast \
+                        lock    v1.3.0 \
+                        rmd160  26b82e9734f643bc70be8c73742d4a4f514b6dd2 \
+                        sha256  f2913fc10731a578c016701bd10e6a267c299b94e69d8362d258ce8482d14faf \
+                        size    11086 \
+                    github.com/spf13/afero \
+                        lock    v1.1.2 \
+                        rmd160  dc2ff3aa582c3dc782e3c062e35b65564bfc44e5 \
+                        sha256  08dca858dce5a4336ca385028ff38e0fa6a9f064f5c874fdabe2096a34b6fc91 \
+                        size    45324 \
+                    github.com/russross/blackfriday \
+                        lock    v1.5.2 \
+                        rmd160  cae679bcc1d73f3b7436b5393e690282799daa31 \
+                        sha256  40b449aee4a4c32edc35254e4df6d4da09448427661e2659806645196f2794c4 \
+                        size    75814 \
+                    github.com/rivo/uniseg \
+                        lock    v0.2.0 \
+                        rmd160  33577def583aa2db50b69ca601e5d29ab201ebc4 \
+                        sha256  2832965221246272462a03ffc8e159c94d8f534827f660f1ac4fc77e5ccd644c \
+                        size    44037 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/pierrec/lz4 \
+                        lock    v2.6.0 \
+                        rmd160  afd76f29dd8423e9cb4f2b4e406ae2617032f164 \
+                        sha256  85de5b3cbdae9ddffce021ad79b40f39d9e3209d76a946facc9614dbf770a3ba \
+                        size    40115584 \
+                    github.com/pelletier/go-toml \
+                        lock    v1.2.0 \
+                        rmd160  8d91b6485f373ccaa894abcb3bd53839e55b9057 \
+                        sha256  0a9503f2b53444e0c3ea960d18febe14d472c16279844f231994c5ccb81dbdff \
+                        size    57515 \
+                    github.com/olekukonko/tablewriter \
+                        lock    v0.0.4 \
+                        rmd160  750bec232562820a4f3ba47cd2864f4c84e7a767 \
+                        sha256  890daf262aee371899075912bab0b3107313bea32846cf796bca83ef9a1dccf5 \
+                        size    19267 \
+                    github.com/noborus/tbln \
+                        lock    v0.0.1 \
+                        rmd160  d133967ce274e01c77381cfd141a267f1c4f98f0 \
+                        sha256  20d744b417a5ec029e656c8f59ae53243286d21a6ceca26c00b612bfe26f67b1 \
+                        size    53243 \
+                    github.com/mitchellh/mapstructure \
+                        lock    v1.1.2 \
+                        rmd160  a4e01781ea5bb0c987e18e8e450c8f1023d5a857 \
+                        sha256  9c1076f5a8e923d028cb65c36143f3b1478cbaa4420e2e8f332719edc2fc4f71 \
+                        size    20992 \
+                    github.com/mitchellh/go-homedir \
+                        lock    v1.1.0 \
+                        rmd160  44b3985e40e5bbb22d11f8622c340f9ed727ea91 \
+                        sha256  024c8a57316c7fbc0eb23cdbfd57f72a74b51beb83d714034d67ee9aba48100c \
+                        size    3366 \
+                    github.com/mattn/go-sqlite3 \
+                        lock    v1.14.6 \
+                        rmd160  39a6b19259c572ca8f21d8482511321bb90b94b1 \
+                        sha256  8559965139a038d1bf7f1787b0b66dc27c777fdf39deda387e329c11dea468db \
+                        size    2367157 \
+                    github.com/mattn/go-runewidth \
+                        lock    v0.0.10 \
+                        rmd160  96c878eca004d6cf8f49ecf3cde98335e7f21499 \
+                        sha256  b78084ce55bc5aaa31d337dcb59624d748fe39006a3df29143fae203065e2a22 \
+                        size    16787 \
+                    github.com/magiconair/properties \
+                        lock    v1.8.0 \
+                        rmd160  327cf3e96df60025444491a413aba0145ef448f3 \
+                        sha256  1a51357a88b298284fa48607836e7d05bee5fc58e00c87ba943a8d719d2ece2c \
+                        size    29500 \
+                    github.com/logrusorgru/aurora \
+                        lock    v2.0.3 \
+                        rmd160  73669a59f9a40fa4efe6d6393955d54dfcae2d05 \
+                        sha256  22344374fdd6f58192ea56207997f259a8deb927baf1618c141eb11fea987fa2 \
+                        size    136791 \
+                    github.com/lib/pq \
+                        lock    v1.9.0 \
+                        rmd160  455f9b2663511530423515dcad937d707e51644d \
+                        sha256  819af4bde70ac0ecbdadcbc14913be411bdf86652684296ca84258114cb4cace \
+                        size    103421 \
+                    github.com/kr/text \
+                        lock    v0.1.0 \
+                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
+                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
+                        size    8691 \
+                    github.com/kr/pty \
+                        lock    v1.1.1 \
+                        rmd160  67ff2355f17e1fe71e958bba46c7f138a7d5ae40 \
+                        sha256  6124bf7646c16cc3d2f1287fe8a5dd3a1930f0333f6362e74006f65d88412a2d \
+                        size    5684 \
+                    github.com/kr/pretty \
+                        lock    v0.1.0 \
+                        rmd160  9aa7a5aad4c48840eecfd0f80186d1fb5ded0fd6 \
+                        sha256  f6c3f89667c63e5b7f1fc6ee2c06b6a6bfdce88f3a965ccd395b64c6f95c9a47 \
+                        size    8553 \
+                    github.com/klauspost/cpuid \
+                        lock    v1.2.0 \
+                        rmd160  43910d3df318a51408fd6823237d39fc6f4f88ce \
+                        sha256  816989fc84edbcb2b4cbe6ef6e736661cf4987ce32f2f4e36a698afbe02f9d81 \
+                        size    278886 \
+                    github.com/klauspost/compress \
+                        lock    v1.11.7 \
+                        rmd160  abdd44b9a8352fa20af72b95b9daee5169aee4d5 \
+                        sha256  4a9bbb306ecc31552781fa033a74c0f9bcb90cad7a9a2b2dba2b5cfa9ee16e81 \
+                        size    17447953 \
+                    github.com/inconshreveable/mousetrap \
+                        lock    v1.0.0 \
+                        rmd160  5c617a09f1432fc543672a0e0c1e13d3752030c2 \
+                        sha256  0e6bae2849f13d12fe361ecac087728e4e97f3482f4cec44f6e7a2c53bb9cd0c \
+                        size    2291 \
+                    github.com/iancoleman/orderedmap \
+                        lock    v0.2.0 \
+                        rmd160  a22b7095d433a838d58c8cac1e21b6bc8de08a51 \
+                        sha256  3f8e70b587858dad27c7b1e2704a4546fca95339c3db7ff09547243fc35dd9a7 \
+                        size    5568 \
+                    github.com/hashicorp/hcl \
+                        lock    v1.0.0 \
+                        rmd160  ad8d0b523bb708fd6ae77df8bb414c103a75aa92 \
+                        sha256  4fc0e87ac9d3d6cd042f044df2db2703bed569051fb8c179d505edeb4433e96e \
+                        size    70636 \
+                    github.com/google/go-cmp \
+                        lock    v0.3.1 \
+                        rmd160  66e42f672a5a40561c388b78b3644abd926e7bef \
+                        sha256  86ee7c90714e7eb5c60d1a8a515235daef806df454c767043b593540e958167f \
+                        size    76416 \
+                    github.com/golang/protobuf \
+                        lock    v1.3.1 \
+                        rmd160  801150957b99de8eef10cb8d5ea2a08b240f2cb5 \
+                        sha256  a53c2c8c5c02311d2fa3bc6656614e20f9e5568b87c9f07702f083457e69f7d2 \
+                        size    310935 \
+                    github.com/go-sql-driver/mysql \
+                        lock    v1.5.0 \
+                        rmd160  c619fb55acd917f9b80c568f54b829836dd757e1 \
+                        sha256  cedc3d58292b89f2d5015dcfb6c7ab41c514cf9ce1b3733285743dc676ec8733 \
+                        size    90506 \
+                    github.com/fsnotify/fsnotify \
+                        lock    v1.4.7 \
+                        rmd160  24712e412814020224e2779186e634610e2f6926 \
+                        sha256  bc839ee158ad34b81c1f11c3b9e3bcbabfba3297f61d165599880c400b8171dc \
+                        size    31147 \
+                    github.com/frankban/quicktest \
+                        lock    v1.7.2 \
+                        rmd160  0c952e977a73b006bb3551305958ab6f8726252b \
+                        sha256  fc72ad55bd91ddecaff38005a35b8f3769796f0fa54fa38b719de9f3bb73d67f \
+                        size    31750 \
+                    github.com/dsnet/golib \
+                        lock    1ea166775780 \
+                        rmd160  3252e85802fe69fe5eab4a93f045d7ba05841dcb \
+                        sha256  07f3a732de0e79a02cd24fc8ef1538359915b84524ac56b3731e691cfb29e9ec \
+                        size    36469 \
+                    github.com/dsnet/compress \
+                        lock    v0.0.1 \
+                        rmd160  44a9ba6d99a11d15815c3600f997b48abfec5bd5 \
+                        sha256  42eac045c3c85d633e26d3dfdf62ff0a2c7b970397baaa0de85f5de783489705 \
+                        size    9963201 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/cpuguy83/go-md2man \
+                        lock    v1.0.10 \
+                        rmd160  cb804116f6ec772494887e899f51badf3e8468a4 \
+                        sha256  226c507b646df43a7cf650d8174a75a07fd41b134159d396fc73a7e88644f833 \
+                        size    43922 \
+                    github.com/coreos/go-semver \
+                        lock    v0.2.0 \
+                        rmd160  57d1d800408e97ddd9cf06552eea5f1caed79c0a \
+                        sha256  db8d86ce1ed133caaa4dd7129afaa71c62d375cd908fc65307d47ab51dec0bd4 \
+                        size    8475 \
+                    go.etcd.io/etcd/v3 \
+                        repo    github.com/etcd-io/etcd \
+                        lock    v3.3.10 \
+                        rmd160  ee0fcae7a63a747d1434eed4d1eb6e00b01bc41e \
+                        sha256  98a2a57b500d501bee216cfd62db9c46cec350dff918d7a34a7e69fc5e58d795 \
+                        size    3527453 \
+                    github.com/armon/consul-api \
+                        lock    eb2c6b5be1b6 \
+                        rmd160  af7689833496c860e043b557a4fac313c56f81a9 \
+                        sha256  75b91ba4d8b1071d9e5370da8570e42bf11ea09205dc1c8e9ded69ee49155194 \
+                        size    17988 \
+                    github.com/BurntSushi/toml \
+                        lock    v0.3.1 \
+                        rmd160  fb9650e2d16525153645e5547626f242f3800149 \
+                        sha256  8cc9e5dc68e247554227973d0b4e023b27bbd9ba5a26e4fb40f44743afcb35f1 \
+                        size    42087


### PR DESCRIPTION
New port for **[trdsql](https://github.com/noborus/trdsql)**

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
