### PR TITLE
libpsl: move to python 3.9

### DIFF
--- a/net/libpsl/Portfile
+++ b/net/libpsl/Portfile
@@ -8,7 +8,7 @@ github.setup        rockdaboot libpsl 0.21.1
 # when incrementing version or revision please check
 # that psl_data_commit and psl_data_date refer to latest
 # publicsuffix/list git master commit
-revision            0
+revision            1
 license             MIT
 description         A C library and utility to handle the Public Suffix List
 long_description    ${description}
@@ -48,7 +48,7 @@ checksums           ${main_distfile} \
 # clang_dependency PortGroup to avoid circular dependencies whilst building.
 # See e.g. https://trac.macports.org/ticket/60419
 
-set py_ver          3.8
+set py_ver          3.9
 set py_ver_nodot    [string map {. {}} ${py_ver}]
 
 depends_build-append \


### PR DESCRIPTION
#### Description

Move dependency from python 3.8 -> python 3.8 now that python 3.9 is now [the default](https://github.com/macports/macports-ports/blob/master/_resources/port1.0/group/python-1.0.tcl#L75) so that +universal works on M1 Macs.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.2 20D64
Xcode 12.4 12D4e

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?