### PR TITLE
emacs-mac-app{,-devel}: fix building for apple silicon

### DIFF
--- a/aqua/emacs-mac-app/Portfile
+++ b/aqua/emacs-mac-app/Portfile
@@ -9,7 +9,7 @@ set emacs_mac_ver   8.2
 bitbucket.setup     mituharu emacs-mac emacs-${emacs_version}-mac-${emacs_mac_ver}
 name                emacs-mac-app
 version             ${emacs_mac_ver}
-revision            0
+revision            1
 categories          aqua editors
 maintainers         {amake @amake} openmaintainer
 
@@ -33,7 +33,8 @@ depends_lib         port:ncurses \
                     port:gmp \
                     port:jansson
 
-patchfiles          patch-src_emacs.c.diff
+patchfiles          patch-src_emacs.c.diff \
+                    patch-apple-silicon-arch.diff
 
 if {${subport} eq ${name}} {
     conflicts       emacs-mac-app-devel

--- a/aqua/emacs-mac-app/files/patch-apple-silicon-arch.diff
+++ b/aqua/emacs-mac-app/files/patch-apple-silicon-arch.diff
@@ -1,0 +1,11 @@
+--- src/Makefile.in	2021-03-27 16:38:19.000000000 +0900
++++ src/Makefile.in	2021-04-02 16:50:00.000000000 +0900
+@@ -346,7 +346,7 @@
+ 
+ ## ARM Macs require that all code have a valid signature.  Since pump
+ ## invalidates the signature, we must re-sign to fix it.
+-DO_CODESIGN=$(patsubst arm-apple-darwin%,yes,@configuration@)
++DO_CODESIGN=$(patsubst aarch64-apple-darwin%,yes,@configuration@)
+ 
+ # 'make' verbosity.
+ AM_DEFAULT_VERBOSITY = @AM_DEFAULT_VERBOSITY@


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

-----

mitsuharu's port [uses](https://bitbucket.org/mituharu/emacs-mac/commits/ef4507125fdad5c3f079dde555b61febde2d43f7) `aarch64-apple-darwin` triplets, but during recent 27.2 merge, this triplets was reverted to `arm64-apple-darwin` that upstream is using. This causes EmacsMac build to fail under Apple Silicon due to missing codesign. This PR fixed that.