### PR TITLE
rav1e tags seem to have a "v" prefix

### DIFF
--- a/multimedia/rav1e/Portfile
+++ b/multimedia/rav1e/Portfile
@@ -4,7 +4,7 @@ PortSystem                  1.0
 PortGroup                   github 1.0
 PortGroup                   cargo  1.0
 
-github.setup                xiph rav1e 0.4.0
+github.setup                xiph rav1e 0.4.0 v
 revision                    0
 
 checksums                   rmd160  e6c17b0c1016c10da0b1aec74fd9ae09c42dbdf7 \


### PR DESCRIPTION
#### Description

I failed to install emacs-app tonight because it wanted librsvg → numerous dependencies → libheif → (new port?) rav1e.  MacPorts couldn't get the source for rav1e, even from GitHub.  I assume it's because tag `0.4.0` doesn't exist but `v0.4.0` does.  This change makes it so I can build rav1e.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15
Xcode 12.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
