### PR TITLE
esmf: fix spelling of SPDX license identifier

### DIFF
--- a/science/esmf/Portfile
+++ b/science/esmf/Portfile
@@ -13,10 +13,10 @@ mpi.setup
 mpi.enforce_variant netcdf-fortran
 
 github.setup        esmf-org esmf 8_0_1 ESMF_
-revision            2
+revision            3
 categories          science devel
 platforms           darwin
-license             UoI-NCSA
+license             NCSA
 maintainers         {takeshi @tenomoto}
 description         software for building and coupling weather, climate, and related models
 long_description    The ESMF defines an architecture for composing complex, coupled \
@@ -72,7 +72,6 @@ if {[variant_isset gcc47] || [variant_isset gcc48] || [variant_isset gcc49] || [
 
 build.target        lib
 pre-build {
-    if {[vercmp [macports_version] 2.5.99] >= 0} {
     build.env       ESMF_DIR=${worksrcpath} \
                     ESMF_F90=${configure.f90} \
                     ESMF_F90COMPILEOPTS=${configure.f90flags} \
@@ -85,20 +84,6 @@ pre-build {
                     ESMF_XERCES_INCLUDE=${prefix}/include \
                     ESMF_XERCESF_LIBPATH=${prefix}/lib \
                     ESMF_XERCES_LIBS=-lxerces-c
-    } else {
-    build.env       ESMF_DIR=${worksrcpath} \
-                    ESMF_F90=${configure.f90} \
-                    ESMF_F90COMPILEOPTS="${configure.f90flags}" \
-                    ESMF_CXX=${configure.cxx} \
-                    ESMF_CXXCOMPILEOPTS="${configure.cxxflags}" \
-                    ESMF_NETCDF=split \
-                    ESMF_NETCDF_INCLUDE=${prefix}/include \
-                    ESMF_NETCDF_LIBPATH=${prefix}/lib \
-                    ESMF_XERCES=standard \
-                    ESMF_XERCES_INCLUDE=${prefix}/include \
-                    ESMF_XERCESF_LIBPATH=${prefix}/lib \
-                    ESMF_XERCES_LIBS=-lxerces-c
-    }
     if {[variant_isset accelerate]} {
         build.env-append    ESMF_LAPACK=system \
                             ESMF_LAPACK_LIBS=-lvecLibFort
@@ -124,7 +109,6 @@ pre-build {
     }
 }
 pre-destroot {
-    if {[vercmp [macports_version] 2.5.99] >= 0} {
     destroot.env    ESMF_DIR=${worksrcpath} \
                     ESMF_F90=${configure.f90} \
                     ESMF_F90COMPILEOPTS=${configure.f90flags} \
@@ -145,28 +129,6 @@ pre-destroot {
                     ESMF_INSTALL_LIBDIR=${destroot}${prefix}/lib \
                     ESMF_INSTALL_BINDIR=${destroot}${prefix}/bin \
                     ESMF_INSTALL_DOCDIR=${destroot}${prefix}/share/doc/${name}
-    } else {
-    destroot.env    ESMF_DIR=${worksrcpath} \
-                    ESMF_F90=${configure.f90} \
-                    ESMF_F90COMPILEOPTS="${configure.f90flags}" \
-                    ESMF_F90LINKOPTS="-L${worksrcpath}/lib ${configure.ldflags}" \
-                    ESMF_CXX=${configure.cxx} \
-                    ESMF_CXXCOMPILEOPTS="${configure.cxxflags}" \
-                    ESMF_CXXLINKOPTS="-L${worksrcpath}/lib ${configure.ldflags}" \
-                    ESMF_NETCDF=split \
-                    ESMF_NETCDF_INCLUDE=${prefix}/include \
-                    ESMF_NETCDF_LIBPATH=${prefix}/lib \
-                    ESMF_XERCES=standard \
-                    ESMF_XERCES_INCLUDE=${prefix}/include \
-                    ESMF_XERCESF_LIBPATH=${prefix}/lib \
-                    ESMF_XERCES_LIBS=-lxerces-c \
-                    ESMF_INSTALL_PREFIX=${destroot}${prefix} \
-                    ESMF_INSTALL_HEADERDIR=${destroot}${prefix}/include/${name} \
-                    ESMF_INSTALL_MODDIR=${destroot}${prefix}/include/${name} \
-                    ESMF_INSTALL_LIBDIR=${destroot}${prefix}/lib \
-                    ESMF_INSTALL_BINDIR=${destroot}${prefix}/bin \
-                    ESMF_INSTALL_DOCDIR=${destroot}${prefix}/share/doc/${name}
-    }
     if {[variant_isset accelerate]} {
         destroot.env-append ESMF_LAPACK=system \
                             ESMF_LAPACK_LIBS=-lvecLibFort


### PR DESCRIPTION
* Use the correct SPDX spelling of license identifier.
* Unblocks binary distributability for ESMF and dependents.

ESMF uses the University of Illinois-NCSA License.  Use the correct identifier from the SPDX license list, so that Macports will make the proper distribution choice.
https://spdx.org/licenses/

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

NOT TESTED.  PORTFILE ADMINISTRATIVE CHANGE ONLY.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->