### PR TITLE
cask: remove python27 variant

### DIFF
--- a/devel/cask/Portfile
+++ b/devel/cask/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 PortGroup           elisp 1.0
 
 github.setup        cask cask 0.8.5 v
-revision            1
+revision            2
 description         Project management tool for Emacs
 long_description    Cask is a project management tool for Emacs that helps \
                     automate the package development cycle\; development, \
@@ -46,8 +46,4 @@ destroot {
 
     # Prevent from self-updating
     touch ${trgdir}/.no-upgrade
-}
-
-variant python27 description {Runs cask with Python 2.7} {
-    python.default_version 27
 }


### PR DESCRIPTION
* Fix issue with python.default_version appended twice
* Fix https://trac.macports.org/ticket/62340

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2
Xcode 12

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
