### PR TITLE
mingw-binutils: Update to 2.36.1

### DIFF
--- a/_resources/port1.0/group/crossbinutils-1.0.tcl
+++ b/_resources/port1.0/group/crossbinutils-1.0.tcl
@@ -56,6 +56,16 @@ array set crossbinutils.versions_info {
         sha256  3ced91db9bf01182b7e420eab68039f2083aed0a214c0424e257eae3ddee8607 \
         size    22031720
     }}
+    2.36 {xz {
+        rmd160  3b9c7a8546771796e405645ed713008e79243868 \
+        sha256  5788292cc5bbcca0848545af05986f6b17058b105be59e99ba7d0f9eb5336fb8 \
+        size    22760136
+    }}
+    2.36.1 {xz {
+        rmd160  65047a9edd726380fa1e117514513c86b77cf3a0 \
+        sha256  e81d9edf373f193af428a0f256674aea62a9d74dfe93f65192d4eae030b0f3b0 \
+        size    22772248
+    }}
 }
 
 proc crossbinutils.setup {target version} {
@@ -137,6 +147,9 @@ proc crossbinutils.setup {target version} {
         reinplace -q "s|bfdincludedir=.*|bfdincludedir='${prefix}/${crossbinutils.target}/host/include'|g"  \
             ${worksrcpath}/bfd/configure                                             \
             ${worksrcpath}/opcodes/configure
+
+        reinplace -q "s|\$(libdir)/bfd-plugins|\"${prefix}/${crossbinutils.target}/host/lib/bfd-plugins\"|g" \
+            ${worksrcpath}/ld/Makefile.in
 
         reinplace -q "s|\$(libdir)|\"${prefix}/${crossbinutils.target}/host/lib\"|g" \
             ${worksrcpath}/libiberty/Makefile.in

--- a/cross/i686-w64-mingw32-binutils/Portfile
+++ b/cross/i686-w64-mingw32-binutils/Portfile
@@ -7,7 +7,7 @@ PortGroup           crossbinutils 1.0
 set mingw_name      w64-mingw32
 set mingw_arch      i686
 set mingw_target    ${mingw_arch}-${mingw_name}
-crossbinutils.setup ${mingw_target} 2.35.1
+crossbinutils.setup ${mingw_target} 2.36.1
 revision            0
 
 maintainers         {mojca @mojca} openmaintainer

--- a/cross/x86_64-w64-mingw32-binutils/Portfile
+++ b/cross/x86_64-w64-mingw32-binutils/Portfile
@@ -7,7 +7,7 @@ PortGroup           crossbinutils 1.0
 set mingw_name      w64-mingw32
 set mingw_arch      x86_64
 set mingw_target    ${mingw_arch}-${mingw_name}
-crossbinutils.setup ${mingw_target} 2.35.1
+crossbinutils.setup ${mingw_target} 2.36.1
 revision            0
 
 maintainers         {mojca @mojca} openmaintainer


### PR DESCRIPTION
#### Description

Updated crossbinutils-1.0.tcl, i686-w64-mingw32-binutils & x86_64-mingw32-binutils

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2 20D64
Xcode 12.4 12D4e

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
