### PR TITLE
android-platforms-tools: Update to 31.0.1

### DIFF
--- a/java/android-platform-tools/Portfile
+++ b/java/android-platform-tools/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 
 name                android-platform-tools
-version             30.0.5
-set ver_hash        eabcd8b4b7ab518c6af9c941af8494072f17ec4b
+version             31.0.1
+set ver_hash        d027ce0f9f214a4bd575a73786b44d8ccf7e7516
 # Starting from 30.0.1 there's this long string in the file name. Probably commit hash.
 # Can be found in https://dl-ssl.google.com/android/repository/repository2-1.xml
 categories          java devel
@@ -24,9 +24,9 @@ master_sites        https://dl.google.com/android/repository
 distname            ${ver_hash}.platform-tools_r${version}-darwin
 use_zip             yes
 
-checksums           rmd160  64da5291523a63aceae790da828845841f87b490 \
-                    sha256  e5780bad71a53cf9d693e1053a0748f49e4a67cc1f71d16a94ab4c943af3345f \
-                    size    13311295
+checksums           rmd160  bf3c5400272541beaeb220d1032c396bc79e2817 \
+                    sha256  09e7c56bb1f9f5adf5f4cc6a868d9a46429e2de7ee93879b34c4ee8211e7d401 \
+                    size    13421165
 
 use_configure       no
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
