### PR TITLE
astroid: new submission

### DIFF
--- a/mail/astroid/Portfile
+++ b/mail/astroid/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        astroidmail astroid 0.15 v
+revision            0
+
+description         Astroid Mail
+long_description    A graphical threads-with-tags style, lightweight and fast, e-mail client for Notmuch
+maintainers         @arietis \
+                    openmaintainer
+categories          mail
+platforms           darwin
+homepage            https://astroidmail.github.io/
+license             GPL-3.0+ LGPL-2.1+
+
+checksums           rmd160  a7babb6609724a7b8fe950bc1321ee61b2af7609 \
+                    sha256  0eb8a5d9d6f48eb79a64a35e7dc0919ee0d20c3104c0f7b2c2d185c6ec24df34 \
+                    size    3365848
+
+depends_build       port:cmake \
+                    port:pkgconfig \
+                    port:scdoc
+
+depends_lib         path:lib/pkgconfig/webkit2gtk-4.0.pc:webkit2-gtk \
+                    port:boost \
+                    port:gtkmm3 \
+                    port:libsass \
+                    port:notmuch \
+                    port:protobuf3-cpp \
+                    port:vte


### PR DESCRIPTION
#### Description
New port for Astroid Mail User Agent.

###### Tested on
macOS 11.2.3 20D91
Xcode 12.3 12C33

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
