### PR TITLE
py*-google-auth: upgrade to 1.25.0

### DIFF
--- a/python/py-google-auth/Portfile
+++ b/python/py-google-auth/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-google-auth
-version             1.11.2
+version             1.25.0
 revision            0
 
 categories-append   www devel
@@ -21,9 +21,9 @@ homepage            https://pypi.python.org/pypi/${python.rootname}
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  bc2c6821b62b5f4a8321f7be1933d2234dbaefab \
-                    sha256  1ee22e22f35d6e00f068d7b3999b2ce24ecb5d0dcbd485aa6896d2b83c8907d6 \
-                    size    88031
+checksums           rmd160  077e7c5a61134747ba2879b9fa0710f05615bff4 \
+                    sha256  514e39f4190ca972200ba33876da5a8857c5665f2b4ccc36c8b8ee21228aae80 \
+                    size    121940
 
 python.versions     27 35 36 37 38 39
 


### PR DESCRIPTION
#### Description

Closes [Trac #61283](https://trac.macports.org/ticket/61283).

Upgrades `py-google-auth` to the latest stable version. Without this change, `fava` fails on startup to a combination of a bad version constraint and the fact that `py-rsa` installs a more recent version.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
