### PR TITLE
pngcheck: update to 3.0.2

### DIFF
--- a/graphics/pngcheck/Portfile
+++ b/graphics/pngcheck/Portfile
@@ -3,7 +3,8 @@
 PortSystem          1.0
 
 name                pngcheck
-version             2.3.0
+version             3.0.2
+revision            0
 categories          graphics
 license             MIT GPL-2
 platforms           darwin
@@ -22,8 +23,9 @@ long_description    pngcheck verifies the integrity of PNG, JNG and MNG files \
 homepage            http://www.libpng.org/pub/png/apps/pngcheck.html
 master_sites        sourceforge:project/png-mng/pngcheck/${version}
 
-checksums           rmd160  6a132516eeaf787eefa4d02eaecb06834fe9d2be \
-                    sha256  77f0a039ac64df55fbd06af6f872fdbad4f639d009bbb5cd5cbe4db25690f35f
+checksums           rmd160  7c9b7b40b73fa930d699e100eacb254d07f0455e \
+                    sha256  0d7e262f24116fddf2847a8ceb5c92d9f5f26efb42e9fff63ec2bb7676131ca7 \
+                    size    63202
 
 depends_lib         port:zlib
 
@@ -43,6 +45,9 @@ destroot {
     set docdir ${prefix}/share/doc/${subport}
     xinstall -d ${destroot}${docdir}
     xinstall -m 644 ${worksrcpath}/README ${destroot}${docdir}
+    set man1dir ${prefix}/share/man/man1
+    xinstall -d ${destroot}${man1dir}
+    xinstall -m 644 ${worksrcpath}/pngcheck.1 ${destroot}${man1dir}
 }
 
 livecheck.regex     ${name}-(\\d+(?:\\.\\d+)*)


### PR DESCRIPTION
#### Description

From changelog:
```
 * 20070709 GRR: tweaked color definitions slightly to work better on terminals
 *               with white/light backgrounds
 * 20070712 GRR: added Makefile.mingw32
 * 20100504 GRR: fixed DHDR (pre-MNG-1.0) bug identified by Winfried <szukw000@arcor.de>
 * 20170713 GRP: added eXIf support (GRR: added check for II/MM/unknown format)
 * 20201012 BB:  converted static const help/usage-related strings to macros so
 *               -Werror=format-security doesn't trigger (Ben Beasley)
 * 20201015 BB:  added (help2man-generated) man pages for all three utils
 * 20201017 GRR: added top-level LICENSE file; fixed various compiler warnings
 * 20201031 GRR: replaced gpl/COPYING (outdated address, references to Library
 *               GPL) with https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt
 *               (thanks to Ben Beasley for catching that)
 * 20201031 GRR: released version 2.4.0
 *               ----------------------
 * 20201113 BB:  fixed buffer-overflow vulnerability discovered by "giantbranch
 *               of NSFOCUS Security Team"
 *               https://bugzilla.redhat.com/show_bug.cgi?id=1897485
 * 20201128 BB:  found and fixed four additional vulnerabilities (null-pointer
 *               dereference and three buffer overruns)
 * 20201209 LP:  fixed an off-by-one bug in check_magic() (Lucy Phipps)
 * 20201209 LL:  converted two zlib-version warnings/errors to go to stderr
 *               (Lemures Lemniscati, actually from 20180318; forwarded by LP)
 * 20201210 BB:  fixed another buffer-overflow vulnerability discovered by
 *               "giantbranch of NSFOCUS Security Team"
 *               https://bugzilla.redhat.com/show_bug.cgi?id=1905775
 * 20201212 GRR: removed -f ("force") option due to multiple security issues
 * 20201212 GRR: released version 3.0.0
 *               ----------------------
 * 20201214 BB:  generalized previous sPLT buffer-overrun fix, and found and
 *               fixed a PPLT vulnerability
 * 20210124 GRR: released version 3.0.1
 *               ----------------------
 * 20201217 BB:  fixed a crash bug (and probable vulnerability) in large (MNG)
 *               LOOP chunks
 * 20210131 GRR: updated Makefile.mingw32 for modern versions and added
 *               Makefile.mingw64 (targets Win64); both are essentially
 *               UNTESTED, however!
 * 20210131 GRR: released version 3.0.2
 *               ----------------------
```

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [x] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7
Xcode 12.4 command line tools

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
Only ran pngcheck.
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
