### PR TITLE
julia: update to 1.6.0

### DIFF
--- a/lang/julia/Portfile
+++ b/lang/julia/Portfile
@@ -8,7 +8,7 @@ PortGroup           compilers 1.0
 compilers.choose    fc f77 f90
 compilers.setup     require_fortran -g95
 
-github.setup        JuliaLang julia 1.5.4 v
+github.setup        JuliaLang julia 1.6.0 v
 revision            0
 categories-append   lang math science
 maintainers         {ieee.org:s.t.smith @essandess} openmaintainer
@@ -26,9 +26,9 @@ github.tarball_from releases
 distfiles           ${name}-${version}-full${extract.suffix}
 
 checksums           ${name}-${version}-full${extract.suffix} \
-                    rmd160  5dacf46cf98aea29ec6ef11ce461ced4ee6ab8eb \
-                    sha256  dbfb8cd544b223eff70f538da7bb9d5b6f76fd0b00dd2385e6254e74ad4e892f \
-                    size    138223428
+                    rmd160  87c637fa1125710deb65d74ad9dc04a0fcd141a9 \
+                    sha256  1b05f42c9368bc2349c47363b7ddc175a2da3cd162d52b6e24c4f5d4d6e1232c \
+                    size    153634233
 
 extract.only        ${distfiles}
 
@@ -86,7 +86,6 @@ post-destroot {
     move ${dpw}/julia-${version}/include/julia ${destroot}${prefix}/include
     move ${dpw}/julia-${version}/lib/julia ${destroot}${prefix}/lib
     move ${dpw}/julia-${version}/lib/libjulia.${short_version}.dylib ${destroot}${prefix}/lib
-    move ${dpw}/julia-${version}/lib/libjulia.${short_version}.dylib.dSYM ${destroot}${prefix}/lib
     move ${dpw}/julia-${version}/lib/libjulia.dylib ${destroot}${prefix}/lib
     move ${dpw}/julia-${version}/lib/libjulia.${major_version}.dylib ${destroot}${prefix}/lib
     move ${dpw}/julia-${version}/share/julia ${destroot}${prefix}/share


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

The `dSYM` file is no longer present in the build result of Julia 1.6.0 (at least on my machine).