### PR TITLE
auto-multiple-choice-devel: update to version 1.5.0_rc2-2-gd3d7ea2

### DIFF
--- a/x11/auto-multiple-choice/Portfile
+++ b/x11/auto-multiple-choice/Portfile
@@ -35,11 +35,11 @@ if {${subport} eq ${name}} {
 } else {
     # devel
     set amc.version.main        1.5.0
-    set amc.version.secondary   rc1-24-gb8156497
+    set amc.version.secondary   rc2-2-gd3d7ea24
     version                 ${amc.version.main}_${amc.version.secondary}
-    checksums               rmd160  79e6e5594c9f288bdc83b48d4a06e3387c43f546 \
-                            sha256  76224d423d79d1cd3633fe0e0464c075beb97c7030490dceeb0598379761367c \
-                            size    11125736
+    checksums               rmd160  5e6df40422f2848525f61eb125093e0ea5a9acff \
+                            sha256  7ea5f7171c98f02177581c0759544a0e1bd5b4c42380af97741e492e5ff17fa1 \
+                            size    11126038
 
     depends_lib-append      port:opencv4
 


### PR DESCRIPTION
auto-multiple-choice-devel: update to version 1.5.0_rc2-2-gd3d7ea2

• Update to 1.5.0_rc2-2-gd3d7ea2

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.2 20D80
Xcode 12.4 12D4e 

+mactex
macOS 10.15.7 19H524
Xcode 12.4 12D4e 

macOS 10.11.6 15G22010
Xcode 8.2.1 8C1002 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
