### PR TITLE
newsboat: update to 2.23

### DIFF
--- a/net/newsboat/Portfile
+++ b/net/newsboat/Portfile
@@ -5,12 +5,13 @@ PortGroup           cargo_fetch 1.0
 PortGroup           github      1.0
 PortGroup           makefile    1.0
 
-github.setup        newsboat newsboat 2.22.1 r
+github.setup        newsboat newsboat 2.23 r
 revision            0
 
 homepage            https://newsboat.org
 
-description         a fork of Newsbeuter, an RSS/Atom feed reader for the text console
+description         a fork of Newsbeuter, an RSS/Atom feed reader for the \
+                    text console
 
 long_description    Newsboat is ${description}. The only difference is that \
                     Newsboat is actively maintained while Newsbeuter isn't.
@@ -24,13 +25,16 @@ maintainers         {en.sent.com:macports @Raimondi} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  49d0e660d156f65f3b258fac6fac69880909e051 \
-                    sha256  0448e8bdfa0d04fe7af001e3415a5768bb8e709cd4d57bfc75f9e54b9a9b6542 \
-                    size    1106776 \
+                    rmd160  ab4bb59a1932420c6311ba1d4fa2ca8022e72257 \
+                    sha256  5d7d759c47f357ab4663af7f1a1ae83e92120a17a3724460180cd5fc4c4edd44 \
+                    size    1131758 \
 
 github.tarball_from         archive
 
 compiler.cxx_standard       2011
+
+patchfiles                  patch-config-sh-ncurses.diff \
+                            patch-libiconv.diff
 
 configure.cmd               ./config.sh
 
@@ -78,93 +82,99 @@ variant tests description {Enable tests} {
 }
 
 cargo.crates \
-    addr2line                       0.13.0  1b6a2d3371669ab3ca9797670853d61402b03d0b4b9ebf33d677dfa720203072 \
+    addr2line                       0.14.0  7c0929d69e78dd9bf5408269919fcbcaeb2e35e5d43e5815517cdc6a8e11a423 \
     adler                            0.2.3  ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e \
-    aho-corasick                    0.7.13  043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86 \
-    arrayvec                         0.5.1  cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8 \
+    aho-corasick                    0.7.15  7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5 \
+    arrayvec                         0.5.2  23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b \
     autocfg                          1.0.1  cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a \
-    backtrace                       0.3.50  46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293 \
+    backtrace                       0.3.55  ef5140344c85b01f9bbb4d4b7288a8aa4b3287ccef913a14bcc78a1063623598 \
     bit-set                          0.5.2  6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de \
-    bit-vec                          0.6.2  5f0dc55f2d8a1a85650ac47858bb001b4c0dd73d79e3c455a842925e68d29cd3 \
+    bit-vec                          0.6.3  349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb \
     bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
     bitvec                          0.19.4  a7ba35e9565969edb811639dbebfe34edc0368e472c5018474c8eb2543397f81 \
     block                            0.1.6  0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a \
     byteorder                        1.3.4  08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de \
-    cc                              1.0.60  ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c \
+    cc                              1.0.66  4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48 \
     cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
+    cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     chrono                          0.4.19  670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73 \
     clap                            2.33.3  37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002 \
     codespan-reporting               0.9.5  6e0762455306b1ed42bc651ef6a2197aabda5e1d4a43c34d5eab5c1a3634e81d \
-    curl-sys            0.4.39+curl-7.74.0  07a8ce861e7b68a0b394e814d7ee9f1b2750ff8bd10372c6ad3bacc10e86f874 \
+    curl-sys            0.4.41+curl-7.75.0  0ec466abd277c7cab2905948f3e94d10bc4963f1f5d47921c1cc4ffd2028fe65 \
     cxx                             0.5.10  ebdd48b6a265557715bbbd72e891c6d26fe0cc58d87a881892a54ae47e0a92aa \
     cxx-build                       0.5.10  42dca43e7e9d853737dc10c2fd8f9d2daaa2ccd1c37b96056e1c492ab34a2004 \
     cxxbridge-flags                 0.5.10  1348c4c636b17ce60fc700963326ff65b19f0e9ee151bcf0a36a165d50d5dc49 \
     cxxbridge-macro                 0.5.10  59f75aad3925fade3d141007be05e9e272cf7cf7bbd089d9bb0d2d5621dbb016 \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
     form_urlencoded                  1.0.0  ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00 \
-    funty                            1.0.1  0ba62103ce691c2fd80fbae2213dfdda9ce60804973ac6b6e97de818ea7f52c8 \
+    funty                            1.1.0  fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7 \
     getrandom                       0.1.15  fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6 \
