### PR TITLE
kustomize: update to 4.0.3

### DIFF
--- a/devel/kustomize/Portfile
+++ b/devel/kustomize/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/kubernetes-sigs/kustomize 4.0.2 kustomize/v
+go.setup            github.com/kubernetes-sigs/kustomize 4.0.3 kustomize/v
 revision            0
 
 categories          devel
@@ -23,9 +23,9 @@ long_description    kustomize lets you customize raw, template-free YAML files f
 
 homepage            https://kustomize.io
 
-checksums           rmd160  374b417229e90c43d5e6c65b403202d9637ed71a \
-                    sha256  62b16d23a25294e78e5ed866c2f2a1ab59edb492b685bffec7afe6a3bc6f8c98 \
-                    size    27899438
+checksums           rmd160  5be830bc921a48c69e2d876ad6900b194e4593f5 \
+                    sha256  5e4e8977953d30b5f39e00eb71cb6b9c41c3acc00e77fa0b021710b7853e985b \
+                    size    27900309
 
 build.dir           ${worksrcpath}/${name}
 


### PR DESCRIPTION
#### Description

Update to Kustomize 4.0.3.

###### Tested on

macOS 11.2.2 20D80
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?