### PR TITLE
freac,boca: add minimum macOS version

### DIFF
--- a/audio/boca/Portfile
+++ b/audio/boca/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           makefile 1.0
+PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        enzo1982 boca 1.0.3 v
 github.tarball_from releases
@@ -31,4 +32,5 @@ depends_lib         port:expat \
 patchfiles          patch-set-install-path-runtime.diff \
                     patch-set-install-path-components.diff
 
-makefile.prefix_name    prefix
+makefile.prefix_name        prefix
+compiler.blacklist-append   {clang < 600.0.57}


### PR DESCRIPTION
#### Description
Abort installation for freac and boca if OS X version is < 10.9. 
Boca fails with compilation errors for OS X < 10.9. freac depends on boca.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
