### PR TITLE
llvm-devel: update to more recent upstream commit

### DIFF
--- a/lang/llvm-devel/Portfile
+++ b/lang/llvm-devel/Portfile
@@ -16,22 +16,22 @@ legacysupport.newest_darwin_requires_legacy 13
 
 # for devel
 PortGroup github        1.0
-set llvm-commit         4bc88a0e9a2ee29959a9053e867ae6f051348554
-set date                20201123
+set llvm-commit         1c5f08312874717caf5d94729d825c32845773ec
+set date                20210305
 set llvm_version        devel
 
 # for release
 # set llvm_version 12
 
-set llvm_version_no_dot 12
-set clang_executable_version 12
-set lldb_executable_version 12
+set llvm_version_no_dot 13
+set clang_executable_version 13
+set lldb_executable_version 13
 
 github.setup            llvm llvm-project ${llvm-commit}
 
-checksums               rmd160  312342e6a4237cd697179dbf3618673df1cd3df8 \
-                        sha256  d5242c02ce65ef36491daf5030613b3e61b82f302cffbb063069236c3bd88ac8 \
-                        size    129093448
+checksums               rmd160  0e49b6e6f6a4d92c0711c96cb63f410d8f6499be \
+                        sha256  e54ae4728298a38c35283cec49b157b957e92ba96d4e374f3a6891a529a93135 \
+                        size    134911797
 
 # for release, use      ${llvm_version}
 # version                 ${llvm_version}
@@ -40,7 +40,7 @@ version                 ${date}-[string range ${llvm-commit} 0 7]
 
 name                    llvm-${llvm_version}
 revision                0
