### PR TITLE
google-cloud-sdk: update to 330.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             329.0.0
+version             330.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,14 +21,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  7789e4c4b2c4ff3dbc0dd6b6e97f8f8de1fc1373 \
-                    sha256  da72313f5762ddc56ce121e2f32c5af2fdf7c93a3667104ccd2e769d0f44d689 \
-                    size    87893287
+    checksums       rmd160  1c1c12defec274bafe8319ecfd7db6bc04903490 \
+                    sha256  befb311315bc1c344c781121d60c9bed817e520f50bec14808cbb3866f9cab09 \
+                    size    88064354
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  c91dac33946db91a0cb33856b0b10ab67c699039 \
-                    sha256  1edda5cc0168e8c350e56ffbec1b5b78638e2c0a48e5dd88699d89ccfb35d688 \
-                    size    110376929
+    checksums       rmd160  45b8493ea7c413c4b890777a3f4782f01e2731f6 \
+                    sha256  86ef62e640a83d14e8761f0b2f23491f49dc9e079480b2be38eb76817c75bd5b \
+                    size    110550348
 }
 
 homepage            https://cloud.google.com/sdk/
@@ -55,6 +55,7 @@ variant alpha description {Add gcloud CLI Alpha Commands} { dict set variant_to_
 variant anthos_auth description {Add Anthos auth} { dict set variant_to_component anthos_auth anthos-auth }
 variant app_engine_go description {Add App Engine Go Extensions} { dict set variant_to_component app_engine_go app-engine-go }
 variant app_engine_java description {Add gcloud app Java Extensions} { dict set variant_to_component app_engine_java app-engine-java }
+variant app_engine_php description {Add gcloud app PHP Extensions} { dict set variant_to_component app_engine_php app-engine-php }
 variant app_engine_python description {Add gcloud app Python Extensions} { dict set variant_to_component app_engine_python app-engine-python }
 variant app_engine_python_extras description {Add gcloud app Python Extensions (Extra Libraries)} { dict set variant_to_component app_engine_python_extras app-engine-python-extras }
 variant appctl description {Add Appctl} { dict set variant_to_component appctl appctl }


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 330.0.0.

###### Tested on

macOS 11.2.2 20D80
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?