### PR TITLE
igraph: update to 0.9.0

### DIFF
--- a/math/igraph/Portfile
+++ b/math/igraph/Portfile
@@ -1,9 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        igraph igraph 0.8.5
+github.setup        igraph igraph 0.9.0
 github.tarball_from releases
 
 categories          math science devel
@@ -15,30 +16,32 @@ long_description    igraph is a C library for network analysis and graph theory,
 homepage            https://igraph.org
 
 platforms           darwin
-depends_lib         port:gmp \
-                    port:libxml2
+depends_lib         port:arpack \
+                    port:glpk \
+                    port:libxml2 \
+                    port:SuiteSparse_CXSparse
 
-checksums           rmd160  ad4364f3c4d8d8608f34a7023c0117a840ccd97b \
-                    sha256  2e5da63a2b8e9bb497893a17cf77c691df1739c298664f8adb1310a01218f95b \
-                    size    3303252
+checksums           rmd160  297c06d217d6c6059b721ec0aa5d59e096004585 \
+                    sha256  012e5d5a50420420588c33ec114c6b3000ccde544db3f25c282c1931c462ad7a \
+                    size    3752584
 
 test.run            yes
 test.target         check
 
-# igraph 0.8.5 embeds GLPK 4.45. Currently GLPK is at version 4.65.
-# Some igraph functions perform better with this new GLPK version.
+# Build options for igraph:
+#  - Do not use ccache to build this port unless MacPorts tells it to.
+#  - Build a shared library.
+#  - Enable link-time optimization.
+#  - Set features and the use of externaly libraries explicitly---do not leave this to auto-detection.
+#  - As of igraph 0.9, linking to GMP provides no tangible benefits, thus disable this.
+#  - Use the vecLib BLAS/LAPACK
+configure.args-append -DUSE_CCACHE=OFF -DBUILD_SHARED_LIBS=ON -DIGRAPH_ENABLE_LTO=ON -DIGRAPH_GLPK_SUPPORT=ON -DIGRAPH_GRAPHML_SUPPORT=ON -DIGRAPH_USE_INTERNAL_ARPACK=OFF -DIGRAPH_USE_INTERNAL_BLAS=OFF -DIGRAPH_USE_INTERNAL_CXSPARSE=OFF -DIGRAPH_USE_INTERNAL_GLPK=OFF -DIGRAPH_USE_INTERNAL_GMP=ON -DIGRAPH_USE_INTERNAL_LAPACK=OFF -DBLA_VENDOR=Apple
 
-variant external_glpk description {Build with external GLPK} {
-    configure.args-append   --with-external-glpk
-    depends_lib-append      port:glpk
+post-destroot {
+    set docdir ${prefix}/share/doc/${name}
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 {*}[glob ${worksrcpath}/doc/html/*] ${destroot}${docdir}
 }
-
-variant external_linalg description {Build with external BLAS, LAPACK, ARPACK} {
-    configure.args-append   --with-external-blas --with-external-lapack --with-external-arpack
-    depends_lib-append      port:lapack port:arpack
-}
-
-default_variants    +external_glpk
 
 # overload the github livecheck regex to look for versions that
 # are just numbers and '.', no letters (e.g., "0.8.0-pre").


### PR DESCRIPTION

#### Description

 * update to 0.9.0
 * make changes necessitated by new CMake build system
 * remove variants
 * install docs

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G8012
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
