### PR TITLE
ninja: fix cross-arch universal build

### DIFF
--- a/devel/ninja/Portfile
+++ b/devel/ninja/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+
 # see https://trac.macports.org/ticket/56494
 PortGroup           muniversal 1.0
 
@@ -55,9 +56,27 @@ configure.post_args --bootstrap \
                     --verbose
 configure.universal_args
 
-build.cmd           ./ninja
-build.target
-build.args          -v
+if {![info exists universal_possible]} {
+    set universal_possible [expr {${os.universal_supported} && [llength ${configure.universal_archs}] >= 2}]
+}
+
+if {${universal_possible} && [variant_isset universal]} {
+
+    foreach my_arch ${configure.universal_archs} {
+        # strip the automatic setting of host
+        set merger_host(${my_arch}) ""
+    }
+
+    # can't reliably rebuild ninja with itself when cross-arch compiling
+    # so install the cross-compiled bootstrap version
+    build {}
+
+} else {
+
+    build.cmd           ./ninja
+    build.target
+    build.args          -v
+}
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin


### PR DESCRIPTION
there are two issues when building ninja universal, using the muniversal PortGroup on BigSur Intel.

1. configure.py: error: option --host: invalid choice: 'aarch64-apple-darwin20.3.0'

This is set by the muniveral PG but to an option the script does not accept.
Simplest solution appears to be to just delete the --host option.

2. :info:build sh: ./ninja: Bad CPU type in executable

The portfile has been written to bootstrap ninja and then rebuild ninja
with itself. This is interesting to do, and proves the built ninja
works, but it is not necessary to do so.

So we adjust the Portfile to only do this for non-universal builds.

Some complicated algorithm of figuring out if the arch would or would not
be runnable by the build system seems both cumbersome and unnecessary.

closes: https://trac.macports.org/ticket/62259

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2 20D64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
