### PR TITLE
libsbmlsim: add python38 and python39 support

### DIFF
--- a/science/libsbmlsim/Portfile
+++ b/science/libsbmlsim/Portfile
@@ -5,6 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 
 github.setup        libsbmlsim libsbmlsim 1.4.0 v
+revision            1
 categories          science
 platforms           darwin
 maintainers         {@funasoul gmail.com:funasoul} openmaintainer
@@ -36,22 +37,34 @@ variant java description {Generate Java language bindings.} {
     configure.args-append  -DWITH_JAVA:BOOL=ON
 }
 
-variant python27 conflicts python36 python37 description {Generate Python version 2.7 language bindings.} {
+variant python27 conflicts python36 python37 python38 python39 description {Generate Python version 2.7 language bindings.} {
     depends_build-append  port:swig port:swig-python
     depends_lib-append      port:python27
     configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python2.7
 }
 
-variant python36 conflicts python27 python37 description {Generate Python version 3.6 language bindings.} {
+variant python36 conflicts python27 python37 python38 python39 description {Generate Python version 3.6 language bindings.} {
     depends_build-append  port:swig port:swig-python
     depends_lib-append      port:python36
     configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python3.6
 }
 
-variant python37 conflicts python27 python36 description {Generate Python version 3.7 language bindings.} {
+variant python37 conflicts python27 python36 python38 python39 description {Generate Python version 3.7 language bindings.} {
     depends_build-append  port:swig port:swig-python
     depends_lib-append      port:python37
     configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python3.7
+}
+
+variant python38 conflicts python27 python36 python37 python39 description {Generate Python version 3.8 language bindings.} {
+    depends_build-append  port:swig port:swig-python
+    depends_lib-append      port:python38
+    configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python3.8
+}
+
+variant python39 conflicts python27 python36 python37 python38 description {Generate Python version 3.9 language bindings.} {
+    depends_build-append  port:swig port:swig-python
+    depends_lib-append      port:python39
+    configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python3.9
 }
 
 variant ruby description {Generate Ruby language bindings.} {


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Add +python38 and +python39 variants to libsbmlsim port.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
