### PR TITLE
google-cloud-sdk: update to 331.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             330.0.0
+version             331.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,14 +21,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  1c1c12defec274bafe8319ecfd7db6bc04903490 \
-                    sha256  befb311315bc1c344c781121d60c9bed817e520f50bec14808cbb3866f9cab09 \
-                    size    88064354
+    checksums       rmd160  bb7445af8dcf4b1d996942f2b72a06cf7c7c8cee \
+                    sha256  080c661ff410cd290830fc2ceb88ce52a0a03161ce27d1294b6b613e5f90e054 \
+                    size    88219612
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  45b8493ea7c413c4b890777a3f4782f01e2731f6 \
-                    sha256  86ef62e640a83d14e8761f0b2f23491f49dc9e079480b2be38eb76817c75bd5b \
-                    size    110550348
+    checksums       rmd160  3a675277726c99c3409213af711dbc78c624a79e \
+                    sha256  32c7b961f4c3d18f772a8900c9bc1300e7f81c0c05d71f93b770a222f00490ba \
+                    size    110705434
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 331.0.0.

###### Tested on

macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?