### PR TITLE
google-cloud-sdk: update to 328.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             327.0.0
+version             328.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,14 +21,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  20370bb5eff268df9fac86101ac21e4378a262fd \
-                    sha256  280944a3129673dee6943920831b83d088ffe905bb98edb9d957770dc896ac9b \
-                    size    87495824
+    checksums       rmd160  3f7a876611da03c8d286bb0836ca78aac2a58288 \
+                    sha256  c43843ed63255685f3c1098d1c2ba3eb77f51e28b1ea83b5d3200f8c65e0f215 \
+                    size    87594511
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  3eaeef841b931a6bd0e412073931b4b198b551a8 \
-                    sha256  f2246a789f279504cc6b0b5432fef60a97ba7c25b5ca4e672da6106cbe5abd8c \
-                    size    109646870
+    checksums       rmd160  26f7bf52a7aef7ee358fb080a22f121ad9650cac \
+                    sha256  6871707329ede314344f527e3934b182db54f56dd514902a0b099049d560f059 \
+                    size    110097588
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 328.0.0.

###### Tested on

macOS 11.2.1 20D74
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?