-subport                 clang-${llvm_version} { revision 1 }
+subport                 clang-${llvm_version} { revision 0 }
 subport                 lldb-${llvm_version} { revision 0 }
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
@@ -85,6 +85,10 @@ if {${subport} eq "llvm-${llvm_version}"} {
 
     default_variants-append +analyzer
 
+    # avoid:
+    #    CMake Error: failed to create symbolic link '___': file already exists
+    use_parallel_build  no
+
 } elseif {${subport} eq "lldb-${llvm_version}"} {
     homepage            https://lldb.llvm.org/
     description         the LLVM debugger
@@ -104,21 +108,22 @@ worksrcdir              llvm-project/llvm
 patch.dir               ${workpath}/llvm-project/llvm
 
 post-extract {
-    move ${workpath}/llvm-project-${llvm-commit} ${workpath}/llvm-project
+    ln -s ${workpath}/llvm-project-${llvm-commit} ${workpath}/llvm-project
 
     if {${subport} eq "llvm-${llvm_version}"} {
         if {[variant_isset polly]} {
-            file rename ${workpath}/llvm-project/polly                        ${worksrcpath}/tools/polly
+            ln -s ${workpath}/llvm-project/polly                        ${worksrcpath}/tools/polly
         }
     } elseif {${subport} eq "clang-${llvm_version}"} {
-        file rename ${workpath}/llvm-project/clang                            ${worksrcpath}/tools/clang
-        file rename ${workpath}/llvm-project/compiler-rt                      ${worksrcpath}/projects/compiler-rt
-        file rename ${workpath}/llvm-project/libcxx                           ${worksrcpath}/projects/libcxx
-        file rename ${workpath}/llvm-project/libcxxabi                        ${worksrcpath}/projects/libcxxabi
-        file copy   ${workpath}/llvm-project/clang-tools-extra                ${worksrcpath}/tools/clang/tools/extra
+        ln -s ${workpath}/llvm-project/clang                            ${worksrcpath}/tools/clang
+        ln -s ${workpath}/llvm-project/compiler-rt                      ${worksrcpath}/projects/compiler-rt
+        ln -s ${workpath}/llvm-project/libcxx                           ${worksrcpath}/projects/libcxx
+        ln -s ${workpath}/llvm-project/libcxxabi                        ${worksrcpath}/projects/libcxxabi
+        ln -s ${workpath}/llvm-project/lld                              ${worksrcpath}/projects/lld
+        ln -s ${workpath}/llvm-project/clang-tools-extra                ${worksrcpath}/tools/clang/tools/extra
     } elseif {${subport} eq "lldb-${llvm_version}"} {
-        file rename ${workpath}/llvm-project/clang                            ${worksrcpath}/tools/clang
-        file rename ${workpath}/llvm-project/lldb                             ${worksrcpath}/tools/lldb
+        ln -s ${workpath}/llvm-project/clang                            ${worksrcpath}/tools/clang
+        ln -s ${workpath}/llvm-project/lldb                             ${worksrcpath}/tools/lldb
     }
 }
 
@@ -193,8 +198,8 @@ configure.args-append \
     -DLLVM_ENABLE_RTTI=ON \
     -DLLVM_INCLUDE_TESTS=OFF \
     -DLLVM_INCLUDE_EXAMPLES=OFF \
-    -DLLVM_ENABLE_FFI=ON \
     -DLLVM_BINDINGS_LIST=none \
+    -DLLVM_ENABLE_FFI=ON \
     -DFFI_INCLUDE_DIR=`pkg-config --cflags-only-I libffi | sed 's/-I//'` \
     -DFFI_LIBRARY_DIR=${prefix}/lib
 
@@ -353,6 +358,8 @@ if {${subport} eq "clang-${llvm_version}"} {
         system "cd ${destroot.dir}/tools/clang && ${destroot.cmd} ${destroot.pre_args} ${destroot.target} ${destroot.post_args}"
         system "cd ${destroot.dir}/projects/compiler-rt && ${destroot.cmd} ${destroot.pre_args} ${destroot.target} ${destroot.post_args}"
         system "cd ${destroot.dir}/projects/libcxx && ${destroot.cmd} ${destroot.pre_args} ${destroot.target} ${destroot.post_args}"
+        system "cd ${destroot.dir}/projects/libcxxabi && ${destroot.cmd} ${destroot.pre_args} ${destroot.target} ${destroot.post_args}"
+        system "cd ${destroot.dir}/projects/lld && ${destroot.cmd} ${destroot.pre_args} ${destroot.target} ${destroot.post_args}"
 
         delete ${destroot}${sub_prefix}/bin/clang
         file rename ${destroot}${sub_prefix}/bin/clang-${clang_executable_version} ${destroot}${sub_prefix}/bin/clang

--- a/lang/llvm-devel/files/0002-Define-EXC_MASK_CRASH-and-MACH_EXCEPTION_CODES-if-th.patch
+++ b/lang/llvm-devel/files/0002-Define-EXC_MASK_CRASH-and-MACH_EXCEPTION_CODES-if-th.patch
@@ -15,7 +15,7 @@ diff --git llvm_master/lib/Support/Unix/Signals.inc macports_master/lib/Support/
 index ec3935928d2..529bbfb34c2 100644
 --- llvm_master/lib/Support/Unix/Signals.inc
 +++ macports_master/lib/Support/Unix/Signals.inc
-@@ -565,6 +565,15 @@ void llvm::sys::PrintStackTraceOnErrorSignal(StringRef Argv0,
+@@ -642,6 +642,15 @@ void llvm::sys::PrintStackTraceOnErrorSignal(StringRef Argv0,
    AddSignalHandler(PrintStackTraceSignalHandler, nullptr);
  
  #if defined(__APPLE__) && ENABLE_CRASH_OVERRIDES

--- a/lang/llvm-devel/files/0003-MacPorts-Only-Don-t-embed-the-deployment-target-in-t.patch
+++ b/lang/llvm-devel/files/0003-MacPorts-Only-Don-t-embed-the-deployment-target-in-t.patch
@@ -15,7 +15,7 @@ diff --git llvm_master/lib/CodeGen/AsmPrinter/AsmPrinter.cpp macports_master/lib
 index 7adc59d096f..336d1384b8d 100644
 --- llvm_master/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
 +++ macports_master/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
-@@ -272,8 +272,10 @@ bool AsmPrinter::doInitialization(Module &M) {
+@@ -286,8 +286,10 @@ bool AsmPrinter::doInitialization(Module &M) {
    // alternative is duplicated code in each of the target asm printers that
    // use the directive, where it would need the same conditionalization
    // anyway.
@@ -27,7 +27,7 @@ index 7adc59d096f..336d1384b8d 100644
 +  }
  
    // Allow the target to emit any magic that it wants at the start of the file.
-   EmitStartOfAsmFile(M);
+   emitStartOfAsmFile(M);
 -- 
 2.21.0 (Apple Git-120)
 

--- a/lang/llvm-devel/files/0005-Threading-Only-call-pthread_setname_np-on-SnowLeopar.patch
+++ b/lang/llvm-devel/files/0005-Threading-Only-call-pthread_setname_np-on-SnowLeopar.patch
@@ -12,7 +12,7 @@ diff --git llvm_master/lib/Support/Unix/Threading.inc macports_master/lib/Suppor
 index ed9a9656305..e8f9a13860f 100644
 --- llvm_master/lib/Support/Unix/Threading.inc
 +++ macports_master/lib/Support/Unix/Threading.inc
-@@ -14,6 +14,7 @@
+@@ -16,6 +16,7 @@
  #include "llvm/ADT/Twine.h"
  
  #if defined(__APPLE__)
@@ -20,7 +20,7 @@ index ed9a9656305..e8f9a13860f 100644
  #include <mach/mach_init.h>
  #include <mach/mach_port.h>
  #endif
-@@ -153,8 +154,10 @@ void llvm::set_thread_name(const Twine &Name) {
+@@ -176,8 +176,10 @@ void llvm::set_thread_name(const Twine &Name) {
    ::pthread_setname_np(::pthread_self(), "%s",
      const_cast<char *>(NameStr.data()));
  #elif defined(__APPLE__)

--- a/lang/llvm-devel/files/0006-Only-call-setpriority-PRIO_DARWIN_THREAD-0-PRIO_DARW.patch
+++ b/lang/llvm-devel/files/0006-Only-call-setpriority-PRIO_DARWIN_THREAD-0-PRIO_DARW.patch
@@ -15,7 +15,7 @@ diff --git llvm_master/lib/Support/Unix/Threading.inc macports_master/lib/Suppor
 index e8f9a13860f..e731f750c1d 100644
 --- llvm_master/lib/Support/Unix/Threading.inc
 +++ macports_master/lib/Support/Unix/Threading.inc
-@@ -237,7 +237,7 @@ SetThreadPriorityResult llvm::set_thread_priority(ThreadPriority Priority) {
+@@ -260,7 +260,7 @@ SetThreadPriorityResult llvm::set_thread_priority(ThreadPriority Priority) {
               &priority)
               ? SetThreadPriorityResult::SUCCESS
               : SetThreadPriorityResult::FAILURE;

--- a/lang/llvm-devel/files/0007-patch-llvm8-tools-dsymutil-symbolmap-use-older-cfname-and-fix-uuid-on-leopard.diff
+++ b/lang/llvm-devel/files/0007-patch-llvm8-tools-dsymutil-symbolmap-use-older-cfname-and-fix-uuid-on-leopard.diff
@@ -2,7 +2,7 @@ diff --git a/tools/dsymutil/SymbolMap.cpp b/tools/dsymutil/SymbolMap.cpp
 index cab9374a..5c2377e4 100644
 --- a/tools/dsymutil/SymbolMap.cpp
 +++ b/tools/dsymutil/SymbolMap.cpp
-@@ -18,8 +18,18 @@
+@@ -17,8 +17,18 @@
  #ifdef __APPLE__
  #include <CoreFoundation/CoreFoundation.h>
  #include <uuid/uuid.h>

--- a/lang/llvm-devel/files/0008-patch-lib-support-unix-path-copyfileclone-on-older-systems.diff
+++ b/lang/llvm-devel/files/0008-patch-lib-support-unix-path-copyfileclone-on-older-systems.diff
@@ -2,8 +2,7 @@ diff --git trunk/lib/Support/Unix/Path.inc.orig trunk/lib/Support/Unix/Path.inc
 index c64c0df..aaa2226 100644
 --- trunk/lib/Support/Unix/Path.inc.orig
 +++ trunk/lib/Support/Unix/Path.inc
-@@ -38,6 +38,9 @@
- @@ -38,6 +38,9 @@
+@@ -39,6 +39,9 @@
  #include <mach-o/dyld.h>
  #include <sys/attr.h>
  #include <copyfile.h>

--- a/lang/llvm-devel/files/1001-MacPorts-Only-Prepare-clang-format-for-replacement-w.patch
+++ b/lang/llvm-devel/files/1001-MacPorts-Only-Prepare-clang-format-for-replacement-w.patch
@@ -56,7 +56,7 @@ diff --git llvm_master/tools/clang/tools/clang-format/clang-format.el macports_m
 index 0b9dc8d6fa..eebc4d115e 100644
 --- llvm_master/tools/clang/tools/clang-format/clang-format.el
 +++ macports_master/tools/clang/tools/clang-format/clang-format.el
-@@ -36,8 +36,7 @@
+@@ -37,8 +37,7 @@
    :group 'tools)
  
  (defcustom clang-format-executable
@@ -70,7 +70,7 @@ diff --git llvm_master/tools/clang/tools/clang-format/clang-format.py macports_m
 index 0c772f91f6..33c96180a4 100644
 --- llvm_master/tools/clang/tools/clang-format/clang-format.py
 +++ macports_master/tools/clang/tools/clang-format/clang-format.py
-@@ -36,7 +36,7 @@ import vim
+@@ -48,7 +48,7 @@ import vim
  
  # set g:clang_format_path to the path to clang-format if it is not on the path
  # Change this to the full path if clang-format is not on the path.

--- a/lang/llvm-devel/files/1002-MacPorts-Only-Fix-name-of-scan-view-executable-insid.patch
+++ b/lang/llvm-devel/files/1002-MacPorts-Only-Fix-name-of-scan-view-executable-insid.patch
@@ -16,4 +16,4 @@ http://trac.macports.org/ticket/35006
 +        if (! -x $ScanView) { $ScanView = Cwd::realpath("$RealBin/../scan-view/scan-view"); }
          if (! -x $ScanView) { $ScanView = "scan-view"; }
          if (! -x $ScanView) { $ScanView = Cwd::realpath("$RealBin/../../scan-view/bin/scan-view"); }
-         exec $ScanView, "$Options{OutputDir}";
+         if (! -x $ScanView) { $ScanView = `which scan-view`; chomp $ScanView; }

--- a/lang/llvm-devel/files/1005-Fixup-libstdc-header-search-paths-for-older-versions.patch
+++ b/lang/llvm-devel/files/1005-Fixup-libstdc-header-search-paths-for-older-versions.patch
@@ -18,7 +18,7 @@ diff --git llvm_master/tools/clang/lib/Driver/ToolChains/Darwin.cpp macports_mas
 index 5de7d7132d..165a331fe5 100644
 --- llvm_master/tools/clang/lib/Driver/ToolChains/Darwin.cpp
 +++ macports_master/tools/clang/lib/Driver/ToolChains/Darwin.cpp
-@@ -1958,7 +1958,7 @@ void DarwinClang::AddClangCXXStdlibIncludeArgs(
+@@ -2097,7 +2097,7 @@ void DarwinClang::AddClangCXXStdlibIncludeArgs(
                                                  "powerpc-apple-darwin10",
                                                  arch == llvm::Triple::ppc64 ? "ppc64" : "");
        IsBaseFound |= AddGnuCPlusPlusIncludePaths(DriverArgs, CC1Args, UsrIncludeCxx,
@@ -27,7 +27,7 @@ index 5de7d7132d..165a331fe5 100644
                                                   arch == llvm::Triple::ppc64 ? "ppc64" : "");
        break;
  
-@@ -1970,7 +1970,7 @@ void DarwinClang::AddClangCXXStdlibIncludeArgs(
+@@ -2109,7 +2109,7 @@ void DarwinClang::AddClangCXXStdlibIncludeArgs(
                                                  arch == llvm::Triple::x86_64 ? "x86_64" : "");
        IsBaseFound |= AddGnuCPlusPlusIncludePaths(DriverArgs, CC1Args, UsrIncludeCxx,
                                                  "4.0.0", "i686-apple-darwin8",

--- a/lang/llvm-devel/files/1009-compilerrt-sanitizer-missingdefs.diff
+++ b/lang/llvm-devel/files/1009-compilerrt-sanitizer-missingdefs.diff
@@ -1,6 +1,6 @@
 --- llvm/projects/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp.orig	2020-05-14 15:13:45.000000000 -0700
 +++ llvm/projects/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp	2020-05-14 15:17:03.000000000 -0700
-@@ -111,6 +111,11 @@
+@@ -119,6 +119,11 @@
  #define VM_MEMORY_SANITIZER 99
  #endif
  

--- a/lang/llvm-devel/files/3001-Fix-missing-long-long-math-prototypes-when-using-the.patch
+++ b/lang/llvm-devel/files/3001-Fix-missing-long-long-math-prototypes-when-using-the.patch
@@ -13,7 +13,7 @@ diff --git llvm_master/projects/libcxx/include/math.h macports_master/projects/l
 index 194df2077..14d14fe08 100644
 --- llvm_master/projects/libcxx/include/math.h
 +++ macports_master/projects/libcxx/include/math.h
-@@ -302,6 +302,32 @@ long double    truncl(long double x);
+@@ -299,6 +299,32 @@ long double    truncl(long double x);
  
  #include_next <math.h>
  

--- a/lang/llvm-devel/files/3002-implement-atomic-using-mutex-lock_guard-for-64b-ops-.patch
+++ b/lang/llvm-devel/files/3002-implement-atomic-using-mutex-lock_guard-for-64b-ops-.patch
@@ -260,7 +260,7 @@ diff --git llvm_master/projects/libcxx/include/atomic macports_master/projects/l
 index afb431eda..b87307977 100644
 --- llvm_master/projects/libcxx/include/atomic
 +++ macports_master/projects/libcxx/include/atomic
-@@ -2439,4 +2439,50 @@ typedef atomic<uintmax_t> atomic_uintmax_t;
+@@ -2801,4 +2801,50 @@ typedef atomic<uintmax_t> atomic_uintmax_t;
  
  _LIBCPP_END_NAMESPACE_STD
  

--- a/lang/llvm-devel/files/5000-patch-compilerrtdarwinutils-find-macosxsdkversion.diff
+++ b/lang/llvm-devel/files/5000-patch-compilerrtdarwinutils-find-macosxsdkversion.diff
@@ -1,6 +1,6 @@
 --- a/projects/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake.orig	2020-04-20 17:14:08.000000000 -0700
 +++ b/projects/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake	2020-04-20 17:31:44.000000000 -0700
-@@ -66,15 +66,6 @@
+@@ -69,15 +69,6 @@
        ERROR_FILE /dev/null
      )
    endif()
@@ -16,7 +16,7 @@
    set(${var} ${var_internal} PARENT_SCOPE)
  endfunction()
  
-@@ -125,6 +116,11 @@
+@@ -128,6 +119,11 @@
      # binaries.
      if ("${os}" STREQUAL "osx")
        find_darwin_sdk_version(macosx_sdk_version "macosx")

--- a/lang/llvm-devel/files/5002-patch-toolchains-darwin-add-back-pre-10.6-link-libs.diff
+++ b/lang/llvm-devel/files/5002-patch-toolchains-darwin-add-back-pre-10.6-link-libs.diff
@@ -15,7 +15,7 @@ diff --git a/tools/clang/lib/Driver/ToolChains/Darwin.cpp b/tools/clang/lib/Driv
 index bea877ae9..26f1ad714 100644
 --- a/tools/clang/lib/Driver/ToolChains/Darwin.cpp
 +++ b/tools/clang/lib/Driver/ToolChains/Darwin.cpp
-@@ -1140,6 +1140,12 @@ void DarwinClang::AddLinkRuntimeLibArgs(const ArgList &Args,
+@@ -1334,6 +1334,12 @@ void DarwinClang::AddLinkRuntimeLibArgs(const ArgList &Args,
          getTriple().getArch() != llvm::Triple::aarch64)
        CmdArgs.push_back("-lgcc_s.1");
    }

--- a/lang/llvm-devel/files/9000-patch-clang-7.0-support-emulated-tls.diff
+++ b/lang/llvm-devel/files/9000-patch-clang-7.0-support-emulated-tls.diff
@@ -2,7 +2,7 @@ diff --git a/tools/clang/lib/Basic/Targets/OSTargets.h b/tools/clang/lib/Basic/T
 index d0354784..102605fe 100644
 --- a/tools/clang/lib/Basic/Targets/OSTargets.h
 +++ b/tools/clang/lib/Basic/Targets/OSTargets.h
-@@ -93,7 +93,7 @@ public:
+@@ -92,7 +92,7 @@ public:
      this->TLSSupported = false;
  
      if (Triple.isMacOSX())
@@ -15,7 +15,7 @@ diff --git a/tools/clang/lib/CodeGen/ItaniumCXXABI.cpp b/tools/clang/lib/CodeGen
 index 00fff144..052924ab 100644
 --- a/tools/clang/lib/CodeGen/ItaniumCXXABI.cpp
 +++ b/tools/clang/lib/CodeGen/ItaniumCXXABI.cpp
-@@ -2255,7 +2255,7 @@ static void emitGlobalDtorWithCXAAtExit(CodeGenFunction &CGF,
+@@ -2507,7 +2507,7 @@ static void emitGlobalDtorWithCXAAtExit(CodeGenFunction &CGF,
    const char *Name = "__cxa_atexit";
    if (TLS) {
      const llvm::Triple &T = CGF.getTarget().getTriple();

--- a/lang/llvm-devel/files/9000-patch-llvm-7.0-support-emulated-tls.diff
+++ b/lang/llvm-devel/files/9000-patch-llvm-7.0-support-emulated-tls.diff
@@ -2,7 +2,7 @@ diff --git a/include/llvm/ADT/Triple.h b/include/llvm/ADT/Triple.h
 index c95b16dd..ecc0f148 100644
 --- a/include/llvm/ADT/Triple.h
 +++ b/include/llvm/ADT/Triple.h
-@@ -682,7 +682,7 @@ public:
+@@ -809,7 +809,7 @@ public:
  
    /// Tests whether the target uses emulated TLS as default.
    bool hasDefaultEmulatedTLS() const {
@@ -10,4 +10,4 @@ index c95b16dd..ecc0f148 100644
 +    return isAndroid() || isOSOpenBSD() || isWindowsCygwinEnvironment() || isMacOSXVersionLT(10, 7);
    }
  
-   /// @}
+   /// Tests whether the target uses -data-sections as default.

--- a/lang/llvm-devel/files/9001-macports-libstdcxx.diff
+++ b/lang/llvm-devel/files/9001-macports-libstdcxx.diff
@@ -1,6 +1,6 @@
 --- orig/tools/clang/include/clang/Lex/HeaderSearchOptions.h
 +++ new/tools/clang/include/clang/Lex/HeaderSearchOptions.h
-@@ -184,6 +184,9 @@ public:
+@@ -189,6 +189,9 @@ public:
    /// Use libc++ instead of the default libstdc++.
    unsigned UseLibcxx : 1;
  
@@ -12,21 +12,21 @@
  
 --- llvm/tools/clang/lib/Frontend/CompilerInvocation.cpp.orig	2020-05-06 08:57:03.000000000 -0700
 +++ llvm/tools/clang/lib/Frontend/CompilerInvocation.cpp	2020-05-07 12:51:38.000000000 -0700
-@@ -2078,8 +2078,10 @@
-   Opts.UseBuiltinIncludes = !Args.hasArg(OPT_nobuiltininc);
-   Opts.UseStandardSystemIncludes = !Args.hasArg(OPT_nostdsysteminc);
-   Opts.UseStandardCXXIncludes = !Args.hasArg(OPT_nostdincxx);
+@@ -2939,8 +2939,10 @@
+ #include "clang/Driver/Options.inc"
+ #undef HEADER_SEARCH_OPTION_WITH_MARSHALLING
+ 
 -  if (const Arg *A = Args.getLastArg(OPT_stdlib_EQ))
 +  if (const Arg *A = Args.getLastArg(OPT_stdlib_EQ)) {
      Opts.UseLibcxx = (strcmp(A->getValue(), "libc++") == 0);
 +    Opts.UseMacPortsLibstdcxx = (strcmp(A->getValue(), "macports-libstdc++") == 0);
 +  }
-   Opts.ResourceDir = std::string(Args.getLastArgValue(OPT_resource_dir));
  
    // Canonicalize -fmodules-cache-path before storing it.
+   SmallString<128> P(Args.getLastArgValue(OPT_fmodules_cache_path));
 --- orig/tools/clang/lib/Frontend/InitHeaderSearch.cpp
 +++ new/tools/clang/lib/Frontend/InitHeaderSearch.cpp
-@@ -110,7 +110,7 @@ static bool CanPrefixSysroot(StringRef Path) {
+@@ -108,7 +108,7 @@ static bool CanPrefixSysroot(StringRef Path) {
  #if defined(_WIN32)
    return !Path.empty() && llvm::sys::path::is_separator(Path[0]);
  #else
@@ -37,7 +37,7 @@
  
 --- orig/tools/clang/include/clang/Driver/ToolChain.h
 +++ new/tools/clang/include/clang/Driver/ToolChain.h
-@@ -91,7 +91,8 @@ public:
+@@ -94,7 +94,8 @@ public:
  
    enum CXXStdlibType {
      CST_Libcxx,
@@ -49,7 +49,7 @@
    enum RuntimeLibType {
 --- orig/tools/clang/lib/Driver/ToolChains/Darwin.cpp
 +++ new/tools/clang/lib/Driver/ToolChains/Darwin.cpp
-@@ -1921,8 +1921,9 @@ void DarwinClang::AddClangCXXStdlibInclu
+@@ -2045,8 +2045,9 @@ void DarwinClang::AddClangCXXStdlibInclu
      return;
  
    llvm::StringRef Sysroot = GetHeaderSysroot(DriverArgs);
@@ -58,9 +58,9 @@
 -  switch (GetCXXStdlibType(DriverArgs)) {
 +  switch (Type) {
    case ToolChain::CST_Libcxx: {
-     // On Darwin, libc++ is installed alongside the compiler in
-     // include/c++/v1, so get from '<install>/bin' to '<install>/include/c++/v1'.
-@@ -1943,6 +1944,7 @@ void DarwinClang::AddClangCXXStdlibInclu
+     // On Darwin, libc++ can be installed in one of the following two places:
+     // 1. Alongside the compiler in         <install>/include/c++/v1
+@@ -2088,6 +2089,7 @@ void DarwinClang::AddClangCXXStdlibInclu
    }
  
    case ToolChain::CST_Libstdcxx:
@@ -68,7 +68,7 @@
      llvm::SmallString<128> UsrIncludeCxx = Sysroot;
      llvm::sys::path::append(UsrIncludeCxx, "usr", "include", "c++");
  
-@@ -1953,10 +1955,17 @@ void DarwinClang::AddClangCXXStdlibInclu
+@@ -2098,10 +2100,17 @@ void DarwinClang::AddClangCXXStdlibInclu
  
      case llvm::Triple::ppc:
      case llvm::Triple::ppc64:
@@ -90,7 +90,7 @@
        IsBaseFound |= AddGnuCPlusPlusIncludePaths(DriverArgs, CC1Args, UsrIncludeCxx,
                                                  "4.0.0", "powerpc-apple-darwin8",
                                                   arch == llvm::Triple::ppc64 ? "ppc64" : "");
-@@ -1964,10 +1973,17 @@ void DarwinClang::AddClangCXXStdlibInclu
+@@ -2109,10 +2118,17 @@ void DarwinClang::AddClangCXXStdlibInclu
  
      case llvm::Triple::x86:
      case llvm::Triple::x86_64:
@@ -112,7 +112,7 @@
        IsBaseFound |= AddGnuCPlusPlusIncludePaths(DriverArgs, CC1Args, UsrIncludeCxx,
                                                  "4.0.0", "i686-apple-darwin8",
                                                   arch == llvm::Triple::x86_64 ? "x86_64" : "");
-@@ -2010,6 +2026,12 @@ void DarwinClang::AddCXXStdlibLibArgs(co
+@@ -2155,6 +2171,12 @@ void DarwinClang::AddCXXStdlibLibArgs(co
      break;
  
    case ToolChain::CST_Libstdcxx:
@@ -127,7 +127,7 @@
      // platforms we care about it was -lstdc++.6, so we search for that
 --- orig/tools/clang/lib/Driver/ToolChains/Hexagon.cpp.orig	2020-05-06 08:57:03.000000000 -0700
 +++ new/tools/clang/lib/Driver/ToolChains/Hexagon.cpp	2020-05-07 12:43:10.000000000 -0700
-@@ -639,6 +639,8 @@
+@@ -643,6 +643,8 @@
        return ToolChain::CST_Libstdcxx;
    }
    StringRef Value = A->getValue();
@@ -138,16 +138,16 @@
  
 --- orig/tools/clang/lib/Driver/ToolChain.cpp
 +++ new/tools/clang/lib/Driver/ToolChain.cpp
-@@ -766,6 +766,8 @@ ToolChain::CXXStdlibType ToolChain::GetCXXStdlibType(const ArgList &Args) const{
-     return ToolChain::CST_Libcxx;
+@@ -965,6 +965,8 @@
+     cxxStdlibType = ToolChain::CST_Libcxx;
    else if (LibName == "libstdc++")
-     return ToolChain::CST_Libstdcxx;
+     cxxStdlibType = ToolChain::CST_Libstdcxx;
 +  else if (LibName == "macports-libstdc++")
-+    return ToolChain::CST_MacPortsLibstdcxx;
++    cxxStdlibType = ToolChain::CST_MacPortsLibstdcxx;
    else if (LibName == "platform")
-     return GetDefaultCXXStdlibType();
- 
-@@ -847,6 +849,7 @@ void ToolChain::AddCXXStdlibLibArgs(const ArgList &Args,
+     cxxStdlibType = GetDefaultCXXStdlibType();
+   else {
+@@ -1060,6 +1062,7 @@
      break;
  
    case ToolChain::CST_Libstdcxx:

--- a/lang/llvm-devel/files/9003-patch-clang-7.0-default-to-libcxx-on-all-systems.diff
+++ b/lang/llvm-devel/files/9003-patch-clang-7.0-default-to-libcxx-on-all-systems.diff
@@ -2,7 +2,7 @@ diff --git llvm-7.0.1.src/tools/clang/lib/Driver/ToolChains/Darwin.cpp llvm-7.0.
 index dc540688..64adab5c 100644
 --- llvm-7.0.1.src/tools/clang/lib/Driver/ToolChains/Darwin.cpp
 +++ llvm-7.0.1.src/tools/clang/lib/Driver/ToolChains/Darwin.cpp
-@@ -700,8 +700,8 @@ types::ID MachO::LookupTypeForExtension(StringRef Ext) const {
+@@ -810,8 +810,8 @@ types::ID MachO::LookupTypeForExtension(StringRef Ext) const {
  bool MachO::HasNativeLLVMSupport() const { return true; }
  
  ToolChain::CXXStdlibType Darwin::GetDefaultCXXStdlibType() const {

--- a/lang/llvm-devel/files/leopard-no-asan.patch
+++ b/lang/llvm-devel/files/leopard-no-asan.patch
@@ -1,6 +1,6 @@
 --- a/projects/compiler-rt/cmake/config-ix.cmake       2015-11-29 22:17:04.000000000 -0800
 +++ b/projects/compiler-rt/cmake/config-ix.cmake       2015-11-29 22:19:16.000000000 -0800
-@@ -361,9 +361,6 @@
+@@ -414,9 +414,6 @@
      else()
        set(SANITIZER_MIN_OSX_VERSION ${DEFAULT_SANITIZER_MIN_OSX_VERSION})
      endif()

--- a/lang/llvm-devel/files/leopard-no-blocks.patch
+++ b/lang/llvm-devel/files/leopard-no-blocks.patch
@@ -12,7 +12,7 @@ diff --git a/lib/Driver/ToolChains.h b/lib/Driver/ToolChains.h
 index 876bb01..27aa2ee 100644
 --- a/tools/clang/lib/Driver/ToolChains/Darwin.h
 +++ b/tools/clang/lib/Driver/ToolChains/Darwin.h
-@@ -257,7 +257,7 @@ public:
+@@ -217,7 +217,7 @@ public:
    bool IsBlocksDefault() const override {
      // Always allow blocks on Apple; users interested in versioning are
      // expected to use /usr/include/Block.h.

--- a/lang/llvm-devel/files/openmp-locations.patch
+++ b/lang/llvm-devel/files/openmp-locations.patch
@@ -2,7 +2,7 @@ diff --git a/lib/Driver/ToolChains/Clang.cpp b/lib/Driver/ToolChains/Clang.cpp
 index 292cf72b56..d8c6327080 100644
 --- a/tools/clang/lib/Driver/ToolChains/Clang.cpp
 +++ b/tools/clang/lib/Driver/ToolChains/Clang.cpp
-@@ -3229,6 +3229,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
+@@ -5532,6 +5532,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
      case Driver::OMPRT_OMP:
      case Driver::OMPRT_IOMP5:
        // Clang can generate useful OpenMP code for these two runtime libraries.
@@ -14,7 +14,7 @@ index 292cf72b56..d8c6327080 100644
 diff -u a/tools/clang/lib/Driver/ToolChains/CommonArgs.cpp.orig b/tools/clang/lib/Driver/ToolChains/CommonArgs.cpp
 --- a/tools/clang/lib/Driver/ToolChains/CommonArgs.cpp.orig	2020-04-19 11:47:05.000000000 -0700
 +++ b/tools/clang/lib/Driver/ToolChains/CommonArgs.cpp	2020-04-19 11:48:11.000000000 -0700
-@@ -521,12 +521,18 @@
+@@ -673,12 +673,18 @@
  
    switch (RTKind) {
    case Driver::OMPRT_OMP:


### PR DESCRIPTION
This update increases the LLVM version from 12->13 even though
version 12 has not been released yet.
Version 12 is at release candidate 3, and a WIP port emscripten
(https://emscripten.org) requires LLVM version 13.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
