### PR TITLE
fzf: update to 0.25.1

### DIFF
--- a/sysutils/fzf/Portfile
+++ b/sysutils/fzf/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/junegunn/fzf 0.25.0
+go.setup            github.com/junegunn/fzf 0.25.1
 revision            0
 
 categories          sysutils
@@ -14,9 +14,9 @@ description         A command-line fuzzy finder written in Go
 long_description    ${description}
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  bb7b266ce23c014d095ed94ea3f73547583e9a79 \
-                        sha256  5dba419e2081e80d91afd7547481b52e156c6b7fce69e1c2ccc7419d9452ee68 \
-                        size    176961
+                        rmd160  14f50ea6cf54b3c67014d20adcb24873a4fccf24 \
+                        sha256  fa667ec0456caf5199cd6a10b886022593bdc30efbad4f45e9aa4cf340ec796a \
+                        size    178010
 
 go.vendors          golang.org/x/text \
                         lock    v0.3.3 \


### PR DESCRIPTION
#### Description

fzf: update to 0.25.1

###### Tested on
macOS 10.15.7 19H114
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
