### PR TITLE
commitizen: update to 2.14.2

### DIFF
--- a/devel/commitizen/Portfile
+++ b/devel/commitizen/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                commitizen
-version             2.14.1
+version             2.14.2
 revision            0
 categories-prepend  devel
 platforms           darwin
@@ -26,9 +26,9 @@ long_description    Commitizen is a tool designed for teams. Its main purpose is
 
 homepage            https://${name}-tools.github.io/${name}/
 
-checksums           rmd160  87e102aba20d27a9ee9332995a5635df2350e417 \
-                    sha256  4202804e098a84443c3c0c0955a92e617110d263e37e6800f9916cf6af20fa20 \
-                    size    30459
+checksums           rmd160  f2841604b74d1eb6a83b4014840d5d0190f6f598 \
+                    sha256  25dda0cd54d12524de5637141291efbc8d83dfe9a779b5d4a65673017389c697 \
+                    size    30456
 
 depends_lib-append \
     port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

Created with [seaport](https://github.com/harens/seaport)

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.1 20C69
xcode-select version 2384.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?