### PR TITLE
ijq: update to 0.2.6 and add man page

### DIFF
--- a/textproc/ijq/Portfile
+++ b/textproc/ijq/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gpanders/ijq 0.2.5 v
+go.setup            github.com/gpanders/ijq 0.2.6 v
 go.package          git.sr.ht/~gpanders/ijq
 revision            0
 
@@ -20,16 +20,21 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 license             GPL-3
 installs_libs       no
 
-build.args          -ldflags \"-X main.Version=v${version}\"
+depends_build-append \
+                    port:scdoc
+
+build.cmd           make
+build.target        all
 
 destroot {
-    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+    system -W ${worksrcpath} \
+        "make DESTDIR=${destroot} prefix=${prefix} install"
 }
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  36a52e8489559f4eae07c743fa884ff75c2b34ff \
-                        sha256  0300fa5e027c01c5c174e0b4272ccffd44e14e5e1af0f8dc2ac3af2a79844401 \
-                        size    19384
+                        rmd160  4772c02cab4024533e400b99050364aea0791b90 \
+                        sha256  b8acfe31a4374185b1b25ed852cd78efe3dc08702e0ef28cc2a83b3d733efd24 \
+                        size    19961
 
 go.vendors          golang.org/x/text \
                         lock    v0.3.5 \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Update ijq to 0.2.6 and add man page.

Thanks @herbygillot for packaging this. I just released a new tag that has some useful autocompletion changes that I'd been sitting on for a while. I also updated the port to include the man page.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G8022
Xcode 11.3.1 11C505


###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
