### PR TITLE
caddy: update to 2.3.0

### DIFF
--- a/www/caddy/Portfile
+++ b/www/caddy/Portfile
@@ -3,32 +3,33 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/mholt/caddy 0.11.4 v
+# Caddy uses its own tool (xcaddy) to build the caddy executable with version
+# information baked in
+go.setup            github.com/caddyserver/xcaddy 0.1.8 v
+
+name                caddy
+version             2.3.0
+revision            0
 categories          www
 platforms           darwin
-supported_archs     i386 x86_64
 license             Apache-2
 maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
 
-description         Caddy HTTP/2 web server
+description         Fast, multi-platform web server with automatic HTTPS
 
-long_description    Caddy is a general-purpose HTTP/2 web server that serves \
-                    HTTPS by default.
+long_description    Caddy 2 is a powerful, enterprise-ready, open source web \
+                    server with automatic HTTPS written in Go
 
 homepage            https://caddyserver.com/
 
-checksums           rmd160  6fc3610c08eb1952061aadc7745e5c2fa402e20e \
-                    sha256  f967bee362eace5c1b75ad113895b509760fd7b5d7f53abbca5a3f46d69625f2 \
-                    size    5790311
+checksums           rmd160  d638e0981e9d9b4ac6f8cadd4d3d3fd7f23fc582 \
+                    sha256  fd4a6f2b25a3bda51cbccb3676374b05c3a855c7783d8173b1631cd4259cc5df \
+                    size    18430
 
-post-extract {
-    reinplace "s|var EnableTelemetry = true|var EnableTelemetry = false|" \
-        ${worksrcpath}/${name}/caddymain/run.go
-}
-
-build.args          -ldflags \"-X ${go.package}/${name}/caddymain.gitTag=v${version}\"
-build.dir           ${worksrcpath}/${name}
+build.env-delete    GO111MODULE=off GOPROXY=off
+build.cmd           go run cmd/xcaddy/main.go
+build.args          build v${version}
 
 destroot {
-    xinstall -m 0755 ${worksrcpath}/${name}/${name} ${destroot}${prefix}/bin/
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
 }


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Update caddy to 2.3.0.

Caddy 2 has a bit of an unorthodox method of adding the version information into the final binary. Where many Go programs use the ldflags trick, Caddy gets its version information from the debug metadata that Go itself bakes into the Caddy module. This means that in order to get the correct version string from `caddy version`, you have to create a new Go module with the version of Caddy you want as a dependency ([see the README](https://github.com/caddyserver/caddy#with-version-information-andor-plugins) for more information). This means this port **must** be built in module mode, so for now the `build.env-delete GO111MODULE=off GOPROXY=off` line is necessary.

Note that if/when #10381 is accepted, we may be able to use that approach to add a `go.vendors` line into this port. But until then, it's not possible (as far as I can tell, I spent a few hours trying to get this to work).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
