### PR TITLE
detekt-cli: new port

### DIFF
--- a/java/detekt-cli/Portfile
+++ b/java/detekt-cli/Portfile
@@ -1,0 +1,51 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           java    1.0
+PortGroup           github  1.0
+
+name                detekt-cli
+
+github.setup        detekt detekt 1.16.0 v
+revision            0
+
+# The resulting .jar uses the version of the latest release candidate.
+set buildversion ${version}-RC3
+
+categories          java devel
+license             Apache-2
+maintainers         {bochtler.io:macports @MarcelBochtler} \
+                    openmaintainer
+platforms           darwin
+description         CLI tool for detekt
+long_description    Detekt is a static code analysis tool for Kotlin.
+homepage            https://detekt.github.io
+
+github.tarball_from archive
+
+distname            v${version}
+checksums           sha256  85099302a9f5e9b5a194f29360bccedc17c75c2b67638ce042e1d0a1608e01b1 \
+                    rmd160  5c36149156ddddf685cc540132d7217340fc717a \
+                    size    2618389
+
+java.fallback       openjdk11
+java.version        1.8+
+
+use_configure       no
+
+depends_build-append \
+                    port:gradle
+
+build.env-append    GRADLE_USER_HOME=${worksrcpath}/${name}
+build.cmd           ${prefix}/bin/gradle
+build.target        ${name}:jar
+
+destroot {
+    set javadir ${destroot}${prefix}/share/java
+    xinstall -m 755 -d ${javadir}/${name}
+    xinstall -m 644 ${worksrcpath}/${name}/build/libs/${name}-${buildversion}.jar ${javadir}/${name}/${name}.jar
+
+    # Install the wrapper script
+    xinstall -m 755 ${filespath}/detekt ${destroot}${prefix}/bin
+    reinplace "s|_PREFIX_|${prefix}|g" ${destroot}${prefix}/bin/detekt
+}

--- a/java/detekt-cli/files/detekt
+++ b/java/detekt-cli/files/detekt
@@ -1,0 +1,2 @@
+#!/bin/sh
+java -jar _PREFIX_/share/java/detekt-cli/detekt-cli.jar "$@"


### PR DESCRIPTION
Add detect-cli, a static code analysis tool for Kotlin: https://github.com/detekt/detekt

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
OS 10.15.7 19H2
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
