### PR TITLE
py-emcee3: submission

### DIFF
--- a/python/py-emcee3/Portfile
+++ b/python/py-emcee3/Portfile
@@ -1,0 +1,51 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-emcee3
+version             3.0.2
+python.rootname     emcee
+
+maintainers         {aronnax @lpsinger} openmaintainer
+
+categories-append   science math
+description         affine-invariant ensemble MCMC sampling
+long_description    emcee is a stable, well tested Python implementation of \
+                    the affine-invariant ensemble sampler for Markov chain \
+                    Monte Carlo (MCMC) proposed by Goodman & Weare (2010). The \
+                    code is open source and has already been used in several \
+                    published projects in the astrophysics literature.
+homepage            https://emcee.readthedocs.io/en/stable/
+
+platforms           darwin
+supported_archs     noarch
+license             MIT
+
+checksums           rmd160  b136daa9c9f4a3f8fe9e5294f551ceb39fc537a2 \
+                    sha256  035a44d7594fdd03efd10a522558cdfaa080e046ad75594d0bf2aec80ec35388 \
+                    size    4054969
+
+python.versions     36 37 38 39
+
+if {${name} ne ${subport}} {
+    conflicts       py${python.version}-emcee
+
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-numpy
+
+    depends_test-append \
+                    port:py${python.version}-h5py \
+                    port:py${python.version}-pytest \
+                    port:py${python.version}-scipy
+
+    test.run        yes
+    test.cmd        py.test-${python.branch}
+    test.target
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
+
+    livecheck.type  none
+}


### PR DESCRIPTION
See https://trac.macports.org/ticket/61496
See https://github.com/macports/macports-ports/pull/10152

#### Description

Instead of updating py-emcee to version 3.0.2, creating py-emcee3 following advice from py-emcee's maintainer in https://github.com/macports/macports-ports/pull/10152 .

Since the automatic detection of emcee's version by setuptools-scm fails with the bare sources, a crude patch to setup.py was added to overcome the issue --- please feel free to provide any robust solution.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
