### PR TITLE
wireguard-go: update to 0.0.20210212

### DIFF
--- a/net/wireguard-go/Portfile
+++ b/net/wireguard-go/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-go
-version             0.0.20201118
+version             0.0.20210212
 revision            0
-checksums           rmd160  40604d819312c6523f921e5661e67b53e0d9e3d0 \
-                    sha256  8b9f3dd5f7083118fae9259868f994562270167a7ee9db28c53f415f0b20a388 \
-                    size    73512
+checksums           rmd160  0ed9ba97bf0386fedfa9b0185a923f89b4626b02 \
+                    sha256  a44dbf8e18fed0d24feb6cc5782d0e7c4dfd0ffe35401a3f5e66c1da2936fa31 \
+                    size    97548
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
#### Description

wireguard-go: update to 0.0.20210212

###### Tested on
macOS 10.15.7 19H114
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
