### PR TITLE
isync: add launchd file

### DIFF
--- a/mail/isync/Portfile
+++ b/mail/isync/Portfile
@@ -1,51 +1,74 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem          1.0
+PortSystem              1.0
 
-name                isync
-version             1.4.1
-revision            0
-categories          mail
-platforms           darwin
-license             GPL-2
-maintainers         {gmail.com:emanuele.giaquinta @exg} openmaintainer
-description         command line utility to synchronize mailboxes
-long_description    isync is a command line utility for synchronizing IMAP4 \
-                    and Maildir mailboxes. With it one can read mail while \
-                    offline, and later synchronize new messages, message \
-                    deletions and flag changes in a fine-grained manner when \
-                    an internet connection is available.
-homepage            http://isync.sourceforge.net/
-master_sites        sourceforge:project/isync/isync/${version}/
+name                    isync
+version                 1.4.1
+revision                1
+categories              mail
+platforms               darwin
+license                 GPL-2
+maintainers             {gmail.com:emanuele.giaquinta @exg} openmaintainer
+description             command line utility to synchronize mailboxes
+long_description        isync is a command line utility for synchronizing IMAP4 \
+                        and Maildir mailboxes. With it one can read mail while \
+                        offline, and later synchronize new messages, message \
+                        deletions and flag changes in a fine-grained manner when \
+                        an internet connection is available.
+homepage                http://isync.sourceforge.net/
+master_sites            sourceforge:project/isync/isync/${version}/
 
-checksums           rmd160  877afe4f90961ed9fb1edef109e28a4fd6289845 \
-                    sha256  0d36dbb57bb06c8bbe10bb66f40ae543095b143443209b7037167be600420150 \
-                    size    336281
+checksums               rmd160  877afe4f90961ed9fb1edef109e28a4fd6289845 \
+                        sha256  0d36dbb57bb06c8bbe10bb66f40ae543095b143443209b7037167be600420150 \
+                        size    336281
 
-compiler.c_standard 2011
+compiler.c_standard     2011
 
-depends_build       port:perl5 \
-                    port:pkgconfig
+depends_build           port:perl5 \
+                        port:pkgconfig
 
-depends_lib         port:cyrus-sasl2 \
-                    port:db53 \
-                    path:lib/libssl.dylib:openssl \
-                    port:zlib
+depends_lib             port:cyrus-sasl2 \
+                        port:db53 \
+                        path:lib/libssl.dylib:openssl \
+                        port:zlib
 
-depends_run         path:share/curl/curl-ca-bundle.crt:curl-ca-bundle
+depends_run             path:share/curl/curl-ca-bundle.crt:curl-ca-bundle
+
+startupitem.name        mbsync
 
 # Patch the sample configuration to use MacPorts certificates and
 # drv_proxy_gen.pl to use MacPorts perl for building on OS X 10.8 and
 # earlier: https://sourceforge.net/p/isync/bugs/37/
 patchfiles          patch-paths.diff
 
+post-extract {
+    xinstall -m 644 -W ${filespath} mbsync.plist ${worksrcpath}
+}
+
 post-patch {
     reinplace "s|@PREFIX@|${prefix}|" \
         ${worksrcpath}/src/drv_proxy_gen.pl \
-        ${worksrcpath}/src/mbsyncrc.sample
+        ${worksrcpath}/src/mbsyncrc.sample \
+        ${worksrcpath}/mbsync.plist
+
+    reinplace "s|@LABEL@|${startupitem.uniquename}|g" ${worksrcpath}/mbsync.plist
+}
+
+post-destroot {
+    set examples_dir ${prefix}/share/examples/${name}
+    xinstall -d ${destroot}${examples_dir}
+    xinstall -m 644 -W ${worksrcpath} mbsync.plist ${destroot}${examples_dir}/${startupitem.plist}
 }
 
 configure.cppflags-append   -I${prefix}/include/db53
 configure.ldflags-append    -L${prefix}/lib/db53
 
-notes "A sample configuration file has been installed in ${prefix}/share/doc/${name}/examples/mbsyncrc.sample"
+notes "
+A sample configuration file has been installed in ${prefix}/share/doc/${name}/examples/mbsyncrc.sample.
+
+A launchd plist file is provided to run mbsync periodically. To use it:
+
+    1. Copy ${prefix}/share/examples/${name}/${startupitem.plist} to ~/Library/LaunchAgents
+    2. Edit ${startupitem.plist} to change the StartInterval to the desired period (in seconds)
+    3. Run 'launchctl load ~/Library/LaunchAgents/${startupitem.plist}'
+"

--- a/mail/isync/files/mbsync.plist
+++ b/mail/isync/files/mbsync.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>KeepAlive</key>
+    <false/>
+    <key>Label</key>
+    <string>@LABEL@</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>@PREFIX@/bin/mbsync</string>
+      <string>-a</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>RunAtLoad</key>
+    <true />
+    <key>StandardErrorPath</key>
+    <string>/dev/null</string>
+    <key>StandardOutPath</key>
+    <string>/dev/null</string>
+  </dict>
+</plist>


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Add launchd file for isync to make it run in the background every 5 minutes.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.4 12D4e


###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
