### PR TITLE
doctl: update to 1.56.0

### DIFF
--- a/www/doctl/Portfile
+++ b/www/doctl/Portfile
@@ -3,12 +3,12 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/digitalocean/doctl 1.46.0 v
+go.setup            github.com/digitalocean/doctl 1.56.0 v
 revision            0
 
-checksums           rmd160  2d75b2653bf2ef5404c8a3ac082b8186e12c7b37 \
-                    sha256  9fd4c0e28ff5512fd293e4a4317137553857579c37a3576b2b4b90fcc6c14005 \
-                    size    4637812
+checksums           rmd160  4fa8f2ac39f2899972520109525ec4d412fdc060 \
+                    sha256  fc5b3b148962f098d4f5bd90b67c06fd9ad3c184d7305b14181aeea1d2bac7c0 \
+                    size    5164863
 
 categories          www devel
 platforms           darwin
@@ -16,8 +16,6 @@ license             Apache-2
 maintainers         {@kritr gmail.com:krdevmail} openmaintainer
 description         A command line interface for the DigitalOcean API
 long_description    ${description}
-
-depends_build-append port:git
 
 set doctl_ver [split ${version} "."]
 set doctl_major [lindex ${doctl_ver} 0]
@@ -37,7 +35,7 @@ build.env-delete    GO111MODULE=off
 build.env-append    GO111MODULE=on \
                     CGO_ENABLED=0
 
-build.target        ${worksrcpath}/cmd/${name}/main.go
+build.target        ${worksrcpath}/cmd/${name}
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
