### PR TITLE
gcc10: use generic SDK if needed

### DIFF
--- a/lang/gcc-devel/Portfile
+++ b/lang/gcc-devel/Portfile
@@ -33,7 +33,7 @@ if { ${build_arch} eq "arm64" } {
 
     # Version must follow same scheme as with GCC snapshots below <version>-<commit-date>
     version         11-20210122
-    revision        0
+    revision        1
     subport         libgcc-devel { revision 0 }
 
     checksums       rmd160  1a67cfb42f9b575345762be65089898e4e176079 \
@@ -44,7 +44,7 @@ if { ${build_arch} eq "arm64" } {
     # Use regular GCC releases and snapshsots
 
     version         11-20210124
-    revision        0
+    revision        1
     subport         libgcc-devel { revision 0 }
 
     checksums       rmd160  451a8bada81f735defd58f5b6217d2c5c828c188 \
@@ -166,7 +166,9 @@ pre-configure {
         #
         # https://trac.macports.org/ticket/53726
         # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=79885
-        configure.args-append --with-sysroot="${configure.sdkroot}"
+
+        # if the sdkroot is one of the current, rapidly changing SDKS, use the generic one
+        configure.args-append --with-sysroot="[regsub {MacOSX1[1-9]\.[0-9]+\.sdk} ${configure.sdkroot} {MacOSX.sdk}]"
     }
 
 }

--- a/lang/gcc10/Portfile
+++ b/lang/gcc10/Portfile
@@ -9,7 +9,7 @@ PortGroup           conflicts_build              1.0
 epoch               5
 name                gcc10
 version             10.2.0
-revision            4
+revision            5
 subport             libgcc10 { revision 3 }
 platforms           darwin
 categories          lang
@@ -146,7 +146,9 @@ pre-configure {
         #
         # https://trac.macports.org/ticket/53726
         # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=79885
-        configure.args-append --with-sysroot="${configure.sdkroot}"
+
+        # if the sdkroot is one of the current, rapidly changing SDKS, use the generic one
+        configure.args-append --with-sysroot="[regsub {MacOSX1[1-9]\.[0-9]+\.sdk} ${configure.sdkroot} {MacOSX.sdk}]"
     }
 
 }

--- a/lang/gcc8/Portfile
+++ b/lang/gcc8/Portfile
@@ -10,7 +10,7 @@ PortGroup xcode_workaround             1.0
 epoch               4
 name                gcc8
 version             8.4.0
-revision            2
+revision            3
 subport             libgcc8 { revision 1 }
 platforms           darwin
 categories          lang
@@ -144,7 +144,7 @@ pre-configure {
         #
         # https://trac.macports.org/ticket/53726
         # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=79885
-        configure.args-append --with-sysroot="${configure.sdkroot}"
+        configure.args-append --with-sysroot="[regsub {MacOSX1[1-9]\.[0-9]+\.sdk} ${configure.sdkroot} {MacOSX.sdk}]"
     }
 
     # TODO: Remove when base automatically creates configure.dir (2.2.1?).

--- a/lang/gcc9/Portfile
+++ b/lang/gcc9/Portfile
@@ -10,7 +10,7 @@ PortGroup           xcode_workaround             1.0
 epoch               3
 name                gcc9
 version             9.3.0
-revision            4
+revision            5
 subport             libgcc9 { revision 3 }
 platforms           darwin
 categories          lang
@@ -137,7 +137,7 @@ pre-configure {
         #
         # https://trac.macports.org/ticket/53726
         # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=79885
-        configure.args-append --with-sysroot="${configure.sdkroot}"
+        configure.args-append --with-sysroot="[regsub {MacOSX1[1-9]\.[0-9]+\.sdk} ${configure.sdkroot} {MacOSX.sdk}]"
     }
 
 }


### PR DESCRIPTION
on the newest systems, where the SDK is
changing rapidly, use a generic SDK reference

this changes MacOSX11.[0-9].sdk to MacOSX.sdk
