### PR TITLE
py-trustme: update to 0.7.0

### DIFF
--- a/python/py-service_identity/Portfile
+++ b/python/py-service_identity/Portfile
@@ -12,7 +12,7 @@ platforms           darwin
 supported_archs     noarch
 license             MIT
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 maintainers         {khindenburg @kurthindenburg} openmaintainer
 

--- a/python/py-trustme/Portfile
+++ b/python/py-trustme/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-trustme
-version             0.5.2
+version             0.7.0
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
 license             {Apache-2 MIT}
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 maintainers         {@jandemter demter.de:jan} openmaintainer
 
@@ -24,9 +24,9 @@ master_sites        pypi:t/trustme
 
 distname            trustme-${version}
 
-checksums           rmd160  1c5bc086145a8c0c51f2aa71250e5ff25412314f \
-                    sha256  8b804c55c7bcb5186f1f408c9da1e5fda915e6fe0142f4411ea900c380456e80 \
-                    size    21819
+checksums           rmd160  5c5f81a35d87a70d43012483bd3948000e67c91f \
+                    sha256  1fde1dd27052ab5e5693e1fbe3ba091a6496daf1125409d73232561145fca369 \
+                    size    27853
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
- Add py39 subport for py-service_identity

Fixes: https://trac.macports.org/ticket/62460


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
