### PR TITLE
josm: update to 17560

### DIFF
--- a/gis/JOSM/Portfile
+++ b/gis/JOSM/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                JOSM
-version             17428
+version             17560
 categories          gis editors java
 platforms           darwin
 license             GPL-2+
@@ -19,9 +19,9 @@ homepage            https://josm.openstreetmap.de
 master_sites        ${homepage}/download/macosx/
 distname            josm-macosx-${version}
 
-checksums           rmd160  86895f240389a65ed6a2fe230595480febb0f6ae \
-                    sha256  f5e1ad59b551cc5acf2c09cdd2ea943e50cbebb0ff4f3cf3fcf8ce7abcf1de88 \
-                    size    14621699
+checksums           rmd160  21d6b7d17e17b0b518e67df5f739d7a3c89a8b6c \
+                    sha256  e1c0d0ecbb43a67f102e0313e9fb5c78e92cf1cd514ad73c6a7f2f20248d199f \
+                    size    14860437
 
 extract.mkdir       yes
 


### PR DESCRIPTION
#### Description
[Changelog (2021-03-14: Stable release 17560)](https://josm.openstreetmap.de/wiki/Changelog#stable-release-21.02)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
