### PR TITLE
git-delta: add shell completions

### DIFF
--- a/textproc/git-delta/Portfile
+++ b/textproc/git-delta/Portfile
@@ -6,7 +6,7 @@ PortGroup           cargo 1.0
 
 github.setup        dandavison delta 0.6.0
 name                git-delta
-revision            0
+revision            1
 
 description         A syntax-highlighter for git and diff output
 
@@ -29,6 +29,14 @@ checksums           ${distname}${extract.suffix} \
 destroot {
     xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/delta \
         ${destroot}${prefix}/bin/
+
+    # Install shell completions
+    xinstall -d ${destroot}${prefix}/share/bash-completion/completions
+	xinstall -m 644 ${worksrcpath}/etc/completion/completion.bash \
+        ${destroot}${prefix}/share/bash-completion/completions/delta
+    xinstall -d ${destroot}${prefix}/share/zsh/site-functions
+	xinstall -m 644 ${worksrcpath}/etc/completion/completion.zsh \
+        ${destroot}${prefix}/share/zsh/site-functions/_delta
 }
 
 notes "


### PR DESCRIPTION
#### Description

This PR adds installation of shell completions for git-delta.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
