### PR TITLE
jruby: New port (v9.2.17.0)

### DIFF
--- a/lang/jruby/Portfile
+++ b/lang/jruby/Portfile
@@ -1,0 +1,100 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           java 1.0
+
+name                jruby
+version             9.2.17.0
+revision            0
+
+java.version        1.8+
+java.fallback       openjdk11
+
+categories          lang ruby java
+platforms           darwin
+license             {EPL-2 GPL-2 LGPL-2.1}
+supported_archs     noarch
+maintainers         {outlook.de:judaew @judaew} \
+                    openmaintainer
+
+description         JRuby is an implementation of the Ruby language using the JVM.
+long_description    \
+    ${description} It aims to be a complete, correct and fast implementation \
+    of Ruby, at the same time as providing powerful new features such as \
+    concurrency without a global-interpreter-lock, true parallelism, and tight \
+    integration to the Java language to allow you to use Java classes in your \
+    Ruby program and to allow JRuby to be embedded into a Java application.
+homepage            https://www.jruby.org
+
+master_sites        https://repo1.maven.org/maven2/org/jruby/jruby-dist/${version}/
+distname            ${name}-dist-${version}-bin
+worksrcdir          ${name}-${version}
+
+checksums           rmd160  1a25a4ce0714d513e1f46c9d1210988a8596b8a6 \
+                    sha256  7701d3537b3a606d2765ac6d5c40e675ddaa01d3cebad26a21a66e3aadd5c202 \
+                    size    25790508
+
+use_configure       no
+build {}
+
+variant default_ruby description {Install without j prefix} {}
+
+variant nailgun description {include Nailgun support} {
+    use_configure   yes
+    configure.cmd   ./configure
+    configure.dir   ${worksrcpath}/tool/nailgun
+
+    build {
+        system -W ${worksrcpath}/tool/nailgun ${build.cmd}
+    }
+
+    post-destroot {
+        xinstall -m 755 -d ${destroot}${prefix}/share/java/${name}/tool/nailgun
+        move ${worksrcpath}/tool/nailgun/ng \
+            ${destroot}/${prefix}/share/java/${name}/tool/nailgun
+    }
+}
+
+destroot {
+    # Remove extraneous files from other platforms
+    delete {*}[glob -directory ${worksrcpath}/bin *.bat *.dll *.exe]
+    delete {*}[glob -directory ${worksrcpath}/lib/jni \
+        *AIX *BSD *Linux *SunOS *Windows]
+
+    xinstall -m 755 -d ${destroot}${prefix}/share/java/${name}
+
+    move \
+        ${worksrcpath}/bin \
+        ${worksrcpath}/lib \
+        ${destroot}${prefix}/share/java/${name}
+
+    move ${worksrcpath}/samples ${destroot}${prefix}/share/java/${name}
+
+    set jruby_prefix ""
+
+    if { ![variant_isset default_ruby] } {
+        set jruby_prefix "j"
+    }
+
+    foreach f { jruby jirb jrubyc jirb_swing } {
+        regsub {^j} $f $jruby_prefix dest
+        if { ${dest} != ${f} } {
+            ln -s ${prefix}/share/java/${name}/bin/${f} \
+                ${destroot}${prefix}/bin/${dest}
+        }
+        ln -s ${prefix}/share/java/${name}/bin/${f} ${destroot}${prefix}/bin/
+    }
+
+    foreach f { ast gem rdoc ri testrb } {
+        ln -s ${prefix}/share/java/${name}/bin/${f} \
+            ${destroot}${prefix}/bin/${jruby_prefix}${f}
+    }
+}
+
+test.run            yes
+test.cmd            bin/jruby
+test.target         samples/java2.rb
+
+livecheck.type      regex
+livecheck.url       https://repo1.maven.org/maven2/org/jruby/jruby-dist/
+livecheck.regex     (\\d+(?:\\.\\d+)*)/


### PR DESCRIPTION

#### Description

See: https://www.jruby.org/2021/03/29/jruby-9-2-17-0.html
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
