### PR TITLE
p5-compress-raw-lzma: update to 2.101.0

### DIFF
--- a/perl/p5-compress-raw-lzma/Portfile
+++ b/perl/p5-compress-raw-lzma/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28 5.30
-perl5.setup         Compress-Raw-Lzma 2.100 ../../authors/id/P/PM/PMQS
+perl5.setup         Compress-Raw-Lzma 2.101 ../../authors/id/P/PM/PMQS
 revision            0
-checksums           rmd160  5b8af69812d8a4705e4ca46729fbc1b72ef2079d \
-                    sha256  5cef2d8ff53ab0361b5afb827b9d7e00d230bdbad577955622c43f933294f42b \
-                    size    117490
+checksums           rmd160  b1cf1b48f6f81f8559fdae8a411ca5cc50631495 \
+                    sha256  bb267fd31981eda11f444038f8a0fca4b94a51ae61b2db71246abf6a4d322a36 \
+                    size    117502
 
 platforms           darwin
 


### PR DESCRIPTION
#### Description

p5-compress-raw-lzma: update to 2.101.0

###### Tested on
macOS 10.15.7 19H114
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
