### PR TITLE
notmuch: add variant for Mutt integration

### DIFF
--- a/mail/notmuch/Portfile
+++ b/mail/notmuch/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           conflicts_build             1.0
+PortGroup           perl5                       1.0
 
 name                notmuch
 version             0.31.2
@@ -81,6 +82,24 @@ variant emacs description {EMACS support} {
     configure.args-append   --with-emacs
 }
 
+variant mutt description {Include Mutt integration} {
+    depends_build-append    bin:pod2man:perl5
+    depends_lib-append      port:perl5 \
+                            port:p${perl5.major}-mailtools \
+                            port:p${perl5.major}-mail-box \
+                            port:p${perl5.major}-mail-message \
+                            port:p${perl5.major}-term-readline-gnu \
+                            port:p${perl5.major}-string-shellquote \
+                            port:p${perl5.major}-mime-types \
+                            port:p${perl5.major}-object-realize-later
+}
+
 livecheck.type      regex
 livecheck.url       [lindex ${master_sites} 0]
 livecheck.regex     ${name}-(\[0-9.\]+)${extract.suffix}
+
+post-destroot {
+    if {[variant_isset mutt]} {
+        system -W ${worksrcpath}/contrib/notmuch-mutt "make DESTDIR=${destroot} prefix=${prefix} V=1 PERL_ABSOLUTE=${prefix}/bin/perl install"
+    }
+}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Add a `mutt` variant to Notmuch which installs the `notmuch-mutt` Perl script.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
