### PR TITLE
py-mpmath: add dependency on py-setuptools_scm

### DIFF
--- a/python/py-mpmath/Portfile
+++ b/python/py-mpmath/Portfile
@@ -33,6 +33,8 @@ if {${name} ne ${subport}} {
         checksums           rmd160  7b0ea9200d2b5f9d6a139e8d5b67ecd07e967952 \
                             sha256  fc17abe05fbab3382b61a123c398508183406fa132e0223874578e20946499f6 \
                             size    512600
+    } else {
+        depends_build-append    port:py${python.version}-setuptools_scm
     }
 
     post-destroot {


### PR DESCRIPTION
#### Description

mpmath depends on setuptools_scm since version 1.2.0 (see https://github.com/fredrik-johansson/mpmath/commit/f7fa465603c2664bebcf8c807e7e54e76c0baa64). Since https://github.com/macports/macports-ports/commit/06caf431441acf904682e611a8942131f16133cf, installing py-mpmath  failed with an error message related to the absence of setuptools_scm unless py-setuptools_scm has been installed manually before.

Fixes https://trac.macports.org/ticket/62392

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.2.2 20D80
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
