### PR TITLE
leocad: new port

### DIFF
--- a/cad/leocad/Portfile
+++ b/cad/leocad/Portfile
@@ -1,0 +1,64 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github  1.0
+PortGroup               qmake5  1.0
+
+github.setup            leozide leocad 21.03 v
+revision                0
+
+homepage                https://leocad.org
+
+description             A CAD application for creating virtual LEGO models
+
+long_description        LeoCAD is a CAD program for creating virtual LEGO(R) \
+                        models. It is fully compatible with the LDraw \
+                        Standard and related tools, and it reads and writes \
+                        LDR and MPD files so that you can share and download \
+                        models from the Internet.
+                        
+categories              cad graphics
+license                 GPL-3
+platforms               darwin
+use_zip                 yes
+
+set ldraw_archive       complete.zip
+extract.only            ${distname}${extract.suffix}
+github.tarball_from     archive
+
+checksums               ${distname}${extract.suffix} \
+                            rmd160  51108082bed1c8654c52ef327c8d0ec5d3fdbf9e \
+                            sha256  35cc701dbc2cffaf560dad89bc1cc79133661bb1ac7c9eca95a55f470d5a9719 \
+                            size    2322979 \
+                        ${ldraw_archive} \
+                            rmd160  a23b0fa61a55d55a1807c5a0515af53b2b8354f8 \
+                            sha256  85cf747b5923f18a8d0f37d0cef647636d70ddfeda5de49ea019e7e440f9e4e0 \
+                            size    56680107
+
+maintainers             {gmail.com:herby.gillot @herbygillot} \
+                        openmaintainer
+
+master_sites-append     https://www.ldraw.org/library/updates/:ldraw
+distfiles-append        ${ldraw_archive}:ldraw
+dist_subdir             ${name}/${version}
+
+depends_lib-append      port:povray \
+                        port:zlib
+
+qt5.depends_build_component \
+                        qttools
+
+qt5.depends_component   qt3d
+
+configure.args-append   leocad.pro
+
+post-extract {
+    copy ${distpath}/${ldraw_archive} ${worksrcpath}/library.bin
+    ln -s ${prefix}/bin/povray ${worksrcpath}/povray
+}
+
+destroot {
+    move \
+        ${worksrcpath}/build/release/LeoCAD.app \
+        ${destroot}${applications_dir}/
+}


### PR DESCRIPTION
#### Description

New port for [LeoCAD](https://www.leocad.org), a CAD program allowing you to design virtual models using LEGO bricks.

![](https://www.leocad.org/towerbridge.png)

Known issues: rendering is broken due to compatibility issues with MacPorts' Pov-Ray.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
