### PR TITLE
tanka: new port

### DIFF
--- a/sysutils/tanka/Portfile
+++ b/sysutils/tanka/Portfile
@@ -1,0 +1,262 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/grafana/tanka 0.14.0 v
+categories          sysutils
+maintainers         {@danieltrautmann danieltrautmann.com:me} openmaintainer
+license             Apache-2
+
+description         Flexible, reusable and concise configuration for Kubernetes
+
+long_description    Grafana Tanka is the robust configuration utility for your \
+                    Kubernetes cluster, powered by the unique Jsonnet language.
+
+homepage            https://tanka.dev
+
+build.pre_args      -o ${worksrcpath}/tk
+build.args          ./cmd/tk
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/tk ${destroot}${prefix}/bin/
+}
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  4214d26e3eeb650cfdd39346008c13797e81f62b \
+                        sha256  9b8b50c73fbe3ca45e20214bbef08686632442136a9ddab9aca5907cc558f923 \
+                        size    1380080
+
+go.vendors          sigs.k8s.io/yaml \
+                        repo    github.com/kubernetes-sigs/yaml \
+                        lock    v1.2.0 \
+                        rmd160  123037650b7c2de2de113292ded3048754e58590 \
+                        sha256  567e5450b666f4fa0caf9465ff37fa6f2caee91828b5e3bfcfb2d43a639f8e20 \
+                        size    92647 \
+                    k8s.io/klog \
+                        repo    github.com/kubernetes/klog \
+                        lock    v2.2.0 \
+                        rmd160  8a9842a6a9084ef60b55d180a02bed241d7d691f \
+                        sha256  0bf173520029a9881eff0f8e357f4abcbfec5b56a6bfb183c1fec0813925cb79 \
+                        size    39971 \
+                    k8s.io/apimachinery \
+                        repo    github.com/kubernetes/apimachinery \
+                        lock    v0.19.2 \
+                        rmd160  cedf01deb3e95182ecde267e20036f79136c2342 \
+                        sha256  9eab1b91080edba92e759aa9f0c97bd8d8fcbbf17013f2506355535316d714aa \
+                        size    538625 \
+                    gopkg.in/yaml.v3 \
+                        lock    fc94e3f71652 \
+                        rmd160  795413c42c3e23e392b013a38d943c0c294c3dc7 \
+                        sha256  8ab9ec0e6380efde355f472b696f1c048bb89a6b14ba9ae3dabf0c3b4a1b6d81 \
+                        size    85343 \
+                    gopkg.in/yaml.v2 \
+                        lock    v2.2.8 \
+                        rmd160  cd9df3ede3e0a28cc30fa7f41f59f20acb91edbf \
+                        sha256  7c8b9e36fac643f1b4a5fc1dc578fb569fc3a1d611c02c3338f4efa84de729fa \
+                        size    72749 \
+                    gopkg.in/inf.v0 \
+                        lock    v0.9.1 \
+                        rmd160  ffe5850db548c2f54472facadcd35d2d2d33a74c \
+                        sha256  5aa9ba7d33226f4833d55ee9e30e21a601e14961d793007e3aaa2ac6aab500c0 \
+                        size    13076 \
+                    gopkg.in/check.v1 \
+                        lock    41f04d3bba15 \
+                        rmd160  1e5543a8e6a3159296ee63e28cbde9931a04f6b3 \
+                        sha256  c41575a73d10809f89b05ef9e783f2d53facdc6573697770d30efb05a9d2dc28 \
+                        size    31612 \
+                    golang.org/x/xerrors \
+                        lock    9bdfabe68543 \
+                        rmd160  eee9929ac1c0380402c45b388077c5c505f13311 \
+                        sha256  dc1be1d7efb43643507e87352ae7161883c48cb5116a20a1739ab93ab558bccf \
+                        size    13661 \
+                    golang.org/x/sys \
+                        lock    ed371f2e16b4 \
+                        rmd160  ae75694302b71e9782dd712f95977a03843cbc8a \
+                        sha256  a29535ff5e884937331b1061e1b1874a2cf040d7d9bd6bc57401bebe4aac65dc \
+                        size    1054584 \
+                    golang.org/x/crypto \
+                        lock    75b288015ac9 \
+                        rmd160  d0df189672060fb880ac1bd440bfe94a5fc3e6d9 \
+                        sha256  290dc7a301e9ad139c8a5bd91bc0fd9936c60e2d7e7f9361eb3766e8b5947e86 \
+                        size    1729939 \
+                    github.com/thoas/go-funk \
+                        lock    v0.4.0 \
+                        rmd160  18e3c3e44ce10e2e753bef6845adf5afa76ed01f \
+                        sha256  2a762427936d0dd30ffd1a90332811912ec28f64dd5d2a873f34e9e963e0b926 \
+                        size    28988 \
+                    github.com/stretchr/testify \
+                        lock    v1.5.1 \
+                        rmd160  db9d43c3c804950ce9650d830f7dea5434ed83c1 \
+                        sha256  e5f566d1c23fb2b987f8a9f139e32866c1eea8c72051da25bbf6880a4f8c541a \
+                        size    78702 \
+                    github.com/stretchr/objx \
+                        lock    v0.2.0 \
+                        rmd160  c56e1cd0bf459aa10978a3db9448860f64ff3464 \
+                        sha256  3e5e938cdfe8b8aa24f9b234cdc61b30cffa37ef385c1c07139af3dde803d622 \
+                        size    80014 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.5 \
+                        rmd160  2ce81608a38c6f383a35bccd24d64361df5828c9 \
+                        sha256  7f41acdcba65b1fab5b9b633947a139f9915b60f94bdab486cdbe9d90c54f61e \
+                        size    50815 \
+                    github.com/spf13/cast \
+                        lock    v1.3.1 \
+                        rmd160  d4ab928edfe2ad8aafbc3248287b788c65ec155f \
+                        sha256  a33b9fbe9c9dd9cc2bb54f43bcd9a4b5503666c028448bc1b600d46961ffb604 \
+                        size    11103 \
+                    github.com/sergi/go-diff \
+                        lock    v1.1.0 \
+                        rmd160  6449feb5884c316206f256e55b81aba3e6a78a9f \
+                        sha256  026d3d6db40ad086954214a7f3f84b66e352d47ce259bb59b7c2b9bd843b9935 \
+                        size    43569 \
+                    github.com/posener/complete \
+                        lock    v1.2.3 \
+                        rmd160  6144bcf9c89075d599423bfc1ed78af017176ec3 \
+                        sha256  10d434d0dd64f516a11e795fe35de984c76ad410f8988e6f4fab2012d1213d59 \
+                        size    22736 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/pkg/errors \
+                        lock    v0.9.1 \
+                        rmd160  dc065c655f8a24c6519b58f9d1202eb266ecda40 \
+                        sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
+                        size    13422 \
+                    github.com/modern-go/reflect2 \
+                        lock    v1.0.1 \
+                        rmd160  5cdaa26d1ee453e37f3a26635aac40397e2f28fa \
+                        sha256  5bcbe1f4c0fa1d853c066a4e6f58eaa5d31ac370c97a3c87e99a6ffecf7b5a65 \
+                        size    14407 \
+                    github.com/modern-go/concurrent \
+                        lock    bacd9c7ef1dd \
+                        rmd160  b039328d6fd40b97513dea8bf5b00adfdd53f14b \
+                        sha256  2f3333805bef60544e64ac9a734522205b513f5c461ba19f3d557510bb205afb \
+                        size    7533 \
+                    github.com/mitchellh/reflectwalk \
+                        lock    v1.0.0 \
+                        rmd160  c8f3f4a948ebfd3f69f22663f856e7309877ba8d \
+                        sha256  117a3a92d72f36187cd4aa728890538c9637be7d4ba9a8d7a777c51a15ea8015 \
+                        size    6149 \
+                    github.com/mitchellh/copystructure \
+                        lock    v1.0.0 \
+                        rmd160  f302c41c8c05f9f254b5c1354e8aa7ba099fc81b \
+                        sha256  5306cd122f11f481baa0b4c17437dd816e9449c8b91d59475c5e1f5b5edc1a9a \
+                        size    8897 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.11 \
+                        rmd160  e7d2dadfe4bff4cd5a5dfece75632e31af6fad44 \
+                        sha256  a8aac03b74f35ec077c589a8ac186b215f14536bb5e262b320ef7ece85bdcab5 \
+                        size    4399 \
+                    github.com/mattn/go-colorable \
+                        lock    v0.1.4 \
+                        rmd160  aeaf016c7ae6cf014233a5a327e4227acf17adea \
+                        sha256  d64a7c2835de356f83a8af8ac9e07ce45d13a5ecb5062efd7f63b85b0b173193 \
+                        size    8987 \
+                    github.com/kr/text \
+                        lock    v0.1.0 \
+                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
+                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
+                        size    8691 \
+                    github.com/kr/pretty \
+                        lock    v0.2.0 \
+                        rmd160  45bbf0be7a3328e33186718ab12cb506c0f5a073 \
+                        sha256  35fb1f8788552fc7df2120bc06dd34e00aa3284d23c250fc1f143eef51d08586 \
+                        size    8762 \
+                    github.com/karrick/godirwalk \
+                        lock    v1.15.5 \
+                        rmd160  09e4dca33354841683ee017d8fb8c09fd5cf60ce \
+                        sha256  9c4e55a115cdb9fed4fe000708a76a4a256e7a417b01676280dba8f17f72fcf5 \
+                        size    24736 \
+                    github.com/imdario/mergo \
+                        lock    v0.3.9 \
+                        rmd160  7a66d9534dce8695eca218269e89837325aaea9c \
+                        sha256  ebfc936c04b3676e5ce8bb1bba848b94f1fe3d64af842451ff7b863841bb1286 \
+                        size    18920 \
+                    github.com/huandu/xstrings \
+                        lock    v1.3.2 \
+                        rmd160  b92c0e29b345b7f7cbe79e773f9855375e7bcb2c \
+                        sha256  97bda2aeca4ae1b66f4113ce16d5d861c124baf8f38e22064f5dbd0accb04c57 \
+                        size    17916 \
+                    github.com/hashicorp/go-multierror \
+                        lock    v1.0.0 \
+                        rmd160  5654b3418ddaf1fc69a9f6387126c1445259114a \
+                        sha256  b16af039752b3be7ccefe05422dc2a48b6b3318188e0ef54ef61276c776f4eb6 \
+                        size    10071 \
+                    github.com/hashicorp/errwrap \
+                        lock    v1.0.0 \
+                        rmd160  d9bf75f667d7bec9b4b11ca34de7ca722495b914 \
+                        sha256  49e80cf52f294ce69fcc8cd26f06b8d8cee2623f6e0012df871b355fb7b17787 \
+                        size    8351 \
+                    github.com/google/uuid \
+                        lock    v1.1.1 \
+                        rmd160  69112e9735ecc1d5360a3cc31531f8be661a007f \
+                        sha256  70be7dec37826f2cbe13acfe534ce74cbb2107c1e348eb4e8365f7d900002e40 \
+                        size    13552 \
+                    github.com/google/gofuzz \
+                        lock    v1.1.0 \
+                        rmd160  0873f06ae34c6d687b120805d740375db12aeab2 \
+                        sha256  7fac594aa1f5962266a5accb83ace991d9311e8e770a153c419a9e96b52713fb \
+                        size    13515 \
+                    github.com/google/go-jsonnet \
+                        lock    v0.17.0 \
+                        rmd160  2f6430ade15419726dac475f6e59ffc13bb69123 \
+                        sha256  e674075c1a78a59707bb69a6435ec06cde4538fde25381928bdd352b0da937e7 \
+                        size    605425 \
+                    github.com/google/go-cmp \
+                        lock    d2fcc899bdc2 \
+                        rmd160  5021dfa1c1da165c38f7a1a0b78794204233735f \
+                        sha256  6631e46f37f68fde3c411c90e9b9186526903a2123222f08de658547b1caafca \
+                        size    99774 \
+                    github.com/gogo/protobuf \
+                        lock    v1.3.1 \
+                        rmd160  16be6b4d8879c774e3b9d9fc29d80cf770632f88 \
+                        sha256  393dda8c157457ce1b3d4003f9012b25528c76b1492d7ba52c9bd7b66c901c13 \
+                        size    2038446 \
+                    github.com/gobwas/glob \
+                        lock    v0.2.3 \
+                        rmd160  1f472cf991498a8091446eb788fe85e0c5403185 \
+                        sha256  2de3694ee0ff41a96b66f9aa3eec51048e620cdd09acc8685f18c3abcd6e14ae \
+                        size    25971 \
+                    github.com/go-logr/logr \
+                        lock    v0.2.0 \
+                        rmd160  40a88db949dfa2a245a79414fea435b6734830be \
+                        sha256  0711805af538385f680e8af5c62f318a9038f7434143d0e36175ef38a31e0c8d \
+                        size    12290 \
+                    github.com/go-clix/cli \
+                        lock    v0.1.1 \
+                        rmd160  44120ddc329af435bc164c9e853c525fb68eb740 \
+                        sha256  14d7f53f907668ba6085d93fa11f9691db2f939abab7590626272b4c0ec0c075 \
+                        size    12321 \
+                    github.com/fatih/structs \
+                        lock    v1.1.0 \
+                        rmd160  8cf8b5356627c4bc6e8f43a195ece010b857bfdf \
+                        sha256  4a358b37e30d02235c902843885326177624ea68074ee747eea5d494e06685ba \
+                        size    14445 \
+                    github.com/fatih/color \
+                        lock    v1.9.0 \
+                        rmd160  1d8418b4f1b3cb597f680b93aaa08afcc9651be4 \
+                        sha256  577c8e778833fec90d76918f138cee9f7765435757b7c92a669e5b34933e0b4f \
+                        size    1231337 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/Masterminds/sprig \
+                        lock    v3.1.0 \
+                        rmd160  b0f805018cff92f35ff80a0b0aeefc0f1835a1ce \
+                        sha256  ef40524fc52d151989b42f77321674ee88b7c654d8e35f449849ca21b695e885 \
+                        size    49999 \
+                    github.com/Masterminds/semver \
+                        lock    v3.1.0 \
+                        rmd160  9566932607417056e0a966ca7c18c0f9515ab532 \
+                        sha256  c50b0ed060252fbd721310c9dde17dc865e2e58c62306009e9d5101932c8c9b9 \
+                        size    24485 \
+                    github.com/Masterminds/goutils \
+                        lock    v1.1.0 \
+                        rmd160  9c73de9ffa7bbf68eb496d9d18f26a206fe5608d \
+                        sha256  d5edbcb0d321e69213764b9db9afea1aee72316b227bc5dbaf0177a726074482 \
+                        size    14608


### PR DESCRIPTION
#### Description

This commit adds the tanka port which provides the tk command.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.1 20D74
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
