### PR TITLE
xcodes: new port for a xcode installation manager

### DIFF
--- a/devel/xcodes/Portfile
+++ b/devel/xcodes/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=portfile:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        RobotsAndPencils xcodes 0.16.0
+categories          devel
+platforms           darwin
+license             MIT
+maintainers         nomaintainer
+supported_archs     x86_64 arm64
+
+checksums           rmd160  edcc789e1e632b736f67e4e76a2c79994af36dcb \
+                    sha256  5ef007970951eab89e7792fd6dfd2f09272fafe54db45e6650022b36802bcd17 \
+                    size    251505
+
+description         The best command-line tool to install and switch between multiple versions of Xcode
+long_description    {*}${description}
+
+use_configure       no
+use_xcode           yes
+
+build.type          xcode
+build.cmd           swift
+build.args          --configuration release -Xswiftc -Onone --disable-sandbox
+build.target        build
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/.build/release/xcodes ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
* install RobotsAndPencils/xcodes version 0.16.0
* build from source to generate architecture specific binaries (arm64)

#### Description
Add port to install `xcodes` command line tool that allows to manage Xcode installations. The port compiles from source instead of downloading the binary tarball because arm64 slices are not provided.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.1
Xcode 12.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
