### PR TITLE
py-ansible-base: Add dependency py-packaging

### DIFF
--- a/python/py-ansible-base/Portfile
+++ b/python/py-ansible-base/Portfile
@@ -51,6 +51,7 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-yaml \
                         port:py${python.version}-setuptools \
                         port:py${python.version}-cryptography \
+                        port:py${python.version}-packaging \
                         port:ansible_select
     select.group    ansible
     select.file     ${filespath}/py${python.version}-ansible


### PR DESCRIPTION
#### Description

A warning is shown at the start of an Ansible run with the following
message:

[WARNING]: packaging Python module unavailable; unable to validate
collection Ansible version requirements

The added dependency fixes this warning.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.2.1 20D74
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?