### PR TITLE
google-cloud-sdk: update to 332.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             331.0.0
+version             332.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,14 +21,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  bb7445af8dcf4b1d996942f2b72a06cf7c7c8cee \
-                    sha256  080c661ff410cd290830fc2ceb88ce52a0a03161ce27d1294b6b613e5f90e054 \
-                    size    88219612
+    checksums       rmd160  e4767b2d9ffe5a537cd3637e1fe6bc477857ada8 \
+                    sha256  9439b4bb8fde2b8605b96141e4f51b4cadac82fe9859f0ab67033e2505d69617 \
+                    size    88318194
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  3a675277726c99c3409213af711dbc78c624a79e \
-                    sha256  32c7b961f4c3d18f772a8900c9bc1300e7f81c0c05d71f93b770a222f00490ba \
-                    size    110705434
+    checksums       rmd160  92cb7e53459e26d5d7b23a32dfb99e8bc609445f \
+                    sha256  1d158a84dfff8f3aa3cacdbbd3fb9cfbea3178728367b20c986760edc1665026 \
+                    size    89323229
 }
 
 homepage            https://cloud.google.com/sdk/
@@ -48,8 +48,8 @@ build               {}
 # MacPorts variants are not allowed to contain '-' and gcloud component names use both '-' and '_',
 # so each variant adds an explicit mapping from variant name to gcloud component name.
 # See https://cloud.google.com/sdk/docs/components for more info about gcloud components.
-# Current list of available components is not documented, but can be found via: docker run -it --rm google/cloud-sdk gcloud components list
-# 'gcloud', 'bq', 'gsutil' and 'core' components are installed by default, so not offered as variants.
+# Current list of available components is not documented by Google, but can be found via: gcloud components list
+# 'gcloud', 'bq', 'gsutil' and 'core' components are installed by default, so are not offered as variants.
 set variant_to_component [dict create]
 variant alpha description {Add gcloud CLI Alpha Commands} { dict set variant_to_component alpha alpha }
 variant anthos_auth description {Add Anthos auth} { dict set variant_to_component anthos_auth anthos-auth }


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 332.0.0.

###### Tested on

macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?