### PR TITLE
llvm/clang/flang/lldb-11: upgrade to 11.0.1

### DIFF
--- a/lang/llvm-11/Portfile
+++ b/lang/llvm-11/Portfile
@@ -5,30 +5,31 @@ PortGroup compiler_blacklist_versions 1.0
 PortGroup active_variants 1.1
 PortGroup cmake         1.0
 PortGroup legacysupport 1.0
-PortGroup github        1.0
 
 # link legacysupport statically for compilers
 legacysupport.use_static yes
-
-# limit legacysupport to 10.9 for now
 legacysupport.newest_darwin_requires_legacy 13
 
 set llvm_version        11
 set clang_executable_version 11
 set lldb_executable_version 11
 
-github.setup            llvm llvm-project 11.0.0 llvmorg-
-
-github.tarball_from     releases
+# the github PortGroup does not serve this version of this project well, as the distnames are changing
+# every point release and the GH portgroup causes major havoc every time when it does
+# when the release finalizes, I will change it to the GH PortGroup at that time, but
+# I'm done wrestling with it for this release
+version                 11.0.1
+master_sites            https://github.com/llvm/llvm-project/releases/download/llvmorg-${version}
+distname                llvm-project-${version}.src
 use_xz                  yes
 
-checksums               rmd160  594eb676d9c9786d809587c39dff087f2e8c9429 \
-                        sha256  b7b639fc675fa1c86dd6d0bc32267be9eb34451748d2efd03f674b773000e92b \
-                        size    84792772
+checksums               rmd160  068b49a6e3a5d1d96347ea03813df96ea30b5b8c \
+                        sha256  af95d00f833dd67114b21c3cfe72dff2e1cdab627651f977b087a837136d653b \
+                        size    84061388
 
 name                    llvm-${llvm_version}
 revision                0
-subport                 clang-${llvm_version} { revision 1 }
+subport                 clang-${llvm_version} { revision 0 }
 subport                 flang-${llvm_version} { revision 0 }
 subport                 lldb-${llvm_version} { revision 0 }
 set suffix              mp-${llvm_version}
