### PR TITLE
broot: update to 1.2.7, enable ARM64 support

### DIFF
--- a/sysutils/broot/Portfile
+++ b/sysutils/broot/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        Canop broot 1.2.4 v
+github.setup        Canop broot 1.2.7 v
 revision            0
 
 homepage            https://dystroy.org/broot
@@ -19,18 +19,23 @@ long_description    broot is a new way to see and navigate directory trees. \
 categories          sysutils
 platforms           darwin
 license             MIT
+supported_archs     x86_64 arm64
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  bb59b4353ff3fa7f650165ef87923e87f17bef0d \
-                    sha256  b77daf0d245fea7b7d800ec7c239f5d71671676fc38db17e38b04e8a66ed38df \
-                    size    6414405
+                    rmd160  5f07ca186bca76537498724f07ce5ca87de31ffd \
+                    sha256  e03b965650871d7888fc129e11da20476784fa32547a6da5d3691149f02d92a8 \
+                    size    6446074
 
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 destroot {
-    xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/${name} ${destroot}${prefix}/bin/
-    xinstall -m 644 ${worksrcpath}/man/page ${destroot}${prefix}/share/man/man1/broot.1
+    xinstall -m 755 \
+        ${worksrcpath}/target/[cargo.rust_platform]/release/${name} \
+        ${destroot}${prefix}/bin/
+
+    xinstall -m 644 ${worksrcpath}/man/page \
+        ${destroot}${prefix}/share/man/man1/broot.1
 }
 
 github.livecheck.regex {([0-9.]+)}
@@ -38,8 +43,9 @@ github.livecheck.regex {([0-9.]+)}
 cargo.crates \
     adler                            0.2.3  ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e \
     adler32                          1.2.0  aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234 \
+    ahash                            0.7.0  efa60d2eadd8b12a996add391db32bd1153eac697ba4869660c0016353611426 \
     aho-corasick                    0.7.15  7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5 \
-    ansi_colours                     1.0.1  1d0f302a81afc6a7f4350c04f0ba7cfab529cc009bca3324b3fb5764e6add8b6 \
+    ansi_colours                     1.0.2  52cb663b84aea8670b4a40368360e29485c11b03d14ff6283261aeccd69d5ce1 \
     ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
     arrayref                         0.3.6  a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544 \
     arrayvec                         0.5.2  23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b \
@@ -50,7 +56,7 @@ cargo.crates \
     bincode                          1.3.1  f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d \
     bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
     blake2b_simd                    0.5.11  afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587 \
-    bstr                            0.2.14  473fc6b38233f9af7baa94fb5852dca389e3d95b8e21c8e3719301462c5d9faf \
+    bstr                            0.2.15  a40b47ad93e1a5404e6c18dec46b628214fee441c70f4ab5d6942142cc268a3d \
     bumpalo                          3.6.0  099e596ef14349721d9016f6b80dd3419ea1bf289ab9b44df8e4dfd3a005d5d9 \
     bytemuck                         1.5.0  5a4bad0c5981acc24bc09e532f35160f952e35422603f0563cd7a73c2c2e65a0 \
     byteorder                        1.4.2  ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b \
@@ -61,9 +67,8 @@ cargo.crates \
     char_reader                      0.1.0  2daa67493227adb60f22eb6dca4dc94d7a2a526b38eab5c1831d617944eb1a07 \
     chrono                          0.4.19  670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73 \
     clap                            2.33.3  37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002 \
-    cli-log                          0.1.0  f47673f2992075892b3e983499410c92af91a7d7cee72cf55ec4caea278de6cf \
+    cli-log                          1.1.0  bb79efde0c2e06b3577eff89b0788967051aaad4bf3bcc74a9638223d57ea321 \
     clipboard-win                    4.0.3  5123c6b97286809fea9e38d2c9bf530edbcb9fc0d8f8272c28b0c95f067fa92d \
