### PR TITLE
auto-multiple-choice-devel: update to version 1.5.0-rc1

### DIFF
--- a/x11/auto-multiple-choice/Portfile
+++ b/x11/auto-multiple-choice/Portfile
@@ -22,44 +22,33 @@ homepage                http://www.auto-multiple-choice.net/
 
 subport auto-multiple-choice-devel {}
 
-set gitlab.home https://gitlab.com
-set gitlab.author jojo_boulix
-set gitlab.project ${name}
-
 if {${subport} eq ${name}} {
     # release
-    set gitlab.commit       "c6041a162202380b065b1b1abbdb016bb6d4b6a8"
-    set amc_revision        "201812291614"
-    set amc_date            "201812291614"
-    revision                1
-    version                 1.4.0-${amc_revision}
-    checksums               rmd160  205d1907927c3e3b230e19f3460d151dfa3dfa7d \
-                            sha256  8362dd01bd902556940a1415f23d00278b36c27e1e3d62e2190e32d78864b0fe \
-                            size    5125388
-    build.cmd               ${prefix}/bin/gmake
+    version                 1.4.0
+    checksums               rmd160  1c4774798321281f2fa76d0fcaeb490bd6ac58d3 \
+                            sha256  6d447bc5053fd2a57f854ead33ac50bb5c3a09e99e6f662c85febc5eb85a9fad \
+                            size    8513750
+
     conflicts               auto-multiple-choice-devel
 } else {
     # devel
-    set gitlab.commit       "3bfa3245ddf9fba8200b87f978061ed256c95210"
-    set amc_revision        "202101081229"
-    set amc_date            "202101081229"
-    version                 1.4.0-${amc_revision}
-    checksums               rmd160  3b5fec09dbcd8520be431723503815a882408ec8 \
-                            sha256  f6bfa2bf3eabc291d7c9ce137d71ed91d51ea141d62239cf546d22f12ba1a63a \
-                            size    7568646
-    build.cmd               ${prefix}/bin/gmake
+    set amc.version.main        1.5.0
+    set amc.version.secondary   rc1-6-g83952a21
+    version                 ${amc.version.main}_${amc.version.secondary}
+    checksums               rmd160  024b99f091f6a7de047feee22e7d66a6839729ec \
+                            sha256  4fd5b20295b6fd9efe697f7a33e9f1eed6cb7feb5f2c1ca6e75eaa20f953d168 \
+                            size    11166385
+
     conflicts               auto-multiple-choice
 }
 
-master_sites            https://gitlab.com/jojo_boulix/auto-multiple-choice/repository/archive.tar.gz?ref=${gitlab.commit}&dummy=
-distname                ${gitlab.project}-${gitlab.commit}-${gitlab.commit}
+master_sites            https://download.auto-multiple-choice.net/precomp/
+distfiles               ${name}_${version}_dist${extract.suffix}
 
-depends_build-append    \
-                        port:dblatex \
-                        port:gmake \
-                        port:gettext \
-                        port:libxslt \
-                        port:p${perl5.major}-xml-libxml
+use_configure           no
+
+depends_build           port:gmake
+build.cmd               ${prefix}/bin/gmake
 
 depends_lib-append      port:opencv
 
@@ -97,27 +86,29 @@ depends_run             \
                         port:texlive-latex-extra \
                         port:unzip
 
-configure {
+build.args              AMCCONF=macports \
+                        BASEPATH=${prefix}
+
+pre-build {
+    build.post_args-append PERLDIR=${perl5.lib}
     if {![variant_isset mactex]} {
         set amc.texmflocal ${texlive_texmflocal}
     }
-    system -W ${worksrcpath} "${build.cmd} version_files AMCCONF=macports BASEPATH=${prefix} PERLPATH=${perl5.bin} PERLDIR=${perl5.lib} SYSTEM_TYPE=macports TEXDIR=${amc.texmflocal}/tex/latex/AMC TEXDOCDIR=${amc.texmflocal}/doc/latex/AMC"
+    build.post_args-append TEXDIR="${amc.texmflocal}/tex/latex/AMC"
+    build.post_args-append TEXDOCDIR="${amc.texmflocal}/doc/latex/AMC"
 }
 
-build.env-append        AMCCONF=macports BASEPATH=${prefix}
+destroot.args           AMCCONF=macports \
+                        BASEPATH=${prefix}
 
 pre-destroot {
     destroot.args-append PERLDIR=${perl5.lib}
-
     if {![variant_isset mactex]} {
         set amc.texmflocal ${texlive_texmflocal}
     }
     destroot.args-append TEXDIR="${amc.texmflocal}/tex/latex/AMC"
     destroot.args-append TEXDOCDIR="${amc.texmflocal}/doc/latex/AMC"
 }
-
-destroot.args           AMCCONF=macports \
-                        BASEPATH=${prefix}
 
 # The mactex variant expects MacTeX to be installed
 # and installs dblatex's stylefiles to MacTeX's texmf (local)
@@ -181,3 +172,7 @@ post-activate {
 post-deactivate {
     amc.mktexlsr
 }
+
+livecheck.type          regex
+livecheck.url           [lindex ${master_sites} 0]#
+livecheck.regex         ${name}_(\[0-9.a-z-\]+_\[0-9.a-z-\]+)_


### PR DESCRIPTION
auto-multiple-choice-devel: update to version 1.5.0-rc1

• Update to 1.5.0-rc1-6-g83952a21
• Reorganize port to use pre-compiled sources with embedded
  documentation to avoid missing font errors during build.

Close https://trac.macports.org/ticket/55802
Close https://trac.macports.org/ticket/58936

#### Description
The new portfile update auto-multiple-choice-devel to version 1.5.0-rc1-6-g83952a21.

Working with auto-multiple-choice' developer, the new version of the portfile is modified to use pre-compiled sources with documentation already generated. This greatly simplify the build and reduce build errors.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on (standard and devel versions)
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2 20D64
Xcode 12.4 12D4e 

macOS 11.1 20C69
Xcode 12.4 12D4e 

+mactex
macOS 10.15.7 19H114
Xcode 12.4 12D4e 

macOS 10.14.6 18G7016
Xcode 11.3.1 11C504 

macOS 10.13.6 17G14042
Xcode 10.1 10B61 

macOS 10.12.6 16G2136
Xcode 9.2 9C40b 

macOS 10.11.6 15G22010
Xcode 8.2.1 8C1002 

macOS 10.10.5 14F2511
Xcode 7.2.1 7C1002 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
