### PR TITLE
cliquer: use makefile portgroup

### DIFF
--- a/math/cliquer/Portfile
+++ b/math/cliquer/Portfile
@@ -1,10 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           makefile 1.0
 
 name                cliquer
 version             1.21
-revision            0
+revision            1
 categories          math science
 license             GPL-2+
 platforms           darwin
@@ -21,8 +22,6 @@ long_description    Cliquer is a program for efficiently finding cliques in arbi
 checksums           rmd160  5c2b8804dff6f3e54701e8ce25fe0c4a282be154 \
                     sha256  ff306d27eda82383c0257065e3ffab028415ac9af73bccfdd9c2405b797ed1f1 \
                     size    100327
-
-use_configure       no
 
 test.run            yes
 test.target         test


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G8022
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
