### PR TITLE
google-cloud-sdk: update to 327.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             326.0.0
+version             327.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,14 +21,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  9bc206b774712dae70dd0eeb0c1f14a99aa76d0e \
-                    sha256  d8fb8e92836ddc3dfaab5691af074981e5c874a239f010c069e4cd6f343389c1 \
-                    size    87377637
+    checksums       rmd160  20370bb5eff268df9fac86101ac21e4378a262fd \
+                    sha256  280944a3129673dee6943920831b83d088ffe905bb98edb9d957770dc896ac9b \
+                    size    87495824
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  b5d72e9660e8ee143d1732f5029028a7cd0d9728 \
-                    sha256  d8d70ad7054c26f237f309f016e0995333cb7d56f5ecdfabb36780d939c6559b \
-                    size    110664247
+    checksums       rmd160  3eaeef841b931a6bd0e412073931b4b198b551a8 \
+                    sha256  f2246a789f279504cc6b0b5432fef60a97ba7c25b5ca4e672da6106cbe5abd8c \
+                    size    109646870
 }
 
 homepage            https://cloud.google.com/sdk/
@@ -74,6 +74,7 @@ variant kpt description {Add kpt} { dict set variant_to_component kpt kpt }
 variant kubectl description {Add kubectl} { dict set variant_to_component kubectl kubectl }
 variant kubectl_oidc description {Add kubectl-oidc} { dict set variant_to_component kubectl_oidc kubectl-oidc }
 variant kustomize description {Add Kustomize} { dict set variant_to_component kustomize kustomize }
+variant local_extract description {Add On-Demand Scanning API extraction helper} { dict set variant_to_component local_extract local-extract }
 variant minikube description {Add Minikube} { dict set variant_to_component minikube minikube }
 variant nomos description {Add Nomos CLI} { dict set variant_to_component nomos nomos }
 variant pkg description {Add pkg} { dict set variant_to_component pkg pkg }


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 327.0.0 and add variant for optional `local-extract` component.

###### Tested on

macOS 11.2.1 20D74
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?