### PR TITLE
msmtp: add mta variant

### DIFF
--- a/mail/msmtp/Portfile
+++ b/mail/msmtp/Portfile
@@ -40,3 +40,19 @@ platform macosx {
 }
 
 livecheck.url       https://marlam.de/msmtp/download/
+
+variant mta description {Use msmtp as the system MTA} {
+    conflicts               postfix opensmtpd
+
+    configure.args-append   --with-msmtpd
+
+    startupitem.create      yes
+    startupitem.name        msmtpd
+    startupitem.executable  ${prefix}/bin/msmtpd
+}
+
+post-destroot {
+    if {[variant_isset mta]} {
+        ln -sf ${prefix}/bin/msmtp ${destroot}${prefix}/sbin/sendmail
+    }
+}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Add `msmtp-mta` subport. This will use `msmtp` as the default MTA (i.e. it symlinks `sendmail` to `msmtp` and provides `msmtpd` which acts as a local SMTP server). It is inspired by the [Debian package of the same name](https://packages.debian.org/en/sid/msmtp-mta).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H524
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
