### PR TITLE
py-botocore: Update to 1.20.41 and add support for py35

### DIFF
--- a/python/py-botocore/Portfile
+++ b/python/py-botocore/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-botocore
-version             1.20.7
+version             1.20.41
 revision            0
 
 platforms           darwin
 supported_archs     noarch
 license             Apache-2
-maintainers         nomaintainer
+maintainers         {outlook.de:judaew @judaew} openmaintainer
 
 description         Low level data driven core of boto 3.
 long_description    A low-level interface to a growing number of Amazon Web \
@@ -19,13 +19,22 @@ long_description    A low-level interface to a growing number of Amazon Web \
 
 homepage            https://github.com/boto/botocore
 
-checksums           rmd160  c1b336148653ebb97d7346c164e0cb88b9582ed0 \
-                    sha256  27ea4a11f5cca9d655cb9ba462ad4a2bb28eb44d061b49e15a3239c040298ed2 \
-                    size    7458254
+checksums           rmd160  56079338b72607b161311ba242bd3a19873a8bea \
+                    sha256  63f650fc96bce141e8194a761e6890fea2fba6e01253aefa31ae69f145015c21 \
+                    size    7572739
 
 python.versions     27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
+    if {${python.version} == 35 } {
+        version             1.19.63
+        revision            0
+        distname            ${python.rootname}-${version}
+        checksums           rmd160  6d806f84076204176d87ff3b96fb91c5fea04ce9 \
+                            sha256  d3694f6ef918def8082513e5ef309cd6cd83b612e9984e3a66e8adc98c650a92 \
+                            size    7437996
+    }
+
     depends_build-append \
                     port:py${python.version}-setuptools
 


### PR DESCRIPTION

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
