### PR TITLE
wezterm: new port

### DIFF
--- a/aqua/wezterm/Portfile
+++ b/aqua/wezterm/Portfile
@@ -1,0 +1,55 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo 1.0
+
+github.setup        wez wezterm 20210314-114017-04b7cedd
+version             20210314
+revision            0
+
+homepage            https://wezfurlong.org/wezterm
+
+description         A GPU-accelerated cross-platform terminal emulator and \
+                    multiplexer written in Rust
+
+long_description    {*}${description}
+
+categories          aqua sysutils
+platforms           darwin
+license             MIT
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+depends_build-append \
+                    port:zip \
+                    port:unzip
+
+depends_lib-append  port:zlib
+
+fetch.type          git
+
+build.pre_args      --release -v -j${build.jobs}
+
+post-extract {
+    system -W ${worksrcpath} "git submodule update --init"
+}
+
+destroot {
+    set wz_zip_name "WezTerm-macos-${version}"
+
+    system  -W ${worksrcpath} "export TAG_NAME=${version} && ./ci/deploy.sh"
+
+    move    ${worksrcpath}/${wz_zip_name}.zip ${destroot}${applications_dir}
+
+    system  -W ${destroot}${applications_dir} "unzip ${wz_zip_name}.zip"
+
+    move    ${destroot}${applications_dir}/${wz_zip_name}/WezTerm.app \
+            ${destroot}${applications_dir}/
+
+    delete  ${destroot}${applications_dir}/${wz_zip_name}
+    delete  ${destroot}${applications_dir}/${wz_zip_name}.zip
+}
+
+github.livecheck.regex {([0-9.]+)}


### PR DESCRIPTION
#### Description

New port for [wezterm](https://wezfurlong.org/wezterm/), a GPU-accelerated cross-platform terminal emulator and multiplexer written in Rust.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
