### PR TITLE
pict2pdf: port abandoned

### DIFF
--- a/graphics/pict2pdf/Portfile
+++ b/graphics/pict2pdf/Portfile
@@ -3,7 +3,7 @@ name		pict2pdf
 version		1.1
 categories	graphics
 license		MIT
-maintainers	bme.ogi.edu:prahl
+maintainers	nomaintainer
 description	Vector-to-vector conversion of PICT files to PDF
 long_description	\
 	pict2pdf converts files in Apple's PICT format to Adobe's PDF \
@@ -16,15 +16,9 @@ master_sites	sourceforge
 checksums       md5 c37627f7483509887f70d07d3f798208
 patchfiles      Makefile.diff
 use_configure   no
-if {[vercmp [macports_version] 2.5.99] >= 0} {
 build.env       PREFIX=${prefix} CC=${configure.cc} LD=${configure.cc} \
                 "CFLAGS=${configure.cflags} ${configure.cc_archflags}" \
                 LDFLAGS=${configure.ld_archflags}
-} else {
-build.env       PREFIX="${prefix}" CC="${configure.cc}" LD="${configure.cc}" \
-                CFLAGS="${configure.cflags} ${configure.cc_archflags}" \
-                LDFLAGS="${configure.ld_archflags}"
-}
 destroot	{ xinstall -m 755 ${worksrcpath}/pict2pdf ${destroot}${prefix}/bin
 		  xinstall -m 644 ${worksrcpath}/pict2pdf.1 \
 		    ${destroot}${prefix}/share/man/man1 }


### PR DESCRIPTION
No MX record for maintainer email address domain
See: https://trac.macports.org/ticket/56593

Cleanup MacPorts < 2.6.0 handling

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### 
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
