### PR TITLE
py-igraph: update dependencies

### DIFF
--- a/python/py-igraph/Portfile
+++ b/python/py-igraph/Portfile
@@ -6,11 +6,12 @@ PortGroup           python 1.0
 name                py-igraph
 python.rootname     python-igraph
 version             0.9.0
+revision            1
 categories-append   math science
 platforms           darwin
 license             GPL-2+
 
-python.versions     27 36 37 38 39
+python.versions     36 37 38 39
 
 maintainers         {snc @nerdling} {gmail.com:szhorvat @szhorvat} openmaintainer
 
@@ -22,49 +23,44 @@ long_description    Python interface to the igraph library for network analysis 
 
 homepage            https://igraph.org/python/
 
-					
 checksums           rmd160  65a9ec40c2ea67786aba9fe79844e061425bbdac \
                     sha256  7aa1d77fa02e27475eb4f14503f3cb342c3ed8990d9224640fd29c70797f2dd6 \
                     size    3366754
 
 if {${name} ne ${subport}} {
     depends_lib-append      port:py${python.version}-texttable \
-                            port:gmp \
-                            port:libxml2
+                            port:arpack \
+                            port:glpk \
+                            port:libxml2 \
+                            port:SuiteSparse_CXSparse
 
     depends_build-append    port:py${python.version}-setuptools \
                             path:bin/cmake:cmake \
-                            port:libtool \
-                            port:autoconf \
-                            port:automake \
                             port:bison \
                             port:flex
 
-    variant external_glpk description {Build with external GLPK} {        
-        depends_lib-append      port:glpk
-    }
-
-    variant external_linalg description {Build with external BLAS, LAPACK, ARPACK} {
-        depends_lib-append      port:lapack port:arpack
-    }
-
-    default_variants        +external_glpk
-
-    set extra_configure_args { }
-
-    if {[variant_isset external_glpk]} {
-        lappend extra_configure_args    --with-external-glpk
-    }
-
-    if {[variant_isset external_linalg]} {
-        lappend extra_configure_args    --with-external-blas --with-external-lapack --with-external-arpack
-    }
+    patchfiles              patch-cmake-args-fix.diff
 
     post-patch {
         reinplace "s|-Werror |-Werror -Wno-unused-function |g" ${worksrcpath}/vendor/source/igraph/etc/cmake/compilers.cmake
     }
 
-    build.env-append        IGRAPH_EXTRA_CONFIGURE_ARGS=[join $extra_configure_args]
+    set extra_cmake_args {
+        -DUSE_CCACHE=OFF
+        -DBUILD_SHARED_LIBS=OFF
+        -DIGRAPH_ENABLE_LTO=ON
+        -DIGRAPH_GLPK_SUPPORT=ON
+        -DIGRAPH_GRAPHML_SUPPORT=ON
+        -DIGRAPH_USE_INTERNAL_ARPACK=OFF
+        -DIGRAPH_USE_INTERNAL_BLAS=OFF
+        -DIGRAPH_USE_INTERNAL_CXSPARSE=OFF
+        -DIGRAPH_USE_INTERNAL_GLPK=OFF
+        -DIGRAPH_USE_INTERNAL_GMP=ON
+        -DIGRAPH_USE_INTERNAL_LAPACK=OFF
+        -DBLA_VENDOR=Apple
+    }
+
+    build.env-append        IGRAPH_CMAKE_EXTRA_ARGS=[join $extra_cmake_args]
 
     pre-test {
         test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]

--- a/python/py-igraph/files/patch-cmake-args-fix.diff
+++ b/python/py-igraph/files/patch-cmake-args-fix.diff
@@ -1,0 +1,26 @@
+--- setup.orig.py	2021-02-25 20:12:21.000000000 +0100
++++ setup.py	2021-03-07 09:49:56.000000000 +0100
+@@ -243,18 +243,18 @@
+         print("Configuring build...")
+         args = [cmake]
+ 
+-        # Add any extra CMake args from environment variables
+-        if "IGRAPH_CMAKE_EXTRA_ARGS" in os.environ:
+-            args.extend(shlex.split(os.environ["IGRAPH_CMAKE_EXTRA_ARGS"]))
+-
+         # Build the Python interface with vendored libraries
+-        for deps in "ARPACK BLAS CXSPARSE GLPK LAPACK".split():
++        for deps in "ARPACK BLAS CXSPARSE GLPK GMP LAPACK".split():
+             args.append("-DIGRAPH_USE_INTERNAL_" + deps + "=ON")
+ 
+         # -fPIC is needed on Linux so we can link to a static igraph lib from a
+         # Python shared library
+         args.append("-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
+ 
++        # Add any extra CMake args from environment variables
++        if "IGRAPH_CMAKE_EXTRA_ARGS" in os.environ:
++            args.extend(shlex.split(os.environ["IGRAPH_CMAKE_EXTRA_ARGS"]))
++
+         # Finally, add the source folder path
+         args.append(str(build_to_source_folder))
+ 


### PR DESCRIPTION
#### Description

 * update dependencies given the changes in python-igraph 0.9
 * build with external (instead of bundled) dependencies when appropriate
 * remove py27 subport as Python 2.7 is no longer supported
 * remove variants
 * See: https://trac.macports.org/ticket/62399

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G8022
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?

