### PR TITLE
py-markdown2: update to 2.4.0, add py39

### DIFF
--- a/python/py-markdown2/Portfile
+++ b/python/py-markdown2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        trentm python-markdown2 2.3.8
+github.setup        trentm python-markdown2 2.4.0
 revision            0
 name                py-markdown2
 
@@ -12,35 +12,34 @@ categories-append   textproc
 platforms           darwin
 supported_archs     noarch
 license             MIT
+supported_archs     noarch
 maintainers         nomaintainer
 
-description         Python implementation of Markdown
-long_description    ${description}
+description         A fast and complete implementation of Markdown in Python
+long_description    {*}${description}. Markdown2 comes with a number of extensions \
+                    for things like syntax coloring, tables, header-ids.
 
-checksums           rmd160  06493d2c806a1fa3d7dcfcf46d845be7c8faf15d \
-                    sha256  4dd7689aa40f92074b2f9097266b1fbd47fad456e5373fe153c2b9906cc8f4f8 \
-                    size    1063009
+checksums           rmd160  20f4b789ec3d2942f0a7ec598ed727595c6e5ca8 \
+                    sha256  7390432aa051a674a3cb77cd1748c9bc4d0ffab3ce358331fe92a6727d245448 \
+                    size    1065930
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
 
-    post-patch {
-        reinplace "s|bdist_wheel||g" ${worksrcpath}/setup.cfg
-    }
+    # Required for code highlighting and tests to pass
+    # See https://github.com/trentm/python-markdown2/issues/388#issuecomment-769236400
+    depends_run-append \
+                    port:py${python.version}-pygments
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
         xinstall -d ${destroot}${docdir}
-        xinstall -m 0644 -W ${worksrcpath} TODO.txt README.md \
+        xinstall -m 644 -W ${worksrcpath} TODO.txt README.md \
             LICENSE.txt CONTRIBUTORS.txt CHANGES.md \
             ${destroot}${docdir}
-    }
-
-    pre-test {
-        reinplace "s|python|${python.bin}|g" ${worksrcpath}/Makefile
     }
 
     test.run        yes


### PR DESCRIPTION
#### Description

I know this is a no maintainer port, but I just wanted this to be reviewed since I made a few minor tweaks.

[README](https://github.com/trentm/python-markdown2/blob/master/README.md) states python 2.6+ and 3.3+ are still supported, with the [setup.py](https://github.com/trentm/python-markdown2/blob/e351f29d37307cb191877a269069636be6a9264d/setup.py#L25) noting 3.9 support. I removed the patches since they didn't seem to be doing anything, and I added a runtime dep on pygments to get the tests to pass (see https://github.com/trentm/python-markdown2/issues/388#issuecomment-769236400).

This should also patch [CVE-2020-11888](https://nvd.nist.gov/vuln/detail/CVE-2020-11888), which affects version 2.3.8 and below.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [x] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
