### PR TITLE
google-cloud-sdk: update to 334.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             333.0.0
+version             334.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,14 +21,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  69d1830fd5b5afd6c9eb60cf533af72ac3f9741d \
-                    sha256  e8450b3b83584d493ded4f6bc08031ad2eec16eabd53c161c9a7f70a130dbf19 \
-                    size    88644763
+    checksums       rmd160  bcd55d22e637f48d9ddac473ce64cf15dc8415fe \
+                    sha256  f3e1868d2aca4fabf14313cb5ab670bb6ceaa6d1d87688a36eda33910cad7f54 \
+                    size    88627916
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  8d98a232775f6a7f909327ac778068d48b5ada9b \
-                    sha256  ed55af0312925a0685fd7d14f459dfb973f826b90ab81eb10ee947413a284c87 \
-                    size    84889907
+    checksums       rmd160  657cbaa35dc10a1c6dbd1e09be4890352fe7311a \
+                    sha256  33700393698a6127682931b498f79c4c7d69ab786ff7872cb67bc0947f6d4f33 \
+                    size    84867661
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 334.0.0.

###### Tested on

macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?