### PR TITLE
micronaut: update to 2.3.1

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       java 1.0
 
-github.setup    micronaut-projects micronaut-starter 2.3.0 v
+github.setup    micronaut-projects micronaut-starter 2.3.1 v
 revision        0
 name            micronaut
 categories      java
@@ -53,9 +53,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  1a3ecf8b77d145d87a503258a87becab4a8e85fe \
-                sha256  5e725fad841b0020502510e56e039809c8a88597cc71a49ff386fabc01451db6 \
-                size    19495093
+checksums       rmd160  46ec806fc4d21e44a643889a5526537602aacfdc \
+                sha256  4edab7992e6f3b0f8d9f784f76f7c00d75434ef18b49ea80a35f97c12a8f2d63 \
+                size    19516030
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 2.3.1.

###### Tested on

macOS 11.1 20C69
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?