### PR TITLE
esmf: fix license identifier

### DIFF
--- a/science/esmf/Portfile
+++ b/science/esmf/Portfile
@@ -13,7 +13,7 @@ mpi.setup
 mpi.enforce_variant netcdf-fortran
 
 github.setup        esmf-org esmf 8_0_1 ESMF_
-revision            3
+revision            2
 categories          science devel
 platforms           darwin
 license             NCSA

--- a/science/esmf/Portfile
+++ b/science/esmf/Portfile
@@ -13,10 +13,10 @@ mpi.setup
 mpi.enforce_variant netcdf-fortran
 
 github.setup        esmf-org esmf 8_0_1 ESMF_
-revision            2
+revision            3
 categories          science devel
 platforms           darwin
-license             UoI-NCSA
+license             NCSA
 maintainers         {takeshi @tenomoto}
 description         software for building and coupling weather, climate, and related models
 long_description    The ESMF defines an architecture for composing complex, coupled \


### PR DESCRIPTION
* Use official SPDX spelling of license identifier.
* Unblocks binary distributability for ESMF and dependents.

ESMF uses the University of Illinois-NCSA License.  Use the correct identifier from the SPDX license list, so that Macports will make the proper distribution choice.
https://spdx.org/licenses/

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

NOT TESTED.  PORTFILE ADMINISTRATIVE CHANGE ONLY.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->