### PR TITLE
rust: update to 1.51.0

### DIFF
--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           legacysupport 1.1
 
 name                rust
-version             1.50.0
-revision            3
+version             1.51.0
+revision            0
 categories          lang devel
 platforms           darwin
 supported_archs     x86_64 arm64
@@ -29,7 +29,7 @@ homepage            https://www.rust-lang.org
 
 # Get from src/stage0.txt
 # Rust stable 1.x usually requires `set rustc_version 1.(x-1)`
-set rustc_version   1.49.0
+set rustc_version   1.50.0
 
 # can use cmake or cmake-devel; default to cmake.
 depends_build       bin:git:git \
@@ -58,34 +58,34 @@ distfiles-append    rust-std-${rustc_version}-${arch}-apple-${os.platform}${extr
                     cargo-${rustc_version}-${arch}-apple-${os.platform}${extract.suffix}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  07633389398c9e746a6d349e97775201aaeeeb3b \
-                    sha256  95978f8d02bb6175ae3238930baf03563c240aedf9a70bebdc3eaa2a8c3c5a5e \
-                    size    159542148
+                    rmd160  86012fa02e52e4a06e5c76aaa482face78b38ef5 \
+                    sha256  7a6b9bafc8b3d81bbc566e7c0d1f17c9f499fd22b95142f7ea3a8e4d1f9eb847 \
+                    size    160954811
 
 checksums-append    rust-std-${rustc_version}-x86_64-apple-${os.platform}${extract.suffix} \
-                    rmd160  b43ecabbcfa19327be5dccf09fc72855d0707a49 \
-                    sha256  c4389a8534b8da3ae3570646d68fea9a25268b17ed138867e31d4517312759af \
-                    size    35384330 \
+                    rmd160  2234575725d792e24fe53e0fbae1c786a31e55d0 \
+                    sha256  a291354e78e8147b22e92c817a0dfee8d3342e07bfafa73a2904a1c99d22c5b8 \
+                    size    40793121 \
                     rustc-${rustc_version}-x86_64-apple-${os.platform}${extract.suffix} \
-                    rmd160  ebe1ff219b1bd8d12a610a3cf228a5eae3de9de6 \
-                    sha256  09333f9aacb9c5959e2a2798d7e283cae674255f063a35ea28f91595caa0a78b \
-                    size    79819120 \
+                    rmd160  a823d7becd0341ced56663056626ee211096201c \
+                    sha256  3637ee8d8bc0f8e922b1f9ec7b6fc00b6efcceae97c337d205a3bc472be7b936 \
+                    size    97361498 \
                     cargo-${rustc_version}-x86_64-apple-${os.platform}${extract.suffix} \
-                    rmd160  83a5c42490e8579d8767dc8c5c4c5e3d13da0bba \
-                    sha256  ab1bcd7840c715832dbe4a2c5cd64882908cc0d0e6686dd6aec43d2e4332a003 \
-                    size    5945516 \
+                    rmd160  1f821ec26255f891e403ced7278a281b294c80ff \
+                    sha256  45640bb1cef40f25ecb4bd2a3bb34fdf884c418e625d4f9c9595d2aca84fad78 \
+                    size    6412639 \
                     rust-std-${rustc_version}-aarch64-apple-${os.platform}${extract.suffix} \
-                    rmd160  1ddc99fbc545b2e601d507d90b5f88bd8cdb1a32 \
-                    sha256  cf3308806fc3b6fe00ce49f1e63b1cb1d1443cc812eff7947257f31f590465d3 \
-                    size    27145897 \
+                    rmd160  26bf61d3106d1ef827707aafd9348d3475b20679 \
+                    sha256  8a1cda91afd3a732d3737b6f933b0b6065949dd8fbc820245a7e2a97ae9a7711 \
+                    size    28059579 \
                     rustc-${rustc_version}-aarch64-apple-${os.platform}${extract.suffix} \
-                    rmd160  2307caf7575c72bf3988698c49cce824dcf71160 \
-                    sha256  3e8c0c9101f27623f7607f2d8acef5f28dcb2bdfcded56f210d9d370cf9a9c06 \
-                    size    70161621 \
+                    rmd160  bc5c28821124b8a2ba09312730f91e75d113193c \
+                    sha256  3abc090591fb7fd0a292eeff4cc6a029841d39b0a768eaf1f0b9e4e06cba8ed7 \
+                    size    87219407 \
                     cargo-${rustc_version}-aarch64-apple-${os.platform}${extract.suffix} \
-                    rmd160  cf2de4de6008e9e176d75f7da7c0809dca9d15eb \
-                    sha256  2bd6eb276193b70b871c594ed74641235c8c4dcd77e9b8f193801c281b55478d \
-                    size    5388171
+                    rmd160  de7cb695c1ebc5e7483ecf7d353d67dba351432a \
+                    sha256  19d526ef3518fb0322f809deddbd4208a27d08efa41d2188348f1be8d3bcfe5e \
+                    size    5820420
 
 if {${os.platform} eq "darwin" && ${os.major} < 14} {
     known_fail yes


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
