### PR TITLE
clang-*: add clangd to clang_select group

### DIFF
--- a/lang/llvm-10/files/mp-clang-10
+++ b/lang/llvm-10/files/mp-clang-10
@@ -12,7 +12,7 @@ bin/clang-cl-mp-10
 bin/clang-query-mp-10
 bin/clang-rename-mp-10
 bin/clang-tidy-mp-10
--
+bin/clangd-mp-10
 -
 -
 -

--- a/lang/llvm-11/files/mp-clang-11
+++ b/lang/llvm-11/files/mp-clang-11
@@ -12,7 +12,7 @@ bin/clang-cl-mp-11
 bin/clang-query-mp-11
 bin/clang-rename-mp-11
 bin/clang-tidy-mp-11
--
+bin/clangd-mp-11
 -
 -
 -

--- a/lang/llvm-5.0/files/mp-clang-5.0
+++ b/lang/llvm-5.0/files/mp-clang-5.0
@@ -12,7 +12,7 @@ bin/clang-cl-mp-5.0
 bin/clang-query-mp-5.0
 bin/clang-rename-mp-5.0
 bin/clang-tidy-mp-5.0
--
+bin/clangd-mp-5.0
 -
 -
 -

--- a/lang/llvm-6.0/files/mp-clang-6.0
+++ b/lang/llvm-6.0/files/mp-clang-6.0
@@ -12,7 +12,7 @@ bin/clang-cl-mp-6.0
 bin/clang-query-mp-6.0
 bin/clang-rename-mp-6.0
 bin/clang-tidy-mp-6.0
--
+bin/clangd-mp-6.0
 -
 -
 -

--- a/lang/llvm-7.0/files/mp-clang-7.0
+++ b/lang/llvm-7.0/files/mp-clang-7.0
@@ -12,7 +12,7 @@ bin/clang-cl-mp-7.0
 bin/clang-query-mp-7.0
 bin/clang-rename-mp-7.0
 bin/clang-tidy-mp-7.0
--
+bin/clangd-mp-7.0
 -
 -
 -

--- a/lang/llvm-8.0/files/mp-clang-8.0
+++ b/lang/llvm-8.0/files/mp-clang-8.0
@@ -12,7 +12,7 @@ bin/clang-cl-mp-8.0
 bin/clang-query-mp-8.0
 bin/clang-rename-mp-8.0
 bin/clang-tidy-mp-8.0
--
+bin/clangd-mp-8.0
 -
 -
 -

--- a/lang/llvm-9.0/files/mp-clang-9.0
+++ b/lang/llvm-9.0/files/mp-clang-9.0
@@ -12,7 +12,7 @@ bin/clang-cl-mp-9.0
 bin/clang-query-mp-9.0
 bin/clang-rename-mp-9.0
 bin/clang-tidy-mp-9.0
--
+bin/clangd-mp-9.0
 -
 -
 -

--- a/lang/llvm-devel/files/mp-clang-devel
+++ b/lang/llvm-devel/files/mp-clang-devel
@@ -12,7 +12,7 @@ bin/clang-cl-mp-devel
 bin/clang-query-mp-devel
 bin/clang-rename-mp-devel
 bin/clang-tidy-mp-devel
--
+bin/clangd-mp-devel
 -
 -
 -

--- a/sysutils/clang_select/files/base
+++ b/sysutils/clang_select/files/base
@@ -12,7 +12,7 @@ bin/clang-mp
 bin/clang-query
 bin/clang-rename
 bin/clang-tidy
-bin/clang-reserved1
+bin/clangd
 bin/clang-reserved2
 bin/clang-reserved3
 bin/clang-reserved4


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Add clangd to clang select group.

I see that clangd was added in #5418 but then reverted by @cjones051073  in #5683. The reversion doesn't provide a reason, so I'm not sure why it was reverted or if clangd is being omitted intentionally for some reason.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G8022
Xcode 11.3.1 11C505


###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
