### PR TITLE
py-virtualenv-clone: add py39 subport

### DIFF
--- a/python/py-virtualenv-clone/Portfile
+++ b/python/py-virtualenv-clone/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  8a925f8a77ec381aba988d03f0ef2f8792be929b \
                     sha256  665e48dd54c84b98b71a657acb49104c54e7652bce9c1c4f6c6976ed4c827a29 \
                     size    6169
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
     depends_lib-append \


### PR DESCRIPTION
#### Description

Upstream tests do not support python 3.9. This patch fixes that:

```
in ~/Repositories/virtualenv-clone
$ git diff
diff --git a/tests/__init__.py b/tests/__init__.py
index 5dc8b12..154265f 100644
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -8,7 +8,7 @@ from unittest import TestCase
 tmplocation = tempfile.mkdtemp()
 venv_path = os.path.realpath(os.path.join(tmplocation,'srs_venv'))
 clone_path = os.path.realpath(os.path.join(tmplocation,'clone_venv'))
-versions = ['2.7', '3.4', '3.5', '3.6', '3.7', '3.8']
+versions = ['3.4', '3.5', '3.6', '3.7', '3.8', '3.9']

 def clean():
     if os.path.exists(tmplocation): shutil.rmtree(tmplocation)
diff --git a/tox.ini b/tox.ini
index 7a02d3f..1a740ba 100644
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,py37,py38
+envlist = py27,py34,py35,py36,py37,py38,py39

 [testenv]
 commands = py.test -v []
```

And the test results are:

```
in ~/Repositories/virtualenv-clone
$ sudo tox -q -e py38 -e py39
===================================== test session starts =====================================
platform darwin -- Python 3.8.9, pytest-6.2.3, py-1.10.0, pluggy-0.13.1 -- /Users/gm/Repositories/virtualenv-clone/.tox/py38/bin/python
cachedir: .tox/py38/.pytest_cache
rootdir: /Users/gm/Repositories/virtualenv-clone
collected 18 items

tests/test_dirmatch.py::TestVirtualenvDirmatch::test_dirmatch PASSED                    [  5%]
tests/test_fixup_scripts.py::TestFixupScripts::test_fixup_abs_link PASSED               [ 11%]
tests/test_fixup_scripts.py::TestFixupScripts::test_fixup_activate PASSED               [ 16%]
tests/test_fixup_scripts.py::TestFixupScripts::test_fixup_pth_file PASSED               [ 22%]
tests/test_fixup_scripts.py::TestFixupScripts::test_fixup_rel_link PASSED               [ 27%]
tests/test_fixup_scripts.py::TestFixupScripts::test_fixup_script_ PASSED                [ 33%]
tests/test_fixup_scripts.py::TestFixupScripts::test_fixup_script_different_version PASSED [ 38%]
tests/test_fixup_scripts.py::TestFixupScripts::test_fixup_script_no_shebang PASSED      [ 44%]
tests/test_fixup_scripts.py::TestFixupScripts::test_fixup_script_version PASSED         [ 50%]
tests/test_virtualenv_clone.py::TestVirtualenvClone::test_clone_contents PASSED         [ 55%]
tests/test_virtualenv_clone.py::TestVirtualenvClone::test_clone_exists PASSED           [ 61%]
tests/test_virtualenv_clone.py::TestVirtualenvClone::test_clone_with_1_arg PASSED       [ 66%]
tests/test_virtualenv_clone.py::TestVirtualenvClone::test_clone_with_bad_src PASSED     [ 72%]
tests/test_virtualenv_clone.py::TestVirtualenvClone::test_clone_with_no_args PASSED     [ 77%]
tests/test_virtualenv_sys.py::TestVirtualenvSys::test_clone_syspath PASSED              [ 83%]
tests/test_virtualenv_sys.py::TestVirtualenvSys::test_clone_version PASSED              [ 88%]
tests/test_virtualenv_sys.py::TestVirtualenvSys::test_virtualenv_syspath PASSED         [ 94%]
tests/test_virtualenv_sys.py::TestVirtualenvSys::test_virtualenv_versions PASSED        [100%]

===================================== 18 passed in 9.32s ======================================
===================================== test session starts =====================================
platform darwin -- Python 3.9.3, pytest-6.2.3, py-1.10.0, pluggy-0.13.1 -- /Users/gm/Repositories/virtualenv-clone/.tox/py39/bin/python
cachedir: .tox/py39/.pytest_cache
rootdir: /Users/gm/Repositories/virtualenv-clone
collected 18 items

tests/test_dirmatch.py::TestVirtualenvDirmatch::test_dirmatch PASSED                    [  5%]
tests/test_fixup_scripts.py::TestFixupScripts::test_fixup_abs_link PASSED               [ 11%]
tests/test_fixup_scripts.py::TestFixupScripts::test_fixup_activate PASSED               [ 16%]
tests/test_fixup_scripts.py::TestFixupScripts::test_fixup_pth_file PASSED               [ 22%]
tests/test_fixup_scripts.py::TestFixupScripts::test_fixup_rel_link PASSED               [ 27%]
tests/test_fixup_scripts.py::TestFixupScripts::test_fixup_script_ PASSED                [ 33%]
tests/test_fixup_scripts.py::TestFixupScripts::test_fixup_script_different_version PASSED [ 38%]
tests/test_fixup_scripts.py::TestFixupScripts::test_fixup_script_no_shebang PASSED      [ 44%]
tests/test_fixup_scripts.py::TestFixupScripts::test_fixup_script_version PASSED         [ 50%]
tests/test_virtualenv_clone.py::TestVirtualenvClone::test_clone_contents PASSED         [ 55%]
tests/test_virtualenv_clone.py::TestVirtualenvClone::test_clone_exists PASSED           [ 61%]
tests/test_virtualenv_clone.py::TestVirtualenvClone::test_clone_with_1_arg PASSED       [ 66%]
tests/test_virtualenv_clone.py::TestVirtualenvClone::test_clone_with_bad_src PASSED     [ 72%]
tests/test_virtualenv_clone.py::TestVirtualenvClone::test_clone_with_no_args PASSED     [ 77%]
tests/test_virtualenv_sys.py::TestVirtualenvSys::test_clone_syspath PASSED              [ 83%]
tests/test_virtualenv_sys.py::TestVirtualenvSys::test_clone_version PASSED              [ 88%]
tests/test_virtualenv_sys.py::TestVirtualenvSys::test_virtualenv_syspath PASSED         [ 94%]
tests/test_virtualenv_sys.py::TestVirtualenvSys::test_virtualenv_versions PASSED        [100%]

===================================== 18 passed in 9.88s ======================================
___________________________________________ summary ___________________________________________
  py38: commands succeeded
  py39: commands succeeded
  congratulations :)
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
MacPorts 2.6.99
macOS 11.2.3 20D91 on arm64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
