### PR TITLE
syncthing: update to 1.13.1

### DIFF
--- a/net/syncthing/Portfile
+++ b/net/syncthing/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/syncthing/syncthing 1.12.1 v
+go.setup            github.com/syncthing/syncthing 1.13.1 v
 categories          net
 platforms           darwin
 license             MPL-2
@@ -18,9 +18,9 @@ long_description    Syncthing replaces proprietary sync and cloud services \
 homepage            https://syncthing.net
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  a158f05e366e6711d53c91f71557823b6e5b7d8a \
-                        sha256  65c578b90ba5b53193e23274e753a829e20216c7fcb17b6765e691e33c9f5a29 \
-                        size    5033543
+                        rmd160  3d9a47b44404938693a2803b448720b187fbb72a \
+                        sha256  110b0d5e0f879ccdaa873820ca6cf9fc7daa65458f7b02b040a3feda0377f297 \
+                        size    5044039
 
 go.vendors          gopkg.in/yaml.v3 \
                         lock    9f266ea9e77c \
@@ -99,10 +99,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  9fb936ce779314cfa755bd208b8a5ba7e4f41c23bd7a1d61bda6facb5d13052b \
                         size    151087 \
                     github.com/syncthing/notify \
-                        lock    9a0e44181151 \
-                        rmd160  44aaebc5bfd99c236bd39a067b72bacd197c8d98 \
-                        sha256  a445d3ffc362cb2a96f2601cfed00a831be9d75db47f11be7df8be433112e88d \
-                        size    57446 \
+                        lock    17de26665ddc \
+                        rmd160  2b1328b56d6cba0fe3717963115dfa6274b1a8a7 \
+                        sha256  fc0ed5b0fe3a4b81e776381368dffbaa7d93621403c8bc7d2027c823073a6b4c \
+                        size    57687 \
                     github.com/stretchr/testify \
                         lock    v1.6.1 \
                         rmd160  7e5b798212a8f15cd58a63985ae0b928eede8e6b \
@@ -119,10 +119,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  ed9418de8c92acfbbd8608745855ebfc67fa686c0a0a5245cf8eece8f540baa9 \
                         size    2144 \
                     github.com/shirou/gopsutil \
-                        lock    v3.20.10 \
-                        rmd160  a805ad80e2bc80782911443c0726ae653a90dde8 \
-                        sha256  6e30413c9644817d228e258aeea6134ef01dcac80fadfa9f5175a1910cb561c7 \
-                        size    278035 \
+                        lock    v3.20.11 \
+                        rmd160  60f9e1f1df95377b0600872e7be6553b69787b8b \
+                        sha256  ef56a4256848df47f3c22adba3c6baf13fbf42525920b23e6949851b575c04f3 \
+                        size    284015 \
                     github.com/sasha-s/go-deadlock \
                         lock    v0.2.0 \
                         rmd160  e9a7e7a4994c375c6fbf1a2773e37e1cd3bf2325 \


### PR DESCRIPTION
#### Description
Updates syncthing to 1.13.1
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2 20D64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
