### PR TITLE
glab: new port

### DIFF
--- a/devel/glab/Portfile
+++ b/devel/glab/Portfile
@@ -1,0 +1,498 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/profclems/glab v1.14.0
+revision            0
+categories          devel
+license             MIT
+
+maintainers         {@harens gmail.com:harensdeveloper} \
+                    openmaintainer
+description         An open-source GitLab CLI Tool
+long_description    ${name} is an open source GitLab CLI tool \
+                    bringing GitLab to your terminal next to where \
+                    you are already working with git and your code.
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  9fafc8fd33aae7050f777cd8191105fde78b67ba \
+                        sha256  2aaea12b5ff95f6ceafc46037f94e0a194bb12855dbcf67bc73714487b0ab2f1 \
+                        size    16427691
+
+build.target        ${worksrcpath}/cmd/glab
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}
+
+post-destroot {
+    # install documentation
+    xinstall -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 644 -W ${worksrcpath} LICENSE README.md ${destroot}${prefix}/share/doc/${name}
+
+    # bash completion
+    set bash_completion_dir ${destroot}${prefix}/etc/bash_completion.d
+    xinstall -d ${bash_completion_dir}
+    system -W ${worksrcpath} "${worksrcpath}/${name} completion --shell bash > ${bash_completion_dir}/${name}"
+
+    # zsh completion
+    set zsh_completion_dir ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -d ${zsh_completion_dir}
+    system -W ${worksrcpath} "${worksrcpath}/${name} completion --shell zsh > ${zsh_completion_dir}/_${name}"
+
+    # fish completion
+    set fish_completion_dir ${destroot}${prefix}/share/fish/completions
+    xinstall -d ${fish_completion_dir}
+    system -W ${worksrcpath} "${worksrcpath}/${name} completion --shell fish > ${fish_completion_dir}/${name}"
+}
+
+# Notes for updating
+# go.googlesource.com/protobuf --> github.com/protocolbuffers/protobuf-go
+go.vendors          gopkg.in/yaml.v3 \
+                        lock    9f266ea9e77c \
+                        rmd160  06dca2ede07b2f31c515b4711fbebc1d5359b5e4 \
+                        sha256  e70dd42fb30b7b2d0129c5cdf0e079caaf5602cab24081fdac830ec01204fa59 \
+                        size    86890 \
+                    gopkg.in/yaml.v2 \
+                        lock    v2.3.0 \
+                        rmd160  2f8fa56d8a413b6288132eeb7f0d7c64d27d877f \
+                        sha256  a8d1a8bc88239d25507456380b47d59ae3683d4a5f4336da4892db1ce026615f \
+                        size    72838 \
+                    gopkg.in/tomb.v1 \
+                        lock    dd632973f1e7 \
+                        rmd160  ae07f5ddbbc6afc772d6dc5273bb72eaba50529a \
+                        sha256  91c562a4e31c89d13e5391143ff653231fc2d80562743db89ce2172ad8f81008 \
+                        size    3636 \
+                    gopkg.in/check.v1 \
+                        lock    788fd7840127 \
+                        rmd160  b63165c8909a27edc15dda210df66a1b49efb49e \
+                        sha256  7e5547c6471cc48da89a7c87f965b20ca5311f43fc4d883ca62f9fccf7551630 \
+                        size    31597 \
+                    google.golang.org/protobuf \
+                        repo    github.com/protocolbuffers/protobuf-go \
+                        lock    v1.23.0 \
+                        rmd160  b9954ce9dc927216440d55f850073bbf47113143 \
+                        sha256  41a885f3290ce459bcd4251a6df0787ead449c835a718f8f46342cad1dc26b85 \
+                        size    1214926 \
+                    google.golang.org/appengine \
+                        repo    github.com/golang/appengine \
+                        lock    v1.6.1 \
+                        rmd160  1aaf527f44d1b4eb210ab52cf3d1a5c1c70310bf \
+                        sha256  9420cc82dd8b0d0825356b17844bf836fd0a0af468b1394c70b498e4a0e471c2 \
+                        size    333388 \
+                    golang.org/x/xerrors \
+                        lock    9bdfabe68543 \
+                        rmd160  eee9929ac1c0380402c45b388077c5c505f13311 \
+                        sha256  dc1be1d7efb43643507e87352ae7161883c48cb5116a20a1739ab93ab558bccf \
+                        size    13661 \
+                    golang.org/x/tools \
+                        lock    11955173bddd \
+                        rmd160  3f018974cbd88912e85ad015d33a5bf3c02cf100 \
+                        sha256  beda28740d4fc61c10f191f7dfb51dcaa6ac5a9c20ec16ab3e1096e987161740 \
+                        size    2651713 \
+                    golang.org/x/time \
+                        lock    555d28b269f0 \
+                        rmd160  135544dd4d3db9cc89a4b1b8ab022546eb651608 \
+                        sha256  f2d3a812000cb243bd740fbb4ec8326a6844856d6e4304ebd3861fcf67ae9b62 \
+                        size    9582 \
+                    golang.org/x/text \
+                        lock    v0.3.5 \
+                        rmd160  2bc41a433ef7cbbf321afed39256a65d43ef3c8b \
+                        sha256  148ec80befd0392454a5d7756abcebeb74f863e6e4b1e1ff63bbe06c2b49e120 \
+                        size    8349629 \
+                    golang.org/x/sys \
+                        lock    4bcb84eeeb78 \
+                        rmd160  ddd98ce5afef6d9a72a9afe1d00662ca0914b18d \
+                        sha256  60343bf080c7967ef9c9b451cb2f6519bfba2b80bad42ec2e6edf4d4871300df \
+                        size    1101928 \
+                    golang.org/x/sync \
+                        lock    112230192c58 \
+                        rmd160  37a8b11def31e2ad355002a8671245962be359f6 \
+                        sha256  951a6df1dadb061510f1c646197dd8f8a7c7842729d02c6a68a86bce66349f79 \
+                        size    16832 \
+                    golang.org/x/oauth2 \
+                        lock    0f29369cfe45 \
+                        rmd160  a2ebd909ab79d080e72933bb8ba5020a6eb71fbc \
+                        sha256  9461d6f2f43e6da87c77d3f93f08cc43b3f5dd96bbc5fb41714bcc0cca17df5b \
+                        size    45486 \
+                    golang.org/x/net \
+                        lock    a7d1128ccaa0 \
+                        rmd160  52541acd3168304f8df883c343465c74271a8697 \
+                        sha256  371de1d00f15ab9d11869c6b600547bcc9f31eae6810e2f067d448e45c556c09 \
+                        size    1177270 \
+                    golang.org/x/lint \
+                        lock    d0100b6bd8b3 \
+                        rmd160  cc82f79de01e4859b438f8203c5a199b730e7c5f \
+                        sha256  0f57ed7c540c419ff6da3c0f4aee4592f6860ede1c951578008a6554504f11a4 \
+                        size    32918 \
+                    golang.org/x/crypto \
+                        lock    75b288015ac9 \
+                        rmd160  d0df189672060fb880ac1bd440bfe94a5fc3e6d9 \
+                        sha256  290dc7a301e9ad139c8a5bd91bc0fd9936c60e2d7e7f9361eb3766e8b5947e86 \
+                        size    1729939 \
+                    github.com/yuin/goldmark \
+                        lock    v1.2.0 \
+                        rmd160  27fbb7a3ad0f28583f4b51b7fb2a9773fca199bf \
+                        sha256  716ddfc3a8dc93ef5d45e3cad7dadcb3d436e99512a77e6e0746ff3d29dd4b70 \
+                        size    228284 \
+                    github.com/xanzy/go-gitlab \
+                        lock    v0.42.0 \
+                        rmd160  98ae463b168682373709ea9487bdea40e9fa557f \
+                        sha256  ab55fbadfac64a700d7aba4c60961fae34f0b3fd47b6b97426ee554ad9c841dc \
+                        size    190776 \
+                    github.com/tidwall/pretty \
+                        lock    v1.0.2 \
+                        rmd160  e75f75a2785ba3ce3069d368ce85d2bf4c64adb8 \
+                        sha256  6cd1240063683c334310292b75f29e4fc0c71041f3f4797710e838ad7176b066 \
+                        size    8866 \
+                    github.com/tcnksm/go-gitconfig \
+                        lock    v0.1.2 \
+                        rmd160  1920a053ae158cd29182fa9c9ba675f92365bd45 \
+                        sha256  88eb568ff082ca3eec0d1bd77ec6816c050f7fd4f34bb95d41b62c0c23126cb3 \
+                        size    4476 \
+                    github.com/stretchr/testify \
+                        lock    v1.7.0 \
+                        rmd160  adae5096e8c4cfcc8e3f6d096646d1165b5ef49a \
+                        sha256  f7dde97d0c9634483ae6ea273968f80f3105c22382a1f841886cd20d57586642 \
+                        size    91096 \
+                    github.com/stretchr/objx \
+                        lock    v0.1.1 \
+                        rmd160  bac62e95f032c4a8d762a87de322e2f97c3d1339 \
+                        sha256  b358ccba683ced77158e36c7f980bff552d5abd9f4f0d9a22aa7e86aef719f9e \
+                        size    75799 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.5 \
+                        rmd160  2ce81608a38c6f383a35bccd24d64361df5828c9 \
+                        sha256  7f41acdcba65b1fab5b9b633947a139f9915b60f94bdab486cdbe9d90c54f61e \
+                        size    50815 \
+                    github.com/spf13/jwalterweatherman \
+                        lock    v1.0.0 \
+                        rmd160  364fd0d61e94bd3651b5506d61f0e9652d6e33a3 \
+                        sha256  e70eb4dbab0603ad35c32bf89cefd595b2d6d56d66695866bfad2350db939404 \
+                        size    6405 \
+                    github.com/spf13/cobra \
+                        lock    v1.1.1 \
+                        rmd160  dedb212124abd6a8ce40e9b1e6e083266a633e6f \
+                        sha256  ac9e1ecebe2ec52aecad8a9bb474c6b9fc828f3c2ae3dcc1ed10e35493527360 \
+                        size    143436 \
+                    github.com/spf13/cast \
+                        lock    v1.3.1 \
+                        rmd160  d4ab928edfe2ad8aafbc3248287b788c65ec155f \
+                        sha256  a33b9fbe9c9dd9cc2bb54f43bcd9a4b5503666c028448bc1b600d46961ffb604 \
+                        size    11103 \
+                    github.com/spf13/afero \
+                        lock    v1.1.2 \
+                        rmd160  dc2ff3aa582c3dc782e3c062e35b65564bfc44e5 \
+                        sha256  08dca858dce5a4336ca385028ff38e0fa6a9f064f5c874fdabe2096a34b6fc91 \
+                        size    45324 \
+                    github.com/shurcooL/sanitized_anchor_name \
+                        lock    v1.0.0 \
+                        rmd160  c7e5322dba53e10db1711d65c146af5649b0c7c8 \
+                        sha256  ed9418de8c92acfbbd8608745855ebfc67fa686c0a0a5245cf8eece8f540baa9 \
+                        size    2144 \
+                    github.com/sergi/go-diff \
+                        lock    v1.0.0 \
+                        rmd160  c5ac5f7253544101282f5477a71560d1fd6c3e58 \
+                        sha256  147eecf13dff7c6715ada19e097d4c3b7d20b169b475861a98e41e27b891d062 \
+                        size    41633 \
+                    github.com/russross/blackfriday \
+                        lock    v2.0.1 \
+                        rmd160  99cb49faff9bf24b8637dcdb3602c27c115810f3 \
+                        sha256  4078d2cd3b1c6952133b214e4eaca95f3b31a01f87a03adabd7712e7d5f20f60 \
+                        size    79665 \
+                    github.com/rivo/uniseg \
+                        lock    v0.2.0 \
+                        rmd160  33577def583aa2db50b69ca601e5d29ab201ebc4 \
+                        sha256  2832965221246272462a03ffc8e159c94d8f534827f660f1ac4fc77e5ccd644c \
+                        size    44037 \
+                    github.com/rivo/tview \
+                        lock    745e4ceeb711 \
+                        rmd160  23eb115ea2e8ad61afd67c5b50e4b12cb29a86b1 \
+                        sha256  5c0001bdccd9702321d702c437b5e33b765b208e3b0a8024233b1e788f58fc75 \
+                        size    2871149 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/pkg/errors \
+                        lock    v0.9.1 \
+                        rmd160  dc065c655f8a24c6519b58f9d1202eb266ecda40 \
+                        sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
+                        size    13422 \
+                    github.com/pelletier/go-toml \
+                        lock    v1.2.0 \
+                        rmd160  8d91b6485f373ccaa894abcb3bd53839e55b9057 \
+                        sha256  0a9503f2b53444e0c3ea960d18febe14d472c16279844f231994c5ccb81dbdff \
+                        size    57515 \
+                    github.com/otiai10/mint \
+                        lock    v1.3.2 \
+                        rmd160  274a71c9e46d219d2bbd884a10d5c90dc9654aaa \
+                        sha256  321c67c846f87c56aadbc6af6c8685ccd2e8ef9eb7ba7c35f5a351a55b62d9c7 \
+                        size    5981 \
+                    github.com/otiai10/curr \
+                        lock    v1.0.0 \
+                        rmd160  01eb81585a8c1f9b41e5674499fd159f4825d746 \
+                        sha256  b8a58f7c53fdbfc3c6cf9865af99d85fd62af320f42aedbb605436ab8035bdd6 \
+                        size    2468 \
+                    github.com/otiai10/copy \
+                        lock    v1.4.2 \
+                        rmd160  21c0dd06dd2d7fe9890a91056a453a6042d38c11 \
+                        sha256  5c84cccd5c6b5532b08664506df0a67909fa4202dd4518e4ca50d4c20580aabf \
+                        size    8395 \
+                    github.com/onsi/gomega \
+                        lock    v1.10.3 \
+                        rmd160  3ce67285e98fcf47d6ae18e2a50b6685c132e323 \
+                        sha256  ff8e349c8e3996170fdf809e659cca57284dfacd62545c39519df5820f7b9c14 \
+                        size    97892 \
+                    github.com/onsi/ginkgo \
+                        lock    v1.12.1 \
+                        rmd160  6679f75d2cbfa444056b7fdb31e5724b0aa0c071 \
+                        sha256  8fbc07272ee58ef50fa44093c1de831782724e1180d08dd7b7a775d2df700900 \
+                        size    139879 \
+                    github.com/olekukonko/tablewriter \
+                        lock    v0.0.4 \
+                        rmd160  750bec232562820a4f3ba47cd2864f4c84e7a767 \
+                        sha256  890daf262aee371899075912bab0b3107313bea32846cf796bca83ef9a1dccf5 \
+                        size    19267 \
+                    github.com/nxadm/tail \
+                        lock    v1.4.4 \
+                        rmd160  33d7373bd1b164159b9032fc8595bb09b25598f6 \
+                        sha256  16d8773e0be69469d3c296ee785bbef433c3442defb68760682cdbcf80ba40ee \
+                        size    1238830 \
+                    github.com/muesli/termenv \
+                        lock    v0.6.0 \
+                        rmd160  8e536a7d42cb2bc516a621460164d87868222a6e \
+                        sha256  92e9250113aa2215883822fc4290ebb7fa790ffa6a36b306ade2c75ae8bee9a4 \
+                        size    405152 \
+                    github.com/muesli/reflow \
+                        lock    v0.1.0 \
+                        rmd160  13053733dc25f1701d054f383406e72e4976d5a0 \
+                        sha256  85df09198af423b2b25e742fec97a4807d5fcc2731a27df2042b86515e64c2d7 \
+                        size    16198 \
+                    github.com/mitchellh/mapstructure \
+                        lock    v1.1.2 \
+                        rmd160  a4e01781ea5bb0c987e18e8e450c8f1023d5a857 \
+                        sha256  9c1076f5a8e923d028cb65c36143f3b1478cbaa4420e2e8f332719edc2fc4f71 \
+                        size    20992 \
+                    github.com/mitchellh/go-homedir \
+                        lock    v1.1.0 \
+                        rmd160  44b3985e40e5bbb22d11f8622c340f9ed727ea91 \
+                        sha256  024c8a57316c7fbc0eb23cdbfd57f72a74b51beb83d714034d67ee9aba48100c \
+                        size    3366 \
+                    github.com/microcosm-cc/bluemonday \
+                        lock    v1.0.2 \
+                        rmd160  78bde56f8c676e8a7f3ed07dfcb63731bb958240 \
+                        sha256  298aa8b8eff4c6beda27bf98eeddd4ebfc63ad01a88fa45880abbc0da6424aab \
+                        size    137682 \
+                    github.com/mgutz/ansi \
+                        lock    d51e80ef957d \
+                        rmd160  a32d3fd46ae68cfd82f31fadc3dfe551966f6a5b \
+                        sha256  27808fbee08992bde76012200be0e24cb1017d39f3c228cc5805875993334b83 \
+                        size    5102 \
+                    github.com/mattn/go-runewidth \
+                        lock    v0.0.10 \
+                        rmd160  96c878eca004d6cf8f49ecf3cde98335e7f21499 \
+                        sha256  b78084ce55bc5aaa31d337dcb59624d748fe39006a3df29143fae203065e2a22 \
+                        size    16787 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.12 \
+                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
+                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
+                        size    4549 \
+                    github.com/mattn/go-colorable \
+                        lock    v0.1.8 \
+                        rmd160  e9948731b241336e8d5aa2a2e25dff26a9dccebe \
+                        sha256  7e815dc076eeb34bf44a348eea7ae9b7a432b37462543cc5b382350d0e91c5f0 \
+                        size    9576 \
+                    github.com/lunixbochs/vtclean \
+                        lock    v1.0.0 \
+                        rmd160  28eb7432d03d69a0e3484c49341dd876769ebe55 \
+                        sha256  f6cbd000c28785924742401aa071061b71e321490cc9bea1cec77bfd2c40eb84 \
+                        size    4223 \
+                    github.com/lucasb-eyer/go-colorful \
+                        lock    v1.0.3 \
+                        rmd160  0d0a283ba00c871d123c951efea0605a869951aa \
+                        sha256  ecd902ddda5d05cc8a857873bf8b984a5cd2d7b75f1185edcfc2c472707958b3 \
+                        size    430208 \
+                    github.com/kr/text \
+                        lock    v0.1.0 \
+                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
+                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
+                        size    8691 \
+                    github.com/kr/pty \
+                        lock    v1.1.4 \
+                        rmd160  c8f7af2b21280ca0435670d02994d1b257061ae4 \
+                        sha256  2a532b818413bde2d59a84f3937a3b933cf85683979e8ce67e153f373c4ff498 \
+                        size    5830 \
+                    github.com/kr/pretty \
+                        lock    v0.1.0 \
+                        rmd160  9aa7a5aad4c48840eecfd0f80186d1fb5ded0fd6 \
+                        sha256  f6c3f89667c63e5b7f1fc6ee2c06b6a6bfdce88f3a965ccd395b64c6f95c9a47 \
+                        size    8553 \
+                    github.com/kballard/go-shellquote \
+                        lock    95032a82bc51 \
+                        rmd160  40415cd59ece9fb38b22170feec07f1f48d518a2 \
+                        sha256  41aa42696f96fb2783c5135d71ff1ec5938dfe178b51eb703e509c8ac0e7db4e \
+                        size    4335 \
+                    github.com/jarcoal/httpmock \
+                        lock    v1.0.7 \
+                        rmd160  b257b588b71cc360c0e86cc770da39fd690ba43d \
+                        sha256  9ebf6881d5e34f6ef31999f707ecf78863abdd8ae9326f41947344e9a767819c \
+                        size    24487 \
+                    github.com/inconshreveable/mousetrap \
+                        lock    v1.0.0 \
+                        rmd160  5c617a09f1432fc543672a0e0c1e13d3752030c2 \
+                        sha256  0e6bae2849f13d12fe361ecac087728e4e97f3482f4cec44f6e7a2c53bb9cd0c \
+                        size    2291 \
+                    github.com/hinshun/vt10x \
+                        lock    1954e6464174 \
+                        rmd160  29d948e8755fbc4fd5000745a47d20b27ab7fae4 \
+                        sha256  31abe1530ab54f5e7dd1892d7affcc45cabade93345357aaad61a50daf11eb55 \
+                        size    1231513 \
+                    github.com/hashicorp/hcl \
+                        lock    v1.0.0 \
+                        rmd160  ad8d0b523bb708fd6ae77df8bb414c103a75aa92 \
+                        sha256  4fc0e87ac9d3d6cd042f044df2db2703bed569051fb8c179d505edeb4433e96e \
+                        size    70636 \
+                    github.com/hashicorp/go-version \
+                        lock    v1.2.1 \
+                        rmd160  0f4bd846a25d1886e0b49389ef64b86942287d26 \
+                        sha256  bf7d66ca91f84f59277141ec22b5f18ba6facaca23d99b36b0c1a08cc0631f4a \
+                        size    13923 \
+                    github.com/hashicorp/go-retryablehttp \
+                        lock    v0.6.4 \
+                        rmd160  677fcd57f1ff70f4bb441a35433995944ea91ba0 \
+                        sha256  6075a70d41a13c7ce6bceb393d1b5d297fcc154519f8d34963703d6995edb9c0 \
+                        size    17002 \
+                    github.com/hashicorp/go-hclog \
+                        lock    v0.9.2 \
+                        rmd160  0bf5170f45d580654ab9ab791ce45cfecb350283 \
+                        sha256  e599db076f0bd5b3448ab270a5d7d18ef87a91cf91ed0be3bda32280b9768421 \
+                        size    26491 \
+                    github.com/hashicorp/go-cleanhttp \
+                        lock    v0.5.1 \
+                        rmd160  421ba8dea2ca1d8a013b682866e75d4a0d724d2f \
+                        sha256  f51adef8dd7f4cd168516a57c65d10d6bdc844e65f86e2c04af95f1afc1b870a \
+                        size    8068 \
+                    github.com/gosuri/uilive \
+                        lock    v0.0.4 \
+                        rmd160  0e4c93664ab9e5d0f0da1e5fa6c7cc2171922388 \
+                        sha256  bc7c21cc891a3de1dc9e5c43e8dd8c4bd5da6ceb17888be041c80dd52078abd2 \
+                        size    153284 \
+                    github.com/google/shlex \
+                        lock    e7afc7fbc510 \
+                        rmd160  4e505c7f96adfae0b23fe7f4d7d3d12cd39beb52 \
+                        sha256  d72b457eb90c286cca39c51f2d60ba241351cbad49f9980e30c43a15b2f09b34 \
+                        size    7342 \
+                    github.com/google/renameio \
+                        lock    v0.1.0 \
+                        rmd160  ba2fe6be9202636dcf17dd2d1c495aceed231cc9 \
+                        sha256  dd166ecfcacfff3e36567edab9ef94affe756932becbf382939c20646f504a83 \
+                        size    9728 \
+                    github.com/google/goterm \
+                        lock    fc88cf888a3f \
+                        rmd160  f9ec53def00acffe1d5fe5976dc0114a02305a73 \
+                        sha256  e3c84437911cb3c3500f4486b1ae9c7dc1e6e020185187203697f4a39401d77a \
+                        size    18304 \
+                    github.com/google/go-querystring \
+                        lock    v1.0.0 \
+                        rmd160  48593728f6bf361fa168bdc87737ee30de24f34b \
+                        sha256  0add5428914c2a378cd9e6e120a4b1e84d69df504b983f99a86aea98a52c5a57 \
+                        size    7536 \
+                    github.com/google/go-cmp \
+                        lock    v0.4.0 \
+                        rmd160  2d73ccb9863b49adb03196aff7c41a7048e646fb \
+                        sha256  e7274fa6cc337c12123a02acc907524b7c3c234af59b2c924664300a57cb3ea0 \
+                        size    81597 \
+                    github.com/golang/protobuf \
+                        lock    v1.4.2 \
+                        rmd160  fbf4477bc008421fde463d79f7bc54a36de91db2 \
+                        sha256  206d74f8fd066bb178135ee9c092e986f8a1e1104df242e148e99e5a839e4ef2 \
+                        size    171802 \
+                    github.com/gdamore/tcell \
+                        lock    v2.1.0 \
+                        rmd160  33e0c62bb584fe9083efcbb9f9287ab2e039b53c \
+                        sha256  a4e74d0a8d3cf0f3ceadcd5ad48ede8faa1d9829716bc5928ec73710c7f4bcc6 \
+                        size    150767 \
+                    github.com/gdamore/encoding \
+                        lock    v1.0.0 \
+                        rmd160  3ed8916f763a5b51db1bcc8bd3ad06cf3d12ec07 \
+                        sha256  4f470c7308790bea8a526ea26cecbaa22345aad8dc566821cda6175b3d241ee1 \
+                        size    10900 \
+                    github.com/fsnotify/fsnotify \
+                        lock    v1.4.7 \
+                        rmd160  24712e412814020224e2779186e634610e2f6926 \
+                        sha256  bc839ee158ad34b81c1f11c3b9e3bcbabfba3297f61d165599880c400b8171dc \
+                        size    31147 \
+                    github.com/dustin/go-humanize \
+                        lock    v1.0.0 \
+                        rmd160  e8641035159ea3e8839ee086f01f966443956303 \
+                        sha256  e45e3181c07b3e2dad8e1317e91a5bbbee4845067e3e3879a585a5254bc6a334 \
+                        size    17273 \
+                    github.com/dlclark/regexp2 \
+                        lock    v1.2.0 \
+                        rmd160  6df6fe44029a4e40275a928ea6dd4d41040172f9 \
+                        sha256  b836f5cbf685a4247e3cc92e243113478bb7a8dba33380e6c1d036a727305c67 \
+                        size    204592 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/danwakefield/fnmatch \
+                        lock    cbb64ac3d964 \
+                        rmd160  19ae7b520847e16b0e8ac23ee5e6c51db3831f46 \
+                        sha256  2b045b8a716e3ca32d2a930781cd421b042d0e861fa3d36a79ed5535b2e5308a \
+                        size    4960 \
+                    github.com/cpuguy83/go-md2man \
+                        lock    v2.0.0 \
+                        rmd160  85f342c341fa928e9ec874490c277bdabf1c39c6 \
+                        sha256  2f3f8bc701df4890a5a4baf0b632ad3290be1e0aaf572b2e58fd57df93efc306 \
+                        size    52040 \
+                    github.com/charmbracelet/glamour \
+                        lock    1246d13c1684 \
+                        rmd160  f711e7cb9bd08afb28e90638a09443bd90c317bf \
+                        sha256  898dca465433795be53bd0e413291b63ae58c5676d867001a04077e869bac217 \
+                        size    511593 \
+                    github.com/alecthomas/repr \
+                        lock    117648cd9897 \
+                        rmd160  1f78bc0844f7ca6ccb93808bb367080e4c3accf8 \
+                        sha256  6715287714f895ceeed848842618084ea0fb4a53f0b904d9c456bea28ea31e16 \
+                        size    4649 \
+                    github.com/alecthomas/colour \
+                        lock    60882d9e2721 \
+                        rmd160  9f588ca134237b19f19199a088974aefebe3b301 \
+                        sha256  9178279e7dbff10a8325724c84b344dfcf365578d30d3f436db5fb1cba1030d5 \
+                        size    3484 \
+                    github.com/alecthomas/chroma \
+                        lock    v0.7.3 \
+                        rmd160  4f5145dd380d8fc274e56e5a149ed1e4a00e900e \
+                        sha256  506cdbd4818eb733db042a83c47a922ce893cb91d3c0a1dbb9ddc07c95c30ea5 \
+                        size    615233 \
+                    github.com/alecthomas/assert \
+                        lock    405dbfeb8e38 \
+                        rmd160  5d141a90e1e313657b558c19d51c3bdd65b0e5e5 \
+                        sha256  8c445be2c7daa6b680bfbf96823192076bbf9c0f514642687d6487fd95630a5e \
+                        size    71075 \
+                    github.com/acarl005/stripansi \
+                        lock    5a71ef0e047d \
+                        rmd160  fd222fb597292536232f066479c48f1e7769373f \
+                        sha256  7c4d6ffa5a4401bffde46366e0c4976893ee8d6210543bc70cc1c514c22e29ae \
+                        size    1479 \
+                    github.com/Netflix/go-expect \
+                        lock    c93bf25de8e8 \
+                        rmd160  a4e10dd1f05c584ae80408e373cc5b9e90581dc7 \
+                        sha256  896ec6b1f14446e88345be7dc7a8575957040b5a3729da1698ca88138e085ee2 \
+                        size    14580 \
+                    github.com/MakeNowJust/heredoc \
+                        lock    v1.0.0 \
+                        rmd160  4499f62cf69e3aecff0fdade702100211f8bea34 \
+                        sha256  68cfbc48a601835ed9d2db3ecb2197214499d0c75dcc2ad72877b9d1cc1e5b95 \
+                        size    3499 \
+                    github.com/AlecAivazis/survey \
+                        lock    v2.2.7 \
+                        rmd160  076b455336dbc247c1f90b845070bc0dac944b68 \
+                        sha256  69f3f4a272597e2e76ab864e2a8b5901df2859392967b0ccec065296067220b5 \
+                        size    1567730


### PR DESCRIPTION
#### Description

See https://github.com/macports/macports-ports/pull/9874

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
xcode-select version 2384.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
