### PR TITLE
libvirt, py-libvirt: update to 7.1.0

### DIFF
--- a/python/py-libvirt/Portfile
+++ b/python/py-libvirt/Portfile
@@ -5,11 +5,11 @@ PortGroup           python 1.0
 
 # Remember to update libvirt and py-libvirt at the same time.
 name                py-libvirt
-version             7.0.0
+version             7.1.0
 revision            0
-checksums           rmd160  10bafde6200bb7adbe3a942a353a083abda8198f \
-                    sha256  7e1663da2587e87106fc226160b33ae2160989c32176ad17d876315d5c1c36b5 \
-                    size    214945
+checksums           rmd160  c794a0aa713b2891ef98112ab8dd4f79a5ba2eb1 \
+                    sha256  faafd31e407f9cb750a73349c007651ca8954ebd455e55b0a20e96de81c50037 \
+                    size    215468
 
 platforms           darwin
 license             MIT

--- a/sysutils/libvirt/Portfile
+++ b/sysutils/libvirt/Portfile
@@ -10,11 +10,11 @@ legacysupport.newest_darwin_requires_legacy 10
 
 # Remember to update libvirt and py-libvirt at the same time.
 name                libvirt
-version             7.0.0
+version             7.1.0
 revision            0
-checksums           rmd160  1601c5f6ef46b048968c88a0bbb534ac95723caa \
-                    sha256  ca3833844d08c22867f1d1a46edc36bda7d6fe1a4f267e7d77100b79fc9ddd89 \
-                    size    8567648
+checksums           rmd160  823d68a726abb51cf45978972db011b598fe9c13 \
+                    sha256  870f180d80256411c5afc39bc5aac4f8acca04a4e0725c576ad24053dc64a06c \
+                    size    8645944
 
 categories          sysutils
 license             LGPL-2.1+
@@ -30,8 +30,8 @@ homepage            https://libvirt.org
 master_sites        ${homepage}/sources/
 use_xz              yes
 
-set python_version  39
 set python_branch   3.9
+set python_version  [string map {. {}} ${python_branch}]
 
 depends_build-append \
                     port:bash-completion \


### PR DESCRIPTION
#### Description

This PR updates libvirt, py-libvirt to v7.1.0, the first version to support Apple Silicon. It is based on https://github.com/macports/macports-ports/pull/10046, opened for the v7.0.0 update.

Two libvirt Meson tests related to TLS are failing. Python tests are successful.

----

```
in ~/Repositories/macports-ports/sysutils/libvirt/work/build
$ meson test
[...]
 73/111 virnettlscontexttest          FAIL            1.29s   killed by signal 6 SIGABRT
11:30:20 VIR_TEST_EXPENSIVE=1 MALLOC_PERTURB_=175 abs_builddir=/opt/local/var/macports/build/_Users_gm_Repositories_macports-ports_sysutils_libvirt/libvirt/work/build/tests abs_top_builddir=/opt/local/var/macports/build/_Users_gm_Repositories_macports-ports_sysutils_libvirt/libvirt/work/build abs_srcdir=/opt/local/var/macports/build/_Users_gm_Repositories_macports-ports_sysutils_libvirt/libvirt/work/libvirt-7.1.0/tests LIBVIRT_AUTOSTART=0 G_DEBUG=fatal-warnings LC_ALL=C abs_top_srcdir=/opt/local/var/macports/build/_Users_gm_Repositories_macports-ports_sysutils_libvirt/libvirt/work/libvirt-7.1.0 /opt/local/var/macports/build/_Users_gm_Repositories_macports-ports_sysutils_libvirt/libvirt/work/build/tests/virnettlscontexttest
----------------------------------- output -----------------------------------
stderr:
TEST: virnettlscontexttest
------------------------------------------------------------------------------

 74/111 virnettlssessiontest          FAIL            1.45s   killed by signal 6 SIGABRT
11:30:20 VIR_TEST_EXPENSIVE=1 MALLOC_PERTURB_=126 abs_builddir=/opt/local/var/macports/build/_Users_gm_Repositories_macports-ports_sysutils_libvirt/libvirt/work/build/tests abs_top_builddir=/opt/local/var/macports/build/_Users_gm_Repositories_macports-ports_sysutils_libvirt/libvirt/work/build abs_srcdir=/opt/local/var/macports/build/_Users_gm_Repositories_macports-ports_sysutils_libvirt/libvirt/work/libvirt-7.1.0/tests LIBVIRT_AUTOSTART=0 G_DEBUG=fatal-warnings LC_ALL=C abs_top_srcdir=/opt/local/var/macports/build/_Users_gm_Repositories_macports-ports_sysutils_libvirt/libvirt/work/libvirt-7.1.0 /opt/local/var/macports/build/_Users_gm_Repositories_macports-ports_sysutils_libvirt/libvirt/work/build/tests/virnettlssessiontest
----------------------------------- output -----------------------------------
stderr:
TEST: virnettlssessiontest
------------------------------------------------------------------------------
[...]
```

```
in ~/Repositories/macports-ports/python/py-libvirt/work/libvirt-python-7.1.0
$ sudo python3.9 ./setup.py test
running test
/opt/local/bin/python3.9 sanitytest.py build/lib.macosx-11.2-arm64-3.9 /opt/local/share/libvirt/api/libvirt-api.xml
/opt/local/bin/python3.9 /opt/local/bin/nosetests-3.9
......
----------------------------------------------------------------------
Ran 6 tests in 0.062s

OK
```
----

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

Darwin Kestrel.local 20.3.0 Darwin Kernel Version 20.3.0: Thu Jan 21 00:06:51 PST 2021; root:xnu-7195.81.3~1/RELEASE_ARM64_T8101 arm64

MacPorts 2.6.4
macOS 11.2.2 20D80
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
