### PR TITLE
wireguard-tools: update to 1.0.20210315

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-tools
-version             1.0.20210223
+version             1.0.20210315
 revision            0
-checksums           rmd160  0e15694ab4b4ae42a5a856a62e4a85f6683cba79 \
-                    sha256  1f72da217044622d79e0bab57779e136a3df795e3761a3fc1dc0941a9055877c \
-                    size    95444
+checksums           rmd160  8934a827fc70e6b74c7931a6e5cc579f96fd0179 \
+                    sha256  af001d5492be6bf58ef0bebe04b446b6f50eb53e1226fab679cc34af40733a22 \
+                    size    96988
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
#### Description
wireguard-tools: update to 1.0.20210315

###### Tested on
macOS 10.15.7 19H114
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
