### PR TITLE
macfuse: new port

### DIFF
--- a/fuse/macfuse/Portfile
+++ b/fuse/macfuse/Portfile
@@ -1,0 +1,77 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        osxfuse osxfuse 4.1.0 macfuse-
+name                macfuse
+conflicts           osxfuse
+categories          fuse
+platforms           darwin
+supported_archs     x86_64
+license             Restrictive
+maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
+
+description         FUSE for macOS
+
+long_description    FUSE extends macOS by adding support for user space file \
+                    systems.
+
+homepage            https://osxfuse.github.io/
+
+github.tarball_from releases
+distname            ${name}-${version}
+use_dmg             yes
+
+checksums           rmd160  2c5e9741b983e660e34139966838af8a49eb3b5c \
+                    sha256  3cb6a49406fd036c50ef1b4ad717a377f4dcf182811bde172d69f1c289791085 \
+                    size    5747012
+
+if {${os.platform} eq "darwin" && ${os.major} < 16} {
+    known_fail yes
+    pre-fetch {
+        ui_error "${name} is only supported on macOS 10.12 or later."
+        return -code error "unsupported platform version"
+    }
+}
+
+set pkg ${workpath}/pkg/Core.pkg
+
+post-extract {
+    system -W ${worksrcpath} \
+        "pkgutil --expand 'Extras/macFUSE ${version}.pkg' ${workpath}/pkg"
+    system -W ${pkg} "gzip -dc Payload | cpio -id"
+}
+
+use_configure       no
+
+build {
+    system -W ${pkg} "codesign --remove-signature \
+        usr/local/lib/libfuse.2.dylib \
+        Library/Frameworks/macFUSE.framework/Versions/A/macFUSE"
+
+    system -W ${pkg} "install_name_tool -id ${prefix}/lib/libfuse.2.dylib \
+        usr/local/lib/libfuse.2.dylib"
+
+    system -W ${pkg} "install_name_tool \
+        -id ${prefix}/Library/Frameworks/macFUSE.framework/Versions/A/macFUSE \
+        -change /usr/local/lib/libfuse.2.dylib ${prefix}/lib/libfuse.2.dylib \
+        Library/Frameworks/macFUSE.framework/Versions/A/macFUSE"
+}
+
+destroot {
+    copy ${pkg}/Library/Filesystems ${destroot}${prefix}/Library
+    copy {*}[glob ${pkg}/Library/Frameworks/*] ${destroot}${prefix}/Library/Frameworks
+    copy {*}[glob ${pkg}/usr/local/include/*] ${destroot}${prefix}/include
+    copy {*}[glob ${pkg}/usr/local/lib/pkgconfig/*] ${destroot}${prefix}/lib/pkgconfig
+    copy {*}[glob -type f ${pkg}/usr/local/lib/*] ${destroot}${prefix}/lib
+}
+
+set dir /Library/Filesystems/macfuse.fs
+
+notes  "
+    Run the following before using macFUSE:
+
+        sudo ln -sn ${prefix}${dir} ${dir}
+        sudo ${dir}/Contents/Resources/load_macfuse
+"


### PR DESCRIPTION
#### Description

osxfuse is no longer open-source, doesn't seem to work, and the name of the project has changed to macfuse, hence the new port.

###### Tested on
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?