### PR TITLE
MacPass: Decreased minimum required macOS version to 10.14

### DIFF
--- a/security/MacPass/Portfile
+++ b/security/MacPass/Portfile
@@ -39,9 +39,9 @@ checksums               ${macpass_hash}.tar.gz \
                         sha256  656d090cca863b236b7d319df4a5853b55ebf9af39a31a08cb471122c9bfbf56 \
                         size    27575
 
-if {${os.platform} eq "darwin" && ${os.major} < 20} {
+if {${os.platform} eq "darwin" && ${os.major} < 18} {
     pre-fetch {
-        ui_error "${name} @${version} requires macOS 11 or greater"
+        ui_error "${name} @${version} requires macOS 10.14 or greater"
         return -code error "incompatible OS X version"
     }
 }


### PR DESCRIPTION
#### Description
I discovered that macpass and all its dependencies support macOS version including 10.14, therefore I decreased the version checking from 11.0 -> 10.14.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1
Xcode 12.3 Build version 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
