### PR TITLE
fix conflict between libshout & libshout2

### DIFF
--- a/audio/libshout/Portfile
+++ b/audio/libshout/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                libshout
 version             1.0.9
-revision            0
+revision            1
 checksums           rmd160  b2369212c732bff9565602a47a2a68f9fd4f6e98 \
                     sha256  191215b71ca6b5a6e999e91acd699dbbcdf53c5be1d928a25acb395d8442a426 \
                     size    169553
@@ -13,7 +13,6 @@ categories          audio net
 platforms           darwin
 license             GPL-2+
 maintainers         nomaintainer
-conflicts           libshout2
 
 description         Data and connectivity lib for the icecast server
 
@@ -38,6 +37,12 @@ patchfiles          apple-patches \
 # Fix implicit declaration of functions and fix build with ccache.
 use_autoreconf      yes
 
-configure.args      --enable-shared \
+configure.args-append \
+                    --enable-shared \
                     --enable-static \
+                    --includedir=${prefix}/include/shout1 \
+                    --libdir=${prefix}/lib/shout1 \
                     --with-pic
+
+# This is an old version, so disable livecheck
+livecheck.type      none

--- a/audio/libshout2/Portfile
+++ b/audio/libshout2/Portfile
@@ -14,7 +14,6 @@ categories      audio net
 license         LGPL
 platforms       darwin
 maintainers     nomaintainer
-conflicts       libshout
 
 description     Data and connectivity lib for the icecast server
 


### PR DESCRIPTION
#### Description

I have fixed the conflict between libshout and libshout2 marked by @ryandesign in 3b4af07 by adjusting the configure arguments passed to libshout. This means that libshout now installs into different directories, but as no ports depend upon it, that ought to be okay. I also disabled the livecheck for libshout while I was at it.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.2.2 20D80
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`? (Note that `port -v lint --nitpick` suggests renaming the patchfiles, and while I've done that with my local version of the port, I didn't feel like including that in this pull request)
- [x] tried existing tests with `sudo port test`? (N/A)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files? (N/A; just libraries)

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
