### PR TITLE
julia: update to 1.5.4

### DIFF
--- a/lang/julia/Portfile
+++ b/lang/julia/Portfile
@@ -8,7 +8,7 @@ PortGroup           compilers 1.0
 compilers.choose    fc f77 f90
 compilers.setup     require_fortran -g95
 
-github.setup        JuliaLang julia 1.5.3 v
+github.setup        JuliaLang julia 1.5.4 v
 revision            0
 categories-append   lang math science
 maintainers         {ieee.org:s.t.smith @essandess} openmaintainer
@@ -26,9 +26,9 @@ github.tarball_from releases
 distfiles           ${name}-${version}-full${extract.suffix}
 
 checksums           ${name}-${version}-full${extract.suffix} \
-                    rmd160  df4f63f7d2db6df2143cf7b3e7d1a8c300f731d7 \
-                    sha256  fb69337ca037576758547c7eed9ae8f153a9c052318327b6b7f1917408c14d91 \
-                    size    138278314
+                    rmd160  5dacf46cf98aea29ec6ef11ce461ced4ee6ab8eb \
+                    sha256  dbfb8cd544b223eff70f538da7bb9d5b6f76fd0b00dd2385e6254e74ad4e892f \
+                    size    138223428
 
 extract.only        ${distfiles}
 
@@ -40,9 +40,7 @@ if {[option gpg_verify.use_gpg_verification]} {
                     ${name}-${version}-full${extract.suffix}.asc
     checksums-append \
                     ${name}-${version}-full${extract.suffix}.asc \
-                    size    866 \
-                    rmd160  aed07c2e553aec2a030491a2a9c69206b69292ad \
-                    sha256  3128c1ae0392008c92798b4e4cbd076088579fcbfbb11a2fdeb5a47a136c3857
+                    size    866
 
     post-checksum {
         gpg_verify.verify_gpg_signature \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

Whe I run `sudo port test julia`, some of the tests did not passed. Failed tests produce very similar logs like these:
```log
:info:test Some tests did not pass: 159 passed, 0 failed, 1 errored, 0 broken.
:info:test Sockets: Error During Test at /opt/local/var/macports/build/_Users_queensferry_.local_share_ports_lang_julia/julia/work/julia-1.5.4/usr/share/julia/stdlib/v1.5/Sockets/test/runtests.jl:120
:info:test   Got exception outside of a @test
:info:test   IOError: bind: name too long (ENAMETOOLONG)
:info:test   Stacktrace:
:info:test    [1] bind(::Sockets.PipeServer, ::String) at /opt/local/var/macports/build/_Users_queensferry_.local_share_ports_lang_julia/julia/work/julia-1.5.4/usr/share/julia/stdlib/v1.5/Sockets/src/PipeServer.jl:59
:info:test    [2] listen at /opt/local/var/macports/build/_Users_queensferry_.local_share_ports_lang_julia/julia/work/julia-1.5.4/usr/share/julia/stdlib/v1.5/Sockets/src/PipeServer.jl:76 [inlined]
```

Such situation was also mentioned in #9173, hence I believe this is a bug with julia itself.