### PR TITLE
opencv4: generate pkg-config file

### DIFF
--- a/graphics/opencv4/Portfile
+++ b/graphics/opencv4/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 
 github.setup        opencv opencv 4.5.0
 name                opencv4
-revision            3
+revision            4
 categories          graphics science
 platforms           darwin
 license             BSD
@@ -227,6 +227,12 @@ configure.args-append \
                     -DOPENCV_PYTHON_SKIP_DETECTION:BOOL=OFF \
                     -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/python \
                     -DPYTHON_DEFAULT_EXECUTABLE:FILEPATH=/usr/bin/python
+
+    if {${name} ne ${subport}} {
+        # generate pkg-config file
+        configure.args-append \
+                    -DOPENCV_GENERATE_PKGCONFIG=YES
+    }
 
 universal_variant   no
 
@@ -574,6 +580,17 @@ post-extract {
 post-destroot {
     ui_debug "${subport}: phase post-destroot running"
     opencv_post_destroot
+
+    if {${name} ne ${subport}} {
+        # Move opencv4.pc to standard location
+        xinstall -d ${destroot}${prefix}/lib/pkgconfig
+        move ${destroot}${prefix}/lib/opencv4/pkgconfig/opencv4.pc \
+             ${destroot}${prefix}/lib/pkgconfig/
+
+        # Fix paths in opencv4.pc
+        reinplace "s|\$\{exec_prefix\}\/||g" ${destroot}${prefix}/lib/pkgconfig/opencv4.pc
+        reinplace "s|\$\{prefix\}\/||g" ${destroot}${prefix}/lib/pkgconfig/opencv4.pc
+    }
 }
 
 if {[string match "py*" ${subport}]} {


### PR DESCRIPTION
fix double paths in opencv4.pc file and move to default location

#### Description

Several packages require a pkg-config file to be properly configured. E.g. gmic and py-gmic, among others. opencv4, by default does not generate this file. This is a blocker in updating those packages to use opencv4 rather than opencv(3).
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G8012
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
