### PR TITLE
ruby-install: update to 0.8.1

### DIFF
--- a/ruby/ruby-install/Portfile
+++ b/ruby/ruby-install/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        postmodern ruby-install 0.7.0 v
+github.setup        postmodern ruby-install 0.8.1 v
 revision            0
 categories          ruby
 license             MIT
@@ -17,9 +17,9 @@ maintainers         {catlett.info:chad @chadcatlett} \
 description         Installs Ruby, JRuby, Rubinius, TruffleRuby or mruby.
 long_description    ${description}
 
-checksums           rmd160  dcd7edba9588c71a51a2416b7277b334f27efd0e \
-                    sha256  2e0c6db77cdf50d30f68db3c10cda72bab6b6d4be12cc11aec6fcfad8f99911f \
-                    size    28545
+checksums           rmd160  6495dc139c37f5426fa3dd15532faf2906647389 \
+                    sha256  e4fc28d7dd92795a3825e7102c3eb48bec20552adb56ffb031d809c57b974f44 \
+                    size    30953
 
 use_configure       no
 


### PR DESCRIPTION
-------

#### Description

Update ruby-install to 0.8.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->