### PR TITLE
openjdk12*, openjdk13*, openjdk14*: obsolete, replace with openjdk15*

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -152,118 +152,58 @@ subport openjdk11-openj9-large-heap {
                  size    195829115
 }
 
+# Remove after 2022-02-15
 subport openjdk12 {
     version      12.0.2
-    revision     0
-
-    set build    10
-    set major    12
-
-    checksums    rmd160  298235796f231dcd79baa1eccce40b4eb4aba456 \
-                 sha256  9919eee037554d40c7d2f219bbd654f2bf119e16a2f4d284d8dedaf525ee59e6 \
-                 size    198392994
+    revision     1
 }
 
+# Remove after 2022-02-15
 subport openjdk12-openj9 {
     version      12.0.2
-    revision     0
-
-    set build    10
-    set openj9_version 0.15.1
-    set major    12
-
-    checksums    rmd160  eb8b931dc23ff3adb998e9c880e027e03b11e7cf \
-                 sha256  20d19ec20f65335edbf4db3861421be393d48720d5a389cd76e1c81a8aff8fee \
-                 size    197951754
+    revision     1
 }
 
+# Remove after 2022-02-15
 subport openjdk12-openj9-large-heap {
     version      12.0.2
-    revision     0
-
-    set build    10
-    set openj9_version 0.15.1
-    set major    12
-
-    checksums    rmd160  01c7e4723cbee7e8a34e605a369a3986ace9d07a \
-                 sha256  d7c4c75f04f75767e26ffa0083c8a365ec95e8f5ccddcc0005dbd538954064b4 \
-                 size    197960269
+    revision     1
 }
 
+# Remove after 2022-02-15
 subport openjdk13 {
     version      13.0.2
-    revision     0
-
-    set build    8
-    set major    13
-
-    checksums    rmd160  0de593a1b3df57a6a91d9ab3e3d0ee7475bc1e0d \
-                 sha256  0ddb24efdf5aab541898d19b7667b149a1a64a8bd039b708fc58ee0284fa7e07 \
-                 size    198206427
+    revision     1
 }
 
+# Remove after 2022-02-15
 subport openjdk13-openj9 {
     version      13.0.2
-    revision     0
-
-    set build    8
-    set openj9_version 0.18.0
-    set major    13
-
-    checksums    rmd160  193fc075719f33545f7f9deafebd783b5d7e8df1 \
-                 sha256  dd8d92eec98a3455ec5cd065a0a6672cc1aef280c6a68c507c372ccc1d98fbaa \
-                 size    201152468
+    revision     1
 }
 
+# Remove after 2022-02-15
 subport openjdk13-openj9-large-heap {
     version      13.0.2
-    revision     0
-
-    set build    8
-    set openj9_version 0.18.0
-    set major    13
-
-    checksums    rmd160  7e71c9b1bd5aa8365af66803e3b5292b391e710b \
-                 sha256  a9b7cf11ec9c5df29a09336c91dd7e3232f6fae423e10eec60836330efc2c8cc \
-                 size    201151793
+    revision     1
 }
 
+# Remove after 2022-02-15
 subport openjdk14 {
     version      14.0.2
-    revision     0
-
-    set build    12
-    set major    14
-
-    checksums    rmd160  2b6beb756626e8ab72eb85d25701be522e5beb3f \
-                 sha256  09b7e6ab5d5eb4b73813f4caa793a0b616d33794a17988fa6a6b7c972e8f3dd3 \
-                 size    195705010
+    revision     1
 }
 
+# Remove after 2022-02-15
 subport openjdk14-openj9 {
     version      14.0.2
-    revision     0
-
-    set build    12
-    set openj9_version 0.21.0
-    set major    14
-
-    checksums    rmd160  0ea69114a43e0c4e3e4cb80abf7bcd9bf86c05ca \
-                 sha256  95e6abcc12dde676ccd5ba65ab86f06ddaa22749dde00e31f4c6d3ea95277359 \
-                 size    200090793
+    revision     1
 }
 
+# Remove after 2022-02-15
 subport openjdk14-openj9-large-heap {
     version      14.0.2
-    revision     0
-
-    set build    12
-    set openj9_version 0.21.0
-    set major    14
-
-    checksums    rmd160  f77124d360ab493a5f69b3b58e5dd9e8d77c718a \
-                 sha256  178270b6cc2213bad148c32e3bced0fb18aafee1f83be735d729e0261b4958da \
-                 size    200881593
+    revision     1
 }
 
 subport openjdk15 {
@@ -340,6 +280,18 @@ if {${subport} eq "openjdk8"} {
     # Remove after 2021-11-28
     PortGroup    obsolete 1.0
     replaced_by  openjdk11
+} elseif {${subport} in [list openjdk12 openjdk13 openjdk14]} {
+    PortGroup    obsolete 1.0
+    # Can replace with openjdk16 when it is added and openjdk15 is obsoleted
+    replaced_by  openjdk15
+} elseif {${subport} in [list openjdk12-openj9 openjdk13-openj9 openjdk14-openj9]} {
+    PortGroup    obsolete 1.0
+    # Can replace with openjdk16-openj9 when it is added and openjdk15-openj9 is obsoleted
+    replaced_by  openjdk15-openj9
+} elseif {${subport} in [list openjdk12-openj9-large-heap openjdk13-openj9-large-heap openjdk14-openj9-large-heap]} {
+    PortGroup    obsolete 1.0
+    # Can replace with openjdk16-openj9-large-heap when it is added and openjdk15-openj9-large-heap is obsoleted
+    replaced_by  openjdk15-openj9-large-heap
 } elseif {[string match *-graalvm ${subport}]} {
     description  GraalVM Community Edition based on OpenJDK ${major}
     long_description ${long_description_graalvm}
@@ -419,11 +371,3 @@ by adding the following line to your shell profile:
 
     export JAVA_HOME=${target}/Contents/Home
 "
-
-if {[string match openjdk12* ${subport}] || [string match openjdk13* ${subport}] || [string match openjdk14* ${subport}]} {
-    notes-append "
-    Warning: Support for OpenJDK ${major} has reached end of life and there will be no more updates.
-             Please consider migrating to a supported OpenJDK version.
-             Currently OpenJDK 8, 11 and 15 are supported.
-    "
-}


### PR DESCRIPTION
#### Description
Public updates for openjdk12, openjdk13, and openjdk14 ended 2019-09, 2020-03, and 2020-09 respectively. No dependents.

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
Only `port info` tested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
