### PR TITLE
neovim: fix crash on Big Sur with Apple Silicon

### DIFF
--- a/editors/neovim/Portfile
+++ b/editors/neovim/Portfile
@@ -5,6 +5,7 @@ PortGroup github 1.0
 PortGroup cmake 1.0
 
 github.setup            neovim neovim 0.4.4 v
+revision                1
 categories              editors
 platforms               darwin
 maintainers             {raimue @raimue} \
@@ -18,6 +19,8 @@ long_description \
     a new plugin architecture, job control, and a remote API.
 
 homepage                https://neovim.io
+
+patchfiles              patch-CMakeLists.diff
 
 checksums               rmd160  740290555b5f031a87ffb6c99a90a03002c31596 \
                         sha256  50a2d5ae4b426bb7e0956f8875136f9ba5846cdac4650e83460135253d48d0b9 \

--- a/editors/neovim/files/patch-CMakeLists.diff
+++ b/editors/neovim/files/patch-CMakeLists.diff
@@ -1,0 +1,21 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6b3a8dc..f3370e3 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -358,16 +358,6 @@ if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
+   add_definitions(-D_GNU_SOURCE)
+ endif()
+ 
+-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND CMAKE_SIZEOF_VOID_P EQUAL 8)
+-  # Required for luajit.
+-  set(CMAKE_EXE_LINKER_FLAGS
+-    "${CMAKE_EXE_LINKER_FLAGS} -pagezero_size 10000 -image_base 100000000")
+-  set(CMAKE_SHARED_LINKER_FLAGS
+-    "${CMAKE_SHARED_LINKER_FLAGS} -image_base 100000000")
+-  set(CMAKE_MODULE_LINKER_FLAGS
+-    "${CMAKE_MODULE_LINKER_FLAGS} -image_base 100000000")
+-endif()
+-
+ include_directories("${PROJECT_BINARY_DIR}/config")
+ include_directories("${PROJECT_SOURCE_DIR}/src")
+ 


### PR DESCRIPTION
The patch was taken from https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/neovim.rb

Closes: https://trac.macports.org/ticket/61550

#### Description
Fix crash on Big Sur with Apple Silicon.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.2 20D80
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
