### PR TITLE
graphene: fix for arm64

### DIFF
--- a/graphics/graphene/Portfile
+++ b/graphics/graphene/Portfile
@@ -53,7 +53,9 @@ configure.args-append \
                     -Dtests=false \
                     -Dbenchmarks=false
 
-if {${build_arch} eq "i386" || ${build_arch} eq "x86_64"} {
+if {${build_arch} eq "arm64"} {
+    supported_archs     arm64
+} elseif {${build_arch} eq "i386" || ${build_arch} eq "x86_64"} {
     supported_archs     i386 x86_64
 } else {
     supported_archs     ppc ppc64


### PR DESCRIPTION
#### Description

On Apple Silicon, the port was trying to compile for ppc/ppc64.

Fixes https://trac.macports.org/ticket/61655.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

MacPorts 2.6.4
macOS 11.2.2 20D80
Xcode 12.4 12D4e
arm64

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
