### PR TITLE
turbovnc-viewer: new port

### DIFF
--- a/x11/turbovnc-viewer/Portfile
+++ b/x11/turbovnc-viewer/Portfile
@@ -1,0 +1,78 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           active_variants 1.1
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+PortGroup           java 1.0
+
+github.setup        TurboVNC turbovnc 2.2.6
+
+name                turbovnc-viewer
+platforms           darwin
+license             GPL-2
+maintainers         {gmail.com:audvare @Tatsh} openmaintainer
+categories          x11 net
+description         TurboVNC VNC viewer.
+long_description    ${description}
+
+checksums           rmd160  de684a6e9c2f2e1ef1f05b98229fd40269d17a7c \
+                    sha256  71a89600d1e4ffe67aa65e5ddc6b21b1659b9105892c07074e99181218dc33e8 \
+                    size    9023665
+
+depends_lib-append  port:libjpeg-turbo
+
+java.version        1.8+
+
+require_active_variants     openjdk11       JNI
+require_active_variants     libjpeg-turbo   java
+
+pre-configure {
+    # This must be called to set ${java.home}
+    java_set_env
+    configure.args \
+        -DTVNC_BUILDSERVER=no \
+        -DCMAKE_C_FLAGS=-I${prefix}/include \
+        -DTJPEG_JAR=${prefix}/share/java/turbojpeg.jar \
+        -DJAVA_INCLUDE_PATH=${java.home}/include \
+        -DJAVA_INCLUDE_PATH2=${java.home}/include/darwin \
+        -DJAVA_AWT_INCLUDE_PATH=${java.home}/include \
+        -DTVNC_BUILDNATIVE=ON
+}
+
+patch {
+    reinplace "s|@VERSION@|${version}|g" ${worksrcpath}/release/Info.plist.in
+    reinplace "s|@PKGVENDOR@|MacPorts|g" ${worksrcpath}/release/Info.plist.in
+    reinplace "s|@BUILD@|${version}|g" ${worksrcpath}/release/Info.plist.in
+    reinplace "s|@CMAKE_PROJECT_NAME@|TurboVNC|g" ${worksrcpath}/release/Info.plist.in
+    reinplace "s|^<dict>|<dict><key>NSHighResolutionCapable</key><true/>|" ${worksrcpath}/release/Info.plist.in
+}
+
+post-destroot {
+    set appdir "${destroot}${applications_dir}/TurboVNC Viewer.app"
+    xinstall -m 0755 -d ${appdir}/Contents/MacOS
+    xinstall -m 0755 -d ${appdir}/Contents/Resources/Java
+    xinstall -m 0755 -d ${appdir}/Contents/Resources/Native
+    xinstall -m 0644 ${worksrcpath}/release/Info.plist.in \
+        ${appdir}/Contents/Info.plist
+    xinstall -m 0755 ${worksrcpath}/unix/vncviewer/JavaAppLauncher \
+        "${appdir}/Contents/MacOS/TurboVNC Viewer"
+    set chan [open ${appdir}/Contents/PkgInfo w+]
+    puts -nonewline ${chan} "APPL????"
+    close ${chan}
+    xinstall -m 0644 ${worksrcpath}/release/turbovnc.icns \
+        ${worksrcpath}/release/vncviewer.icns ${appdir}/Contents/Resources/
+    xinstall -m 0755 ${prefix}/lib/libturbojpeg.dylib \
+        ${cmake.build_dir}/java/libturbovnchelper.dylib \
+        ${appdir}/Contents/Resources/Native/
+    xinstall -m 0644 ${cmake.build_dir}/java/VncViewer.jar \
+        ${appdir}/Contents/Resources/Java/
+}
+
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    known_fail yes
+    pre-fetch {
+        ui_error "${name} @${version} requires OS X 10.7 or later."
+        return -code error "incompatible OS X version"
+    }
+}


### PR DESCRIPTION
#### Description

Since #10156 was merged, this can now be added.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
