### PR TITLE
Fix hdf4 with variants +gcc10 and +szip

### DIFF
--- a/science/hdf4/Portfile
+++ b/science/hdf4/Portfile
@@ -70,6 +70,8 @@ if {[fortran_variant_isset]} {
     configure.args-delete   --disable-fortran --enable-shared
 }
 
+compilers.allow_arguments_mismatch  yes
+
 if {[variant_isset g95]} {
     configure.fflags-append -fno-second-underscore
 }

--- a/science/hdf4/Portfile
+++ b/science/hdf4/Portfile
@@ -39,7 +39,8 @@ patchfiles          patch-configure.diff \
                     patch-mfhdf-test-tfile.c.diff \
                     patch-mfhdf-test-tncvargetfill.c.diff \
                     patch-mfhdf-test-tsd.c.diff \
-                    patch-mfhdf-test-tszip.c.diff
+                    patch-mfhdf-test-tszip.c.diff \
+                    patch-hdf-test-mgr.c.diff
 
 configure.args      --disable-netcdf --disable-fortran \
                     --with-jpeg=${prefix} --enable-shared \

--- a/science/hdf4/files/patch-hdf-test-mgr.c.diff
+++ b/science/hdf4/files/patch-hdf-test-mgr.c.diff
@@ -1,0 +1,13 @@
+--- hdf/test/mgr.c.orig	2020-03-03 10:40:50.000000000 -0700
++++ hdf/test/mgr.c	2021-04-05 19:46:00.000000000 -0700
+@@ -29,6 +29,10 @@
+ #include "tproto.h"
+ #include "mfgr.h"
+ 
++#ifdef H4_HAVE_LIBSZ
++extern void test_mgr_szip();
++#endif
++
+ /* Local pre-processor macros */
+ #define XDIM    0
+ #define YDIM    1


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
