### PR TITLE
openjdk16, openjdk16-openj9: new subports

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -18,7 +18,6 @@ if {${subport} eq "openjdk"} {
 }
 
 # Dummy default values for the obsoleted openjdk port
-set major        ${version}
 set build        0
 set openj9_version 0
 
@@ -41,30 +40,36 @@ set long_description_graalvm \
     "GraalVM is a universal virtual machine for running applications written in JavaScript, Python, Ruby, R,\
     JVM-based languages like Java, Scala, Groovy, Kotlin, Clojure, and LLVM-based languages such as C and C++."
 
-set long_description_oracle_openjdk \
-    "Production-ready, free and open-source build of the Java Development Kit, an implementation of the Java Standard\
-    Edition (SE) ${major} Platform. OpenJDK is the official reference implementation of Java SE. Included components\
-    are the HotSpot virtual machine, the Java class library and the Java compiler."
-
 subport openjdk8 {
     version      8u282
     revision     0
 
     set build    08
-    set major    8
+
+    description  Open Java Development Kit 8 (AdoptOpenJDK) with HotSpot VM
+    long_description ${long_description_adoptopenjdk_hotspot}
+
+    master_sites https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk${version}-b${build}/
+    distname     OpenJDK8U-jdk_x64_mac_hotspot_${version}b${build}
+    worksrcdir   jdk${version}-b${build}
+
+    configure.cxx_stdlib libstdc++
 
     checksums    rmd160  3187d760b3cbeaaf01d47481f069a3e2d1011cfd \
                  sha256  1766d756f6e4a5d41b539f2ecf83e5a33e9336bd75f1602e8f4b4afbb8f47aaa \
                  size    101808251
-
-    configure.cxx_stdlib libstdc++
 }
 
 subport openjdk8-graalvm {
     version      21.0.0.2
     revision     0
 
-    set major    8
+    description  GraalVM Community Edition based on OpenJDK 8
+    long_description ${long_description_graalvm}
+
+    master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/
+    distname     graalvm-ce-java8-darwin-amd64-${version}
+    worksrcdir   graalvm-ce-java8-${version}
     
     checksums    rmd160  2fc5f23a1558b5e125ef91ad137270fe4f2b4d0c \
                  sha256  25a653a44b3ad63479d7ae35d921c8d39282ff1849243f1afc0ffddd443e9079 \
@@ -76,8 +81,14 @@ subport openjdk8-openj9 {
     revision     0
 
     set build    08
-    set major    8
     set openj9_version 0.24.0
+
+    description  Open Java Development Kit 8 (AdoptOpenJDK) with Eclipse OpenJ9 VM
+    long_description ${long_description_adoptopenjdk_openj9}
+
+    master_sites https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
+    distname     OpenJDK8U-jdk_x64_mac_openj9_${version}b${build}_openj9-${openj9_version}
+    worksrcdir   jdk${version}-b${build}
 
     checksums    rmd160  b66caafe41d50052fa438dfcef5fdf58430f42c8 \
                  sha256  265d4fb01b61ed7a3a9fae6a50bcf6322687b5f08de8598d8e42263cbd8b5772 \
@@ -89,8 +100,14 @@ subport openjdk8-openj9-large-heap {
     revision     0
 
     set build    08
-    set major    8
     set openj9_version 0.24.0
+
+    description  Open Java Development Kit 8 (AdoptOpenJDK) with Eclipse OpenJ9 VM for large heap sizes
+    long_description ${long_description_adoptopenjdk_openj9xl}
+
+    master_sites https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
+    distname     OpenJDK8U-jdk_x64_mac_openj9_macosXL_${version}b${build}_openj9-${openj9_version}
+    worksrcdir   jdk${version}-b${build}
 
     checksums    rmd160  e4797c143ca666baa428a252bb130251af25a1b2 \
                  sha256  64f2b106bc5c65ed963a72893e3d676df58704718dd86fc0fcbbb61e615e4742 \
@@ -101,6 +118,9 @@ subport openjdk8-openj9-large-heap {
 subport openjdk10 {
     version      10.0.2
     revision     3
+
+    PortGroup    obsolete 1.0
+    replaced_by  openjdk11
 }
 
 subport openjdk11 {
@@ -108,7 +128,13 @@ subport openjdk11 {
     revision     0
 
     set build    9
-    set major    11
+
+    description  Open Java Development Kit 11 (AdoptOpenJDK) with HotSpot VM
+    long_description ${long_description_adoptopenjdk_hotspot}
+
+    master_sites https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${version}%2B${build}/
+    distname     OpenJDK11U-jdk_x64_mac_hotspot_${version}_${build}
+    worksrcdir   jdk-${version}+${build}
 
     checksums    rmd160  3c1f62a95095aee9f0ee3d02ba4a4a67f5425ba1 \
                  sha256  ee7c98c9d79689aca6e717965747b8bf4eec5413e89d5444cc2bd6dbd59e3811 \
@@ -119,7 +145,12 @@ subport openjdk11-graalvm {
     version      21.0.0.2
     revision     0
 
-    set major    11
+    description  GraalVM Community Edition based on OpenJDK 11
+    long_description ${long_description_graalvm}
+
+    master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/
+    distname     graalvm-ce-java11-darwin-amd64-${version}
+    worksrcdir   graalvm-ce-java11-${version}
     
     checksums    rmd160  64053c14a3e03b49d69564d99fad84453c097afb \
                  sha256  6714be01bd17c2c049435c02e19dd2bcba96ea9e44152911ed0082bc968618d6 \
@@ -132,7 +163,13 @@ subport openjdk11-openj9 {
 
     set build    9
     set openj9_version 0.24.0
-    set major    11
+
+    description  Open Java Development Kit 11 (AdoptOpenJDK) with Eclipse OpenJ9 VM
+    long_description ${long_description_adoptopenjdk_openj9}
+
+    master_sites https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
+    distname     OpenJDK11U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
+    worksrcdir   jdk-${version}+${build}
 
     checksums    rmd160  68da07a92466f0ce17d814e29f20985b95689853 \
                  sha256  58f931dc30160b04da2d94af32e0dfa384f4b2cf92b7217c0937fd057e668d54 \
@@ -145,7 +182,13 @@ subport openjdk11-openj9-large-heap {
 
     set build    9
     set openj9_version 0.24.0
-    set major    11
+
+    description  Open Java Development Kit 11 (AdoptOpenJDK) with Eclipse OpenJ9 VM for large heap sizes
+    long_description ${long_description_adoptopenjdk_openj9xl}
+
+    master_sites https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
+    distname     OpenJDK11U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
+    worksrcdir   jdk-${version}+${build}
 
     checksums    rmd160  66e4e36eb013a66d7970c3874046b80e771cd36d \
                  sha256  ac6998c1a7945dab9d008e3702a69ed86488321aea197961f72375e8bc8bc114 \
@@ -211,7 +254,13 @@ subport openjdk15 {
     revision     0
 
     set build    7
-    set major    15
+
+    description  Open Java Development Kit 15 (AdoptOpenJDK) with HotSpot VM
+    long_description ${long_description_adoptopenjdk_hotspot}
+
+    master_sites https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-${version}%2B${build}/
+    distname     OpenJDK15U-jdk_x64_mac_hotspot_${version}_${build}
+    worksrcdir   jdk-${version}+${build}
 
     checksums    rmd160  74950bb51052416c41fcc4e33db077919e504097 \
                  sha256  d358a7ff03905282348c6c80562a4da2e04eb377b60ad2152be4c90f8d580b7f \
@@ -224,7 +273,13 @@ subport openjdk15-openj9 {
 
     set build    7
     set openj9_version 0.24.0
-    set major    15
+
+    description  Open Java Development Kit 16 (AdoptOpenJDK) with Eclipse OpenJ9 VM
+    long_description ${long_description_adoptopenjdk_openj9}
+
+    master_sites https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
+    distname     OpenJDK15U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
+    worksrcdir   jdk-${version}+${build}
 
     checksums    rmd160  76b4e46152ba4ddca1274b20eb75fd22fdb1b34e \
                  sha256  1336ae5529af3a0e35ae569e4188944831aeed7080a482f2490fc619380cbe53 \
@@ -237,11 +292,54 @@ subport openjdk15-openj9-large-heap {
 
     set build    7
     set openj9_version 0.24.0
-    set major    15
+
+    description  Open Java Development Kit 15 (AdoptOpenJDK) with Eclipse OpenJ9 VM for large heap sizes
+    long_description ${long_description_adoptopenjdk_openj9xl}
+
+    master_sites https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
+    distname     OpenJDK15U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
+    worksrcdir   jdk-${version}+${build}
 
     checksums    rmd160  ed1021fa9c1e6960d5b2fcbb7317d1fa7a4844d0 \
                  sha256  b9192784a877b2066c7f60eea9901f1181d19b3a39260bc04f1a33febbdb342d \
                  size    195261675
+}
+
+subport openjdk16 {
+    version      16
+    revision     0
+
+    set build    36
+
+    description  Open Java Development Kit 16 (AdoptOpenJDK) with HotSpot VM
+    long_description ${long_description_adoptopenjdk_hotspot}
+
+    master_sites https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-${version}%2B${build}/
+    distname     OpenJDK16-jdk_x64_mac_hotspot_${version}_${build}
+    worksrcdir   jdk-${version}+${build}
+
+    checksums    rmd160  7ef653cce09364235a659cc9dd721281fec95d98 \
+                 sha256  b66761b55fd493ed2a5f4df35a32b338ec34a9e0a1244439e3156561ab27c511 \
+                 size    199955659
+}
+
+subport openjdk16-openj9 {
+    version      16
+    revision     0
+
+    set build    36
+    set openj9_version 0.25.0
+
+    description  Open Java Development Kit 16 (AdoptOpenJDK) with Eclipse OpenJ9 VM
+    long_description ${long_description_adoptopenjdk_openj9}
+
+    master_sites https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
+    distname     OpenJDK16-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
+    worksrcdir   jdk-${version}+${build}
+
+    checksums    rmd160  94087f2b59cc2a27d289488f7b76a714a57706b5 \
+                 sha256  e6075cbe939b4de165cc8b4b91352f8885d549873f5cd419e75eba737502542e \
+                 size    206412428
 }
 
 # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
@@ -253,34 +351,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 14} {
     }
 }
 
-if {${subport} eq "openjdk8"} {
-    description  Open Java Development Kit ${major} (AdoptOpenJDK) with HotSpot VM
-    long_description ${long_description_adoptopenjdk_hotspot}
-
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}/
-    distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}b${build}
-    worksrcdir   jdk${version}-b${build}
-
-    configure.cxx_stdlib libstdc++
-} elseif {${subport} eq "openjdk8-openj9"} {
-    description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM
-    long_description ${long_description_adoptopenjdk_openj9}
-
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
-    distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}b${build}_openj9-${openj9_version}
-    worksrcdir   jdk${version}-b${build}
-} elseif {${subport} eq "openjdk8-openj9-large-heap"} {
-    description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM for large heap sizes
-    long_description ${long_description_adoptopenjdk_openj9xl}
-
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
-    distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}b${build}_openj9-${openj9_version}
-    worksrcdir   jdk${version}-b${build}
-} elseif {${subport} eq "openjdk10"} {
-    # Remove after 2021-11-28
-    PortGroup    obsolete 1.0
-    replaced_by  openjdk11
-} elseif {${subport} in [list openjdk12 openjdk13 openjdk14]} {
+if {${subport} in [list openjdk12 openjdk13 openjdk14]} {
     PortGroup    obsolete 1.0
     # Can replace with openjdk16 when it is added and openjdk15 is obsoleted
     replaced_by  openjdk15
@@ -290,36 +361,8 @@ if {${subport} eq "openjdk8"} {
     replaced_by  openjdk15-openj9
 } elseif {${subport} in [list openjdk12-openj9-large-heap openjdk13-openj9-large-heap openjdk14-openj9-large-heap]} {
     PortGroup    obsolete 1.0
-    # Can replace with openjdk16-openj9-large-heap when it is added and openjdk15-openj9-large-heap is obsoleted
+    # Can replace with openjdk16-openj9 when it is added and openjdk15-openj9-large-heap is obsoleted
     replaced_by  openjdk15-openj9-large-heap
-} elseif {[string match *-graalvm ${subport}]} {
-    description  GraalVM Community Edition based on OpenJDK ${major}
-    long_description ${long_description_graalvm}
-
-    master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/
-    distname     graalvm-ce-java${major}-darwin-amd64-${version}
-    worksrcdir   graalvm-ce-java${major}-${version}
-} elseif {[string match *-openj9-large-heap ${subport}]} {
-    description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM for large heap sizes
-    long_description ${long_description_adoptopenjdk_openj9xl}
-
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
-    distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
-    worksrcdir   jdk-${version}+${build}
-} elseif {[string match *-openj9 ${subport}]} {
-    description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM
-    long_description ${long_description_adoptopenjdk_openj9}
-
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
-    distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
-    worksrcdir   jdk-${version}+${build}
-} else {
-    description  Open Java Development Kit ${major} (AdoptOpenJDK) with HotSpot VM
-    long_description ${long_description_adoptopenjdk_hotspot}
-
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}/
-    distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}_${build}
-    worksrcdir   jdk-${version}+${build}
 }
 
 if {[string match *-graalvm ${subport}]} {


### PR DESCRIPTION
#### Description

Added subports for AdoptOpenJDK 16 with HotSpot VM and OpenJ9 VM.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?