### PR TITLE
dav1d: update to 0.8.1

### DIFF
--- a/multimedia/dav1d/Portfile
+++ b/multimedia/dav1d/Portfile
@@ -7,7 +7,7 @@ PortGroup           muniversal 1.0
 name                dav1d
 # Please increase the revision of ffmpeg and ffmpeg-devel whenever
 # dav1d's version is updated.
-version             0.8.0
+version             0.8.1
 revision            0
 categories          multimedia
 platforms           darwin
@@ -21,12 +21,15 @@ long_description    dav1d is an AV1 decoder that is open-source, cross-platform 
 homepage            https://www.videolan.org/projects/dav1d.html
 master_sites        https://code.videolan.org/videolan/dav1d/-/archive/${version}/
 distname            ${name}_${version}
-checksums           rmd160  5f9a42eb55ad1a6fcc5c7f8bb77354cf628a81c4 \
-                    sha256  f95acff2aa6c68f7f0d3b9acc8993aed3baed0aef5e7a84f541bdb579005465f \
-                    size    668924
+checksums           rmd160  118e9b354d3a86d4c1da8ff69802af6477646281 \
+                    sha256  eebe6b748c5afc4f45253a3d60de45a50cf34126410be6cb7901324b796c9229 \
+                    size    674922
 use_bzip2           yes
 
-depends_build-append  port:nasm
+# nasm is not needed on arm64 platforms
+if { ${build_arch} in "i386 x86_64" || [variant_isset universal] } {
+    depends_build-append  port:nasm
+}
 
 configure.args-append \
                     -Denable_tests=false


### PR DESCRIPTION
- bump associated ports (ffmpeg, ffmpeg-devel, mpv)

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
