### PR TITLE
libmed: added patch for test10 compilation failure

### DIFF
--- a/science/libmed/Portfile
+++ b/science/libmed/Portfile
@@ -8,7 +8,8 @@ name                    libmed
 version                 4.0.0
 # Must rebuild afer upgrading HDF5. Keep revision number even if 0.
 revision                1
-patchfiles              patch-hdf5-1.12.diff
+patchfiles              patch-hdf5-1.12.diff \
+                        patch-test10.diff
 categories              science devel
 platforms               darwin
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer

--- a/science/libmed/files/patch-test10.diff
+++ b/science/libmed/files/patch-test10.diff
@@ -1,0 +1,169 @@
+Patches test10 to avoid conflict with _a, _b and constants defined in internal header files.
+--- tests/c/test10.c.orig	2018-12-10 10:17:58.000000000 +0000
++++ tests/c/test10.c	2021-02-08 10:30:35.000000000 +0000
+@@ -14,8 +14,8 @@
+  *  You should have received a copy of the GNU Lesser General Public License
+  *  along with MED.  If not, see <http://www.gnu.org/licenses/>.
+  */
+-#define _a 0.446948490915965
+-#define _b 0.091576213509771
++#define _A 0.446948490915965
++#define _B 0.091576213509771
+ #define _p1 0.11169079483905
+ #define _p2 0.0549758718227661
+ 
+@@ -103,8 +103,8 @@
+ 
+   /* Constantes */
+ 
+-  med_float gscoo1_1[12] = { 2*_b-1, 1-4*_b, 2*_b-1, 2*_b-1, 1-4*_b,
+-                             2*_b-1, 1-4*_a, 2*_a-1, 2*_a-1, 1-4*_a, 2*_a-1, 2*_a-1 };
++  med_float gscoo1_1[12] = { 2*_B-1, 1-4*_B, 2*_B-1, 2*_B-1, 1-4*_B,
++                             2*_B-1, 1-4*_A, 2*_A-1, 2*_A-1, 1-4*_A, 2*_A-1, 2*_A-1 };
+   med_float wg1_1[6] = { 4*_p2, 4*_p2, 4*_p2, 4*_p1, 4*_p1, 4*_p1 };
+ 
+   med_int   nval1_1= 1*6; /*1 valeurs et 6 points de gauss par valeur */
+--- tests/c/test10_f32.c.orig	2018-12-10 17:42:27.000000000 +0000
++++ tests/c/test10_f32.c	2021-02-08 10:30:35.000000000 +0000
+@@ -14,8 +14,8 @@
+  *  You should have received a copy of the GNU Lesser General Public License
+  *  along with MED.  If not, see <http://www.gnu.org/licenses/>.
+  */
+-#define _a 0.446948490915965
+-#define _b 0.091576213509771
++#define _A 0.446948490915965
++#define _B 0.091576213509771
+ #define _p1 0.11169079483905
+ #define _p2 0.0549758718227661
+ 
+@@ -103,8 +103,8 @@
+ 
+   /* Constantes */
+ 
+-  med_float gscoo1_1[12] = { 2*_b-1, 1-4*_b, 2*_b-1, 2*_b-1, 1-4*_b,
+-                             2*_b-1, 1-4*_a, 2*_a-1, 2*_a-1, 1-4*_a, 2*_a-1, 2*_a-1 };
++  med_float gscoo1_1[12] = { 2*_B-1, 1-4*_B, 2*_B-1, 2*_B-1, 1-4*_B,
++                             2*_B-1, 1-4*_A, 2*_A-1, 2*_A-1, 1-4*_A, 2*_A-1, 2*_A-1 };
+   med_float wg1_1[6] = { 4*_p2, 4*_p2, 4*_p2, 4*_p1, 4*_p1, 4*_p1 };
+ 
+   med_int   nval1_1= 1*6; /*1 valeurs et 6 points de gauss par valeur */
+--- tests/c/test10_f32_i32.c.orig	2018-12-10 17:42:27.000000000 +0000
++++ tests/c/test10_f32_i32.c	2021-02-08 10:30:35.000000000 +0000
+@@ -14,8 +14,8 @@
+  *  You should have received a copy of the GNU Lesser General Public License
+  *  along with MED.  If not, see <http://www.gnu.org/licenses/>.
+  */
+-#define _a 0.446948490915965
+-#define _b 0.091576213509771
++#define _A 0.446948490915965
++#define _B 0.091576213509771
+ #define _p1 0.11169079483905
+ #define _p2 0.0549758718227661
+ 
+@@ -103,8 +103,8 @@
+ 
+   /* Constantes */
+ 
+-  med_float gscoo1_1[12] = { 2*_b-1, 1-4*_b, 2*_b-1, 2*_b-1, 1-4*_b,
+-                             2*_b-1, 1-4*_a, 2*_a-1, 2*_a-1, 1-4*_a, 2*_a-1, 2*_a-1 };
++  med_float gscoo1_1[12] = { 2*_B-1, 1-4*_B, 2*_B-1, 2*_B-1, 1-4*_B,
++                             2*_B-1, 1-4*_A, 2*_A-1, 2*_A-1, 1-4*_A, 2*_A-1, 2*_A-1 };
+   med_float wg1_1[6] = { 4*_p2, 4*_p2, 4*_p2, 4*_p1, 4*_p1, 4*_p1 };
+ 
+   med_int   nval1_1= 1*6; /*1 valeurs et 6 points de gauss par valeur */
+--- tests/c/test10_f32_i64.c.orig	2018-12-10 17:42:27.000000000 +0000
++++ tests/c/test10_f32_i64.c	2021-02-08 10:30:35.000000000 +0000
+@@ -14,8 +14,8 @@
+  *  You should have received a copy of the GNU Lesser General Public License
+  *  along with MED.  If not, see <http://www.gnu.org/licenses/>.
+  */
+-#define _a 0.446948490915965
+-#define _b 0.091576213509771
++#define _A 0.446948490915965
++#define _B 0.091576213509771
+ #define _p1 0.11169079483905
+ #define _p2 0.0549758718227661
+ 
+@@ -103,8 +103,8 @@
+ 
+   /* Constantes */
+ 
+-  med_float gscoo1_1[12] = { 2*_b-1, 1-4*_b, 2*_b-1, 2*_b-1, 1-4*_b,
+-                             2*_b-1, 1-4*_a, 2*_a-1, 2*_a-1, 1-4*_a, 2*_a-1, 2*_a-1 };
++  med_float gscoo1_1[12] = { 2*_B-1, 1-4*_B, 2*_B-1, 2*_B-1, 1-4*_B,
++                             2*_B-1, 1-4*_A, 2*_A-1, 2*_A-1, 1-4*_A, 2*_A-1, 2*_A-1 };
+   med_float wg1_1[6] = { 4*_p2, 4*_p2, 4*_p2, 4*_p1, 4*_p1, 4*_p1 };
+ 
+   med_int   nval1_1= 1*6; /*1 valeurs et 6 points de gauss par valeur */
+--- tests/c/test10_i32.c.orig	2018-12-10 17:42:27.000000000 +0000
++++ tests/c/test10_i32.c	2021-02-08 10:30:35.000000000 +0000
+@@ -14,8 +14,8 @@
+  *  You should have received a copy of the GNU Lesser General Public License
+  *  along with MED.  If not, see <http://www.gnu.org/licenses/>.
+  */
+-#define _a 0.446948490915965
+-#define _b 0.091576213509771
++#define _A 0.446948490915965
++#define _B 0.091576213509771
+ #define _p1 0.11169079483905
+ #define _p2 0.0549758718227661
+ 
+@@ -103,8 +103,8 @@
+ 
+   /* Constantes */
+ 
+-  med_float gscoo1_1[12] = { 2*_b-1, 1-4*_b, 2*_b-1, 2*_b-1, 1-4*_b,
+-                             2*_b-1, 1-4*_a, 2*_a-1, 2*_a-1, 1-4*_a, 2*_a-1, 2*_a-1 };
++  med_float gscoo1_1[12] = { 2*_B-1, 1-4*_B, 2*_B-1, 2*_B-1, 1-4*_B,
++                             2*_B-1, 1-4*_A, 2*_A-1, 2*_A-1, 1-4*_A, 2*_A-1, 2*_A-1 };
+   med_float wg1_1[6] = { 4*_p2, 4*_p2, 4*_p2, 4*_p1, 4*_p1, 4*_p1 };
+ 
+   med_int   nval1_1= 1*6; /*1 valeurs et 6 points de gauss par valeur */
+--- tests/c/test10_i64.c.orig	2018-12-10 17:42:27.000000000 +0000
++++ tests/c/test10_i64.c	2021-02-08 10:30:35.000000000 +0000
+@@ -14,8 +14,8 @@
+  *  You should have received a copy of the GNU Lesser General Public License
+  *  along with MED.  If not, see <http://www.gnu.org/licenses/>.
+  */
+-#define _a 0.446948490915965
+-#define _b 0.091576213509771
++#define _A 0.446948490915965
++#define _B 0.091576213509771
+ #define _p1 0.11169079483905
+ #define _p2 0.0549758718227661
+ 
+@@ -103,8 +103,8 @@
+ 
+   /* Constantes */
+ 
+-  med_float gscoo1_1[12] = { 2*_b-1, 1-4*_b, 2*_b-1, 2*_b-1, 1-4*_b,
+-                             2*_b-1, 1-4*_a, 2*_a-1, 2*_a-1, 1-4*_a, 2*_a-1, 2*_a-1 };
++  med_float gscoo1_1[12] = { 2*_B-1, 1-4*_B, 2*_B-1, 2*_B-1, 1-4*_B,
++                             2*_B-1, 1-4*_A, 2*_A-1, 2*_A-1, 1-4*_A, 2*_A-1, 2*_A-1 };
+   med_float wg1_1[6] = { 4*_p2, 4*_p2, 4*_p2, 4*_p1, 4*_p1, 4*_p1 };
+ 
+   med_int   nval1_1= 1*6; /*1 valeurs et 6 points de gauss par valeur */
+--- tests/c/test10_mem.c.orig	2017-07-10 15:25:25.000000000 +0100
++++ tests/c/test10_mem.c	2021-02-08 10:30:35.000000000 +0000
+@@ -14,8 +14,8 @@
+  *  You should have received a copy of the GNU Lesser General Public License
+  *  along with MED.  If not, see <http://www.gnu.org/licenses/>.
+  */
+-#define _a 0.446948490915965
+-#define _b 0.091576213509771
++#define _A 0.446948490915965
++#define _B 0.091576213509771
+ #define _p1 0.11169079483905
+ #define _p2 0.0549758718227661
+ 
+@@ -74,8 +74,8 @@
+ 
+   /* Constantes */
+ 
+-  med_float gscoo1_1[12] = { 2*_b-1, 1-4*_b, 2*_b-1, 2*_b-1, 1-4*_b,
+-                             2*_b-1, 1-4*_a, 2*_a-1, 2*_a-1, 1-4*_a, 2*_a-1, 2*_a-1 };
++  med_float gscoo1_1[12] = { 2*_B-1, 1-4*_B, 2*_B-1, 2*_B-1, 1-4*_B,
++                             2*_B-1, 1-4*_A, 2*_A-1, 2*_A-1, 1-4*_A, 2*_A-1, 2*_A-1 };
+   med_float wg1_1[6] = { 4*_p2, 4*_p2, 4*_p2, 4*_p1, 4*_p1, 4*_p1 };
+ 
+   med_int   nval1_1= 1*6; /*1 valeurs et 6 points de gauss par valeur */


