### PR TITLE
fselect: new port

### DIFF
--- a/sysutils/fselect/Portfile
+++ b/sysutils/fselect/Portfile
@@ -1,0 +1,180 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo 1.0
+
+github.setup        jhspetersson fselect 0.7.4
+revision            0
+
+description         Find files with SQL-like queries
+
+long_description    ${name} allows for searching files with SQL-like queries. \
+                    It allows complex queries with aggregate, statistics, \
+                    date, and other functions. ${name} can also search within \
+                    archives, images (width, height, and EXIF metadata), MP3 \
+                    metadata, extended file attributes, file hashes, MIME \
+                    types, and more. Also supports various options for output \
+                    formatting (CSV, JSON, and others).
+
+categories          sysutils
+platforms           darwin
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+license             MIT
+installs_libs       no
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  014634f3c3216dd8475168fa6bb29d1d7bcfb5cf \
+                    sha256  83ba411b23f83c57ab56d5b5f264bd310aa2bc3e8a88cd436dbcb9e5f81133b5 \
+                    size    64764
+
+destroot {
+    xinstall -m 755 \
+        ${worksrcpath}/target/[cargo.rust_platform]/release/${name} \
+        ${destroot}${prefix}/bin/
+
+    xinstall -m 0644 \
+        ${worksrcpath}/docs/fselect.1 ${destroot}${prefix}/share/man/man1/
+}
+
+cargo.crates \
+    adler32                          1.2.0  aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234 \
+    ahash                            0.4.7  739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e \
+    aho-corasick                    0.7.15  7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5 \
+    ansi_term                       0.12.1  d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2 \
+    app_dirs                         1.2.1  e73a24bad9bd6a94d6395382a6c69fe071708ae4409f763c5475e14ee896313d \
+    atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+    autocfg                          1.0.1  cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a \
+    base64                          0.13.0  904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd \
+    bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
+    bitreader                        0.3.3  70a57a98015fc89125fae6054685a2586739fba82c8dbfe550dac9a5a76791a6 \
+    bitstream-io                     1.0.0  03539c739e37dab2c322ce07b1990089ca1fc7ad14b813e1538bf11bef98fe06 \
+    block-buffer                     0.9.0  4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4 \
+    block-padding                    0.2.1  8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae \
+    bstr                            0.2.15  a40b47ad93e1a5404e6c18dec46b628214fee441c70f4ab5d6942142cc268a3d \
+    bytecount                        0.6.2  72feb31ffc86498dacdbd0fcebb56138e7177a8cc5cea4516031d15ae85a742e \
+    byteorder                        1.4.3  14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610 \
+    bzip2                            0.3.3  42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b \
+    bzip2-sys                 0.1.10+1.0.8  17fa3d1ac1ca21c5c4e36a97f3c3eb25084576f6fc47bf0139c1123434216c6c \
+    cc                              1.0.67  e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd \
+    cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
+    cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
+    chrono                          0.4.19  670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73 \
+    chrono-english                   0.1.6  0be5180df5f7c41fc2416bc038bc8d78d44db8136c415b94ccbc95f523dc38e9 \
+    cloudabi                         0.0.3  ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
+    cpuid-bool                       0.1.2  8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634 \
+    crc32fast                        1.2.1  81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a \
+    csv                              1.1.6  22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1 \
+    csv-core                        0.1.10  2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90 \
+    digest                           0.9.0  d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066 \
+    dirs-next                        2.0.0  b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1 \
+    dirs-sys-next                    0.1.2  4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d \
+    either                           1.6.1  e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457 \
+    endian-type                      0.1.2  c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d \
+    env_logger                       0.8.3  17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f \
+    fallible_collections             0.3.1  9599e8ccc571becb62700174680e54e5c50fc5b4d34c1c56d8915e0325650fea \
+    fixedbitset                      0.2.0  37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d \
+    flate2                          1.0.14  2cfff41391129e0a856d6d822600b8d71179d46879e310417eb9c762eb178b42 \
+    fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
+    fs2                              0.4.3  9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213 \
+    generic-array                   0.14.4  501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817 \
+    getrandom                       0.1.16  8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce \
+    getrandom                        0.2.2  c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8 \
+    hashbrown                        0.9.1  d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04 \
+    hermit-abi                      0.1.18  322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c \
+    humansize                        1.1.0  b6cab2627acfc432780848602f3f558f7e9dd427352224b0d9324025796d2a5e \
+    humantime                        2.1.0  9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4 \
+    imagesize                        0.8.8  fd27b2139f540ac627a6cb1b96105e86bfc5136d06236ea90272eec35a4f5088 \
+    indexmap                         1.6.2  824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3 \
+    itertools                        0.8.2  f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484 \
+    itoa                             0.4.7  dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736 \
+    kamadak-exif                     0.5.4  70494964492bf8e491eb3951c5d70c9627eb7100ede6cc56d748b9a3f302cfb6 \
+    keccak                           0.1.0  67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7 \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    libc                            0.2.92  56d855069fafbb9b344c0f962150cd2c1187975cb1c22c1522c240d8c4986714 \
+    lock_api                         0.3.4  c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75 \
+    log                             0.4.14  51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710 \
+    lscolors                         0.7.1  d24b894c45c9da468621cdd615a5a79ee5e5523dd4f75c76ebc03d458940c16e \
+    matroska                         0.5.5  e5ca9fc05d566a45f61b7df39c02ca4a685bfba9e7f8c1d85ea7fca4fd01c172 \
+    memchr                           1.0.2  148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a \
+    memchr                           2.3.4  0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525 \
+    miniz_oxide                      0.3.7  791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435 \
+    mp3-metadata                     0.3.3  eb969bc3573726b0bf60238d5d70f1aa6cc0f9e87f8db3e047b8309317319699 \
+    mp4parse                        0.11.5  d39b95509eef169a7e7e144074d937a34147314fea16a551f1385de1b29c93f3 \
+    mutate_once                      0.1.1  16cf681a23b4d0a43fc35024c176437f9dcd818db34e0f42ab456a0ee5ad497b \
+    nibble_vec                       0.1.0  77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43 \
+    nix                             0.20.0  fa9b4819da1bc61c0ea48b63b7bc8604064dd43013e7cc325df098d49cd7c18a \
+    nom                              3.2.1  05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b \
+    num-integer                     0.1.44  d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db \
+    num-traits                      0.2.14  9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290 \
+    ole32-sys                        0.2.0  5d2c49021782e5233cd243168edfa8037574afed4eba4bbaf538b3d8d1789d8c \
+    opaque-debug                     0.3.0  624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5 \
+    parking_lot                     0.10.2  d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e \
+    parking_lot_core                 0.7.2  d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3 \
+    petgraph                         0.5.1  467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7 \
+    phf                              0.8.0  3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12 \
+    phf_generator                    0.8.0  17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526 \
+    phf_macros                       0.8.0  7f6fde18ff429ffc8fe78e2bf7f8b7a5a5a6e2a8b58bc5a9ac69198bbda9189c \
+    phf_shared                       0.8.0  c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7 \
+    pkg-config                      0.3.19  3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c \
+    ppv-lite86                      0.2.10  ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857 \
+    proc-macro-hack                 0.5.19  dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5 \
+    proc-macro2                     1.0.26  a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec \
+    quote                            1.0.9  c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7 \
+    radix_trie                       0.2.1  c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd \
+    rand                             0.7.3  6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
+    rand                             0.8.3  0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e \
+    rand_chacha                      0.2.2  f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402 \
+    rand_chacha                      0.3.0  e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d \
+    rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
+    rand_core                        0.6.2  34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7 \
+    rand_hc                          0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
+    rand_hc                          0.3.0  3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73 \
+    rand_pcg                         0.2.1  16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429 \
+    redox_syscall                   0.1.57  41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce \
+    redox_syscall                    0.2.5  94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9 \
+    redox_users                      0.4.0  528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64 \
+    regex                            1.4.5  957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19 \
+    regex-automata                   0.1.9  ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4 \
+    regex-syntax                    0.6.23  24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548 \
+    rustyline                        8.0.0  b9e1b597fcd1eeb1d6b25b493538e5aa19629eb08932184b85fef931ba87e893 \
+    ryu                              1.0.5  71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e \
+    scanlex                          0.1.4  088c5d71572124929ea7549a8ce98e1a6fd33d0a38367b09027b382e67c033db \
+    scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
+    serde                          1.0.125  558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171 \
+    serde_derive                   1.0.125  b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d \
+    serde_json                      1.0.64  799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79 \
+    sha-1                            0.9.4  dfebf75d25bd900fd1e7d11501efab59bc846dbc76196839663e6637bba9f25f \
+    sha2                             0.9.3  fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de \
+    sha3                             0.9.1  f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809 \
+    shell32-sys                      0.1.2  9ee04b46101f57121c9da2b151988283b6beb79b34f5bb29a58ee48cb695122c \
+    siphasher                        0.3.5  cbce6d4507c7e4a3962091436e56e95290cb71fa302d0d270e32130b75fbff27 \
+    smallvec                         1.6.1  fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e \
+    static_assertions                1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
+    syn                             1.0.68  3ce15dd3ed8aa2f8eeac4716d6ef5ab58b6b9256db41d7e1a0224c2788e8fd87 \
+    termcolor                        1.1.2  2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4 \
+    thiserror                       1.0.24  e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e \
+    thiserror-impl                  1.0.24  7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0 \
+    time                            0.1.43  ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438 \
+    toml                             0.5.8  a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa \
+    tree_magic                       0.2.3  b1d99367ce3e553a84738f73bd626ccca541ef90ae757fdcdc4cbe728e6cb629 \
+    typenum                         1.13.0  879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06 \
+    unicode-segmentation             1.7.1  bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796 \
+    unicode-width                    0.1.8  9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3 \
+    unicode-xid                      0.2.1  f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564 \
+    users                           0.11.0  24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032 \
+    utf8parse                        0.2.0  936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372 \
+    version_check                    0.9.3  5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe \
+    wana_kana                        2.0.1  737522ce61d011eb538ecba26b46699759bcc290f422af571ac713d360909b92 \
+    wasi      0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
+    wasi     0.10.2+wasi-snapshot-preview1  fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6 \
+    winapi                           0.2.8  167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
+    winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
+    winapi-build                     0.1.1  2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                      0.1.5  70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    xattr                            0.2.2  244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c \
+    xdg                              2.2.0  d089681aa106a86fade1b0128fb5daf07d5867a509ab036d99988dec80429a57 \
+    zip                             0.5.11  8264fcea9b7a036a4a5103d7153e988dbc2ebbafb34f68a3c2d404b6b82d74b6


### PR DESCRIPTION
#### Description

New port for [fselect](https://github.com/jhspetersson/fselect), a SQL-like file search utility.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
