### PR TITLE
syncthing: update to 1.15.1

### DIFF
--- a/net/syncthing/Portfile
+++ b/net/syncthing/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/syncthing/syncthing 1.14.0 v
+go.setup            github.com/syncthing/syncthing 1.15.1 v
 categories          net
 platforms           darwin
 license             MPL-2
@@ -18,9 +18,9 @@ long_description    Syncthing replaces proprietary sync and cloud services \
 homepage            https://syncthing.net
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  63cf92d80710cd751b7a2f2fa6158fe64403b7f0 \
-                        sha256  496591f73c4a25dac1444389631bd342a3540ca412b9aeb5a0db14fc63b8aa68 \
-                        size    5072193
+                        rmd160  751e7570d0eafc1f187864f1e374e9f4ab92dc98 \
+                        sha256  607ca3f2004d8fe0c38083b4cfa9947dfbdab1b4cbb73c25e49094e473672241 \
+                        size    6110774
 
 go.vendors          gopkg.in/yaml.v3 \
                         lock    9f266ea9e77c \
@@ -38,10 +38,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  91c562a4e31c89d13e5391143ff653231fc2d80562743db89ce2172ad8f81008 \
                         size    3636 \
                     gopkg.in/check.v1 \
-                        lock    41f04d3bba15 \
-                        rmd160  1e5543a8e6a3159296ee63e28cbde9931a04f6b3 \
-                        sha256  c41575a73d10809f89b05ef9e783f2d53facdc6573697770d30efb05a9d2dc28 \
-                        size    31612 \
+                        lock    038fdea0a05b \
+                        rmd160  0f1896097db9d42b2fb5d62999bb52c77635f758 \
+                        sha256  a82bd5c6960aa523c4dd8b30d52c3a7e8a5382e91f25862ef277bedf5c107007 \
+                        size    31647 \
                     google.golang.org/protobuf \
                         repo    github.com/protocolbuffers/protobuf-go \
                         lock    v1.23.0 \
@@ -53,6 +53,11 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  6e8267f353e153297f205e4be219236d6ae43880 \
                         sha256  9a500a49d83a09e7de6c71b215d1c14b81e315d26884530ef327c95ddf1f2d28 \
                         size    13667 \
+                    golang.org/x/tools \
+                        lock    v0.1.0 \
+                        rmd160  ed8549ff61216e862597412cca9a2f3cd3448147 \
+                        sha256  7ee4ceea7cc41925aa41c185d17886694bcd611cb9896be15e578a491c8594c0 \
+                        size    2683296 \
                     golang.org/x/time \
                         lock    3af7569d3a1e \
                         rmd160  6ec4017fbe0897df74acfb012623482602c33dae \
@@ -64,15 +69,20 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  4f7508324739fdddcc1bf653a755608aa8ed0119d297ba7460d812e67d661e6a \
                         size    8347767 \
                     golang.org/x/sys \
-                        lock    da207088b7d1 \
-                        rmd160  8c8111fa56a17c9a6dc921bbde2495f3b8bca3c9 \
-                        sha256  0e42fcc8a45bf8c25a070d0f7245f8a62b45bb9a4966c893c1bc8506b011e88c \
-                        size    1085059 \
+                        lock    b64e53b001e4 \
+                        rmd160  eb9c17a2964f138171e208deb3c3ebc8a9f8ff02 \
+                        sha256  5bc19a2c586a4703fcd4bca3fe19d093dd9bd614527cfb96c3845dcd1b49a6f9 \
+                        size    1103887 \
                     golang.org/x/net \
                         lock    ff519b6c9102 \
                         rmd160  78d6174e2b669f537a5df1e2945d47f737b9e7ae \
                         sha256  abe822419126a02ff65c26fe14994787b0d29a1b7633471fd3ed04c3e6b1c150 \
                         size    1248882 \
+                    golang.org/x/mod \
+                        lock    v0.3.0 \
+                        rmd160  0f19d3d89a7745c9877e5095399e24bdb2a79908 \
+                        sha256  d4e740958a7d07574b73c6b6a5ab717cd0bc219416e47c5950fe3cefab414f92 \
+                        size    93933 \
                     golang.org/x/crypto \
                         lock    9e8e0b390897 \
                         rmd160  bd4738a1bbf4d94ec5f840e7425ffa473c6b97bd \
