### PR TITLE
py-mpi4py: add Python 3.9 subport

### DIFF
--- a/python/py-mpi4py/Portfile
+++ b/python/py-mpi4py/Portfile
@@ -33,7 +33,7 @@ checksums           rmd160  ee5b2f5540558b986aa21c6e5f56b0c6c4f1db7e \
 
 mpi.setup           require
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

py-mpi4py: add Python 3.9 subport

Fixes: [py39-h5py depends on nonexistent port py39-mpi4py](https://trac.macports.org/ticket/62217)

Notes:
- As part of this PR, a source install of `py39-h5py +mpich` was also tested. (Selecting any of the MPI-related variants, adds a dependency on `py-mpi4py`.)
- When trace mode is enabled, installs for the various subports of `py-mpi4py` fail due to the following lib being hidden: `${prefix}/lib/libhwloc.15.dylib`. Since this is a pre-existing issue, it is well outside the scope of this PR.

###### Type(s)
- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14019
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
