### PR TITLE
Fix broken py-ansible and add new py-ansible-base subport to fixe missing binaries

### DIFF
--- a/python/py-ansible/Portfile
+++ b/python/py-ansible/Portfile
@@ -6,6 +6,7 @@ PortGroup           select 1.0
 
 name                py-ansible
 version             2.10.5
+revision            1
 license             GPL-3+
 
 categories-append   sysutils
@@ -44,25 +45,52 @@ if {${name} ne ${subport}} {
             }
         }
     }
-    depends_lib-append  port:py${python.version}-six \
-                        port:py${python.version}-paramiko \
-                        port:py${python.version}-httplib2 \
-                        port:py${python.version}-jinja2 \
-                        port:py${python.version}-yaml \
-                        port:py${python.version}-setuptools \
-                        port:py${python.version}-cryptography \
-                        port:ansible_select
+
+    if {[string match {py??-ansible-base} ${subport}]} {
+        depends_lib-append  port:py${python.version}-six \
+                            port:py${python.version}-paramiko \
+                            port:py${python.version}-httplib2 \
+                            port:py${python.version}-jinja2 \
+                            port:py${python.version}-yaml \
+                            port:py${python.version}-setuptools \
+                            port:py${python.version}-cryptography \
+                            port:ansible_select
+    } else {
+        depends_lib-append port:py${python.version}-ansible-base
+    }
     select.group    ansible
     select.file     ${filespath}/py${python.version}-ansible
+    notes "
+    To make the Python ${python.branch} version of Ansible the one that is run\
+    when you execute the commands without a version suffix, e.g. 'ansible', run:
+         
+    port select --set ${select.group} [file tail ${select.file}]
+    "
     build.env-append    ANSIBLE_SKIP_CONFLICT_CHECK=1
     destroot.env-append ANSIBLE_SKIP_CONFLICT_CHECK=1
-    notes "
-To make the Python ${python.branch} version of Ansible the one that is run\
-when you execute the commands without a version suffix, e.g. 'ansible', run:
-
-port select --set ${select.group} [file tail ${select.file}]
-"
     livecheck.type  none
 } else {
     livecheck.name  ansible
+}
+
+foreach python.vers ${python.versions} {
+    subport py${python.vers}-ansible-base {
+        set python.version  ${python.vers}
+        description         Base binaries/libraries for py${python.version}-anible-base
+        long_description    Ansible is a radically simple model-driven configuration \
+                            management, multi-node deployment, and remote task execution \
+                            system.  Ansible works over SSH and does not require any software \
+                            or daemons to be installed on remote nodes.  Extension modules can \
+                            be written in any language and are transferred to managed machines \
+                            automatically.
+
+        distname            ansible-base-${version}
+        master_sites        pypi:a/ansible-base
+        homepage            https://github.com/ansible/ansible-base
+
+        distname            ansible-base-${version}
+        checksums           rmd160  da931ad31099820fb6236d2d3131602644e8b5b4 \
+                            sha256  33ae323923b841f3d822f355380ce7c92610440362efeed67b4b39db41e555af \
+                            size    5714628
+    }
 }


### PR DESCRIPTION
#### Description

The current py-ansible @2.10.5 is broken as it does not include ansible-base which provides the binaries.

[Trac ticket: 62324](https://trac.macports.org/ticket/62324)

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.1 20D74
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
