### PR TITLE
oauth2-proxy: update to 7.0.0

### DIFF
--- a/security/oauth2-proxy/Portfile
+++ b/security/oauth2-proxy/Portfile
@@ -1,14 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
-PortGroup               github 1.0
+PortGroup               golang 1.0
 
-github.setup            oauth2-proxy oauth2-proxy 6.1.1 v
+go.setup                github.com/oauth2-proxy/oauth2-proxy 7.0.0 v
 revision                0
-
-categories              security net
-license                 MIT
-platforms               darwin
 
 homepage                https://oauth2-proxy.github.io/oauth2-proxy
 
@@ -19,12 +15,12 @@ long_description        A reverse proxy and static file server that provides \
                         authentication using Providers (Google, GitHub, and \
                         others) to validate accounts by email, domain or group.
 
+categories              security net
+license                 MIT
+platforms               darwin
+
 maintainers             {gmail.com:herby.gillot @herbygillot} \
                         openmaintainer
-
-checksums               rmd160  7c0ed4bb858f0e413eaee344e893e79cf15a98c9 \
-                        sha256  b09519dfc2b7b8f3e55317edf1094095de7a36f40a046873d5b5ebda4877a80a \
-                        size    430508
 
 set o2p_conf_dir        ${prefix}/etc/${name}
 set o2p_log_dir         ${prefix}/var/log/${name}
@@ -39,9 +35,6 @@ set o2p_user            oauth2proxy
 build.cmd               make
 build.pre_args          VERSION=${version}
 build.args              ${name}
-
-depends_build           port:go
-use_configure           no
 
 add_users               ${o2p_user} \
                         group=${o2p_user} \
@@ -65,6 +58,14 @@ post-extract {
 
     reinplace "s|@LOGFILE@|${o2p_log_file}|g" \
         ${workpath}/org.macports.${name}.plist
+
+    # Modify the Makefile to disable fetching dependencies during build
+    reinplace {s|GO111MODULE=on|GO111MODULE=off|g} ${worksrcpath}/Makefile
+
+    # Modify the Makefile to build the current worksrcpath rather than
+    # referencing the project's go module specifically.
+    reinplace -E {s|(.*build.*) github.com/oauth2-proxy/oauth2-proxy/v7(.*)|\1 .\2|} \
+        ${worksrcpath}/Makefile
 }
 
 
