### PR TITLE
Update databases/beekeeper-studio/Portfile to respect compiler

### DIFF
--- a/databases/beekeeper-studio/Portfile
+++ b/databases/beekeeper-studio/Portfile
@@ -35,7 +35,8 @@ checksums           ${distname}${extract.suffix} \
 
 depends_build       port:yarn
 
-build.env-append    CSC_IDENTITY_AUTO_DISCOVERY=false
+build.env-append    CSC_IDENTITY_AUTO_DISCOVERY=false \
+                    CXX=${configure.cxx}
 
 use_configure       no
 use_xcode           yes


### PR DESCRIPTION
[Use the right compiler](https://trac.macports.org/wiki/UsingTheRightCompiler)

#### Description

This fixes https://trac.macports.org/ticket/62298

###### Type(s)

- [x] bugfix

###### Tested on
macOS 11.2 20D64
Xcode 12.4 12D4e

###### Verification
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
