### PR TITLE
hugo: update to 0.81.0

### DIFF
--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gohugoio/hugo 0.80.0 v
+go.setup            github.com/gohugoio/hugo 0.81.0 v
 revision            0
-checksums           rmd160  052ea03bf07ea4c7b7a3cd64bce63324a53fead0 \
-                    sha256  cce12471d65f69005890aeca48c089d7d88a77c863402e8ca77712d09f0a503c \
-                    size    36209678
+checksums           rmd160  d6a9f12b539d367e416b9bc28d8114d517063c8a \
+                    sha256  14632c5776e9582f73c784941082d84ff8da967d19f6d0aefb95f97ac56818f8 \
+                    size    37354036
 
 categories          www
 platforms           darwin


### PR DESCRIPTION
#### Description

hugo: update to 0.81.0

###### Tested on
macOS 10.15.7 19H114
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
