### PR TITLE
pango: Fix +universal

### DIFF
--- a/x11/pango/Portfile
+++ b/x11/pango/Portfile
@@ -3,6 +3,7 @@
 PortSystem              1.0
 PortGroup               active_variants 1.1
 PortGroup               gobject_introspection 1.0
+PortGroup               muniversal 1.0
 
 # Please keep the pango and pango-devel ports as similar as possible.
 


### PR DESCRIPTION
#### Description

Currently `pango` +universal only builds a single arch. The following fix was taken from another Port.

Here's what happens currently when pango +universal is required.
```
:info:build ld: warning: ignoring file /opt/local/lib/libpangocairo-1.0.dylib, file was built for x86_64 which is not the architecture being linked (i386): /opt/local/lib/libpangocairo-1.0.dylib
:info:build ld: warning: ignoring file /opt/local/lib/libpango-1.0.dylib, file was built for x86_64 which is not the architecture being linked (i386): /opt/local/lib/libpango-1.0.dylib
```
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G7016
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
