### PR TITLE
ijq: new port

### DIFF
--- a/textproc/ijq/Portfile
+++ b/textproc/ijq/Portfile
@@ -1,0 +1,73 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/gpanders/ijq 0.2.5 v
+go.package          git.sr.ht/~gpanders/ijq
+revision            0
+
+homepage            https://sr.ht/~gpanders/ijq
+
+description         Interactive jq tool. Like jqplay for the commandline.
+
+long_description    {*}${description}
+
+categories          textproc devel sysutils
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    {@gpanders gpanders.com:greg} \
+                    openmaintainer
+license             GPL-3
+installs_libs       no
+
+build.args          -ldflags \"-X main.Version=v${version}\"
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  36a52e8489559f4eae07c743fa884ff75c2b34ff \
+                        sha256  0300fa5e027c01c5c174e0b4272ccffd44e14e5e1af0f8dc2ac3af2a79844401 \
+                        size    19384
+
+go.vendors          golang.org/x/text \
+                        lock    v0.3.5 \
+                        rmd160  2bc41a433ef7cbbf321afed39256a65d43ef3c8b \
+                        sha256  148ec80befd0392454a5d7756abcebeb74f863e6e4b1e1ff63bbe06c2b49e120 \
+                        size    8349629 \
+                    golang.org/x/sys \
+                        lock    4bcb84eeeb78 \
+                        rmd160  ddd98ce5afef6d9a72a9afe1d00662ca0914b18d \
+                        sha256  60343bf080c7967ef9c9b451cb2f6519bfba2b80bad42ec2e6edf4d4871300df \
+                        size    1101928 \
+                    github.com/rivo/uniseg \
+                        lock    v0.2.0 \
+                        rmd160  33577def583aa2db50b69ca601e5d29ab201ebc4 \
+                        sha256  2832965221246272462a03ffc8e159c94d8f534827f660f1ac4fc77e5ccd644c \
+                        size    44037 \
+                    github.com/rivo/tview \
+                        lock    745e4ceeb711 \
+                        rmd160  23eb115ea2e8ad61afd67c5b50e4b12cb29a86b1 \
+                        sha256  5c0001bdccd9702321d702c437b5e33b765b208e3b0a8024233b1e788f58fc75 \
+                        size    2871149 \
+                    github.com/mattn/go-runewidth \
+                        lock    v0.0.10 \
+                        rmd160  96c878eca004d6cf8f49ecf3cde98335e7f21499 \
+                        sha256  b78084ce55bc5aaa31d337dcb59624d748fe39006a3df29143fae203065e2a22 \
+                        size    16787 \
+                    github.com/lucasb-eyer/go-colorful \
+                        lock    v1.0.3 \
+                        rmd160  0d0a283ba00c871d123c951efea0605a869951aa \
+                        sha256  ecd902ddda5d05cc8a857873bf8b984a5cd2d7b75f1185edcfc2c472707958b3 \
+                        size    430208 \
+                    github.com/gdamore/tcell \
+                        lock    v2.1.0 \
+                        rmd160  33e0c62bb584fe9083efcbb9f9287ab2e039b53c \
+                        sha256  a4e74d0a8d3cf0f3ceadcd5ad48ede8faa1d9829716bc5928ec73710c7f4bcc6 \
+                        size    150767 \
+                    github.com/gdamore/encoding \
+                        lock    v1.0.0 \
+                        rmd160  3ed8916f763a5b51db1bcc8bd3ad06cf3d12ec07 \
+                        sha256  4f470c7308790bea8a526ea26cecbaa22345aad8dc566821cda6175b3d241ee1 \
+                        size    10900


### PR DESCRIPTION
@gpanders, `ijq` is super useful and should definitely be in ports.

Should I set you as maintainer instead?

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.4 12D4e


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
