### PR TITLE
py-vcversioner: Add Python 39, Remove Python 35

### DIFF
--- a/python/py-vcversioner/Portfile
+++ b/python/py-vcversioner/Portfile
@@ -11,8 +11,6 @@ platforms           darwin
 license             ISC
 supported_archs     noarch
 
-python.versions     27 35 36 37 38
-
 maintainers         {stromnov @stromnov} openmaintainer
 
 description         Take version numbers from version control
@@ -23,13 +21,12 @@ long_description    Elevator pitch: you can write a setup.py with no \
                     extract a version from it.
 
 homepage            https://github.com/habnabit/${python.rootname}
-master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
-
-distname            ${python.rootname}-${version}
 
 checksums           rmd160  b7f3e58ffedb53a6a2824ffbe60c3ec8f01049ee \
                     sha256  dae60c17a479781f44a4010701833f1829140b1eeccd258762a74974aa06e19b \
                     size    9024
+
+python.versions     27 36 37 38 39
 
 if {${subport} ne ${name}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
