### PR TITLE
vmdktool: fix implicit function declaration

### DIFF
--- a/sysutils/vmdktool/Portfile
+++ b/sysutils/vmdktool/Portfile
@@ -27,7 +27,8 @@ checksums           sha1    ed80b62cd7a97582192ad3a8f97bf73eee9ed36a \
 
 depends_lib         port:zlib
 
-patchfiles          patch-Makefile.diff
+patchfiles          patch-Makefile.diff \
+                    patch-expand_number.c.diff
 
 use_configure       no
 

--- a/sysutils/vmdktool/files/patch-expand_number.c.diff
+++ b/sysutils/vmdktool/files/patch-expand_number.c.diff
@@ -1,0 +1,14 @@
+ctype.h is needed for defining tolower(). Why was this header deliberately excluded?
+
+--- expand_number.c.orig
++++ expand_number.c
+@@ -31,9 +31,7 @@
+ #endif
+ 
+ #include <sys/types.h>
+-#ifndef __APPLE__
+ #include <ctype.h>
+-#endif
+ #include <errno.h>
+ #include <inttypes.h>
+ #include <stdint.h>


### PR DESCRIPTION
#### Description

Fix error observed under Xcode 12:
```
expand_number.c:76:6: error: implicitly declaring library function 'tolower' with type 'int (int)' [-Werror,-Wimplicit-function-declaration]
          s = tolower(*endptr);
              ^
expand_number.c:76:6: note: include the header <ctype.h> or explicitly provide a declaration for 'tolower'
1 error generated.
```

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7
Xcode 12.4 command line tools

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
