### PR TITLE
git: update to 2.31.0

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 name                git
-version             2.30.2
+version             2.31.0
 revision            0
 
 description         A fast version control system
@@ -24,13 +24,13 @@ distfiles           git-${version}${extract.suffix} \
                     git-manpages-${version}${extract.suffix}
 
 checksums           git-${version}.tar.xz \
-                    rmd160  8679eea01784e38b1402e47695e78d72ed486381 \
-                    sha256  41f7d90c71f9476cd387673fcb10ce09ccbed67332436a4cc58d7af32c355faa \
-                    size    6329820 \
+                    rmd160  f39c8428b7245bd6e853214f93f18487b639f694 \
+                    sha256  e8f162cbdb3283e13cd7388d864ed23485f1b046a19e969f12ed2685fb789a40 \
+                    size    6414252 \
                     git-manpages-${version}.tar.xz \
-                    rmd160  daded25eedf5609049ce43d962d0d8d633d002ea \
-                    sha256  5e64ace225e6dd0749b09c7adce765a538a922699c8997421ee255c3165e2aaa \
-                    size    482180
+                    rmd160  22d1dc2c8383a9318d13a6011e38f0ba8aa52c9d \
+                    sha256  185ddcbc31ae6b8d33c3ab78f6022ee6cc79dd867c1b2e5c3767821124e780ec \
+                    size    487764
 
 perl5.require_variant   yes
 perl5.conflict_variants yes
@@ -42,8 +42,7 @@ depends_lib-append  port:curl \
                     port:zlib \
                     path:lib/libssl.dylib:openssl \
                     port:expat \
-                    port:libiconv \
-                    port:python38
+                    port:libiconv
 
 depends_run-append  port:p${perl5.major}-authen-sasl \
                     port:p${perl5.major}-error \
@@ -76,7 +75,6 @@ build.args          CFLAGS="${CFLAGS}" \
                     OPENSSLDIR=${prefix} \
                     ICONVDIR=${prefix} \
                     PERL_PATH="${prefix}/bin/perl${perl5.major}" \
-                    PYTHON_PATH="${prefix}/bin/python3.8" \
                     NO_FINK=1 \
                     NO_DARWIN_PORTS=1 \
                     NO_R_TO_GCC_LINKER=1 \
@@ -145,9 +143,9 @@ variant pcre description {Use pcre} {
 variant doc description {Install HTML and plaintext documentation} {
     distfiles-append        git-htmldocs-${version}${extract.suffix}
     checksums-append        git-htmldocs-${version}.tar.xz \
-                            rmd160  1e1757931595bca67413d53aa10744fa760b7e25 \
-                            sha256  29b8ab81966ec7c1a3ed47fb7fe23f0b78289c18d11d58c0dc8749613e0419dc \
-                            size    1342648
+                            rmd160  b939fa33d2fefa62063c1917017359bb78ac95fd \
+                            sha256  2ff3c0403870c3f02cdd46af1cd749b0c5d7826bfe00bee09ba1d0c2f19f554b \
+                            size    1357332
 
     patchfiles-append       patch-git-subtree.html.diff
 
@@ -236,6 +234,15 @@ variant diff_highlight description {Install git diff-highlight utility from cont
         xinstall -m 755 "${worksrcpath}/contrib/diff-highlight/diff-highlight" \
             "${destroot}${prefix}/bin/"
     }
+}
+
+# Python is only needed to enable certain tools for interacting with other
+# version control systems, such as git-p4 (for interfacing with Perforce)
+variant python description {Build with Python 3 support} {
+
+    depends_lib-append  port:python39
+
+    build.args-append   PYTHON_PATH="${prefix}/bin/python3.9"
 }
 
 platform darwin 8 {


### PR DESCRIPTION
#### Description

git does not require Python in order to be built.  Python is mainly used for some utilities used to interact with other version control systems, specifically `git-p4` (for interacting with Perforce).

So in addition to upgrading git, this change removes Python as a required dependency, and makes it a non-default variant instead.

Fixes: https://trac.macports.org/ticket/58862

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
