### PR TITLE
golang-1.0: use vendored modules

### DIFF
--- a/_resources/port1.0/group/golang-1.0.tcl
+++ b/_resources/port1.0/group/golang-1.0.tcl
@@ -273,7 +273,7 @@ proc handle_set_go_vendors {vendors_str} {
 # Support for additional hosts not conforming to this pattern will take some
 # work.
 post-extract {
-    if {${fetch.type} eq "standard"} {
+    if {${fetch.type} eq "standard" && ![file exists ${worksrcpath}]} {
         # Don't try to create the worksrcpath using go.{domain,author,project}
         # as the result will not be accurate when go.package has been
         # customized.

--- a/_resources/port1.0/group/golang-1.0.tcl
+++ b/_resources/port1.0/group/golang-1.0.tcl
@@ -307,7 +307,7 @@ pre-build {
     if {[file exists ${worksrcpath}/go.mod]} {
         # Generate modules.txt file
         system -W ${worksrcpath} "${go.bin} mod vendor"
-    } else {
+    } elseif {[file exists ${worksrcpath}/vendor]} {
         # If this is a non-module package, then just rename the 'vendor'
         # directory to $GOPATH/src and set the GOPATH environment variable
         file mkdir ${gopath}

--- a/devel/gopls/Portfile
+++ b/devel/gopls/Portfile
@@ -82,14 +82,14 @@ go.vendors          github.com/yuin/goldmark \
 
 post-extract {
     # Author uses custom host name for his packages
-    xinstall -d -m 755 ${gopath}/src/mvdan.cc/xurls
-    move ${gopath}/src/github.com/mvdan/xurls ${gopath}/src/mvdan.cc/xurls/v2
+    xinstall -d -m 755 ${worksrcpath}/vendor/mvdan.cc/xurls
+    move ${worksrcpath}/vendor/github.com/mvdan/xurls ${worksrcpath}/vendor/mvdan.cc/xurls/v2
 
-    xinstall -d -m 755 ${gopath}/src/mvdan.cc
-    move ${gopath}/src/github.com/mvdan/gofumpt ${gopath}/src/mvdan.cc
+    xinstall -d -m 755 ${worksrcpath}/vendor/mvdan.cc
+    move ${worksrcpath}/vendor/github.com/mvdan/gofumpt ${worksrcpath}/vendor/mvdan.cc
 
-    xinstall -d -m 755 ${gopath}/src/honnef.co/go
-    move ${gopath}/src/github.com/dominikh/go-tools ${gopath}/src/honnef.co/go/tools
+    xinstall -d -m 755 ${worksrcpath}/vendor/honnef.co/go
+    move ${worksrcpath}/vendor/github.com/dominikh/go-tools ${worksrcpath}/vendor/honnef.co/go/tools
 }
 
 build.dir           ${worksrcpath}/${name}

--- a/devel/kustomize/Portfile
+++ b/devel/kustomize/Portfile
@@ -37,11 +37,6 @@ build.args          -ldflags \" \
                         -X sigs.k8s.io/kustomize/api/provenance.buildDate=unknown \
                     \"
 
-# FIXME: This port currently can't be built without allowing go mod to fetch
-# dependencies during the build phase. See
-# https://trac.macports.org/ticket/61192
-build.env-delete    GOPROXY=off GO111MODULE=off
-
 destroot {
     xinstall -m 0755 ${build.dir}/${name} ${destroot}${prefix}/bin/
 }

--- a/devel/shfmt/Portfile
+++ b/devel/shfmt/Portfile
@@ -107,8 +107,8 @@ go.vendors          mvdan.cc/editorconfig \
                         sha256  648758575d338a1abcc7f3f3cbc9c138f079355d4defe709949ecd7e639c48a2 \
                         size    8407
 
+build.dir           ${worksrcpath}/cmd/shfmt
 build.pre_args      -ldflags '-X main.version=${version}'
-build.post_args     ${go.package}/cmd/shfmt
 
 depends_build-append  port:scdoc
 
@@ -117,7 +117,7 @@ post-build {
 }
 
 destroot {
-    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin
+    xinstall -m 0755 ${worksrcpath}/cmd/shfmt/${name} ${destroot}${prefix}/bin
     xinstall -m 0644 ${worksrcpath}/shfmt.1.gz ${destroot}${prefix}/share/man/man1
 }
 

--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -31,11 +31,6 @@ set go_ldflags      "-w -s \
     -X ${go.package}/cmd.date=unknown"
 build.args          -ldflags \"${go_ldflags}\" ${go.package}
 
-# FIXME: This port currently can't be built without allowing go mod to fetch
-# dependencies during the build phase. See
-# https://trac.macports.org/ticket/61192
-build.env-delete    GOPROXY=off GO111MODULE=off
-
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
 }


### PR DESCRIPTION
#### Description

This addresses https://trac.macports.org/ticket/61192 by putting vendored dependencies into the `vendor` directory during the extract phase, thus avoiding downloading dependencies during the build phase. However, this also has the added benefit of supporting Go modules (which are increasingly common).

If the package being installed contains a `go.mod` file then this will use the vendored dependencies under the `vendor` directory without downloading anything else; otherwise, the `vendor` directory is simply used as the `GOPATH`.

Some background: I was trying to update the caddy port (which is now quite out-of-date), but the mechanism that Caddy uses to insert version information into the binary is only possible using Go module mode. However, [#61992][1] disables Go's module mode across the board, forcing all Go ports to use the old GOPATH mode.

I think it is a good idea to have some path forward for migrating to module mode, as this is the direction the Go ecosystem is moving and not adapting will just add further maintenance burden to Go port maintainers.

This solution enables Go ports to utilize Go modules while still satisfying the requirements of [#61192][1].

I am new to the MacPorts community and I did my best to adhere to conventions and standards as well as I could, but undoubtedly there are likely ways that this PR can be improved and I am of course happy to accept any feedback.

I am also marking this as a Draft because, as written, this breaks some current Go ports (e.g. I know for sure that it breaks shfmt), but I don't think it is that difficult to fix those. Before going through and extensively testing and fixing existing Go ports, I wanted to solicit feedback from MacPorts maintainers on this idea in general.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] ~~checked your Portfile with `port lint`?~~ N/A
- [ ] ~~tried existing tests with `sudo port test`?~~ N/A
- [ ] ~~tried a full install with `sudo port -vst install`?~~ N/A
- [ ] ~~tested basic functionality of all binary files?~~ N/A

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

[1]: https://trac.macports.org/ticket/61192