### PR TITLE
libelf: fix build defect #61564 - implicit declaration of function

### DIFF
--- a/devel/libelf/Portfile
+++ b/devel/libelf/Portfile
@@ -25,6 +25,8 @@ patchfiles      elf_repl.diff
 
 depends_lib	    port:gettext
 
+use_autoreconf      yes
+
 configure.args			    --disable-compat
 build.pre_args-append		instroot=${destroot}
 destroot.pre_args-append	instroot=${destroot}


### PR DESCRIPTION
This PR fixes the build defect #61564 by using autoreconf

Closes: https://trac.macports.org/ticket/61564

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.2.1 20D74
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
