### PR TITLE
liblas: create liblas-config needed for grass7

### DIFF
--- a/gis/grass7/Portfile
+++ b/gis/grass7/Portfile
@@ -67,8 +67,7 @@ configure.args-append \
     --with-png-includes=${prefix}/include \
     --with-png-libs=${prefix}/lib \
     --with-geos=${prefix}/bin/geos-config \
-    --with-liblas-includes=${prefix}/include/liblas \
-    --with-liblas-libs=${prefix}/lib \
+    --with-liblas=${prefix}/bin/liblas-config \
     --without-postgres \
     --with-pthread \
     --with-cairo \
@@ -140,7 +139,7 @@ foreach pjver ${proj_versions} {
     lappend proj_variants proj${pjver}
 }
 foreach proj_ver ${proj_versions} {
-    
+
     set index [lsearch -exact ${proj_variants} proj${proj_ver}]
     set cflcts [lreplace ${proj_variants} ${index} ${index}]
 

--- a/gis/liblas/Portfile
+++ b/gis/liblas/Portfile
@@ -7,7 +7,7 @@ PortGroup           boost   1.0
 
 github.setup        libLAS libLAS 70a170b086cbd8b639f500d8d40d90b05fcccb04
 version             1.8.1-20210507
-revision            3
+revision            4
 checksums           rmd160  c9a134f8dbfc76035d1a902a0ba1f194bbf3f0dd \
                     sha256  5a72982cf00d2562284fd394055e7c2bdc38f391a38ce2eab99d913a662b812d \
                     size    10743378
@@ -30,7 +30,8 @@ github.tarball_from archive
 
 compiler.cxx_standard   2011
 
-patchfiles          patch-gt_wkt_srs_cpp.diff
+patchfiles          patch-gt_wkt_srs_cpp.diff \
+                    patch-apps_CMakeLists.txt.diff
 
 configure.args-append \
                     -DWITH_GEOTIFF=ON \

--- a/gis/liblas/Portfile
+++ b/gis/liblas/Portfile
@@ -5,12 +5,13 @@ PortGroup           cmake   1.1
 PortGroup           github  1.0
 PortGroup           boost   1.0
 
-github.setup        libLAS libLAS 70a170b086cbd8b639f500d8d40d90b05fcccb04
-version             1.8.1-20210507
-revision            4
-checksums           rmd160  c9a134f8dbfc76035d1a902a0ba1f194bbf3f0dd \
-                    sha256  5a72982cf00d2562284fd394055e7c2bdc38f391a38ce2eab99d913a662b812d \
-                    size    10743378
+github.setup        libLAS libLAS e6a1aaed412d638687b8aec44f7b12df7ca2bbbb
+github.tarball_from archive
+version             1.8.1-20210819
+revision            0
+checksums           rmd160  2fca9309ae78305236b5ae9cfd732f5472c46bf5 \
+                    sha256  6ffb77728631d092656879c5bfb97a78a38b18a15d2dd7b53513135fd0c50287 \
+                    size    10742415
 
 name                liblas
 license             BSD
@@ -26,7 +27,6 @@ long_description \
     interchange and archival.
 
 homepage            https://liblas.org/
-github.tarball_from archive
 
 compiler.cxx_standard   2011
 

--- a/gis/liblas/Portfile
+++ b/gis/liblas/Portfile
@@ -40,7 +40,7 @@ configure.args-append \
 
 configure.env-append    GDAL_HOME=${prefix}
 
-variant proj6 conflicts {proj7 proj8} {
+variant proj6 conflicts proj7 proj8 description "Build with proj6" {
     configure.args-append \
                     -DPROJ4_INCLUDE_DIR=${prefix}/lib/proj6 \
                     -DPROJ4_LIBRARY=${prefix}/lib/proj6
@@ -48,14 +48,14 @@ variant proj6 conflicts {proj7 proj8} {
 }
 
 
-variant proj7 conflicts {proj6 proj8} {
+variant proj7 conflicts proj6 proj8 description "Build with proj7" {
     configure.args-append \
                     -DPROJ4_INCLUDE_DIR=${prefix}/lib/proj7 \
                     -DPROJ4_LIBRARY=${prefix}/lib/proj7
     depends_lib-append  port:proj7
 }
 
-variant proj8 conflicts {proj6 proj7} {
+variant proj8 conflicts proj6 proj7 description "Build with proj8" {
     configure.args-append \
                     -DPROJ4_INCLUDE_DIR=${prefix}/lib/proj8 \
                     -DPROJ4_LIBRARY=${prefix}/lib/proj8

--- a/gis/liblas/files/patch-apps_CMakeLists.txt.diff
+++ b/gis/liblas/files/patch-apps_CMakeLists.txt.diff
@@ -1,0 +1,13 @@
+Install both a .pc file (for pkgconfig) and liblas-config (for autotools)
+based builds.
+--- apps/CMakeLists.txt.orig	2021-08-28 20:18:25.000000000 -0400
++++ apps/CMakeLists.txt	2021-08-28 20:18:32.000000000 -0400
+@@ -216,8 +216,6 @@
+       DESTINATION ${LIBLAS_LIB_DIR}/pkgconfig
+       PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
+
+-  else()
+-
+     # Autoconf compatibility variables to use the same script source.
+     set(prefix ${CMAKE_INSTALL_PREFIX})
+     set(exec_prefix ${CMAKE_INSTALL_PREFIX}/bin)


### PR DESCRIPTION
#### Description

Presently liblas creates a liblas.pc file if pkg-config is installed. However, grass7 needs a liblas-config file for proper configuration.

This PR make liblas install a liblas-config file (instead of liblas.pc) as well as configures grass7 accordingly.

The other dependant of liblas: saga, compiled without complaint.

Addresses https://trac.macports.org/ticket/62489,

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
