### PR TITLE
vips: update to version 8.10.5

### DIFF
--- a/graphics/vips/Portfile
+++ b/graphics/vips/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           gobject_introspection 1.0
 
-github.setup        libvips libvips 8.10.2 v
-revision            2
+github.setup        libvips libvips 8.10.5 v
+revision            0
 name                vips
 distname            vips-${version}
 description         VIPS is an image processing library.
@@ -18,9 +18,9 @@ license             LGPL-2.1+
 homepage            https://libvips.github.io/libvips/
 github.tarball_from releases
 
-checksums           rmd160  3dad13d495727ab9af737c7df9ebee9420c49c3a \
-                    sha256  c1d0d9cb54d75cd4f66dce787fbcac99f834f6621fbf47bce9e02ef65b4ab02a \
-                    size    19518825
+checksums           rmd160  7607b66c59b328811f62da1fd184475b8d7170d0 \
+                    sha256  a4eef2f5334ab6dbf133cd3c6d6394d5bdb3e76d5ea4d578b02e1bc3d9e1cfd8 \
+                    size    19519397
 
 # minor tweak to allow build with older compilers
 # StandaloneFuzzTargetMain.c:31: error: 'for' loop initial declaration used outside C99 mode


### PR DESCRIPTION
#### Description
* update vips to version 8.10.5

Closes: https://trac.macports.org/ticket/62420

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.2 20D80
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? (no tests exist)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
