### PR TITLE
py-base58: new port

### DIFF
--- a/python/py-base58/Portfile
+++ b/python/py-base58/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-base58
+version             2.1.0
+platforms           darwin
+license             MIT
+supported_archs     noarch
+
+maintainers         {@harens gmail.com:harensdeveloper} \
+                    openmaintainer
+
+description         Base58 and Base58Check implementation compatible \
+                    with what is used by the bitcoin network.
+long_description    {*}${description}. Any other alternative alphabet \
+                    (like the XRP one) can be used.
+
+homepage            https://github.com/keis/base58
+
+checksums           rmd160 4f994206f68e1c0cd897f17a221b7a1c92871431 \
+                    sha256 171a547b4a3c61e1ae3807224a6f7aec75e364c4395e7562649d7335768001a2 \
+                    size   6351
+
+python.versions     38 39
+
+if {${name} ne ${subport}} {
+
+    depends_build-append \
+                        port:py${python.version}-setuptools
+
+    livecheck.type      none
+}


### PR DESCRIPTION
#### Description

Dependency 3 on the roadmap to adding [Ciphey](https://github.com/Ciphey) (3 more to go).

See https://github.com/macports/macports-ports/pull/9920 and https://github.com/macports/macports-ports/pull/9913 for the others so far.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
xcode-select version 2384.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
