### PR TITLE
weechat: update to 3.1

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -10,11 +10,11 @@ legacysupport.newest_darwin_requires_legacy 10
 
 conflicts           weechat-devel
 name                weechat
-version             3.0.1
+version             3.1
 revision            0
-checksums           rmd160  30e748302dc073b602acabca5b0e237aa35548b3 \
-                    sha256  781d9bfc7e1321447de9949263b82e3ee45639b7d71693558f40ff87211ca6dd \
-                    size    2215312
+checksums           rmd160  de2cd7e33bda4d6c4092e9ac12afcaa28de02568 \
+                    sha256  a55a2975aa119f76983412507e3ddb3fe68d0744e08739681ddc17744e77a4f7 \
+                    size    2230316
 
 master_sites        https://weechat.org/files/src/
 use_xz              yes


### PR DESCRIPTION
#### Description

weechat: update to 3.1

###### Tested on
macOS 10.15.7 19H114
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
