### PR TITLE
freac: add missing codecs

### DIFF
--- a/aqua/smooth/Portfile
+++ b/aqua/smooth/Portfile
@@ -33,7 +33,6 @@ checksums           rmd160  b53e8720b3e3e8fad48e7c1f6f1dd55a910758f8 \
 depends_lib         port:bzip2 \
                     port:curl \
                     port:fribidi \
-                    port:gtk3 \
                     path:include/turbojpeg.h:libjpeg-turbo \
                     port:libxml2
 

--- a/audio/freac/Portfile
+++ b/audio/freac/Portfile
@@ -6,6 +6,7 @@ PortGroup           makefile 1.0
 
 github.setup        enzo1982 freac 1.1.3 v
 github.tarball_from releases
+revision            1
 
 categories          audio
 platforms           darwin
@@ -24,6 +25,21 @@ checksums           rmd160  2f1f9ea871793cec1a8fe02a96fb9c03b1fa0c49 \
 
 depends_lib         port:boca \
                     port:smooth
+
+depends_run         path:lib/libavcodec.dylib:ffmpeg \
+                    port:flac \
+                    port:lame \
+                    port:libfdk-aac \
+                    port:libogg \
+                    port:libopus \
+                    port:libsamplerate \
+                    port:libsndfile \
+                    port:libvorbis \
+                    port:mp4v2 \
+                    port:mpg123 \
+                    port:rubberband \
+                    port:speex \
+                    port:wavpack
 
 makefile.prefix_name    prefix
 


### PR DESCRIPTION
#### Description
freac: Added missing audio codecs and DSP libraries
smooth: Removed gtk dependency as it is not needed for macOS

Note: Both changes have been suggested by fre:ac's author.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1
Xcode 12.3 Build version 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
