### PR TITLE
micronaut: update to 2.3.4

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       java 1.0
 
-github.setup    micronaut-projects micronaut-starter 2.3.3 v
+github.setup    micronaut-projects micronaut-starter 2.3.4 v
 revision        0
 name            micronaut
 categories      java
@@ -53,9 +53,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  971c4d105ffa4f69e3f217a92c8ce570f043c7a2 \
-                sha256  dd118d72862d1823af377e32add1978a52bc701ecc5d1700cdcbe110f3e28acf \
-                size    19525923
+checksums       rmd160  18e295c6e276c7aaad1c1df3cb8f936ba01624fd \
+                sha256  52803f78cedf2d87ed9129b64237c3e3a2fddba8bbc0fda7f976731c90eca119 \
+                size    19527874
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 2.3.4.

###### Tested on

macOS 11.2.2 20D80
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?