### PR TITLE
meson: add shell completion and editor syntax files

### DIFF
--- a/devel/meson/Portfile
+++ b/devel/meson/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           github 1.0
 
 github.setup        mesonbuild meson 0.57.1
-revision            0
+revision            1
 
 github.tarball_from releases
 license             Apache-2
@@ -104,6 +104,26 @@ post-destroot {
             reinplace "s|@@PREFIX@@|${prefix}|g" ${f}
         }
     }
+
+    # install shell completion files
+    set bash_completion_dir ${prefix}/share/bash-completion/completions
+    xinstall -d ${destroot}${bash_completion_dir}
+    xinstall -m 644 ${worksrcpath}/data/shell-completions/bash/meson ${destroot}${bash_completion_dir}
+
+    set zsh_completion_dir ${prefix}/share/zsh/site-functions
+    xinstall -d ${destroot}${zsh_completion_dir}
+    xinstall -m 644 ${worksrcpath}/data/shell-completions/zsh/_meson ${destroot}${zsh_completion_dir}
+
+    # install editor syntax files
+    set vim_dir ${prefix}/share/vim/vimfiles
+    foreach d {ftdetect ftplugin syntax indent} {
+        xinstall -d ${destroot}${vim_dir}/${d}
+        xinstall -m 644 ${worksrcpath}/data/syntax-highlighting/vim/${d}/meson.vim ${destroot}${vim_dir}/${d}
+    }
+
+    set emacs_lispdir ${prefix}/share/emacs/site-lisp
+    xinstall -d ${destroot}${emacs_lispdir}
+    xinstall -m 644 ${worksrcpath}/data/syntax-highlighting/emacs/meson.el ${destroot}${emacs_lispdir}
 }
 
 # the following block avoids requiring users to 'sudo port select python3 python37'


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Add shell completion and editor syntax files for Meson.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G8022
Xcode 11.3.1 11C505


###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
