### PR TITLE
syncthing-macos: update to 1.13.1-1

### DIFF
--- a/net/syncthing-macos/Portfile
+++ b/net/syncthing-macos/Portfile
@@ -3,12 +3,12 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            syncthing syncthing-macos 1.9.0-1 v
+github.setup            syncthing syncthing-macos 1.13.1-1 v
 revision                0
 
-checksums               rmd160  19bfd9310380f5028c5c641e7f444893aabf1b7e \
-                        sha256  06c93dca93db79a02b7ff9fef25913b14f5c28096bc8dfe819448f6bd98e20ee \
-                        size    7474749
+checksums               rmd160  2bf595c15ff7efdcf853fd1e9ab2d6bdae84ef61 \
+                        sha256  2d9b204c850d95aa7c2c742c26033f00f3902d0a98950755e165ad8aab34eef3 \
+                        size    12198931
 
 categories              net aqua
 maintainers             {@lbschenkel lbschenkel} openmaintainer


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
update syncthing-macos to version 1.13.1-1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G8022
Xcode 11.3.1 11C504


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
