### PR TITLE
gopls: update to 0.6.6

### DIFF
--- a/devel/gopls/Portfile
+++ b/devel/gopls/Portfile
@@ -11,54 +11,54 @@ maintainers         {ra1nb0w @ra1nb0w} openmaintainer
 description         gopls is the official language server for the Go language
 long_description    ${description}
 
-go.setup            golang.org/x/tools 0.6.2 gopls/v
+go.setup            golang.org/x/tools 0.6.6 gopls/v
 checksums           tools-${version}.tar.gz \
-                    rmd160  8844759d20802f8a3702f09d5942f6a393069b96 \
-                    sha256  5103ccf16200000f92d1024cd662c589c7cae20955c9275234a10e942eff455a \
-                    size    2674226
+                    rmd160  1fa365f712928d574660d5b6e88a421e8877fba6 \
+                    sha256  eb212db3c41fa1b234b239892853329b0abf71e6c683da1d84f6be330127bff6 \
+                    size    2710293
 github.tarball_from archive
 github.livecheck.regex  {([0-9.]+)}
 
 go.vendors          github.com/yuin/goldmark \
-                        lock    v1.1.27 \
-                        rmd160  9fd3d8f647ca9093190a377e7c753d39f1c75b3d \
-                        sha256  97ee87084f754b960b9303a3dbf90ca35f39c04f97e423d834100c8fde733472 \
-                        size    225392 \
+                        lock    v1.2.1 \
+                        rmd160  bfa2a3a3a6f25b7f40c4436e6e479d65e36d68aa \
+                        sha256  25cb7a8140e2488912f3423da2dbe754ef03fc92cd2545048c1897a0bda2d863 \
+                        size    228498 \
                     golang.org/x/net \
-                        lock    3b0461eec859 \
-                        rmd160  24dae39afb612a8977e6f4a91596c64d15dd3664 \
-                        sha256  15f077bb408fb71b22e4015312be5fab7010576e824fdbfdfdb697b611621197 \
-                        size    1099249 \
+                        lock    f5854403a974 \
+                        rmd160  cfaf8471269327bcdce1142b44ded72a4584ddf9 \
+                        sha256  a1fcb7946757072ba7453de05fa82e9b977318307a88082c5e4b24057885babb \
+                        size    1178342 \
                     golang.org/x/sync \
-                        lock    112230192c58 \
-                        rmd160  37a8b11def31e2ad355002a8671245962be359f6 \
-                        sha256  951a6df1dadb061510f1c646197dd8f8a7c7842729d02c6a68a86bce66349f79 \
-                        size    16832 \
+                        lock    67f06af15bc9 \
+                        rmd160  1975599ab89b8c6a6b7fbca131efb1b705f7f022 \
+                        sha256  78883bdc5e24128ee3700bfe03eddb759dbaabdeb99eeda2826bf95a2784d18e \
+                        size    18695 \
                     golang.org/x/sys \
-                        lock    d0b11bdaac8a \
-                        rmd160  77203a57d29688c77187c209ff21dff6327e80fa \
-                        sha256  587f757e86a33b31d7d8443a08ec8c18f64f7eb30d27aa9c01199cf934d45966 \
-                        size    1243198 \
+                        lock    22da62e12c0c \
+                        rmd160  15c235353d480b46af88f988d1cb58ee77194ea6 \
+                        sha256  2ef3888e228c2e10bd71add7c893d88260477cad9c5d529d95e899e62b57916b \
+                        size    1106946 \
                     golang.org/x/xerrors \
-                        lock    1b5146add898 \
-                        rmd160  2cc4b800c18d0a62360e39184f2a99b1ebd49a95 \
-                        sha256  6369e59584a604215ed9649649fe273e46295d3fb8d5a811f4028844c861faaa \
-                        size    12201 \
+                        lock    5ec99f83aff1 \
+                        rmd160  6e8267f353e153297f205e4be219236d6ae43880 \
+                        sha256  9a500a49d83a09e7de6c71b215d1c14b81e315d26884530ef327c95ddf1f2d28 \
+                        size    13667 \
                     github.com/dominikh/go-tools \
