### PR TITLE
dialog: update to 1.3-20210117

### DIFF
--- a/devel/dialog/Portfile
+++ b/devel/dialog/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                dialog
 epoch               20150920
-version             1.3-20180621
+version             1.3-20210117
 categories          devel
 license             LGPL-2.1
 maintainers         nomaintainer
@@ -24,14 +24,18 @@ master_sites        ftp://ftp.invisible-island.net/pub/dialog/ \
 #worksrcdir ${name}-${version}
 extract.suffix      .tgz
 
-checksums           rmd160  af3134df81324175bc95f9bcc4ac691a2a04d094 \
-                    sha256  4a4859e2b22d24e46c1a529b5a5605b95503aa04da4432f7bbd713e3e867587a \
-                    size    529123
+checksums           rmd160  e55b51d9c9e8836328be7f1dcddcdfe739f86fcb \
+                    sha256  3c1ed08f44bcf6f159f2aa6fde765db94e8997b3eefb49d8b4c86691693c43e1 \
+                    size    558091
 
+depends_build       port:pkgconfig
 depends_lib         port:ncurses
 
 configure.args      --mandir=${prefix}/share/man \
                     --with-ncursesw
+
+test.run            yes
+test.target         check
 
 if {${name} == ${subport}} {
 


### PR DESCRIPTION
Allows the port to compile under Big Sur.
Addresses https://trac.macports.org/ticket/61498.

#### Description

Allows the port to compile under Big Sur.
Addresses https://trac.macports.org/ticket/61498.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 11.2.1 20D74
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files? (Got it to show a dialog with `dialog --yesno "Hello" 10 30`, but I'm not familiar with dialog in general.)
