### PR TITLE
swig-java: fix build on Big Sur with Apple Silicon

### DIFF
--- a/devel/swig/Portfile
+++ b/devel/swig/Portfile
@@ -94,8 +94,13 @@ subport swig-java {
     PortGroup               java 1.0
 
     java.version            1.4+
-    # Set fallback to an LTS Java version
-    java.fallback           openjdk8
+    if { ${build_arch} eq "arm64"  } {
+        # Set fallback to an LTS Java version
+        java.fallback           zulu-jdk8
+    } else {
+        # Set fallback to an LTS Java version
+        java.fallback           openjdk8
+    }
 }
 
 subport swig-php {
@@ -306,6 +311,7 @@ if {${swig.lang} eq ""} {
 # doesn't exist and swig has only Python
 subport swig-python3 {
     PortGroup       obsolete 1.0
+
     replaced_by     swig-python
     version         4.0.1
     revision        2

--- a/devel/swig3/Portfile
+++ b/devel/swig3/Portfile
@@ -5,8 +5,9 @@ PortSystem      1.0
 name            swig3
 version         3.0.12
 revision        2
-checksums       rmd160 41877e9de3ff598731ef36161f77fa66dec3c301 \
-                sha256 7cf9f447ae7ed1c51722efc45e7f14418d15d7a1e143ac9f09a668999f4fc94d
+checksums       rmd160  41877e9de3ff598731ef36161f77fa66dec3c301 \
+                sha256  7cf9f447ae7ed1c51722efc45e7f14418d15d7a1e143ac9f09a668999f4fc94d \
+                size    8149820
 
 categories      devel
 maintainers     {michaelld @michaelld} openmaintainer
@@ -96,8 +97,14 @@ subport swig3-java {
     PortGroup               java 1.0
 
     java.version            1.4+
-    # Set fallback to an LTS Java version
-    java.fallback           openjdk8
+    if { ${build_arch} eq "arm64"   } {
+        # Set fallback to an LTS Java version
+        java.fallback           zulu-jdk8
+    } else {
+        # Set fallback to an LTS Java version
+        java.fallback           openjdk8
+
+    }
 }
 
 subport swig3-php {


### PR DESCRIPTION
* Changed to use zulu-jdk8 instead of openjdk8 on arm64.

#### Description
Fixed a problem where swig-java build would fail with the following message on Big Sur with Apple Silicon.

```sh
$ sudo port install swig-java
--->  Computing dependencies for swig-java
Error: Cannot install swig-java for the arch 'arm64' because
Error: its dependency openjdk8 only supports the arch 'x86_64'.
Error: Follow https://guide.macports.org/#project.tickets to report a bug.
Error: Processing of port swig-java failed
```
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.1 20D74
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
