### PR TITLE
josm: update to 17580

### DIFF
--- a/gis/JOSM/Portfile
+++ b/gis/JOSM/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                JOSM
-version             17560
+version             17580
 categories          gis editors java
 platforms           darwin
 license             GPL-2+
@@ -17,11 +17,11 @@ long_description    ${name} is a feature-rich editor for the \
 homepage            https://josm.openstreetmap.de
 
 master_sites        ${homepage}/download/macosx/
-distname            josm-macosx-${version}
+distname            josm-macos-${version}-java16
 
-checksums           rmd160  21d6b7d17e17b0b518e67df5f739d7a3c89a8b6c \
-                    sha256  e1c0d0ecbb43a67f102e0313e9fb5c78e92cf1cd514ad73c6a7f2f20248d199f \
-                    size    14860437
+checksums           rmd160  81c8dc133e63a4fc89d20f618c6412eca120118b \
+                    sha256  c18f7b4ba47d138bde1345ce2ebeb78481180ad47773f58d3a71fd5092c9132b \
+                    size    39682999
 
 extract.mkdir       yes
 


### PR DESCRIPTION
#### Description
https://josm.openstreetmap.de/wiki/Changelog#stable-release-21.02:

> First version 17560 was released as stable version and **due to major bug version 17580 was released as hotfix**.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
