### PR TITLE
vmd: new port

### DIFF
--- a/textproc/vmd/Portfile
+++ b/textproc/vmd/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        yoshuawuyts vmd 1.34.0
+revision            0
+
+description         Preview markdown files
+
+long_description    Preview markdown files in a separate window. Markdown is \
+                    formatted exactly the same as on GitHub.
+
+categories          textproc
+license             MIT
+platforms           darwin
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  16931fc68d1cf07851a62c8e7536d13840b5d210 \
+                    sha256  27c5ff27cd6746d2084063cf9931cf63f523ad0b126bff2de25a637562fadc65 \
+                    size    697266
+
+depends_build       port:yarn
+
+build.env-append    CSC_IDENTITY_AUTO_DISCOVERY=false
+
+use_configure       no
+use_xcode           yes
+
+build {
+    # Fetch and build JS dependencies
+    system -W ${worksrcpath} "${build.env} yarn install --frozen-lockfile"
+
+    # Build electron app
+    system -W ${worksrcpath} "${build.env} yarn pack-mac"
+}
+
+destroot {
+    copy ${worksrcpath}/build/${name}-darwin-x64/${name}.app \
+        ${destroot}${applications_dir}
+
+    ln -s ${applications_dir}/${name}.app/Contents/MacOS/vmd \
+        ${destroot}${prefix}/bin/
+}
+
+github.livecheck.regex {([0-9.]+)}


### PR DESCRIPTION
#### Description

New port for **[vmd](https://github.com/yoshuawuyts/vmd)**, a Markdown previewer that can be started from the command line (`$ vmd ./path/README.md`).

![](https://raw.githubusercontent.com/yoshuawuyts/vmd/master/docs/screenshot.png)

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
