### PR TITLE
kotlin: update to 1.4.31

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           java 1.0
 
-github.setup        JetBrains kotlin 1.4.30 v
+github.setup        JetBrains kotlin 1.4.31 v
 revision            0
 github.tarball_from releases
 distname            ${name}-compiler-${version}
@@ -23,9 +23,9 @@ long_description    Kotlin is a pragmatic programming language for JVM \
 
 homepage            https://kotlinlang.org/
 
-checksums           rmd160  860d6e685b0c8cc3effaa1900c80f6f98d062cea \
-                    sha256  7b0aae9dca5ea899ef05dedc0a6fdd6e359451e56ff0dd3354443b3208b31800 \
-                    size    62879866
+checksums           rmd160  229dd4bf2303673a9748940483183ed09905fdff \
+                    sha256  b50e7016febf7510325d685ae69cc62f49a7ca7f670cb4e0888112e3ec09c6ec \
+                    size    62879831
 
 java.version        1.8+
 java.fallback       openjdk8


### PR DESCRIPTION
#### Description

Update to Kotlin 1.4.31.

###### Tested on

macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?