### PR TITLE
kustomize: update to 3.10.0

### DIFF
--- a/devel/kustomize/Portfile
+++ b/devel/kustomize/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/kubernetes-sigs/kustomize 3.9.4 kustomize/v
+go.setup            github.com/kubernetes-sigs/kustomize 3.10.0 kustomize/v
 revision            0
 
 categories          devel
@@ -23,9 +23,9 @@ long_description    kustomize lets you customize raw, template-free YAML files f
 
 homepage            https://kustomize.io
 
-checksums           rmd160  6b16546537711afcd56ecfe3b06ba5948dcda017 \
-                    sha256  d89f25c2cffbd286685b8776c7142e5aa5ff38497f76fd576f915344543c52b0 \
-                    size    28169325
+checksums           rmd160  510168560dfbe247154e49529d941d6987ffae77 \
+                    sha256  44aba59a9f250e47090aae2d8a6ee33d5a5ea473187c6ab6ec856d4a775a2a80 \
+                    size    28021744
 
 build.dir           ${worksrcpath}/${name}
 


### PR DESCRIPTION
#### Description

Update to Kustomize 3.10.0.

###### Tested on

macOS 11.2.1 20D74
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?