-    cloudabi                         0.0.3  ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
     color_quant                      1.1.0  3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b \
     const_fn                         0.4.5  28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6 \
     constant_time_eq                 0.1.5  245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc \
@@ -76,8 +81,8 @@ cargo.crates \
     crossbeam-epoch                  0.9.1  a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d \
     crossbeam-queue                  0.3.1  0f6cb3c7f5b8e51bc3ebb73a2327ad4abdbd119dc13223f14f961d2f38486756 \
     crossbeam-utils                  0.8.1  02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d \
-    crossterm                       0.17.7  6f4919d60f26ae233e14233cc39746c8c8bb8cd7b05840ace83604917b51b6c7 \
-    crossterm_winapi                 0.6.2  c2265c3f8e080075d9b6417aa72293fc71662f34b4af2612d8d1b074d29510db \
+    crossterm                       0.19.0  7c36c10130df424b2f3552fcc2ddcd9b28a27b1e54b358b45874f88d1ca6888c \
+    crossterm_winapi                 0.7.0  0da8964ace4d3e4a044fd027919b2237000b24315a37c916f61809f1ff2140b9 \
     csv                              1.1.5  f9d58633299b24b515ac72a3f869f8b91306a3cec616a602843a383acd6f9e97 \
     csv-core                        0.1.10  2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90 \
     custom_error                     1.8.0  51ac5e99a7fea3ee8a03fa4721a47e2efd3fbb38358fc61192a54d4c6f866c12 \
@@ -103,6 +108,7 @@ cargo.crates \
     idna                             0.2.1  de910d521f7cc3135c4de8db1cb910e0b5ed1dc6f57c381cd07e8e661ce10094 \
     image                          0.23.13  293f07a1875fa7e9c5897b51aa68b2d8ed8271b87e1a44cb64b9c3d98aabbc0d \
     indexmap                         1.6.1  4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b \
+    instant                          0.1.9  61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec \
     is_executable                    0.1.2  302d553b8abc8187beb7d663e34c065ac4570b273bc9511a50e940e99409c577 \
     itertools                        0.9.0  284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b \
     itertools                       0.10.0  37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319 \
@@ -114,18 +120,18 @@ cargo.crates \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
     lazycell                         1.3.0  830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55 \
     lfs-core                         0.3.1  f74e84d029af0a4327dd19368cf3783052faaadf1e71bd70bae8796487c95caa \
-    libc                            0.2.85  7ccac4b00700875e6a07c6cde370d44d32fa01c5a65cdd2fca6858c479d28bb3 \
+    libc                            0.2.86  b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c \
     libgit2-sys              0.12.18+1.1.0  3da6a42da88fc37ee1ecda212ffa254c25713532980005d5f7c0b0fbe7e6e885 \
     libz-sys                         1.1.2  602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655 \
     line-wrap                        0.1.1  f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9 \
     linked-hash-map                  0.5.4  7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3 \
-    lock_api                         0.3.4  c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75 \
+    lock_api                         0.4.2  dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312 \
     log                             0.4.14  51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710 \
     matches                          0.1.8  7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
     memchr                           2.3.4  0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525 \
     memmap                           0.7.0  6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b \
     memoffset                        0.6.1  157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87 \
-    minimad                          0.6.9  cb5ed7ea8b54916318ac7ec6ff06b2b428fdf9cb54d1867714f699dbd1659ad4 \
+    minimad                          0.7.0  1f608f20e91ebfa44263b3b5eee1f6cea8e67a8dfd0ad037a5b56f1f3fa071dd \
     miniz_oxide                      0.3.7  791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435 \
     miniz_oxide                      0.4.3  0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d \
     mio                              0.7.7  e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7 \
@@ -141,8 +147,8 @@ cargo.crates \
     onig_sys                        69.6.0  ed063c96cf4c0f2e5d09324409d158b38a0a85a7b90fbd68c8cad75c495d5775 \
     oorandom                        11.1.3  0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575 \
     open                             1.4.0  7c283bf0114efea9e42f1a60edea9859e8c47528eae09d01df4b29c1e489cc48 \
