### PR TITLE
nomad: set supported_archs

### DIFF
--- a/net/nomad/Portfile
+++ b/net/nomad/Portfile
@@ -22,6 +22,7 @@ platforms           darwin
 categories          net
 license             MPL-2
 installs_libs       no
+supported_archs     x86_64
 
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer


### PR DESCRIPTION
#### Description

Added `supported_archs` so nomad can be built under Apple Silicon via Rosetta. This changes make behavior of nomad port consistent with other HashiCorp tools such as `terraform`, `vault` and `consul`. Without `supported_archs` port will try to build nomad under arm64 and fail since `go` specify `x86_64` for its arch. 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
