### PR TITLE
aom: revert native variant, allow runtime cpu detection

### DIFF
--- a/multimedia/aom/Portfile
+++ b/multimedia/aom/Portfile
@@ -7,7 +7,7 @@ PortGroup               compiler_blacklist_versions 1.0
 
 name                    aom
 version                 3.0.0
-revision                2
+revision                3
 categories              multimedia
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
 platforms               darwin
@@ -31,6 +31,9 @@ git.branch              v${version}
 compiler.cxx_standard   2011
 compiler.c_standard     2011
 
+# error: assigning to '__m256i' (vector of 4 'long long' values) from incompatible type 'int'
+compiler.blacklist-append {clang < 800}
+
 set pyver               3.9
 set python_version      [string index ${pyver} 0][string index ${pyver} end]
 
@@ -38,44 +41,33 @@ depends_build-append    port:git \
                         port:perl5 \
                         port:python${python_version}
 
-# possible values of AOM_TARGET_CPU: arm64 x86_64 x86 ppc generic
 configure.args-append   -DBUILD_SHARED_LIBS=ON \
                         -DENABLE_EXAMPLES=OFF \
                         -DDENABLE_TESTS=OFF \
                         -DENABLE_DOCS=OFF \
                         -DGIT_EXECUTABLE=${prefix}/bin/git \
                         -DPERL_EXECUTABLE=${prefix}/bin/perl \
-                        -DPYTHON_EXECUTABLE=${prefix}/bin/python${pyver} \
-                        -DAOM_TARGET_CPU=generic
+                        -DPYTHON_EXECUTABLE=${prefix}/bin/python${pyver}
 
+# possible values of AOM_TARGET_CPU: arm64 x86_64 x86 ppc generic
+# see https://trac.macports.org/ticket/62611 for CONFIG_RUNTIME_CPU_DETECT
+set merger_configure_args(arm64)       "-DAOM_TARGET_CPU=arm64 -DCONFIG_RUNTIME_CPU_DETECT=OFF"
+set merger_configure_args(x86_64)       -DAOM_TARGET_CPU=x86_64
+set merger_configure_args(i386)         -DAOM_TARGET_CPU=x86
+set merger_configure_args(ppc)          -DAOM_TARGET_CPU=ppc
+set merger_configure_args(ppc64)        -DAOM_TARGET_CPU=ppc
 if {![info exists universal_possible]} {
     set universal_possible [expr {${os.universal_supported} && [llength ${configure.universal_archs}] >= 2}]
 }
-
-variant native description {enable auto selection of cpu flags like avx/avx2/neon} {
-    configure.args-delete               -DAOM_TARGET_CPU=generic
-
-    # ensure all AVX2 functions are defined
-    # see https://trac.macports.org/ticket/62608
-    compiler.blacklist-append           {clang < 800}
-
-    # see https://trac.macports.org/ticket/62611 for CONFIG_RUNTIME_CPU_DETECT
-    set merger_configure_args(arm64)    "-DAOM_TARGET_CPU=arm64 -DCONFIG_RUNTIME_CPU_DETECT=OFF"
-    set merger_configure_args(x86_64)   -DAOM_TARGET_CPU=x86_64
-    set merger_configure_args(i386)     -DAOM_TARGET_CPU=x86
-    set merger_configure_args(ppc)      -DAOM_TARGET_CPU=ppc
-    set merger_configure_args(ppc64)    -DAOM_TARGET_CPU=ppc
-
-    if {${universal_possible} && [variant_isset universal]} {
-        if {"x86_64" in ${configure.universal_archs} || "i386" in ${configure.universal_archs}} {
-            depends_build-append        port:yasm
-        }
-    } else {
-        if {${configure.build_arch} in {i386 x86_64}} {
-            depends_build-append        port:yasm
-        }
-        configure.args-append           {*}$merger_configure_args(${configure.build_arch})
+if {${universal_possible} && [variant_isset universal]} {
+    if {"x86_64" in ${configure.universal_archs} || "i386" in ${configure.universal_archs}} {
+        depends_build-append        port:yasm
     }
+} else {
+    if {${configure.build_arch} in {i386 x86_64}} {
+        depends_build-append        port:yasm
+    }
+    configure.args-append           {*}$merger_configure_args(${configure.build_arch})
 }
 
 livecheck.type          regex


### PR DESCRIPTION
#### Description

See discussions in https://github.com/macports/macports-ports/commit/6a1f839833a71be9b6c69d7e6ddca7a039d46673 and https://github.com/macports/macports-ports/commit/dafdf1644c207c48f0ca8eab0d255326fe2057f1

I mis-lead the maintainer into suggesting a native variant would be useful. These are useful when ports perform build-the CPU detection and bake into the binaries what it finds based on the build CPU. arm does not do this, and instead uses runtime CPU detection, and as such its perfectly fine, in fact better, to allow this unconditionally as it then allows the best performance on the users machine, based on what that machine supports. This PR reverts the additional of a native PR and goes back to just blacklisting older clangs by default, which is all that was required to fix the avx2 compilation issues.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
