### PR TITLE
Remove u prefix from universal-ctags binary

### DIFF
--- a/devel/ctags/Portfile
+++ b/devel/ctags/Portfile
@@ -22,7 +22,7 @@ maintainers         nomaintainer
 license             {GPL-2 public-domain}
 
 # developer_cmds installs BSD ctags.
-conflicts           developer_cmds
+conflicts           developer_cmds universal-ctags
 
 description         Reimplementation of ctags(1)
 

--- a/devel/developer_cmds/Portfile
+++ b/devel/developer_cmds/Portfile
@@ -7,7 +7,7 @@ categories              devel
 maintainers             nomaintainer
 
 # We install BSD ctags, conflicting with Exuberant Ctags.
-conflicts               ctags
+conflicts               ctags universal-ctags
 
 homepage                http://opensource.apple.com/source/${name}/
 master_sites            http://opensource.apple.com/tarballs/${name}/

--- a/devel/global/Portfile
+++ b/devel/global/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                global
 version             6.6.6
-revision            0
+revision            1
 checksums           rmd160  a6b98c13fe02b4efebc5d5a4e9670b79b58db3c9 \
                     sha256  758078afff98d4c051c58785c7ada3ed1977fabb77f8897ff657b71cc62d4d5d \
                     size    2991256
@@ -33,16 +33,12 @@ set python_bin      ${prefix}/bin/python${python_branch}
 
 depends_lib         port:libtool \
                     port:ncurses \
-                    port:ctags \
-                    port:universal-ctags \
                     port:py${python_version}-pygments
 
 # universal-ctags is not universal
 universal_variant   no
 
-configure.args      --with-exuberant-ctags=${prefix}/bin/ctags \
-                    --with-universal-ctags=${prefix}/bin/uctags \
-                    --with-sqlite3
+configure.args      --with-sqlite3
 
 configure.env-append \
                     "PYTHON=${python_bin}"
@@ -58,6 +54,22 @@ post-patch {
 # we always build .so (and not always .la) so let's use .so.
 post-destroot {
     reinplace {s,\.la,.so,g} ${destroot}${prefix}/share/gtags/gtags.conf
+}
+
+variant ctags conflicts universal_ctags description {Build with Exuberant Ctags support} {
+    depends_lib-append      port:ctags
+    configure.args-append   --with-exuberant-ctags=${prefix}/bin/ctags \
+                            --with-universal-ctags=no
+}
+
+variant universal_ctags conflicts ctags description {Build with Universal Ctags support} {
+    depends_lib-append      port:universal-ctags
+    configure.args-append   --with-universal-ctags=${prefix}/bin/ctags \
+                            --with-exuberant-ctags=no
+}
+
+if {![variant_isset universal_ctags]} {
+    default_variants    +ctags
 }
 
 livecheck.type      regex

--- a/devel/universal-ctags/Portfile
+++ b/devel/universal-ctags/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 github.setup        universal-ctags ctags 5.9.20201227.0 p
 name                universal-ctags
 epoch               1
-revision            0
+revision            1
 
 categories          devel
 platforms           darwin
@@ -20,6 +20,7 @@ long_description \
     started by Reza Jelveh and was later moved to the universal-ctags organization.
 
 homepage            https://ctags.io
+conflicts           ctags developer_cmds
 
 checksums           rmd160  1020ed7bd8f86ccf97f0108c4b155aa76c04fe47 \
                     sha256  140904a75405df063b0e201aaf7e9147a92cee2b492d6a507c9984cf60bf5ba0 \
@@ -39,7 +40,7 @@ pre-patch {
 
 use_autoconf        yes
 autoconf.cmd        ./autogen.sh
-configure.args      --program-prefix=u --enable-json --enable-yaml
+configure.args      --enable-json --enable-yaml
 
 depends_build       port:autoconf \
                     port:automake \

--- a/textproc/source-highlight/Portfile
+++ b/textproc/source-highlight/Portfile
@@ -41,7 +41,7 @@ configure.args  --infodir=${prefix}/share/info \
 test.run        yes
 test.target     check
 
-depends_lib     port:ctags
+depends_lib     bin:ctags:ctags
 
 livecheck.type  regex
 livecheck.url   https://ftp.gnu.org/gnu/src-highlite/?C=M&O=D


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Install universal-ctags as `${prefix}/bin/ctags`. Universal Ctags is designed to be a drop-in replacement for Exuberant Ctags. Installing it as `uctags` defeats the point.

This reverts the change from 0b86afc1b91a5f12b8eabd8499c3cb87c3d5d02b which was meant to address a conflict in the `global` port. To address that conflict, provide `+ctags` and `+universal_ctags` variants for `global` to use *either* Exuberant Ctags *or* Universal Ctags, not both.

(Note that I did try to simply use `depends_lib bin:ctags:ctags` in the global port and allow the configure script to pick up which version of Ctags is installed. Unfortunately, the global configure script has a bug: it checks to see if `ctags` is Exuberant Ctags using `ctags --version | grep 'Exuberant Ctags'` which doesn't work because the Universal Ctags `--version` information *also* includes the phrase "Exuberant Ctags". So the configure script mistakenly assumes Exuberant is installed even when it is not.)

See also: https://trac.macports.org/ticket/60563

If this approach is undesirable then I propose implementing `ctags_select` to allow the user to choose which version of ctags `${prefix}/bin/ctags` links to while still allowing multiple versions to be installed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.4 12D4e


###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
