### PR TITLE
openjdk: update to GraalVM 21.0.0.2

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -61,14 +61,14 @@ subport openjdk8 {
 }
 
 subport openjdk8-graalvm {
-    version      21.0.0
+    version      21.0.0.2
     revision     0
 
     set major    8
     
-    checksums    rmd160  81a22898316b657c8a8c9320d1b208959354ee23 \
-                 sha256  9192d8370b544c0efd36ef744f5933bd2d694d0cc9cb5e7f53d3b7e58f433b3e \
-                 size    349292989
+    checksums    rmd160  2fc5f23a1558b5e125ef91ad137270fe4f2b4d0c \
+                 sha256  25a653a44b3ad63479d7ae35d921c8d39282ff1849243f1afc0ffddd443e9079 \
+                 size    349277690
 }
 
 subport openjdk8-openj9 {
@@ -116,14 +116,14 @@ subport openjdk11 {
 }
 
 subport openjdk11-graalvm {
-    version      21.0.0
+    version      21.0.0.2
     revision     0
 
     set major    11
     
-    checksums    rmd160  4496162ca0f7eead7fcc70d1c1349e051b211695 \
-                 sha256  0e6b9af45d0ba40d8e61b16708361f794e17430f5098760bd03584ebcc950fa9 \
-                 size    446431096
+    checksums    rmd160  64053c14a3e03b49d69564d99fad84453c097afb \
+                 sha256  6714be01bd17c2c049435c02e19dd2bcba96ea9e44152911ed0082bc968618d6 \
+                 size    448204139
 }
 
 subport openjdk11-openj9 {


### PR DESCRIPTION
#### Description

Update to GraalVM 21.0.0.2.

###### Tested on

macOS 11.2.1 20D74
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?