### PR TITLE
py-click-spinner: Add python38 subport

### DIFF
--- a/python/py-click-spinner/Portfile
+++ b/python/py-click-spinner/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160 43dfb738f28b36b24ea3b54ff934062bb6407b53 \
                     sha256 87eacf9d7298973a25d7615ef57d4782aebf913a532bba4b28a37e366e975daf \
                     size   18720
 
-python.versions     39
+python.versions     38 39
 
 if {${name} ne ${subport}} {
 


### PR DESCRIPTION
#### Description

In anticipation for adding [Ciphey](https://github.com/Ciphey/Ciphey), I thought I'd add the python38 subport for one of it's dependencies.

This is since Ciphey currently doesn't support python 3.9: https://github.com/Ciphey/Ciphey/issues/558

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
xcode-select version 2384.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
