### PR TITLE
igraph: make compatible with old clang

### DIFF
--- a/math/igraph/Portfile
+++ b/math/igraph/Portfile
@@ -5,6 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 
 github.setup        igraph igraph 0.9.0
+revision            0
 github.tarball_from releases
 
 categories          math science devel
@@ -34,8 +35,23 @@ test.target         check
 #  - Enable link-time optimization.
 #  - Set features and the use of externaly libraries explicitly---do not leave this to auto-detection.
 #  - As of igraph 0.9, linking to GMP provides no tangible benefits, thus disable this.
-#  - Use the vecLib BLAS/LAPACK
-configure.args-append -DUSE_CCACHE=OFF -DBUILD_SHARED_LIBS=ON -DIGRAPH_ENABLE_LTO=ON -DIGRAPH_GLPK_SUPPORT=ON -DIGRAPH_GRAPHML_SUPPORT=ON -DIGRAPH_USE_INTERNAL_ARPACK=OFF -DIGRAPH_USE_INTERNAL_BLAS=OFF -DIGRAPH_USE_INTERNAL_CXSPARSE=OFF -DIGRAPH_USE_INTERNAL_GLPK=OFF -DIGRAPH_USE_INTERNAL_GMP=ON -DIGRAPH_USE_INTERNAL_LAPACK=OFF -DBLA_VENDOR=Apple
+#  - Use the vecLib BLAS/LAPACK.
+#  - Do not error on unknown diagnostic options, in order to support building with old clang versions.
+configure.args-append \
+                    -DUSE_CCACHE=OFF \
+                    -DBUILD_SHARED_LIBS=ON \
+                    -DIGRAPH_ENABLE_LTO=ON \
+                    -DIGRAPH_GLPK_SUPPORT=ON \
+                    -DIGRAPH_GRAPHML_SUPPORT=ON \
+                    -DIGRAPH_USE_INTERNAL_ARPACK=OFF \
+                    -DIGRAPH_USE_INTERNAL_BLAS=OFF \
+                    -DIGRAPH_USE_INTERNAL_CXSPARSE=OFF \
+                    -DIGRAPH_USE_INTERNAL_GLPK=OFF \
+                    -DIGRAPH_USE_INTERNAL_GMP=ON \
+                    -DIGRAPH_USE_INTERNAL_LAPACK=OFF \
+                    -DBLA_VENDOR=Apple \
+                    -DCMAKE_C_FLAGS=-Wno-unknown-warning-option \
+                    -DCMAKE_CXX_FLAGS=-Wno-unknown-warning-option
 
 post-destroot {
     set docdir ${prefix}/share/doc/${name}


### PR DESCRIPTION
#### Description

 * make compatible with old clang: do not error on unknown diagnostic options

This PR attempts to make this port compatible with OS X 10.7, where the included compiler does not support the `-Wno-varargs` option, which causes the build to fail.  https://build.macports.org/builders/ports-10.7_x86_64-builder/builds/45964/steps/install-port/logs/stdio

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G8022
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?