@@ -99,20 +109,15 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  9fb936ce779314cfa755bd208b8a5ba7e4f41c23bd7a1d61bda6facb5d13052b \
                         size    151087 \
                     github.com/syncthing/notify \
-                        lock    17de26665ddc \
-                        rmd160  2b1328b56d6cba0fe3717963115dfa6274b1a8a7 \
-                        sha256  fc0ed5b0fe3a4b81e776381368dffbaa7d93621403c8bc7d2027c823073a6b4c \
-                        size    57687 \
+                        lock    f45149b04939 \
+                        rmd160  e2f2f392b355ec28fa8cb3237fb051097e6a46af \
+                        sha256  5c1ed415aa68c8cf7e369c49e50922a446def96b652a67b1b0fec5e8cb28fd59 \
+                        size    58257 \
                     github.com/stretchr/testify \
                         lock    v1.6.1 \
                         rmd160  7e5b798212a8f15cd58a63985ae0b928eede8e6b \
                         sha256  44d77d9b5c1dc08fa710eac9bb324898210660458085cdf965b78a39b1010f2a \
                         size    84248 \
-                    github.com/spaolacci/murmur3 \
-                        lock    v1.1.0 \
-                        rmd160  53215abb0d59b6c64e926e90fb33da1906a1a525 \
-                        sha256  54d6a3300600dd2f5e444f6d19fe1f91e1174329cdfff1d50dae837689214a68 \
-                        size    7396 \
                     github.com/shurcooL/sanitized_anchor_name \
                         lock    v1.0.0 \
                         rmd160  c7e5322dba53e10db1711d65c146af5649b0c7c8 \
@@ -184,10 +189,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  0f702ef1efa02abd2a70a5fbd33353338c7f67acaaafea707a162ec30ddb5d0b \
                         size    7750 \
                     github.com/onsi/gomega \
-                        lock    v1.10.1 \
-                        rmd160  fbdb25ab0da7cc358134327f3bf7390aae2a9e7f \
-                        sha256  f5d901f5a7321a7ed7317d1ae305bb27b7c3febc3cede1c887e2d76a8e995da6 \
-                        size    97315 \
+                        lock    v1.10.3 \
+                        rmd160  3ce67285e98fcf47d6ae18e2a50b6685c132e323 \
+                        sha256  ff8e349c8e3996170fdf809e659cca57284dfacd62545c39519df5820f7b9c14 \
+                        size    97892 \
                     github.com/onsi/ginkgo \
                         lock    v1.14.0 \
                         rmd160  a1ff8b445c4b593fc8c399993c90f8ff423260fa \
@@ -198,6 +203,11 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  33d7373bd1b164159b9032fc8595bb09b25598f6 \
                         sha256  16d8773e0be69469d3c296ee785bbef433c3442defb68760682cdbcf80ba40ee \
                         size    1238830 \
+                    github.com/niemeyer/pretty \
+                        lock    a10e7caefd8e \
+                        rmd160  46bcfc3db9e3d98acbacd1f96d9483fa360f88b7 \
+                        sha256  97b952a32175ba84349ef352e523bfa15bf3a06e07e44458a908061fbc519b40 \
+                        size    9405 \
                     github.com/miscreant/miscreant.go \
                         lock    26d376326b75 \
                         rmd160  cd64e010e3f36e163e269369dc7fb0c710ca41a9 \
@@ -208,6 +218,11 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  50654a6c3da3bcc426cb9189299e1d8d76f52a2b \
                         sha256  ab49163b74a1b89c8ab795eda31cbf65af572fe3f87028cc1234bac2ae45706c \
                         size    65042 \
+                    github.com/maxbrunsfeld/counterfeiter \
+                        lock    v6.3.0 \
+                        rmd160  6de0ee901ff8b710410086de41ea0110b33baeb9 \
+                        sha256  2fd84b07268d2e3ca3043483bd833b86bfc10fc3edc4aa8f2c6b51c4b939d2c7 \
+                        size    48496 \
                     github.com/matttproud/golang_protobuf_extensions \
                         lock    v1.0.1 \
                         rmd160  e28c4169919e72c08ee6520ad2ce16943d18e40c \
