### PR TITLE
k9s: update to 0.24.6

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.24.4 v
+go.setup            github.com/derailed/k9s 0.24.6 v
 homepage            https://k9scli.io
 
 categories          sysutils devel
@@ -20,9 +20,9 @@ platforms           darwin
 supported_archs     x86_64
 license             Apache-2
 
-checksums           rmd160  74e63ef8c752003140d56cefa06ba7953896a30c \
-                    sha256  2338011d4b38821a95777c64dc9e62f96fe54a7ba0f004c29ec61e725d4b7c58 \
-                    size    6190416
+checksums           rmd160  b9150f1eab293dec5bd7168ed7e8edc1913ddcbe \
+                    sha256  9c1642eba1aca0bec829042d8c9a017b4b00abc096438eada3cf6fed60ff2423 \
+                    size    6190716
 
 # Reproduce the "build" target from the upstream Makefile
 set go_ldflags      "-w -s \


### PR DESCRIPTION
#### Description

Update to K9s 0.24.6.

###### Tested on

macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?