### PR TITLE
edbrowse: port abandoned

### DIFF
--- a/www/edbrowse/Portfile
+++ b/www/edbrowse/Portfile
@@ -7,7 +7,7 @@ version             3.4.10
 revision            4
 categories          www
 license             GPL
-maintainers         email.uc.edu:obrienj
+maintainers         nomaintainer
 description         A combination editor, browser, and mail client that is \
                     100% text based.
 long_description    Edbrowse is a combination editor, browser, and mail client \
@@ -49,11 +49,9 @@ use_configure       no
 variant universal {}
 
 configure.cppflags-append -I${prefix}/include/mozjs185
-if {[vercmp [macports_version] 2.5.99] >= 0} {
-build.env-append    "CC=${configure.cc} [get_canonical_archflags cc]" CFLAGS=${configure.cflags} "CPPFLAGS=${configure.cppflags} -DSYSBSD -DXP_UNIX -DX86_LINUX"
-} else {
-build.env-append    CC="${configure.cc} [get_canonical_archflags cc]" CFLAGS="${configure.cflags}" CPPFLAGS="${configure.cppflags} -DSYSBSD -DXP_UNIX -DX86_LINUX"
-}
+build.env-append    "CC=${configure.cc} [get_canonical_archflags cc]" \
+                    CFLAGS=${configure.cflags} \
+                    "CPPFLAGS=${configure.cppflags} -DSYSBSD -DXP_UNIX -DX86_LINUX"
 build.args          STRIP=''
 
 destroot {


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/62386

Cleanup MacPorts < 2.6.0 handling
Breakup long lines

#### Description


<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
Untested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
