### PR TITLE
py-loguru: new port

### DIFF
--- a/python/py-loguru/Portfile
+++ b/python/py-loguru/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-loguru
+version             0.5.3
+platforms           darwin
+license             MIT
+supported_archs     noarch
+
+maintainers         {@harens gmail.com:harensdeveloper} \
+                    openmaintainer
+
+description         Python logging made (stupidly) simple
+long_description    {*}${description}. Loguru is a library \
+                    which aims to bring enjoyable logging in Python.
+
+homepage            https://loguru.readthedocs.io/en/stable/index.html
+
+checksums           rmd160 a0450cb82e158fcb657dcc3ce6cde30e04fdc316 \
+                    sha256 b28e72ac7a98be3d28ad28570299a393dfcd32e5e3f6a353dec94675767b6319 \
+                    size   122800
+
+python.versions     38 39
+
+if {${name} ne ${subport}} {
+
+    depends_build-append \
+                        port:py${python.version}-setuptools
+
+    livecheck.type      none
+}


### PR DESCRIPTION
#### Description

Dependency 6 on the roadmap to adding [Ciphey](https://github.com/Ciphey) (the final one 🎉).

See https://github.com/macports/macports-ports/pull/9923, #9922, #9921, #9920 and #9913 for the others dependencies.

_That's enough python ports for one day I think :)_

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
xcode-select version 2384.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
