### PR TITLE
deno: add support for aarch64

### DIFF
--- a/devel/deno/Portfile
+++ b/devel/deno/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        denoland deno 1.7.2 v
-revision            0
+revision            1
 
 homepage            https://deno.land
 
@@ -24,17 +24,28 @@ long_description    Deno is a a secure runtime for JavaScript and TypeScript. \
 categories          devel
 license             MIT
 platforms           darwin
-supported_archs     x86_64
+supported_archs     arm64 x86_64
 
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  dec99a38ae19bd1f28e84eebc1414099c302c502 \
+checksums           ${name}-x86_64-apple-darwin.zip \
+                    rmd160  dec99a38ae19bd1f28e84eebc1414099c302c502 \
                     sha256  41bd15dc5df8c2fa446424851d46b6430a4730b9c47d6b092dc0ae4c73b8485c \
-                    size    19271398
+                    size    19271398 \
+                    ${name}-aarch64-apple-darwin.zip \
+                    rmd160  81c7f56fb0919f659e376504cef287d767b544ac \
+                    sha256  abb6e4f1b8258c28647bdfd4e7921fcce1ea8301d94af13322693f9dc57a806d \
+                    size    19589391
+
+if {${build_arch} eq "arm64"} {
+    set release_arch aarch64
+} else {
+    set release_arch x86_64
+}
 
 github.tarball_from releases
-distname            ${name}-x86_64-apple-darwin
+distname            ${name}-${release_arch}-apple-darwin
 dist_subdir         ${name}/${version}
 extract.mkdir       yes
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Add support for `aarch64` to deno

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.3 Beta (20E5172i)
Xcode CLT 12.5 beta

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? n/a (no tests)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
