### PR TITLE
p5-io-compress: update to 2.102

### DIFF
--- a/perl/p5-io-compress/Portfile
+++ b/perl/p5-io-compress/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28 5.30
-perl5.setup         IO-Compress 2.100 ../../authors/id/P/PM/PMQS
+perl5.setup         IO-Compress 2.102 ../../authors/id/P/PM/PMQS
+revision            0
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
 description         Perl interface to allow reading and writing of \
@@ -16,14 +17,22 @@ homepage            https://metacpan.org/release/${perl5.module}/
 
 platforms           darwin
 
-checksums           rmd160  dcc07cd7ff0c0c57ad6cb44aebdbc3aa9828c69f \
-                    sha256  2d23b0be2e2967c604c407d415588920a69083587d0f65f355137592989c6c36 \
-                    size    291283
+checksums           rmd160  fec926f23c48304d71173cf330d02677d49a8f91 \
+                    sha256  d6fa7f9a5beee446452a0fbc43589a0c73fe7e925c075b98628b018048dc72a4 \
+                    size    292833
 
-if {${perl5.major} != ""} {
+if {${perl5.major} ne ""} {
     depends_lib-append \
                     port:p${perl5.major}-compress-raw-bzip2 \
                     port:p${perl5.major}-compress-raw-zlib
+
+    depends_test-append \
+                    port:p${perl5.major}-test-cpan-meta \
+                    port:p${perl5.major}-test-cpan-meta-json \
+                    port:p${perl5.major}-test-pod
+
+    # run all tests
+    test.env-append COMPRESS_ZLIB_RUN_ALL=1
 
     supported_archs noarch
     perl5.link_binaries no


### PR DESCRIPTION
#### Description

p5-io-compress: update to 2.102
* tests: add dependencies to run all tests
* tests: run all tests

###### Tested on
macOS 10.14.6 18G6020
Xcode 11.3.1 11C504

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
