### PR TITLE
Hyperscan: Update to version 5.4.0

### DIFF
--- a/textproc/hyperscan/Portfile
+++ b/textproc/hyperscan/Portfile
@@ -5,35 +5,41 @@ PortGroup           cmake                       1.1
 PortGroup           github                      1.0
 PortGroup           legacysupport               1.0
 
-github.setup        intel hyperscan 5.3.0 v
+github.setup        intel hyperscan 5.4.0 v
 revision            0
 
 categories          textproc
 license             BSD
 maintainers         nomaintainer
 platforms           darwin
-homepage            https://www.hyperscan.io/
+
 description         High-performance regular expression matching library.
-long_description    ${description}  It follows the regular expression syntax of the\
-                    commonly-used libpcre library, but is a standalone library with its\
-                    own C API.\
-                    Hyperscan uses hybrid automata techniques to allow simultaneous matching\
-                    of large numbers (up to tens of thousands) of regular expressions and for\
-                    the matching of regular expressions across streams of data.\
-                    Hyperscan is typically used in a DPI library stack.
 
-checksums           rmd160  eaba1f75f07c07a4218730661cb67aa1a103ddf6 \
-                    sha256  b14fe95b04773cd911b7c53e85e4ba6da5eb167427b0df6d7eb696d5647edfc0 \
-                    size    1824384
+long_description    {*}${description} It follows the regular \
+                    expression syntax of the commonly-used libpcre \
+                    library, but is a standalone library with its own \
+                    C API.  Hyperscan uses hybrid automata techniques \
+                    to allow simultaneous matching of large numbers \
+                    (up to tens of thousands) of regular expressions \
+                    and for the matching of regular expressions across \
+                    streams of data.  Hyperscan is typically used in a \
+                    DPI library stack.
 
-set python3_version \
-                    3.7
-set python3_version_nickname \
-                    [join [lrange [split ${python3_version} .] 0 1] {}]
+homepage            https://www.hyperscan.io/
+
+checksums           rmd160  6125895aa0b4f3a54b4ece0130b7a200357d862d \
+                    sha256  864a42d6fb1a816de623379ccfdb3beafc4e400178e5a5bc1fa0d455c1a540c9 \
+                    size    1845250
+
+# Use ${python.default_version}
+# name consistency with ${prefix}/var/macports/sources/rsync.macports.org/macports/release/tarballs/ports/_resources/port1.0/group/python-1.0.tcl
+set python_default_version 39
+set python_version  ${python_default_version}
+set python_branch   [string index ${python_version} 0].[string range ${python_version} 1 end]
 
 depends_build-append \
     port:pkgconfig \
-    port:python${python3_version_nickname} \
+    port:python${python_version} \
     port:ragel
 
 depends_lib-append \
@@ -48,4 +54,4 @@ compiler.cxx_standard   2011
 cmake.build_type    Release
 
 configure.args-append \
-    -DPYTHON_EXECUTABLE=${prefix}/bin/python${python3_version}
+    -DPYTHON_EXECUTABLE=${prefix}/bin/python${python_branch}


### PR DESCRIPTION
Hyperscan: Update to version 5.4.0

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
