### PR TITLE
ossp-uuid: configure +perl5_32 variant correctly

### DIFF
--- a/devel/ossp-uuid/Portfile
+++ b/devel/ossp-uuid/Portfile
@@ -6,7 +6,7 @@ PortGroup               perl5 1.0
 
 name                    ossp-uuid
 version                 1.6.2
-revision                11
+revision                12
 categories              devel
 license                 MIT
 platforms               darwin
@@ -92,7 +92,7 @@ foreach branch ${perl5.branches} {
     license_noconflict perl${branch}
 }
 
-if {[variant_isset perl5_26] || [variant_isset perl5_28] || [variant_isset perl5_30]} {
+if {[variant_isset perl5_26] || [variant_isset perl5_28] || [variant_isset perl5_30] || [variant_isset perl5_32]} {
     configure.perl          ${perl5.bin}
     configure.args-delete   --without-perl
     configure.args-append   --with-perl --with-perl-compat


### PR DESCRIPTION
#### Description

`+perl5_32` variant was added in 2426aa1016
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7
Xcode 12.4 command line tools

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
