### PR TITLE
flameshot: transition to Qt5 portgroup

### DIFF
--- a/sysutils/flameshot/Portfile
+++ b/sysutils/flameshot/Portfile
@@ -3,6 +3,7 @@
 PortSystem              1.0
 PortGroup               github  1.0
 PortGroup               cmake   1.1
+PortGroup               qt5     1.0
 
 github.setup            flameshot-org flameshot 0.9.0 v
 revision                0
@@ -26,12 +27,14 @@ checksums               rmd160  0051ec957c550a3acc99f0251e7d78ffc6e78570 \
 maintainers             {gmail.com:herby.gillot @herbygillot} \
                         openmaintainer
 
-depends_build-append    port:openssl
+github.tarball_from     releases
 
-depends_lib-append      path:lib/libssl.dylib:openssl \
-                        port:qt5-qtbase \
-                        port:qt5-qtsvg \
-                        port:qt5-qttools
+qt5.depends_build_component \
+                        qttools
+
+qt5.depends_component   qtsvg
+
+depends_lib-append      path:lib/libssl.dylib:openssl
 
 cmake.build_dir         ${worksrcpath}/build
 
@@ -53,7 +56,3 @@ destroot {
     copy ${build_src_dir}/share/zsh/site-functions/_flameshot \
         ${destroot}${prefix}/share/zsh/site-functions/
 }
-
-notes "
-    You can launch ${name} from the MacPorts directory within your Applications folder
-"


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
