### PR TITLE
asciidoc: Fix checksums error due to stealth upgrade

### DIFF
--- a/textproc/asciidoc/Portfile
+++ b/textproc/asciidoc/Portfile
@@ -4,11 +4,12 @@ PortSystem          1.0
 
 PortGroup           github 1.0
 
-github.setup        asciidoc asciidoc-py3 9.0.5
+version             9.1.0
+github.setup        asciidoc asciidoc-py3 ${version}
 revision            0
-checksums           rmd160  8940c0c8b830f43c97cf163a28bf1bcef31dd173 \
-                    sha256  71acadb505bc34971cdc78a1555e342dfe6da0f0f78b173d96d0dd8519083487 \
-                    size    1119595
+checksums           rmd160  4fef2148ed93859afe13031e0c953bbe0dabba29 \
+                    sha256  98941741bcef1b172bce735c9393255c095fe88642ac725a43a32afda0d73a4a \
+                    size    1131368
 name                asciidoc
 
 categories          textproc


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.1 20D74
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

Reference trac ticket 62273 (https://trac.macports.org/ticket/62273)
