### PR TITLE
texlive-bin-extra: add p5.28-unicode-linebreak dependency

### DIFF
--- a/tex/texlive-bin-extra/Portfile
+++ b/tex/texlive-bin-extra/Portfile
@@ -5,7 +5,7 @@ PortGroup           texlive 1.0
 
 name                texlive-bin-extra
 version             54608
-revision            1
+revision            2
 
 categories          tex
 maintainers         {dports @drkp}
@@ -49,6 +49,7 @@ depends_run-append  port:p5.28-yaml-tiny \
                     port:p5.28-getopt-long \
                     port:p5.28-data-dumper \
                     port:p5.28-log-log4perl \
-                    port:p5.28-log-dispatch
+                    port:p5.28-log-dispatch \
+                    port:p5.28-unicode-linebreak
 
 texlive.texmfport


### PR DESCRIPTION
#### Description

latexindent requires Unicode/GCString.pm which is part of p5.28-unicode-linebreak.

See: https://trac.macports.org/ticket/60712

Above ticket has been closed with the update to texlive 2020. However the dependency is currently still missing.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? (none available)
- [ ] tried a full install with `sudo port -vst install`? (without trace mode only)
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
