### PR TITLE
lagrange: new port

### DIFF
--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        skyjake lagrange 1.1.0 v
+github.tarball_from releases
+categories          net gemini
+platforms           darwin
+license             BSD
+maintainers         {@sikmir gmail.com:sikmir} openmaintainer
+
+description         A Beautiful Gemini Client
+long_description    ${description}
+
+checksums           rmd160  e3a135d68ca28beb1b95765efbecbfe47c5f90d6 \
+                    sha256  291e1d17520eebc470efe852d5cbecec4989369ccce369f6633443e2ef2fd11c \
+                    size    14296829
+
+depends_build-append \
+                    port:pkgconfig
+depends_lib-append  port:libsdl2 \
+                    port:libunistring \
+                    port:openssl \
+                    port:pcre \
+                    port:zlib
+
+destroot {
+    copy ${build.dir}/Lagrange.app ${destroot}${applications_dir}
+}


### PR DESCRIPTION
#### Description
[Lagrange](https://github.com/skyjake/lagrange) is a desktop GUI client for browsing Geminispace.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
