### PR TITLE
ninja: fix cross-arch universal build

### DIFF
--- a/devel/ninja/Portfile
+++ b/devel/ninja/Portfile
@@ -2,8 +2,6 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
-# see https://trac.macports.org/ticket/56494
-PortGroup           muniversal 1.0
 
 epoch               1
 github.setup        ninja-build ninja 1.10.2 v
@@ -40,7 +38,8 @@ github.tarball_from archive
 
 installs_libs       no
 
-patchfiles          patch-configure.py-bootstrap-only.diff
+patchfiles          patch-configure.py-bootstrap-only.diff \
+                    patch-ninja-configure.py-remove-mmd.diff
 
 depends_build-append \
                     port:re2c

--- a/devel/ninja/files/patch-ninja-configure.py-remove-mmd.diff
+++ b/devel/ninja/files/patch-ninja-configure.py-remove-mmd.diff
@@ -1,0 +1,11 @@
+--- configure.py.orig	2021-02-13 23:21:58.000000000 -0800
++++ configure.py	2021-02-13 23:22:17.000000000 -0800
+@@ -425,7 +425,7 @@
+     )
+ else:
+     n.rule('cxx',
+-        command='$cxx -MMD -MT $out -MF $out.d $cflags -c $in -o $out',
++        command='$cxx $cflags -c $in -o $out',
+         depfile='$out.d',
+         deps='gcc',
+         description='CXX $out')


### PR DESCRIPTION
Apple's gcc compilers do not allow dependency file generation
when multiple arch flags are used

This resulted in the muniversal portgroup being used to repair the
universal build of ninja several years ago, however this has it's own
issues by not allowing a cross-arch universal binary to be built,
due to the way the ninja bootstraps itself during compilation.

if we strip the (unnecessary) dependency file generation by removing
the dependency flags, then the muniversal PortGroup is no longer
needed and the cross-arch universal build can succeed without
using the muniversal portgroup.

see: https://gcc.gnu.org/onlinedocs/gcc/Preprocessor-Options.html
see: https://github.com/macports/macports-base/commit/701e7b2597f2da954a390b1b63aa90d6f7aaba20
see: https://trac.macports.org/ticket/56494

closes: https://trac.macports.org/ticket/62259


