### PR TITLE
shtools 4.8 (revision 1): add support for compilers PortGroup

### DIFF
--- a/science/shtools/Portfile
+++ b/science/shtools/Portfile
@@ -1,10 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
+PortGroup           github    1.0
+PortGroup           compilers 1.0
 
 name                shtools
-revision            0
+revision            1
 
 categories          science math
 platforms           darwin
@@ -27,20 +28,30 @@ checksums           sha256  c36fc86810017e544abbfb12f8ddf6f101a1ac8b89856a76d7d9
 
 use_configure       no
 
-build.target        fortran F95="${prefix}/bin/gfortran-mp-10"
+compilers.choose    f90
+compilers.setup     default_fortran
+
+pre-build {
+    build.args      F95=${configure.f90}
+}
+build.target        fortran
 
 variant openmp description {Add OpenMP support} {
     use_parallel_build      no
     build.target-append     fortran-mp
 }
 
+pre-test {
+    test.args       F95=${configure.f90} \
+                    PREFIX=${prefix} \
+                    LAPACK="-lopenblas" \
+                    BLAS=""
+}
 test.run            yes
 test.target         fortran-tests-no-timing
-test.args           PREFIX=${prefix} F95="${prefix}/bin/gfortran-mp-10" LAPACK="-lopenblas" BLAS=""
 
 destroot.args       PREFIX=${prefix}
 
-depends_build       port:gcc10
-depends_test        port:gcc10
+depends_test        port:[fortran_variant_name]
 depends_lib         port:fftw-3 \
                     port:openblas


### PR DESCRIPTION
#### Description

This is a revision that adds support for the compilers PortGroup. The previous revision 0 hard-coded `gcc10` and `gfortran-10` compiler names, which I was told was not best practice.... This portfile only requires a Fortran 90 compiler, and here I do the following

* use the compilers PortGroup
* choose and setup the Fortran compiler with `compilers.choose    f90` and `compilers.setup     default_fortran`
* use `pre-build {build.args      F95=${configure.f90}}` to set the makefile arguement (similarly for test)
* add `depends_test        port:[fortran_variant_name]` which sets compiler port as a dependency for compiling and running the tests.

I have tested a couple gcc versions on my system, and everything works fine.
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H15
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
