### PR TITLE
rust: correct Rust's build spec for ARM64

### DIFF
--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                rust
 version             1.50.0
-revision            0
+revision            1
 categories          lang devel
 platforms           darwin
 supported_archs     x86_64 arm64
@@ -94,6 +94,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
 }
 
 set rust_platform       ${arch}-apple-${os.platform}
+set rust_build_spec     ${configure.build_arch}-apple-${os.platform}
 set rust_root           ${worksrcpath}/build/stage0-${arch}
 
 post-extract {
@@ -108,7 +109,7 @@ configure.args          --enable-vendor \
                         --disable-codegen-tests \
                         --disable-docs \
                         --release-channel=stable \
-                        --build=${rust_platform} \
+                        --build=${rust_build_spec} \
                         --local-rust-root=${rust_root} \
                         --set=target.${rust_platform}.cc=${configure.cc} \
                         --set=target.${rust_platform}.cxx=${configure.cxx} \


### PR DESCRIPTION
#### Description

ARM64 Rust in MacPorts is currently building with a spec that looks like `aarch64-apple-darwin`.  Appears that it should be `arm64-apple-darwin` instead.


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.4 12D4e