### PR TITLE
fix parenthesis in patch-lib-update.js.diff

### DIFF
--- a/devel/npm7/Portfile
+++ b/devel/npm7/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                npm7
 version             7.7.6
-revision            0
+revision            1
 categories          devel
 platforms           darwin
 supported_archs     noarch

--- a/devel/npm7/files/patch-lib-update.js.diff
+++ b/devel/npm7/files/patch-lib-update.js.diff
@@ -7,7 +7,7 @@
 +    // Prevent the npm package in global from updating. Prevent
 +    // 'npm update -g' since it'll implicity upgrade npm and also
 +    // prevent 'npm update -g npm'.
-+    if (this.npm.config.get('global') {
++    if (this.npm.config.get('global')) {
 +      if (!args.length || (args.length && args.find(e => e === 'npm'))) {
 +        log.error('update', 'Ignoring attempt to update npm in ' + global);
 +        log.error('update', 'which is part of the MacPorts npm7 base');


### PR DESCRIPTION
#### Description

Missing parenthesis in patch leads to failure of `npm up -g <package>` 

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3
Xcode 12.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
