### PR TITLE
Gildas: update to 202102a

### DIFF
--- a/science/gildas/Portfile
+++ b/science/gildas/Portfile
@@ -5,7 +5,7 @@ PortGroup           compilers 1.0
 PortGroup           active_variants 1.1 
 
 name                gildas
-version             202101a
+version             202102a
 set my_version      [string tolower [clock format [clock scan 2000-[string range ${version} 4 5]-10] -format %b]][string range ${version} 2 3][string range ${version} 6 end]
 categories          science
 platforms           darwin
@@ -30,9 +30,9 @@ master_sites        https://www.iram.fr/~gildas/dist/ \
 distname            ${name}-src-${my_version}
 use_xz              yes
 
-checksums           rmd160  ee2436fe2e28d0fada5601673d77cf0535d47ea1 \
-                    sha256  07962cd5e43a672f07e2d37e0a9cf6b1ad9cb1be22299c8e272adcc242cb876f \
-                    size    42942192
+checksums           rmd160  68c9a6ccdc18e25ff1af9822af47adbf3d2a9170 \
+                    sha256  a7d5ac991e3f506a698cbe689ff403a2d8ce4c08c68fb439b8d3a5f66b8a9014 \
+                    size    42941124
 
 patch.pre_args      -p1
 patchfiles          patch-admin-Makefile.def.diff \


### PR DESCRIPTION

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 11.1 20C69
Xcode: xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
