### PR TITLE
llvm-11: update to 11.0.1

### DIFF
--- a/lang/llvm-11/Portfile
+++ b/lang/llvm-11/Portfile
@@ -17,18 +17,19 @@ set llvm_version        11
 set clang_executable_version 11
 set lldb_executable_version 11
 
-github.setup            llvm llvm-project 11.0.0 llvmorg-
+github.setup            llvm llvm-project 11.0.1 llvmorg-
 
 github.tarball_from     releases
 use_xz                  yes
+extract.suffix          .src.tar.xz
 
-checksums               rmd160  594eb676d9c9786d809587c39dff087f2e8c9429 \
-                        sha256  b7b639fc675fa1c86dd6d0bc32267be9eb34451748d2efd03f674b773000e92b \
-                        size    84792772
+checksums               rmd160  068b49a6e3a5d1d96347ea03813df96ea30b5b8c \
+                        sha256  af95d00f833dd67114b21c3cfe72dff2e1cdab627651f977b087a837136d653b \
+                        size    84061388
 
 name                    llvm-${llvm_version}
 revision                0
-subport                 clang-${llvm_version} { revision 1 }
+subport                 clang-${llvm_version} { revision 0 }
 subport                 flang-${llvm_version} { revision 0 }
 subport                 lldb-${llvm_version} { revision 0 }
 set suffix              mp-${llvm_version}


### PR DESCRIPTION

Update to 11.0.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
