### PR TITLE
git: fix gitk failing to attach to window

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -5,6 +5,7 @@ PortGroup           perl5 1.0
 
 name                git
 version             2.32.0
+revision            1
 
 description         A fast version control system
 long_description    Git is a fast, scalable, distributed open source version \
@@ -53,7 +54,8 @@ depends_run-append  port:p${perl5.major}-authen-sasl \
 patchfiles          patch-Makefile.diff \
                     patch-git-gui-Makefile.diff \
                     patch-git-subtree.1.diff \
-                    patch-sha1dc-older-apple-gcc-versions.diff
+                    patch-sha1dc-older-apple-gcc-versions.diff \
+                    patch-gitk-git-gitk.diff
 patch.pre_args      -p1
 
 extract.only        git-${version}${extract.suffix} \

--- a/devel/git/files/patch-gitk-git-gitk.diff
+++ b/devel/git/files/patch-gitk-git-gitk.diff
@@ -1,0 +1,11 @@
+--- a/gitk-git/gitk	2021-02-08 23:20:55.000000000 +0000
++++ b/gitk-git/gitk	2021-02-11 12:30:24.000000000 +0000
+@@ -12658,7 +12658,7 @@
+     wm iconphoto . -default gitlogo gitlogo32
+ }
+ # wait for the window to become visible
+-tkwait visibility .
++if {![winfo viewable .]} {tkwait visibility .}
+ set_window_title
+ update
+ readrefs


### PR DESCRIPTION
#### Description

On recently released macOS versions, gitk shows a blank window when
launched.

See Git pull request—[gitk: check main window visibility before waiting for it to show #944](https://github.com/git/git/pull/944)

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7
Xcode 12.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
    - 4 tests failing in `t7063-status-untracked-cache.sh`, but they also fail for me in the pre-patched version.  All the tests pass with the same patch applied in a Debian environment.
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
