### PR TITLE
py-coloredlogs: update to 15.0, add py38 and 39

### DIFF
--- a/python/py-coloredlogs/Portfile
+++ b/python/py-coloredlogs/Portfile
@@ -4,10 +4,10 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-coloredlogs
-version             10.0
-checksums           rmd160  58d28b616c4d2ccb2bc8601f5a23979829e52b4e \
-                    sha256  b869a2dda3fa88154b9dd850e27828d8755bfab5a838a1c97fbc850c6e377c36 \
-                    size    273273
+version             15.0
+checksums           rmd160  95b85be648929d6cb0d7a93edd9b29acbc17831d \
+                    sha256  5e78691e2673a8e294499e1832bb13efcfb44a86b92e18109fa18951093218ab \
+                    size    278159
 
 categories-append   devel
 platforms           darwin
@@ -20,10 +20,7 @@ long_description    The coloredlogs package enables colored terminal \
     output for Python’s logging module.
 homepage            https://coloredlogs.readthedocs.io/
 
-master_sites        pypi:c/${python.rootname}
-distname            ${python.rootname}-${version}
-
-python.versions     36 37
+python.versions     36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_lib-append  \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
