### PR TITLE
zig: update to 0.7.1

### DIFF
--- a/lang/zig/Portfile
+++ b/lang/zig/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 
-github.setup        ziglang zig 0.5.0
+github.setup        ziglang zig 0.7.1
 github.tarball_from archive
 revision            0
 
@@ -21,22 +21,18 @@ long_description    Zig is a general-purpose programming language designed for \
 
 homepage            https://ziglang.org/
 
-set llvm_version    9.0
+set llvm_version    11
 
 depends_lib-append  port:llvm-${llvm_version}
 
-checksums           rmd160  f6c957f66ebf9c981fea61cba4875081661ec3c6 \
-                    sha256  abe3e8ef064225f342bb24165e3c8a35f8f2c45930489a53897e835e984117eb \
-                    size    15743912
+checksums           rmd160  011844de4bdb2b0836aac91a6d593036d940a089 \
+                    sha256  796f16fe8d99007fa3a8d8d5c721ba1e2579d7725d3e3af245c6097fb2ff8a0b \
+                    size    16082917
 
 set llvm_config     LLVM_CONFIG=llvm-config-mp-${llvm_version}
 
-compiler.blacklist-append *gcc* clang 
+compiler.blacklist-append \
+                    *gcc* clang
 compiler.fallback   macports-clang-${llvm_version}
 compiler.whitelist  macports-clang-${llvm_version}
 cmake.module_path   [list ${prefix}/libexec/llvm-${llvm_version}]
-
-# This build system is unusual in that it wants to install files to the
-# destroot at build time. This may get fixed in the future.
-# https://github.com/ziglang/zig/issues/2928
-build.args-append   DESTDIR=${destroot}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Update zig to 0.7.1

Closes https://trac.macports.org/ticket/62560

Depends on #10404.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.4 12D4e


###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
