### PR TITLE
py-astropy-healpix: update to 0.6

### DIFF
--- a/python/py-astropy-healpix/Portfile
+++ b/python/py-astropy-healpix/Portfile
@@ -4,19 +4,20 @@ PortSystem 1.0
 PortGroup python 1.0
 PortGroup github 1.0
 
-github.setup        astropy astropy-healpix 0.5 v
-name                py-${name}
+name                py-astropy-healpix
+version             0.6
+distname            astropy_healpix-${version}
 categories-append   science
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 license             BSD
 platforms           darwin
 maintainers         {aronnax @lpsinger} openmaintainer
 description         BSD-licensed HEALPix for Astropy
 long_description    ${description}
 
-checksums           rmd160  cda3daa9fc0140c9540a7e69eba8e8be918a4ee1 \
-                    sha256  74a7034aef93dcfb3788f55681be0bf67f0c3c6e774b642285de95a86ef2dce7 \
-                    size    109762
+checksums           rmd160  4812dc4877abe809543f25a94c1b8694bfbcbf78 \
+                    sha256  409a6621c383641456c074f0f0350a24a4a58e910eaeef14e9bbce3e00ad6690 \
+                    size    104224
 
 if {${name} ne ${subport}} {
     if {${python.version} <= 35} {
@@ -25,20 +26,22 @@ if {${name} ne ${subport}} {
         checksums   rmd160  c1fd460298029d8624908bc8bcf0a793afaa158b \
                     sha256  69ef64ce4a88539b04fef918eaf5a8f41b3e5b36acb9022bd92df5154b060cc3 \
                     size    113042
-    }
 
-    # By default, astropy downloads an astropy-helpers package for setup.py.
-    # The --offline and --no-git flags prevent this and use a bundled version.
-    build.cmd  ${python.bin} setup.py --no-user-cfg --use-system-astropy-helpers
-    destroot.cmd  ${python.bin} setup.py --no-user-cfg --use-system-astropy-helpers
+        depends_build-append \
+                    port:py${python.version}-astropy-helpers \
+                    port:py${python.version}-setuptools
+
+        # By default, astropy downloads an astropy-helpers package for setup.py.
+        # The --offline and --no-git flags prevent this and use a bundled version.
+        build.cmd  ${python.bin} setup.py --no-user-cfg --use-system-astropy-helpers
+        destroot.cmd  ${python.bin} setup.py --no-user-cfg --use-system-astropy-helpers
+    } else {
+        depends_build-append port:py${python.version}-extension-helpers
+    }
 
     depends_lib-append \
                     port:py${python.version}-astropy \
                     port:py${python.version}-numpy
-
-    depends_build-append \
-                    port:py${python.version}-astropy-helpers \
-                    port:py${python.version}-setuptools
 
     livecheck.type  none
 }


### PR DESCRIPTION
#### Description

Update py-astropy-healpix to version 0.6.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.4 12D4e
