### PR TITLE
gh: Add completion variants for bash, zsh, fish

### DIFF
--- a/devel/gh/Portfile
+++ b/devel/gh/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 
 github.setup        cli cli 1.8.0 v
-revision            0
+revision            1
 name                gh
 categories          devel
 platforms           darwin
@@ -48,6 +48,19 @@ destroot {
     set docdir ${prefix}/share/doc/${name}
     xinstall -d ${destroot}${docdir}
     xinstall -m 0644 -W ${worksrcpath} LICENSE ${destroot}${docdir}
+
+    # Shell completions
+    xinstall -d ${destroot}${prefix}/share/bash-completion/completions
+    exec ${destroot}${prefix}/bin/gh completion -s bash >> \
+        ${destroot}${prefix}/share/bash-completion/completions/gh
+
+    xinstall -d ${destroot}${prefix}/share/zsh/site-functions
+    exec ${destroot}${prefix}/bin/gh completion -s zsh >> \
+        ${destroot}${prefix}/share/zsh/site-functions/_gh
+
+    xinstall -d ${destroot}${prefix}/share/fish/completions
+    exec ${destroot}${prefix}/bin/gh completion -s fish >> \
+        ${destroot}${prefix}/share/fish/completions/gh.fish
 }
 
 github.livecheck.regex {([0-9.]+)}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
