### PR TITLE
pyotherside, yubico-authenticator: handling for python3xx

### DIFF
--- a/aqua/yubico-authenticator/Portfile
+++ b/aqua/yubico-authenticator/Portfile
@@ -27,8 +27,8 @@ checksums           rmd160  00a95de9e22c9a22f3de845f9bd12ca97be99a9e \
                     size    5657222
 
 # Python version must be synced with pyotherside and yubikey-manager ports
-set python.version  39
-set python.branch   [string range ${python.version} 0 end-1].[string index ${python.version} end]
+set python.branch   3.9
+set python.version  [join [split ${python.branch} "."] ""]
 set python.prefix   ${frameworks_dir}/Python.framework/Versions/${python.branch}
 set python.pkgd     ${python.prefix}/lib/python${python.branch}/site-packages
 set python.bin      ${python.prefix}/bin/python${python.branch}

--- a/devel/pyotherside/Portfile
+++ b/devel/pyotherside/Portfile
@@ -22,8 +22,8 @@ checksums           rmd160  ec121ed89fc3b16c208cf65fbca4fd6a75214c29 \
                     sha256  41d17354dcab44dbc721e777cdc52a9bfc0d72916bbcbb5d014eed5a74013f7a \
                     size    185258
 
-set python.version  39
-set python.branch   [string range ${python.version} 0 end-1].[string index ${python.version} end]
+set python.branch   3.9
+set python.version  [join [split ${python.branch} "."] ""]
 
 depends_lib-append  port:python${python.version}
 


### PR DESCRIPTION
Will be needed for migration to Python 3.10; see https://lists.macports.org/pipermail/macports-dev/2020-October/042521.html

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### ~~Tested on~~
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
Only verified `port info` for `python.branch` set to `3.9` and `3.10`.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
