### PR TITLE
ncarg: add three missing dependencies

### DIFF
--- a/science/ncarg/Portfile
+++ b/science/ncarg/Portfile
@@ -11,7 +11,7 @@ compilers.allow_arguments_mismatch \
 
 name                        ncarg
 version                     6.6.2
-revision                    5
+revision                    6
 epoch                       1
 set version_no_dot [join [split ${version} "."] ""]
 categories                  science
@@ -57,16 +57,18 @@ depends_lib                 path:lib/pkgconfig/cairo.pc:cairo \
                             port:gdal       \
                             port:udunits2   \
                             port:vis5d      \
+                            port:hdf4       \
+                            port:hdf5       \
                             port:hdfeos     \
                             port:hdfeos5    \
+                            port:netcdf     \
                             port:wgrib2     \
                             port:curl       \
                             port:libpng     \
                             port:libxml2    \
                             port:gsl        \
                             port:xorg-libXaw
-depends_build               port:hdf5 \
-                            port:triangle \
+depends_build               port:triangle \
                             port:flex
 depends_run                 bin:ESMF_RegridWeightGen:esmf \
                             port:rangs-gshhs-ncarg


### PR DESCRIPTION
* HDF4 and Netcdf are direct library dependencies.
* HDF5 is a direct library dependency, not just a build dependency.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
