### PR TITLE
cargo-bootstrap: update to 1.50.0

### DIFF
--- a/devel/cargo/Portfile
+++ b/devel/cargo/Portfile
@@ -9,16 +9,17 @@ if {${subport} ne "${name}-bootstrap"} {
 
     github.setup    rust-lang ${name} 0.51.0
 } else {
-    version         0.47.0
+    version         1.50.0
 }
 PortGroup           cargo 1.0
 
-revision            0
+revision            1
 categories          devel
 platforms           darwin
-supported_archs     x86_64
+supported_archs     x86_64 arm64
 license             {MIT Apache-2}
-maintainers         nomaintainer
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
 
 description         The Rust package manager
 
@@ -32,8 +33,7 @@ installs_libs       no
 if {${subport} ne "${name}-bootstrap"} {
     # can use cmake or cmake-devel; default to cmake.
     depends_build   port:pkgconfig \
-                    path:bin/cmake:cmake \
-                    bin:python:python27
+                    path:bin/cmake:cmake
 
     depends_lib     path:lib/libssl.dylib:openssl \
                     port:curl \
@@ -102,17 +102,27 @@ if {${subport} ne "${name}-bootstrap"} {
         }
     }
 } else {
-    master_sites-append https://static.rust-lang.org/dist/:stage0
+    master_sites-append https://static.rust-lang.org/dist/:rust_dist
+
+    set arch ${configure.build_arch}
+    if {${configure.build_arch} eq "arm64"} {
+        set arch "aarch64"
+    }
 
     checksums-append \
+        ${name}-${version}-aarch64-apple-darwin${extract.suffix} \
+                    rmd160  de7cb695c1ebc5e7483ecf7d353d67dba351432a \
+                    sha256  19d526ef3518fb0322f809deddbd4208a27d08efa41d2188348f1be8d3bcfe5e \
+                    size    5820420 \
         ${name}-${version}-x86_64-apple-darwin${extract.suffix} \
-                    rmd160  123269f99aba6a0def22e77603ada120947023a9 \
-                    sha256  6e8f3319069dd14e1ef756906fa0ef3799816f1aba439bdeea9d18681c353ad6 \
-                    size    5685128
+                    rmd160  1f821ec26255f891e403ced7278a281b294c80ff \
+                    sha256  45640bb1cef40f25ecb4bd2a3bb34fdf884c418e625d4f9c9595d2aca84fad78 \
+                    size    6412639
 
-    set rust_platform [cargo.rust_platform ${configure.build_arch}]
-    distfiles  ${name}-${version}-${rust_platform}${extract.suffix}:stage0
-    worksrcdir ${name}-${version}-${rust_platform}
+
+    set cargo_dist_suffix ${arch}-apple-${os.platform}
+    distfiles  ${name}-${version}-${cargo_dist_suffix}${extract.suffix}:rust_dist
+    worksrcdir ${name}-${version}-${cargo_dist_suffix}
 
     build {}
 


### PR DESCRIPTION
- Use Rust 1.50.0's prebuilt cargo as bootstrap

- Enable ARM64 support for both cargo and cargo-bootstrap

Fixes:  https://trac.macports.org/ticket/60943

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
