### PR TITLE
kubeseal: update to 0.14.1

### DIFF
--- a/sysutils/kubeseal/Portfile
+++ b/sysutils/kubeseal/Portfile
@@ -1,11 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
+PortGroup           golang 1.0
 
+go.setup            github.com/bitnami-labs/sealed-secrets 0.14.1 v
 name                kubeseal
-github.setup        bitnami-labs sealed-secrets 0.12.6 v
 revision            0
+
 categories          sysutils
 platforms           darwin
 supported_archs     x86_64
@@ -15,23 +16,21 @@ description         Kubernetes tool for one-way encrypted Secrets
 long_description    CLI for {*}${description}
 
 maintainers         @tux-o-matic \
+                    {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-github.tarball_from releases
-distfiles           kubeseal-darwin-amd64
-dist_subdir         ${name}/${version}
+# Allow fetching deps at build time
+build.env-delete    GO111MODULE=off GOPROXY=off
 
-checksums           rmd160  9c10aa3ac6181feaa4048221689af975b8716d9d \
-                    sha256  2cf77775b0c16f68a498ea537673489a185d441bd1fbf86e86e722433b6612d1 \
-                    size    34836064
+build.pre_args      -ldflags \"-X main.VERSION=${version}\"
+build.args          ./cmd/${name}
 
-use_configure       no
-
-build {}
+checksums           rmd160  bf70d9e1ebf4e908f5db9d7489ed495210c3086e \
+                    sha256  38076f15b791e104e1903bd3f859045753878af5a48afee0f0ca6c23f880862e \
+                    size    6525012
 
 destroot {
-    xinstall ${distpath}/kubeseal-darwin-amd64 \
-             ${destroot}${prefix}/bin/kubeseal
+    xinstall -m 0755 ${worksrcpath}/kubeseal ${destroot}${prefix}/bin/kubeseal
 }
 
 github.livecheck.regex  {([\d.]+)}


### PR DESCRIPTION
- build from source

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
