### PR TITLE
name-that-hash: new port

### DIFF
--- a/security/name-that-hash/Portfile
+++ b/security/name-that-hash/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                name-that-hash
+version             1.1.0
+revision            0
+categories-prepend  security
+platforms           darwin
+license             GPL-3
+supported_archs     noarch
+
+python.default_version \
+                    39
+
+maintainers         {@harens gmail.com:harensdeveloper} \
+                    openmaintainer
+
+description         The Modern Hash Identification System
+long_description    Don't know what type of hash it is? Name \
+                    That Hash will name that hash type! Identify MD5, \
+                    SHA256 and 3000+ other hashes.
+
+homepage            https://nth.skerritt.blog
+
+checksums           rmd160  c4209da2bb7358050c6159284d7f89e3d1882257 \
+                    sha256  9b7c7fac719958bef4226ba4df66b314264a82193fa14eeffb4b5fd7e82a61f4 \
+                    size    24828
+
+depends_lib-append \
+    port:py${python.version}-setuptools
+
+depends_run-append \
+    port:py${python.version}-click \
+    port:py${python.version}-loguru \
+    port:py${python.version}-rich


### PR DESCRIPTION
#### Description

Created with [seaport](https://github.com/harens/seaport)

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.1 20C69
xcode-select version 2384.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?