### PR TITLE
ansifilter: update to 2.18

### DIFF
--- a/textproc/ansifilter/Portfile
+++ b/textproc/ansifilter/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 
 name            ansifilter
-version         2.17
+version         2.18
 revision        0
 categories      textproc
 maintainers     {evermeet.cx:tessarek @tessus} openmaintainer
@@ -20,9 +20,9 @@ homepage        http://www.andre-simon.de/doku/ansifilter/en/ansifilter.php
 master_sites    http://www.andre-simon.de/zip/
 use_bzip2       yes
 
-checksums       rmd160  deccc97918724720a9450311efd5a45548c8af77 \
-                sha256  5985beb39c960a3cb5b0e70d6a121687043dc8458e5783777ff250303cccc42f \
-                size    436116
+checksums       rmd160  b374e90fbd5e833998a51957c63d8e244af5419c \
+                sha256  66cf017d36a43d5f6ae20609ce3b58647494ee6c0e41fc682c598bffce7d7d39 \
+                size    436432
 
 use_configure   no
 


### PR DESCRIPTION
#### Description

ansifilter: update to 2.18

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] update

###### Tested on
macOS 10.14.6 18G8012
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
