### PR TITLE
libslirp: new port

### DIFF
--- a/net/libslirp/Portfile
+++ b/net/libslirp/Portfile
@@ -1,0 +1,20 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           meson 1.0
+name                libslirp
+version             4.4.0
+license             BSD
+categories          net
+platforms           darwin
+maintainers         @WaluigiWare64
+description         General purpose TCP-IP emulator
+long_description    libslirp is a user-mode networking library used by virtual machines, containers or various tools.
+homepage            https://gitlab.freedesktop.org/slirp/libslirp/
+master_sites        https://gitlab.freedesktop.org/slirp/libslirp/uploads/a30aeca3c6ad23f176065d0ee832957b/
+use_xz              yes
+checksums           rmd160  6b2cdd33304a813f3161348e2f4a1b58056b4b4a \
+                    sha256  e903fc14c26030b51711bd7f098697c2393f237199e3681c2e22ea013c3635a7 \
+                    size    99740
+depends_lib         port:glib2
+depends_build       port:pkgconfig

--- a/net/libslirp/Portfile
+++ b/net/libslirp/Portfile
@@ -4,19 +4,15 @@ PortSystem              1.0
 PortGroup               meson 1.0
 PortGroup               gitlab 1.0
 
-name                    libslirp
-version                 4.4.0
+gitlab.instance         https://gitlab.freedesktop.org
+gitlab.setup            slirp libslirp 4.4.0 v
+
 license                 BSD
 categories              net
 platforms               darwin
 maintainers             @WaluigiWare64
 description             General purpose TCP-IP emulator
 long_description        libslirp is a user-mode networking library used by virtual machines, containers or various tools.
-homepage                https://gitlab.freedesktop.org/slirp/libslirp/
-
-gitlab.instance         https://gitlab.freedesktop.org
-gitlab.setup            slirp libslirp ${version} v
-
 checksums               rmd160  567e979fa12f43e4e475e28b9c626c9be3410144 \
                         sha256  e81de709e1e1ff418f8292e5a2a2d14fe0abc3c3912881d0e7ab338834e3907c \
                         size    98342

--- a/net/libslirp/Portfile
+++ b/net/libslirp/Portfile
@@ -1,20 +1,21 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem          1.0
-PortGroup           meson 1.0
-name                libslirp
-version             4.4.0
-license             BSD
-categories          net
-platforms           darwin
-maintainers         @WaluigiWare64
-description         General purpose TCP-IP emulator
-long_description    libslirp is a user-mode networking library used by virtual machines, containers or various tools.
-homepage            https://gitlab.freedesktop.org/slirp/libslirp/
-master_sites        https://gitlab.freedesktop.org/slirp/libslirp/uploads/a30aeca3c6ad23f176065d0ee832957b/
-use_xz              yes
-checksums           rmd160  6b2cdd33304a813f3161348e2f4a1b58056b4b4a \
-                    sha256  e903fc14c26030b51711bd7f098697c2393f237199e3681c2e22ea013c3635a7 \
-                    size    99740
-depends_lib         port:glib2
-depends_build       port:pkgconfig
+PortSystem              1.0
+PortGroup               meson 1.0
+
+name                    libslirp
+version                 4.4.0
+license                 BSD
+categories              net
+platforms               darwin
+maintainers             @WaluigiWare64
+description             General purpose TCP-IP emulator
+long_description        libslirp is a user-mode networking library used by virtual machines, containers or various tools.
+homepage                https://gitlab.freedesktop.org/slirp/libslirp/
+master_sites            https://gitlab.freedesktop.org/slirp/libslirp/uploads/a30aeca3c6ad23f176065d0ee832957b/
+use_xz                  yes
+checksums               rmd160  6b2cdd33304a813f3161348e2f4a1b58056b4b4a \
+                        sha256  e903fc14c26030b51711bd7f098697c2393f237199e3681c2e22ea013c3635a7 \
+                        size    99740
+depends_lib             port:glib2
+depends_build-append    port:pkgconfig

--- a/net/libslirp/Portfile
+++ b/net/libslirp/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem              1.0
 PortGroup               meson 1.0
+PortGroup               gitlab 1.0
 
 name                    libslirp
 version                 4.4.0
@@ -12,10 +13,12 @@ maintainers             @WaluigiWare64
 description             General purpose TCP-IP emulator
 long_description        libslirp is a user-mode networking library used by virtual machines, containers or various tools.
 homepage                https://gitlab.freedesktop.org/slirp/libslirp/
-master_sites            https://gitlab.freedesktop.org/slirp/libslirp/uploads/a30aeca3c6ad23f176065d0ee832957b/
-use_xz                  yes
-checksums               rmd160  6b2cdd33304a813f3161348e2f4a1b58056b4b4a \
-                        sha256  e903fc14c26030b51711bd7f098697c2393f237199e3681c2e22ea013c3635a7 \
-                        size    99740
+
+gitlab.instance         https://gitlab.freedesktop.org
+gitlab.setup            slirp libslirp ${version} v
+
+checksums               rmd160  567e979fa12f43e4e475e28b9c626c9be3410144 \
+                        sha256  e81de709e1e1ff418f8292e5a2a2d14fe0abc3c3912881d0e7ab338834e3907c \
+                        size    98342
 depends_lib             port:glib2
 depends_build-append    port:pkgconfig


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
This pull request adds the `libslirp` library, a general purpose TCP-IP emulator.
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.0.1 20B29
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
