### PR TITLE
commitizen: update to 2.15.1

### DIFF
--- a/devel/commitizen/Portfile
+++ b/devel/commitizen/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                commitizen
-version             2.15.0
+version             2.15.1
 revision            0
 categories-prepend  devel
 platforms           darwin
@@ -26,9 +26,9 @@ long_description    Commitizen is a tool designed for teams. Its main purpose is
 
 homepage            https://${name}-tools.github.io/${name}/
 
-checksums           rmd160  d72a855a9f3ad48bdc1505e84531d5b4c1a476a2 \
-                    sha256  1fa6348e4003ecf3eb377f6ac1ed914d0e8e16b60a24332562e30a93aefa6887 \
-                    size    30549
+checksums           rmd160  ffbdbc8b5ec83c7b86a3390edf555fee8a906196 \
+                    sha256  674166c6b2fb9a57aa370b643cae5c79f685c9bf68eb3e10cc35844d629692b9 \
+                    size    30562
 
 depends_lib-append \
     port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

Created with [seaport](https://github.com/harens/seaport)

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.1 20C69
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?