### PR TITLE
rb-mustache: Update to 1.1.1, add Ruby 3.0 support

### DIFF
--- a/ruby/rb-mustache/Portfile
+++ b/ruby/rb-mustache/Portfile
@@ -1,10 +1,10 @@
 PortSystem          1.0
 PortGroup           ruby 1.0
 
-ruby.branches       2.7 2.6 2.5 2.4
-ruby.setup          mustache 1.1.0 gem
+ruby.branches       3.0 2.7 2.6 2.5 2.4
+ruby.setup          mustache 1.1.1 gem
 revision            0
-maintainers         nomaintainer
+maintainers         {outlook.de:judaew} openmaintainer
 description         Logic-less templates, implemented in Ruby.
 long_description    \
     Inspired by ctemplate and et, Mustache is a framework-agnostic way to \
@@ -14,8 +14,8 @@ license             MIT
 platforms           darwin
 homepage            https://github.com/mustache/mustache
 
-checksums           rmd160  36626a07282c67d781282ed35ffa71bc5cf634f2 \
-                    sha256  7365441281b93b9a3e7299c432af1b971435155168ef12631a72bbdaf9ed2899 \
+checksums           rmd160  bad296ce20b6eebd2d75e921ad2f49ae03e70812 \
+                    sha256  90891fdd50b53919ca334c8c1031eada1215e78d226d5795e523d6123a2717d0 \
                     size    42496
 
 if {${name} ne ${subport}} {


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
