### PR TITLE
mpich: Update to 3.4.1, move (back) to ch3

### DIFF
--- a/science/mpich/Portfile
+++ b/science/mpich/Portfile
@@ -8,8 +8,7 @@ PortGroup           legacysupport 1.1
 
 # make sure to keep in sync with mpi-doc
 name                mpich
-version             3.4
-# Note multiple revisions in Portfile (for various sub-ports to reduce builds)
+version             3.4.1
 revision            0
 
 license             BSD
@@ -37,9 +36,9 @@ homepage            https://www.mpich.org/
 master_sites        ${homepage}static/downloads/${version}
 
 checksums \
-    rmd160  1407ba488c3be54acfa133cb6b2aefa115183e3c \
-    sha256  ce5e238f0c3c13ab94a64936060cff9964225e3af99df1ea11b130f20036c24b \
-    size    30716482
+    rmd160  e1ada31903d2ad7a6331aabbbf67eb058366d9d7 \
+    sha256  8836939804ef6d492bcee7d54abafd6477d2beca247157d92688654d13779727 \
+    size    30720928
 
 livecheck.type      regex
 livecheck.regex     {href=.([0-9.p]+)/}
@@ -75,6 +74,7 @@ if { ${os.major} < 16 } {
 if { ${os.major} > 10 } {
     set clist(gcc9)    {macports-gcc-9}
     set clist(gcc10)    {macports-gcc-10}
+    set clist(gccdevel)    {macports-gcc-devel}
 }
 # clang 6+ only available on macOS10.9 (Darwin13) and newer
 if { ${os.major} > 12 } {
@@ -154,6 +154,10 @@ configure.args      --disable-dependency-tracking    \
                     --enable-versioning              \
                     --with-pm=hydra                  \
                     --with-thread-package=posix      \
+                    --with-device=ch3                \
+                    --with-hwloc-prefix=${prefix}    \
+                    --enable-nemesis-shm-collectives \
+                    --enable-alloca                  \
                     "F90FLAGS='' F90=''"
 
 variant threads description {Build with full thread support} {
@@ -236,6 +240,12 @@ if {${name} ne ${subport} && [string first "-devel" $subport] < 0} {
     # avoid dependency on port:bash
     configure.env-append \
         BASH_SHELL=/bin/bash
+
+    variant tuned description {Build with more optimizations} {
+        configure.args-replace      --enable-fast=O2 \
+                                    --enable-fast=all
+        configure.cppflags-append   -fomit-frame-pointer -O2
+    }
 
     # setting xFLAGS resulting in mpicc, etc. always using these flags
     # setting MPICHLIB_xFLAGS only uses them for building the library
@@ -327,7 +337,7 @@ if {${name} ne ${subport} && [string first "-devel" $subport] < 0} {
         } {}
         default_variants-append     +fortran
 
-        if {${cname} eq "gcc10"} {
+        if {${cname} eq "gcc10" || ${cname} eq "gccdevel"} {
             # see https://lists.mpich.org/pipermail/discuss/2020-January/005862.html
             # see https://github.com/pmodels/mpich/issues/4300
             # see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91556
@@ -357,7 +367,7 @@ if {${name} ne ${subport} && [string first "-devel" $subport] < 0} {
                 configure.args-append lt_cv_ld_force_load=no
             }
 
-            if {[variant_isset gcc10]} {
+            if {[variant_isset gcc10] || [variant_isset gccdevel]} {
                 # see https://lists.mpich.org/pipermail/discuss/2020-January/005862.html
                 # see https://github.com/pmodels/mpich/issues/4300
                 # see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91556
@@ -409,11 +419,6 @@ pre-built packages for ${subport} by running:
                                 --with-pm=gforker
     }
 
-    variant tuned description {Build with more optimizations} {
-        configure.args-replace  --enable-fast=O2 \
-                                --enable-fast=all
-        configure.args-append   MPICHLIB_CFLAGS='-fomit-frame-pointer -O2'
-    }
 } else {
     depends_lib-append  port:${name}-default
     conflicts-append    mpich-devel

--- a/science/mpich/files/mpich-gccdevel-fortran
+++ b/science/mpich/files/mpich-gccdevel-fortran
@@ -1,0 +1,11 @@
+bin/mpicc-mpich-gccdevel
+bin/mpichversion-mpich-gccdevel
+bin/mpicxx-mpich-gccdevel
+bin/mpiexec-mpich-gccdevel
+bin/mpirun-mpich-gccdevel
+bin/mpif77-mpich-gccdevel
+bin/mpif90-mpich-gccdevel
+bin/parkill-mpich-gccdevel
+lib/mpich-gccdevel/pkgconfig/mpich.pc
+-
+bin/mpifort-mpich-gccdevel


### PR DESCRIPTION
Maintainer update: previous build completed with broken output

Moved back to ch3; see https://github.com/pmodels/mpich/issues/5041