### PR TITLE
KeePassXC: update to version 2.6.4

### DIFF
--- a/security/KeePassXC/Portfile
+++ b/security/KeePassXC/Portfile
@@ -20,7 +20,7 @@ platforms               darwin
 license                 GPL-2+
 license_noconflict      openssl
 
-github.setup            keepassxreboot keepassxc 2.6.3
+github.setup            keepassxreboot keepassxc 2.6.4
 revision                0
 github.tarball_from     releases
 distname                keepassxc-${version}-src
@@ -29,12 +29,12 @@ distfiles-append        ${distname}${extract.suffix}.sig
 
 # See keepassxc-${version}-src.tar.xz.DIGEST on upstream GitHub releases page for SHA256 sums
 checksums               ${distname}${extract.suffix} \
-                        rmd160  19905c6bbe4cb2aa8f049944a3a820d2328ff287 \
-                        sha256  e7e0b6ed8f3881c5b9579074bc3cde3991b28c1a3d1c852c46f2b7930a10f7d1 \
-                        size    7562816 \
+                        rmd160  cfc515bfcda0c54c132ea44f6a2374aa2b1e0b37 \
+                        sha256  e536e2a71c90fcf264eb831fb1a8b518ee1b03829828f862eeea748d3310f82b \
+                        size    7575164 \
                         ${distname}${extract.suffix}.sig \
-                        rmd160  e9fae371c739f35467d44ada579a9681b15f369f \
-                        sha256  2df21e996386e34d1a305070159d9b9abd33e5b5b72461a6ff768ee09df7ffd3 \
+                        rmd160  127e840b31666ecfd44dce4124f21cc48231cf13 \
+                        sha256  849367d10f6ca0936f130c4d091e10f422c863ee5088439a2b13bcc58dff8937 \
                         size    499
 
 gpg_verify.use_gpg_verification \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G7016
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
