### PR TITLE
ttyrec: Fix -Wimplicit-function-declaration

### DIFF
--- a/sysutils/ttyrec/Portfile
+++ b/sysutils/ttyrec/Portfile
@@ -25,7 +25,8 @@ checksums           rmd160  f7538fa742d1c1e07b8b48f3fa79cfcf13ca8044 \
 
 use_configure       no
 
-patchfiles          patch-ttyrec.c-openpty-in-utilh.diff
+patchfiles          patch-ttyrec.c-openpty-in-utilh.diff \
+                    implicit.patch
 configure.cflags-append \
                     -DHAVE_openpty
 

--- a/sysutils/ttyrec/files/implicit.patch
+++ b/sysutils/ttyrec/files/implicit.patch
@@ -1,0 +1,31 @@
+Fix -Wimplicit-function-declaration
+
+On modern macOS implicit function declarations are now a compile error,
+because Apple's new M1 chips use a different calling convention for
+variadic functions (and the compiler thus needs to know the function
+declaration to figure out which calling convension to use for the
+invocation).
+
+Include signal.h for kill(2) and declare set_progname() in io.h to fix
+two implicit declaration warnings.
+
+Upstream-Status: Submitted [email to maintainer]
+--- ./io.h.orig	2021-02-12 19:51:53.000000000 +0100
++++ ./io.h	2021-02-12 19:51:34.000000000 +0100
+@@ -9,5 +9,6 @@
+ int     edup            (int oldfd);
+ int     edup2           (int oldfd, int newfd);
+ FILE*   efdopen         (int fd, const char *mode);
++void    set_progname    (const char *name);
+ 
+ #endif
+--- ./ttyrec.c.orig	2021-02-12 19:49:11.000000000 +0100
++++ ./ttyrec.c	2021-02-12 19:49:33.000000000 +0100
+@@ -49,6 +49,7 @@
+ #include <sys/time.h>
+ #include <sys/file.h>
+ #include <sys/signal.h>
++#include <signal.h>
+ #include <stdio.h>
+ #include <time.h>
+ #include <unistd.h>


### PR DESCRIPTION
#### Description

No revbump because it either built correctly (albeit with warnings) or not at all.

Closes: https://trac.macports.org/ticket/62267


###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G8022
Xcode 11.3.1 11C504


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
