### PR TITLE
subtitleripper: add maintainer's GitHub handle, cleanup MacPorts < 2.6.0 handling

### DIFF
--- a/multimedia/subtitleripper/Portfile
+++ b/multimedia/subtitleripper/Portfile
@@ -7,7 +7,7 @@ version             0.3-4
 revision            3
 categories          multimedia
 platforms           darwin
-maintainers         shortround.net:stephen
+maintainers         {@stack shortround.net:stephen}
 
 description         DVD subtitle ripper
 
@@ -36,15 +36,9 @@ if {${os.platform} eq "darwin" && ${os.major} >= 11} {
     set defines -DHAVE_GETLINE
 }
 
-if {[vercmp [macports_version] 2.5.99] >= 0} {
 build.env           DEFINES=${defines} \
                     "INCLUDES=${configure.cppflags} -I${prefix}/include/netpbm" \
                     "LDFLAGS=${configure.ldflags} ${configure.ld_archflags}"
-} else {
-build.env           DEFINES="${defines}" \
-                    INCLUDES="${configure.cppflags} -I${prefix}/include/netpbm" \
-                    LDFLAGS="${configure.ldflags} ${configure.ld_archflags}"
-}
 build.args          CC="${configure.cc}" \
                     COPT="${configure.cflags} ${configure.cc_archflags}"
 


### PR DESCRIPTION

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
