### PR TITLE
Update older ruby versions' config.guess and config.sub

### DIFF
--- a/lang/ruby/Portfile
+++ b/lang/ruby/Portfile
@@ -84,6 +84,15 @@ patchfiles		patch-vendordir.diff \
 # http://chopine.be/lrz/ruby-osx-patches/ignore-gsetcontext.diff
 patchfiles-append patch-node.h.diff
 
+# replace old config.{guess,sub} with recent versions from automake
+depends_build-append    port:automake
+post-patch {
+    set automake_dirs [glob -directory ${prefix}/share automake-*]
+    set automake_dir [lindex [lsort -command vercmp $automake_dirs] end]
+    copy -force ${automake_dir}/config.guess ${automake_dir}/config.sub \
+        ${worksrcpath}
+}
+
 use_parallel_build		no
 
 # [OK] apple-gcc-4.2

--- a/lang/ruby19/Portfile
+++ b/lang/ruby19/Portfile
@@ -26,8 +26,6 @@ long_description	Ruby is the interpreted scripting language for quick \
 
 homepage			http://www.ruby-lang.org/
 license				{Ruby BSD}
-# configure does not accept darwin arm64
-supported_archs     x86_64 i386 ppc
 
 master_sites		ruby:1.9
 use_bzip2			yes
@@ -70,6 +68,15 @@ patchfiles-append	patch-ext-openssl-openssl_missing.diff \
 
 # fix extensions failing to configure due to not including the right headers
 patchfiles-append   implicit.patch
+
+# replace old config.{guess,sub} with recent versions from automake
+depends_build-append    port:automake
+post-patch {
+    set automake_dirs [glob -directory ${prefix}/share automake-*]
+    set automake_dir [lindex [lsort -command vercmp $automake_dirs] end]
+    copy -force ${automake_dir}/config.guess ${automake_dir}/config.sub \
+        ${worksrcpath}/tool
+}
 
 # ruby-1.9.3 supports Xcode-4.2 clang and gcc-4.2.
 # ruby built with llvm-gcc will be broken.

--- a/lang/ruby20/Portfile
+++ b/lang/ruby20/Portfile
@@ -24,8 +24,6 @@ long_description    Ruby is the interpreted scripting language for quick \
 
 homepage            http://www.ruby-lang.org/
 license             {Ruby BSD}
-# configure does not accept darwin arm64
-supported_archs     x86_64 i386 ppc
 
 master_sites        ruby:2.0
 use_bzip2           yes
@@ -72,6 +70,15 @@ patchfiles          patch-ext-tk-extconf.rb.diff
 #                             from RUBY_ARCH and RUBY_PLATFORM in config.h
 #                             https://trac.macports.org/ticket/58255
 patchfiles-append   patch-configure_cxx11.diff
+
+# replace old config.{guess,sub} with recent versions from automake
+depends_build-append    port:automake
+post-patch {
+    set automake_dirs [glob -directory ${prefix}/share automake-*]
+    set automake_dir [lindex [lsort -command vercmp $automake_dirs] end]
+    copy -force ${automake_dir}/config.guess ${automake_dir}/config.sub \
+        ${worksrcpath}/tool
+}
 
 # [NOTE] workaround for mismatch of sdk versions on macOS 11.x,
 # such as MacOSX11.0.sdk (buildbot) <=> MacOSX11.1.sdk (user's Mac).

--- a/lang/ruby21/Portfile
+++ b/lang/ruby21/Portfile
@@ -24,8 +24,6 @@ long_description    Ruby is the interpreted scripting language for quick \
 
 homepage            http://www.ruby-lang.org/
 license             {Ruby BSD}
-# configure does not accept darwin arm64
-supported_archs     x86_64 i386 ppc
 
 master_sites        ruby:2.1
 use_bzip2           yes
@@ -56,6 +54,15 @@ patchfiles          patch-ext_openssl_ossl.h.diff
 #                             from RUBY_ARCH and RUBY_PLATFORM in config.h
 #                             https://trac.macports.org/ticket/58255
 patchfiles-append   patch-configure_cxx11.diff
+
+# replace old config.{guess,sub} with recent versions from automake
+depends_build-append    port:automake
+post-patch {
+    set automake_dirs [glob -directory ${prefix}/share automake-*]
+    set automake_dir [lindex [lsort -command vercmp $automake_dirs] end]
+    copy -force ${automake_dir}/config.guess ${automake_dir}/config.sub \
+        ${worksrcpath}/tool
+}
 
 configure.args      --enable-shared \
                     --disable-install-doc \

