### PR TITLE
ocaml-doc: update to 4.08

### DIFF
--- a/lang/ocaml-doc/Portfile
+++ b/lang/ocaml-doc/Portfile
@@ -1,7 +1,7 @@
 PortSystem 1.0
 
 name                ocaml-doc
-version             4.01
+version             4.08
 license             Permissive
 platforms           darwin
 maintainers         nomaintainer
@@ -13,8 +13,9 @@ homepage            https://ocaml.org
 master_sites        http://caml.inria.fr/pub/distrib/ocaml-${version} \
                     ftp://ftp.inria.fr/INRIA/Projects/cristal/ocaml/ocaml-${version}
 distname            ocaml-${version}-refman-html
-checksums           rmd160  0cfdd75eb93aa637fe9f364e854a2c51cfc1f8c6 \
-                    sha256  01019c8f8a29a8a7f422e090704b666ade2a007d57ea9412285f88f716656001
+checksums           rmd160  249d58ef866e9bae7ada66bbca53684f8015a392 \
+                    sha256  7e27bfb9e45b1618ab7c8461cb6c6244b006125593475c87ba49dd09746b5e77 \
+                    size    1704609
 
 set docdir          ${prefix}/share/doc/${name}-${version}
 


### PR DESCRIPTION
Matches current Macports version of OCaml (was 4.01).

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.4 12D4e
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
