### PR TITLE
rust-analyzer: update to 2021-03-08

### DIFF
--- a/devel/rust-analyzer/Portfile
+++ b/devel/rust-analyzer/Portfile
@@ -3,7 +3,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        rust-analyzer rust-analyzer 2021-01-18
+github.setup        rust-analyzer rust-analyzer 2021-03-08
 revision            0
 
 homepage            https://rust-analyzer.github.io
@@ -16,7 +16,6 @@ long_description    rust-analyzer is an experimental modular compiler \
 
 categories          devel
 platforms           darwin
-supported_archs     x86_64
 license             Apache-2
 
 maintainers         @fabius openmaintainer
@@ -24,9 +23,9 @@ maintainers         @fabius openmaintainer
 github.tarball_from archive
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  c0db3ee3e3f6db7a03f8b53fa45b180b760f6504 \
-                        sha256  009ab946848719bb05bcaddab1cf5a75a45c5a92ae6dc31763adb42c3229f7db \
-                        size    1435696
+                        rmd160  b8421f627274ea084f1dc149ea95d1cbca263253 \
+                        sha256  75d810a4b3fd08d8d0948186f077b754ab9a2a02af3d3c6947e0baa58576e43d \
+                        size    1713825
 
 post-extract {
     file delete ${worksrcpath}/lib/README.md
@@ -38,119 +37,113 @@ destroot {
 
 cargo.crates \
     addr2line                       0.14.1  a55f82cfe485775d02112886f4169bde0c5894d75e79ead7eafe7e40a25e45f7 \
-    adler                            0.2.3  ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e \
+    adler                            1.0.2  f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe \
+    always-assert                    0.1.2  fbf688625d06217d5b1bb0ea9d9c44a1635fd0ee3534466388d18203174f4d11 \
     ansi_term                       0.12.1  d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2 \
-    anyhow                          1.0.37  ee67c11feeac938fae061b232e38e0b6d94f97a9df10e6271319325ac4c56a86 \
+    anyhow                          1.0.38  afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1 \
     anymap                          0.12.1  33954243bd79057c2de7338850b85983a44588021f8a5fee574a8888c6de4344 \
     arrayvec                         0.5.2  23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b \
     atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
     autocfg                          1.0.1  cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a \
-    backtrace                       0.3.55  ef5140344c85b01f9bbb4d4b7288a8aa4b3287ccef913a14bcc78a1063623598 \
-    base64                          0.12.3  3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff \
+    backtrace                       0.3.56  9d117600f438b1707d4e4ae15d3595657288f8235a0eb593e80ecc98ab34e1bc \
     bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
-    byteorder                        1.3.4  08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de \
+    byteorder                        1.4.2  ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b \
+    camino                           1.0.2  cd065703998b183ed0b348a22555691373a9345a1431141e5778b48bb17e4703 \
     cargo-platform                   0.1.1  0226944a63d1bf35a3b5f948dd7c59e263db83695c9e8bffc4037de02e30f1d7 \
-    cargo_metadata                  0.12.2  11a47b6286279a9998588ef7050d1ebc2500c69892a557c90fe5d071c64415dc \
-    cc                              1.0.66  4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48 \
-    cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
+    cargo_metadata                  0.13.1  081e3f0755c1f380c2d010481b6fa2e02973586d5f2b24eebb7a2a1d98b143d8 \
+    cc                              1.0.67  e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
-    chalk-derive                    0.47.0  3f00f6342a387edc822002d36a381e117afcac9f744951ff75fbf4a218edea5c \
-    chalk-ir                        0.47.0  c686e69913591ae753e5526e73cbee39db3d9b0a92cc9078ab780cabf1c70aa9 \
-    chalk-recursive                 0.47.0  310fdcac0340dab4163b766baa8067266e3b909108d1ac1b5246c033bde63975 \
-    chalk-solve                     0.47.0  c3c3252116111c3548f1164ab8d98c67c49848b3bde10dd11b650fd023e91c72 \
+    chalk-derive                    0.59.0  4b9000fbcb67353dc8973ab9fd136277d321d85b79bd36b8756bb3ae0979a94a \
+    chalk-ir                        0.59.0  b23528d61b3557c676eccf508fa0771a38453b379f0b780154eaa7f70afe8dfc \
+    chalk-recursive                 0.59.0  a8bdd37afc666b771de8b4429fe014363d0e74aae5cc26f320f60a3eab34d744 \
+    chalk-solve                     0.59.0  4182c42ca319cb71c89898ebc3d2671d1fa7d928123b171b66f1797a2000b9c8 \
     chrono                          0.4.19  670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73 \
     cmake                           0.1.45  eb6210b637171dfba4cda12e579ac6dc73f5165ad56133e5d72ef3131f320855 \
-    const_fn                         0.4.4  cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826 \
+    countme                          2.0.4  328b822bdcba4d4e402be8d9adb6eebf269f969f8eadef977a553ff3c4fbcb58 \
     crc32fast                        1.2.1  81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a \
-    crossbeam-channel                0.4.4  b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87 \
     crossbeam-channel                0.5.0  dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775 \
     crossbeam-deque                  0.8.0  94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9 \
-    crossbeam-epoch                  0.9.1  a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d \
-    crossbeam-utils                  0.7.2  c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8 \
-    crossbeam-utils                  0.8.1  02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d \
+    crossbeam-epoch                  0.9.3  2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12 \
+    crossbeam-utils                  0.8.3  e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49 \
+    dashmap                          4.0.2  e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c \
     dissimilar                       1.0.2  fc4b29f4b9bb94bf267d57269fd0706d343a160937108e9619fe380645428abb \
     drop_bomb                        0.1.5  9bda8e21c04aca2ae33ffc2fd8c23134f3cac46db123ba97bd9d3f3b8a4a85e1 \
     either                           1.6.1  e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457 \
     ena                             0.14.0  d7402b94a93c24e742487327a7cd839dc9d36fec9de9fb25b09f2dae459f36c3 \
-    env_logger                       0.8.2  f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e \
+    env_logger                       0.8.3  17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f \
     expect-test                      1.1.0  2300477aab3a378f2ca00a4fbd4dc713654ab7ed790e4017493cb33656280633 \
-    filetime                        0.2.13  0c122a393ea57648015bf06fbd3d372378992e86b9ff5a7a497b076a28c79efe \
+    filetime                        0.2.14  1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8 \
     fixedbitset                      0.2.0  37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d \
-    flate2                          1.0.19  7411863d55df97a419aa64cb4d2f167103ea9d767e2c54a1868b7ac3f6b47129 \
-    form_urlencoded                  1.0.0  ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00 \
+    flate2                          1.0.20  cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0 \
+    form_urlencoded                  1.0.1  5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191 \
+    fs_extra                         1.2.0  2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394 \
     fsevent                          2.0.2  97f347202c95c98805c216f9e1df210e8ebaec9fdb2365700a43c10797a35e63 \
     fsevent-sys                      3.0.2  77a29c77f1ca394c3e73a9a5d24cfcabb734682d9634fc398f2204a63c994120 \
     fst                              0.4.5  d79238883cf0307100b90aba4a755d8051a3182305dfe7f649a1e9dc0517006f \
-    fuchsia-zircon                   0.3.3  2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
-    fuchsia-zircon-sys               0.3.3  3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
     gimli                           0.23.0  f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce \
     hashbrown                        0.9.1  d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04 \
-    hashbrown                       0.10.0  2140e9c963869f01789fa4fef4805211081ec794af5fc77c0d5b377906118853 \
     heck                             0.3.2  87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac \
-    hermit-abi                      0.1.17  5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8 \
+    hermit-abi                      0.1.18  322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c \
     home                             0.5.3  2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654 \
-    idna                             0.2.0  02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9 \
+    idna                             0.2.2  89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21 \
     indexmap                         1.6.1  4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b \
-    inotify                          0.8.3  46dd0a94b393c730779ccfd2a872b67b1eb67be3fc33082e733bdb38b5fde4d4 \
-    inotify-sys                      0.1.4  c4563555856585ab3180a5bf0b2f9f8d301a728462afffc8195b3f5394229c55 \
+    inotify                          0.9.2  d19f57db1baad9d09e43a3cd76dcf82ebdafd37d75c9498b87762dba77c93f15 \
+    inotify-sys                      0.1.5  e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb \
     instant                          0.1.9  61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec \
-    iovec                            0.1.4  b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e \
-    itertools                        0.9.0  284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b \
     itertools                       0.10.0  37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319 \
     itoa                             0.4.7  dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736 \
+    jemalloc-ctl                     0.3.3  c502a5ff9dd2924f1ed32ba96e3b65735d837b4bfd978d3161b1702e66aca4b7 \
+    jemalloc-sys                     0.3.2  0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45 \
+    jemallocator                     0.3.2  43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69 \
     jod-thread                       0.1.2  8b23360e99b8717f20aaa4598f5a6541efbe30630039fbc7706cf954a87947ae \
-    kernel32-sys                     0.2.2  7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
-    lazycell                         1.3.0  830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55 \
-    libc                            0.2.81  1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb \
-    libloading                       0.6.6  e9367bdfa836b7e3cf895867f7a570283444da90562980ec2263d6e1569b16bc \
-    libmimalloc-sys                 0.1.18  82151ff13433c4d403cb15d0e6fbda14b24d65bd1a5b33f7d52ec983cc00752d \
+    libc                            0.2.88  03b07a082330a35e43f63177cc01689da34fbffa0105e1246cf0311472cac73a \
+    libloading                       0.7.0  6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a \
+    libmimalloc-sys                 0.1.20  e58f42b6424a0ed536678c65fd97cd64b4344bcf86251e284f7c0ce9eee40e64 \
     lock_api                         0.4.2  dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312 \
-    log                             0.4.11  4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b \
+    log                             0.4.14  51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710 \
     lsp-server                       0.5.0  69b18dfe0e4a380b872aa79d8e0ee6c3d7a9682466e84b83ad807c88b3545f79 \
-    lsp-types                       0.86.0  f2a5c40d566f2704dac30859bca152217583fc94fd5b178d8baba915e1abd382 \
+    lsp-types                       0.88.0  d8e8e042772e4e10b3785822f63c82399d0dd233825de44d2596f7fa86e023e0 \
     matchers                         0.0.1  f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1 \
     matches                          0.1.8  7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
-    maybe-uninit                     2.0.0  60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00 \
     memchr                           2.3.4  0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525 \
-    memmap                           0.7.0  6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b \
-    memoffset                        0.5.6  043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa \
+    memmap2                          0.2.1  04e3e85b970d650e2ae6d70592474087051c11c54da7f7b4949725c5735fbcc6 \
     memoffset                        0.6.1  157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87 \
-    mimalloc                        0.1.22  4a5d2c9cb18f9cdc6d88f4aca6d3d8ea89c4c8202d6facfc7e56efdee97b80fa \
-    miniz_oxide                      0.4.3  0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d \
-    mio                             0.6.23  4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4 \
-    mio-extras                       2.0.6  52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19 \
-    miow                             0.2.2  ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d \
-    net2                            0.2.37  391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae \
-    notify                     5.0.0-pre.4  a8b946889dfdad884379cd56367d93b6d0ce8889cc027d26a69a3a31c0a03bb5 \
+    mimalloc                        0.1.24  757efec188b3d2088949d912e01ea2fe87164ed6376b6c5d7dd4f3ce1668a93d \
+    miniz_oxide                      0.4.4  a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b \
+    mio                              0.7.9  a5dede4e2065b3842b8b0af444119f3aa331cc7cc2dd20388bfb0f5d5a38823a \
+    miow                             0.3.6  5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897 \
+    notify                     5.0.0-pre.6  e5fd82b93434edb9c00ae65ee741e0e081cdc8c63346ab9f687935a629aaf4c3 \
+    ntapi                            0.3.6  3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44 \
     num-integer                     0.1.44  d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db \
     num-traits                      0.2.14  9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290 \
     num_cpus                        1.13.0  05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3 \
-    object                          0.22.0  8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397 \
     object                          0.23.0  a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4 \
-    once_cell                        1.5.2  13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0 \
+    once_cell                        1.7.2  af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3 \
     oorandom                        11.1.3  0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575 \
     parking_lot                     0.11.1  6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb \
-    parking_lot_core                 0.8.2  9ccb628cad4f84851442432c60ad8e1f607e29752d0bf072cbd0baf28aa34272 \
+    parking_lot_core                 0.8.3  fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018 \
+    paste                           0.1.18  45ca20c77d80be666aef2b45486da86238fabe33e38306bd3118fe4af33fa880 \
+    paste-impl                      0.1.18  d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6 \
     percent-encoding                 2.1.0  d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
     perf-event                       0.4.6  b7a1c2678a77d65edf773bd900f5b87f0944ac3421949842a2c6a4efe42d6c66 \
     perf-event-open-sys              1.0.1  ce9bedf5da2c234fdf2391ede2b90fabf585355f33100689bc364a3ea558561a \
     pest                             2.1.3  10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53 \
     petgraph                         0.5.1  467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7 \
-    pico-args                        0.3.4  28b9b4df73455c861d7cbf8be42f01d3b373ed7f02e378d55fa84eafc6f638b1 \
-    pin-project-lite                 0.2.0  6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c \
+    pin-project-lite                 0.2.6  dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905 \
+    proc-macro-hack                 0.5.19  dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5 \
     proc-macro2                     1.0.24  1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71 \
     pulldown-cmark                   0.8.0  ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8 \
     pulldown-cmark-to-cmark          6.0.0  e8f2b9878102358ec65434fdd1a9a161f8648bb2f531acc9260e4d094c96de23 \
-    quote                            1.0.8  991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df \
+    quote                            1.0.9  c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7 \
     rayon                            1.5.0  8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674 \
     rayon-core                       1.9.0  9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a \
-    redox_syscall                   0.1.57  41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce \
-    regex                            1.4.2  38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c \
+    redox_syscall                    0.2.5  94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9 \
+    regex                            1.4.3  d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a \
     regex-automata                   0.1.9  ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4 \
-    regex-syntax                    0.6.21  3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189 \
-    rowan                           0.10.5  e1898adeafc7d3c69913b33ee1acbbb39c726a9dbe05ff77c08b52957643e8db \
-    rustc-ap-rustc_lexer           697.0.0  67adbe260a0a11910624d6d28c0304fcf7b063e666682111005c83b09f73429d \
+    regex-syntax                    0.6.22  b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581 \
+    rowan                           0.12.6  a1b36e449f3702f3b0c821411db1cbdf30fb451726a9456dce5dabcd44420043 \
+    rustc-ap-rustc_lexer           709.0.0  f69f83314702aaccf29c7401cc63bb0d9fa7869a185a23b8379f08c91514b3f3 \
     rustc-demangle                  0.1.18  6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232 \
     rustc-hash                       1.1.0  08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2 \
     ryu                              1.0.5  71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e \
@@ -161,51 +154,46 @@ cargo.crates \
     scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
     semver                          0.11.0  f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6 \
     semver-parser                   0.10.2  00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7 \
-    serde                          1.0.118  06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800 \
-    serde_derive                   1.0.118  c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df \
-    serde_json                      1.0.61  4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a \
+    serde                          1.0.123  92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae \
+    serde_derive                   1.0.123  9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31 \
+    serde_json                      1.0.64  799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79 \
     serde_path_to_error              0.1.4  42f6109f0506e20f7e0f910e51a0079acf41da8e0694e6442527c4ddf5a2b158 \
     serde_repr                       0.1.6  2dc6b7951b17b051f3210b063f12cc17320e2fe30ae05b0fe2a3abb068551c76 \
     sharded-slab                     0.1.1  79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3 \
-    slab                             0.4.2  c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8 \
-    smallvec                         1.6.0  1a55ca5f3b68e41c979bf8c46a6f1da892ca4db8f94023ce0bd32407573b1ac0 \
+    smallvec                         1.6.1  fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e \
     smol_str                        0.1.17  6ca0f7ce3a29234210f0f4f0b56f8be2e722488b95cb522077943212da3b32eb \
-    stable_deref_trait               1.2.0  a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3 \
-    syn                             1.0.57  4211ce9909eb971f111059df92c45640aad50a619cf55cd76476be803c4c68e6 \
+    socket2                         0.3.19  122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e \
+    syn                             1.0.61  ed22b90a0e734a23a7610f4283ac9e5acfb96cbb30dfefa540d66f866f1c09c5 \
     synstructure                    0.12.4  b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701 \
     termcolor                        1.1.2  2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4 \
     text-size                        1.1.0  288cb548dbe72b652243ea797201f3d481a0609a967980fcc5b2315ea811560a \
-    thread_local                     1.0.1  d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14 \
+    thread_local                     1.1.3  8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd \
     threadpool                       1.8.1  d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa \
-    time                            0.1.44  6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255 \
-    tinyvec                          1.1.0  ccf8dbc19eb42fba10e8feaaec282fb50e2c14b2726d6301dbfeed0f73306a6f \
+    tinyvec                          1.1.1  317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023 \
     tinyvec_macros                   0.1.0  cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c \
-    tracing                         0.1.22  9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3 \
-    tracing-attributes              0.1.11  80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada \
+    tracing                         0.1.25  01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f \
+    tracing-attributes              0.1.13  a8a9bd1db7706f2373a190b0d067146caa39350c486f3d455b0e33b431f94c07 \
     tracing-core                    0.1.17  f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f \
-    tracing-log                      0.1.1  5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9 \
+    tracing-log                      0.1.2  a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3 \
     tracing-serde                    0.1.2  fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b \
-    tracing-subscriber              0.2.15  a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401 \
-    tracing-tree                     0.1.7  023e80cdb7c8468b7aade1d756afa2acbe2ae0a6142a25ec664b5239d6ef2794 \
-    triomphe                         0.1.2  6e9d872053cf9e5a833d8c1dd772cdc38ab66a908129d6f73c049c986161d07c \
+    tracing-subscriber              0.2.16  8ab8966ac3ca27126141f7999361cc97dd6fb4b71da04c02044fa9045d98bb96 \
+    tracing-tree                     0.1.8  1a60657cfbf397c603257a8230b3f427e6a2a4e5911a59331b9bb4dffff5b608 \
     ucd-trie                         0.1.3  56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c \
-    ungrammar                        1.8.0  e33a2183403af89252547c4219a06a6cc8aef6302fee67e10e8431866af3ee72 \
+    ungrammar                       1.11.0  84c629795d377049f2a1dc5f42cf505dc5ba8b28a5df0a03f4183a24480e4a6a \
     unicase                          2.6.0  50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6 \
     unicode-bidi                     0.3.4  49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5 \
-    unicode-normalization           0.1.16  a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606 \
+    unicode-normalization           0.1.17  07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef \
     unicode-segmentation             1.7.1  bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796 \
     unicode-xid                      0.2.1  f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564 \
-    url                              2.2.0  5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e \
+    url                              2.2.1  9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b \
     version_check                    0.9.2  b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed \
     walkdir                          2.3.1  777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d \
-    wasi     0.10.0+wasi-snapshot-preview1  1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f \
-    winapi                           0.2.8  167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
-    winapi-build                     0.1.1  2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
     winapi-util                      0.1.5  70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
     write-json                       0.1.2  06069a848f95fceae3e5e03c0ddc8cb78452b56654ee0c8e68f938cf790fb9e3 \
-    ws2_32-sys                       0.2.1  d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e \
-    xshell                           0.1.8  ed373ede30cea03e8c0af22f48ee1ba80efbf06fec8b4746977e6ee703878de0 \
-    xshell-macros                    0.1.8  7f6af9f8119104697b0105989a73c578ce33f922d9d6f3dae0e8ae3d538db321 \
+    xflags                           0.2.1  59ad6ce6a0b7224130015b4ebac796478ac04e0079f5d222a690efea06a9208a \
+    xflags-macros                    0.2.1  c8037d3ca14996158b03c0fa905d0834906ef0fc7044df72c1f5ff690e5e62c9 \
+    xshell                           0.1.9  6f18102278453c8f70ea5c514ac78cb4c73a0ef72a8273d17094b52f9584c0c1 \
+    xshell-macros                    0.1.9  6093c460064572007f885facc70bb0ca5e40a83ea7ff8b16c1abbee56fd2e767 \


### PR DESCRIPTION
- Remove incorrect specification of 'supported_archs'

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
