### PR TITLE
ortep3: new port

### DIFF
--- a/science/ortep3/Portfile
+++ b/science/ortep3/Portfile
@@ -1,0 +1,60 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           compilers 1.0
+
+name                ortep3
+version             1.0.3
+revision            0
+categories          science chemistry
+platforms           darwin
+license             public-domain
+maintainers         {@kamischi web.de:karl-michael.schindler} openmaintainer
+description         Thermal ellipsoid plot program
+long_description    ortep3 is a thermal ellipsoid plot program for crystal \
+                    structure illustrations
+homepage            https://ornl-ndav.github.io/ortep/ortep.html
+master_sites        https://github.com/ornl-ndav/ortep/raw/master/
+distfiles           ortep.f
+checksums           md5     76a252c8938e9b23abbfaf1f0b0a2647 \
+                    sha256  9935184a66d2b3bdadf20b4eba5c2e42e5dfb39ddd268956e417afb27d1a4c54 \
+                    rmd160  edcac4b789916910f7cf08925413ace321863417 \
+                    size    177233
+depends_lib         port:aquaterm \
+                    port:libpng \
+                    port:pgplot \
+                    port:xorg-libX11
+
+compilers.choose    fc f77 f90
+compilers.setup     require_fortran
+use_configure       no
+
+extract.suffix
+extract.mkdir       yes
+extract.cmd         cp
+extract.pre_args
+extract.post_args   ${worksrcpath}/
+
+post-patch {
+    # Extract the license from the source code file
+    system -W ${worksrcpath} "head -n 20 ortep.f > LICENSE"
+}
+
+use_parallel_build  no
+
+build {
+    system -W ${worksrcpath} "${configure.f90} \
+        -fdiagnostics-color=auto -std=legacy  \
+        -F${prefix}/Library/Frameworks -framework AquaTerm \
+        -L${prefix}/lib -lpng  -lpgplot \
+        -L/opt/X11/lib -lX11 \
+        -o ortep3 ortep.f"
+}
+
+destroot {
+    xinstall -m 0755 -W ${worksrcpath} ortep3 \
+        ${destroot}${prefix}/bin
+    xinstall -d ${destroot}${prefix}/share/doc/ortep3
+    xinstall -m 0444 -W ${worksrcpath} LICENSE \
+        ${destroot}${prefix}/share/doc/ortep3
+}


### PR DESCRIPTION
#### Description

ortep3 is a thermal ellipsoid plot program for crystal structure illustrations.

###### Type(s)
- [*] enhancement

###### Tested on
macOS 11.2.1 20D74
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [*] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [*] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [*] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [*] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [*] checked your Portfile with `port lint`?
- [] tried existing tests with `sudo port test`? Does not have tests.
- [*] tried a full install with `sudo port -vst install`?
- [*] tested basic functionality of all binary files?