-                        lock    v0.0.1-2020.1.4 \
-                        rmd160  71b3ae6c58d0e80a644692c5aec2e5464743b508 \
-                        sha256  3494d6fd5fb6c0958af8145902231adc09009e1cb5dd633508f630123b607d17 \
-                        size    406037 \
+                        lock    v0.1.1 \
+                        rmd160  b248a77374ad46911b806573183ee3a87f2d3d5e \
+                        sha256  d04cfaa042402c10cf5f8ee0d41f825aa48fcf5f5c3f1f7cb9a0e06c22bde1b8 \
+                        size    468575 \
                     github.com/sergi/go-diff \
                         lock    v1.1.0 \
                         rmd160  6449feb5884c316206f256e55b81aba3e6a78a9f \
                         sha256  026d3d6db40ad086954214a7f3f84b66e352d47ce259bb59b7c2b9bd843b9935 \
                         size    43569 \
                     golang.org/x/mod \
-                        lock    v0.2.0 \
-                        rmd160  d3e7249fdb5bbf52bae173899cf440a86af34415 \
-                        sha256  8dc23eb611e895afa9bae9ae942e99c95c9b567f7682ae0e66fdc9f4c17c36e5 \
-                        size    91781 \
+                        lock    v0.4.1 \
+                        rmd160  c96b842a5189b7efca5466e347b279cfeebd8fbf \
+                        sha256  9370678c647c8fbab251e6d06eb6420c7c8be01cd97b5177a7205fce5128205a \
+                        size    102768 \
                     github.com/mvdan/xurls \
                         lock    v2.2.0 \
                         rmd160  10e68fe71c4260eb00e3ec5a42d1001706b4c1ec \
@@ -70,15 +70,15 @@ go.vendors          github.com/yuin/goldmark \
                         sha256  8cc9e5dc68e247554227973d0b4e023b27bbd9ba5a26e4fb40f44743afcb35f1 \
                         size    42087  \
                     github.com/mvdan/gofumpt \
-                        lock    4fd085cb6d5f \
-                        rmd160  cc7513a8f27334597a5106c88b7321613a2af1f7 \
-                        sha256  df5bc99c0ad162100994b5eb551d807c6b7c1ad5b7db5b4d478c599a556cd21e \
-                        size    136509 \
+                        lock    v0.1.0 \
+                        rmd160  3b0d5b619e1c5c946a01d4578b4016258de9b4dc \
+                        sha256  dee96c8204c68b1ab1a3f0e1a775a9b418240fae8ebc99259373e3732ff42cd5 \
+                        size    140650 \
                     github.com/google/go-cmp \
-                        lock    v0.5.1 \
-                        rmd160  f557725ca7d868edfc5d70b1d69bd33570ef5c81 \
-                        sha256  e2c3dc6f5e6e07e5034cad315b76919ee7a7dbdf122ff76eeabd2d8b719a3d57 \
-                        size    99629
+                        lock    v0.5.4 \
+                        rmd160  e53e85e2f7651ce4e0dd20f8621380a60d9d5cc0 \
+                        sha256  4b3ea98b1c2c83814a405d824c68521315dbddd9dada9a9992d1abebd2cca290 \
+                        size    101028
 
 post-extract {
     # Author uses custom host name for his packages
@@ -98,9 +98,10 @@ destroot {
     xinstall -m 0755 ${worksrcpath}/${name}/${name} \
         ${destroot}${prefix}/bin/${name}
 
-    xinstall -d -m 755 ${destroot}${prefix}/share/doc/${name}
-    xinstall -m 0644 {*}[glob ${worksrcpath}/${name}/doc/*] \
-        ${destroot}${prefix}/share/doc/${name}
+    set dest_doc ${destroot}${prefix}/share/doc/${name}
+    xinstall -d -m 755 ${dest_doc}
+    xinstall -m 0644 {*}[glob ${worksrcpath}/${name}/doc/*.md] ${dest_doc}
+    copy ${worksrcpath}/${name}/doc/design ${dest_doc}
 }
 
 test.run yes


### PR DESCRIPTION
#### Description

Updating gopls to 0.6.6 along with dependencies.
Changing doc installation a bit because of layout changes in doc folder.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
