### PR TITLE
ghc: Update to version 8.10.4

### DIFF
--- a/lang/ghc/Portfile
+++ b/lang/ghc/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           gpg_verify 1.0
 
 name                ghc
-version             8.10.3
+version             8.10.4
 revision            0
 categories          lang haskell
 maintainers         {ieee.org:s.t.smith @essandess} openmaintainer
@@ -41,13 +41,13 @@ distfiles           ${distname}-x86_64-apple-darwin${extract.suffix} \
                     ${distname}-testsuite${extract.suffix}
 
 checksums           ${distname}-x86_64-apple-darwin${extract.suffix} \
-                    rmd160  2b111b7272c133225fc0ab0196a5fd3a1305afb7 \
-                    sha256  2635f35d76e44e69afdfd37cae89d211975cc20f71f784363b72003e59f22015 \
-                    size    193854504 \
+                    rmd160  740e68e1d3f3fe3b74fd8ed7b5e4d57950a37e2a \
+                    sha256  725ecf6543e63b81a3581fb8c97afd21a08ae11bc0fa4f8ee25d45f0362ef6d5 \
+                    size    193880272 \
                     ${distname}-testsuite${extract.suffix} \
-                    rmd160  a56666b34b679c3927c66859a5ba8468e745347d \
-                    sha256  8f82e69067fe69a1fd0916325d8c76c90b050393e9c37a70274d60f9b34cfe00 \
-                    size    2261376
+                    rmd160  444b1e05cf95665b47b7fddd99bca0e86df3ca17 \
+                    sha256  01cbec3cf5d7e17dcafe98a7645b43205c10d8592e6c0de1f5dcbf0b60a074ca \
+                    size    2236932
 
 gpg_verify.use_gpg_verification \
                     yes
@@ -109,9 +109,9 @@ if { [variant_isset "prebuilt"] } {
                     ${distname}-src${extract.suffix}
     checksums-append \
                     ${distname}-src${extract.suffix} \
-                    rmd160  2cbd70a2d0e20fa19f9e00b755015bb28e1ac268 \
-                    sha256  ccdc8319549028a708d7163e2967382677b1a5a379ff94d948195b5cf46eb931 \
-                    size    19872356
+                    rmd160  9b7ab19c21229f0c565c19e851323529c4184f4b \
+                    sha256  52af871b4e08550257d720c2944ac85727d0b948407cef1bebfe7508c224910e \
+                    size    19818108
 
     depends_build-append \
                     port:alex \


### PR DESCRIPTION
ghc: Update to version 8.10.4

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
