### PR TITLE
igraph: require C++11

### DIFF
--- a/math/igraph/Portfile
+++ b/math/igraph/Portfile
@@ -29,6 +29,9 @@ checksums           rmd160  297c06d217d6c6059b721ec0aa5d59e096004585 \
 test.run            yes
 test.target         check
 
+compiler.cxx_standard \
+                    2011
+
 # Build options for igraph:
 #  - Do not use ccache to build this port unless MacPorts tells it to.
 #  - Build a shared library.


### PR DESCRIPTION
#### Description

 * Require C++11 in order to fix building on old systems

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
