### PR TITLE
mpich: Apply workaround on gccdevel too

### DIFF
--- a/science/mpich/Portfile
+++ b/science/mpich/Portfile
@@ -334,6 +334,13 @@ if {${name} ne ${subport} && [string first "-devel" $subport] < 0} {
             configure.fflags-append -fallow-argument-mismatch
         }
 
+        if {${cname} eq "gccdevel"} {
+            # see https://lists.mpich.org/pipermail/discuss/2020-January/005862.html
+            # see https://github.com/pmodels/mpich/issues/4300
+            # see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91556
+            configure.fflags-append -fallow-argument-mismatch
+        }
+        
         # GCC C++ always uses libstdc++
         # see https://trac.macports.org/ticket/59185
         configure.cxx_stdlib libstdc++
@@ -358,6 +365,13 @@ if {${name} ne ${subport} && [string first "-devel" $subport] < 0} {
             }
 
             if {[variant_isset gcc10]} {
+                # see https://lists.mpich.org/pipermail/discuss/2020-January/005862.html
+                # see https://github.com/pmodels/mpich/issues/4300
+                # see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91556
+                configure.fflags-append -fallow-argument-mismatch
+            }
+            
+            if {[variant_isset gccdevel]} {
                 # see https://lists.mpich.org/pipermail/discuss/2020-January/005862.html
                 # see https://github.com/pmodels/mpich/issues/4300
                 # see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91556


### PR DESCRIPTION
#### Description

Building mpich on Apple Silicon.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
Apple M1, macOS 11
