### PR TITLE
mpich: re-enable ch4; disable ipv6

### DIFF
--- a/science/mpich/Portfile
+++ b/science/mpich/Portfile
@@ -9,7 +9,7 @@ PortGroup           legacysupport 1.1
 # make sure to keep in sync with mpi-doc
 name                mpich
 version             3.4.1
-revision            0
+revision            1
 
 license             BSD
 categories          science parallel net
@@ -154,9 +154,7 @@ configure.args      --disable-dependency-tracking    \
                     --enable-versioning              \
                     --with-pm=hydra                  \
                     --with-thread-package=posix      \
-                    --with-device=ch3                \
                     --with-hwloc-prefix=${prefix}    \
-                    --enable-nemesis-shm-collectives \
                     --enable-alloca                  \
                     "F90FLAGS='' F90=''"
 
@@ -173,7 +171,8 @@ platform darwin {
     }
 
     if {${name} ne ${subport}} {
-        patchfiles-append       patch-no_qmkshrobj.diff
+        patchfiles-append       patch-no_qmkshrobj.diff \
+                                patch-ch4-ipv6.diff
     }
 }
 
@@ -241,10 +240,16 @@ if {${name} ne ${subport} && [string first "-devel" $subport] < 0} {
     configure.env-append \
         BASH_SHELL=/bin/bash
 
-    variant tuned description {Build with more optimizations} {
+    # Renamed to standardaized 'native' name; remove 2022/02
+    variant tuned requires native description {Build with more optimizations} {
+    }
+
+    variant native description {Build for local machine} {
         configure.args-replace      --enable-fast=O2 \
                                     --enable-fast=all
-        configure.cppflags-append   -fomit-frame-pointer -O2
+        # Note these need to be above the following foreach
+        configure.cflags-append     -march=native
+        configure.cxxflags-append   -march=native
     }
 
     # setting xFLAGS resulting in mpicc, etc. always using these flags

--- a/science/mpich/files/patch-ch4-ipv6.diff
+++ b/science/mpich/files/patch-ch4-ipv6.diff
@@ -1,0 +1,12 @@
+--- src/util/mpir_cvars.c.orig	2021-02-19 13:22:26.000000000 -0600
++++ src/util/mpir_cvars.c	2021-02-19 13:23:31.000000000 -0600
+@@ -6778,6 +6778,9 @@
+     rc = MPL_env2bool("MPIR_CVAR_OFI_SKIP_IPV6", &(MPIR_CVAR_OFI_SKIP_IPV6));
+     MPIR_ERR_CHKANDJUMP1((-1 == rc),mpi_errno,MPI_ERR_OTHER,"**envvarparse","**envvarparse %s","MPIR_CVAR_OFI_SKIP_IPV6");
+ 
++    /* DISABLE IPV6 FOR NOW. https://github.com/pmodels/mpich/issues/5041 */
++    MPIR_CVAR_OFI_SKIP_IPV6 = 1;
++
+     defaultval.d = -1;
+     MPIR_T_CVAR_REGISTER_STATIC(
+         MPI_INT,


### PR DESCRIPTION
Following [upstream discussion](https://github.com/pmodels/mpich/issues/5041), re-enabling CH4 while disabling IPV6 with crowbar in patch after environment variable checks. (The library now thinks that `MPIR_CVAR_OFI_SKIP_IPV6=1` in the environment regardless of actual setting.).

Passes (single computer) executions of parallel code in standard (i.e. not --enable-fast=all, which disabled the tripping asserts; note things _were wrong_ but did not impact single-computer execution) configuration which failed previously.