### PR TITLE
wireguard-tools: update to 1.0.20210223

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-tools
-version             1.0.20200827
+version             1.0.20210223
 revision            0
-checksums           rmd160  4e3bc2439fb7bdca127d8a75051eced78774729f \
-                    sha256  51bc85e33a5b3cf353786ae64b0f1216d7a871447f058b6137f793eb0f53b7fd \
-                    size    94788
+checksums           rmd160  0e15694ab4b4ae42a5a856a62e4a85f6683cba79 \
+                    sha256  1f72da217044622d79e0bab57779e136a3df795e3761a3fc1dc0941a9055877c \
+                    size    95444
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
#### Description

wireguard-tools: update to 1.0.20210223

###### Tested on
macOS 10.15.7 19H114
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
