### PR TITLE
ftgl: attempt to fix build on macOS 11, other minor fixes

### DIFF
--- a/graphics/ftgl/Portfile
+++ b/graphics/ftgl/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem                 1.0
 PortGroup         github   1.0
-PortGroup         cxx11    1.1
 
 github.setup      frankheckenbach ftgl 2.4.0 v
 
@@ -18,6 +17,8 @@ long_description  FTGL takes freetype fonts, decodes them, and generate an OpenG
 checksums         rmd160  c904e2aa2e5dc5329867ce120f4b1ebe1910ff65 \
                   sha256  933a371dbb2f44c9fa3121484d46081b5f1ed08c18908ba49bff92811629aede \
                   size    630956
+
+compiler.cxx_standard 2011
 
 configure.cmd     ./autogen.sh && ./configure
 

--- a/graphics/ftgl/Portfile
+++ b/graphics/ftgl/Portfile
@@ -32,6 +32,9 @@ depends_build-append \
     port:libtool \
     port:pkgconfig
 
+configure.env-append \
+    LIBTOOLIZE=${prefix}/bin/glibtoolize
+
 # Note, this package finds OpenGL.framework... perhaps there should be
 # an x11 variant for mesa?
 

--- a/graphics/ftgl/Portfile
+++ b/graphics/ftgl/Portfile
@@ -41,6 +41,14 @@ configure.env-append \
 # Skip building the example program by failing to find GLUT
 configure.args  --with-glut-inc=/dev/null --with-glut-lib=/dev/null
 
+if {${os.platform} eq "darwin" && ${os.major} >= 20} {
+    # configure: error: GL library could not be found
+    configure.ldflags-append -framework OpenGL
+
+    # https://trac.macports.org/ticket/61210
+    configure.ldflags-append -framework GLUT
+}
+
 # Build requires c++11 but does not seem to explicitly enable it...
 configure.cxxflags-append -std=c++11
 


### PR DESCRIPTION
See: https://trac.macports.org/ticket/61210


#### Description
Also switch from deprecated `cxx11 1.1` portgroup to `compiler.cxx_standard 2011`, and specify glibtoolize path to avoid complaint:

```
Warning:  libtoolize does not appear to be available.  This means that
the automatic build preparation via autoreconf will probably not work.
Preparing the build by running each step individually, however, should
work and will be done automatically for you if autoreconf fails.

Fortunately, glibtoolize was found which means that your system may simply
have a non-standard or incomplete GNU Autotools install.  If you have
sufficient system access, it may be possible to quell this warning by
running:

   ln -s /opt/local/bin/glibtoolize /opt/local/bin/libtoolize

Run that as root or with proper permissions to the /opt/local/bin directory
```

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7
Xcode 12.4 command line tools

I have verified the approach appends `-framework GLUT` to the affected linking command on macOS 10.15, but have constrained it to apply only to on macOS 11 and later where the issue is observed.
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
Commits separated for clarity.
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
