### PR TITLE
libp11: update to 0.4.11

### DIFF
--- a/security/libp11/Portfile
+++ b/security/libp11/Portfile
@@ -3,9 +3,9 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            OpenSC libp11 0.4.10 libp11-
+github.setup            OpenSC libp11 0.4.11 libp11-
 github.tarball_from     releases
-revision                1
+revision                0
 categories              security
 platforms               darwin
 license                 LGPL-2.1
@@ -15,9 +15,9 @@ description             Interface to access PKCS#11 objects.
 long_description        libp11 is a library implementing a thin layer on top of PKCS#11 API \
                         to make using PKCS#11 implementations easier.
 
-checksums               rmd160  3a1368ff10f8481ee6a49812ceabd9877a171436 \
-                        sha256  639ea43c3341e267214b712e1e5e12397fd2d350899e673dd1220f3c6b8e3db4 \
-                        size    496891
+checksums               rmd160  00392cf1ae584ecc3075e2c9efd7bb0fc02cd45e \
+                        sha256  57d47a12a76fd92664ae30032cf969284ebac1dfc25bf824999d74b016d51366 \
+                        size    500433
 
 depends_build           port:docbook-xsl-nons \
                         port:gengetopt \
@@ -25,3 +25,6 @@ depends_build           port:docbook-xsl-nons \
                         port:libxslt \
                         port:pkgconfig
 depends_lib             path:lib/libcrypto.dylib:openssl
+
+test.run                yes
+test.target             check


### PR DESCRIPTION
Update to libp11 0.4.11:
* Pick up a change allowing the port to compile under macOS 11 Big Sur
* Enable tests

Closes https://trac.macports.org/ticket/61989

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 11.2.2 20D80
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
