### PR TITLE
postgresql-jdbc: update to version 42.2.19

### DIFF
--- a/java/postgresql-jdbc/Portfile
+++ b/java/postgresql-jdbc/Portfile
@@ -6,7 +6,7 @@ PortGroup           java 1.0
 name                postgresql-jdbc
 set version_major   42
 set version_minor   2
-set version_patch   16
+set version_patch   19
 version             ${version_major}.${version_minor}.${version_patch}
 categories          java databases
 license             BSD
@@ -23,9 +23,9 @@ distname            ${name}-${version}.src
 worksrcdir          ${name}-${version_major}.${version_minor}-${version_patch}.src
 
 master_sites        ${homepage}/download/
-checksums           rmd160  e6366e275d75ca948249c74b35502b0f55210e34 \
-                    sha256  8f51b029b13987b4d967f8668955fa1da1b04ece7c16cfd92d90d8ec5e6739a6 \
-                    size    1426823
+checksums           rmd160  881895379df659e0a1aa0700c9ed47ba51393f64 \
+                    sha256  d30257ed692703f73adc6136b204c39f33151a5076203649f52f786fccfd3a2c \
+                    size    1440741
 
 java.version        1.8*
 java.fallback       openjdk8


### PR DESCRIPTION
#### Description

update to version 42.2.19

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

MacPorts 2.6.4
macOS 11.2.1 20D74
Xcode 12.4 12D4e
Matching Java Virtual Machines (3):
    15.0.2 (x86_64) "AdoptOpenJDK" - "OpenJDK 15.0.2" /Library/Java/JavaVirtualMachines/openjdk15/Contents/Home
    11.0.10 (x86_64) "AdoptOpenJDK" - "OpenJDK 11.0.10" /Library/Java/JavaVirtualMachines/openjdk11/Contents/Home
    1.8.0_282 (x86_64) "AdoptOpenJDK" - "OpenJDK 8" /Library/Java/JavaVirtualMachines/openjdk8/Contents/Home
/Library/Java/JavaVirtualMachines/openjdk15/Contents/Home

MacPorts 2.6.4
macOS 10.15.7 19H524
Xcode 12.4 12D4e
Matching Java Virtual Machines (6):
    15.0.2, x86_64:	"OpenJDK 15.0.2"	/Library/Java/JavaVirtualMachines/openjdk15/Contents/Home
    14.0.2, x86_64:	"OpenJDK 14.0.2"	/Library/Java/JavaVirtualMachines/openjdk14/Contents/Home
    13.0.2, x86_64:	"OpenJDK 13.0.2"	/Library/Java/JavaVirtualMachines/openjdk13/Contents/Home
    12.0.2, x86_64:	"OpenJDK 12.0.2"	/Library/Java/JavaVirtualMachines/openjdk12/Contents/Home
    11.0.10, x86_64:	"OpenJDK 11.0.10"	/Library/Java/JavaVirtualMachines/openjdk11/Contents/Home
    1.8.0_282, x86_64:	"OpenJDK 8"	/Library/Java/JavaVirtualMachines/openjdk8/Contents/Home
/Library/Java/JavaVirtualMachines/openjdk15/Contents/Home

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
