### PR TITLE
devel-dyncall: Update to 1.2 ; Add amd & amd64 platforms

### DIFF
--- a/devel/dyncall/Portfile
+++ b/devel/dyncall/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           cmake 1.0
 
 name                dyncall
-version             0.9
+version             1.2
 categories          devel
 platforms           darwin
 maintainers         uni-goettingen.de:dadler
 license             BSD
-supported_archs     i386 ppc x86_64
+supported_archs     i386 ppc x86_64 arm arm64
 
 description         Foreign Function Interface and Dynamic Binding Linkage Framework
 
@@ -23,8 +23,9 @@ long_description    DynCall is a suite of three libraries (dyncall, dynload \
 homepage            http://dyncall.org/
 master_sites        ${homepage}r${version}
 
-checksums           rmd160  e085e463c06997eaecd408d33a091311cc63c199 \
-                    sha256  8a7628fd00b4e0acc952c5d9d03035de90f349d4d4dfdad4c48a037f2a0979f9
+checksums           rmd160  773806fdd410ace4b997650cde2ade25f687e317 \
+                    sha256  e88154c0243421560704f5c7294afbdec9e991afa0601d5adff5042ea81808d7 \
+                    size    523701
 
 cmake.out_of_source yes
 


### PR DESCRIPTION
#### Description

Update to dyncall to 1.2; add amd & amd64 platforms

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.2.1 20D74
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [na] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
