### PR TITLE
p5-mail-spamassassin: Update to v3.4.5

### DIFF
--- a/perl/p5-mail-spamassassin/Portfile
+++ b/perl/p5-mail-spamassassin/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28 5.30
-perl5.setup         Mail-SpamAssassin 3.4.4
-revision            1
+perl5.setup         Mail-SpamAssassin 3.4.5
+revision            0
 categories-append   mail
 license             Apache-2
 platforms           darwin
@@ -19,9 +19,9 @@ long_description    SpamAssassin(tm) is a mail filter to identify spam. \
 
 homepage            https://spamassassin.apache.org/
 
-checksums           rmd160  414fdfcb544afd44f3e17dbced145f26fe827e2e\
-                    sha256  8ea27a165b81e3ce8c84ae85c3ecba1f2edfa04ef4a86f07fe28ab612fc8ff60\
-                    size    3274482
+checksums           rmd160 6c837a11e15dfdef1824adff6d608b29ffeceeca\
+                    sha256 a640842c5f3f468e3a21cbb9c555647306ec77807e57c5744ef0065e4a8675f6\
+                    size   6572220
 
 if {${perl5.major} != ""} {
     depends_lib-append \
@@ -43,7 +43,7 @@ if {${perl5.major} != ""} {
 # use Time::HiRes 1.9739+ for Sierra+ compatibility
 # use Time::HiRes 1.9751+ for most recent macOS fixes
 # https://metacpan.org/changes/distribution/Time-HiRes
-# perl 5.24.2 core version is 1.9733 
+# perl 5.24.2 core version is 1.9733
 # perl 5.26.1 core version is 1.9741
     depends_lib-append \
                     port:p${perl5.major}-time-hires
@@ -103,7 +103,7 @@ if {${perl5.major} != ""} {
     foreach file ${conf_files} {
         append conf_file_notes "cp ${file}.sample ${file}\n"
     }
-    
+
     notes "If you're running spamassassin for the first time, you should copy the\
 following configuration files and remove the .sample extension:\n\ncd\
 ${prefix}/etc/mail/spamassassin\n${conf_file_notes}"


### PR DESCRIPTION
p5-mail-spamassassin:

* Update to v3.4.5
* Fix for CVE-2020-1946

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [x] security fix

###### Tested on
macOS 10.14.6 18G8022
Xcode 11.0 11A420a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
