### PR TITLE
auctex:  add texlive-bin-extra as build-dep

### DIFF
--- a/editors/auctex/Portfile
+++ b/editors/auctex/Portfile
@@ -22,7 +22,8 @@ checksums           rmd160  7caab047d23c936fa1d95b5b66e41305e691a466 \
                     sha256  2fd4fe30b69457c9277fe204d3e83c8472bcf500c8fe4a810d744406174ca9dd \
                     size    1534283
 
-depends_build-append    port:texlive-latex
+depends_build-append    port:texlive-latex \
+                        port:texlive-bin-extra
 
 # We want emacs from MacPorts since this will install stuff in emacs'
 # site-lisp and we want it to go into ${prefix}'s site-lisp.


### PR DESCRIPTION
* add texlive-bin-extra as build depedency

#### Description

I found that the configure step failed without `texlive-bin-extra` installed, something about not detecting the texmf directory. 

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H512
Xcode 11.7 11E801a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
