### PR TITLE
lagrange: update to 1.1.2

### DIFF
--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -8,7 +8,7 @@ PortGroup           legacysupport 1.1
 # strnlen
 legacysupport.newest_darwin_requires_legacy 10
 
-github.setup        skyjake lagrange 1.1.0 v
+github.setup        skyjake lagrange 1.1.2 v
 github.tarball_from releases
 categories          net gemini
 platforms           darwin
@@ -18,15 +18,16 @@ maintainers         {@sikmir gmail.com:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    ${description}
 
-checksums           rmd160  e3a135d68ca28beb1b95765efbecbfe47c5f90d6 \
-                    sha256  291e1d17520eebc470efe852d5cbecec4989369ccce369f6633443e2ef2fd11c \
-                    size    14296829
+checksums           rmd160  a7f024a38b6ba40b813d93d540a9c03aae4e585a \
+                    sha256  e419c7827d3dda2cf5fd667eb4bed33a74c0174a91f71072080fb418f74d0e92 \
+                    size    14299169
 
 depends_build-append \
                     port:pkgconfig
 depends_lib-append  port:libsdl2 \
                     port:libunistring \
                     path:lib/libssl.dylib:openssl \
+                    port:mpg123 \
                     port:pcre \
                     port:zlib
 


### PR DESCRIPTION
#### Description
* [changelog](https://github.com/skyjake/lagrange/releases)
* added `mpg123` lib for MPEG audio support

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
