### PR TITLE
glab: update to 1.15.0

### DIFF
--- a/devel/glab/Portfile
+++ b/devel/glab/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/profclems/glab v1.14.0
+go.setup            github.com/profclems/glab 1.15.0 v
 revision            0
 categories          devel
 license             MIT
@@ -15,12 +15,22 @@ long_description    ${name} is an open source GitLab CLI tool \
                     bringing GitLab to your terminal next to where \
                     you are already working with git and your code.
 
-checksums           ${distname}${extract.suffix} \
-                        rmd160  9fafc8fd33aae7050f777cd8191105fde78b67ba \
-                        sha256  2aaea12b5ff95f6ceafc46037f94e0a194bb12855dbcf67bc73714487b0ab2f1 \
-                        size    16427691
+homepage            https://glab.readthedocs.io/
 
-build.target        ${worksrcpath}/cmd/glab
+checksums           ${distname}${extract.suffix} \
+                        rmd160  fdb9452da5bed1622cc14edc87c40d1539682266 \
+                        sha256  410ac712b5016e80095983e316702ec3cce14681bd62001fac1bd54e976fd1ce \
+                        size    16428800
+
+# Version number is set at build
+# Otherwise, it states that it's a developer build
+set build_date      [exec date +%Y-%m-%d]
+
+build.pre_args      -ldflags \
+                      '-X main.build=${build_date} \
+                       -X main.version=${version}'
+
+build.args          ${worksrcpath}/cmd/glab
 
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
@@ -55,15 +65,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  e70dd42fb30b7b2d0129c5cdf0e079caaf5602cab24081fdac830ec01204fa59 \
                         size    86890 \
                     gopkg.in/yaml.v2 \
-                        lock    v2.3.0 \
-                        rmd160  2f8fa56d8a413b6288132eeb7f0d7c64d27d877f \
-                        sha256  a8d1a8bc88239d25507456380b47d59ae3683d4a5f4336da4892db1ce026615f \
-                        size    72838 \
-                    gopkg.in/tomb.v1 \
-                        lock    dd632973f1e7 \
-                        rmd160  ae07f5ddbbc6afc772d6dc5273bb72eaba50529a \
-                        sha256  91c562a4e31c89d13e5391143ff653231fc2d80562743db89ce2172ad8f81008 \
-                        size    3636 \
+                        lock    v2.4.0 \
+                        rmd160  66e9feb7944b3804efa63155ed9b618717b8955c \
+                        sha256  72812077e7f20278003de6ab0d85053d89131d64c443f39115a022114fd032b6 \
+                        size    73231 \
                     gopkg.in/check.v1 \
                         lock    788fd7840127 \
                         rmd160  b63165c8909a27edc15dda210df66a1b49efb49e \
@@ -137,20 +142,15 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  716ddfc3a8dc93ef5d45e3cad7dadcb3d436e99512a77e6e0746ff3d29dd4b70 \
                         size    228284 \
                     github.com/xanzy/go-gitlab \
-                        lock    v0.42.0 \
-                        rmd160  98ae463b168682373709ea9487bdea40e9fa557f \
-                        sha256  ab55fbadfac64a700d7aba4c60961fae34f0b3fd47b6b97426ee554ad9c841dc \
-                        size    190776 \
+                        lock    v0.44.0 \
+                        rmd160  9e8c0ef5c647c27bc34915dcb99cfd540d58d8ce \
+                        sha256  fbe62f5740edf501fe5d94d9d152aac9876f461b13c93efc96f2f5c97bb605b8 \
+                        size    196085 \
                     github.com/tidwall/pretty \
-                        lock    v1.0.2 \
-                        rmd160  e75f75a2785ba3ce3069d368ce85d2bf4c64adb8 \
-                        sha256  6cd1240063683c334310292b75f29e4fc0c71041f3f4797710e838ad7176b066 \
-                        size    8866 \
-                    github.com/tcnksm/go-gitconfig \
-                        lock    v0.1.2 \
-                        rmd160  1920a053ae158cd29182fa9c9ba675f92365bd45 \
-                        sha256  88eb568ff082ca3eec0d1bd77ec6816c050f7fd4f34bb95d41b62c0c23126cb3 \
-                        size    4476 \
+                        lock    v1.0.5 \
+                        rmd160  4a86a71cc823653e0dd47686a61e7a6ffd9bfc6d \
+                        sha256  eab45411cde0637bb58b461cec73d97ab4c69b8cbfe80843380c103efc1fd71a \
+                        size    9658 \
                     github.com/stretchr/testify \
                         lock    v1.7.0 \
                         rmd160  adae5096e8c4cfcc8e3f6d096646d1165b5ef49a \
@@ -172,10 +172,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  e70eb4dbab0603ad35c32bf89cefd595b2d6d56d66695866bfad2350db939404 \
                         size    6405 \
                     github.com/spf13/cobra \
