### PR TITLE
fzf: update to 0.26.0

### DIFF
--- a/sysutils/fzf/Portfile
+++ b/sysutils/fzf/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/junegunn/fzf 0.25.1
+go.setup            github.com/junegunn/fzf 0.26.0
 revision            0
 
 categories          sysutils
@@ -14,11 +14,16 @@ description         A command-line fuzzy finder written in Go
 long_description    ${description}
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  14f50ea6cf54b3c67014d20adcb24873a4fccf24 \
-                        sha256  fa667ec0456caf5199cd6a10b886022593bdc30efbad4f45e9aa4cf340ec796a \
-                        size    178010
+                        rmd160  178443ccd0f8d2a73f58f45e5943b3fd59fae10d \
+                        sha256  8acc2e2ab53750bbfbca62cd286063303e18b404914d83d1c0cf21a2d333c034 \
+                        size    182289
 
-go.vendors          golang.org/x/text \
+go.vendors          golang.org/x/tools \
+                        lock    90fa682c2a6e \
+                        rmd160  afeef309693d107de47d23c8ec5b52df037b9905 \
+                        sha256  7b9c5ab345041195f6ca303f14c528ed19fd1b52ca6d0402679c64023d07dc85 \
+                        size    2332207 \
+                    golang.org/x/text \
                         lock    v0.3.3 \
                         rmd160  babfa547ba9a9dab7fe08fa5543f1d8e7ae00301 \
                         sha256  1c4a8c12295d484e0360d8e010ebc4b8a9a05aa2a07c10c3d3e5b17aa063f0db \
@@ -33,6 +38,11 @@ go.vendors          golang.org/x/text \
                         rmd160  1975599ab89b8c6a6b7fbca131efb1b705f7f022 \
                         sha256  78883bdc5e24128ee3700bfe03eddb759dbaabdeb99eeda2826bf95a2784d18e \
                         size    18695 \
+                    golang.org/x/net \
+                        lock    eb5bcb51f2a3 \
+                        rmd160  cb943e35e512e30b1a1ee9a9af23e200de7fc2fd \
+                        sha256  50ba342bcc50da4b4590ee91a6586f9d0aab43907596c2a0995e6f0868353e7a \
+                        size    976956 \
                     golang.org/x/crypto \
                         lock    9e8e0b390897 \
                         rmd160  bd4738a1bbf4d94ec5f840e7425ffa473c6b97bd \


### PR DESCRIPTION
#### Description
fzf: update to 0.26.0
* update vendors using `go2port`

###### Tested on
macOS 10.14.6 18G6020
Xcode 11.3.1 11C504

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?