### PR TITLE
gobject-introspection: fix build with new autoconf

### DIFF
--- a/gnome/gobject-introspection/Portfile
+++ b/gnome/gobject-introspection/Portfile
@@ -25,7 +25,8 @@ checksums           rmd160  6455f1b5e4427b8f0a26efb94597a476ed9ca96e \
                     size    1285000
 
 depends_build       port:pkgconfig \
-                    port:autoconf-archive
+                    port:autoconf-archive \
+                    port:gtk-doc
 
 depends_lib         path:lib/pkgconfig/cairo.pc:cairo \
                     path:lib/pkgconfig/glib-2.0.pc:glib2 \
@@ -37,7 +38,8 @@ depends_run         bin:glibtool:libtool
 
 patchfiles          no-env-shebang.patch \
                     patch-fix-rpath-gir-typelib.diff \
-                    patch-fix-scanner-in-build-execution.diff
+                    patch-fix-scanner-in-build-execution.diff \
+                    patch-find_cpp.diff
 
 post-patch {
     reinplace "s|libcairo-gobject.2.dylib|${prefix}/lib/libcairo-gobject.2.dylib|g" ${worksrcpath}/configure.ac

--- a/gnome/gobject-introspection/files/patch-find_cpp.diff
+++ b/gnome/gobject-introspection/files/patch-find_cpp.diff
@@ -1,0 +1,11 @@
+See https://trac.macports.org/ticket/62428
+--- configure.ac.orig	2021-03-14 18:49:04.000000000 -0700
++++ configure.ac	2021-03-14 19:01:50.000000000 -0700
+@@ -48,6 +48,7 @@
+ # Checks for programs.
+ AC_PROG_CC
+ AM_PROG_CC_C_O
++AC_PROG_CPP
+ AC_PROG_MKDIR_P
+ 
+ # Initialize libtool


### PR DESCRIPTION
Fixes https://trac.macports.org/ticket/62391

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
