### PR TITLE
git: remove python as required dependency

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                git
 version             2.31.0
-revision            0
+revision            1
 
 description         A fast version control system
 long_description    Git is a fast, scalable, distributed open source version \
@@ -42,8 +42,7 @@ depends_lib-append  port:curl \
                     port:zlib \
                     path:lib/libssl.dylib:openssl \
                     port:expat \
-                    port:libiconv \
-                    port:python38
+                    port:libiconv
 
 depends_run-append  port:p${perl5.major}-authen-sasl \
                     port:p${perl5.major}-error \
@@ -76,7 +75,6 @@ build.args          CFLAGS="${CFLAGS}" \
                     OPENSSLDIR=${prefix} \
                     ICONVDIR=${prefix} \
                     PERL_PATH="${prefix}/bin/perl${perl5.major}" \
-                    PYTHON_PATH="${prefix}/bin/python3.8" \
                     NO_FINK=1 \
                     NO_DARWIN_PORTS=1 \
                     NO_R_TO_GCC_LINKER=1 \
@@ -236,6 +234,15 @@ variant diff_highlight description {Install git diff-highlight utility from cont
         xinstall -m 755 "${worksrcpath}/contrib/diff-highlight/diff-highlight" \
             "${destroot}${prefix}/bin/"
     }
+}
+
+# Python is only needed to enable certain tools for interacting with other
+# version control systems, such as git-p4 (for interfacing with Perforce).
+# This variant enables git to use MacPorts' Python as it builds these
+# additional tools.
+variant python description {Build with Python support} {
+    depends_lib-append  port:python39
+    build.args-append   PYTHON_PATH="${prefix}/bin/python3.9"
 }
 
 platform darwin 8 {


### PR DESCRIPTION
Make Python available as an optional variant instead.

Python is only needed for a particular script for interacting with other version control systems (specifically Perforce).  It is not needed to build git.

Fixes: https://trac.macports.org/ticket/58862

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
