### PR TITLE
py-pygithub: update to v1.54

### DIFF
--- a/python/py-pygithub/Portfile
+++ b/python/py-pygithub/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        PyGithub PyGithub 1.52 v
+github.setup        PyGithub PyGithub 1.54 v
 name                py-pygithub
 platforms           darwin
 license             LGPL-3+
@@ -14,11 +14,11 @@ maintainers         {raimue @raimue} \
 description         Python module for Github API v3
 long_description    ${description}
 
-checksums           rmd160  7ebb4117d680b1aaa472376817f964fc78b07dfe \
-                    sha256  71811997f1b40cadc02cf0d8bbeef83db67221ec997f8bb23b0ba91c4f8981d3 \
-                    size    3021836
+checksums           rmd160  2bda7c70a65e453053236f5e7fd29e8f0a036f11 \
+                    sha256  196cab6dd6421b194245dc8943dce5be3ecc4536af1e2f0b5573939e03f65585 \
+                    size    3117724
 
-python.versions     27 35 36 37 38
+python.versions     35 36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
add py39-pygithub subport
drop py27-pygithub subport (unsupported since v1.46)

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
MacPorts 2.6.4
macOS 11.2.3 20D91 on arm64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried upstream tests with `sudo pytest`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
