### PR TITLE
py-emcee: update to version 3.0.2

### DIFF
--- a/python/py-emcee/Portfile
+++ b/python/py-emcee/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        dfm emcee 2.2.1 v
+github.setup        dfm emcee 3.0.2 v
 name                py-emcee
 
 maintainers         {aronnax @lpsinger} openmaintainer
@@ -17,17 +17,16 @@ long_description    emcee is a stable, well tested Python implementation of \
                     code is open source and has already been used in several \
                     published projects in the astrophysics literature.
 homepage            https://github.com/dfm/emcee
-distname            ${python.rootname}-${version}
 
 platforms           darwin
 supported_archs     noarch
 license             MIT
 
-checksums           rmd160  9d877a80ce5a19b8c442d225a27a57fe548a14f0 \
-                    sha256  afb252b304051ca7a936e81adfa69c92b37fdafd8d3be95e920059f08dcf2d00 \
-                    size    769439
+checksums           rmd160  1dd6aee5026240e5f48218fcf9ac1f22687dddcb \
+                    sha256  b5921ecee38098adbc10038957af93292d53ddfb9a3a828f474f249885cd8f9e \
+                    size    4052353
 
-python.versions     27 35 36 37 38
+python.versions     36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -38,6 +37,9 @@ if {${name} ne ${subport}} {
 
     depends_test-append \
                     port:py${python.version}-nose
+
+    patchfiles-append patch.diff
+
     test.run        yes
     test.cmd        nosetests-${python.branch}
     test.target

--- a/python/py-emcee/files/patch.diff
+++ b/python/py-emcee/files/patch.diff
@@ -1,0 +1,10 @@
+--- setup.py.orig	2019-11-15 13:39:19.000000000 +0100
++++ setup.py	2021-03-05 12:59:05.000000000 +0100
+@@ -52,6 +52,7 @@
+                 "src", NAME, "{0}_version.py".format(NAME)
+             ),
+             "write_to_template": '__version__ = "{version}"\n',
++            "fallback_version": "3.0.2",
+         },
+         author=find_meta("author"),
+         author_email=find_meta("email"),


### PR DESCRIPTION
See https://trac.macports.org/ticket/61496

#### Description

Tentative update to version 3.0.2.
Since the automatic detection of emcee's version by setuptools-scm fails with the bare sources, a crude patch to `setup.py` was added to overcome the issue --- please feel free to provide any robust solution.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
