### PR TITLE
py-h5py: Update to 3.2.0; upstream dropped py36.

### DIFF
--- a/python/py-h5py/Portfile
+++ b/python/py-h5py/Portfile
@@ -5,16 +5,16 @@ PortGroup               github 1.0
 PortGroup               python 1.0
 PortGroup               mpi 1.0
 
-github.setup            h5py h5py 3.1.0
+github.setup            h5py h5py 3.2.0
 name                    py-h5py
 
 # h5py needs to be re-built after hdf5 upgrades
-revision                1
+revision                0
 
 checksums \
-    rmd160  33c00c39247373e65bd55bcf4983157d6196398a \
-    sha256  91000a731669ae2689867078212fec88ca9b5eddae3dd1768093cd18a788e493 \
-    size    390571
+    rmd160  72d4ff9e0af762acb8589a0f892b7110efe91bf7 \
+    sha256  eef643bc6fdf00b21b12d0ee932965a46f6752143ee456e92abd413570eb700a \
+    size    395662
 
 platforms               darwin
 license                 BSD
@@ -34,7 +34,7 @@ long_description  \
 
 homepage                https://www.h5py.org
 
-python.versions         36 37 38 39
+python.versions         37 38 39
 
 # Only check against releases.
 github.livecheck.regex      {([0-9.]+)}
@@ -48,12 +48,11 @@ if {${name} ne ${subport}} {
                             port:py${python.version}-pkgconfig \
                             port:hdf5
 
-    if {${python.version} >= 36} {
-        build.env-append        HDF5_DIR=${prefix}
-        destroot.env-append     HDF5_DIR=${prefix}
-        post-patch {
-            reinplace "/=={np_min}/s/==/>=/" setup.py
-        }
+    build.env-append        HDF5_DIR=${prefix}
+    destroot.env-append     HDF5_DIR=${prefix}
+
+    post-patch {
+        reinplace "/=={np_min}/s/==/>=/" setup.py
     }
 
     post-destroot {
@@ -70,15 +69,8 @@ if {${name} ne ${subport}} {
         mpi.enforce_variant     hdf5 \
                                 py${python.version}-mpi4py
 
-        if {${python.version} >= 36} {
-            build.env-append        HDF5_MPI=ON
-            destroot.env-append     HDF5_MPI=ON
-        } else {
-            use_configure           yes
-            configure.cmd           ${build.cmd} configure
-            configure.args          --mpi
-            configure.pre_args
-        }
+        build.env-append        HDF5_MPI=ON
+        destroot.env-append     HDF5_MPI=ON
     }
 
     livecheck.type          none


### PR DESCRIPTION
Maintainer update.