--- a/lang/ruby22/Portfile
+++ b/lang/ruby22/Portfile
@@ -25,8 +25,6 @@ long_description    Ruby is the interpreted scripting language for quick \
 
 homepage            http://www.ruby-lang.org/
 license             {Ruby BSD}
-# configure does not accept darwin arm64
-supported_archs     x86_64 i386 ppc
 
 master_sites        ruby:2.2
 use_bzip2           yes
@@ -59,6 +57,15 @@ patchfiles-append   patch-internal.h.diff
 #                             from RUBY_ARCH and RUBY_PLATFORM in config.h
 #                             https://trac.macports.org/ticket/58255
 patchfiles-append   patch-configure_cxx11.diff
+
+# replace old config.{guess,sub} with recent versions from automake
+depends_build-append    port:automake
+post-patch {
+    set automake_dirs [glob -directory ${prefix}/share automake-*]
+    set automake_dir [lindex [lsort -command vercmp $automake_dirs] end]
+    copy -force ${automake_dir}/config.guess ${automake_dir}/config.sub \
+        ${worksrcpath}/tool
+}
 
 configure.args      --enable-shared \
                     --disable-install-doc \

--- a/lang/ruby23/Portfile
+++ b/lang/ruby23/Portfile
@@ -24,8 +24,6 @@ long_description    Ruby is the interpreted scripting language for quick \
 
 homepage            http://www.ruby-lang.org/
 license             {Ruby BSD}
-# configure does not accept darwin arm64
-supported_archs     x86_64 i386 ppc
 
 master_sites        ruby:2.3
 use_bzip2           yes
@@ -59,6 +57,15 @@ patchfiles-append   patch-tiger.diff
 #                             from RUBY_ARCH and RUBY_PLATFORM in config.h
 #                             https://trac.macports.org/ticket/58255
 patchfiles-append   patch-configure_cxx11.diff
+
+# replace old config.{guess,sub} with recent versions from automake
+depends_build-append    port:automake
+post-patch {
+    set automake_dirs [glob -directory ${prefix}/share automake-*]
+    set automake_dir [lindex [lsort -command vercmp $automake_dirs] end]
+    copy -force ${automake_dir}/config.guess ${automake_dir}/config.sub \
+        ${worksrcpath}/tool
+}
 
 configure.args      --enable-shared \
                     --disable-install-doc \

--- a/lang/ruby24/Portfile
+++ b/lang/ruby24/Portfile
@@ -60,6 +60,15 @@ depends_run         port:ruby_select
 depends_build       port:pkgconfig
 depends_skip_archcheck pkgconfig
 
+# replace old config.{guess,sub} with recent versions from automake
+depends_build-append    port:automake
+post-patch {
+    set automake_dirs [glob -directory ${prefix}/share automake-*]
+    set automake_dir [lindex [lsort -command vercmp $automake_dirs] end]
+    copy -force ${automake_dir}/config.guess ${automake_dir}/config.sub \
+        ${worksrcpath}/tool
+}
+
 select.group        ruby
 select.file         ${filespath}/ruby24
 

--- a/lang/ruby25/Portfile
+++ b/lang/ruby25/Portfile
@@ -20,8 +20,6 @@ long_description    Ruby is the interpreted scripting language for quick \
 
 homepage            http://www.ruby-lang.org/
 license             {Ruby BSD}
-# configure does not accept darwin arm64
-supported_archs     x86_64 i386 ppc
 
 master_sites        ruby:2.5
 use_bzip2           yes
@@ -62,6 +60,15 @@ patchfiles-append   patch-osversions.diff
 #                             from RUBY_ARCH and RUBY_PLATFORM in config.h
 #                             https://trac.macports.org/ticket/58255
 patchfiles-append   patch-configure_cxx11.diff
+
+# replace old config.{guess,sub} with recent versions from automake
+depends_build-append    port:automake
+post-patch {
+    set automake_dirs [glob -directory ${prefix}/share automake-*]
+    set automake_dir [lindex [lsort -command vercmp $automake_dirs] end]
+    copy -force ${automake_dir}/config.guess ${automake_dir}/config.sub \
+        ${worksrcpath}/tool
+}
 
 configure.args      --enable-shared \
                     --enable-install-static-library \


### PR DESCRIPTION
#### Description

Should enable configure to accept darwin arm64.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix
