### PR TITLE
ki-shell: new submission

### DIFF
--- a/java/ki-shell/Portfile
+++ b/java/ki-shell/Portfile
@@ -1,0 +1,64 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+PortGroup       java 1.0
+
+name            ki-shell
+version         0.3.3
+revision        0
+
+categories      java
+platforms       darwin
+maintainers     {breun.nl:nils @breun} openmaintainer
+license         Apache-2
+supported_archs noarch
+
+description     Kotlin Language Interactive Shell (ki)
+
+long_description The shell is an extensible implementation of Kotlin REPL with reach set of features including: \
+                \n\
+                \n* Syntax highlight \
+                \n* Type inference command \
+                \n* Downloading dependencies in runtime using Maven coordinates \
+                \n* List declared symbols
+
+homepage        https://github.com/Kotlin/kotlin-interactive-shell
+master_sites    https://search.maven.org/remotecontent?filepath=org/jetbrains/kotlinx/${name}/${version}/
+
+distname        ${name}-${version}-archive
+
+checksums       rmd160  b3443bcfe9f4d78ed3758530fec1c0934f47a37e \
+                sha256  ea7461051589f86c80babd9a54b8c7a6bb29a77ac134498a63f26c54a28508ef \
+                size    60319541
+
+use_zip         yes
+use_configure   no
+
+java.version    1.8+
+java.fallback   openjdk11
+
+build {}
+
+destroot {
+    set target ${prefix}/share/java/${name}
+    set dest_target ${destroot}${target}
+
+    # Create the target java directory
+    xinstall -m 755 -d ${dest_target}
+
+    # Copy over the needed elements of our directory tree
+    foreach d { bin lib } {
+        copy ${worksrcpath}/${d} ${dest_target}
+    }
+
+    # Remove extraneous bat files
+    foreach f [glob -directory ${dest_target}/bin *.bat] {
+        delete ${f}
+    }
+
+    # Create launch script
+    set launch_script [open ${destroot}${prefix}/bin/ki w 0755]
+    puts $launch_script "#!/usr/bin/env bash"
+    puts $launch_script "${target}/bin/ki.sh $@"
+    close $launch_script
+}


### PR DESCRIPTION
#### Description

New port for [Kotlin Language Interactive Shell](https://github.com/Kotlin/kotlin-interactive-shell).

###### Tested on

macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?