### PR TITLE
rtl_433: update to release 20.11

### DIFF
--- a/science/rtl_433/Portfile
+++ b/science/rtl_433/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.0
 PortGroup           github 1.0
 
-github.setup        merbanan rtl_433 19.08
+github.setup        merbanan rtl_433 20.11
 epoch               1
 
 categories          science comms
@@ -15,8 +15,9 @@ maintainers         {@ducksauz duksta.org:john} openmaintainer
 description         RTL-SDR 433.92 MHz generic data receiver
 long_description    rtl_433 turns your Realtek RTL2832 based DVB dongle into a 433.92 MHz generic data receiver
 
-checksums           rmd160  bcfdfdc04e6b8837ff88692d1a95677d80555b8b \
-                    sha256  703a3b81e2b680ed820fc7acd475a14014e96a0592044cc4d4fab5bd59ccaf04 \
-                    size    743505
+checksums           rmd160  306761e1be9328712ce22e86451304bfc4ddd4b8 \
+                    sha256  0afff585be6c09b4c61cd89cf73b5488433eab81c7a46658db4bc98c33b30755 \
+                    size    873379
 
 depends_lib-append  port:rtl-sdr
+


### PR DESCRIPTION
#### Description

Updating rtl_433 to release 20.11.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H524
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
