### PR TITLE
google-cloud-sdk: update to 335.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             334.0.0
+version             335.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,14 +21,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  bcd55d22e637f48d9ddac473ce64cf15dc8415fe \
-                    sha256  f3e1868d2aca4fabf14313cb5ab670bb6ceaa6d1d87688a36eda33910cad7f54 \
-                    size    88627916
+    checksums       rmd160  4a8ce96a2bc53629c0c70b070abe02ad6aa1d4c4 \
+                    sha256  e1d244cc85486d30eb79ffb06b9fde8c7c63c4d5ca16cae34805deb071475654 \
+                    size    88691550
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  657cbaa35dc10a1c6dbd1e09be4890352fe7311a \
-                    sha256  33700393698a6127682931b498f79c4c7d69ab786ff7872cb67bc0947f6d4f33 \
-                    size    84867661
+    checksums       rmd160  3b303dbf8df0c5cd9f0e403ca43c82289929d33d \
+                    sha256  10c281ec93214058d04badec1832d57932c11a79e9cf5fa0da4bb0e7f92b1a6d \
+                    size    84928337
 }
 
 homepage            https://cloud.google.com/sdk/
@@ -65,7 +65,6 @@ variant cbt description {Add Cloud Bigtable Command Line Tool} { dict set varian
 variant cloud_build_local description {Add Google Cloud Build Local Builder} { dict set variant_to_component cloud_build_local cloud-build-local }
 variant cloud_datastore_emulator description {Add Cloud Datastore Emulator} { dict set variant_to_component cloud_datastore_emulator cloud-datastore-emulator }
 variant cloud_firestore_emulator description {Add Cloud Firestore Emulator} { dict set variant_to_component cloud_firestore_emulator cloud-firestore-emulator }
-variant cloud_spanner_emulator description {Add Cloud Spanner Emulator} { dict set variant_to_component cloud_spanner_emulator cloud-spanner-emulator }
 variant cloud_sql_proxy description {Add Cloud SQL Proxy} { dict set variant_to_component cloud_sql_proxy cloud_sql_proxy }
 variant config_connector description {Add config connector} { dict set variant_to_component config_connector config-connector }
 variant datalab description {Add Cloud Datalab Command Line Tool} { dict set variant_to_component datalab datalab }


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 335.0.0.

###### Tested on

macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?