### PR TITLE
go-1.4: attempt to add legacysupport for clock_gettime

### DIFF
--- a/lang/go-1.4/Portfile
+++ b/lang/go-1.4/Portfile
@@ -2,10 +2,12 @@
 
 PortSystem          1.0
 
+PortGroup           legacysupport 1.0
+
 name                go-1.4
 
 version             1.4.3
-revision            1
+revision            2
 categories          lang
 platforms           darwin
 license             BSD
@@ -29,7 +31,8 @@ distfiles           go${version}.src.tar.gz
 worksrcdir          go
 
 checksums           rmd160  b1fbb2805a777c8107e7c946f36a881303ac5e35 \
-                    sha256  9947fc705b0b841b5938c48b22dc33e9647ec0752bae66e50278df4f23f64959
+                    sha256  9947fc705b0b841b5938c48b22dc33e9647ec0752bae66e50278df4f23f64959 \
+                    size    10875170
 
 set GOROOT          ${worksrcpath}
 set GOROOT_FINAL    ${prefix}/lib/${name}
@@ -50,8 +53,13 @@ switch ${build_arch} {
 
 use_configure       no
 
-if {${os.platform} eq "darwin" && ${os.major} >= 16} {
-    patchfiles-append patch-src-runtime-sys_darwin_386-sierra-clock_gettime.diff
+if {${os.platform} eq "darwin"} {
+    if {${os.major} >= 16} {
+        patchfiles-append patch-src-runtime-sys_darwin_386-sierra-clock_gettime.diff
+    } else {
+        # clock_gettime
+        legacysupport.newest_darwin_requires_legacy 15
+    }
 }
 
 build.dir           ${worksrcpath}/src


### PR DESCRIPTION
See: https://trac.macports.org/ticket/62337

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
