### PR TITLE
qemu: fix +vnc build

### DIFF
--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -8,7 +8,7 @@ PortGroup legacysupport 1.0
 
 name                    qemu
 version                 5.2.0
-revision                0
+revision                1
 categories              emulators
 license                 GPL-2+
 platforms               darwin
@@ -210,6 +210,7 @@ variant vnc description {Support VNC server} {
                             port:cyrus-sasl2 \
                             path:include/turbojpeg.h:libjpeg-turbo \
                             port:libpng
+    depends_build-append    port:cyrus-sasl2
 }
 
 variant vde description {Support VDE networking} {


### PR DESCRIPTION
#### Description

I was hitting errors building qemu 5.2.0 with +vnc

```
:info:configure Has header "sasl/sasl.h" : YES 
:info:configure ../qemu-5.2.0/meson.build:659:2: ERROR: C shared library 'sasl2' not found
:info:configure A full log can be found at /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_emulators_qemu/qemu/work/build/meson-logs/meson-log.txt
:info:configure ERROR: meson setup failed
```

adding cyrus-sasl2 to depends_build resolved the issue for me.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H524
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
