### PR TITLE
udunits2: retroactive license update

### DIFF
--- a/science/udunits2/Portfile
+++ b/science/udunits2/Portfile
@@ -6,9 +6,10 @@ PortGroup           cmake 1.0
 
 github.setup        Unidata UDUNITS-2 2.2.27.27 v
 github.tarball_from archive
+revision            1
 name                udunits2
 maintainers         {takeshi @tenomoto}
-license             UCAR-Unidata
+license             Apache-2.0
 platforms           darwin
 categories          science
 


### PR DESCRIPTION
* Update udunits2 port license from private, to OSI-approved Apache-2.0.
* Update retroactively for current and upcoming Macports versions.
* Purpose:  Make udunits2 and dependents binary distributable.

Upstream already changed their license two months ago to Apache-2.0:
https://github.com/Unidata/UDUNITS-2/commit/c790c5bbe23c2cb2b4c56671a4570cabf439c06c
https://github.com/Unidata/UDUNITS-2/issues/102

However, the updated package version 2.3.0 is not released, and there is no time table for release.  Macports binaries of udunits2 and dependents, such as ncarg/NCL, are currently blocked for public distribution.

I would like to accelerate distributability for both current 2.2.27.27 and upcoming 2.2.28 versions.  Therefore I propose this retroactive license update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
NOT TESTED.  PORTFILE ADMINISTRATIVE CHANGE ONLY.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
