### PR TITLE
igraph: update to 0.9.1

### DIFF
--- a/math/igraph/Portfile
+++ b/math/igraph/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        igraph igraph 0.9.0
+github.setup        igraph igraph 0.9.1
 revision            0
 github.tarball_from releases
 
@@ -22,9 +22,9 @@ depends_lib         port:arpack \
                     port:libxml2 \
                     port:SuiteSparse_CXSparse
 
-checksums           rmd160  297c06d217d6c6059b721ec0aa5d59e096004585 \
-                    sha256  012e5d5a50420420588c33ec114c6b3000ccde544db3f25c282c1931c462ad7a \
-                    size    3752584
+checksums           rmd160  3f35656783543e0fd4d9169ec05e00f8d7affe0f \
+                    sha256  1902810650e8f9d98feefa3eca735db5a879416d00a08f68aad2ca07964cee9f \
+                    size    3803713
 
 test.run            yes
 test.target         check
@@ -35,15 +35,14 @@ compiler.cxx_standard \
 # Build options for igraph:
 #  - Do not use ccache to build this port unless MacPorts tells it to.
 #  - Build a shared library.
-#  - Enable link-time optimization.
+#  - Enable link-time optimization when available.
 #  - Set features and the use of externaly libraries explicitly---do not leave this to auto-detection.
-#  - As of igraph 0.9, linking to GMP provides no tangible benefits, thus disable this.
+#  - As of igraph 0.9.1, linking to GMP provides no tangible benefits, thus disable this.
 #  - Use the vecLib BLAS/LAPACK.
-#  - Do not error on unknown diagnostic options, in order to support building with old clang versions.
 configure.args-append \
                     -DUSE_CCACHE=OFF \
                     -DBUILD_SHARED_LIBS=ON \
-                    -DIGRAPH_ENABLE_LTO=ON \
+                    -DIGRAPH_ENABLE_LTO=AUTO \
                     -DIGRAPH_GLPK_SUPPORT=ON \
                     -DIGRAPH_GRAPHML_SUPPORT=ON \
                     -DIGRAPH_USE_INTERNAL_ARPACK=OFF \
@@ -52,9 +51,7 @@ configure.args-append \
                     -DIGRAPH_USE_INTERNAL_GLPK=OFF \
                     -DIGRAPH_USE_INTERNAL_GMP=ON \
                     -DIGRAPH_USE_INTERNAL_LAPACK=OFF \
-                    -DBLA_VENDOR=Apple \
-                    -DCMAKE_C_FLAGS=-Wno-unknown-warning-option \
-                    -DCMAKE_CXX_FLAGS=-Wno-unknown-warning-option
+                    -DBLA_VENDOR=Apple
 
 post-destroot {
     set docdir ${prefix}/share/doc/${name}


### PR DESCRIPTION
 * update to 0.9.1
 * use link-time optimization only when available, to support older systems
 * remove obsolete workaround to ignore unknown compiler options

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G8022
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
