### PR TITLE
py-mecab: Update to version 0.996.2, Add Python 37 38 39, Remove Python 27

### DIFF
--- a/python/py-mecab/Portfile
+++ b/python/py-mecab/Portfile
@@ -4,38 +4,30 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-mecab
-version             0.996
-python.versions     27
+version             0.996.2
 categories-append   textproc japanese
 maintainers         nomaintainer
-
-description         a Python module for MeCab
-long_description    ${description}
-
-master_sites        macports_distfiles:mecab
-checksums           rmd160  c46ee001b058fa84cff4694f25369dc5d46995a4 \
-                    sha256  d305c30af9e781e70f7619a0b444ac1101f2faaf3922415a0d6c49da85a63511
-
-homepage            http://taku910.github.io/mecab/
-platforms           darwin
 license             {GPL LGPL BSD}
+platforms           darwin
 
-distname            mecab-python-${version}
-dist_subdir         mecab
+description         A Python module for MeCab
+long_description    {*}${description}
+
+checksums           rmd160  2ab0878c8ebbe11ddce9946e025130ba9fffa551 \
+                    sha256  ec8e46e4930e091c25f9f2dc740543bfc483482917dc1340fd914a9344de5b10 \
+                    size    62484
+
+homepage            https://github.com/ikegami-yukino/mecab/tree/master/mecab/python
+
+python.versions     37 38 39
 
 if {${name} ne ${subport}} {
-    depends_lib-append  path:bin/mecab-config:mecab-utf8
+    depends_build-append \
+                    port:py${python.version}-setuptools
 
-    post-patch {
-        reinplace "s|#!/usr/bin/python|#!${python.bin}|" \
-            ${worksrcpath}/test.py
-    }
+    depends_lib-append \
+                    path:bin/mecab-config:mecab-utf8
 
-    post-destroot {
-        set exdir ${destroot}${prefix}/share/doc/${subport}/examples
-        xinstall -m 755 -d ${exdir}
-        xinstall -m 755 ${worksrcpath}/test.py ${exdir}
-    }
+    livecheck.type  none
 }
 
-livecheck.type      none


### PR DESCRIPTION
py-mecab: Update to version 0.996.2, Add Python 37 38 39, Remove Python 27

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
