### PR TITLE
folderify: update to 2.2.3

### DIFF
--- a/sysutils/folderify/Portfile
+++ b/sysutils/folderify/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                folderify
-version             2.2.0
+version             2.2.3
 revision            0
 categories-prepend  sysutils amusements
 platforms           darwin
@@ -22,9 +22,9 @@ long_description    Generate a native macOS folder icon from a mask file
 
 homepage            https://github.com/lgarron/folderify
 
-checksums           rmd160  4d7337deec16dfe46c1cc707d170c9a1c1b8510e \
-                    sha256  e9b8c30bf60e53f56864fd818ea4bf5928a2acc183db415aa16ae24545a423af \
-                    size    4579767
+checksums           rmd160  edd5141b70f45009b172eab2a42f0e65a640cde7 \
+                    sha256  d6754df2f001657a01062d851e5980622adb43cafb35ab6bc7c26e62529f3291 \
+                    size    5638525
 
 depends_lib-append \
                     port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

Created with [seaport](https://github.com/harens/seaport)

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.1 20C69
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?