### PR TITLE
aws-iam-authenticator: new port

### DIFF
--- a/sysutils/aws-iam-authenticator/Portfile
+++ b/sysutils/aws-iam-authenticator/Portfile
@@ -1,0 +1,47 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+# UPDATE THESE IN SYNC!
+set version         0.5.2
+set commit          292b9b82df69b87af962b92485b254d9f4b10f00
+
+go.setup            github.com/kubernetes-sigs/aws-iam-authenticator ${version} v
+revision            0
+go.package          sigs.k8s.io/aws-iam-authenticator
+
+description         AWS IAM Authenticator for Kubernetes
+long_description    Use IAM credentials to authenticate to Kubernetes.
+
+categories          sysutils
+platforms           darwin
+license             Apache-2
+
+maintainers         @asobrien \
+                    openmaintainer
+
+checksums           rmd160  0bf5bee637fe3ae2faf96d24d5b95621c8e6c00c \
+                    sha256  a24cd391de7a5f736d1a9436054188b97fd30e01c0f707afea08c31b41720653 \
+                    size    6073567
+
+
+build.args          -ldflags=\"-s -w \
+                    -X main.version=${version} \
+                    -X main.commit=${commit}\"
+build.args-append   ./cmd/${name}
+
+# Do not build on macOS 10.10 and earlier
+if {${os.platform} eq "darwin" && ${os.major} < 15} {
+    known_fail yes
+
+    pre-fetch {
+        ui_error "${name} does not build on macOS 10.10 and earlier"
+        return -code error "unsupported platform version"
+    }
+}
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}
+


### PR DESCRIPTION
#### Description

aws-iam-authenticator is a tool that uses AWS IAM credentials to authenticate to a Kubernetes cluster.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.13.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
