### PR TITLE
minipro: fix checksums

### DIFF
--- a/devel/minipro/Portfile
+++ b/devel/minipro/Portfile
@@ -20,9 +20,9 @@ master_sites        https://gitlab.com/DavidGriffith/minipro/-/archive/${version
 
 distfiles           minipro-${version}.tar.gz
 
-checksums           rmd160  c02b039b1868e2bcf71d595f936cd632dc9796c7 \
-                    sha256  1c7559fd45c5cfc1d83cd0dfe2dd132cb621afbd113ab18dec1b5e6832f7121d \
-                    size    388759
+checksums           rmd160  69bf57063a8ed6fd8bd248d4fc0daf6352ef58ce \
+                    sha256  80ce742675f93fd4e2a30ab31a7e4f3fcfed8d56aa7cf9b3938046268004dae7 \
+                    size    388754
 
 depends_build       port:pkgconfig
 


### PR DESCRIPTION
#### Description

Port currenty fails due to checksum mismatches. This PR fixes that.

```
--->  Checksumming minipro-0.5.tar.gz
DEBUG: Calculated (rmd160) is 69bf57063a8ed6fd8bd248d4fc0daf6352ef58ce
Portfile checksum: minipro-0.5.tar.gz rmd160 c02b039b1868e2bcf71d595f936cd632dc9796c7
Error: Checksum (rmd160) mismatch for minipro-0.5.tar.gz
Distfile checksum: minipro-0.5.tar.gz rmd160 69bf57063a8ed6fd8bd248d4fc0daf6352ef58ce
DEBUG: Calculated (sha256) is 80ce742675f93fd4e2a30ab31a7e4f3fcfed8d56aa7cf9b3938046268004dae7
Error: Checksum (sha256) mismatch for minipro-0.5.tar.gz
Portfile checksum: minipro-0.5.tar.gz sha256 1c7559fd45c5cfc1d83cd0dfe2dd132cb621afbd113ab18dec1b5e6832f7121d
Distfile checksum: minipro-0.5.tar.gz sha256 80ce742675f93fd4e2a30ab31a7e4f3fcfed8d56aa7cf9b3938046268004dae7
DEBUG: Calculated (size) is 388754
Error: Checksum (size) mismatch for minipro-0.5.tar.gzPortfile checksum: minipro-0.5.tar.gz size 388759
Distfile checksum: minipro-0.5.tar.gz size 388754

The correct checksum line may be:
checksums           rmd160  69bf57063a8ed6fd8bd248d4fc0daf6352ef58ce \
                    sha256  80ce742675f93fd4e2a30ab31a7e4f3fcfed8d56aa7cf9b3938046268004dae7 \
                    size    388754
Error: Failed to checksum minipro: Unable to verify file checksums
```


<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->

macOS 10.15.7 19H114
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