-    gettext-rs                       0.5.0  1b95fa19cca70adf9888150e979839ae9bd58f85a1a42e4753699112875189e1 \
-    gettext-sys                     0.19.9  e034c4ba5bb796730a6cc5eb0d654c16885006a7c3d6c6603581ed809434f153 \
-    gimli                           0.22.0  aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724 \
+    getrandom                        0.2.0  ee8025cf36f917e6a52cce185b7c7177689b838b7ec138364e50cc2277a56cf4 \
+    gettext-rs                       0.6.0  3df4e7a9dc238dddd30f183d43e4f497990885daa211fcf01657159ade8f1610 \
+    gettext-sys                     0.21.0  885d118016f633f99f741afe6c1433c040813a3cbc755cbfdf85f963e02fad80 \
+    gimli                           0.23.0  f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce \
     idna                             0.2.0  02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9 \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
-    lexical-core                     0.7.4  db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616 \
-    libc                            0.2.81  1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb \
+    lexical-core                     0.7.5  21f866863575d0e1d654fbeeabdc927292fdf862873dc3c96c6f753357e13374 \
+    libc                            0.2.90  ba4aede83fc3617411dc6993bc8c70919750c1c257c6ca6a502aed6e0e2394ae \
     libz-sys                         1.1.2  602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655 \
     link-cplusplus                   1.0.4  f96aa785c87218ec773df6c510af203872b34e2df2cf47d6e908e5f36231e354 \
     locale_config                    0.3.0  08d2c35b16f4483f6c26f0e4e9550717a2f6575bcd6f12a53ff0c490a94a6934 \
     malloc_buf                       0.0.6  62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb \
     matches                          0.1.8  7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
-    memchr                           2.3.3  3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400 \
-    miniz_oxide                      0.4.2  c60c0dfe32c10b43a144bad8fc83538c52f58302c92300ea7ec7bf7b38d5a7b9 \
+    memchr                           2.3.4  0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525 \
+    miniz_oxide                      0.4.3  0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d \
     natord                           1.0.9  308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c \
-    nom                              6.0.1  88034cfd6b4a0d54dd14f4a507eceee36c0b70e5a02236c4e4df571102be17f0 \
-    num-integer                     0.1.43  8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b \
-    num-traits                      0.2.12  ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611 \
+    nom                              6.1.2  e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2 \
+    num-integer                     0.1.44  d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db \
+    num-traits                      0.2.14  9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290 \
     objc                             0.2.7  915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1 \
     objc-foundation                  0.1.1  1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9 \
     objc_id                          0.1.1  c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b \
-    object                          0.20.0  1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5 \
-    once_cell                        1.5.2  13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0 \
-    openssl-sys                     0.9.58  a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de \
+    object                          0.22.0  8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397 \
+    once_cell                        1.7.2  af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3 \
     percent-encoding                 2.1.0  d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
-    pkg-config                      0.3.18  d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33 \
-    ppv-lite86                       0.2.9  c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20 \
+    pkg-config                      0.3.19  3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c \
+    ppv-lite86                      0.2.10  ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857 \
     proc-macro2                     1.0.24  1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71 \
     proptest                        0.10.1  12e6c80c1139113c28ee4670dc50cc42915228b51f56a9e407f0ec60f966646f \
     quick-error                      1.2.3  a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0 \
-    quote                            1.0.7  aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37 \
+    quote                            1.0.8  991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df \
     radium                           0.5.3  941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8 \
     rand                             0.7.3  6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
+    rand                             0.8.3  0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e \
     rand_chacha                      0.2.2  f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402 \
+    rand_chacha                      0.3.0  e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d \
     rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
+    rand_core                        0.6.2  34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7 \
     rand_hc                          0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
+    rand_hc                          0.3.0  3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73 \
     rand_xorshift                    0.2.0  77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8 \
-    redox_syscall                   0.1.57  41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce \
-    regex                            1.3.9  9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6 \
-    regex-syntax                    0.6.18  26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8 \
+    redox_syscall                    0.2.4  05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570 \
+    regex                            1.4.2  38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c \
+    regex-syntax                    0.6.21  3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189 \
     remove_dir_all                   0.5.3  3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7 \
-    rustc-demangle                  0.1.16  4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783 \
+    rustc-demangle                  0.1.18  6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232 \
     rusty-fork                       0.3.0  cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f \
     ryu                              1.0.5  71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e \
     scratch                          1.0.0  7e114536316b51a5aa7a0e59fc49661fd263c5507dd08bd28de052e57626ce69 \
