### PR TITLE
maven3: update to 3.8.1

### DIFF
--- a/java/maven3/Portfile
+++ b/java/maven3/Portfile
@@ -5,7 +5,7 @@ PortGroup select 1.0
 PortGroup java 1.0
 
 name            maven3
-version         3.6.3
+version         3.8.1
 revision        0
 
 categories      java devel
@@ -35,9 +35,9 @@ master_sites    apache:maven/maven-3/${version}/binaries
 distname        apache-maven-${version}-bin
 worksrcdir      apache-maven-${version}
 
-checksums       rmd160  825e2cca16a72da4bb0a4b5add615e155623c05e \
-                sha256  26ad91d751b3a9a53087aefa743f4e16a17741d3915b219cf74112bf87a438c5 \
-                size    9506321
+checksums       rmd160  ec30917d520723a29f8e34e75ecd1dac495b13ac \
+                sha256  b98a1905eb554d07427b2e5509ff09bd53e2f1dd7a0afa38384968b113abef02 \
+                size    9536838
 
 java.version    1.7+
 java.fallback   openjdk11


### PR DESCRIPTION
#### Description

Update to Apache Maven 3.8.1.

###### Tested on

macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?