### PR TITLE
py-deprecated: update to v1.2.12

### DIFF
--- a/python/py-deprecated/Portfile
+++ b/python/py-deprecated/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        tantale deprecated 1.2.9 v
+github.setup        tantale deprecated 1.2.12 v
 name                py-deprecated
 revision            0
 
@@ -17,11 +17,11 @@ description         Python @deprecated decorator to deprecate old python classes
                     functions or methods.
 long_description    ${description}
 
-checksums           rmd160  c78dba890ad38d4001b2b8ba68215bd8b5a32def \
-                    sha256  4912a61f48e7b6e0e4516b0c0c0446111b94dc7f16bef2bf14a46a2066e99020 \
-                    size    5332823
+checksums           rmd160  f7c741fd03df28396d8c8f8c4231a080d41a4239 \
+                    sha256  8e63b1f54a200a4f3100f8d64a3708d80976f17312cfe01745382d827f2869db \
+                    size    2969947
 
-python.versions     36 37 38
+python.versions     36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description
py-deprecated: update to v1.2.12
add py39-deprecated subport

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
MacPorts 2.6.4
macOS 11.2.3 20D91 on arm64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

- [x] tried upstream tests with `pytest`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
