### PR TITLE
bat: add man and shell completions

### DIFF
--- a/textproc/bat/Portfile
+++ b/textproc/bat/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cargo 1.0
 
 github.setup        sharkdp bat 0.18.0 v
-revision            0
+revision            1
 
 description         A cat(1) clone with syntax highlighting and Git integration.
 
@@ -31,6 +31,21 @@ destroot {
     xinstall -m 755 \
         ${worksrcpath}/target/[cargo.rust_platform]/release/${name} \
         ${destroot}${prefix}/bin/
+
+    set assets_path [glob ${worksrcpath}/target/[cargo.rust_platform]/release/build/${name}-*]/out/assets/
+    # Install man
+    xinstall -m 644 ${assets_path}/manual/${name}.1 ${destroot}${prefix}/share/man/man1/
+    # Install shell completions
+    set bash_comp_path ${destroot}${prefix}/share/bash-completion/completions
+    xinstall -d ${bash_comp_path}
+    # Use simple _longopt-based completions file until bat ships with its own bash completions file
+    xinstall -m 644 ${filespath}/bat.bash ${bash_comp_path}/${name}
+    set zsh_comp_path ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -d ${zsh_comp_path}
+    xinstall -m 644 ${assets_path}/completions/${name}.zsh ${zsh_comp_path}/_${name}
+    set fish_comp_path ${destroot}${prefix}/share/fish/completions
+    xinstall -d ${fish_comp_path}
+    xinstall -m 644 ${assets_path}/completions/${name}.fish ${fish_comp_path}
 }
 
 cargo.crates \

--- a/textproc/bat/files/bat.bash
+++ b/textproc/bat/files/bat.bash
@@ -1,0 +1,1 @@
+complete -F _longopt bat


### PR DESCRIPTION
#### Description

This PR adds installation of man page and shell completions. `bat` doesn't ship with shell completions file for bash, so using a simple one that uses `_longopt` function from `bash-completion` package which extracts command line options from `--help` output.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
