### PR TITLE
http-prompt: update to version 2.1.0

### DIFF
--- a/net/http-prompt/Portfile
+++ b/net/http-prompt/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        eliangcs http-prompt 1.0.0 v
-revision            2
+github.setup        eliangcs http-prompt 2.1.0 v
+revision            0
 
 maintainers         {lbschenkel @lbschenkel}
 categories          net
@@ -15,24 +15,22 @@ long_description    ${description}
 platforms           darwin
 license             MIT
 
-checksums           rmd160  14fcbea963f715df4edaedc5d2fbbb26ab15f617 \
-                    sha256  63e25c04e30ae419f5353df229825633d4f6222a39f0406a5893bd306359cdd0 \
-                    size    323848
+checksums           rmd160  a946f0baa01a21d2374605128738593ce6e0c0ef \
+                    sha256  cc360fdfce570f908f34bdfff5f9049c717c1b5d716af5b49c9e19a375063270 \
+                    size    323308
 
 patchfiles          patch-cli.py.diff \
                     patch-utils.py.diff \
+                    patch-test_interaction.py.diff \
                     patch-requirements.txt.diff
 
 # It MUST match default_version of httpie
-python.default_version 37
+python.default_version 38
 
 depends_lib-append  port:py${python.version}-click \
                     port:py${python.version}-parsimonious \
                     port:py${python.version}-prompt_toolkit \
                     port:py${python.version}-pygments \
-                    port:py${python.version}-requests \
-                    port:py${python.version}-setuptools \
-                    port:py${python.version}-six \
                     port:httpie
 
 python.link_binaries_suffix
@@ -40,7 +38,10 @@ python.link_binaries_suffix
 depends_test-append port:py${python.version}-mock \
                     port:py${python.version}-pexpect \
                     port:py${python.version}-pytest \
-                    port:py${python.version}-pytest-cov
+                    port:py${python.version}-pytest-cov \
+                    port:py${python.version}-twine \
+                    port:py${python.version}-wheel
+
 test.run            yes
 test.cmd            py.test-${python.branch}
 test.target

--- a/net/http-prompt/files/patch-cli.py.diff
+++ b/net/http-prompt/files/patch-cli.py.diff
@@ -1,7 +1,7 @@
---- http_prompt/cli.py.orig	2019-03-11 10:35:47.000000000 -0400
-+++ http_prompt/cli.py	2019-03-11 10:36:10.000000000 -0400
-@@ -9,11 +9,11 @@
- 
+--- http_prompt/cli.py.orig 2021-03-05 17:17:16.000000000 +0300
++++ http_prompt/cli.py  2021-03-21 17:36:10.000000000 +0300
+@@ -13,11 +13,11 @@
+
  from httpie.plugins import FormatterPlugin  # noqa, avoid cyclic import
  from httpie.output.formatters.colors import Solarized256Style
 -from prompt_toolkit import prompt, AbortAction
@@ -14,56 +14,17 @@
 +from prompt_toolkit.styles.pygments import style_from_pygments_cls
  from pygments.styles import get_style_by_name
  from pygments.util import ClassNotFound
- from six.moves.http_cookies import SimpleCookie
-@@ -48,7 +48,7 @@
-     cookie = SimpleCookie(base_value)
-     for k, v in cookies.items():
-         cookie[k] = v
--    return str(cookie.output(header='', sep=';').lstrip())
-+    return cookie.output(header='', sep=';').lstrip()
- 
- 
- class ExecutionListener(object):
-@@ -89,7 +89,7 @@
-               callback=normalize_url)
- @click.option('--env', help="Environment file to preload.",
-               type=click.Path(exists=True))
--@click.argument('url', default='')
-+@click.argument('url', default='http://localhost:8000')
- @click.argument('http_options', nargs=-1, type=click.UNPROCESSED)
- @click.version_option(message='%(version)s')
- def cli(spec, env, url, http_options):
-@@ -119,8 +119,7 @@
-         finally:
-             f.close()
- 
--    if url:
--        url = fix_incomplete_url(url)
-+    url = fix_incomplete_url(url)
-     context = Context(url, spec=spec)
- 
-     output_style = cfg.get('output_style')
-@@ -135,7 +134,7 @@
+
+@@ -140,7 +140,7 @@
          style_class = get_style_by_name(cfg['command_style'])
      except ClassNotFound:
          style_class = Solarized256Style
 -    style = style_from_pygments(style_class)
 +    style = style_from_pygments_cls(style_class)
- 
+
      listener = ExecutionListener(cfg)
- 
-@@ -145,8 +144,8 @@
-     else:
-         if env:
-             load_context(context, env)
--            if url:
--                # Overwrite the env url if not default
-+            if url != 'http://localhost:8000':
-+                # overwrite the env url if not default
-                 context.url = url
- 
-         if http_options:
-@@ -159,7 +158,9 @@
+
+@@ -164,7 +164,9 @@
              text = prompt('%s> ' % context.url, completer=completer,
                            lexer=lexer, style=style, history=history,
                            auto_suggest=AutoSuggestFromHistory(),

--- a/net/http-prompt/files/patch-test_interaction.py.diff
+++ b/net/http-prompt/files/patch-test_interaction.py.diff
@@ -1,0 +1,11 @@
+--- tests/test_interaction.py.orig	2021-03-05 17:17:16.000000000 +0300
++++ tests/test_interaction.py	2021-03-21 18:21:07.000000000 +0300
+@@ -60,7 +60,7 @@
+         bin_path = get_http_prompt_path()
+         child = pexpect.spawn(bin_path, env=os.environ)
+
+-        child.expect_exact('http://localhost:8000> ')
++        child.expect_exact('http://localhost:8000>')
+
+         # Enter 'htpie', switch to command mode (ESC),
+         # move two chars left (hh), and insert (i) a 't'

--- a/net/http-prompt/files/patch-utils.py.diff
+++ b/net/http-prompt/files/patch-utils.py.diff
@@ -1,11 +1,11 @@
---- http_prompt/utils.py.orig	2019-03-11 10:36:49.000000000 -0400
-+++ http_prompt/utils.py	2019-03-11 10:36:38.000000000 -0400
-@@ -3,7 +3,7 @@
- import math
+--- http_prompt/utils.py.orig	2021-03-05 17:17:16.000000000 +0300
++++ http_prompt/utils.py	2021-03-21 17:28:35.000000000 +0300
+@@ -4,7 +4,7 @@
  import re
- 
+ import shlex
+
 -from prompt_toolkit.shortcuts import create_output
 +from prompt_toolkit.output.defaults import create_output
- from six.moves import range
- 
- 
+
+
+ RE_ANSI_ESCAPE = re.compile(r'\x1b[^m]*m')


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
