### PR TITLE
jdupes: update to 1.19.2

### DIFF
--- a/sysutils/jdupes/Portfile
+++ b/sysutils/jdupes/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        jbruchon jdupes 1.19.1 v
+github.setup        jbruchon jdupes 1.19.2 v
 revision            0
-checksums           rmd160  3a29220cce0458fcfc6e2d794700898531ca9d14 \
-                    sha256  a5728d75c16b3b03aec934e0599519931270b56f8d360909d05c8fa7d984e53a \
-                    size    92693
+checksums           rmd160  c36edced52adc25cb860c82ad3fc4b9c5e758285 \
+                    sha256  af2422f8e839e46b645719a1e4d23608db68f112263ec461bb46a1cb2cba36d3 \
+                    size    93228
 
 platforms           darwin
 categories          sysutils


### PR DESCRIPTION
#### Description
jdupes: update to 1.19.2

###### Tested on
macOS 10.15.7 19H524
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