@@ -102,3 +103,425 @@ notes "
 
     To stop and remove the service, do: \$ sudo port unload ${name}
 "
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  c7f4f190a21cf1daf45a72ca9669f16e19def66a \
+                        sha256  cb4715525d3a5059ef972b87cb2f1da2b89410300d218141da22bd298b962675 \
+                        size    722449
+
+go.vendors          k8s.io/klog \
+                        repo    github.com/kubernetes/klog \
+                        lock    v2.4.0 \
+                        rmd160  02ff48e3980539c788767bc98b52836d43eb1f32 \
+                        sha256  8b377fdcb6f9b0799b0aefaafd8b91248fb8aed76f62d7a56fab62d2baf1923f \
+                        size    42281 \
+                    k8s.io/gengo \
+                        repo    github.com/kubernetes/gengo \
+                        lock    83324d819ded \
+                        rmd160  c4eaf2be43b201ce9a2d54b0dfad387fb2e32ecf \
+                        sha256  3a818197b4d277593a2c3cd3a730a24d7708fc5bcaf0c5e751a7a6c5a1354e4d \
+                        size    93254 \
+                    k8s.io/apimachinery \
+                        repo    github.com/kubernetes/apimachinery \
+                        lock    v0.19.3 \
+                        rmd160  cb0daa395df6c8326f1b3b9eb4ab59b12643e10c \
+                        sha256  68c1a3875be4331b180764a3fb3a01377be7a27c20186023e6d20da740825773 \
+                        size    538650 \
+                    gopkg.in/yaml.v3 \
+                        lock    9f266ea9e77c \
+                        rmd160  06dca2ede07b2f31c515b4711fbebc1d5359b5e4 \
+                        sha256  e70dd42fb30b7b2d0129c5cdf0e079caaf5602cab24081fdac830ec01204fa59 \
+                        size    86890 \
+                    gopkg.in/yaml.v2 \
+                        lock    v2.3.0 \
+                        rmd160  2f8fa56d8a413b6288132eeb7f0d7c64d27d877f \
+                        sha256  a8d1a8bc88239d25507456380b47d59ae3683d4a5f4336da4892db1ce026615f \
+                        size    72838 \
+                    gopkg.in/tomb.v1 \
+                        lock    dd632973f1e7 \
+                        rmd160  ae07f5ddbbc6afc772d6dc5273bb72eaba50529a \
+                        sha256  91c562a4e31c89d13e5391143ff653231fc2d80562743db89ce2172ad8f81008 \
+                        size    3636 \
+                    gopkg.in/square/go-jose.v2 \
+                        lock    v2.4.1 \
+                        rmd160  13157c27eb1d33007764973b71da5fb883526f4e \
+                        sha256  b33e6c447c948b16057bb16eebdaa5b446e6489f0d0677a7cfae627ef8d500e4 \
+                        size    304102 \
+                    gopkg.in/natefinch/lumberjack.v2 \
+                        lock    v2.0.0 \
+                        rmd160  931b7db0e3893f0f6515a8113e7c35aa3e45c9da \
+                        sha256  1f7796430424a4dd4c74f73929e7e82384672f6c2c311c5b671e6c36353780f3 \
+                        size    12640 \
+                    gopkg.in/ini.v1 \
+                        lock    v1.51.0 \
+                        rmd160  fb3d5484b20da6eee5d89fcf693f9fb94e834d5d \
+                        sha256  f7760de2e1e32ed627a3526d3aedafd2c979a40208fdf871fff032e4cb969d98 \
+                        size    43548 \
+                    gopkg.in/check.v1 \
+                        lock    41f04d3bba15 \
+                        rmd160  1e5543a8e6a3159296ee63e28cbde9931a04f6b3 \
+                        sha256  c41575a73d10809f89b05ef9e783f2d53facdc6573697770d30efb05a9d2dc28 \
+                        size    31612 \
+                    google.golang.org/protobuf \
+                        repo    github.com/protocolbuffers/protobuf-go \
+                        lock    v1.24.0 \
+                        rmd160  f07fa7c6929c6859609eb530e11b1179ed4510a2 \
+                        sha256  0c63461d06e3d1f4a916000b953619f78aca6c9aacdbb1b426f851ab5eb9e66a \
+                        size    1227955 \
+                    google.golang.org/grpc \
+                        repo    github.com/grpc/grpc-go \
+                        lock    v1.27.0 \
+                        rmd160  c24620168088a8fe5918df6db7ef637bc11cf46c \
+                        sha256  8bacd20d8d50d5d0251c5de36e499932fa4ee8b4e9fcd190cf85155942992504 \
+                        size    825979 \
+                    google.golang.org/genproto \
+                        repo    github.com/googleapis/go-genproto \
+                        lock    cb27e3aa2013 \
+                        rmd160  f3c94d0c3129c395d89a2a7d982eb864f961dfea \
+                        sha256  3da27c47ecfe5e05f805d0b239e4aa5ecfbdbc666cf258a1bb9f415dab28faef \
+                        size    9293290 \
+                    google.golang.org/appengine \
+                        repo    github.com/golang/appengine \
+                        lock    v1.6.5 \
+                        rmd160  07930ae377345a90ef1f84200cdb2c292b192c60 \
+                        sha256  544d882b8fc91ac0813e239d9602034bae8d9b5b7fd1e5872323680a4f493bdd \
+                        size    332918 \
+                    google.golang.org/api \
+                        repo    github.com/googleapis/google-api-go-client \
+                        lock    v0.20.0 \
+                        rmd160  5be2893b4245c39cf29052376be0dcdcdd4feec9 \
+                        sha256  3e8bb3f9e77fddc2a45498cbcfd1facee652c20e2d2d3878da794beae7def2b5 \
+                        size    14019305 \
+                    golang.org/x/xerrors \
+                        lock    9bdfabe68543 \
+                        rmd160  eee9929ac1c0380402c45b388077c5c505f13311 \
+                        sha256  dc1be1d7efb43643507e87352ae7161883c48cb5116a20a1739ab93ab558bccf \
+                        size    13661 \
+                    golang.org/x/tools \
+                        lock    26f46d2f7ef8 \
+                        rmd160  7c5aeab40463b73ef6057f76242cfdfd8b888ebb \
+                        sha256  83e008a5160eebc98b3b2f43c4d9790d6c2d6df562b932d4b6132eab02b90aff \
+                        size    2432701 \
+                    golang.org/x/text \
+                        lock    v0.3.3 \
+                        rmd160  babfa547ba9a9dab7fe08fa5543f1d8e7ae00301 \
+                        sha256  1c4a8c12295d484e0360d8e010ebc4b8a9a05aa2a07c10c3d3e5b17aa063f0db \
+                        size    7745597 \
+                    golang.org/x/sys \
+                        lock    ed371f2e16b4 \
+                        rmd160  ae75694302b71e9782dd712f95977a03843cbc8a \
+                        sha256  a29535ff5e884937331b1061e1b1874a2cf040d7d9bd6bc57401bebe4aac65dc \
+                        size    1054584 \
+                    golang.org/x/oauth2 \
+                        lock    bf48bf16ab8d \
+                        rmd160  c1d307776adc90ce1a323b0a6cacab759bf1671e \
+                        sha256  ff3e74cdfe9c0b13d9d8e6f04551460efc01ca58b2332ebeb6f93b6c09c789bc \
+                        size    47023 \
+                    golang.org/x/net \
+                        lock    ab3426394381 \
+                        rmd160  e74cee73965d58ff027e1ba0e0131f9630125409 \
+                        sha256  49fe6598268f2cc9b50dea06a00f5c03c71a54d2893ebf9fbfa193486b65cd83 \
+                        size    1177682 \
+                    golang.org/x/mod \
+                        lock    v0.2.0 \
+                        rmd160  d3e7249fdb5bbf52bae173899cf440a86af34415 \
+                        sha256  8dc23eb611e895afa9bae9ae942e99c95c9b567f7682ae0e66fdc9f4c17c36e5 \
+                        size    91781 \
+                    golang.org/x/crypto \
+                        lock    75b288015ac9 \
+                        rmd160  d0df189672060fb880ac1bd440bfe94a5fc3e6d9 \
+                        sha256  290dc7a301e9ad139c8a5bd91bc0fd9936c60e2d7e7f9361eb3766e8b5947e86 \
+                        size    1729939 \
+                    go.opentelemetry.io/otel \
+                        repo    github.com/open-telemetry/opentelemetry-go \
+                        lock    v0.11.0 \
+                        rmd160  dd00c59578b8af9893d5cda8d8e597ecf9597d03 \
+                        sha256  dd1e209262c197119b560a59e7a1113be9b20ca9de25b4e466c73cd1f10972de \
+                        size    429792 \
+                    go.opencensus.io \
+                        repo    github.com/census-instrumentation/opencensus-go \
+                        lock    v0.21.0 \
+                        rmd160  0359becd5ab02b633f7b7cf70f686abf161b9f6f \
+                        sha256  abc4402e2783e1420dc07bc339825e87e8ffcc990876c917ea19de56fde2d1c6 \
+                        size    161466 \
+                    github.com/yuin/gopher-lua \
+                        lock    ab39c6098bdb \
+                        rmd160  cb9f019eb9dcae8f8535eea12ddcce50c197758a \
+                        sha256  19afead308e71eef0d2aeb4fd31cdbb6bc19347692577eb5bdb0a4987280afe2 \
+                        size    161554 \
+                    github.com/yhat/wsutil \
+                        lock    1d66fa95c997 \
+                        rmd160  2ebddcd94a42405cd6fde89d669140cd9679862f \
+                        sha256  9d5376cb46ce28eb091f80868eb623aa12090b73ad84249d9c4bc64869a24268 \
+                        size    11166 \
+                    github.com/vmihailenco/tagparser \
+                        lock    v0.1.1 \
+                        rmd160  01df8f852a8ae594cbc8c05fe80dec5e122f423b \
+                        sha256  92e86149a8bf43f119f72650f54e452690117c9d66d9019691dc0304de594f52 \
+                        size    3656 \
+                    github.com/vmihailenco/msgpack \
+                        lock    v4.3.11 \
+                        rmd160  5a9ce8aa6f988b18c12c193830ed111f857ba61d \
+                        sha256  211014282f1f1d8f9b962e91e6e645926e5d88bb87213476614450f85e053977 \
+                        size    31486 \
+                    github.com/subosito/gotenv \
+                        lock    v1.2.0 \
+                        rmd160  359083733ab5db2a09169c8d6d070b03463aef60 \
+                        sha256  01fc25c8959371d006a0460132b72710ac120d5400fceebbc1d321d2e9bcd4a0 \
+                        size    7375 \
+                    github.com/stretchr/testify \
+                        lock    v1.6.1 \
+                        rmd160  7e5b798212a8f15cd58a63985ae0b928eede8e6b \
+                        sha256  44d77d9b5c1dc08fa710eac9bb324898210660458085cdf965b78a39b1010f2a \
+                        size    84248 \
+                    github.com/spf13/viper \
+                        lock    v1.6.3 \
+                        rmd160  07642d1e44e2d8d792d90e9f4a64743e893dd52a \
+                        sha256  4ee7b7c00545dc6f7247196aa2d2a21082147b4d6ca182625dcdc45189905f08 \
+                        size    52323 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.5 \
+                        rmd160  2ce81608a38c6f383a35bccd24d64361df5828c9 \
+                        sha256  7f41acdcba65b1fab5b9b633947a139f9915b60f94bdab486cdbe9d90c54f61e \
+                        size    50815 \
+                    github.com/spf13/jwalterweatherman \
+                        lock    v1.0.0 \
+                        rmd160  364fd0d61e94bd3651b5506d61f0e9652d6e33a3 \
+                        sha256  e70eb4dbab0603ad35c32bf89cefd595b2d6d56d66695866bfad2350db939404 \
+                        size    6405 \
+                    github.com/spf13/cast \
+                        lock    v1.3.0 \
+                        rmd160  26b82e9734f643bc70be8c73742d4a4f514b6dd2 \
+                        sha256  f2913fc10731a578c016701bd10e6a267c299b94e69d8362d258ce8482d14faf \
+                        size    11086 \
+                    github.com/spf13/afero \
+                        lock    v1.1.2 \
+                        rmd160  dc2ff3aa582c3dc782e3c062e35b65564bfc44e5 \
+                        sha256  08dca858dce5a4336ca385028ff38e0fa6a9f064f5c874fdabe2096a34b6fc91 \
+                        size    45324 \
+                    github.com/smartystreets/goconvey \
+                        lock    v1.6.4 \
+                        rmd160  a3dfad6131b94d809efad84d30ce45828c6da756 \
+                        sha256  a03963296bb6d031934a651c1e637e8ab2ce9604ce6a16c158ff551e44e7ba79 \
+                        size    1478824 \
+                    github.com/smartystreets/assertions \
+                        lock    b2de0cb4f26d \
+                        rmd160  32d7082172ea8c4a03119f3ffb803f8aad9744ce \
+                        sha256  469875871db96f87e62f76f0bfc4b3b0b9e4761c2a14d4ce12f246797a7c342c \
+                        size    52177 \
+                    github.com/pquerna/cachecontrol \
+                        lock    1555304b9b35 \
+                        rmd160  0a0f37cba23e467f89c717d93a37c5b34005b64e \
+                        sha256  51832af12991acba3c87afe472abf3e0c44fdc152f88d53d53db36eb2f63eec2 \
+                        size    18999 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/pierrec/lz4 \
+                        lock    v2.5.2 \
+                        rmd160  1c544bbc624aa38a9c7626a09f2826deb1670f08 \
+                        sha256  b8c11390dfa2b7e1e7ec7daa056079c8eceebe9855eade7d4153505648c573d5 \
+                        size    20509730 \
+                    github.com/pelletier/go-toml \
+                        lock    v1.2.0 \
+                        rmd160  8d91b6485f373ccaa894abcb3bd53839e55b9057 \
+                        sha256  0a9503f2b53444e0c3ea960d18febe14d472c16279844f231994c5ccb81dbdff \
+                        size    57515 \
+                    github.com/onsi/gomega \
+                        lock    v1.10.2 \
+                        rmd160  92d7d47a1c603925db12f33dba05742d39aa71df \
+                        sha256  c2c42c237da5a1ce8f8f6da2c0eb61ce355eb4cab1f74df57c3d38a65fe210a1 \
+                        size    97371 \
+                    github.com/onsi/ginkgo \
+                        lock    v1.14.1 \
+                        rmd160  9e5907d0b53c2e4a5220691a4aea91b7d7116577 \
+                        sha256  64935ee71bdd64314e857bb5d50a042e273ad3e5c99f413ceb26143438356f36 \
+                        size    145879 \
+                    github.com/oauth2-proxy/tools/reference-gen \
+                        lock    56ffd7384404 \
+                        rmd160  02f2685b6b925e01e51e18383e0025d7297a54e5 \
+                        sha256  f92d7d4ce670e1020dca16b0ea64bb609444893397b18875c08a7158d7f64563 \
+                        size    8483 \
+                    github.com/nxadm/tail \
+                        lock    v1.4.4 \
+                        rmd160  33d7373bd1b164159b9032fc8595bb09b25598f6 \
+                        sha256  16d8773e0be69469d3c296ee785bbef433c3442defb68760682cdbcf80ba40ee \
+                        size    1238830 \
+                    github.com/mitchellh/mapstructure \
+                        lock    v1.1.2 \
+                        rmd160  a4e01781ea5bb0c987e18e8e450c8f1023d5a857 \
+                        sha256  9c1076f5a8e923d028cb65c36143f3b1478cbaa4420e2e8f332719edc2fc4f71 \
+                        size    20992 \
+                    github.com/mbland/hmacauth \
+                        lock    44256dfd4bfa \
+                        rmd160  4604e51dd650b22eac1fcbcd4052c784267abdd6 \
+                        sha256  26111e6d13232b766b7b935c36838c361858dd81734b3ef2da104ee0ef482ffb \
+                        size    6203 \
+                    github.com/matryer/is \
+                        lock    v1.2.0 \
+                        rmd160  fc796e3cd470d513b3286d5ab802132eca806fb8 \
+                        sha256  f0ed0ce99a56aaa4c7ecfa874a9ce4471833ddeff41c5d7dd16c6ae99f39f20a \
+                        size    251064 \
+                    github.com/magiconair/properties \
+                        lock    v1.8.1 \
+                        rmd160  c9768d4c6f488f56d9451cfe00898b00fa185e5a \
+                        sha256  ba7ce8c50bdc43c67c5fd97e741ae49c9279c0d42b8e79f978e6e0cd814fec7c \
+                        size    29730 \
+                    github.com/kr/text \
+                        lock    v0.1.0 \
+                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
+                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
+                        size    8691 \
+                    github.com/kr/pretty \
+                        lock    v0.2.0 \
+                        rmd160  45bbf0be7a3328e33186718ab12cb506c0f5a073 \
+                        sha256  35fb1f8788552fc7df2120bc06dd34e00aa3284d23c250fc1f143eef51d08586 \
+                        size    8762 \
+                    github.com/justinas/alice \
+                        lock    v1.2.0 \
+                        rmd160  19db417afc916532911047c356d895a2a86c321e \
+                        sha256  affa6bb2d87a98a4df3dd87e44bcf44f434cacb2b9a6c29937e1bbce5207fac7 \
+                        size    4574 \
+                    github.com/jtolio/gls \
+                        lock    v4.20.0 \
+                        rmd160  8e721b1aa6de0606caa5a2a038ddd53a0d05d7b4 \
+                        sha256  6f98dcae4c326cbfb0400e6a01604511e544957ea88494e979ace881e2058cbb \
+                        size    7308 \
+                    github.com/hashicorp/hcl \
+                        lock    v1.0.0 \
+                        rmd160  ad8d0b523bb708fd6ae77df8bb414c103a75aa92 \
+                        sha256  4fc0e87ac9d3d6cd042f044df2db2703bed569051fb8c179d505edeb4433e96e \
+                        size    70636 \
+                    github.com/hashicorp/golang-lru \
+                        lock    v0.5.1 \
+                        rmd160  dd02645a94c90ef435ed1662531754761e4a4d8b \
+                        sha256  d9393f70b3fcd62d078e0ceefe9f6605d5086a986ba6cd7ed268b980eb1b6bf4 \
+                        size    12986 \
+                    github.com/gopherjs/gopherjs \
+                        lock    0766667cb4d1 \
+                        rmd160  fe92e39110b5c188dcce98abb3b9aa1b64d68f94 \
+                        sha256  abe56698d0855027a1f6030a44924895d781b19526aa8f9b3ef49ed4199f7c57 \
+                        size    217261 \
+                    github.com/googleapis/gax-go \
+                        lock    v2.0.5 \
+                        rmd160  51d16b7dba4977419402a29e93c4526bf2828937 \
+                        sha256  56ab19319dfb8cc80bc1a437317f6d861ca3597c986d9d5fd4de4523ef6fc8e8 \
+                        size    15336 \
+                    github.com/google/uuid \
+                        lock    v1.1.1 \
+                        rmd160  69112e9735ecc1d5360a3cc31531f8be661a007f \
+                        sha256  70be7dec37826f2cbe13acfe534ce74cbb2107c1e348eb4e8365f7d900002e40 \
+                        size    13552 \
+                    github.com/google/go-cmp \
+                        lock    v0.5.1 \
+                        rmd160  f557725ca7d868edfc5d70b1d69bd33570ef5c81 \
+                        sha256  e2c3dc6f5e6e07e5034cad315b76919ee7a7dbdf122ff76eeabd2d8b719a3d57 \
+                        size    99629 \
+                    github.com/gomodule/redigo \
+                        lock    v1.8.1 \
+                        rmd160  0493224a1c8876ea996db75fa06d7db3fba4f55f \
+                        sha256  a57516c072b186703b8d302d27ff78f5475b007aee6e31bd38e05c601f400730 \
+                        size    47584 \
+                    github.com/golang/protobuf \
+                        lock    v1.4.2 \
+                        rmd160  fbf4477bc008421fde463d79f7bc54a36de91db2 \
+                        sha256  206d74f8fd066bb178135ee9c092e986f8a1e1104df242e148e99e5a839e4ef2 \
+                        size    171802 \
+                    github.com/golang/glog \
+                        lock    23def4e6c14b \
+                        rmd160  b5bd9166cd1e073a035b5bbd3c4d9febf2c917a7 \
+                        sha256  2826d20759090e909ba0f8771def236ad6433fc3e44bdc28374b309efe3e57cf \
+                        size    19662 \
+                    github.com/go-redis/redis \
+                        lock    v8.2.3 \
+                        rmd160  8c9c1d8a17ce9b447378125cce4209c5dc76a156 \
+                        sha256  aaa0d0f656773459e4d2ec65e35768de8ac745987b05dd2ae22e72f2a3156b13 \
+                        size    119579 \
+                    github.com/go-logr/logr \
+                        lock    v0.2.0 \
+                        rmd160  40a88db949dfa2a245a79414fea435b6734830be \
+                        sha256  0711805af538385f680e8af5c62f318a9038f7434143d0e36175ef38a31e0c8d \
+                        size    12290 \
+                    github.com/ghodss/yaml \
+                        lock    25d852aebe32 \
+                        rmd160  fb2fb29a0c5b95e485a6e7bed63dbc165110b13a \
+                        sha256  e025e463df43a9f16843ff833e05d66ec4e701e11fb2079c4a169744e5bbede9 \
+                        size    14358 \
+                    github.com/fsnotify/fsnotify \
+                        lock    v1.4.9 \
+                        rmd160  4660b5721da8aea4c890786e49d7cec39c2e04d3 \
+                        sha256  7920cf1e5ccf268962fcff0b501398ed6c28ed75b1e1281fb17b19a8b0e4db5c \
+                        size    31910 \
+                    github.com/frankban/quicktest \
+                        lock    v1.10.0 \
+                        rmd160  d9b4ed64236049b4f48d02d4a43edb9fa4ce682c \
+                        sha256  0cc8f34a2dfa1e1a4e180d9d55ef759432fba27cb99ecc67603be70f62436aaf \
+                        size    33174 \
+                    github.com/dgryski/go-rendezvous \
+                        lock    9f7001d12a5f \
+                        rmd160  4d1eeaa165f0be9013b55c1c7026567e611f9098 \
+                        sha256  19e5550cfc67862f16c4129065fab02876c787fe2fc628452a01735e7b2c6fc2 \
+                        size    1708 \
+                    github.com/dgrijalva/jwt-go \
+                        lock    v3.2.0 \
+                        rmd160  7441af83a55ddda618b3d1f813bfc9e2feaad17f \
+                        sha256  de52f4d01154b4fdaf32dedb5f98de6ea19f3ad69307f388a5b8a562a8948078 \
+                        size    36979 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/coreos/go-oidc \
+                        lock    v2.2.1 \
+                        rmd160  d91319f3d8e0a3c82d9a2ee16e0fc101208c253f \
+                        sha256  cb7f8f625e511034f24505efeee92be610f2cbd957114d9c591aea9f29afa22c \
+                        size    24141 \
+                    github.com/cespare/xxhash \
+                        lock    v2.1.1 \
+                        rmd160  0c0da0840864215209db2afcd2ee92a52ca2d4d1 \
+                        sha256  7416baf9eeefe07e3c50c57826d839cdbba125ea0a6d74af378e865df4f25e00 \
+                        size    9300 \
+                    github.com/bmizerany/assert \
+                        lock    b7ed37b82869 \
+                        rmd160  cc0e24c59b3efd76d821706eedb45002a8d7bcaf \
+                        sha256  36b96edebdba23f599a9f7db19897fff644f10def6c1609dbaa72202ba666e0f \
+                        size    1472 \
+                    github.com/bitly/go-simplejson \
+                        lock    v0.5.0 \
+                        rmd160  52b43a167474e3f3a617a27103a0b2c4f99f6e24 \
+                        sha256  3b03470c620db4eca1d16205bd53352af94b28db38281e1833976d1843ac8a19 \
+                        size    5998 \
+                    github.com/alicebob/miniredis \
+                        lock    v2.13.0 \
+                        rmd160  1235cd5a1bb6f1e61e9df8dd865d486cf87072a3 \
+                        sha256  689eab5d0e80fcb3b3889bc9754c882e330715c30f9aa9cef2a7950500f6955f \
+                        size    124698 \
+                    github.com/alicebob/gopher-json \
+                        lock    a9ecdc9d1d3a \
+                        rmd160  8a88168f1e36f8abdaf60f812f364d42fc8cda6b \
+                        sha256  d35ead0bafcc61cbeaf1939427b0cfa9b5d347267172d541942f86f00f6a458c \
+                        size    3635 \
+                    github.com/FZambia/sentinel \
+                        lock    v1.0.0 \
+                        rmd160  11d76ca669fc3b26fbb12a727439470281d492ce \
+                        sha256  a0a3b5076f42bc210bf24e728fd8892f09138c78efd3386c2304d81d1b1ba465 \
+                        size    7924 \
+                    github.com/BurntSushi/toml \
+                        lock    v0.3.1 \
+                        rmd160  fb9650e2d16525153645e5547626f242f3800149 \
+                        sha256  8cc9e5dc68e247554227973d0b4e023b27bbd9ba5a26e4fb40f44743afcb35f1 \
+                        size    42087 \
+                    github.com/Bose/minisentinel \
+                        lock    917c5a9223bb \
+                        rmd160  2f6381d134ce486aeaeb331c9c25dc9197c72beb \
+                        sha256  02260eb635a9da45ed0e0872e05614018bce888093f173b0b47edad934ee47a9 \
+                        size    8356 \
+                    cloud.google.com/go \
+                        repo    github.com/googleapis/google-cloud-go \
+                        lock    v0.38.0 \
+                        rmd160  d396e91498fbf3d2834cfd451147c559d29e0d09 \
+                        sha256  6a5b67f8c169baf8bf4871bc45bd72536f6300173ad72fbda8f03aa078d3fb95 \
+                        size    1919706


### PR DESCRIPTION
- use golang portgroup
- vendor dependencies

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 11.6 11E708

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
