### PR TITLE
mozjs60: arm64: Code sign virtualenv python on arm64.

### DIFF
--- a/lang/mozjs60/Portfile
+++ b/lang/mozjs60/Portfile
@@ -45,7 +45,8 @@ if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
 }
 
 patchfiles          patch-js.pc.in.diff \
-                    patch-js-config.in.diff
+                    patch-js-config.in.diff \
+                    patch-virtualenv-arm64-codesign.diff
 
 # Use absolute path for install_name
 post-patch {

--- a/lang/mozjs60/files/patch-virtualenv-arm64-codesign.diff
+++ b/lang/mozjs60/files/patch-virtualenv-arm64-codesign.diff
@@ -1,0 +1,17 @@
+--- third_party/python/virtualenv/virtualenv.py.orig	2021-02-01 22:20:21.000000000 -0600
++++ third_party/python/virtualenv/virtualenv.py	2021-02-01 22:28:31.000000000 -0600
+@@ -1339,6 +1339,14 @@
+                              "have Apple's development tools installed")
+                 raise
+ 
++        # For macOS on arm64, the copied binary needs to be ad-hoc codesigned.
++
++        if os.uname()[4] == 'arm64':
++            codesign_cmd = ["codesign", "--sign", "-", "--force",
++                           "--preserve-metadata=entitlements,requirements,flags,runtime", py_executable]
++            subprocess.call(codesign_cmd)
++
++
+     if not is_win:
+         # Ensure that 'python', 'pythonX' and 'pythonX.Y' all exist
+         py_exe_version_major = 'python%s' % sys.version_info[0]


### PR DESCRIPTION
This port uses an embedded copy of virtualenv to create a python2.7
virtual environment. On arm64, the created (copied?) python has an
invalid code signature and is killed when run. This commit adds
a patch to ad-hoc code sign the created python executable on arm64.

This addresses https://trac.macports.org/ticket/61606. So it improves but does not fix the port on arm64. Now the configure environment assumes iphoneos when it detects the arm architecture.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
