### PR TITLE
spring-boot-cli: update to 2.4.4

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            spring-boot-cli
-version         2.4.2
+version         2.4.4
 revision        0
 
 categories      java
@@ -30,9 +30,9 @@ master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/
 
 distname        ${name}-${version}-bin
 
-checksums       rmd160  d205503baaa0f8e298ae77e3597d0d3bfe7d8435 \
-                sha256  20317394ea38bba16385d1ed8e02eda73ae4dc88a1d5e2cb99798f6f8a803229 \
-                size    11704632
+checksums       rmd160  443bd98cd6244d9dffc2c9f551db17904dc13266 \
+                sha256  d0b5e2293db691a706f5fed6547e0921362f0168d03e2707a104c814f1af3318 \
+                size    11702754
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
#### Description

Update to Spring Boot CLI 2.4.4.

###### Tested on

macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?