### PR TITLE
syncthing: update to 1.14.0

### DIFF
--- a/net/syncthing/Portfile
+++ b/net/syncthing/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/syncthing/syncthing 1.13.1 v
+go.setup            github.com/syncthing/syncthing 1.14.0 v
 categories          net
 platforms           darwin
 license             MPL-2
@@ -18,9 +18,9 @@ long_description    Syncthing replaces proprietary sync and cloud services \
 homepage            https://syncthing.net
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  3d9a47b44404938693a2803b448720b187fbb72a \
-                        sha256  110b0d5e0f879ccdaa873820ca6cf9fc7daa65458f7b02b040a3feda0377f297 \
-                        size    5044039
+                        rmd160  63cf92d80710cd751b7a2f2fa6158fe64403b7f0 \
+                        sha256  496591f73c4a25dac1444389631bd342a3540ca412b9aeb5a0db14fc63b8aa68 \
+                        size    5072193
 
 go.vendors          gopkg.in/yaml.v3 \
                         lock    9f266ea9e77c \
@@ -273,6 +273,11 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  3b78ee895c6d3d02bbc65ad2ed24aee73020815f \
                         sha256  9ccb9f16909c0a992b2b0f319937d73778c7b97eae57fd6a0a1aa0faf0b11d41 \
                         size    4907 \
+                    github.com/hashicorp/golang-lru \
+                        lock    v0.5.1 \
+                        rmd160  dd02645a94c90ef435ed1662531754761e4a4d8b \
+                        sha256  d9393f70b3fcd62d078e0ceefe9f6605d5086a986ba6cd7ed268b980eb1b6bf4 \
+                        size    12986 \
                     github.com/greatroar/blobloom \
                         lock    v0.5.0 \
                         rmd160  57f4c4fbc0679178345214eb6eea91fb81743434 \
@@ -449,10 +454,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  6ead3d46eebdc505730eeeb67f1f51db8f5685a289a21bb8652ded419e98355c \
                         size    12375 \
                     github.com/AudriusButkevicius/pfilter \
-                        lock    c55ef6137fc6 \
-                        rmd160  f4a19907214e15e2460a0279c02950a5d21dc1c4 \
-                        sha256  bd4daa7fdd0212753aefbef8818eedb38bbec97b43a3e5465a1891b5f0deb5cc \
-                        size    3244
+                        lock    7468b85d810a \
+                        rmd160  ae256c2bccf0a0ad889cee14e8244ffe4635c501 \
+                        sha256  1676b316eb16e30a5cdff9e3ca4115ade3b1da9d15d23ff68dd12629d56ab80b \
+                        size    3280
 
 build.cmd           ${go.bin} run build.go
 build.target        install syncthing


### PR DESCRIPTION
#### Description
Updates syncthing to 1.14.0
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.2 20D80
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
