### PR TITLE
dspdfviewer: new port

### DIFF
--- a/office/dspdfviewer/Portfile
+++ b/office/dspdfviewer/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+PortGroup           qt5 1.0
+
+github.setup        dannyedel dspdfviewer 1.15.1 v
+categories          office
+platforms           darwin
+license             GPL-2+
+maintainers         {@ryanakca debian.org:rak} \
+                    openmaintainer
+description         dual-screen LaTeX beamer presentation viewer
+long_description    Provides a dual-screen presentation viewer for slides \
+                    produced with the beamer LaTeX package. It takes slides \
+                    produced with the "show notes on second screen" beamer \
+                    option, splits them, and shows the slides in one window \
+                    and the notes in a second window. The second window also \
+                    includes a talk timer, a preview of upcoming slides, and \
+                    other features.
+
+checksums           rmd160  82b190c46afe5fdf1feb5d121cf9a25a53da9612 \
+                    sha256  38a78b9d04ccc6eccea67857032baab06fc85e142c1c442253efe1466841dfd8 \
+                    size    165198
+
+qt5.depends_component \
+                    qttools
+
+depends_build-append \
+                    port:boost
+
+depends_lib-append \
+                    port:poppler-qt5
+
+# Use prerendered pdfs for testing instead of requiring a pdflatex installation
+configure.args-append \
+                    -DUsePrerenderedPDF=ON


### PR DESCRIPTION
#### Description

```
description         dual-screen LaTeX beamer presentation viewer
long_description    Provides a dual-screen presentation viewer for slides \
                    produced with the beamer LaTeX package. It takes slides \
                    produced with the "show notes on second screen" beamer \
                    option, splits them, and shows the slides in one window \
                    and the notes in a second window. The second window also \
                    includes a talk timer, a preview of upcoming slides, and \
                    other features.
```


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.1 20C69
Xcode 12.4 12D4e


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