-    parking_lot                     0.10.2  d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e \
-    parking_lot_core                 0.7.2  d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3 \
+    parking_lot                     0.11.1  6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb \
+    parking_lot_core                 0.8.3  fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018 \
     pathdiff                         0.1.0  a3bf70094d203e07844da868b634207e71bfab254fe713171fae9a6e751ccf31 \
     percent-encoding                 2.1.0  d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
     phf                              0.8.0  3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12 \
@@ -158,20 +164,20 @@ cargo.crates \
     ppv-lite86                      0.2.10  ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857 \
     proc-macro-hack                 0.5.19  dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5 \
     proc-macro2                     1.0.24  1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71 \
-    quote                            1.0.8  991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df \
+    quote                            1.0.9  c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7 \
     rand                             0.7.3  6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
     rand                             0.8.3  0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e \
     rand_chacha                      0.2.2  f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402 \
     rand_chacha                      0.3.0  e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d \
     rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
-    rand_core                        0.6.1  c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5 \
+    rand_core                        0.6.2  34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7 \
     rand_hc                          0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
     rand_hc                          0.3.0  3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73 \
     rand_pcg                         0.2.1  16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429 \
     rayon                            1.5.0  8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674 \
     rayon-core                       1.9.0  9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a \
     redox_syscall                   0.1.57  41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce \
-    redox_syscall                    0.2.4  05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570 \
+    redox_syscall                    0.2.5  94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9 \
     redox_users                      0.3.5  de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d \
     regex                            1.4.3  d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a \
     regex-automata                   0.1.9  ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4 \
@@ -203,8 +209,9 @@ cargo.crates \
     syn                             1.0.60  c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081 \
     syntect                          4.5.0  2bfac2b23b4d049dc9a89353b4e06bbc85a8f42020cccbe5409a115cf19031e5 \
     tempfile                         3.2.0  dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22 \
-    termimad                         0.9.5  9c0301aa5081d4c41d5ebf728ec7c3e825cebd1d8f301d95d65e27a9d93fef18 \
-    terminal-clipboard               0.1.1  b7d0bd72c5576dacccc02c15f7aa568e8ef46286b489eebe09de7c4451d493a4 \
+    termimad                        0.10.0  e984b607674dbb8ebb48c378fd62a64c8d39a0e251227c065e4864b5ce2e6526 \
+    terminal-clipboard               0.2.1  17a6b9bf0e5a40b6955cf6f384df9b7ed54106ff57b721f88614f30013d5ef5a \
+    termux-clipboard                 0.1.0  9f6aff13ca3293315b94f6dbd9c69e1c958fe421c294681e2ffda80c9858e36f \
     textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
     thiserror                       1.0.23  76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146 \
     thiserror-impl                  1.0.23  9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1 \
@@ -217,13 +224,14 @@ cargo.crates \
     toml                             0.5.8  a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa \
     umask                            1.0.0  982efbf70ec4d28f7862062c03dd1a4def601a5079e0faf1edc55f2ad0f6fe46 \
     unicode-bidi                     0.3.4  49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5 \
-    unicode-normalization           0.1.16  a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606 \
+    unicode-normalization           0.1.17  07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef \
     unicode-width                    0.1.8  9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3 \
     unicode-xid                      0.2.1  f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564 \
     url                              2.2.0  5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e \
     users                           0.10.0  aa4227e95324a443c9fcb06e03d4d85e91aabe9a5a02aa818688b6918b6af486 \
     vcpkg                           0.2.11  b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb \
     vec_map                          0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
+    version_check                    0.9.2  b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed \
     walkdir                          2.3.1  777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d \
     wasi      0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
     wasi     0.10.2+wasi-snapshot-preview1  fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6 \


### PR DESCRIPTION

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.4 12D4e


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
