### PR TITLE
lang/sbcl - Add support for arm64 arch

### DIFF
--- a/lang/sbcl/Portfile
+++ b/lang/sbcl/Portfile
@@ -15,7 +15,7 @@ categories      lang
 license         BSD
 maintainers     {easieste @easye} openmaintainer
 platforms       darwin
-supported_archs i386 x86_64
+supported_archs i386 x86_64 arm64
 description     The Steel Bank Common Lisp system
 
 long_description \
@@ -64,6 +64,17 @@ if {${build_arch} eq "x86_64"} {
         size    10038928
     global host_lisp
     set host_lisp "\"${workpath}/${name}-${bootversion}-x86-64-darwin/src/runtime/sbcl --core ${workpath}/${name}-${bootversion}-x86-64-darwin/output/sbcl.core --disable-debugger --sysinit /dev/null --userinit /dev/null\" "
+}
+if {${build_arch} eq "arm64"} {
+    set bootversion 2.1.2
+    master_sites-append sourceforge:project/sbcl/sbcl/${bootversion}:sbcl_arm64
+    distfiles-append    ${name}-${bootversion}-arm64-darwin-binary${extract.suffix}:sbcl_arm64
+    checksums-append    ${name}-${bootversion}-arm64-darwin-binary${extract.suffix} \
+        rmd160  ce5856a0e1f0040e95c9d79ef0a6199a0f932ab3 \
+        sha256  1f400b8a05dc588ca9740f9f4dfee3111b1cc1b6fb40801f728c42b460e1d115 \
+        size    9204605
+    global host_lisp
+    set host_lisp "\"${workpath}/${name}-${bootversion}-arm64-darwin/src/runtime/sbcl --core ${workpath}/${name}-${bootversion}-arm64-darwin/output/sbcl.core --disable-debugger --sysinit /dev/null --userinit /dev/null\" "
 }
 # Note that i386 support is currently untested; build reports welcome
 if {${build_arch} eq "i386"} {


### PR DESCRIPTION
#### Description

Made a new build section for the M1 Macs. Uses 2.1.2 as the bootstrap since that's the first version that supports arm64.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
