### PR TITLE
micronaut: update to 2.4.1

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       java 1.0
 
-github.setup    micronaut-projects micronaut-starter 2.4.0 v
+github.setup    micronaut-projects micronaut-starter 2.4.1 v
 revision        0
 name            micronaut
 categories      java
@@ -53,9 +53,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  7f567c87f6e3d603db067871a69e9ad1979f17b0 \
-                sha256  7efcfaed7e5b489c52b49a8eda895d95142162002f246f8caf430c1bd1b50dfa \
-                size    19971491
+checksums       rmd160  646b7acd1b77f6a43d76068e9f1a9221f1f10911 \
+                sha256  84d45fc27e61187194b06ce719a2748c83018f50d62b9730c11ed0e85dbf581c \
+                size    20047321
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 2.4.1.

###### Tested on

macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?