### PR TITLE
lang/rust: update to 1.49 and arm64 support

### DIFF
--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -1,13 +1,13 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=portfile:et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=portfile:et:sw=4:ts=4:sts=4:ft=tcl
 
 PortSystem          1.0
 
 name                rust
-version             1.47.0
+version             1.49.0
 revision            0
 categories          lang devel
 platforms           darwin
-supported_archs     x86_64
+supported_archs     x86_64 arm64
 license             {MIT Apache-2} BSD zlib NCSA Permissive
 maintainers         {g5pw @g5pw} \
                     {gmail.com:herby.gillot @herbygillot} \
@@ -27,46 +27,67 @@ long_description    Rust is a curly-brace, block-structured expression \
 homepage            https://www.rust-lang.org/
 
 # Get from src/stage0.txt
-set ruststd_version 1.46.0
-set rustc_version   1.46.0
-set cargo_version   0.47.0
-set llvm_version    9.0
+# This part requires some special attention on the next stable release.
+# Rust stable 1.x usually requires `set rust_version 1.(x-1)`
+set rust_version    1.49.0
+set llvm_version    11
 
 # can use cmake or cmake-devel; default to cmake.
-depends_build       path:bin/cmake:cmake \
-                    bin:python2.7:python27
+depends_build       port:cmake \
+                    port:python39 \
+                    port:git \
+                    port:openssl \
+                    port:ninja \
+                    port:gmake
 
 depends_lib         port:llvm-${llvm_version} \
                     port:libffi
+
+
+set arch ${build_arch}
+if {${build_arch} == "arm64"} {
+    set arch "aarch64"
+}
+
 
 master_sites        https://static.rust-lang.org/dist
 
 distname            ${name}c-${version}-src
 
-patchfiles          patch-src-librustc-llvm-lib.diff
-
-distfiles-append    rust-std-${ruststd_version}-${build_arch}-apple-${os.platform}${extract.suffix} \
-                    rustc-${rustc_version}-${build_arch}-apple-${os.platform}${extract.suffix} \
-                    cargo-${cargo_version}-${build_arch}-apple-${os.platform}${extract.suffix}
+distfiles-append    rust-std-${rust_version}-${arch}-apple-${os.platform}${extract.suffix} \
+                    rustc-${rust_version}-${arch}-apple-${os.platform}${extract.suffix} \
+                    cargo-${rust_version}-${arch}-apple-${os.platform}${extract.suffix}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  2fee85c5e52046982a51eff62f64e123f798ed56 \
-                    sha256  3185df064c4747f2c8b9bb8c4468edd58ff4ad6d07880c879ac1b173b768d81d \
-                    size    151861620 \
+                    rmd160  f690ef8098a64eaf1dab3122140cacf0cf4d6a32 \
+                    sha256  b50aefa8df1fdfc9bccafdbf37aee611c8dfe81bf5648d5f43699c50289dc779 \
+                    size    157809463 \
 
 checksums-append \
