### PR TITLE
skaffold: update to 1.20.0

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 1.19.0 v
+github.setup        GoogleContainerTools skaffold 1.20.0 v
 revision            0
 
 categories          devel
@@ -23,9 +23,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  1cd04330492db1d194efe52d896c8c8df646b220 \
-                    sha256  ee4ad5cf9c65d0f4827dd7763b96b8750d4e93676b0391bb6b267eb670a9f602 \
-                    size    18976315
+checksums           rmd160  9acb11626eda9c6e5ea0feb05f3dc21989a2513f \
+                    sha256  d47ee974acf1c4432dab3ecdffeadbe271d2ff8098b811da2e73a04f9d9af957 \
+                    size    19031153
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 1.20.0.

###### Tested on

macOS 11.2.1 20D74
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?