### PR TITLE
haproxy: Update to 2.3.9 and enable JIT

### DIFF
--- a/net/haproxy/Portfile
+++ b/net/haproxy/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           legacysupport 1.1
 
 name                haproxy
-version             2.2.6
+version             2.3.9
 revision            0
 
 set branch          [join [lrange [split ${version} .] 0 1] .]
@@ -29,9 +29,9 @@ homepage            https://www.haproxy.org/
 master_sites        ${homepage}download/${branch}/src/ \
                     https://sources.openwrt.org/
 
-checksums           rmd160  b25ae5caf161dbfa63b670fa91a0356e4c9d751a \
-                    sha256  be1c6754cbaceafc4837e0c6036c7f81027a3992516435cbbbc5dc749bf5a087 \
-                    size    2890554
+checksums           rmd160  faad1d19764c3009ce5e650bacf3de35738cec6b \
+                    sha256  77110bc1272bad18fff56b30f4614bcc1deb50600ae42cb0f0b161fc41e2ba96 \
+                    size    2928660
 
 depends_lib         path:lib/libssl.dylib:openssl \
                     port:pcre \
@@ -47,6 +47,7 @@ build.args          CC="${configure.cc} [get_canonical_archflags]" \
                     USE_LIBCRYPT=1 \
                     USE_OPENSSL=1 \
                     USE_PCRE=1 \
+                    USE_PCRE_JIT=1 \
                     USE_THREAD=1 \
                     USE_ZLIB=1
 


### PR DESCRIPTION
Target `USE_PCRE_JIT` enable JIT for faster regex on libpcre

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
