### PR TITLE
libfec: fix build for arm64 machines

### DIFF
--- a/science/libfec/Portfile
+++ b/science/libfec/Portfile
@@ -19,6 +19,9 @@ checksums rmd160 aa5f9e55f535d4ac27503effefd8d8ff3af8fd27 \
           size   130532
 revision  0
 
+
+patchfiles          patch-config-sub.diff
+
 use_autoreconf  yes
 
 configure.args-append \

--- a/science/libfec/files/patch-config-sub.diff
+++ b/science/libfec/files/patch-config-sub.diff
@@ -1,0 +1,11 @@
+--- config.sub.orig
++++ config.sub
+@@ -260,7 +260,7 @@ case $basic_machine in
+ 	# FIXME: clean up the formatting here.
+ 	vax-* | tahoe-* | i*86-* | i860-* | ia64-* | m32r-* | m68k-* | m68000-* \
+ 	      | m88k-* | sparc-* | ns32k-* | fx80-* | arc-* | c[123]* \
+-	      | arm-*  | armbe-* | armle-* | armv*-* | strongarm-* | xscale-* \
++	      | arm64-* | arm-*  | armbe-* | armle-* | armv*-* | strongarm-* | xscale-* \
+ 	      | mips-* | pyramid-* | tron-* | a29k-* | romp-* | rs6000-* \
+ 	      | power-* | none-* | 580-* | cray2-* | h8300-* | h8500-* | i960-* \
+ 	      | xmp-* | ymp-* \


### PR DESCRIPTION
Add a pattern match in config.sub so that arm64 darwin machines are
recognised.

#### Description

Fix the build of libfec to support arm64 machines.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
