### PR TITLE
python ports: add 3.9 subports for py-absl, py-gast, py-grpcio, py-h5py, py-termcolor

### DIFF
--- a/python/py-absl/Portfile
+++ b/python/py-absl/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  273c9431f2642ffdf6ad5cbf8025e98f3a3d3eac \
                     sha256  673cccb88d810e5627d0c1c818158485d106f65a583880e2f730c997399bcfa7 \
                     size    110452
 
-python.versions     27 36 37 38
+python.versions     27 36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-gast/Portfile
+++ b/python/py-gast/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-gast
-version             0.3.2
+version             0.4.0
 platforms           darwin
 license             BSD
 maintainers         {emcrisostomo @emcrisostomo} openmaintainer
@@ -16,20 +16,18 @@ long_description    A generic AST to represent Python2 and Python3’s Abstract 
                     ast.parse from the standard ast module.
 
 homepage            https://github.com/serge-sans-paille/gast
-master_sites        pypi:g/gast
-distname            gast-${version}
 
-checksums           rmd160  d7a304998ddb70564acf8837cd93ce8741f864b8 \
-                    sha256  5c7617f1f6c8b8b426819642b16b9016727ddaecd16af9a07753e537eba8a3a5 \
-                    size    13657
+checksums           rmd160  2f953846e11ce313959a31b47816d56b7328faea \
+                    sha256  40feb7b8b8434785585ab224d1568b857edb18297e5a3047f1ba012bc83b42c1 \
+                    size    13804
 
-python.versions     27 35 36 37 38
+supported_archs     noarch
+
+python.versions     27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_build-append \
                         port:py${python.version}-setuptools
 
     livecheck.type      none
-} else {
-    livecheck.type      pypi
 }

--- a/python/py-grpcio/Portfile
+++ b/python/py-grpcio/Portfile
@@ -4,24 +4,22 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-grpcio
-version             1.25.0
+version             1.35.0
 revision            0
 platforms           darwin
 license             Apache-2
 maintainers         {emcrisostomo @emcrisostomo} openmaintainer
 
 description         HTTP/2-based RPC framework
-long_description    ${description}
+long_description    {*}${description}
 
 homepage            https://grpc.io/
-master_sites        pypi:g/grpcio
-distname            ${python.rootname}-${version}
 
-checksums           rmd160  253563c73d5a3923e9428defeacf2085b44c83e5 \
-                    sha256  c948c034d8997526011960db54f512756fb0b4be1b81140a15b4ef094c6594a4 \
-                    size    15358518
+checksums           rmd160  e96515543d98ea5cbb3b07e93c900065d3547102 \
+                    sha256  7bd0ebbb14dde78bf66a1162efd29d3393e4e943952e2f339757aa48a184645c \
+                    size    21166864
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_build-append    \
@@ -54,6 +52,4 @@ if {${name} ne ${subport}} {
 
     test.run            yes
     livecheck.type      none
-} else {
-    livecheck.type      pypi
 }

--- a/python/py-h5py/Portfile
+++ b/python/py-h5py/Portfile
@@ -34,17 +34,16 @@ long_description  \
 
 homepage                https://www.h5py.org
 
-python.versions         36 37 38
-python.default_version  37
+python.versions         36 37 38 39
 
 # Only check against releases.
 github.livecheck.regex      {([0-9.]+)}
 
 if {${name} ne ${subport}} {
-    depends_lib-append      port:py${python.version}-cached-property
     depends_build-append    port:py${python.version}-cython
 
-    depends_lib-append      port:py${python.version}-numpy \
+    depends_lib-append      port:py${python.version}-cached-property \
+                            port:py${python.version}-numpy \
                             port:py${python.version}-six \
                             port:py${python.version}-pkgconfig \
                             port:hdf5

--- a/python/py-termcolor/Portfile
+++ b/python/py-termcolor/Portfile
@@ -10,7 +10,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -18,9 +18,6 @@ description         ANSII Color formatting for output in terminal.
 long_description    termcolor is a Python module to format colored output in terminal.
 
 homepage            https://pypi.python.org/pypi/termcolor
-master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
-
-distname            ${python.rootname}-${version}
 
 checksums           rmd160  1555f55ff04abff3929dd86215dcd679c3c4813f \
                     sha256  1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b \


### PR DESCRIPTION
#### Description

* Add Python 3.9 subports: py-absl, py-gast, py-grpcio, py-h5py, py-termcolor
* py-gast: update to 0.4.0; remove unnecessary declarations for 'master_sites' and 'distname'
* py-grpcio: update to 1.35.0; remove unnecessary declarations for 'master_sites' and 'distname'
* py-h5py: remove unnecessary declaration 'python.default_version'
* py-termcolor: remove unnecessary declarations for 'master_sites' and 'distname'

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G2136
Xcode 9.2 9C40b

macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
