### PR TITLE
p5-compress-raw-bzip2: update to version 2.101

### DIFF
--- a/perl/p5-compress-raw-bzip2/Portfile
+++ b/perl/p5-compress-raw-bzip2/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28 5.30
-perl5.setup         Compress-Raw-Bzip2 2.100 ../../authors/id/P/PM/PMQS
+perl5.setup         Compress-Raw-Bzip2 2.101 ../../authors/id/P/PM/PMQS
+revision            0
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
 description         Perl low-level interface to bzip2 compression library
@@ -14,8 +15,18 @@ long_description    Compress::Raw::Bzip2 provides an interface to the \
                     IO::Compress::Bzip2 and IO::Compress::Bunzip2.
 platforms           darwin
 
-checksums           rmd160  b287233934a718419acd0494a4f6302fe449d965 \
-                    sha256  2f1fe7ef2bf7cf87c8dbc82a605fd4a1411997858d802d0b1ead4745955cda04 \
-                    size    138698
+checksums           rmd160  8231976c3df4d8b9f91f9cf53845beeb51de023d \
+                    sha256  0c9b134fd388290e30e90fc9f63900966127f98e76b054ecd481eb3b5500b8d8 \
+                    size    138718
+
+if {${perl5.major} ne ""} {
+    depends_test-append \
+                    port:p${perl5.major}-test-cpan-meta \
+                    port:p${perl5.major}-test-cpan-meta-json \
+                    port:p${perl5.major}-test-pod
+
+    supported_archs noarch
+    perl5.link_binaries no
+}
 
 # builds using embedded bzip2 source, no external dependency required


### PR DESCRIPTION
#### Description
p5-compress-raw-bzip2: update to version 2.101
* add dependencies for tests

###### Tested on
macOS 10.14.6 18G6020
Xcode 11.3.1 11C504

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?