### PR TITLE
ftnchek: new port

### DIFF
--- a/devel/ftnchek/Portfile
+++ b/devel/ftnchek/Portfile
@@ -1,0 +1,60 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+PortGroup       compilers 1.0
+
+name            ftnchek
+version         3.3.1
+revision        0
+categories      devel
+platforms       darwin
+license         MIT
+maintainers     {@kamischi web.de:karl-michael.schindler} openmaintainer
+homepage        https://www.dsm.fordham.edu/~ftnchek
+master_sites    ${homepage}/download/
+distfiles       ${name}-${version}.tar.gz
+checksums       rmd160  44074d9d8ec04f51a5cfbee71686463b97d8bae2 \
+                sha256  d92212dc0316e4ae711f7480d59e16095c75e19aff6e0095db2209e7d31702d4 \
+                size    1048638
+
+description     Fortran 77 source code analyzer
+
+long_description {
+ftnchek is a static analyzer for Fortran 77 programs. It is designed  \
+to detect certain errors in a Fortran program that a compiler usually  \
+does not. ftnchek is not primarily intended to detect syntax errors.  \
+Its purpose is to assist the user in finding semantic errors.  \
+Semantic errors are legal in the Fortran language but are wasteful  \
+or may cause incorrect operation. For example, variables which are  \
+never used may indicate some omission in the program; uninitialized  \
+variables contain garbage which may cause incorrect results to be  \
+calculated; and variables which are not declared may not have the  \
+intended type. ftnchek is intended to assist users in the debugging  \
+of their Fortran program. It is not intended to catch all syntax errors.  \
+This is the function of the compiler. Prior to using ftnchek, the user  \
+should verify that the program compiles correctly.
+}
+
+configure.args --disable-submodel
+
+destroot {
+    xinstall -m 0755 -W ${worksrcpath} ftnchek  \
+        ${destroot}${prefix}/bin
+    xinstall -m 0755 -W ${worksrcpath} dcl2inc.awk  \
+        ${destroot}${prefix}/lib
+    xinstall -m 0755 -W ${worksrcpath} dcl2inc  \
+        ${destroot}${prefix}/bin
+    xinstall -d ${destroot}${prefix}/share/man/man1
+    xinstall -m 0644 -W ${worksrcpath} ftnchek.1  \
+        ${destroot}${prefix}/share/man/man1/ftnchek.1
+    xinstall -m 0644 -W ${worksrcpath} dcl2inc.man  \
+        ${destroot}${prefix}/share/man/man1/dcl2inc.1
+    xinstall -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 0644 -W ${worksrcpath} LICENSE README  \
+        FAQ INSTALL ToDo PATCHES ftnchek.ps dcl2inc.ps  \
+        ${destroot}${prefix}/share/doc/${name}
+    xinstall -d ${destroot}${prefix}/share/doc/${name}/html
+    xinstall -m 0644 {*}[glob ${worksrcpath}/html/*]  \
+        ${destroot}${prefix}/share/doc/${name}/html
+    file link -symbolic ${destroot}${prefix}/share/doc/${name}/index.html html/index.html 
+}


### PR DESCRIPTION
#### Description

ftnchek is a Fortran 77 source code analyzer.

###### Type(s)
- [*] enhancement

###### Tested on
macOS 11.2.1 20D74
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [*] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [*] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [*] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [*] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [*] checked your Portfile with `port lint`?
- [*] tried a full install with `sudo port -vst install`?
- [*] tested basic functionality of all binary files?
