### PR TITLE
py-cipheycore: Add compiler blacklist

### DIFF
--- a/python/py-cipheycore/Portfile
+++ b/python/py-cipheycore/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 
 github.setup        ciphey cipheycore 0.3.2 v
 name                py-cipheycore
-revision            0
+revision            1
 python.versions     38 39
 
 description         Some cryptanalysis tidbits written in a proper language
@@ -34,8 +34,9 @@ if {${name} ne ${subport}} {
     # Use the build and destroot stage of python PG
     # This installs the generated python package
 
-    # cmake only necessary for the subports
     PortGroup           cmake 1.1
+
+    PortGroup           compiler_blacklist_versions 1.0
 
     depends_build-append \
                         port:py${python.version}-setuptools \
@@ -43,6 +44,18 @@ if {${name} ne ${subport}} {
                         port:poetry \
                         port:swig-python \
                         port:swig
+
+    # cipheycore requires C++20 standard
+    # This acts as a baseline (with additional blacklisting below)
+    compiler.cxx_standard 2017
+
+    # See https://en.cppreference.com/w/cpp/compiler_support/20
+    # Couldn't get gcc to play nicely with cipheycore
+    # For clang < 1000: target_compile_features The compiler feature "cxx_std_20"
+    # is not known to CXX compiler "AppleClang" version ...
+    # clang < 5 is blocked by cxx_standard 2017
+    compiler.blacklist-append *gcc* {clang < 1000} {macports-clang-[5-9].0}
+    compiler.fallback-append  macports-clang-10 macports-clang-11
 
     # Build the generated python package
     build.cmd           ${python.bin} setup.py


### PR DESCRIPTION
#### Description

The buildbots pre-10.14 are running into the following issue for py-cipheycore (here's an example from the [10.13 buildbot](https://build.macports.org/builders/ports-10.13_x86_64-builder/builds/102853/steps/install-port/logs/stdio)):
```
CMake Error at CMakeLists.txt:20 (target_compile_features):
  target_compile_features The compiler feature "cxx_std_20" is not known to
  CXX compiler

  "AppleClang"

  version 9.1.0.9020039.
```

_[Here's the line in question.](https://github.com/Ciphey/CipheyCore/blob/657e4c934bd1e747034c5c766269d31646b95e36/CMakeLists.txt#L20)_

However, macOS 10.14+ has AppleClang 10+, so this isn't an issue for the post-10.14 buildbots (see [C++20 compiler support](https://en.cppreference.com/w/cpp/compiler_support/20)). I therefore set this AppleClang version as a restriction.

Output from `port info py39-cipheycore` for devices that have AppleClang 10+:
```
Build Dependencies:   cmake, py39-setuptools, boost, poetry, swig-python, swig
```

And the new output for devices that have a lower version:
```
Build Dependencies:   cmake, py39-setuptools, boost, poetry, swig-python, swig, clang-9.0
```

I built py-cipheycore with clang 9 on both macOS 10.15.6 and 11.1, and I built it with clang 8-5 on just macOS 10.15.6. Surprisingly, it all worked fine.

I don't have a pre-Mojave device to test the different clang 3s, so I set that as a restriction just to be safe.

My experience with different C++ compilers is very limited, so any advice or reviews are appreciated. Thanks.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
xcode-select version 2384.

macOS 10.15.6 19G73
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