-    section_testing                  0.0.4  ece4d7d98fdab75ddff5c4fad54a4c7ad0222a13c8a3c6859f1037a1d9e53f28 \
+    section_testing                  0.0.5  5fd2493b68af689f4863060b240cbdffb350cee9ed69e2c50f8d71a62ca2aea1 \
     static_assertions                1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
-    syn                             1.0.48  cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac \
+    syn                             1.0.55  a571a711dddd09019ccc628e1b17fe87c59b09d513c06c026877aa708334f37a \
     tap                              1.0.0  36474e732d1affd3a6ed582781b3683df3d0563714c59c39591e8ff707cf078e \
-    tempfile                         3.1.0  7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9 \
-    termcolor                        1.1.0  bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f \
+    tempfile                         3.2.0  dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22 \
+    termcolor                        1.1.2  2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4 \
     textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
     thread_local                     1.0.1  d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14 \
     time                            0.1.44  6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255 \
-    tinyvec                          0.3.4  238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117 \
+    tinyvec                          1.1.0  ccf8dbc19eb42fba10e8feaaec282fb50e2c14b2726d6301dbfeed0f73306a6f \
+    tinyvec_macros                   0.1.0  cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c \
     unicode-bidi                     0.3.4  49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5 \
-    unicode-normalization           0.1.13  6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977 \
+    unicode-normalization           0.1.16  a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606 \
     unicode-width                    0.1.8  9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3 \
     unicode-xid                      0.2.1  f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564 \
-    url                              2.2.0  5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e \
-    vcpkg                           0.2.10  6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c \
+    url                              2.2.1  9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b \
+    vcpkg                           0.2.11  b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb \
     version_check                    0.9.2  b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed \
     wait-timeout                     0.2.0  9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6 \
     wasi      0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \

--- a/net/newsboat/files/patch-config-sh-ncurses.diff
+++ b/net/newsboat/files/patch-config-sh-ncurses.diff
@@ -1,0 +1,14 @@
+--- config.sh	2021-03-22 07:05:13.000000000 -0400
++++ config.sh	2021-03-22 07:06:15.000000000 -0400
+@@ -101,10 +101,10 @@
+ check_pkg "libcurl" || check_custom "libcurl" "curl-config" || fail "libcurl"
+ check_pkg "libxml-2.0" || check_custom "libxml2" "xml2-config" || fail "libxml2"
+ check_pkg "stfl" || fail "stfl"
++check_pkg "ncurses" || fail "ncurses"
+ ( check_pkg "json" "" 0.11 || check_pkg "json-c" "" 0.11 ) || fail "json-c"
+ 
+ if [ `uname -s` = "Darwin" ]; then
+-	check_custom "ncurses5.4" "ncurses5.4-config" || fail "ncurses5.4"
+     # rand crate needs Security framework, and rustc doesn't (can't) link it
+     # into libnewsboat.a
+     echo 'LDFLAGS+=-framework Security' >> config.mk

--- a/net/newsboat/files/patch-libiconv.diff
+++ b/net/newsboat/files/patch-libiconv.diff
@@ -1,0 +1,26 @@
+--- rust/libnewsboat/src/utils.rs	2021-03-27 01:08:32.000000000 -0400
++++ rust/libnewsboat/src/utils.rs	2021-03-27 01:09:23.000000000 -0400
+@@ -891,11 +891,11 @@
+ 
+ // On FreeBSD, link with GNU libiconv; the iconv implementation in libc doesn't support //TRANSLIT
+ // and WCHAR_T. This is also why we change the symbol names from "iconv" to "libiconv" below.
+-#[cfg_attr(target_os = "freebsd", link(name = "iconv"))]
++#[cfg_attr(target_os = "macos", link(name = "iconv"))]
+ extern "C" {
+-    #[cfg_attr(target_os = "freebsd", link_name = "libiconv_open")]
++    #[cfg_attr(target_os = "macos", link_name = "libiconv_open")]
+     pub fn iconv_open(tocode: *const c_char, fromcode: *const c_char) -> iconv_t;
+-    #[cfg_attr(target_os = "freebsd", link_name = "libiconv")]
++    #[cfg_attr(target_os = "macos", link_name = "libiconv")]
+     pub fn iconv(
+         cd: iconv_t,
+         inbuf: *mut *mut c_char,
+@@ -903,7 +903,7 @@
+         outbuf: *mut *mut c_char,
+         outbytesleft: *mut size_t,
+     ) -> size_t;
+-    #[cfg_attr(target_os = "freebsd", link_name = "libiconv_close")]
++    #[cfg_attr(target_os = "macos", link_name = "libiconv_close")]
+     pub fn iconv_close(cd: iconv_t) -> c_int;
+ }
+ 


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
