### PR TITLE
p5-test-cpan-meta-json: new port

### DIFF
--- a/perl/p5-test-cpan-meta-json/Portfile
+++ b/perl/p5-test-cpan-meta-json/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.branches      5.26 5.28 5.30
+perl5.setup         Test-CPAN-Meta-JSON 0.16 ../../authors/id/B/BA/BARBIE
+revision            0
+checksums           rmd160  2c188894b62e906b491e0ea7a67ee0f47ce56a40 \
+                    sha256 67ac509adffb1d2b256a8f8c0523e00761d960166192c6070298f7088a9ae9c9 \
+                    size 21892
+
+platforms           darwin
+
+license             Artistic-2
+maintainers         {isi.edu:calvin @cardi} openmaintainer
+description         Test::CPAN::Meta::JSON - Validate a META.json file within a CPAN distribution.
+long_description    ${description}
+
+if {${perl5.major} ne ""} {
+    depends_lib-append \
+                    port:p${perl5.major}-json
+
+    supported_archs noarch
+    perl5.link_binaries no
+}


### PR DESCRIPTION
#### Description
p5-test-cpan-meta-json: new port

###### Tested on
macOS 10.14.6 18G6020
Xcode 11.3.1 11C504

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?

