### PR TITLE
nco: update to 4.9.8

### DIFF
--- a/science/nco/Portfile
+++ b/science/nco/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           compilers 1.0
 PortGroup           github 1.0
 
-github.setup        nco nco 4.9.3
-revision            2
+github.setup        nco nco 4.9.8
+revision            0
 platforms           darwin
 maintainers         {takeshi @tenomoto}
 license             GPL-3
@@ -19,9 +19,9 @@ if {${os.major} > 12} {
     compilers.setup -clang33 -clang34
 }
 
-checksums           rmd160  4b2efd6cb9a3d0c2778a2a7ec7fef94e469a79a0 \
-                    sha256  44cba2788636a7d9c3918b743b15876b23b2d4f0966378e9b3743d61a7492cfc \
-                    size    5303027
+checksums           rmd160  8e2fc1c4d2e659e2e5edce08e2db32795628e112 \
+                    sha256  6d0e4bad362706026a63fb411884ee165cf27d7fcbfa6cb5dc8b2d6a19d9c8c0 \
+                    size    5392794
 
 homepage            http://nco.sourceforge.net/
 long_description \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
This is to implement the upstream update to version 4.9.8

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3
Xcode Command Line Tools 12.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
