### PR TITLE
gtk3: fix build on 10.11

### DIFF
--- a/gnome/gtk3/Portfile
+++ b/gnome/gtk3/Portfile
@@ -58,6 +58,9 @@ legacysupport.newest_darwin_requires_legacy 10
 use_autoreconf      yes
 autoreconf.args     -fvi
 
+# OS X 10.11 and earlier does not have NSEventTypeTabletProximity and the version check macro is broken
+# see https://gitlab.gnome.org/GNOME/gtk/-/issues/3592
+patchfiles   patch-gdk_quartz-10.11_compat.diff
 
 # gtk3 +quartz uses instancetype which is not available
 # before approximately Xcode 4.6 (#49391)

--- a/gnome/gtk3/files/patch-gdk_quartz-10.11_compat.diff
+++ b/gnome/gtk3/files/patch-gdk_quartz-10.11_compat.diff
@@ -1,0 +1,22 @@
+--- gdk/quartz/gdkinternal-quartz.h.orig	2021-04-05 15:46:38.000000000 +0200
++++ gdk/quartz/gdkinternal-quartz.h	2021-04-05 15:46:49.000000000 +0200
+@@ -75,7 +75,7 @@
+   GDK_QUARTZ_EVENT_SUBTYPE_EVENTLOOP
+ } GdkQuartzEventSubType;
+ 
+-#if MAC_OS_X_VERSION_MIN_REQUIRED >= 10130
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 101300
+ #define GDK_QUARTZ_EVENT_TABLET_PROXIMITY NSEventTypeTabletProximity
+ #define GDK_QUARTZ_EVENT_SUBTYPE_TABLET_PROXIMITY NSEventSubtypeTabletProximity
+ #define GDK_QUARTZ_EVENT_SUBTYPE_TABLET_POINT NSEventSubtypeTabletPoint
+--- ./modules/input/imquartz.c.orig	2021-04-05 16:09:16.000000000 +0200
++++ ./modules/input/imquartz.c	2021-04-05 16:09:25.000000000 +0200
+@@ -37,7 +37,7 @@
+ #define GTK_IM_CONTEXT_QUARTZ(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), GTK_IM_CONTEXT_TYPE_QUARTZ, GtkIMContextQuartz))
+ #define GTK_IM_CONTEXT_QUARTZ_GET_CLASS(obj) (G_TYPE_INSTANCE_GET_CLASS((obj), GTK_IM_CONTEXT_TYPE_QUARTZ, GtkIMContextQuartzClass))
+ 
+-#if MAC_OS_X_VERSION_MIN_REQUIRED < 10120
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 101200
+ #define NS_EVENT_KEY_DOWN NSKeyDown
+ #else
+ #define NS_EVENT_KEY_DOWN NSEventTypeKeyDown


### PR DESCRIPTION
#### Description

fix 10.11 compatibility break, caused by typos in version macro check

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
```
macOS 10.11.6 15G22010
Xcode 8.2.1 8C1002
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- ~~tried existing tests with `sudo port test`?~~
- ~~tried a full install with `sudo port -vst install`?~~
- [x] tried a full install from source using `sudo port -d install -n gtk3`
- [ ] tested basic functionality of all binary files?
