### PR TITLE
libreoffice: use system clucene

### DIFF
--- a/devel/clucene/Portfile
+++ b/devel/clucene/Portfile
@@ -7,7 +7,7 @@ PortGroup               muniversal 1.0
 
 name                    clucene
 version                 2.3.3.4
-revision                1
+revision                2
 set branch              [join [lrange [split ${version} .] 0 1] .]
 categories              devel
 platforms               darwin
@@ -33,7 +33,17 @@ patch.pre_args          -p1
 patchfiles              0001-Fix-.pc-file-by-adding-clucene-shared-library.patch
 
 patchfiles-append       patch-src-shared-CLucene-LuceneThreads.h.diff \
-                        patch-src-shared-CLucene-config-repl_tchar.h.diff
+                        patch-src-shared-CLucene-config-repl_tchar.h.diff \
+                        patch-${name}-contribs-lib.diff 
+
+post-patch {
+    # patch out installing bundled Boost headers
+    reinplace "/ADD_SUBDIRECTORY (src\\/ext)/d" CMakeLists.txt
+    system "rm -rf src/ext"
+}
+
+configure.args-append   -DBUILD_CONTRIBS_LIB=ON \
+                        -DLIB_DESTINATION=${destroot}/lib
 
 conflicts_build         ${name}
 

--- a/devel/clucene/files/patch-clucene-contribs-lib.diff
+++ b/devel/clucene/files/patch-clucene-contribs-lib.diff
@@ -1,0 +1,42 @@
+diff -NaurpBb clucene-core-2.3.3.4/CMakeLists.txt clucene-core-2.3.3.4-mod/CMakeLists.txt
+--- clucene-core-2.3.3.4/CMakeLists.txt	2011-03-17 03:21:07.000000000 +0300
++++ clucene-core-2.3.3.4-mod/CMakeLists.txt	2011-08-16 16:56:55.968268152 +0400
+@@ -163,7 +163,7 @@ IF ( BUILD_CONTRIBS )
+   SET(BUILD_CONTRIBS_LIB 1)
+ ENDIF ( BUILD_CONTRIBS )
+ IF ( BUILD_CONTRIBS_LIB )
+-  ADD_SUBDIRECTORY (src/contribs-lib EXCLUDE_FROM_ALL)
++  ADD_SUBDIRECTORY (src/contribs-lib)
+ ENDIF ( BUILD_CONTRIBS_LIB )
+ 
+ 
+diff -NaurpBb clucene-core-2.3.3.4/src/contribs-lib/CMakeLists.txt clucene-core-2.3.3.4-mod/src/contribs-lib/CMakeLists.txt
+--- clucene-core-2.3.3.4/src/contribs-lib/CMakeLists.txt	2011-03-17 03:21:07.000000000 +0300
++++ clucene-core-2.3.3.4-mod/src/contribs-lib/CMakeLists.txt	2011-08-16 17:14:13.499275499 +0400
+@@ -106,9 +106,26 @@ add_library(clucene-contribs-lib SHARED
+ )
+ TARGET_LINK_LIBRARIES(clucene-contribs-lib ${clucene_contrib_extra_libs})
+ 
++#install public headers.
++FOREACH(file ${HEADERS})
++	get_filename_component(apath ${file} PATH)
++	get_filename_component(aname ${file} NAME)
++	file(RELATIVE_PATH relpath ${CMAKE_SOURCE_DIR}/src/contribs-lib ${apath})
++	IF ( NOT aname MATCHES "^_.*" )
++		install(FILES ${file} 
++		        DESTINATION include/${relpath}
++		        COMPONENT development)
++	ENDIF ( NOT aname MATCHES "^_.*" )
++ENDFOREACH(file)
++
+ #set properties on the libraries
+ SET_TARGET_PROPERTIES(clucene-contribs-lib PROPERTIES
+     VERSION ${CLUCENE_VERSION}
+     SOVERSION ${CLUCENE_SOVERSION}
+     COMPILE_DEFINITIONS_DEBUG _DEBUG
+ )
++
++#and install library
++install(TARGETS clucene-contribs-lib 
++        DESTINATION ${LIB_DESTINATION}  
++        COMPONENT runtime )

--- a/office/libreoffice/Portfile
+++ b/office/libreoffice/Portfile
@@ -33,7 +33,6 @@ extract.only        ${main_distfile} \
 master_sites        ${main_uri}:main \
                     ${extern_uri}:opens \
                     ${addons_uri}:ucpp \
-                    ${addons_uri}:clucene-core \
                     ${addons_uri}:mythes \
                     ${addons_uri}:dtoa \
                     ${addons_uri}:abw \
@@ -53,7 +52,6 @@ distfiles           ${main_distfile}:main \
                     ${name}-dictionaries-${version}.tar.xz:dicts \
                     ${name}-translations-${version}.tar.xz:translations \
                     0168229624cfac409e766913506961a8-ucpp-1.3.2.tar.gz:ucpp \
-                    48d647fbd8ef8889e5a7f422c1bfda94-clucene-core-2.3.3.4.tar.gz:clucene-core \
                     f543e6e2d7275557a839a164941c0a86e5f2c3f2a0042bfc434c88c6dde9e140-opens___.ttf:opens \
                     dtoa-20180411.tgz:dtoa
 
@@ -73,10 +71,6 @@ checksums           libreoffice-7.1.0.3.tar.xz \
                     rmd160  dbeb7a7f8c89961ca2e544b810345d025561866b \
                     sha256  983941d31ee8d366085cadf28db75eb1f5cb03ba1e5853b98f12f7f51c63b776 \
                     size    96939 \
-                    48d647fbd8ef8889e5a7f422c1bfda94-clucene-core-2.3.3.4.tar.gz \
-                    rmd160  5acfc9c8acd167b3684cfc731a60fd9c5465cc9b \
-                    sha256  ddfdc433dd8ad31b5c5819cc4404a8d2127472a3b720d3e744e8c51d79732eab \
-                    size    2241498 \
                     f543e6e2d7275557a839a164941c0a86e5f2c3f2a0042bfc434c88c6dde9e140-opens___.ttf \
                     rmd160  b9e2cc0c836faa59eca3bfc0f24e1b790646b112 \
                     sha256  f543e6e2d7275557a839a164941c0a86e5f2c3f2a0042bfc434c88c6dde9e140 \
@@ -103,6 +97,7 @@ depends_lib-append  \
     port:boost \
     port:box2d \
     port:bzip2 \
+    port:clucene \
     port:curl \
     port:expat \
     port:gdbm \
@@ -224,6 +219,7 @@ configure.args-append  \
     --with-package-version=${version} \
     --with-parallelism=${build.jobs} \
     --with-product-name=${product_name} \
+    --with-system-clucene \
     --with-system-epoxy \
     --with-system-gpgmepp \
     --with-system-headers \
@@ -258,8 +254,6 @@ configure.args-append  \
 # This is not a mistake, despite requiring port:openssl in depends_lib. Some
 # internals still require libcrypto.
 configure.args-append --disable-openssl
-# "Your version of libclucene has contribs-lib missing."
-configure.args-append --without-system-clucene
 
 build.target    build-nocheck
 


### PR DESCRIPTION
#### Description

Please merge #9861 before this one.

<!-- Note: it is best to make pull requests from a branch rather than from master -->
- clucene: install contribs-lib (many thanks to Gentoo)
- libreoffice: use system clucene

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