@@ -103,14 +104,11 @@ if {${subport} eq "llvm-${llvm_version}"} {
 # for devel version only
 # default_variants-append +assertions
 
-# the backtik pkgconfig setting in the ffi config line requires pkg-config
-depends_build-append    port:pkgconfig
-
-worksrcdir              llvm-project-${version}/llvm
+worksrcdir              llvm-project/llvm
 patch.dir               ${workpath}/llvm-project/llvm
 
 post-extract {
-    ln -s ${workpath}/llvm-project-${version} ${workpath}/llvm-project
+    ln -s ${workpath}/${distname} ${workpath}/llvm-project
 
     if {${subport} eq "llvm-${llvm_version}"} {
         if {[variant_isset polly]} {
@@ -172,6 +170,13 @@ if {${subport} eq "lldb-${llvm_version}"} {
         1005-Fixup-libstdc-header-search-paths-for-older-versions.patch \
         1007-Fix-float.h-to-work-on-Snow-Leopard-and-earlier.patch \
         openmp-locations.patch
+
+    # https://github.com/llvm/llvm-project/commit/1fdec59bffc11ae37eb51a1b9869f0696bfd5312
+    # remove in lldb-11.0.2
+    patchfiles-append \
+        4000-patch-lldb-D95683.diff
+
+
 }
 
 configure.post_args         ../${worksrcdir}
@@ -199,9 +204,9 @@ configure.args-append \
     -DLLVM_ENABLE_RTTI=ON \
     -DLLVM_INCLUDE_TESTS=OFF \
     -DLLVM_INCLUDE_EXAMPLES=OFF \
-    -DLLVM_ENABLE_FFI=ON \
     -DLLVM_BINDINGS_LIST=none \
-    -DFFI_INCLUDE_DIR=`pkg-config --cflags-only-I libffi | sed 's/-I//'` \
+    -DLLVM_ENABLE_FFI=ON \
+    -DFFI_INCLUDE_DIR=${prefix}/include \
     -DFFI_LIBRARY_DIR=${prefix}/lib
 
 if {${subport} eq "llvm-${llvm_version}"} {
@@ -220,8 +225,8 @@ if {${subport} eq "llvm-${llvm_version}"} {
         -DCLANG_ENABLE_ARCMT=OFF \
         -DDARWIN_PREFER_PUBLIC_SDK=ON \
         -DLLVM_BUILD_RUNTIME=ON \
-        -DLIBCXX_ENABLE_SHARED=OFF \
-        -DLIBCXX_INSTALL_LIBRARY=OFF
+        -DLIBCXX_ENABLE_SHARED=ON \
+        -DLIBCXX_INSTALL_LIBRARY=ON
 
 } elseif {${subport} eq "flang-${llvm_version}"} {
 
@@ -384,6 +389,7 @@ if {${subport} eq "clang-${llvm_version}"} {
         system "cd ${destroot.dir}/tools/clang && ${destroot.cmd} ${destroot.pre_args} ${destroot.target} ${destroot.post_args}"
         system "cd ${destroot.dir}/projects/compiler-rt && ${destroot.cmd} ${destroot.pre_args} ${destroot.target} ${destroot.post_args}"
         system "cd ${destroot.dir}/projects/libcxx && ${destroot.cmd} ${destroot.pre_args} ${destroot.target} ${destroot.post_args}"
+        system "cd ${destroot.dir}/projects/libcxxabi && ${destroot.cmd} ${destroot.pre_args} ${destroot.target} ${destroot.post_args}"
 
         delete ${destroot}${sub_prefix}/bin/clang
         file rename ${destroot}${sub_prefix}/bin/clang-${clang_executable_version} ${destroot}${sub_prefix}/bin/clang

--- a/lang/llvm-11/files/4000-patch-lldb-D95683.diff
+++ b/lang/llvm-11/files/4000-patch-lldb-D95683.diff
@@ -1,0 +1,150 @@
+From 1fdec59bffc11ae37eb51a1b9869f0696bfd5312 Mon Sep 17 00:00:00 2001
+From: Andi-Bogdan Postelnicu <abpostelnicu@me.com>
+Date: Wed, 3 Feb 2021 17:38:49 +0000
+Subject: [PATCH] [lldb] Fix fallout caused by D89156 on 11.0.1 for MacOS
+
+Fix fallout caused by D89156 on 11.0.1 for MacOS
+
+Differential Revision: https://reviews.llvm.org/D95683
+---
+ .../Platform/MacOSX/PlatformAppleTVSimulator.cpp       |  8 ++++----
+ .../Plugins/Platform/MacOSX/PlatformAppleTVSimulator.h |  2 +-
+ .../Platform/MacOSX/PlatformAppleWatchSimulator.cpp    |  8 ++++----
+ .../Platform/MacOSX/PlatformAppleWatchSimulator.h      |  2 +-
+ .../Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp   |  2 +-
+ .../Plugins/Platform/MacOSX/PlatformiOSSimulator.cpp   | 10 +++++-----
+ .../Plugins/Platform/MacOSX/PlatformiOSSimulator.h     |  2 +-
+ 7 files changed, 17 insertions(+), 17 deletions(-)
+
+diff --git llvm_master/tools/lldb/source/Plugins/Platform/MacOSX/PlatformAppleTVSimulator.cpp llvm_master/tools/lldb/source/Plugins/Platform/MacOSX/PlatformAppleTVSimulator.cpp
+index 461624a2adaa..cecffacf69fd 100644
+--- llvm_master/tools/lldb/source/Plugins/Platform/MacOSX/PlatformAppleTVSimulator.cpp
++++ llvm_master/tools/lldb/source/Plugins/Platform/MacOSX/PlatformAppleTVSimulator.cpp
+@@ -282,7 +282,7 @@ Status PlatformAppleTVSimulator::GetSymbolFile(const FileSpec &platform_file,
+ Status PlatformAppleTVSimulator::GetSharedModule(
+     const ModuleSpec &module_spec, lldb_private::Process *process,
+     ModuleSP &module_sp, const FileSpecList *module_search_paths_ptr,
+-    ModuleSP *old_module_sp_ptr, bool *did_create_ptr) {
++    llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules, bool *did_create_ptr) {
+   // For AppleTV, the SDK files are all cached locally on the host system. So
+   // first we ask for the file in the cached SDK, then we attempt to get a
+   // shared module for the right architecture with the right UUID.
+@@ -296,9 +296,9 @@ Status PlatformAppleTVSimulator::GetSharedModule(
+                               module_search_paths_ptr);
+   } else {
+     const bool always_create = false;
+-    error = ModuleList::GetSharedModule(
+-        module_spec, module_sp, module_search_paths_ptr, old_module_sp_ptr,
+-        did_create_ptr, always_create);
++    error = ModuleList::GetSharedModule(module_spec, module_sp,
++                                        module_search_paths_ptr, old_modules,
++                                        did_create_ptr, always_create);
+   }
+   if (module_sp)
+     module_sp->SetPlatformFileSpec(platform_file);
+diff --git llvm_master/tools/lldb/source/Plugins/Platform/MacOSX/PlatformAppleTVSimulator.h llvm_master/tools/lldb/source/Plugins/Platform/MacOSX/PlatformAppleTVSimulator.h
+index 5a7b0ee0d7dc..247cac06a320 100644
+--- llvm_master/tools/lldb/source/Plugins/Platform/MacOSX/PlatformAppleTVSimulator.h
++++ llvm_master/tools/lldb/source/Plugins/Platform/MacOSX/PlatformAppleTVSimulator.h
+@@ -55,7 +55,7 @@ class PlatformAppleTVSimulator : public PlatformAppleSimulator {
+   GetSharedModule(const lldb_private::ModuleSpec &module_spec,
+                   lldb_private::Process *process, lldb::ModuleSP &module_sp,
+                   const lldb_private::FileSpecList *module_search_paths_ptr,
+-                  lldb::ModuleSP *old_module_sp_ptr,
++                  llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules,
+                   bool *did_create_ptr) override;
+ 
+   uint32_t
+diff --git llvm_master/tools/lldb/source/Plugins/Platform/MacOSX/PlatformAppleWatchSimulator.cpp llvm_master/tools/lldb/source/Plugins/Platform/MacOSX/PlatformAppleWatchSimulator.cpp
+index 03a8fcd31360..372dd9de9757 100644
+--- llvm_master/tools/lldb/source/Plugins/Platform/MacOSX/PlatformAppleWatchSimulator.cpp
++++ llvm_master/tools/lldb/source/Plugins/Platform/MacOSX/PlatformAppleWatchSimulator.cpp
+@@ -283,7 +283,7 @@ Status PlatformAppleWatchSimulator::GetSymbolFile(const FileSpec &platform_file,
+ Status PlatformAppleWatchSimulator::GetSharedModule(
+     const ModuleSpec &module_spec, lldb_private::Process *process,
+     ModuleSP &module_sp, const FileSpecList *module_search_paths_ptr,
+-    ModuleSP *old_module_sp_ptr, bool *did_create_ptr) {
++    llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules, bool *did_create_ptr) {
+   // For AppleWatch, the SDK files are all cached locally on the host system.
+   // So first we ask for the file in the cached SDK, then we attempt to get a
+   // shared module for the right architecture with the right UUID.
+@@ -297,9 +297,9 @@ Status PlatformAppleWatchSimulator::GetSharedModule(
+                               module_search_paths_ptr);
+   } else {
+     const bool always_create = false;
+-    error = ModuleList::GetSharedModule(
+-        module_spec, module_sp, module_search_paths_ptr, old_module_sp_ptr,
+-        did_create_ptr, always_create);
++    error = ModuleList::GetSharedModule(module_spec, module_sp,
++                                        module_search_paths_ptr, old_modules,
++                                        did_create_ptr, always_create);
+   }
+   if (module_sp)
+     module_sp->SetPlatformFileSpec(platform_file);
+diff --git llvm_master/tools/lldb/source/Plugins/Platform/MacOSX/PlatformAppleWatchSimulator.h llvm_master/tools/lldb/source/Plugins/Platform/MacOSX/PlatformAppleWatchSimulator.h
+index 96dcd16ffa99..5becb8c0bf20 100644
+--- llvm_master/tools/lldb/source/Plugins/Platform/MacOSX/PlatformAppleWatchSimulator.h
++++ llvm_master/tools/lldb/source/Plugins/Platform/MacOSX/PlatformAppleWatchSimulator.h
+@@ -55,7 +55,7 @@ class PlatformAppleWatchSimulator : public PlatformAppleSimulator {
+   GetSharedModule(const lldb_private::ModuleSpec &module_spec,
+                   lldb_private::Process *process, lldb::ModuleSP &module_sp,
+                   const lldb_private::FileSpecList *module_search_paths_ptr,
+-                  lldb::ModuleSP *old_module_sp_ptr,
++                  llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules,
+                   bool *did_create_ptr) override;
+ 
+   uint32_t
+diff --git llvm_master/tools/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp llvm_master/tools/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
+index 79cbc940feb5..6d1cf804a0ae 100644
+--- llvm_master/tools/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
++++ llvm_master/tools/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
+@@ -730,7 +730,7 @@ Status PlatformDarwinKernel::GetSharedModule(
+     // framework on macOS systems, a chance.
+     error = PlatformDarwin::GetSharedModule(module_spec, process, module_sp,
+                                             module_search_paths_ptr,
+-                                            old_module_sp_ptr, did_create_ptr);
++                                            old_modules, did_create_ptr);
+     if (error.Success() && module_sp.get()) {
+       return error;
+     }
+diff --git llvm_master/tools/lldb/source/Plugins/Platform/MacOSX/PlatformiOSSimulator.cpp llvm_master/tools/lldb/source/Plugins/Platform/MacOSX/PlatformiOSSimulator.cpp
+index a890d0afdf1e..e293bd5b644c 100644
+--- llvm_master/tools/lldb/source/Plugins/Platform/MacOSX/PlatformiOSSimulator.cpp
++++ llvm_master/tools/lldb/source/Plugins/Platform/MacOSX/PlatformiOSSimulator.cpp
+@@ -286,8 +286,8 @@ Status PlatformiOSSimulator::GetSymbolFile(const FileSpec &platform_file,
+ 
+ Status PlatformiOSSimulator::GetSharedModule(
+     const ModuleSpec &module_spec, Process *process, ModuleSP &module_sp,
+-    const FileSpecList *module_search_paths_ptr, ModuleSP *old_module_sp_ptr,
+-    bool *did_create_ptr) {
++    const FileSpecList *module_search_paths_ptr,
++    llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules, bool *did_create_ptr) {
+   // For iOS, the SDK files are all cached locally on the host system. So first
+   // we ask for the file in the cached SDK, then we attempt to get a shared
+   // module for the right architecture with the right UUID.
+@@ -301,9 +301,9 @@ Status PlatformiOSSimulator::GetSharedModule(
+                               module_search_paths_ptr);
+   } else {
+     const bool always_create = false;
+-    error = ModuleList::GetSharedModule(
+-        module_spec, module_sp, module_search_paths_ptr, old_module_sp_ptr,
+-        did_create_ptr, always_create);
++    error = ModuleList::GetSharedModule(module_spec, module_sp,
++                                        module_search_paths_ptr, old_modules,
++                                        did_create_ptr, always_create);
+   }
+   if (module_sp)
+     module_sp->SetPlatformFileSpec(platform_file);
+diff --git llvm_master/tools/lldb/source/Plugins/Platform/MacOSX/PlatformiOSSimulator.h llvm_master/tools/lldb/source/Plugins/Platform/MacOSX/PlatformiOSSimulator.h
+index 4d416d759bd2..cc8e45a2be29 100644
+--- llvm_master/tools/lldb/source/Plugins/Platform/MacOSX/PlatformiOSSimulator.h
++++ llvm_master/tools/lldb/source/Plugins/Platform/MacOSX/PlatformiOSSimulator.h
+@@ -57,7 +57,7 @@ class PlatformiOSSimulator : public PlatformAppleSimulator {
+   GetSharedModule(const lldb_private::ModuleSpec &module_spec,
+                   lldb_private::Process *process, lldb::ModuleSP &module_sp,
+                   const lldb_private::FileSpecList *module_search_paths_ptr,
+-                  lldb::ModuleSP *old_module_sp_ptr,
++                  llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules,
+                   bool *did_create_ptr) override;
+ 
+   uint32_t


### PR DESCRIPTION
NEW in this release: we install both
libcxx and libcxxabi tucked away in the llvm library directory.

These are not used by any software at present, all of
which is hardcoded to use /usr/lib/libc++*.dylib

But it is there, including in static lib formats, for people
to experiment with.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G8012
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
