### PR TITLE
google-cloud-sdk: update to 329.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             328.0.0
+version             329.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,14 +21,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  3f7a876611da03c8d286bb0836ca78aac2a58288 \
-                    sha256  c43843ed63255685f3c1098d1c2ba3eb77f51e28b1ea83b5d3200f8c65e0f215 \
-                    size    87594511
+    checksums       rmd160  7789e4c4b2c4ff3dbc0dd6b6e97f8f8de1fc1373 \
+                    sha256  da72313f5762ddc56ce121e2f32c5af2fdf7c93a3667104ccd2e769d0f44d689 \
+                    size    87893287
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  26f7bf52a7aef7ee358fb080a22f121ad9650cac \
-                    sha256  6871707329ede314344f527e3934b182db54f56dd514902a0b099049d560f059 \
-                    size    110097588
+    checksums       rmd160  c91dac33946db91a0cb33856b0b10ab67c699039 \
+                    sha256  1edda5cc0168e8c350e56ffbec1b5b78638e2c0a48e5dd88699d89ccfb35d688 \
+                    size    110376929
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 329.0.0.

###### Tested on

macOS 11.2.1 20D74
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?