### PR TITLE
rancher-cli: update to 2.4.10

### DIFF
--- a/devel/rancher-cli/Portfile
+++ b/devel/rancher-cli/Portfile
@@ -3,10 +3,10 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/rancher/cli 2.4.9 v
+go.setup            github.com/rancher/cli 2.4.10 v
 name                rancher-cli
 revision            0
-categories          devel
+categories          devel sysutils
 platforms           darwin
 license             Apache-2
 maintainers         {emcrisostomo @emcrisostomo} \
@@ -19,16 +19,12 @@ long_description    The Rancher CLI (Command Line Interface) is a unified \
                     this tool, you can operate Rancher using a command \
                     line rather than the GUI.
 
-checksums           rmd160  25becc934645dc71b427cd11394b83ade55cba05 \
-                    sha256  31bfcc47cdcda10720aead5e7ae8f7a6e4bfe359d82bcca5d2883deba2b0e7e3 \
-                    size    2251473
+checksums           rmd160  0f0779946615833943392c6581a6db955b50edc5 \
+                    sha256  d34563ecb737d8a359856d2e1ce2de8876a64d71fb5f5499b82f801c79d72ab8 \
+                    size    2251779
 
-build.target        github.com/rancher/cli
-
-pre-build {
-    build.cmd ${go.bin} build -ldflags \
-        "\"-w -X main.VERSION=${version}\""
-}
+build.pre_args-append       -ldflags "\"-w -X main.VERSION=${version}\""
+build.args                  github.com/rancher/cli
 
 destroot {
     xinstall -m 755 ${worksrcpath}/cli ${destroot}${prefix}/bin/rancher


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
