### PR TITLE
josm: update to 17428

### DIFF
--- a/gis/JOSM/Portfile
+++ b/gis/JOSM/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                JOSM
-version             17329
+version             17428
 categories          gis editors java
 platforms           darwin
 license             GPL-2+
@@ -19,9 +19,9 @@ homepage            https://josm.openstreetmap.de
 master_sites        ${homepage}/download/macosx/
 distname            josm-macosx-${version}
 
-checksums           rmd160  0f1cbf7a6f84e48c0637673ddf23876a25fe784d \
-                    sha256  8ee90b469a10fb89341b7b7475a0ab647a4bd1b9d9ab9d58ac39b2859d950944 \
-                    size    14598047
+checksums           rmd160  86895f240389a65ed6a2fe230595480febb0f6ae \
+                    sha256  f5e1ad59b551cc5acf2c09cdd2ea943e50cbebb0ff4f3cf3fcf8ce7abcf1de88 \
+                    size    14621699
 
 extract.mkdir       yes
 


### PR DESCRIPTION
#### Description
[Changelog (2020-12-29: Stable release 17428)](https://josm.openstreetmap.de/wiki/Changelog#stable-release-20.12)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
