### PR TITLE
libreoffice: switch to accepted patch

### DIFF
--- a/office/libreoffice/Portfile
+++ b/office/libreoffice/Portfile
@@ -137,7 +137,8 @@ depends_lib-append  \
     port:xz \
     port:zlib
 # Try to keep this in sync with the Python portgroup.
-set python_version 38
+set pyver 3.8
+set python_version [string index ${pyver} 0][string index ${pyver} end]
 depends_run-append \
     port:python${python_version} \
     port:py${python_version}-lxml
@@ -163,7 +164,20 @@ pre-configure {
 use_xcode           yes
 # CMS_NO_REGISTER_KEYWORD required for C++17 or newer compiler.
 configure.env-append  \
-    "LCMS2_CFLAGS=-I${prefix}/include -DCMS_NO_REGISTER_KEYWORD=1"
+    "LCMS2_CFLAGS=-I${prefix}/include -DCMS_NO_REGISTER_KEYWORD=1" \
+    PYTHON=${prefix}/bin/python${pyver}
+# PYTHON_CFLAGS and PYTHON_LIBS have to be non-empty
+set python_cflags [exec pkg-config --cflags python-${pyver}]
+set python_libs [exec pkg-config --libs python-${pyver}]
+if {${python_cflags} == ""} {
+    set python_cflags "-I${prefix}/include"
+}
+if {${python_libs} == ""} {
+    set python_libs "-L${prefix}/lib"
+}
+configure.env-append \
+    PYTHON_CFLAGS=${python_cflags} \
+    PYTHON_LIBS=${python_libs}
 # Most arguments are from
 # https://wiki.documentfoundation.org/LibreOffice_Vanilla_for_Mac#LibreOffice_Vanilla
 configure.args-append  \

--- a/office/libreoffice/files/patch-configure.diff
+++ b/office/libreoffice/files/patch-configure.diff
@@ -1,25 +1,38 @@
+From d1dc51f95f9e831aa6adbbeff549c2017d2dfd82 Mon Sep 17 00:00:00 2001
+From: Andrew Udvare <audvare@gmail.com>
+Date: Tue, 29 Dec 2020 15:18:06 -0500
+Subject: [PATCH] configure.ac: allow --enable-python=system on macOS if PYTHON is non-empty
+
+This will work as long as a valid Python is in PATH, such as /usr/bin/python3
+from Xcode or another version in some prefix like /opt/local.
+
+Change-Id: Ic967c3ce2f9949d94c11c3449363841a1565cfa9
+Reviewed-on: https://gerrit.libreoffice.org/c/core/+/108486
+Tested-by: Jenkins
+Reviewed-by: Michael Stahl <michael.stahl@allotropia.de>
+---
+
 diff --git configure.ac configure.ac
-index e4ef8bec2b3e..402979d77ffe 100644
+index e660733..78bb799 100644
 --- configure.ac
 +++ configure.ac
-@@ -8845,10 +8845,6 @@ AC_SUBST(XMLLINT)
+@@ -9238,8 +9238,9 @@
  # Optionally user can pass an option to configure, i. e.
  # ./configure PYTHON=/usr/bin/python
  # =====================================================================
 -if test $_os = Darwin -a "$enable_python" != no -a "$enable_python" != fully-internal -a "$enable_python" != internal; then
--    # Only allowed choices for macOS are 'no', 'internal' (default), and 'fully-internal'
--    enable_python=internal
--fi
++if test $_os = Darwin -a "$enable_python" != no -a "$enable_python" != fully-internal -a "$enable_python" != internal -a "$enable_python" != system; then
+     # Only allowed choices for macOS are 'no', 'internal' (default), and 'fully-internal'
++    # unless PYTHON is defined as above which allows 'system'
+     enable_python=internal
+ fi
  if test "$build_os" != "cygwin" -a "$enable_python" != fully-internal; then
-     if test -n "$PYTHON"; then
-         PYTHON_FOR_BUILD=$PYTHON
-@@ -8918,9 +8914,6 @@ fully-internal)
+@@ -9311,7 +9312,7 @@
      ;;
  system)
      AC_MSG_RESULT([system])
 -    if test "$_os" = Darwin; then
--        AC_MSG_ERROR([--enable-python=system doesn't work on macOS because the version provided is obsolete])
--    fi
++    if test "$_os" = Darwin -a -z "$PYTHON"; then
+         AC_MSG_ERROR([--enable-python=system doesn't work on macOS because the version provided is obsolete])
+     fi
      ;;
- *)
-     AC_MSG_ERROR([Incorrect --enable-python option])


### PR DESCRIPTION
Correctly set PYTHON/etc environment variables to force system Python.

No revision bump because this change does not change functionality.

See: [Gerrit](https://gerrit.libreoffice.org/c/core/+/108486)

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [x] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2 20D64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
