### PR TITLE
lagrange: update to 1.2.2

### DIFF
--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -8,7 +8,7 @@ PortGroup           legacysupport 1.1
 # strnlen
 legacysupport.newest_darwin_requires_legacy 10
 
-github.setup        skyjake lagrange 1.1.2 v
+github.setup        skyjake lagrange 1.2.2 v
 github.tarball_from releases
 categories          net gemini
 platforms           darwin
@@ -18,9 +18,9 @@ maintainers         {@sikmir gmail.com:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    ${description}
 
-checksums           rmd160  a7f024a38b6ba40b813d93d540a9c03aae4e585a \
-                    sha256  e419c7827d3dda2cf5fd667eb4bed33a74c0174a91f71072080fb418f74d0e92 \
-                    size    14299169
+checksums           rmd160  dc872a1604a8341bbe2a21507e72ee9f891c957f \
+                    sha256  66f7d06359c8d2de72787b02062d9bf4190a8667b6dd00b329b9bb6549bdac55 \
+                    size    14354957
 
 depends_build-append \
                     port:pkgconfig


### PR DESCRIPTION
#### Description
[changelog](https://github.com/skyjake/lagrange/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
