### PR TITLE
eksctl: update to 0.43.0

### DIFF
--- a/sysutils/eksctl/Portfile
+++ b/sysutils/eksctl/Portfile
@@ -1,34 +1,35 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 PortSystem          1.0
-PortGroup           github 1.0
+PortGroup           golang 1.0
 
-maintainers         {@szczad gmail.com:szczad} openmaintainer
+go.setup            github.com/weaveworks/eksctl 0.43.0 v
+revision            0
 
-github.setup        weaveworks eksctl 0.37.0
-github.tarball_from releases
-
-supported_archs     x86_64
-
-categories          sysutils
-platforms           darwin
-license             Apache-2.0
-homepage            https://eksctl.io/
+homepage            https://eksctl.io
 
 description         Simple CLI tool for creating clusterrs on AWS EKS
+
 long_description    eksctl is a simple CLI tool for creating clusters on EKS - Amazon’s \
                     new managed Kubernetes service for EC2. It is written in Go, uses \
                     CloudFormation, was created by Weaveworks.
 
-distname            eksctl_Darwin_amd64
-checksums           rmd160  32c868652bb9941195eb4c511d652b8124a53057 \
-                    sha256  e63349d961a5f9c7f13690b1915b8c6bd345d552673dae18b360d2a4b63cf5a8 \
-                    size    21133785
-dist_subdir         ${name}/${version}
+maintainers         {@szczad gmail.com:szczad} \
+                    {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
 
-extract.mkdir       yes
-use_configure       no
+categories          sysutils
+platforms           darwin
+license             Apache-2.0
+installs_libs       no
 
-build {}
+checksums           rmd160  5a2daaee76d9bf50b4b58b72ca2baa21afb6ab8a \
+                    sha256  cf4e95c291c01e20d5d532a30b5048190e24a6728b6093557510fe0f347f2aba \
+                    size    9854508
+
+# Allow fetching dependencies
+build.env-delete    GO111MODULE=off GOPROXY=off
+build.cmd           make
+build.target        binary
 
 destroot {
     xinstall ${worksrcpath}/eksctl \


### PR DESCRIPTION
- build from source
- switch to golang portgroup

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
