### PR TITLE
macports-libcxx

### DIFF
--- a/lang/macports-libcxx/Portfile
+++ b/lang/macports-libcxx/Portfile
@@ -1,0 +1,60 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                macports-libcxx
+categories          lang
+platforms           darwin
+maintainers         {kencu @kencu} openmaintainer
+license             MIT
+homepage            http://macports.org
+
+description         provides a newer libc++ from llvm for older systems
+long_description    This port installs a recent libc++ from llvm \
+                    to use on older systems instead of the system libc++.
+version             11
+revision            0
+
+depends_build       port:clang-${version}
+
+master_sites
+fetch {}
+checksum {}
+use_configure no
+build {}
+
+destroot {
+
+    xinstall -d ${destroot}${prefix}/include/libcxx
+    copy  ${prefix}/libexec/llvm-${version}/lib/c++/v1 ${destroot}${prefix}/include/libcxx/
+
+    # disable Apple libc++ availability tests, as we're using a new libc++ with these headers
+    system -W ${destroot}${prefix}/include/libcxx/v1 "patch -p0 < ${filespath}/patch-disable-availabilty.diff"
+
+    xinstall -d ${destroot}${prefix}/lib/libcxx
+    copy  ${prefix}/libexec/llvm-${version}/lib/libc++.1.0.dylib ${destroot}${prefix}/lib/libcxx/libc++.1.0.dylib
+    system -W  ${destroot}${prefix}/lib/libcxx/  "install_name_tool -id ${prefix}/lib/libcxx/libc++.1.0.dylib libc++.1.0.dylib"
+    system -W  ${destroot}${prefix}/lib/libcxx/  "install_name_tool -delete_rpath @loader_path/../lib libc++.1.0.dylib"
+    system -W  ${destroot}${prefix}/lib/libcxx/  "install_name_tool -change @rpath/libc++abi.1.dylib ${prefix}/lib/libcxx/libc++abi.1.dylib libc++.1.0.dylib"
+    system -W  ${destroot}${prefix}/lib/libcxx/  "ln -s libc++.1.0.dylib libc++.1.dylib"
+    system -W  ${destroot}${prefix}/lib/libcxx/  "ln -s libc++.1.dylib libc++.dylib"
+
+    copy  ${prefix}/libexec/llvm-${version}/lib/libc++abi.1.0.dylib ${destroot}${prefix}/lib/libcxx/libc++abi.1.0.dylib
+    system -W  ${destroot}${prefix}/lib/libcxx/  "install_name_tool -id ${prefix}/lib/libcxx/libc++abi.1.0.dylib libc++abi.1.0.dylib"
+    system -W  ${destroot}${prefix}/lib/libcxx/  "install_name_tool -delete_rpath @loader_path/../lib libc++abi.1.0.dylib"
+    system -W  ${destroot}${prefix}/lib/libcxx/  "ln -s libc++abi.1.0.dylib libc++abi.1.dylib"
+    system -W  ${destroot}${prefix}/lib/libcxx/  "ln -s libc++abi.1.dylib libc++abi.dylib"
+
+}
+
+notes "
+To enable a newer libc++ in your projects or Portfiles, use a recent compiler and add\
+something like the following:
+
+configure.cxxflags-append -nostdinc++ -I${prefix}/include/libcxx/v1
+configure.ldflags-append  -L${prefix}/lib/libcxx
+
+A suitable Portfile block you might use is here:
+<https://github.com/macports/macports-ports/pull/10238#issuecomment-799000887>.
+
+"

--- a/lang/macports-libcxx/Portfile
+++ b/lang/macports-libcxx/Portfile
@@ -45,6 +45,8 @@ destroot {
     system -W  ${destroot}${prefix}/lib/libcxx/  "ln -s libc++abi.1.0.dylib libc++abi.1.dylib"
     system -W  ${destroot}${prefix}/lib/libcxx/  "ln -s libc++abi.1.dylib libc++abi.dylib"
 
+    copy  ${prefix}/libexec/llvm-${version}/lib/libc++experimental.a ${destroot}${prefix}/lib/libcxx/libc++experimental.a
+
 }
 
 notes "

--- a/lang/macports-libcxx/files/patch-disable-availabilty.diff
+++ b/lang/macports-libcxx/files/patch-disable-availabilty.diff
@@ -1,0 +1,12 @@
+--- __config.old	2021-03-14 23:24:47.000000000 -0700
++++ __config	2021-03-14 23:27:23.000000000 -0700
+@@ -20,6 +20,9 @@
+ #pragma GCC system_header
+ #endif
+ 
++// we are not going to use Apple Availability testing in these headers
++#define _LIBCPP_DISABLE_AVAILABILITY
++
+ #ifdef __cplusplus
+ 
+ #ifdef __GNUC__


### PR DESCRIPTION
The macports-libcxx port uses the libc++*.dylibs and headers installed with clang-11, modifies them slightly to use full path id's and linking (rather than the rpath links clang-11 makes for them) and then installs them in a reasonable location for ports to use them.

The mkvtoolnix demonstrator is just the first port that needed these features that I have tried.The minor mods made in the mkvtoolnix portfile could easily be a PortGroup once we sort out a reliable incantation that works broadly.

Perhaps consider this a technology preview for the moment, technical improvements or feedback welcome. I have no doubt there are other methods that might be used to do this better or improve this.

