### PR TITLE
auto-multiple-choice-devel: update to version 1.5.0_rc1-24-gb8156497

### DIFF
--- a/x11/auto-multiple-choice/Portfile
+++ b/x11/auto-multiple-choice/Portfile
@@ -29,15 +29,19 @@ if {${subport} eq ${name}} {
                             sha256  6d447bc5053fd2a57f854ead33ac50bb5c3a09e99e6f662c85febc5eb85a9fad \
                             size    8513750
 
+    depends_lib-append      port:opencv
+
     conflicts               auto-multiple-choice-devel
 } else {
     # devel
     set amc.version.main        1.5.0
-    set amc.version.secondary   rc1-6-g83952a21
+    set amc.version.secondary   rc1-24-gb8156497
     version                 ${amc.version.main}_${amc.version.secondary}
-    checksums               rmd160  024b99f091f6a7de047feee22e7d66a6839729ec \
-                            sha256  4fd5b20295b6fd9efe697f7a33e9f1eed6cb7feb5f2c1ca6e75eaa20f953d168 \
-                            size    11166385
+    checksums               rmd160  79e6e5594c9f288bdc83b48d4a06e3387c43f546 \
+                            sha256  76224d423d79d1cd3633fe0e0464c075beb97c7030490dceeb0598379761367c \
+                            size    11125736
+
+    depends_lib-append      port:opencv4
 
     conflicts               auto-multiple-choice
 }
@@ -49,8 +53,6 @@ use_configure           no
 
 depends_build           port:gmake
 build.cmd               ${prefix}/bin/gmake
-
-depends_lib-append      port:opencv
 
 depends_run             \
                         port:gdk-pixbuf2 \


### PR DESCRIPTION
auto-multiple-choice-devel: update to version 1.5.0_rc1-24-gb8156497

• Update to 1.5.0_rc1-24-gb8156497
• Use of OpenCV 4

#### Description
Move from opencv to opencv4

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.1 20D74
Xcode 12.4 12D4e 

+mactex
macOS 10.15.7 19H524
Xcode 12.4 12D4e 

macOS 10.11.6 15G22010
Xcode 8.2.1 8C1002 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
