### PR TITLE
mame: update to 0.229

### DIFF
--- a/emulators/mame/Portfile
+++ b/emulators/mame/Portfile
@@ -62,14 +62,14 @@ if {${g_mame_os_major} >= 18} {
 
 if {${g_mame_latest}} {
     set g_mame_release \
-                    "0227"
+                    "0229"
 
-    revision        2
+    revision        0
 
     checksums       \
-                    rmd160  862df6a449329fe5b16e6d46a030fe157c3a8eb3 \
-                    sha256  95dbce00a4f05a35f66ef966fe9efad1e4e78ce62e0eba3f7031dfa6737829a5 \
-                    size    195226157
+                    rmd160  785ca63ce613fe79d3b33e1178730c47fc96b93e \
+                    sha256  414921771ada0804a8c7f3540e33338e8495e16a3bca78a5a2b355abafa51e6a \
+                    size    195637912
 } else {
     set g_mame_release \
                     "0226"
@@ -344,12 +344,13 @@ if {[info exists mame.override.build.gmake.args]} {
 
 proc mame_arch_setup {p_arch_64} {
     global executable
+    global g_mame_latest
 
     # Architecture setup - 64-bit vs 32-bit
-    if {${p_arch_64}} {
-        set executable "mame64"
-    } else {
-        set executable "mame"
+    set executable "mame"
+    # Starting with release 0.229, executable no longer has suffix '64' for 64-bit build
+    if {${p_arch_64} && !${g_mame_latest}} {
+        set executable "${executable}64"
     }
 
     # Remember to append a 'd' suffix for debug builds


### PR DESCRIPTION
#### Description

Update Mame to 0.229.

Fixes: [mame: update to 0.229](https://trac.macports.org/ticket/62483)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
