### PR TITLE
subversion-javahlbindings: remove old pre-activate

### DIFF
--- a/devel/subversion-javahlbindings/Portfile
+++ b/devel/subversion-javahlbindings/Portfile
@@ -101,19 +101,6 @@ platform puredarwin {		configure.args-append \
 					--disable-keychain
 				}
 
-pre-activate	{
-		#- this port used to create a symlink directly in ${prefix} which was fixed in 1.8.1_1
-		#- we need to remove this symlink from ${prefix} though, so upgrades work
-		#- this can eventually be removed, origionally added 2013-07-25
-		set badfile ${prefix}/lib/libsvnjavahl-1.jnilib
-		if {[file exists ${badfile}] && [registry_file_registered ${badfile}] == "0"} {
-			if {[catch {delete ${badfile}}]} {
-				ui_warn "Cannot delete ${badfile}; please remove it manually"
-			}
-		}
-
-		}
-
 livecheck.type	regex
 livecheck.url	https://svn.apache.org/repos/asf/subversion/tags/
 livecheck.regex	"(\\d+\\.\\d+\\.\\d+)/"


### PR DESCRIPTION
Added in 6d0aba8e6f over 7 years ago

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
