### PR TITLE
lang/{rakudo,nqp,MoarVM}: Update to 2021.02(.1)

### DIFF
--- a/lang/MoarVM/Portfile
+++ b/lang/MoarVM/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 name                MoarVM
-version             2020.12
+version             2021.02
 categories          lang devel
 platforms           darwin
 license             Artistic-2 MIT BSD ISC public-domain
@@ -16,9 +16,9 @@ long_description    MoarVM is a virtual machine built especially for \
 homepage            https://moarvm.org/
 master_sites        https://moarvm.org/releases/
 
-checksums           rmd160  c7929d8953c02b2913f746b9f95436084a808ffe \
-                    sha256  08914f1c464151ebc678cf0d360c9e479a036178fa7c9ddfd34aa4d556d03ea2 \
-                    size    5429137
+checksums           rmd160  3482004e668eaa0310bc7105032af91e89c4bccb \
+                    sha256  19a0c3679e7be8081ddea28a02264be8a821cf624452e35977f8a4b9764d3123 \
+                    size    5451480
 
 # TODO: https://github.com/MoarVM/MoarVM/issues/321
 # conflicts         dyncall libtommath libuv

--- a/lang/nqp/Portfile
+++ b/lang/nqp/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        Raku nqp 2020.12
+github.setup        Raku nqp 2021.02
 description         A lightweight Perl-6 like language for virtual machines
 long_description    This is "Not Quite Perl" -- a lightweight Perl 6-like \
                     environment for virtual machines.  The key feature of \
@@ -21,9 +21,9 @@ platforms           darwin
 github.tarball_from \
                     releases
 
-checksums           rmd160  27620dfc6d642e42c3bac50d8852c1a66ccc3389 \
-                    sha256  fd445b3c3b844a2fc523dc567b2a65c4dc2cc9a3f42ef2e860ef71174823068e \
-                    size    3957981
+checksums           rmd160  47f060ccd9d8f0a02b6a9c6d175ee16bf20287cd \
+                    sha256  d24b1dc8c9f5e743787098a19c9d17b75f57dd34d293716d5b15b9105037d4ef \
+                    size    3987077
 
 depends_build       port:perl5
 

--- a/lang/rakudo/Portfile
+++ b/lang/rakudo/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rakudo rakudo 2020.12
+github.setup        rakudo rakudo 2021.02.1
 description         Perl6 compiler
 long_description    Rakudo is a compiler for the Perl 6 language (version 6.d) \
                     Rakudo is built using NQP (Not Quite Perl 6), which in \
@@ -19,9 +19,9 @@ homepage            https://rakudo.org/
 github.tarball_from \
                     releases
 
-checksums           rmd160  4a710f326304b594364bc949fdde260bad0abd5d \
-                    sha256  c7ccfbb832b97607282d2cd4747e68522e522fe254e329a869053145218f6cbc \
-                    size    5690849
+checksums           rmd160  fcb77e56c033aa3be7f15bb7748dd4bcb5193f60 \
+                    sha256  c8ea8d8bff3c3c983d1f7967321bcb5b72043b2fb5f3da6e8187af5306e998f7 \
+                    size    5709586
 
 depends_build       port:perl5
 


### PR DESCRIPTION
#### Description

Update:
  MoarVM and nqp to 2021.02
  rakudo to 2021.02.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.1 20D74
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [na] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
