### PR TITLE
fcat: new port

### DIFF
--- a/devel/fcat/Portfile
+++ b/devel/fcat/Portfile
@@ -1,0 +1,58 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+name            fcat
+version         1.0
+revision        0
+categories      devel
+platforms       darwin
+license         restrictive nomirror
+maintainers     {@kamischi web.de:karl-michael.schindler} openmaintainer
+homepage        http://yifanhu.net/SOFTWARE/FCAT/
+master_sites    ${homepage}
+distname        ${name}
+checksums       rmd160  8632806c49472bfaa47d950a43931ef89be2e660 \
+                sha256  2218a9daf99bc2f1e877e1fe75196b2d6be288413f098a79910cc6ec51ff01ab \
+                size    9601
+
+description     Fortran Coverage Analysis Tool
+
+long_description \
+    The FCAT tool is used for the Coverage Analysis of FORTRAN codes. \
+    This includes: \
+    \n- finding out "cold-spot" in Fortran codes \
+    \n\t(the part of the codes that are never executed), \
+    \n\tand flags these parts line-by-line. \
+    \n- finding out "hot-spot" in Fortran codes \
+    \n\t(the part of the codes that are most frequently executed), \
+    \n\tand gives a line by line profile. \
+    \nIt is designed to work mainly with F90/F95, even though it can \
+      also work with fixed formatted FORTRAN, thus F77.
+
+# patch to correctly treat dimension declarations.
+# '&' represent the existing string, '?' is the separator
+# '\' is the esc character and therefore needs to be escaped in the
+# replacemant string. i.e. '\\' gives '\' in the result.
+
+post-extract {
+    reinplace "s?dimension.*||?&         /^(\\s*dimension\\s+)/i ||?g" ${worksrcpath}/bin/fcat
+}
+
+supported_archs noarch
+depends_lib     path:bin/perl:perl5
+configure.perl  /usr/bin/perl
+use_configure   no
+build           {}
+
+destroot {
+    xinstall -m 0755 -W ${worksrcpath}/bin fcat \
+        ${destroot}${prefix}/bin
+    xinstall -d ${destroot}${prefix}/share/doc/${name}/example
+    xinstall -m 0644 -W ${worksrcpath} README \
+        ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 0644 -W ${worksrcpath}/example a.f90 b.f90 c.f90 Makefile \
+        ${destroot}${prefix}/share/doc/${name}/example
+}
+
+livecheck.type   none


### PR DESCRIPTION
#### Description

fcat is a Fortran coverage analysis tool.

###### Type(s)

- [x] enhancement

###### Tested on
macOS 11.2.1 20D74
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