-                    rust-std-${ruststd_version}-x86_64-apple-${os.platform}${extract.suffix} \
-                    rmd160  bd8d58fca200428b03603d770beeee8bf94e5de6 \
-                    sha256  8c897982bc38c9528b448fe551f089fee7716e692dece98052f4459ccc6e591c \
-                    size    22888748 \
-                    rustc-${rustc_version}-x86_64-apple-${os.platform}${extract.suffix} \
-                    rmd160  1503424f7cfeee88d6b7133ed5db689fb786bd34 \
-                    sha256  f690b375df7b1399e5baa69b64932e3e4a3f2b651e5ef2ebc85509bee777a9d9 \
-                    size    73665558 \
-                    cargo-${cargo_version}-x86_64-apple-${os.platform}${extract.suffix} \
-                    rmd160  123269f99aba6a0def22e77603ada120947023a9 \
-                    sha256  6e8f3319069dd14e1ef756906fa0ef3799816f1aba439bdeea9d18681c353ad6 \
-                    size    5685128
+                    rust-std-${rust_version}-x86_64-apple-${os.platform}${extract.suffix} \
+                    rmd160  b43ecabbcfa19327be5dccf09fc72855d0707a49 \
+                    sha256  c4389a8534b8da3ae3570646d68fea9a25268b17ed138867e31d4517312759af \
+                    size    35384330 \
+                    rustc-${rust_version}-x86_64-apple-${os.platform}${extract.suffix} \
+                    rmd160  ebe1ff219b1bd8d12a610a3cf228a5eae3de9de6 \
+                    sha256  09333f9aacb9c5959e2a2798d7e283cae674255f063a35ea28f91595caa0a78b \
+                    size    79819120 \
+                    cargo-${rust_version}-x86_64-apple-${os.platform}${extract.suffix} \
+                    rmd160  83a5c42490e8579d8767dc8c5c4c5e3d13da0bba \
+                    sha256  ab1bcd7840c715832dbe4a2c5cd64882908cc0d0e6686dd6aec43d2e4332a003 \
+                    size    5945516 \
+                    rust-std-${rust_version}-aarch64-apple-${os.platform}${extract.suffix} \
+                    rmd160  1ddc99fbc545b2e601d507d90b5f88bd8cdb1a32 \
+                    sha256  cf3308806fc3b6fe00ce49f1e63b1cb1d1443cc812eff7947257f31f590465d3 \
+                    size    27145897 \
+                    rustc-${rust_version}-aarch64-apple-${os.platform}${extract.suffix} \
+                    rmd160  2307caf7575c72bf3988698c49cce824dcf71160 \
+                    sha256  3e8c0c9101f27623f7607f2d8acef5f28dcb2bdfcded56f210d9d370cf9a9c06 \
+                    size    70161621 \
+                    cargo-${rust_version}-aarch64-apple-${os.platform}${extract.suffix} \
+                    rmd160  cf2de4de6008e9e176d75f7da7c0809dca9d15eb \
+                    sha256  2bd6eb276193b70b871c594ed74641235c8c4dcd77e9b8f193801c281b55478d \
+                    size    5388171
 
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
     known_fail yes
@@ -77,16 +98,16 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
 }
 
 post-extract {
-    set rust_root     ${worksrcpath}/build/stage0-${build_arch}
-    set rust_platform ${build_arch}-apple-${os.platform}
+    set rust_root     ${worksrcpath}/build/stage0-${arch}
+    set rust_platform ${arch}-apple-${os.platform}
     file mkdir ${rust_root}
-    system "cp -r ${workpath}/rust-std-${ruststd_version}-${rust_platform}/rust-std-${rust_platform}/* ${rust_root}"
-    system "cp -r ${workpath}/rustc-${rustc_version}-${rust_platform}/rustc/* ${rust_root}"
-    system "cp -r ${workpath}/cargo-${cargo_version}-${rust_platform}/cargo/* ${rust_root}"
+    system "cp -r ${workpath}/rust-std-${rust_version}-${rust_platform}/rust-std-${rust_platform}/* ${rust_root}"
+    system "cp -r ${workpath}/rustc-${rust_version}-${rust_platform}/rustc/* ${rust_root}"
+    system "cp -r ${workpath}/cargo-${rust_version}-${rust_platform}/cargo/* ${rust_root}"
 }
 
-set rust_platform       ${build_arch}-apple-${os.platform}
-set rust_root           ${worksrcpath}/build/stage0-${build_arch}
+set rust_platform       ${arch}-apple-${os.platform}
+set rust_root           ${worksrcpath}/build/stage0-${arch}
 
 configure.args          --enable-vendor \
                         --default-linker=${configure.cc} \
@@ -107,7 +128,7 @@ post-configure {
     xinstall -d -m 0755 ${workpath}/.home/.cargo
     set config [open ${workpath}/.home/.cargo/config w]
 
-    set rust_platform ${build_arch}-apple-${os.platform}
+    set rust_platform ${arch}-apple-${os.platform}
     puts ${config} "\[target.${rust_platform}\]"
     puts ${config} "linker = \"${configure.cc}\""
 

--- a/lang/rust/files/patch-src-librustc-llvm-lib.diff
+++ b/lang/rust/files/patch-src-librustc-llvm-lib.diff
@@ -1,8 +1,0 @@
---- src/librustc_llvm/lib.rs.orig	2019-09-23 21:15:52.000000000 +0000
-+++ src/librustc_llvm/lib.rs	2019-10-09 05:55:05.000000000 +0000
-@@ -106,3 +106,5 @@
-                  LLVMInitializeWebAssemblyTargetMC,
-                  LLVMInitializeWebAssemblyAsmPrinter);
- }
-+
-+#[link(name = "ffi")] extern {}


### PR DESCRIPTION
#### Description
This PR  bumps the version and provides support for rust on Apple Silicon.
I'm not too sure about the arch stanza (`set arch aarch64`). Is there a cleaner way to have the build_arch be  aarch64 instead of arm64?
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
