### PR TITLE
libvirt: update to 7.0.0

### DIFF
--- a/python/py-libvirt/Portfile
+++ b/python/py-libvirt/Portfile
@@ -5,11 +5,11 @@ PortGroup           python 1.0
 
 # Remember to update libvirt and py-libvirt at the same time.
 name                py-libvirt
-version             6.6.0
+version             7.0.0
 revision            0
-checksums           rmd160  ca152fa69d318df7b4562b95228a8975281225f3 \
-                    sha256  68763f7b7b955032665aa4e0ea0668fc45067574bf2bf6b9f091ffdfd71aea25 \
-                    size    202990
+checksums           rmd160  10bafde6200bb7adbe3a942a353a083abda8198f \
+                    sha256  7e1663da2587e87106fc226160b33ae2160989c32176ad17d876315d5c1c36b5 \
+                    size    214945
 
 platforms           darwin
 license             MIT
@@ -26,7 +26,7 @@ homepage            https://libvirt.org
 master_sites        ${homepage}/sources/python
 distname            libvirt-python-${version}
 
-python.versions     35 36 37 38
+python.versions     35 36 37 38 39
 
 
 if {${name} ne ${subport}} {

--- a/sysutils/libvirt/Portfile
+++ b/sysutils/libvirt/Portfile
@@ -3,17 +3,18 @@
 PortSystem          1.0
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           legacysupport 1.0
+PortGroup           meson 1.0
 
 # O_CLOEXEC
 legacysupport.newest_darwin_requires_legacy 10
 
 # Remember to update libvirt and py-libvirt at the same time.
 name                libvirt
-version             6.6.0
+version             7.0.0
 revision            0
-checksums           rmd160  72294aa39f53386cfcd8812ddf243bd7aa9ee29c \
-                    sha256  94e52ddd2d71b650e1a7eb5ab7e651f9607ecee207891216714020b8ff081ef9 \
-                    size    9305836
+checksums           rmd160  1601c5f6ef46b048968c88a0bbb534ac95723caa \
+                    sha256  ca3833844d08c22867f1d1a46edc36bda7d6fe1a4f267e7d77100b79fc9ddd89 \
+                    size    8567648
 
 categories          sysutils
 license             LGPL-2.1+
@@ -29,13 +30,14 @@ homepage            https://libvirt.org
 master_sites        ${homepage}/sources/
 use_xz              yes
 
-depends_build       port:autoconf \
-                    port:automake \
+set python_version  39
+set python_branch   3.9
+
+depends_build-append \
                     port:bash-completion \
-                    port:libtool \
                     port:pkgconfig \
-                    port:python38 \
-                    port:py38-docutils \
+                    port:python${python_version} \
+                    port:py${python_version}-docutils \
                     port:perl5
 
 depends_lib         port:curl \
@@ -50,97 +52,76 @@ depends_lib         port:curl \
 # error: You need at least XCode Clang v5.1 to compile QEMU
 compiler.blacklist-append apple-gcc* gcc-3.3 *gcc-4.* macports-clang-3.3 {clang < 503}
 
+patchfiles-append   patch-meson.diff
+
 # libvirt build scripts require python 3.x
-configure.python    ${prefix}/bin/python3.8
+configure.python    ${prefix}/bin/python${python_branch}
 configure.perl      ${prefix}/bin/perl5
+configure.env       PATH=${frameworks_dir}/Python.framework/Versions/${python_branch}/bin:$env(PATH)
 
-configure.args      ac_cv_path_RST2HTML=${prefix}/bin/rst2html-3.8.py \
-                    ac_cv_path_RST2MAN=${prefix}/bin/rst2man-3.8.py \
-                    --disable-silent-rules \
-                    --enable-debug \
-                    --without-apparmor \
-                    --without-attr \
-                    --without-audit \
-                    --with-bash-completion \
-                    --with-bash-completions-dir=${prefix}/share/bash-completion/completions \
-                    --without-bhyve \
-                    --without-blkid \
-                    --without-capng \
-                    --with-curl \
-                    --without-dbus \
-                    --with-driver-modules \
-                    --without-dtrace \
-                    --with-esx \
-                    --without-fuse \
-                    --without-glusterfs \
-                    --without-hal \
-                    --without-hyperv \
-                    --with-init-script=none \
-                    --without-libpcap \
-                    --without-libssh \
-                    --with-libvirtd \
-                    --without-libxl \
-                    --without-lxc \
-                    --without-macvtap \
-                    --without-netcf \
-                    --without-network \
-                    --without-numactl \
-                    --without-openvz \
-                    --without-openwsman \
-                    --without-pm-utils \
-                    --without-polkit \
-                    --without-qemu \
-                    --with-readline \
-                    --with-remote \
-                    --without-sanlock \
-                    --without-sasl \
-                    --with-secrets \
-                    --without-selinux \
-                    --without-ssh2 \
-                    --without-sysctl \
-                    --with-test \
-                    --without-udev \
-                    --with-vbox \
-                    --without-virtualport \
-                    --with-vmware \
-                    --without-vz \
-                    --without-wireshark-dissector \
-                    --with-yajl
-
-# As of 5.10.0, an out-of-source build is required.
-configure.cmd       ../${worksrcdir}/autogen.sh --no-git
-configure.dir       ${workpath}/build
-build.dir           ${configure.dir}
-post-extract {
-    file mkdir ${configure.dir}
-}
+configure.args      -Dapparmor=disabled \
+                    -Dattr=disabled \
+                    -Daudit=disabled \
+                    -Dbash_completion=enabled \
+                    -Dbash_completion_dir=${prefix}/share/bash-completion/completions \
+                    -Dblkid=disabled \
+                    -Dcapng=disabled \
+                    -Dcurl=enabled \
+                    -Ddriver_bhyve=disabled \
+                    -Ddriver_esx=enabled \
+                    -Ddriver_hyperv=disabled \
+                    -Ddriver_libvirtd=enabled \
+                    -Ddriver_libxl=disabled \
+                    -Ddriver_lxc=disabled \
+                    -Ddriver_network=disabled \
+                    -Ddriver_openvz=disabled \
+                    -Ddriver_qemu=disabled \
+                    -Ddriver_remote=enabled \
+                    -Ddriver_secrets=enabled \
+                    -Ddriver_test=enabled \
+                    -Ddriver_vbox=enabled \
+                    -Ddriver_vmware=enabled \
+                    -Ddriver_vz=disabled \
+                    -Ddtrace=disabled \
+                    -Dfuse=disabled \
+                    -Dglusterfs=disabled \
+                    -Dinit_script=none \
+                    -Dlibpcap=disabled \
+                    -Dlibssh=disabled \
+                    -Dlibssh2=disabled \
+                    -Dnetcf=disabled \
+                    -Dnumactl=disabled \
+                    -Dopenwsman=disabled \
+                    -Dpm_utils=disabled \
+                    -Dpolkit=disabled \
+                    -Dreadline=enabled \
+                    -Dsanlock=disabled \
+                    -Dsasl=disabled \
+                    -Dselinux=disabled \
+                    -Dsysctl_config=disabled \
+                    -Dudev=disabled \
+                    -Dwireshark_dissector=disabled \
+                    -Dyajl=enabled
 
 # As of 5.10.0, pregenerated files are no longer included in the tarball,
 # and rpcgen on OS X 10.11 and earlier is not able to generate them; see:
 # https://bugzilla.redhat.com/show_bug.cgi?id=1785575
 depends_build-append \
                     port:rpcgen-mt
-configure.args-append \
-                    ac_cv_path_RPCGEN=${prefix}/bin/rpcgen-mt
-
-# As of 5.10.0, disabling dependency tracking causes build failure; see:
-# https://bugzilla.redhat.com/show_bug.cgi?id=1783626
-# Upstream will not fix this; instead, they will switch to meson.
-configure.universal_args-delete --disable-dependency-tracking
 
 variant fuse description {FUSE support} {
     depends_lib-append      port:osxfuse
-    configure.args-replace  --without-fuse --with-fuse
+    configure.args-replace  -Dfuse=disabled -Dfuse=enabled
 }
 
 variant libssh2 description {Enable the libssh2 transport} {
     depends_lib-append      port:libssh2
-    configure.args-replace  --without-ssh2 --with-ssh2
+    configure.args-replace  -Dlibssh2=disabled -Dlibssh2=enabled
 }
 
 variant sasl description {Use Cyrus SASL for authentication} {
     depends_lib-append      port:cyrus-sasl2
-    configure.args-replace  --without-sasl --with-sasl
+    configure.args-replace  -Dsasl=disabled -Dsasl=enabled
 }
 
 notes "

--- a/sysutils/libvirt/Portfile
+++ b/sysutils/libvirt/Portfile
@@ -87,7 +87,6 @@ configure.args      ac_cv_path_RST2HTML=${prefix}/bin/rst2html-3.8.py \
                     --without-numactl \
                     --without-openvz \
                     --without-openwsman \
-                    --without-phyp \
                     --without-pm-utils \
                     --without-polkit \
                     --without-qemu \
@@ -137,10 +136,6 @@ variant fuse description {FUSE support} {
 variant libssh2 description {Enable the libssh2 transport} {
     depends_lib-append      port:libssh2
     configure.args-replace  --without-ssh2 --with-ssh2
-}
-
-variant phyp requires libssh2 description {Phyp driver support} {
-    configure.args-replace  --without-phyp --with-phyp
 }
 
 variant sasl description {Use Cyrus SASL for authentication} {

--- a/sysutils/libvirt/files/patch-meson.diff
+++ b/sysutils/libvirt/files/patch-meson.diff
@@ -1,0 +1,11 @@
+--- meson.build
++++ meson.build
+@@ -892,7 +892,7 @@ required_programs = [
+ ]
+ 
+ required_programs_groups = [
+-  {'name':'rpcgen', 'prog':['rpcgen', 'portable-rpcgen']},
++  {'name':'rpcgen', 'prog':['rpcgen-mt', 'rpcgen', 'portable-rpcgen']},
+   {'name':'rst2html', 'prog':['rst2html5', 'rst2html5.py', 'rst2html5-3']},
+   {'name':'rst2man', 'prog':['rst2man', 'rst2man.py', 'rst2man-3']},
+ ]


### PR DESCRIPTION
#### Description

Update libvirt to latest upstream release 7.0.0. In version 6.7.0 libvirt moved from autotools to meson as build system so the update is a bit more complex.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.1 20D75
Xcode CLI 12.4.0.0.1.1610135815

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
