### PR TITLE
stgit: Fix html_man_docs variant and add other files

### DIFF
--- a/devel/stgit/Portfile
+++ b/devel/stgit/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 
 github.setup        stacked-git stgit 1.0 v
 github.tarball_from releases
-revision            1
+revision            2
 
 categories          devel python
 platforms           darwin
@@ -38,9 +38,6 @@ checksums           rmd160  106d3f89ffffeaf617bcf6a43f847bf63103aed9 \
 python.default_version 38
 depends_run         port:git
 
-set stgdocs         "${worksrcpath}/Documentation/stg.txt"
-set stgman          ""
-
 post-build {
     system -W ${worksrcpath} "PYTHON=${python.bin} make all"
 }
@@ -52,55 +49,46 @@ post-destroot {
     # Install what little documentation there is
     xinstall -m 644 -W ${worksrcpath} COPYING \
         ${destroot}${prefix}/share/doc/${name}
-    xinstall -m 644 {*}[glob ${stgdocs}] \
+    xinstall -m 644 {*}[glob ${worksrcpath}/Documentation/*.txt] \
         ${destroot}${prefix}/share/doc/${name}
-    if {${stgman} != ""} {
-        xinstall -m 644 {*}[glob ${stgman}] \
-            ${destroot}${prefix}/share/man/man1
-    }
-}
 
-default_variants +bash_completion
+    # Install shell completion (bash, zsh, fish)
+    xinstall -d ${destroot}${prefix}/share/bash-completion/completions
+    move ${destroot}${prefix}/share/stgit/completion/stgit.bash \
+        ${destroot}${prefix}/share/bash-completion/completions/stg
+    xinstall -d ${destroot}${prefix}/share/zsh/site-functions
+    move ${destroot}${prefix}/share/stgit/completion/stgit.zsh \
+        ${destroot}${prefix}/share/zsh/site-functions/_stg
+    xinstall -d ${destroot}${prefix}/share/fish/completions
+    move ${destroot}${prefix}/share/stgit/completion/stg.fish \
+        ${destroot}${prefix}/share/fish/completions/stg.fish
 
-variant bash_completion {
-    post-destroot {
-        set bash_compl_path ${prefix}/share/bash-completion/completions
-        xinstall -d ${destroot}${bash_compl_path}
-        move ${destroot}${prefix}/share/stgit/completion/stgit.bash \
-                 ${destroot}${bash_compl_path}/stg
-    }
-}
+    # Install vim and emacs plugin
+    xinstall -d ${destroot}${prefix}/share/vim/vimfiles/ftdetect
+    xinstall -m 644 ${worksrcpath}/contrib/vim/ftdetect/stg.vim \
+        ${destroot}${prefix}/share/vim/vimfiles/ftdetect
+    xinstall -d ${destroot}${prefix}/share/vim/vimfiles/syntax
+    xinstall -m 644 {*}[glob ${worksrcpath}/contrib/vim/syntax/*.vim] \
+        ${destroot}${prefix}/share/vim/vimfiles/syntax
 
-variant zsh_completion {
-    post-destroot {
-        set zsh_compl_path ${prefix}/share/zsh/site-functions
-        xinstall -d ${destroot}${zsh_compl_path}
-        move ${destroot}${prefix}/share/stgit/completion/stgit.zsh \
-                 ${destroot}${zsh_compl_path}/_stg
-    }
-}
-
-variant fish_completion \
-    description {Enable completion support for Fish} {
-    post-destroot {
-        set fish_compl_path ${prefix}/share/fish/completions
-        xinstall -d ${destroot}${fish_compl_path}
-        move ${destroot}${prefix}/share/stgit/completion/stgit.fish \
-                 ${destroot}${fish_compl_path}/stg.fish
-    }
+    xinstall -d ${destroot}${prefix}/share/emacs/site-lisp
+    xinstall -m 644 ${worksrcpath}/contrib/stgit.el \
+        ${destroot}${prefix}/share/emacs/site-lisp
 }
 
 variant html_man_docs \
     description {Build and install documentation in HTML and manpage format} {
-    # Need to add post-destroot addition of extra docs...
-    lappend stgdocs ${worksrcpath}/Documentation/*.html
-    lappend stgman ${worksrcpath}/Documentation/*.1
     depends_build-append    port:asciidoc port:xmlto
+
     post-build {
         system -W ${worksrcpath} "PYTHON=${python.bin} make doc -j${build.jobs} V=1"
     }
-}
 
-livecheck.type      regex
-livecheck.url       ${homepage}
-livecheck.regex     "${name}-(\\d+\\.\\d+\\.\\d+)"
+    # install documentatuin and man-pages
+    post-destroot {
+        xinstall -m 644 {*}[glob ${worksrcpath}/Documentation/*.html] \
+            ${destroot}${prefix}/share/doc/${name}
+        xinstall -m 644 {*}[glob ${worksrcpath}/Documentation/*.1] \
+            ${destroot}${prefix}/share/man/man1
+    }
+}


### PR DESCRIPTION
Changes:
- Fix build html_man_docs variant
- Shell completion available default with no variants
- Add vim and emacs plugin
- Remove wrong regex for livecheck

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
