### PR TITLE
jsonnet-bundler: new port

### DIFF
--- a/devel/jsonnet-bundler/Portfile
+++ b/devel/jsonnet-bundler/Portfile
@@ -1,0 +1,86 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/jsonnet-bundler/jsonnet-bundler 0.4.0 v
+categories          devel
+maintainers         {@danieltrautmann danieltrautmann.com:me} openmaintainer
+license             Apache-2
+
+description         A jsonnet package manager
+
+long_description    The jsonnet-bundler is a package manager for Jsonnet.
+
+build.pre_args      -o ${worksrcpath}/jb
+build.args          ./cmd/jb
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/jb ${destroot}${prefix}/bin/
+}
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  9d2d44f416471fed7cb193dd169f870277092fe9 \
+                        sha256  d4d724730a0762f9537a227d9a4c57f493abec83068fc351c5f0b40c2c313974 \
+                        size    1267984
+
+go.vendors          gopkg.in/alecthomas/kingpin.v2 \
+                        lock    v2.2.6 \
+                        rmd160  af6db4648ec7638fb5cab49fd9536caa705f5fed \
+                        sha256  31378085783496cff78c7d41479ccd6206c4f4e3892909ef0c2cd39e2de3b039 \
+                        size    44374 \
+                    golang.org/x/sys \
+                        lock    10058d7d4faa \
+                        rmd160  f9c5a586192dad71e135969d1a59011d0cc6b114 \
+                        sha256  daadcb33c6ed442873d1dc900ff56950eb2e3a96042054e3120da24857e3569f \
+                        size    1258096 \
+                    github.com/stretchr/testify \
+                        lock    v1.3.0 \
+                        rmd160  80582370443047a1d7020211865d85d54c036eea \
+                        sha256  ac782171992e3af1c8ac8384cbf4a39706ec5f9e3c6eed57a246e02dce571762 \
+                        size    102899 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/pkg/errors \
+                        lock    v0.8.0 \
+                        rmd160  762fc7077449a4f2467de5398bd50501ea2d7be4 \
+                        sha256  3bb85e407ab7aaf2b1e3f23b7242ded175345000b55642dc286c481e8d32d970 \
+                        size    11350 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.6 \
+                        rmd160  22bea334f5d47dfa7eb2c5afd48f35433b40eb34 \
+                        sha256  6374cc94922860b09cdd99b84c9bb743a04f6177f493ffb20340b8e4ba7e3025 \
+                        size    3567 \
+                    github.com/mattn/go-colorable \
+                        lock    v0.0.9 \
+                        rmd160  7251bb6bf8e5651a52c8e3244d7117918e812f89 \
+                        sha256  22ae6fdf63bccd195bf108013ba477c896a11fffdbb3398487914e32e1db9b2a \
+                        size    7602 \
+                    github.com/fatih/color \
+                        lock    v1.7.0 \
+                        rmd160  8a65cf00de5399f4498b41b0baed82da363f02d5 \
+                        sha256  a553c1229fe10a6b0765cbbb90245bf3383a99ba52b9608052420b40ca30d148 \
+                        size    816675 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.0 \
+                        rmd160  0303eae19a01f38fe314921fd965e4d09b9ef3ad \
+                        sha256  810a597004388d68bb92d8aa612375419ba1080dd5fc2c66dd41b58f0ba4442c \
+                        size    42348 \
+                    github.com/campoy/embedmd \
+                        lock    v1.0.0 \
+                        rmd160  ae5742221def8027c7fb6d9e5daa53534970c0ee \
+                        sha256  6737eed330b1c1af5733d81751b7a6a93074f04729b7e03582157050692b5357 \
+                        size    14936 \
+                    github.com/alecthomas/units \
+                        lock    2efee857e7cf \
+                        rmd160  b1fc6e021a0e5579179bf8629e4a50221e4aa805 \
+                        sha256  ebe15098493671b52f282853872f23517613ad484b550881bef8eb1a1257b5aa \
+                        size    3454 \
+                    github.com/alecthomas/template \
+                        lock    a0175ee3bccc \
+                        rmd160  ed34ba888ec2b18c8fa2d745ff25dec1ce67d6d4 \
+                        sha256  be0a63f0fece9a590713aa740e64b7cc4e923d57706d3b4f478c1cae0fd135b0 \
+                        size    55257


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
This commit adds the jsonnet-bundler port which provides the jb command.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.1 20D74
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
