### PR TITLE
weechat: update to 3.0.1

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -10,14 +10,18 @@ legacysupport.newest_darwin_requires_legacy 10
 
 conflicts           weechat-devel
 name                weechat
-version             3.0
+version             3.0.1
 revision            0
-checksums           rmd160  08e1903cfd3f63463ead1155af83537c815518ed \
-                    sha256  6cb7d25a363b66b835f1b9f29f3580d6f09ac7d38505b46a62c178b618d9f1fb \
-                    size    2215408
+checksums           rmd160  30e748302dc073b602acabca5b0e237aa35548b3 \
+                    sha256  781d9bfc7e1321447de9949263b82e3ee45639b7d71693558f40ff87211ca6dd \
+                    size    2215312
 
 master_sites        https://weechat.org/files/src/
 use_xz              yes
+
+livecheck.type      regex
+livecheck.regex     ^(\[0-9.\]*)$
+livecheck.url       https://weechat.org/dev/info/stable/
 
 homepage            https://weechat.org/
 license             GPL-3


### PR DESCRIPTION
#### Description

weechat: update to 3.0.1
* update livecheck URL

###### Tested on
macOS 10.15.7 19H114
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?