### PR TITLE
py-cipheycore: Fix python3 configuration

### DIFF
--- a/python/py-cipheycore/Portfile
+++ b/python/py-cipheycore/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 
 github.setup        ciphey cipheycore 0.3.2 v
 name                py-cipheycore
-revision            1
+revision            2
 python.versions     38 39
 
 description         Some cryptanalysis tidbits written in a proper language
@@ -64,8 +64,11 @@ if {${name} ne ${subport}} {
     use_configure       yes
 
     # Remove dependency on gtest
+    # Set the build dep python's headers
+    # Fixes segmentation fault if different python version also installed
     configure.args-append \
-                        "-DCIPHEY_CORE_TEST=OFF"
+                        -DCIPHEY_CORE_TEST=OFF \
+                        -DCIPHEY_CORE_PYTHON=${frameworks_dir}/Python.framework/Versions/${python.branch}
 
     # We use make for configure, not the setup.py
     # (since python package hasn't been generated yet)


### PR DESCRIPTION
#### Description

_Apologies for all these bug fixes for cipheycore. Loads of Ciphey users who use macOS have issues with cipheycore (e.g. https://github.com/Ciphey/Ciphey/issues/256 https://github.com/Ciphey/Ciphey/issues/362), which is why I think it's so important to have a working MacPorts portfile. Hopefully, this should be the last bug fix before adding ciphey._

cipheycore builds fine if only it's equivalent python version is active (i.e. py38-cipheycore builds fine if only python38 is active). This is fine for the buildbots, but not if the user has to build from source and has different python versions active. If the wrong python version is found, a segmentation fault occurs at runtime. This sort of issue is very similar to https://trac.macports.org/ticket/59946, and a temporary fix before this PR is merged would be to use trace mode.

The reason why this happens is explained here https://github.com/Ciphey/Ciphey/issues/238#issuecomment-688630158.

This bug fix manually sets the build dependency python to be used during the configure stage. It sets `-DCIPHEY_CORE_PYTHON` to the folder containing the python headers (see https://github.com/Ciphey/CipheyCore#linuxosxother-unices).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
xcode-select version 2384.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
