### PR TITLE
zathura: add variant with synctex support

### DIFF
--- a/office/zathura/Portfile
+++ b/office/zathura/Portfile
@@ -42,6 +42,11 @@ depends_lib         port:desktop-file-utils \
                     port:libmagic \
                     path:lib/libgirara-gtk3.dylib:girara
 
+# meson will automatically detect if synctex is available and link
+# against it. Explicitly disable it to avoid breaking zathura if
+# ever users uninstall texlive-bin
+configure.args-append   -Dsynctex=disabled
+
 # blacklist compilers that don't support -std=c11
 compiler.blacklist  *gcc-4.* {clang < 300}
 
@@ -75,6 +80,12 @@ subport ${name}-docs {
     }
 
     unset notes
+}
+
+variant synctex description "Enable synctex support" {
+    depends_lib-append  port:texlive-bin
+
+    configure.args-replace -Dsynctex=disabled -Dsynctex=enabled
 }
 
 livecheck.type      regex


### PR DESCRIPTION
#### Description

zathura needs synctex support to be able to synchronize latex-generated PDFs with text editors.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.1 20C69
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
