### PR TITLE
py-publicsuffix2: Add Python 39, Remove Python 35

### DIFF
--- a/python/py-publicsuffix2/Portfile
+++ b/python/py-publicsuffix2/Portfile
@@ -15,7 +15,7 @@ license             {MIT MPL-2}
 maintainers         nomaintainer
 
 description         Get a public suffix for a domain name using the Public Suffix List
-long_description    ${description}
+long_description    {*}${description}
 
 homepage            https://github.com/nexB/python-publicsuffix2
 
@@ -23,7 +23,7 @@ checksums           rmd160  54344704c8e8315db56e1296d6b8244af5d4e0d8 \
                     sha256  b4ef022fccd7b4968151af208b0f890e55c00b24892a1a826b2b7a381215bafa \
                     size    98142
 
-python.versions     27 35 36 37 38
+python.versions     27 36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
