### PR TITLE
bettercap: new port

### DIFF
--- a/net/bettercap/Portfile
+++ b/net/bettercap/Portfile
@@ -1,0 +1,304 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/bettercap/bettercap 2.30.2 v
+revision            0
+
+homepage            https://www.bettercap.org
+
+description         The Swiss Army knife for 802.11, BLE and Ethernet \
+                    networks reconnaissance and MITM attacks.
+
+long_description    bettercap is a powerful, easily extensible and portable \
+                    framework written in Go which aims to offer to security \
+                    researchers, red teamers and reverse engineers an easy to \
+                    use, all-in-one solution with all the features they might \
+                    possibly need for performing reconnaissance and attacking \
+                    WiFi networks, Bluetooth Low Energy devices, wireless HID \
+                    devices and Ethernet networks.
+
+categories          net security
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+license             GPL-3
+installs_libs       no
+
+depends_build-append \
+                    port:python39
+
+depends_lib-append  port:libpcap \
+                    port:libusb
+
+build.cmd           make
+build.target        build
+
+destroot {
+    system -W ${worksrcpath} "make -w PREFIX=${destroot}${prefix} install"
+}
+
+notes \
+  "PLEASE NOTE: bettercap will install its caplets to /usr/local/share/bettercap"
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  1c50874628f8a4503c29a722035704ad3c738747 \
+                        sha256  6e005fdad4e032097ebd2e78adec4aec777cf18dc826ba0b2eb0dda040d4ba8e \
+                        size    1346904
+
+go.vendors          honnef.co/go/tools \
+                        repo    github.com/dominikh/go-tools \
+                        lock    v0.0.0-2019.2.1 \
+                        rmd160  e30fb658b10be8ec9df1e0672396207f882fa8a3 \
+                        sha256  d5e38a585f1fd8be764dc62dba8a2e92e125398e944c8bcd7721e5329b694c7b \
+                        size    366135 \
+                    gopkg.in/sourcemap.v1 \
+                        lock    v1.0.5 \
+                        rmd160  76b8e83f152fd3165e3fe61af6236b304d013277 \
+                        sha256  c0812e6da42c36fdfe817782c9f62ced1f4735b5e514812032428bae617940cd \
+                        size    5366 \
+                    golang.org/x/tools \
+                        lock    6e04913cbbac \
+                        rmd160  8dff255370c50485d22fa30b1f6f9a9b77c7b48e \
+                        sha256  45f33dbfd2857b19558c2b27c5c48283f3971605fa6fe955e8469bf8c8ce9b43 \
+                        size    2153046 \
+                    golang.org/x/text \
+                        lock    v0.3.3 \
+                        rmd160  babfa547ba9a9dab7fe08fa5543f1d8e7ae00301 \
+                        sha256  1c4a8c12295d484e0360d8e010ebc4b8a9a05aa2a07c10c3d3e5b17aa063f0db \
+                        size    7745597 \
+                    golang.org/x/sys \
+                        lock    479acdf4ea46 \
+                        rmd160  2c445b5b6d35dd7041be3a40814adb0bcdae6bb2 \
+                        sha256  147558494903b88251d1bc1b1a0b9bab2dc245e0c7cabfd3470b64328b5f4671 \
+                        size    1177447 \
+                    golang.org/x/sync \
+                        lock    112230192c58 \
+                        rmd160  37a8b11def31e2ad355002a8671245962be359f6 \
+                        sha256  951a6df1dadb061510f1c646197dd8f8a7c7842729d02c6a68a86bce66349f79 \
+                        size    16832 \
+                    golang.org/x/net \
+                        lock    05aa5d4ee321 \
+                        rmd160  71c0cb87a8656720e27876ddc0fe5adbaa8d9e39 \
+                        sha256  7ae1117b5a6dd680c9329abcf66abb1b85c0bbdf87e9d3b844cbb2cc4c381048 \
+                        size    1179122 \
+                    golang.org/x/crypto \
+                        lock    5c72a883971a \
+                        rmd160  090821b28d0329a087b91a964a53937f3ce0047a \
+                        sha256  a82c522eb9ec32fd6d5511793d1325495caf63371fffc5ac82f1fea63e99664a \
+                        size    1732437 \
+                    github.com/thoj/go-ircevent \
+                        lock    8e7ce4b5a1eb \
+                        rmd160  777cdb19d92baa9176aa69c592899c6160ecaa90 \
+                        sha256  cf8ef4b904fc2a4326b5fac03d5a05a087f021292acc87a6fc01b59af89c4ab1 \
+                        size    12751 \
+                    github.com/tarm/serial \
+                        lock    98f6abe2eb07 \
+                        rmd160  7d4a6330b3abf4960b5ca2b31b82a4b95746c069 \
+                        sha256  5e108cf7a25a39dbfcace3525d2e6f1d3dbe104695ea73cf93ff9e2b95e5a8d4 \
+                        size    8121 \
+                    github.com/stretchr/testify \
+                        lock    v1.3.0 \
+                        rmd160  80582370443047a1d7020211865d85d54c036eea \
+                        sha256  ac782171992e3af1c8ac8384cbf4a39706ec5f9e3c6eed57a246e02dce571762 \
+                        size    102899 \
+                    github.com/robertkrimen/otto \
+                        lock    ef014fd054ac \
+                        rmd160  aeda7f83b069fbecd47e22ab52247a72e718c154 \
+                        sha256  1f30d004cc65a2880cf33802a0812bcb97c02eea7d194f8cc40e3f53b3b35450 \
+                        size    252235 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/pkg/errors \
+                        lock    v0.9.1 \
+                        rmd160  dc065c655f8a24c6519b58f9d1202eb266ecda40 \
+                        sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
+                        size    13422 \
+                    github.com/mitchellh/go-homedir \
+                        lock    v1.1.0 \
+                        rmd160  44b3985e40e5bbb22d11f8622c340f9ed727ea91 \
+                        sha256  024c8a57316c7fbc0eb23cdbfd57f72a74b51beb83d714034d67ee9aba48100c \
+                        size    3366 \
+                    github.com/miekg/dns \
+                        lock    v1.1.31 \
+                        rmd160  5affed05bcc2d87724b71d32c069628e9607dea3 \
+                        sha256  65f010621da670a2aafd91a0ecdf7b5cb511328d2fed299d3baed2f8e34e276c \
+                        size    188619 \
+                    github.com/mgutz/logxi \
+                        lock    aebf8a7d67ab \
+                        rmd160  20ddaf56c2363ef7b6e2fd5052757648ab5236bc \
+                        sha256  ee1b020e5a91b515c98c9864f53ee963700a2ee535d3db340d4477fba2a6a9c8 \
+                        size    305677 \
+                    github.com/mgutz/ansi \
+                        lock    d51e80ef957d \
+                        rmd160  a32d3fd46ae68cfd82f31fadc3dfe551966f6a5b \
+                        sha256  27808fbee08992bde76012200be0e24cb1017d39f3c228cc5805875993334b83 \
+                        size    5102 \
+                    github.com/mdlayher/dhcp6 \
+                        lock    2a67805d7d0b \
+                        rmd160  3a0436c5508522bbcd1a506f1c17ceb9beac6f18 \
+                        sha256  257f0106c5e0cd13881bc1a76a618205f8c732e13a73774f98035add809cd92a \
+                        size    44013 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.12 \
+                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
+                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
+                        size    4549 \
+                    github.com/mattn/go-colorable \
+                        lock    v0.1.7 \
+                        rmd160  47f774c77efaa0bbcd982cb65bed426d047780ba \
+                        sha256  68de4e31d97da97efc400096c599ea37c6cf1cb91501004f05a1017f4653f926 \
+                        size    9570 \
+                    github.com/malfunkt/iprange \
+                        lock    v0.9.0 \
+                        rmd160  7962417ecd73ec2517c1f39bfd2e014548aa64c7 \
+                        sha256  6bc80953efb37f8b30ee99ec738f46d1180fa1f6de17b3dd4a4fa41054c833b1 \
+                        size    8484 \
+                    github.com/kr/binarydist \
+                        lock    v0.1.0 \
+                        rmd160  0f610dd1225b8da38971c7d0a9f1b44a890f918c \
+                        sha256  bf09d3dc86eae0e57d3775b5dfd3e02fc6935f9d51a73a4832199d254f54d86f \
+                        size    12322 \
+                    github.com/koppacetic/go-gpsd \
+                        lock    v0.4.0 \
+                        rmd160  699bb601315e103f84f23270fa6786c5f8ddde8b \
+                        sha256  ecdd30443972447bfacfe20959e9814c374c9833cc6e06d6e13942c8f10fe667 \
+                        size    3899 \
+                    github.com/jpillora/go-tld \
+                        lock    v1.0.0 \
+                        rmd160  c2ea720d513f3c02c96294f64d89f28af1a32499 \
+                        sha256  14135be445d883a6a99b589464bbed9968624dac508028965172c9e1e3abec06 \
+                        size    3415 \
+                    github.com/inconshreveable/go-vhost \
+                        lock    06d84117953b \
+                        rmd160  333e1e63f855ee36c719ecbbd107e8cb9972b49f \
+                        sha256  323eb2d9fb1e08f6af7c482ba6c05f42cc2367e3ddd8949ab4189db4764a7160 \
+                        size    10189 \
+                    github.com/hashicorp/mdns \
+                        lock    v1.0.3 \
+                        rmd160  5c50ca9d05f0e29bc59d1577509ce1af129b3953 \
+                        sha256  33307117bbed89beef5357bc3a00f8ca213e48ac2de7a3920301835d3801dfd0 \
+                        size    11966 \
+                    github.com/gorilla/websocket \
+                        lock    v1.4.2 \
+                        rmd160  784f79f05da87fc2f2af618ad4e1eb576d7c16d8 \
+                        sha256  7805b8fc2002f7d1a7acdaa98feee2d6746d9241db0c597e0ee256cf0ff93a0b \
+                        size    54121 \
+                    github.com/gorilla/mux \
+                        lock    v1.8.0 \
+                        rmd160  0671fd049b24cb4c682168aef4e176793dd624a7 \
+                        sha256  b94c995107eaf9f5bcaa0a29629fb6c23bab9ec0606071c09070e143fdf323fa \
+                        size    45524 \
+                    github.com/google/gousb \
+                        lock    v2.1.0 \
+                        rmd160  17d638432a1c26153ef9f17e36ab3b7b5870b41a \
+                        sha256  08f9cc5fffecec911287dfddd638ca0179e6fdc509d56030bf90525e98f85a9e \
+                        size    251622 \
+                    github.com/google/gopacket \
+                        lock    v1.1.18 \
+                        rmd160  3441843e4d4d44007a157e4118335522c0af219d \
+                        sha256  a8a6117a7263b73311ead64ba7a3333ba73075c134cd29a67153bbb113b012ee \
+                        size    938891 \
+                    github.com/google/go-querystring \
+                        lock    v1.0.0 \
+                        rmd160  48593728f6bf361fa168bdc87737ee30de24f34b \
+                        sha256  0add5428914c2a378cd9e6e120a4b1e84d69df504b983f99a86aea98a52c5a57 \
+                        size    7536 \
+                    github.com/google/go-github \
+                        lock    v17.0.0 \
+                        rmd160  2c1917adfc161a2252354d558352180079005d8d \
+                        sha256  c064b8849dcf8e184e1333f8411c7285e0abeb321ffc268b3798f84d6db5f947 \
+                        size    212064 \
+                    github.com/golang/groupcache \
+                        lock    8c9f03a8e57e \
+                        rmd160  b2514822acfad511ef9c9909f251cf18a3347ccd \
+                        sha256  ba910d9b0c49b9e15e605c6f5f373e2a2eeae2e7c59ed72bd6866446f6a5f94e \
+                        size    26050 \
+                    github.com/gobwas/glob \
+                        lock    e7a84e9525fe \
+                        rmd160  b856676359c9b7b1784cfb03aedc6c148213c1dc \
+                        sha256  0d768f1e6d063bab65db1b05041833e2c721e5ffae47c56dfd1a2859b66ee8d2 \
+                        size    26232 \
+                    github.com/evilsocket/islazy \
+                        lock    v1.10.6 \
+                        rmd160  b0dd3531ef250881ddcf7e9070249db11d954bea \
+                        sha256  3e46459422bd617f0d4b4cd3e365207d880137ce86ad7ad01d6324c3db270b9f \
+                        size    26716 \
+                    github.com/elazarl/goproxy \
+                        lock    0581fc3aee2d \
+                        rmd160  97a39021e117802a739919493e0e2880bbf81e5a \
+                        sha256  831c291aa7d4a2a8d18c6fb91008985108a79e418ffa9e55e08d2ca112a30c7d \
+                        size    108510 \
+                    github.com/dustin/go-humanize \
+                        lock    v1.0.0 \
+                        rmd160  e8641035159ea3e8839ee086f01f966443956303 \
+                        sha256  e45e3181c07b3e2dad8e1317e91a5bbbee4845067e3e3879a585a5254bc6a334 \
+                        size    17273 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/chzyer/test \
+                        lock    a1ea475d72b1 \
+                        rmd160  61f83d79b356cde63a27df0f2832ef92fcbc216d \
+                        sha256  98d0c7d1dec438459e31886d65190bb45f70c4ed73e35f5ab2f3b8de582ea309 \
+                        size    4007 \
+                    github.com/chzyer/logex \
+                        lock    v1.1.10 \
+                        rmd160  105d839f798ba0c3e27b3db4e790d9d21a928029 \
+                        sha256  947e61095044d310b0ad92f10ac77c36eaa3c3e2e6181e87428ad10c20930ba3 \
+                        size    4351 \
+                    github.com/chifflier/nfqueue-go \
+                        lock    61ca646babef \
+                        rmd160  da0c38c42b3434e5d6da93a138b81291b12a06d3 \
+                        sha256  27995b2d3503dce1839cf7ee2e3be15e3cffa712c9ffb9040f533cccfde48345 \
+                        size    12585 \
+                    github.com/bettercap/recording \
+                        lock    3ce1dcf032e3 \
+                        rmd160  83afc72f72943264f9c25d843f610ccb49a6bf1c \
+                        sha256  992ca2dd41f7e415bf017b77e3f6321ce4597aaa14d33dee88625eb17520d9e7 \
+                        size    15711 \
+                    github.com/bettercap/readline \
+                        lock    655e48bcb7bf \
+                        rmd160  b1e43f7d26c59671afa96c161d2efcd6e776e2d5 \
+                        sha256  3089bef8b1a76809897932f4d720cd87a8b10c25b6d9b0722170efb3e75ef6f7 \
+                        size    36933 \
+                    github.com/bettercap/nrf24 \
+                        lock    aa37e6d0e0eb \
+                        rmd160  ea44f2c4662d67140645ee212963695a6dc7e6b2 \
+                        sha256  332e0f3cf89beabcd3447396681fc2f4a0f17b49bbb89a30214aede0fd38187a \
+                        size    15548 \
+                    github.com/bettercap/gatt \
+                        lock    569d3d9372bb \
+                        rmd160  a1d48a6dfea1c1d72c0b30f861dfb3355a004e08 \
+                        sha256  ac4873ab63c15e28c39c91d5d109928274dbd1b8ad3077beb06d1d9df850dcb5 \
+                        size    90448 \
+                    github.com/antchfx/xpath \
+                        lock    v1.1.10 \
+                        rmd160  506f4949f680a9ee56c92f91b93431299de97d3b \
+                        sha256  1c5abce2c01b3bf5ddb127ba07005062994178efce13b67b69f39c4e11dbaa46 \
+                        size    26095 \
+                    github.com/antchfx/jsonquery \
+                        lock    v1.1.4 \
+                        rmd160  2419c82be765ba79fd7e9110ed74e69fb042d43b \
+                        sha256  f39338ba58db3865ce85ecd325f9c59d9fb4989189b3d260257a95cb346bcc71 \
+                        size    7232 \
+                    github.com/adrianmo/go-nmea \
+                        lock    v1.3.0 \
+                        rmd160  f177451dc5d89b002358e4e87a8353df829d9d3c \
+                        sha256  87db10c3a23c272b19547d1ff403bc4935124374f569d5009aae630d33082a60 \
+                        size    27100 \
+                    github.com/acarl005/stripansi \
+                        lock    5a71ef0e047d \
+                        rmd160  fd222fb597292536232f066479c48f1e7769373f \
+                        sha256  7c4d6ffa5a4401bffde46366e0c4976893ee8d6210543bc70cc1c514c22e29ae \
+                        size    1479 \
+                    github.com/BurntSushi/toml \
+                        lock    v0.3.1 \
+                        rmd160  fb9650e2d16525153645e5547626f242f3800149 \
+                        sha256  8cc9e5dc68e247554227973d0b4e023b27bbd9ba5a26e4fb40f44743afcb35f1 \
+                        size    42087


### PR DESCRIPTION
#### Description

New port for [bettercap](https://www.bettercap.org), a Wifi, Bluetooth LE, & Ethernet Swiss Army knife recon, attack and MITM tool.

<img src="https://raw.githubusercontent.com/bettercap/media/master/ui-events.png" />

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
