### PR TITLE
gitea: new portgroup

### DIFF
--- a/_resources/port1.0/group/gitea-1.0.tcl
+++ b/_resources/port1.0/group/gitea-1.0.tcl
@@ -1,0 +1,80 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+#
+# This PortGroup accommodates projects hosted in Gitea
+#
+# Usage:
+#
+# PortGroup     gitea 1.0
+# gitea.setup   author project 1.0.0 v
+#
+# This portgroup works very similarly to the github-1.0 portgroup.
+#
+# For any port that is hosted on gitea.com, or a hosted Gitea instance, this
+# portgroup can be used to automatically setup details like project name,
+# master_sites, livecheck options and more.
+#
+# Using gitea.setup, the format is:
+#
+# gitea.setup   <author> <project_name> <version> <version_prefix> <version_suffix>
+#
+# If a project is on a hosted Gitea instance, that can be set using the
+# 'gitea.domain' option:
+#
+# gitea.domain  mydomain.com/gitea
+
+options gitea.author gitea.project gitea.version gitea.tag_prefix gitea.tag_suffix
+
+options gitea.domain
+default gitea.domain        gitea.com
+
+options gitea.homepage
+default gitea.homepage      {https://${gitea.domain}/${gitea.author}/${gitea.project}}
+
+options gitea.master_sites
+default gitea.master_sites  {${gitea.homepage}/archive}
+
+options gitea.livecheck.branch
+default gitea.livecheck.branch master
+
+options gitea.livecheck.regex
+default gitea.livecheck.regex {(\[0-9]\[^<]+)}
+
+proc gitea.setup {gitea_author gitea_project gitea_version {gitea_tag_prefix ""} {gitea_tag_suffix ""}} {
+    global gitea.author gitea.project gitea.version gitea.tag_prefix gitea.tag_suffix
+    global gitea.homepage gitea.master_sites gitea.livecheck.branch gitea.livecheck.regex
+    global PortInfo
+
+    gitea.author            ${gitea_author}
+    gitea.project           ${gitea_project}
+    gitea.version           ${gitea_version}
+    gitea.tag_prefix        ${gitea_tag_prefix}
+    gitea.tag_suffix        ${gitea_tag_suffix}
+
+    if {!([info exists PortInfo(name)] && (${PortInfo(name)} ne ${gitea.project}))} {
+        name                ${gitea.project}
+    }
+
+    version                 ${gitea.version}
+    default homepage        ${gitea.homepage}
+    git.url                 ${gitea.homepage}.git
+
+    set _gitea_branch       [join ${gitea.tag_prefix}]${gitea.version}[join ${gitea.tag_suffix}]
+
+    git.branch              ${_gitea_branch}
+    default master_sites    ${gitea.master_sites}
+    distname                ${_gitea_branch}
+
+    if {[join ${gitea.tag_prefix}] eq "" && \
+        [join ${gitea.tag_suffix}] eq "" && \
+        [regexp "^\[0-9a-f\]{7,}\$" ${gitea.version}] && \
+        ![regexp "^\[0-9\]{8}\$" ${gitea.version}]} {
+        livecheck.type          regexm
+        default livecheck.url   {${gitea.homepage}/commits/${gitea.livecheck.branch}}
+        livecheck.regex         commit/(\[0-9a-f\]{[string length ${gitea.version}]})\[0-9a-f\]*
+    } else {
+        livecheck.type          regex
+        default livecheck.url   {${gitea.homepage}/tags}
+        default livecheck.regex {[list archive/[join ${gitea.tag_prefix}][join ${gitea.livecheck.regex}][join ${gitea.tag_suffix}]\\.tar\\.gz]}
+    }
+    livecheck.version       ${gitea.version}
+}

--- a/_resources/port1.0/group/golang-1.0.tcl
+++ b/_resources/port1.0/group/golang-1.0.tcl
@@ -85,6 +85,10 @@ proc go.setup {go_package go_version {go_tag_prefix ""} {go_tag_suffix ""}} {
             uplevel "PortGroup sourcehut 1.0"
             sourcehut.setup ${go.author} ${go.project} ${go_version} ${go_tag_prefix} ${go_tag_suffix}
         }
+        gitea.com {
+            uplevel "PortGroup gitea 1.0"
+            gitea.setup ${go.author} ${go.project} ${go_version} ${go_tag_prefix} ${go_tag_suffix}
+        }
         default {
             if {!([info exists PortInfo(name)] && (${PortInfo(name)} ne ${go.project}))} {
                 name    ${go.project}
@@ -340,6 +344,8 @@ post-extract {
         if {[file exists [glob -nocomplain ${workpath}/${go.author}-${go.project}-*]]} {
             # GitHub and Bitbucket follow this path
             move [glob ${workpath}/${go.author}-${go.project}-*] ${worksrcpath}
+        } elseif  {[file exists ${workpath}/${go.project}]} {
+            move ${workpath}/${go.project} ${worksrcpath}
         } else {
             # GitLab follows this path
             move [glob ${workpath}/${go.project}-*] ${worksrcpath}

--- a/devel/gitea-tea/Portfile
+++ b/devel/gitea-tea/Portfile
@@ -1,0 +1,47 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            gitea.com/gitea/tea 0.7.0 v
+go.package          code.gitea.io/tea
+name                gitea-tea
+revision            0
+
+homepage            https://code.gitea.io/tea
+
+description         A command line tool to interact with Gitea servers
+
+long_description    {*}${description}. tea is the official CLI for Gitea. \
+                    It can be used to manage most entities on one or multiple \
+                    Gitea instances and provides local helpers like \'tea \
+                    pull checkout\'. tea makes use of context provided by \
+                    the repository in \$PWD if available, but is still usable \
+                    independently of \$PWD.
+
+categories          devel
+license             MIT
+installs_libs       no
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+build.args-append   -ldflags \"-s -w -X main.Version=${go.version}\"
+
+checksums           rmd160  06ce504246a2eb1ed9bb64bb6290f2ee45cbc0cc \
+                    sha256  0d65b49410321535ffcbba7795651cbef81911552f12f7617c9cf77a9d7d5da9 \
+                    size    4419268
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/tea ${destroot}${prefix}/bin/
+
+    set zsh_comp_dir ${prefix}/share/zsh/site-functions
+    xinstall -d ${destroot}/${zsh_comp_dir}
+    xinstall -m 0644 ${worksrcpath}/contrib/autocomplete.sh \
+        ${destroot}${zsh_comp_dir}/_tea
+
+    set bash_comp_dir ${prefix}/share/bash-completion/completions
+    xinstall -d ${destroot}${bash_comp_dir}
+    xinstall -m 0644 ${worksrcpath}/contrib/autocomplete.sh \
+        ${destroot}${bash_comp_dir}/tea
+}


### PR DESCRIPTION
#### Description

This PR seeks to add a new portgroup for projects hosted in [Gitea](https://gitea.com).
Being that you can run a private Gitea instance yourself, the portgroup potentially supports using custom domains via `gitea.domain`, but this hasn't been tested.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -d install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
