### PR TITLE
redis: fix compilation on arm64

### DIFF
--- a/databases/redis/Portfile
+++ b/databases/redis/Portfile
@@ -23,7 +23,8 @@ checksums           rmd160  590bec2469980b73e80286cfac7c23aa69d7a9a9 \
                     sha256  79bbb894f9dceb33ca699ee3ca4a4e1228be7fb5547aeb2f99d921e86c1285bd \
                     size    2271970
 
-patchfiles          patch-redis.conf.diff
+patchfiles          patch-redis.conf.diff \
+                    patch-arm64.diff
 
 post-patch {
     reinplace "s|@PREFIX@|${prefix}|g" ${worksrcpath}/redis.conf

--- a/databases/redis/files/patch-arm64.diff
+++ b/databases/redis/files/patch-arm64.diff
@@ -1,0 +1,13 @@
+--- src/debug.c.orig	2021-02-07 02:40:15.441617896 -0500
++++ src/debug.c	2021-02-07 02:36:13.753866520 -0500
+@@ -53,6 +53,10 @@
+ #endif
+ #endif
+
++#if defined(__APPLE__) && defined(__arm64__) && defined(USE_JEMALLOC)
++#include <mach/mach.h>
++#endif
++
+ /* ================================= Debugging ============================== */
+
+ /* Compute the sha1 of string at 's' with 'len' bytes long.


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/61808

I will work to get this patch upstream as it is a legit bug there. Not bumping the revision because this is only unbreaking arm64.

#### Description

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H512
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
