### PR TITLE
msmtp: fix startupitem

### DIFF
--- a/mail/msmtp/Portfile
+++ b/mail/msmtp/Portfile
@@ -35,6 +35,8 @@ configure.args      --disable-silent-rules \
                     --with-libgsasl \
                     --without-libsecret
 
+startupitem.name    msmtpd
+
 platform macosx {
     configure.args-append   --with-macosx-keyring
 }
@@ -47,7 +49,6 @@ variant mta description {Use msmtp as the system MTA} {
     configure.args-append   --with-msmtpd
 
     startupitem.create      yes
-    startupitem.name        msmtpd
     startupitem.executable  ${prefix}/bin/msmtpd
 }
 


### PR DESCRIPTION
#### Description

The startupitem.name needs to be specified outside of the variant so
that `port load msmtp` works as expected.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G8022
Xcode 11.3.1 11C505


###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
