### PR TITLE
orcus: change to C++17 standard

### DIFF
--- a/devel/orcus/Portfile
+++ b/devel/orcus/Portfile
@@ -24,7 +24,8 @@ checksums           rmd160  8c18cf3459d8054dd36215db16c99720dcc55a3c \
                     size    7945943
 
 use_autoreconf      yes
-configure.cxxflags-append -std=c++14
+compiler.cxx_standard 2017
+configure.cxxflags-append -std=gnu++17
 configure.args      --disable-python \
                     --disable-static \
                     --disable-werror \


### PR DESCRIPTION
Based on the author's update
See https://gitlab.com/orcus/orcus/-/commit/1579c12111074a50f2307b8fa749a68749af11ba

Also see https://trac.macports.org/ticket/62484

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [x] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
