### PR TITLE
f77_diagram: new port

### DIFF
--- a/devel/f77_diagram/Portfile
+++ b/devel/f77_diagram/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+name            f77_diagram
+version         0.0.2
+revision        0
+categories      devel
+platforms       darwin
+license         GPL
+maintainers     {@kamischi web.de:karl-michael.schindler} openmaintainer
+homepage        http://www.deater.net/weave/vmwprod/${name}
+master_sites    ${homepage}
+distfiles       ${name}-${version}.tar.gz
+checksums       rmd160  4424ace98a8e0d6026875d75ce42fc7cfc10a26a \
+                sha256  0413c60a0c54d4ba228b7e5eb783f13960f76933f6774c569ef46dc6a4d401fc \
+                size    17444
+
+description     Fortran 77 flowcharting utility
+
+long_description \
+    f77_diagram will create a flow-chart of (hopefully) any F77 FORTRAN program.
+
+use_configure   no
+
+destroot {
+    xinstall -m 0755 -W ${worksrcpath} f77_diagram  \
+        ${destroot}${prefix}/bin
+    xinstall -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 0644 -W ${worksrcpath} BUGS CHANGES COPYING README \
+        ${destroot}${prefix}/share/doc/${name}
+    xinstall -d ${destroot}${prefix}/share/examples/${name}
+    xinstall -m 0644 -W ${worksrcpath} if_test.f prime.f \
+        ${destroot}${prefix}/share/examples/${name}
+}


### PR DESCRIPTION
#### Description

f77_diagram creates a flow-chart of any FORTRAN 77 program.

###### Type(s)

- [x] enhancement

###### Tested on
macOS 11.2.1 20D74
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
