### PR TITLE
py-h5py: Restore 27 and 36 (down-rev) for deps.

### DIFF
--- a/python/py-h5py/Portfile
+++ b/python/py-h5py/Portfile
@@ -5,16 +5,16 @@ PortGroup               github 1.0
 PortGroup               python 1.0
 PortGroup               mpi 1.0
 
-github.setup            h5py h5py 3.2.1
+github.setup            h5py h5py 3.3.0
 name                    py-h5py
 
 # h5py needs to be re-built after hdf5 upgrades
 revision                0
 
 checksums \
-    rmd160  57cfc9f6690745d4f1864b59ef183fe6f5f79326 \
-    sha256  e87268f6dc04d5d2b5cf8d6d8765d0e6db9335935d41b60198f49658e649517d \
-    size    395914
+    rmd160  f3bfe3205c40380dcda050c53846042817a7e274 \
+    sha256  64061e4a5797c8fce05515c747d94bffbeae389945c8f534d202273398564814 \
+    size    400501
 
 platforms               darwin
 license                 BSD


### PR DESCRIPTION
Maintainer update.

Addressing ticket [#62359](https://trac.macports.org/ticket/62398), but still leaving py35 (EOL) flavors off. I don't really want to have the 27 version anymore, but until tools using h5py all upgrade, we're stuck.