### PR TITLE
kubectx: update to 0.9.2

### DIFF
--- a/sysutils/kubectx/Portfile
+++ b/sysutils/kubectx/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        ahmetb kubectx 0.9.1 v
-revision            1
+github.setup        ahmetb kubectx 0.9.2 v
+revision            0
 categories          sysutils
 platforms           darwin
 supported_archs     noarch
@@ -15,9 +15,9 @@ description         Power tools for kubectl
 long_description    kubectx helps you switch between clusters back and forth. \
                     kubens helps you switch between Kubernetes namespaces smoothly.
 
-checksums           rmd160  dc6a1b33555b13c07970f53a08ad3ca7bf85552e \
-                    sha256  6c1f140b5e02988b13aa87be6e788af98ba93c947aaa48c9a015209c49a00dc9 \
-                    size    512930
+checksums           rmd160  f78af218c9b5ed883e99f4c62ef17bd42c1f73ee \
+                    sha256  64ecc453e5c6b9a8a5f58a86aa8b52fcaf272dde3d7b1c7f8bd270758adb111a \
+                    size    521105
 
 depends_run         path:${prefix}/bin/kubectl:kubectl-1.19
 


### PR DESCRIPTION
#### Description

Update to kubectx 0.9.2.

###### Tested on

macOS 11.2.1 20D74
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?