### PR TITLE
libsdl_mixer: fix build on newer systems

### DIFF
--- a/audio/libsdl_mixer/Portfile
+++ b/audio/libsdl_mixer/Portfile
@@ -28,7 +28,8 @@ depends_lib     port:libsdl \
                 port:libvorbis \
                 port:libmikmod
 
-patchfiles      Makefile.in.diff
+patchfiles      Makefile.in.diff \
+                patch-implicit_declaration.diff
 
 configure.args  --disable-sdltest \
                 --disable-smpegtest \

--- a/audio/libsdl_mixer/files/patch-implicit_declaration.diff
+++ b/audio/libsdl_mixer/files/patch-implicit_declaration.diff
@@ -1,0 +1,13 @@
+Avoid:
+    mixer.c:153:46: error: implicit declaration of function 'Mix_InitFluidSynth' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
+
+--- mixer.c.orig	2012-01-15 15:01:05.000000000 -0700
++++ mixer.c	2021-04-03 10:50:42.000000000 -0700
+@@ -38,6 +38,7 @@
+ #include "dynamic_mod.h"
+ #include "dynamic_mp3.h"
+ #include "dynamic_ogg.h"
++#include "dynamic_fluidsynth.h"
+ 
+ #define __MIX_INTERNAL_EFFECT__
+ #include "effects_internal.h"


### PR DESCRIPTION
Avoid the error:
implicit declaration of function 'Mix_InitFluidSynth' is invalid in C99

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
