### PR TITLE
kubectx: update to 0.9.3

### DIFF
--- a/sysutils/kubectx/Portfile
+++ b/sysutils/kubectx/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        ahmetb kubectx 0.9.2 v
+github.setup        ahmetb kubectx 0.9.3 v
 revision            0
 categories          sysutils
 platforms           darwin
@@ -15,9 +15,9 @@ description         Power tools for kubectl
 long_description    kubectx helps you switch between clusters back and forth. \
                     kubens helps you switch between Kubernetes namespaces smoothly.
 
-checksums           rmd160  f78af218c9b5ed883e99f4c62ef17bd42c1f73ee \
-                    sha256  64ecc453e5c6b9a8a5f58a86aa8b52fcaf272dde3d7b1c7f8bd270758adb111a \
-                    size    521105
+checksums           rmd160  6b5c706da0b9c4d9ee01ba1214964542615a8a4f \
+                    sha256  d9083c82a80c8192da406c76c9d7b5bca04bf4be10c6d195055e4af3a790ed13 \
+                    size    520535
 
 depends_run         path:${prefix}/bin/kubectl:kubectl-1.19
 


### PR DESCRIPTION
#### Description

Update to kubectx 0.9.3.

###### Tested on

macOS 11.2.2 20D80
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?