### PR TITLE
flameshot: new port

### DIFF
--- a/sysutils/flameshot/Portfile
+++ b/sysutils/flameshot/Portfile
@@ -1,0 +1,59 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github  1.0
+PortGroup               cmake   1.1
+
+github.setup            flameshot-org flameshot 0.9.0 v
+revision                0
+
+homepage                https://flameshot.org
+
+description             Powerful yet simple to use screenshot software
+
+long_description        {*}${description} supporting in-app screenshot \
+                        editing, Imgur upload, customizable appearance and \
+                        more.
+
+categories              sysutils graphics
+license                 GPL-3
+platforms               darwin
+
+checksums               rmd160  0051ec957c550a3acc99f0251e7d78ffc6e78570 \
+                        sha256  07aea231e64c7aa15fc2768eb93f4b04cb6215dc261c016055e8d8dfb47d771b \
+                        size    7659853
+
+maintainers             {gmail.com:herby.gillot @herbygillot} \
+                        openmaintainer
+
+depends_build-append    port:openssl
+
+depends_lib-append      path:lib/libssl.dylib:openssl \
+                        port:qt5-qtbase \
+                        port:qt5-qtsvg \
+                        port:qt5-qttools
+
+cmake.build_dir         ${worksrcpath}/build
+
+configure.args-append   -DENABLE_CACHE=OFF
+
+destroot {
+    set build_src_dir   ${cmake.build_dir}/src
+
+    copy ${build_src_dir}/flameshot.app ${destroot}${applications_dir}/
+
+    ln -s ${applications_dir}/flameshot.app/Contents/MacOS/${name} \
+        ${destroot}${prefix}/bin/
+
+    xinstall -d ${destroot}${prefix}/bash-completion/completions
+    copy ${build_src_dir}/share/bash-completion/completions/flameshot \
+        ${destroot}${prefix}/bash-completion/completions/
+
+    xinstall -d ${destroot}${prefix}/share/zsh/site-functions
+    copy ${build_src_dir}/share/zsh/site-functions/_flameshot \
+        ${destroot}${prefix}/share/zsh/site-functions/
+}
+
+notes "
+    You can launch ${name} from the MacPorts directory within your Applications folder
+"


### PR DESCRIPTION
#### Description

New port for [Flameshot](https://flameshot.org), QT-based screenshot software.

<img src="https://flameshot.org/media/animatedUsage.gif" />

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
