### PR TITLE
p5-io-compress-lzma: update to 2.101

### DIFF
--- a/perl/p5-io-compress-lzma/Portfile
+++ b/perl/p5-io-compress-lzma/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28 5.30
-perl5.setup         IO-Compress-Lzma 2.100 ../../authors/id/P/PM/PMQS
+perl5.setup         IO-Compress-Lzma 2.101 ../../authors/id/P/PM/PMQS
 revision            0
-checksums           rmd160  2edd0f5a9d33a9f0c7bc99771fa16c7c1c2c1ec3 \
-                    sha256  25117139d6cb7c19ce645fa2a5e3b2b937187e581ec9544705fc505270c46556 \
-                    size    102359
+checksums           rmd160  108e6af2d8fd9fc57bf8718740ad7916be19a920 \
+                    sha256  1ae686dbe45dbdcf0c7cccf8a0cd81a579a019601f8e35533db93dcdd8282a90 \
+                    size    102393
 
 platforms           darwin
 
@@ -18,10 +18,22 @@ description         Perl interface to allow reading and writing of \
                     lzma files/buffers.
 long_description    ${description}
 
-if {${perl5.major} != ""} {
+if {${perl5.major} ne ""} {
     depends_lib-append \
                     port:p${perl5.major}-compress-raw-lzma \
                     port:p${perl5.major}-io-compress
 
+    depends_test-append \
+                    port:lzip \
+                    port:p${perl5.major}-io-string \
+                    port:p${perl5.major}-test-cpan-meta \
+                    port:p${perl5.major}-test-cpan-meta-json \
+                    port:p${perl5.major}-test-pod \
+                    port:p7zip
+
+    # run all tests
+    test.env-append COMPRESS_ZLIB_RUN_ALL=1
+
     supported_archs noarch
+    perl5.link_binaries no
 }


### PR DESCRIPTION
#### Description
p5-io-compress-lzma: update to 2.101
* tests: add dependencies to run all tests
* tests: run all tests

###### Tested on
macOS 10.14.6 18G6020
Xcode 11.3.1 11C504

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?