### PR TITLE
libreoffice: move pkg-config calls to pre-configure

### DIFF
--- a/office/libreoffice/Portfile
+++ b/office/libreoffice/Portfile
@@ -166,18 +166,20 @@ use_xcode           yes
 configure.env-append  \
     "LCMS2_CFLAGS=-I${prefix}/include -DCMS_NO_REGISTER_KEYWORD=1" \
     PYTHON=${prefix}/bin/python${pyver}
-# PYTHON_CFLAGS and PYTHON_LIBS have to be non-empty
-set python_cflags [exec pkg-config --cflags python-${pyver}]
-set python_libs [exec pkg-config --libs python-${pyver}]
-if {${python_cflags} == ""} {
-    set python_cflags "-I${prefix}/include"
+pre-configure {
+    # PYTHON_CFLAGS and PYTHON_LIBS have to be non-empty
+    set python_cflags [exec pkg-config --cflags python-${pyver}]
+    set python_libs [exec pkg-config --libs python-${pyver}]
+    if {${python_cflags} == ""} {
+        set python_cflags "-I${prefix}/include"
+    }
+    if {${python_libs} == ""} {
+        set python_libs "-L${prefix}/lib"
+    }
+    configure.env-append \
+        PYTHON_CFLAGS=${python_cflags} \
+        PYTHON_LIBS=${python_libs}
 }
-if {${python_libs} == ""} {
-    set python_libs "-L${prefix}/lib"
-}
-configure.env-append \
-    PYTHON_CFLAGS=${python_cflags} \
-    PYTHON_LIBS=${python_libs}
 # Most arguments are from
 # https://wiki.documentfoundation.org/LibreOffice_Vanilla_for_Mac#LibreOffice_Vanilla
 configure.args-append  \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [x] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2 20D64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
