### PR TITLE
gdal: Update to 3.2.2

### DIFF
--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -11,11 +11,11 @@ PortGroup           conflicts_build 1.0
 PortGroup           debug 1.0
 
 mpi.setup
-github.setup        OSGeo gdal 3.2.1 v
-revision            1
-checksums           rmd160  698a78422729f2b299c604d4f50e236c86fcf258 \
-                    sha256  6c588b58fcb63ff3f288eb9f02d76791c0955ba9210d98c3abd879c770ae28ea \
-                    size    12184208
+github.setup        OSGeo gdal 3.2.2 v
+revision            0
+checksums           rmd160  d58c88f673c0e529436f87d2f1329d9743920a8d \
+                    sha256  a7e1e414e5c405af48982bf4724a3da64a05770254f2ce8affb5f58a7604ca57 \
+                    size    12251728
 
 categories          gis
 license             MIT BSD
@@ -109,15 +109,12 @@ configure.args-append \
                     --without-mrsid \
                     --without-jp2mrsid \
                     --without-msg \
-                    --without-bsb \
                     --without-oci \
-                    --without-grib \
                     --without-mysql \
                     --without-ingres \
                     --without-xerces \
                     --without-odbc \
                     --without-idb \
-                    --without-sde \
                     --without-opencl \
                     --without-perl \
                     --without-python \


### PR DESCRIPTION
Gdal 3.2.2 is a bugfix release.
Also fixed portfile for some configure warnings.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G7016
Xcode 11.5 11E608c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?    (Not using sudo)
- [x] tried a full install with `port -vs install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->