### PR TITLE
openjdk15: obsolete OpenJDK 15 ports, replace by OpenJDK 16 equivalents

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -9,6 +9,7 @@ platforms        darwin
 license          GPL-2
 supported_archs  x86_64
 
+# Latest Long Term Support (LTS) major version
 version          11
 
 if {${subport} eq "openjdk"} {
@@ -249,60 +250,22 @@ subport openjdk14-openj9-large-heap {
     revision     1
 }
 
+# Remove after 2022-03-22
 subport openjdk15 {
     version      15.0.2
-    revision     0
-
-    set build    7
-
-    description  Open Java Development Kit 15 (AdoptOpenJDK) with HotSpot VM
-    long_description ${long_description_adoptopenjdk_hotspot}
-
-    master_sites https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-${version}%2B${build}/
-    distname     OpenJDK15U-jdk_x64_mac_hotspot_${version}_${build}
-    worksrcdir   jdk-${version}+${build}
-
-    checksums    rmd160  74950bb51052416c41fcc4e33db077919e504097 \
-                 sha256  d358a7ff03905282348c6c80562a4da2e04eb377b60ad2152be4c90f8d580b7f \
-                 size    195232978
+    revision     1
 }
 
+# Remove after 2022-03-22
 subport openjdk15-openj9 {
     version      15.0.2
-    revision     0
-
-    set build    7
-    set openj9_version 0.24.0
-
-    description  Open Java Development Kit 16 (AdoptOpenJDK) with Eclipse OpenJ9 VM
-    long_description ${long_description_adoptopenjdk_openj9}
-
-    master_sites https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
-    distname     OpenJDK15U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
-    worksrcdir   jdk-${version}+${build}
-
-    checksums    rmd160  76b4e46152ba4ddca1274b20eb75fd22fdb1b34e \
-                 sha256  1336ae5529af3a0e35ae569e4188944831aeed7080a482f2490fc619380cbe53 \
-                 size    195257737
+    revision     1
 }
 
+# Remove after 2022-03-22
 subport openjdk15-openj9-large-heap {
     version      15.0.2
-    revision     0
-
-    set build    7
-    set openj9_version 0.24.0
-
-    description  Open Java Development Kit 15 (AdoptOpenJDK) with Eclipse OpenJ9 VM for large heap sizes
-    long_description ${long_description_adoptopenjdk_openj9xl}
-
-    master_sites https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
-    distname     OpenJDK15U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
-    worksrcdir   jdk-${version}+${build}
-
-    checksums    rmd160  ed1021fa9c1e6960d5b2fcbb7317d1fa7a4844d0 \
-                 sha256  b9192784a877b2066c7f60eea9901f1181d19b3a39260bc04f1a33febbdb342d \
-                 size    195261675
+    revision     1
 }
 
 subport openjdk16 {
@@ -351,18 +314,14 @@ if {${os.platform} eq "darwin" && ${os.major} < 14} {
     }
 }
 
-if {${subport} in [list openjdk12 openjdk13 openjdk14]} {
+if {${subport} in [list openjdk12 openjdk13 openjdk14 openjdk15]} {
     PortGroup    obsolete 1.0
-    # Can replace with openjdk16 when it is added and openjdk15 is obsoleted
-    replaced_by  openjdk15
-} elseif {${subport} in [list openjdk12-openj9 openjdk13-openj9 openjdk14-openj9]} {
+    # Can replace with openjdk17 when it is added and openjdk16 is obsoleted
+    replaced_by  openjdk16
+} elseif {${subport} in [list openjdk12-openj9 openjdk12-openj9-large-heap openjdk13-openj9 openjdk13-openj9-large-heap openjdk14-openj9 openjdk14-openj9-large-heap openjdk15-openj9 openjdk15-openj9-large-heap]} {
     PortGroup    obsolete 1.0
-    # Can replace with openjdk16-openj9 when it is added and openjdk15-openj9 is obsoleted
-    replaced_by  openjdk15-openj9
-} elseif {${subport} in [list openjdk12-openj9-large-heap openjdk13-openj9-large-heap openjdk14-openj9-large-heap]} {
-    PortGroup    obsolete 1.0
-    # Can replace with openjdk16-openj9 when it is added and openjdk15-openj9-large-heap is obsoleted
-    replaced_by  openjdk15-openj9-large-heap
+    # Can replace with openjdk17-openj9 when it is added and openjdk16-openj9 is obsoleted
+    replaced_by  openjdk16-openj9
 }
 
 if {[string match *-graalvm ${subport}]} {


### PR DESCRIPTION
#### Description

Obsolete OpenJDK 15 ports, replace by OpenJDK 16 equivalents.

###### Tested on

macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?