### PR TITLE
Add pngpaste @ version 0.2.3

### DIFF
--- a/sysutils/pngpaste/Portfile
+++ b/sysutils/pngpaste/Portfile
@@ -1,0 +1,21 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        jcsalterego pngpaste 0.2.3
+categories          sysutils
+platforms           darwin
+license             BSD
+maintainers         {@telotortium gmail.com:rirelan} openmaintainer
+description         Paste PNG into files
+long_description    {*}${description} on MacOS, much like pbpaste does for text.
+
+checksums           rmd160  76e0c4526d0afcc7458c4a394182c2a0e23c91ff \
+                    sha256  ebbe5235c373095af1f060bc561d1c91141a4d72870547685f95d1d7d94ad480 \
+                    size    4163
+
+use_configure       no
+destroot            {
+    xinstall ${worksrcpath}/pngpaste ${destroot}${prefix}/bin
+}


### PR DESCRIPTION
#### Description

Add pngpaste @ version 0.2.3

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.2.2 20D80
Xcode 12.4 12D4e

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
