### PR TITLE
octave: bump to 6.2.0

### DIFF
--- a/math/octave/Portfile
+++ b/math/octave/Portfile
@@ -7,7 +7,7 @@ PortGroup           compiler_blacklist_versions 1.0
 PortGroup           linear_algebra 1.0
 
 name                octave
-version             6.1.0
+version             6.2.0
 set package_version 6.x.x
 revision            0
 
@@ -25,9 +25,9 @@ homepage            https://www.gnu.org/software/octave
 
 master_sites        gnu:octave
 
-checksums           rmd160  4f2094359ae531e08a01460f6b8ac8788cc933da \
-                    sha256  6ff34e401658622c44094ecb67e497672e4337ca2d36c0702d0403ecc60b0a57 \
-                    size    32592405
+checksums           rmd160  a7d084c684f233b2c674d3cb0dc1c38e3ca16751 \
+                    sha256  457d1fda8634a839e2fd7cfc55b98bd56f36b6ae73d31bb9df43dde3012caa7c \
+                    size    32620419
 
 # see https://lists.gnu.org/archive/html/octave-maintainers/2016-05/msg00286.html
 compiler.cxx_standard \
@@ -466,6 +466,10 @@ if { ([variant_isset fltk] && [variant_isset qt4]) || ([variant_isset fltk] && [
     notes-append "unless octave is run with --no-gui-libs, graphics_toolkit(\"fltk\") will cause a crash"
 }
 
+if {[variant_isset qt4]} {
+    notes-append "on-disk documentation is not building at present with qt4 variant, but online is available"
+}
+
 variant sound description {enable audio support (file I/O and playback)} {
     depends_lib-append port:libsndfile
     depends_lib-append port:portaudio
@@ -596,7 +600,10 @@ variant docs description {build documentation files} {
 
     configure.args-replace --disable-docs --enable-docs
 }
-default_variants-append +docs
+# the documentation is not building when using qt4 at present
+if {![variant_isset qt4]} {
+    default_variants-append +docs
+}
 
 # GraphicsMagick and octave need to be built with the same C++ standard library
 # or else undefined symbols:

--- a/math/octave/files/patch-octave6-qt4-fixes.diff
+++ b/math/octave/files/patch-octave6-qt4-fixes.diff
@@ -1,21 +1,5 @@
-diff --git libgui/src/octave-dock-widget.cc libgui/src/octave-dock-widget.cc
-index dccc5c8..0f1117d 100644
---- libgui/src/octave-dock-widget.cc
-+++ libgui/src/octave-dock-widget.cc
-@@ -504,9 +504,11 @@ namespace octave
-     QVariant dock_geom
-       = settings->value (dw_dock_geometry.key.arg (objectName ()),
-                          dw_dock_geometry.def);
-+#if QT_VERSION >= 0x050200
-     if (dock_geom.canConvert (QMetaType::QRect))
-       m_recent_dock_geom = dock_geom.toRect ();
-     else
-+#endif
-       m_recent_dock_geom = dw_dock_geometry.def.toRect ();
- 
-     notice_settings (settings);  // call individual handler
 diff --git libgui/src/octave-qobject.cc libgui/src/octave-qobject.cc
-index 8ecf1ce..427952b 100644
+index 1320283..42cfaca 100644
 --- libgui/src/octave-qobject.cc
 +++ libgui/src/octave-qobject.cc
 @@ -73,7 +73,7 @@ static void disable_app_nap (void)
@@ -26,23 +10,4 @@ index 8ecf1ce..427952b 100644
 +  process_info_class = reinterpret_cast<Class> (objc_getClass ("NSProcessInfo"));
    if (process_info_class == nil)
      return;
- 
-diff --git libgui/src/resource-manager.cc libgui/src/resource-manager.cc
-index f5be8c3..ee263af 100644
---- libgui/src/resource-manager.cc
-+++ libgui/src/resource-manager.cc
-@@ -241,8 +241,14 @@ namespace octave
-   // if macOS default font is not available): use QFontDatabase
-   if (default_family.isEmpty ())
-     {
-+
-+#if QT_VERSION >= 0x050200
-       // Get the system's default monospaced font
-       QFont fixed_font = QFontDatabase::systemFont (QFontDatabase::FixedFont);
-+#else
-+      QFont fixed_font;
-+      fixed_font.setStyleHint (QFont::Monospace);
-+#endif
-       default_family = fixed_font.defaultFamily ();
-     }
  


### PR DESCRIPTION
small tweak needed to qt4 variant

documentation building has changed; qt4 variant is not
building the documentation at present

the same default system language error in the qt4 variant
remains as before with 6.1.0

you must manually set the language in the preferences

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15, 10.6.8
Xcode 12.4, 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