@@ -248,11 +263,6 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
                         sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
                         size    8691 \
-                    github.com/kr/pretty \
-                        lock    v0.1.0 \
-                        rmd160  9aa7a5aad4c48840eecfd0f80186d1fb5ded0fd6 \
-                        sha256  f6c3f89667c63e5b7f1fc6ee2c06b6a6bfdce88f3a965ccd395b64c6f95c9a47 \
-                        size    8553 \
                     github.com/kballard/go-shellquote \
                         lock    95032a82bc51 \
                         rmd160  40415cd59ece9fb38b22170feec07f1f48d518a2 \
@@ -348,26 +358,6 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  ec42eaffe2cf17a46e12c7c2a7d436c0f68ba655 \
                         sha256  b4205ec400df652238f7ed287c4b77b5f17a17d5793cd5371b7cc5e0f07dfeed \
                         size    7690 \
-                    github.com/dustin/go-humanize \
-                        lock    v1.0.0 \
-                        rmd160  e8641035159ea3e8839ee086f01f966443956303 \
-                        sha256  e45e3181c07b3e2dad8e1317e91a5bbbee4845067e3e3879a585a5254bc6a334 \
-                        size    17273 \
-                    github.com/dgryski/go-farm \
-                        lock    6a90982ecee2 \
-                        rmd160  a9f7f2372bd4bce849b55eef441e43b9a09330b0 \
-                        sha256  e90d46f1d9f70d28d20e4791aad8c2dbe7900d65bf42140018c443b3480eef72 \
-                        size    26795 \
-                    github.com/dgraph-io/ristretto \
-                        lock    8f368f2f2ab3 \
-                        rmd160  f99c7fbe446e02237d2c373cb6c9047ed624a526 \
-                        sha256  96eb4b33abfe0194bb1f813cdb7c4961ab583f8ea47560555071bf1ffc525d99 \
-                        size    39675 \
-                    github.com/dgraph-io/badger \
-                        lock    v2.0.3 \
-                        rmd160  fa3b561afae5c30f56812b5dd105857ca47f1400 \
-                        sha256  39507b49d5f0bc50c10dcdc4234a8c4226dbffeb773ede26dcf20f39b87c5f2b \
-                        size    332700 \
                     github.com/dchest/siphash \
                         lock    v1.2.2 \
                         rmd160  2bd73ba3ee5e184fa5dfb3c05f1d09677cf40d01 \
@@ -428,21 +418,16 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  c6c5c7fd2132f01925c7fccd9d27c9d7a80f2adb \
                         sha256  78da4421e9f9fa2ee5e3855bdd31cfb04c7e823d9c0ec385cc2c008132d98b96 \
                         size    10874 \
+                    github.com/alecthomas/kong \
+                        lock    v0.2.12 \
+                        rmd160  7e4eb2c2b1bb08ede1dfc78540becd5ed9e207aa \
+                        sha256  8a2d5fd67faee4ee5eaef031b1ea14b4bb7a356ce76b72a1ad04df2ee85efcd3 \
+                        size    283874 \
                     github.com/StackExchange/wmi \
                         lock    cbe66965904d \
                         rmd160  1c28ff3f595532ab67c85f5232c9228cf97d65d9 \
                         sha256  01b78146552b0c7d6126b64cdf4f7c40fe1e1e15a9f822d4a1bc6db5df1f48ca \
                         size    11289 \
-                    github.com/OneOfOne/xxhash \
-                        lock    v1.2.2 \
-                        rmd160  35e2c7b623c069fc08aec00990ca5c82ad831a22 \
-                        sha256  e6a73b9f6acc9b361ea77edcb6f29103e96ac0c623c6d2882909698180e54694 \
-                        size    13444 \
-                    github.com/DataDog/zstd \
-                        lock    v1.4.1 \
-                        rmd160  86c75e5feafd8e615a7eea3b97680c0543a95380 \
-                        sha256  f62a03934f91b063545ce33c40526d33d52fb07dbfbced5dd5b531295b37af4c \
-                        size    498943 \
                     github.com/Azure/go-ntlmssp \
                         lock    66371956d46c \
                         rmd160  74dcc3f7e70c2dbdf032390bd8734e0fc514ce65 \


### PR DESCRIPTION
#### Description

Updates syncthing to 1.15.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
