### PR TITLE
meson: update to 0.56.2

### DIFF
--- a/devel/meson/Portfile
+++ b/devel/meson/Portfile
@@ -4,9 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        mesonbuild meson 0.55.3
-
-revision            1
+github.setup        mesonbuild meson 0.56.2
+revision            0
 
 github.tarball_from releases
 license             Apache-2
@@ -15,7 +14,7 @@ maintainers         {soap.za.net:git @SoapZA} openmaintainer
 platforms           darwin
 supported_archs     noarch
 installs_libs       no
-homepage            https://mesonbuild.com/
+homepage            https://mesonbuild.com
 
 description         Meson - A high productivity build system
 long_description    Meson is a build system designed to optimize programmer productivity. \
@@ -24,14 +23,14 @@ long_description    Meson is a build system designed to optimize programmer prod
                     Valgrind, CCache and the like. It is both extremely fast, and, even more importantly, \
                     as user friendly as possible.
 
-checksums           rmd160  b1e7f12184a7a61ae8bfa7ed210af8020d531009 \
-                    sha256  6bed2a25a128bbabe97cf40f63165ebe800e4fcb46db8ab7ef5c2b5789f092a5 \
-                    size    1740465
+checksums           rmd160  50db2f70e1984c8ace05fb1655f282c5de37d08a \
+                    sha256  3cb8bdb91383f7f8da642f916e4c44066a29262caa499341e2880f010edb87f4 \
+                    size    1794847
 
 # as of verison 0.45.0,requires python 3.5 or better
 
-python.versions         38
-python.default_version  38
+python.versions         39
+python.default_version  39
 python.link_binaries    no
 
 depends_build-append \
@@ -52,9 +51,6 @@ if {${os.platform} eq "darwin" && ${os.major} <= 10} {
                     remove-Wl,-no_weak_imports.patch
 }
 
-# https://github.com/mesonbuild/meson/pull/7871
-patchfiles-append   patch-meson-powermacintosh.diff
-
 # https://github.com/mesonbuild/meson/issues/6187
 patchfiles-append   patch-meson-32bit-apple.diff
 
@@ -70,6 +66,9 @@ platform darwin 8 {
                         size    1740465
 
     patchfiles-append patch-meson55-tiger-no-rpath-fix.diff
+
+    # https://github.com/mesonbuild/meson/pull/7871
+    patchfiles-append   patch-meson-powermacintosh.diff
 }
 
 # add a search path for crossfiles in our prefix

--- a/devel/meson/Portfile
+++ b/devel/meson/Portfile
@@ -29,7 +29,7 @@ checksums           rmd160  50db2f70e1984c8ace05fb1655f282c5de37d08a \
 
 # as of verison 0.45.0,requires python 3.5 or better
 
-python.versions         39
+python.versions         36 37 38 39
 python.default_version  39
 python.link_binaries    no
 
@@ -65,10 +65,10 @@ platform darwin 8 {
                         sha256  6bed2a25a128bbabe97cf40f63165ebe800e4fcb46db8ab7ef5c2b5789f092a5 \
                         size    1740465
 
-    patchfiles-append patch-meson55-tiger-no-rpath-fix.diff
-
     # https://github.com/mesonbuild/meson/pull/7871
     patchfiles-append   patch-meson-powermacintosh.diff
+
+    patchfiles-append patch-meson55-tiger-no-rpath-fix.diff
 }
 
 # add a search path for crossfiles in our prefix


### PR DESCRIPTION
- switch to Python 3.9 as that is now the MacPorts default Python
  version
- remove powermacintosh patch, changes are present upstream

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
