### PR TITLE
wxMaxima: update to 21.02.0

### DIFF
--- a/math/wxMaxima/Portfile
+++ b/math/wxMaxima/Portfile
@@ -7,7 +7,7 @@ PortGroup           cmake 1.1
 PortGroup           wxWidgets 1.0
 PortGroup           github 1.0
 
-github.setup        wxMaxima-developers wxmaxima 20.04.0 Version-
+github.setup        wxMaxima-developers wxmaxima 21.02.0 Version-
 name                wxMaxima
 maintainers         @MSoegtropIMC
 license             GPL-2
@@ -19,9 +19,9 @@ description         Graphical user interface for Maxima based on wxWidgets
 long_description    Maxima is a Computer Algebra System (CAS) and wxMaxima is a work book style \
                     graphical front end for it based on wxWidgets
 
-checksums           rmd160  0c10602f6f1d777ff16fe85500f57222eb07fc27 \
-                    sha256  055ff34eb98539716a18f7cc11861b5a790fde46aaafabb68f1e690cb649d9df \
-                    size    15314478
+checksums           rmd160  1160cba3db29ab059afcd2dafbbe02425b2f83f0 \
+                    sha256  a8fd7228beeaa93ae8017d24d3bb652815ed159bd943a6e7c939643a705e3500 \
+                    size    16251280
 
 universal_variant   no
 
@@ -35,19 +35,16 @@ depends_run-append  port:gnuplot \
                     port:maxima
 
 post-patch {
-    reinplace -W ${worksrcpath} "s|OSX_MACPORTS_PREFIX \"/opt/local\"|OSX_MACPORTS_PREFIX \"${prefix}\" // patched by MacPorts|" src/Dirstructure.cpp
-    reinplace -W ${worksrcpath} "s|OSX_MACPORTS_PREFER 0|OSX_MACPORTS_PREFER 1 // patched by MacPorts|" src/Dirstructure.cpp
+    reinplace -W ${worksrcpath} "s|OSX_MACPORTS_PREFIX \"/opt/local\"|OSX_MACPORTS_PREFIX \"${prefix}\" // patched by MacPorts|" src/Dirstructure.h
+    reinplace -W ${worksrcpath} "s|OSX_MACPORTS_PREFER 0|OSX_MACPORTS_PREFER 1 // patched by MacPorts|" src/Dirstructure.h
 }
 
 configure.cppflags-append \
                     -I${prefix}/include/libomp
 
-configure.args      -DCCACHE_PROGRAM= \
-                    -DOpenMP_CXX_FLAGS="-Xpreprocessor -fopenmp" \
-                    -DOpenMP_CXX_LIB_NAMES=libomp \
-                    -DOpenMP_libomp_LIBRARY=${prefix}/lib/libomp/libomp.dylib \
+configure.args      -DCMAKE_BUILD_TYPE=Release \
+                    -DCCACHE_PROGRAM= \
                     -DUSE_CPPCHECK=YES \
-                    -DUSE_OPENMP=YES \
                     -DwxWidgets_CONFIG_EXECUTABLE:FILEPATH=${wxWidgets.wxconfig}
 
 destroot {
@@ -71,11 +68,12 @@ You might have to restart wxMaxima for this to take effect.
 wxMaxima and Maxima startup files can typically be found in:
   ~/.maxima
 
-ATTENTION: On macOS Catalina 10.15.X there are issues with the\
-menus (they don't work reliably). There is currently no solution for this.\
-wxMaxima on macOS up to and including 10.14.X works fine.\
-On macOS 10.15.X the only workaround is to click the menu multiple times or to\
-use shortcut keys.
+ATTENTION: On macOS BigSur there is an issue with wxWidgets, which has the\
+effect that wxMaxima does not start. In order to fix this, run these\
+commands:
+  sudo port -f uninstall wxwidgets-3.0
+  sudo port -v -s install wxwidgets-3.0
+If this does not help, you need to update XCode.
 "
 
 github.livecheck.regex  {([a-z0-9.]+)}


### PR DESCRIPTION
#### Description

Update wxMaxima to version 21.02.0.

Fixes: [60493](https://trac.macports.org/ticket/60493)

Does not fix 61933 which is a wxWidgets / MacPorts infrastructure issue (outdated XCode on MacPorts build servers), but contains instructions for an easy workaround in the post install notes. 

###### Type(s)

- [x] bugfix
- [x] enhancement

###### Tested on

macOS 10.15.6 19G2021
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
