### PR TITLE
samurai: update to 1.2

### DIFF
--- a/devel/samurai/Portfile
+++ b/devel/samurai/Portfile
@@ -1,14 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
+PortGroup           github   1.0
+PortGroup           makefile 1.0
 
-github.setup        michaelforney samurai 0.7
-categories          devel
-platforms           darwin
-maintainers         nomaintainer
-license             Apache-2
-installs_libs       no
+github.setup        michaelforney samurai 1.2
+revision            0
 
 description         ninja-compatible build tool written in C.
 
@@ -20,21 +17,28 @@ long_description    samurai (samu) is a compatible replacement ninja build tool 
                     It is feature-complete and supports most of the same options as ninja. \
                     The port provides the native `samu` command and a symlink so it can be called \
                     as `ninja` by standard build systems.
+
 conflicts           ninja
 
-checksums           rmd160  dd72603a03490a50f378ef228d1d86f3238ca0b1 \
-                    sha256  41ca07134e0ee1dc5f0f8f83a432f8c285cb1615508cb9dc2b47290c6e0c3943 \
-                    size    28217
-
+categories          devel
+platforms           darwin
+maintainers         nomaintainer
+license             Apache-2
 installs_libs       no
-use_configure       no
 
-build.pre_args-delete all
+checksums           rmd160  77ec117bd14e2dbbf57aa016ed1973990eb2c368 \
+                    sha256  ddb3725e58bb4f8f645bf8a4f6a8d01c650999a13fc88c9c5f5037e327842c22 \
+                    size    32540
+
+patch {
+    reinplace "s|/usr/local|${prefix}|g" ${worksrcpath}/Makefile
+}
+
 build.env-append    CC=${configure.cc} \
                     "CFLAGS=${configure.cflags}" \
                     "LDFLAGS=${configure.ldflags}"
-destroot.post_args-append \
-                    PREFIX=${prefix}
+
+build.target        samu
 
 post-destroot {
     ln -s samu ${destroot}${prefix}/bin/ninja


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