-                        lock    v1.1.1 \
-                        rmd160  dedb212124abd6a8ce40e9b1e6e083266a633e6f \
-                        sha256  ac9e1ecebe2ec52aecad8a9bb474c6b9fc828f3c2ae3dcc1ed10e35493527360 \
-                        size    143436 \
+                        lock    v1.1.3 \
+                        rmd160  d9647d9a480ffb4d35ef6602c05cae452dcf30f9 \
+                        sha256  433b6fbdec0dc61ab23a2be8e7f004ff5608ba0778d4b4ede438f6d1227adb77 \
+                        size    146625 \
                     github.com/spf13/cast \
                         lock    v1.3.1 \
                         rmd160  d4ab928edfe2ad8aafbc3248287b788c65ec155f \
@@ -241,26 +241,11 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  21c0dd06dd2d7fe9890a91056a453a6042d38c11 \
                         sha256  5c84cccd5c6b5532b08664506df0a67909fa4202dd4518e4ca50d4c20580aabf \
                         size    8395 \
-                    github.com/onsi/gomega \
-                        lock    v1.10.3 \
-                        rmd160  3ce67285e98fcf47d6ae18e2a50b6685c132e323 \
-                        sha256  ff8e349c8e3996170fdf809e659cca57284dfacd62545c39519df5820f7b9c14 \
-                        size    97892 \
-                    github.com/onsi/ginkgo \
-                        lock    v1.12.1 \
-                        rmd160  6679f75d2cbfa444056b7fdb31e5724b0aa0c071 \
-                        sha256  8fbc07272ee58ef50fa44093c1de831782724e1180d08dd7b7a775d2df700900 \
-                        size    139879 \
                     github.com/olekukonko/tablewriter \
                         lock    v0.0.4 \
                         rmd160  750bec232562820a4f3ba47cd2864f4c84e7a767 \
                         sha256  890daf262aee371899075912bab0b3107313bea32846cf796bca83ef9a1dccf5 \
                         size    19267 \
-                    github.com/nxadm/tail \
-                        lock    v1.4.4 \
-                        rmd160  33d7373bd1b164159b9032fc8595bb09b25598f6 \
-                        sha256  16d8773e0be69469d3c296ee785bbef433c3442defb68760682cdbcf80ba40ee \
-                        size    1238830 \
                     github.com/muesli/termenv \
                         lock    v0.6.0 \
                         rmd160  8e536a7d42cb2bc516a621460164d87868222a6e \
@@ -337,10 +322,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  41aa42696f96fb2783c5135d71ff1ec5938dfe178b51eb703e509c8ac0e7db4e \
                         size    4335 \
                     github.com/jarcoal/httpmock \
-                        lock    v1.0.7 \
-                        rmd160  b257b588b71cc360c0e86cc770da39fd690ba43d \
-                        sha256  9ebf6881d5e34f6ef31999f707ecf78863abdd8ae9326f41947344e9a767819c \
-                        size    24487 \
+                        lock    v1.0.8 \
+                        rmd160  912228203a9916aa17927157926e372b1ffb7776 \
+                        sha256  4abf6bda5912853c512f9c0776f27ad6a7b179ad80be4a91c55e205edf8954f3 \
+                        size    25106 \
                     github.com/inconshreveable/mousetrap \
                         lock    v1.0.0 \
                         rmd160  5c617a09f1432fc543672a0e0c1e13d3752030c2 \
@@ -426,6 +411,11 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  24712e412814020224e2779186e634610e2f6926 \
                         sha256  bc839ee158ad34b81c1f11c3b9e3bcbabfba3297f61d165599880c400b8171dc \
                         size    31147 \
+                    github.com/fatih/color \
+                        lock    v1.7.0 \
+                        rmd160  8a65cf00de5399f4498b41b0baed82da363f02d5 \
+                        sha256  a553c1229fe10a6b0765cbbb90245bf3383a99ba52b9608052420b40ca30d148 \
+                        size    816675 \
                     github.com/dustin/go-humanize \
                         lock    v1.0.0 \
                         rmd160  e8641035159ea3e8839ee086f01f966443956303 \
@@ -456,6 +446,11 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  f711e7cb9bd08afb28e90638a09443bd90c317bf \
                         sha256  898dca465433795be53bd0e413291b63ae58c5676d867001a04077e869bac217 \
                         size    511593 \
+                    github.com/briandowns/spinner \
+                        lock    v1.12.0 \
+                        rmd160  218b46d75af2632fd9268476cc5f90fcabe87e83 \
+                        sha256  2505ebb15156b5f914b1da98578a71f8ce1ace530c3eceef03666d2b00467c95 \
+                        size    1309932 \
                     github.com/alecthomas/repr \
                         lock    117648cd9897 \
                         rmd160  1f78bc0844f7ca6ccb93808bb367080e4c3accf8 \


### PR DESCRIPTION
#### Description

Also fixes a minor issue relating to the output of `glab version`

Before:

```
glab version DEV
```

Now:
```
glab version 1.15.0 (2021-02-15)
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
