### PR TITLE
py-stevedore: add py39-stevedore subport

### DIFF
--- a/python/py-stevedore/Portfile
+++ b/python/py-stevedore/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  de1f8e7334aeb7daaf887f8f08441c0050369bc4 \
                     sha256  e0739f9739a681c7a1fda76a102b65295e96a144ccdb552f2ae03c5f0abe8a14 \
                     size    505482
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-setuptools \


### PR DESCRIPTION
#### Description

Upstream tests for stevedore 1.31 do not support Python 3.8/3.9. However, I patched `tox.ini`:

```
in ~/Repositories/macports-ports/python/py-stevedore/work/stevedore-1.31.0
$ git diff tox.ini
diff --git a/tox.ini b/tox.ini
index 95ea48f..2020d1f 100644
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.0
-envlist = py27,py37,pep8,docs
+envlist = py27,py37,py38,py39,pep8,docs

 [testenv]
 install_command = pip install {opts} {packages}
```

...and ran them successfully:

```
in ~/Repositories/macports-ports/python/py-stevedore/work/stevedore-1.31.0
$ sudo tox -q -e py38 -e py39
[...]
__________________________________ summary ___________________________________
  py38: commands succeeded
  py39: commands succeeded
  congratulations :)
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
MacPorts 2.6.99
macOS 11.2.3 20D91 on arm64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
