### PR TITLE
google-cloud-sdk: update to 326.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             325.0.0
+version             326.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,14 +21,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  98e31e2129003f7ce5e59fa766cb0f01e6ab4176 \
-                    sha256  ca31b437868284fd1b03748e4f3707ad3c796379a1646775b073c4fd8255e529 \
-                    size    87274051
+    checksums       rmd160  9bc206b774712dae70dd0eeb0c1f14a99aa76d0e \
+                    sha256  d8fb8e92836ddc3dfaab5691af074981e5c874a239f010c069e4cd6f343389c1 \
+                    size    87377637
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  894b32b9a9eeb6464840ab28f46886ff9977a039 \
-                    sha256  da3cbb3157b98b1a5923e0866e3a1b8d35eadfd36b9a1f4a88ca3de6770ffb26 \
-                    size    110085875
+    checksums       rmd160  b5d72e9660e8ee143d1732f5029028a7cd0d9728 \
+                    sha256  d8d70ad7054c26f237f309f016e0995333cb7d56f5ecdfabb36780d939c6559b \
+                    size    110664247
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 326.0.0.

###### Tested on

macOS 11.2 20D64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?