### PR TITLE
p5-compress-raw-zlib: update to version 2.101

### DIFF
--- a/perl/p5-compress-raw-zlib/Portfile
+++ b/perl/p5-compress-raw-zlib/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28 5.30
-perl5.setup         Compress-Raw-Zlib 2.100 ../../authors/id/P/PM/PMQS
+perl5.setup         Compress-Raw-Zlib 2.101 ../../authors/id/P/PM/PMQS
+revision            0
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
 description         The Compress::Raw::Zlib module provides a Perl \
@@ -13,8 +14,21 @@ long_description    ${description}
 
 platforms           darwin
 
-checksums           rmd160  badcc850b396b3611e661fdf5a09fd49b45ad152 \
-                    sha256  9fc6016cb2b07a1a41794f0c555e4449d16979716a8b4c704e86bbaaaa15992a \
-                    size    254557
+checksums           rmd160  012d9f4013aee9624bf1fa85c22905366a11aab2 \
+                    sha256  9d1b9515e8277c1b007e33fad1fd0f18717d56bf647e3794d61289c45b1aabb2 \
+                    size    254576
+
+if {${perl5.major} ne ""} {
+    depends_test-append \
+                    port:p${perl5.major}-test-cpan-meta \
+                    port:p${perl5.major}-test-cpan-meta-json \
+                    port:p${perl5.major}-test-pod
+
+    # run all tests
+    test.env-append COMPRESS_ZLIB_RUN_ALL=1
+
+    supported_archs noarch
+    perl5.link_binaries no
+}
 
 # builds using embedded zlib source, no external dependency required


### PR DESCRIPTION
#### Description
p5-compress-raw-zlib: update to version 2.101
* tests: add dependencies to run all tests
* tests: run all available tests

###### Tested on
macOS 10.14.6 18G6020
Xcode 11.3.1 11C504

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
