### PR TITLE
wireguard-go: update to 0.0.20210323

### DIFF
--- a/net/wireguard-go/Portfile
+++ b/net/wireguard-go/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-go
-version             0.0.20210212
+version             0.0.20210323
 revision            0
-checksums           rmd160  0ed9ba97bf0386fedfa9b0185a923f89b4626b02 \
-                    sha256  a44dbf8e18fed0d24feb6cc5782d0e7c4dfd0ffe35401a3f5e66c1da2936fa31 \
-                    size    97548
+checksums           rmd160  b7937ac593f8636980c0a9a1fb83cbf61fe863f6 \
+                    sha256  88e864b28bbf4502bbef71c7a8483921f7888fdb09cff1dbc90e9551e1ab5e24 \
+                    size    105056
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
#### Description
wireguard-go: update to 0.0.20210323

###### Tested on
macOS 10.15.7 19H524
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
