### PR TITLE
SFML: Support Apple Silicon.

### DIFF
--- a/multimedia/sfml/Portfile
+++ b/multimedia/sfml/Portfile
@@ -44,6 +44,8 @@ depends_lib-append  port:freetype \
 
 cmake.out_of_source yes
 
+patchfiles          patch-apple-silicon.diff
+
 configure.args-append \
                     -DSFML_USE_SYSTEM_DEPS=TRUE \
                     -DSFML_BUILD_DOC=TRUE \

--- a/multimedia/sfml/files/patch-apple-silicon.diff
+++ b/multimedia/sfml/files/patch-apple-silicon.diff
@@ -1,0 +1,25 @@
+diff -ruN SFML-2.5.1.orig/CMakeLists.txt SFML-2.5.1/CMakeLists.txt
+--- CMakeLists.txt.orig	2018-10-15 12:41:39.000000000 -0700
++++ CMakeLists.txt	2021-02-22 10:49:59.000000000 -0800
+@@ -29,9 +29,6 @@
+ 
+ # add some default value for some additional macOS variable
+ # note that those variables are ignored on other systems
+-if(NOT CMAKE_OSX_ARCHITECTURES)
+-    set(CMAKE_OSX_ARCHITECTURES "x86_64" CACHE STRING "macOS architecture to build; 64-bit is expected" FORCE)
+-endif()
+ if(NOT CMAKE_OSX_SYSROOT)
+     # query the path to the default SDK, will fail on non-macOS, but it's okay.
+     execute_process(COMMAND xcodebuild -sdk macosx -version Path
+@@ -252,11 +249,6 @@
+         endif()
+     endif()
+ 
+-    # only the default architecture (i.e. 64-bit) is supported
+-    if(NOT CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64")
+-        message(FATAL_ERROR "Only 64-bit architecture is supported")
+-    endif()
+-
+     # configure Xcode templates
+     set(XCODE_TEMPLATES_ARCH "\$(NATIVE_ARCH_ACTUAL)")
+ endif()


### PR DESCRIPTION
Add a patch to remove the check for x86_64 architecture in
CMakeLists.txt allowing the package to build for arm64.

Closes: https://trac.macports.org/ticket/62334

Signed-off-by: Rafael Kitover <rkitover@gmail.com>

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.1 20D74
Xcode 12.5 12E5234g

I do not have access to an Apple Silicon device right now, but I checked that it builds when passing -DCMAKE_OSX_ARCHITECTURES=arm64, at least up to the linking stage because I don't have libraries for that arch.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
