### PR TITLE
micronaut: update to 2.3.2

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       java 1.0
 
-github.setup    micronaut-projects micronaut-starter 2.3.1 v
+github.setup    micronaut-projects micronaut-starter 2.3.2 v
 revision        0
 name            micronaut
 categories      java
@@ -53,9 +53,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  46ec806fc4d21e44a643889a5526537602aacfdc \
-                sha256  4edab7992e6f3b0f8d9f784f76f7c00d75434ef18b49ea80a35f97c12a8f2d63 \
-                size    19516030
+checksums       rmd160  859670a10e1d91eeb4e9cc2b86995456bdf0d053 \
+                sha256  0f88c48b46368d2d2c41b178fd095170ee281717f836b671b8a8e8518e13900e \
+                size    19522016
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 2.3.2.

###### Tested on

macOS 11.2.1 20D74
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?