### PR TITLE
py-py2app: Rev bump to 0.24

### DIFF
--- a/python/py-py2app/Portfile
+++ b/python/py-py2app/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-py2app
-version             0.23
+version             0.24
 categories-append   devel
 license             {MIT PSF}
 maintainers         {jmr @jmroot} openmaintainer
@@ -18,9 +18,9 @@ platforms           darwin
 
 homepage            https://github.com/ronaldoussoren/py2app
 
-checksums           md5 6cfa83ca979ee28b35b8a0478ed76221 \
-                    rmd160 af07b4829b5100a69abf750e9e95e6902b0a081b \
-                    sha256 772f7b30cac260537ecfada2801d1e9833010caf6d0439e80e64e1a558718d39
+checksums           md5 cf9a2a27d150856f9845cb5ef9249e81 \
+                    rmd160 597e745425c76d765067b8f0ec25de83a411144d \
+                    sha256 753915b2efaa72b23de1553e00f2cd9d3b4fdc05269ccae4b65c710e38121d67
 
 python.versions     27 35 36 37 38 39
 


### PR DESCRIPTION
#### Description

Rev bump py-py2app to 0.24 to add universal2 and arm64 bindings.

Closes ticket [62362](https://trac.macports.org/ticket/62362)

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
