### PR TITLE
kustomize: update to 3.9.3

### DIFF
--- a/devel/kustomize/Portfile
+++ b/devel/kustomize/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/kubernetes-sigs/kustomize 3.9.2 kustomize/v
+go.setup            github.com/kubernetes-sigs/kustomize 3.9.3 kustomize/v
 revision            0
 
 categories          devel
@@ -23,9 +23,9 @@ long_description    kustomize lets you customize raw, template-free YAML files f
 
 homepage            https://kustomize.io
 
-checksums           rmd160  934f7a452c39c997fa79a9a3d9c01b9588c3ea91 \
-                    sha256  fe8a6c39a392c7e2d3d35eeaa5ac9184241081ed534f6d96a5e53fc84e6ac299 \
-                    size    28122563
+checksums           rmd160  ce68aab2b90411a8782dd33be684cf45cb86dac0 \
+                    sha256  b70a4fd92931685f886d2ef00d6e9c3d3ccc636462032e90d8bb573c18321621 \
+                    size    28158224
 
 build.dir           ${worksrcpath}/${name}
 


### PR DESCRIPTION
#### Description

Update to Kustomize 3.9.3.

###### Tested on

macOS 11.2 20D64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?