### PR DESCRIPTION
#### Description

This PR fixes an issue in libmed causing a compile failure in `tests/c/test10*.c`, which can be seen in the recent PR to fix HDF5 1.12+ (#9681). These files define constants via macros named `_a` and `_b`; however these are at conflict with the internal header `_fd_def.h`, which defines a function `__darwin_check_fd_set` with parameters named `_a` and `_b`. For example:

```
  In file included from /opt/local/var/macports/build/_Users_runner_work_macports-ports_macports-ports_ports_science_libmed/libmed/work/med-4.0.0/tests/c/test10_i32.c:29:
  In file included from /opt/local/var/macports/build/_Users_runner_work_macports-ports_macports-ports_ports_science_libmed/libmed/work/build/include/med.h:22:
  In file included from /opt/local/include/hdf5.h:22:
  In file included from /opt/local/include/H5public.h:38:
  In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include/sys/types.h:184:
  /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include/sys/_types/_fd_def.h:58:27: error: expected ')'
  __darwin_check_fd_set(int _a, const void *_b)
                            ^
  /opt/local/var/macports/build/_Users_runner_work_macports-ports_macports-ports_ports_science_libmed/libmed/work/med-4.0.0/tests/c/test10_i32.c:17:12: note: expanded from macro '_a'
  #define _a 0.446948490915965
             ^
  /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include/sys/_types/_fd_def.h:58:22: note: to match this '('
  __darwin_check_fd_set(int _a, const void *_b)
                       ^
  /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include/sys/_types/_fd_def.h:58:27: error: parameter name omitted
  __darwin_check_fd_set(int _a, const void *_b)
                            ^
  /opt/local/var/macports/build/_Users_runner_work_macports-ports_macports-ports_ports_science_libmed/libmed/work/med-4.0.0/tests/c/test10_i32.c:17:12: note: expanded from macro '_a'
  #define _a 0.446948490915965
```

This patch simply renames the macros to `_A` and `_B` in these files. I have not tested libmed directly, but I have tested one of its dependencies, gmsh, which seems to work fine.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
   have tried this with gmsh

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
