### PR TITLE
Revbumps for geos 3.9.1

### DIFF
--- a/databases/spatialite/Portfile
+++ b/databases/spatialite/Portfile
@@ -5,7 +5,7 @@ PortGroup           debug 1.0
 
 name                spatialite
 version             5.0.1
-revision            0
+revision            1
 categories          databases gis
 platforms           darwin
 license             {MPL-1.1 GPL-2+ LGPL-2.1+}

--- a/python/py-cartopy/Portfile
+++ b/python/py-cartopy/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 github.setup        SciTools cartopy 0.18.0 v
 
 name                py-${github.project}
-revision            0
+revision            1
 categories-append   science gis graphics
 platforms           darwin
 license             LGPL-3


### PR DESCRIPTION
Rev bumps due to unmanaged ABI changes in Geos 3.9.1 update.  Presumably needed for ports using the Geos C++ API.

See: https://github.com/macports/macports-ports/commit/bfd0852ca50838dfa6b02655c6d745b49bf86e99

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->