### PR TITLE
julia: add p7zip dependency

### DIFF
--- a/lang/julia/Portfile
+++ b/lang/julia/Portfile
@@ -9,7 +9,7 @@ compilers.choose    fc f77 f90
 compilers.setup     require_fortran -g95
 
 github.setup        JuliaLang julia 1.6.0 v
-revision            0
+revision            1
 categories-append   lang math science
 maintainers         {ieee.org:s.t.smith @essandess} openmaintainer
 platforms           darwin
@@ -49,6 +49,8 @@ if {[option gpg_verify.use_gpg_verification]} {
             ${distpath}/${name}-${version}-full${extract.suffix}
     }
 }
+
+depends_run-append  port:p7zip
 
 # julia build is `make && make install`
 # see https://github.com/JuliaLang/julia/blob/master/Makefile


### PR DESCRIPTION
#### Description

p7zip is required by Julia's package manager Pkg. If it is not installed, Pkg will fail to download and extract any registry data and is therefore unable to install any packages.

This is probably a change in Julia 1.6.0. It looks like Linux distributions had to make the same change: https://bugs.archlinux.org/task/70166

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (none)
- [x] checked your Portfile with `port lint`? (missing checksums warning not caused by this change)
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
