### PR TITLE
py-scikit-build: Add Python 39, Remove Python 35

### DIFF
--- a/python/py-scikit-build/Portfile
+++ b/python/py-scikit-build/Portfile
@@ -10,18 +10,18 @@ categories-append   devel
 platforms           darwin
 license             BSD
 
-python.versions     27 35 36 37 38
-
 maintainers         {stromnov @stromnov} openmaintainer
 
 description         Improved build system generator for CPython extensions.
-long_description    ${description}
+long_description    {*}${description}
 
 homepage            https://github.com/scikit-build/scikit-build
 
 checksums           rmd160  23bce589a14cc3a6a60919c4de87ca71c1ea1872 \
                     sha256  da40dfd69b2456fad1349a894b90180b43712152b8a85d2a00f4ae2ce8ac9a5c \
                     size    132025
+
+python.versions     27 36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-wheel \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
