### PR TITLE
icu-doxygen-docs: make obsolete

### DIFF
--- a/devel/icu/Portfile
+++ b/devel/icu/Portfile
@@ -55,7 +55,6 @@ configure.args      --disable-layoutex \
 
 subport ${name}-docs {
     revision                0
-    conflicts               ${name}-doxygen-docs
     supported_archs         noarch
 
     description-append      (documentation)
@@ -74,20 +73,6 @@ subport ${name}-docs {
         xinstall -m 755 -d ${destroot}${docdir}
         copy ${worksrcpath}/doc/html ${destroot}${docdir}
     }
-}
-
-subport ${name}-doxygen-docs {
-    revision                0
-    conflicts               ${name}-docs
-    supported_archs         noarch
-
-    depends_build-append    port:doxygen
-
-    description-append      (build documentation)
-    long_description-append Build documentation.
-
-    build.target            doc
-    destroot.target         install-doc
 }
 
 subport ${name}-lx {
@@ -213,6 +198,14 @@ if { ${subport} ne "${name}-docs" } {
             xinstall -d -m 0755 ${worksrcpath}/data/out
         }
     }
+}
+
+subport ${name}-doxygen-docs {
+    # remove after 20220407
+    PortGroup               obsolete 1.0
+
+    revision                1
+    replaced_by             ${name}-docs
 }
 
 if {${subport} eq ${name}} {


### PR DESCRIPTION
Anyone feel an overwhelming need for this port?

This port was added > 10 years ago when apparently the premade zip documents were found to be incomplete but this is no longer the case and the zip documents in the icu-doc port actually have more files than the icu-doxygen-docs port now.

I am trying to simplify, deobfuscate, and otherwise bring the icu port into a more easily manageable condition.