### PR TITLE
add new port: janet

### DIFF
--- a/lang/janet/Portfile
+++ b/lang/janet/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           makefile 1.0
+
+github.setup        janet-lang janet 1.15.3 v
+categories          lang
+platforms           darwin
+license             MIT
+
+maintainers         {@tsujp wz.ht:jc+macports} openmaintainer
+description         A dynamic language and bytecode vm
+long_description    Janet is a functional and imperative programming \
+                    language and bytecode interpreter. It is a lisp-like \
+                    language, but lists are replaced by other data structures. \
+                    The language also supports bridging to native code written in C, \
+                    meta-programming with macros, and bytecode assembly.
+
+homepage            https://janet-lang.org/
+
+checksums           rmd160 dfe40985067b851b15519fbb278e44a1254c4553 \
+                    sha256 061ca6dec7684d824b9a74f738d546ff620c41608e87ebe988bb68f548f39b88 \
+                    size   598864
+
+destroot.keepdirs   ${destroot}${prefix}/lib/${name}
+
+test.run            yes


### PR DESCRIPTION
#### Description

Janet is a dynamic lisp-like language and bytecode vm, tiny, embeddable.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.2 20D64
Xcode 12.4 12D4e

###### Verification

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`? (the `t` flag is breaking the build on M1 machines causing tar to have failed permissions)
- [x] tested basic functionality of all binary files?