### PR TITLE
taskwarrior-tui: new port

### DIFF
--- a/office/taskwarrior-tui/Portfile
+++ b/office/taskwarrior-tui/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo 1.0
+
+github.setup        kdheepak taskwarrior-tui 0.12.2 v
+revision            0
+
+description         A terminal user interface for taskwarrior
+
+long_description    {*}${description}
+
+categories          office
+platforms           darwin
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+license             MIT
+
+checksums           rmd160  e857bcf288d615904b30b20a067e18d86be6ff1d \
+                    sha256  00173e58cbd45132766cafbf8350a0e2ca3c5ff86a013b175ed2054250ccf8dd \
+                    size    43521
+
+build.pre_args      --release -v -j${build.jobs}
+
+depends_run-append  port:task
+
+destroot {
+    xinstall -m 755 \
+        ${worksrcpath}/target/[cargo.rust_platform]/release/${name} \
+        ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

New port for [taskwarrior-tui](https://github.com/kdheepak/taskwarrior-tui), a CLI UI for Taskwarrior

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
