### PR TITLE
go: change bootstrap process and support arm64

### DIFF
--- a/lang/go/Portfile
+++ b/lang/go/Portfile
@@ -176,7 +176,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
 subport ${name}-bootstrap {
     # unset build dependencies
     depends_build
-    distfiles           ${distname}.darwin-${build_arch}${extract.suffix}
+    distfiles           ${distname}.darwin-${GOARCH}${extract.suffix}
     build {}
     destroot {
         set grfdir ${destroot}${GOROOT_FINAL}

--- a/lang/go/Portfile
+++ b/lang/go/Portfile
@@ -9,6 +9,7 @@ legacysupport.newest_darwin_requires_legacy 13
 name                go
 epoch               2
 version             1.16
+revision            1
 categories          lang
 platforms           darwin freebsd linux
 license             BSD
@@ -27,23 +28,33 @@ long_description    \
 
 homepage            https://golang.org/
 master_sites        https://storage.googleapis.com/golang/
-distfiles           ${name}${version}.src.tar.gz
+distname            ${name}${version}
+distfiles           ${distname}.src${extract.suffix}
 worksrcdir          ${name}
 
-checksums           rmd160  1009890b7d4bbf6d8888a6f7adae8b0e42edb7ae \
+checksums           ${distname}.src${extract.suffix} \
+                    rmd160  1009890b7d4bbf6d8888a6f7adae8b0e42edb7ae \
                     sha256  7688063d55656105898f323d90a79a39c378d86fe89ae192eb3b7fc46347c95a \
-                    size    20895394
+                    size    20895394 \
+                    ${distname}.darwin-amd64${extract.suffix} \
+                    rmd160  f838ec882147fdf2d192d280fa7a1eb802811d34 \
+                    sha256  6000a9522975d116bf76044967d7e69e04e982e9625330d9a539a8b45395f9a8 \
+                    size    130169373 \
+                    ${distname}.darwin-arm64${extract.suffix} \
+                    rmd160  ff5d1565fb9961a472b4846efa364016444a7217 \
+                    sha256  4dac57c00168d30bbd02d95131d5de9ca88e04f2c5a29a404576f30ae9b54810 \
+                    size    125661998
 
 maintainers         {ciserlohn @ci42} \
                     {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-depends_build       port:go-1.4
+depends_build       port:${name}-bootstrap
 
 set GOROOT          ${worksrcpath}
-set GOROOT_FINAL    ${prefix}/lib/${name}
+set GOROOT_FINAL    ${prefix}/lib/${subport}
 
-supported_archs     i386 x86_64
+supported_archs     i386 x86_64 arm64
 
 switch ${build_arch} {
     i386 {
@@ -62,7 +73,7 @@ use_configure       no
 build.dir           ${worksrcpath}/src
 build.cmd           ./make.bash
 build.target
-build.env           GOROOT_BOOTSTRAP=${prefix}/lib/go-1.4 \
+build.env           GOROOT_BOOTSTRAP=${prefix}/lib/${name}-bootstrap \
                     GOROOT=${GOROOT} \
                     GOARCH=${GOARCH} \
                     GOOS=darwin \
@@ -159,6 +170,20 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
     pre-fetch {
         ui_error "${name} @${version} requires OS X 10.7 or greater."
         return -code error "incompatible Mac OS X version"
+    }
+}
+
+subport ${name}-bootstrap {
+    # unset build dependencies
+    depends_build
+    distfiles           ${distname}.darwin-${build_arch}${extract.suffix}
+    build {}
+    destroot {
+        set grfdir ${destroot}${GOROOT_FINAL}
+        xinstall -d ${grfdir}
+        foreach f {bin pkg src} {
+            copy ${worksrcpath}/${f} ${grfdir}
+        }
     }
 }
 


### PR DESCRIPTION
Switching from using Go 1.4 as a build toolchain to binary Go in order to be able to build for darwin-arm64

* add go-bootstrap subport that uses binary Go release
* add support for arm64

Closes: https://trac.macports.org/ticket/60942

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.1 20D74
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
