### PR TITLE
inspectrum: update to 0.2.3

### DIFF
--- a/science/inspectrum/Portfile
+++ b/science/inspectrum/Portfile
@@ -6,11 +6,10 @@ PortGroup           github 1.0
 PortGroup           qt5 1.0
 PortGroup           app 1.0
 
-github.setup        miek inspectrum d6115cb458068fa64c7bbd9020bcbab3373fee0e
-version             20191102
-checksums           rmd160 d0dbbda96fe5ca060aada402d986b34c4a63b67b \
-                    sha256 5497f4357f8603634ee0a43dc4eae9997ab35436438078c4dd6b0c5f01944836 \
-                    size   109324
+github.setup        miek inspectrum 0.2.3 v
+checksums           rmd160  94082f94f5756a3241633c161c0c1188ff45a0bc \
+                    sha256  21fa1eb6d2ca81ee3c208fba776626672a8e66b0d6dce747832fa66eff6469b8 \
+                    size    109587
 revision            0
 
 # Disable livecheck as using github commit


### PR DESCRIPTION
#### Description

Update inspectrum to version 0.2.3.  The current version fails to
build with versions of Qt>5.15.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3 12C33


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
