### PR TITLE
fpc-cross-*: new cross targets.

### DIFF
--- a/lang/fpc/Portfile
+++ b/lang/fpc/Portfile
@@ -115,6 +115,104 @@ subport "${name}-cross" {
     }
 }
 
+subport "${name}-cross-arm-wince" {
+    revision                0
+    worksrcdir              fpcbuild-${version}/fpcsrc
+    use_parallel_build      no
+    use_configure           no
+    depends_build-append    port:${name} port:${name}-cross
+#    build.target            rtl packages
+#    destroot.target         rtl_install packages_install
+    build.target            rtl
+    destroot.target         rtl_install
+
+# target specifics
+    description     FPC cross-compiler for arm-wince
+    long_description \
+        This Pascal crosscompiler produces arm executables, \
+        which run natively on arm-wince systems. \n \
+        Get help with: \n \
+        fpc -h \n \
+        Compile and link a Pascal file with: \n \
+        \n \
+        fpc -Parm -Twince FILENAME
+
+    build.args      PP=ppcarm CPU_TARGET=arm OS_TARGET=wince OPT="-ap -v0"
+    destroot.args   CPU_TARGET=arm OS_TARGET=wince CROSSINSTALL=1 INSTALL_PREFIX=${destroot}${prefix}
+
+# remove duplicate doc and bin files
+    post-destroot   {
+        file delete -force ${destroot}${prefix}/share
+        file delete -force ${destroot}${prefix}/bin
+    }
+}
+
+foreach ostarget {nativent win32 wince} {
+    subport "${name}-cross-i386-$ostarget" {
+        revision                0
+        worksrcdir              fpcbuild-${version}/fpcsrc
+        use_parallel_build      no
+        use_configure           no
+        depends_build-append    port:${name} port:${name}-cross
+#        build.target            rtl packages
+#        destroot.target         rtl_install packages_install
+        build.target            rtl
+        destroot.target         rtl_install
+
+# target specifics
+        description     FPC cross-compiler for i386-$ostarget
+        long_description \
+            This Pascal crosscompiler produces i386 executables, \
+            which run natively on i386-$ostarget systems. \n \
+            Get help with: \n \
+            fpc -h \n \
+            Compile and link a Pascal file with: \n \
+            \n \
+            fpc -Pi386 -T$ostarget FILENAME
+
+        build.args      PP=ppc386 CPU_TARGET=i386 OS_TARGET=$ostarget OPT="-ap -v0"
+        destroot.args   CPU_TARGET=i386 OS_TARGET=$ostarget CROSSINSTALL=1 INSTALL_PREFIX=${destroot}${prefix}
+
+# remove duplicate doc and bin files
+        post-destroot   {
+            file delete -force ${destroot}${prefix}/share
+            file delete -force ${destroot}${prefix}/bin
+        }
+    }
+}
+
+subport "${name}-cross-x86-64-win64" {
+    revision                0
+    worksrcdir              fpcbuild-${version}/fpcsrc
+    use_parallel_build      no
+    use_configure           no
+    depends_build-append    port:${name} port:${name}-cross
+#    build.target            rtl packages
+#    destroot.target         rtl_install packages_install
+    build.target            rtl
+    destroot.target         rtl_install
+
+# target specifics
+    description     FPC cross-compiler for x86_64-win64
+    long_description \
+        This Pascal crosscompiler produces x86_64 executables, \
+        which run natively on x86_64-win64 systems. \n \
+        Get help with: \n \
+        fpc -h \n \
+        Compile and link a Pascal file with: \n \
+        \n \
+        fpc -Px86_64 -Twin64 FILENAME
+
+    build.args      PP=ppcx64 CPU_TARGET=x86_64 OS_TARGET=win64 OPT="-ap -v0"
+    destroot.args   CPU_TARGET=x86_64 OS_TARGET=win64 CROSSINSTALL=1 INSTALL_PREFIX=${destroot}${prefix}
+
+# remove duplicate doc and bin files
+    post-destroot   {
+        file delete -force ${destroot}${prefix}/share
+        file delete -force ${destroot}${prefix}/bin
+    }
+}
+
 if {${subport} eq "${name}"} {
     revision            1
 


### PR DESCRIPTION
#### Description

This adds cross targets for fpc, which do not require external tools. These targets use internal assemblers and linkers.

###### Type(s)

- [x] enhancement

###### Tested on

macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [*] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [*] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [*] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [*] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [*] checked your Portfile with `port lint`?
- [*] tried existing tests with `sudo port test`?
- [*] tried a full install with `sudo port -vst install`?
- [*] tested basic functionality of all binary files?
