### PR TITLE
ghidra: new port

### DIFF
--- a/devel/ghidra/Portfile
+++ b/devel/ghidra/Portfile
@@ -1,0 +1,50 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           app 1.0
+
+name                ghidra
+homepage            https://ghidra-sre.org/
+master_sites        ${homepage}
+version             9.2.2
+use_zip             yes
+distname            ${name}_${version}_PUBLIC_20201229
+checksums           rmd160  2b7a239329ba515010ff52725da08eb656f168f7 \
+                    sha256  8cf8806dd5b8b7c7826f04fad8b86fc7e07ea380eae497f3035f8c974de72cf8 \
+                    size    317805407
+revision            0
+
+categories          devel
+maintainers         {1e0.co.uk:dev @hexagonal-sun} openmaintainer
+description         A software reverse engineering (SRE) suite of tools developed by NSA's \
+                    Research Directorate in support of the Cybersecurity mission
+long_description    ${description}
+license             Apache
+platforms           darwin
+
+depends_lib-append  port:zulu-jdk11
+use_configure       no
+universal_variant   no
+
+build {}
+
+set javadest        "${prefix}/share/java/${name}-${version}"
+destroot {
+    file mkdir "${destroot}${javadest}"
+    file copy "${worksrcpath}/Extensions" "${destroot}${javadest}/"
+    file copy "${worksrcpath}/GPL" "${destroot}${javadest}/"
+    file copy "${worksrcpath}/Ghidra" "${destroot}${javadest}/"
+    file copy "${worksrcpath}/LICENSE" "${destroot}${javadest}/"
+    file copy "${worksrcpath}/docs" "${destroot}${javadest}/"
+    file copy "${worksrcpath}/ghidraRun" "${destroot}${javadest}/"
+    file copy "${worksrcpath}/licenses" "${destroot}${javadest}/"
+    file copy "${worksrcpath}/server" "${destroot}${javadest}/"
+    file copy "${worksrcpath}/support" "${destroot}${javadest}/"
+}
+
+# app settings
+app.create yes
+app.name GHIDRA
+app.executable "${javadest}/ghidraRun"
+app.icon "support/ghidra.ico"
+app.retina yes


### PR DESCRIPTION
#### Description

Adds a new port for the NSA's reverse engineering framework, [ghidra](https://ghidra-sre.org/).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] submission
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
