### PR TITLE
bitwarden-cli: new port

### DIFF
--- a/security/bitwarden-cli/Portfile
+++ b/security/bitwarden-cli/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                bitwarden-cli
+version             1.15.1
+revision            0
+
+categories          security
+license             GPL-3
+maintainers         {bochtler.io:macports @MarcelBochtler} \
+                    openmaintainer
+platforms           darwin
+description         Bitwarden password manager CLI
+long_description    CLI implementation of the Bitwarden password manager.
+homepage            https://bitwarden.com
+
+checksums           rmd160  60a228382ca8feb4c871e6f70c52648c3d9f610b \
+                    sha256  ecb0f098a09d58ac813d862305b32c1c3bae3e2285444c1ff326560ab29c25eb \
+                    size    19376210
+
+master_sites        https://github.com/bitwarden/cli/releases/download/v${version}/
+distname            bw-macos-${version}
+use_zip             yes
+
+use_configure       no
+
+build               {}
+
+destroot {
+    xinstall -m 755 ${workpath}/bw ${destroot}${prefix}/bin
+}
+
+livecheck.type      regex
+livecheck.url       https://github.com/bitwarden/cli/releases
+livecheck.regex     bw-macos-(\\d+\\.\\d+\\.\\d+)\.zip


### PR DESCRIPTION
#### Description

CLI implementation of the Bitwarden password manager.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H2
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
