### PR TITLE
cmake: Remove support for python27

### DIFF
--- a/devel/cmake/Portfile
+++ b/devel/cmake/Portfile
@@ -47,7 +47,7 @@ if {${subport} eq ${name}} {
     checksums       rmd160  f06e1e943457f79715bae77f347e2417b72a3326 \
                     sha256  5bff94ab6638995ffd029c9e319e96572fcec21abc9264ccdd03df97adac1113 \
                     size    7138448
-    revision        0
+    revision        1
 
     gitlab.livecheck.regex {([0-9.]+)}
     compiler.cxx_standard 2011
@@ -245,7 +245,7 @@ if {${subport} eq ${name}} {
     }
 
     # Supported pythons
-    set python_versions {27 35 36 37 38 39}
+    set python_versions {35 36 37 38 39}
 
     set python_isset false
     foreach pyver ${python_versions} {


### PR DESCRIPTION
Fix: https://trac.macports.org/ticket/62178

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
