### PR TITLE
fzf: update to 0.27.0

### DIFF
--- a/sysutils/fzf/Portfile
+++ b/sysutils/fzf/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/junegunn/fzf 0.26.0
+go.setup            github.com/junegunn/fzf 0.27.0
 revision            0
 
 categories          sysutils
@@ -14,65 +14,60 @@ description         A command-line fuzzy finder written in Go
 long_description    ${description}
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  178443ccd0f8d2a73f58f45e5943b3fd59fae10d \
-                        sha256  8acc2e2ab53750bbfbca62cd286063303e18b404914d83d1c0cf21a2d333c034 \
-                        size    182289
+                        rmd160  bf0def3dec71948144e7e0e0ce2b6264ab76588b \
+                        sha256  ddbe914a3ee1d839c492a7f97cc5697c4932b9056e7a2457e873f47706a8570d \
+                        size    183011
 
-go.vendors          golang.org/x/tools \
-                        lock    90fa682c2a6e \
-                        rmd160  afeef309693d107de47d23c8ec5b52df037b9905 \
-                        sha256  7b9c5ab345041195f6ca303f14c528ed19fd1b52ca6d0402679c64023d07dc85 \
-                        size    2332207 \
-                    golang.org/x/text \
-                        lock    v0.3.3 \
-                        rmd160  babfa547ba9a9dab7fe08fa5543f1d8e7ae00301 \
-                        sha256  1c4a8c12295d484e0360d8e010ebc4b8a9a05aa2a07c10c3d3e5b17aa063f0db \
-                        size    7745597 \
+go.vendors          golang.org/x/text \
+                        lock    v0.3.6 \
+                        rmd160  e3da48fcc60d98e202458228188bf6dac408e309 \
+                        sha256  6b2d69df22b5ba1634bc6730c3f03404db499536a96c48b8016da80ced804450 \
+                        size    8356058 \
+                    golang.org/x/term \
+                        lock    de623e64d2a6 \
+                        rmd160  8f8c61baa39ab9af01714065975f9c1b41c3baf5 \
+                        sha256  ea781a5a35d70ed6f86287db5296e3b438625120be22bd9e208432dca8fd8f18 \
+                        size    15357 \
                     golang.org/x/sys \
-                        lock    119d4633e4d1 \
-                        rmd160  ff96c15036f10cb4c2e209003e8c0368eaba3197 \
-                        sha256  442977a4c5259a8f9b2327d127f8da6eaaa02cdcbcbfe7b573e9f57570f208bc \
-                        size    1072778 \
+                        lock    5e06dd20ab57 \
+                        rmd160  0e29fa746c2128c6d39e6b6b846d79384c3e9cb8 \
+                        sha256  93b0de8ad37fc1f97bc1f0a782fcb666b5ec01a8bcd6f5bce9bbc673c7f7d16b \
+                        size    1218990 \
                     golang.org/x/sync \
-                        lock    67f06af15bc9 \
-                        rmd160  1975599ab89b8c6a6b7fbca131efb1b705f7f022 \
-                        sha256  78883bdc5e24128ee3700bfe03eddb759dbaabdeb99eeda2826bf95a2784d18e \
-                        size    18695 \
-                    golang.org/x/net \
-                        lock    eb5bcb51f2a3 \
-                        rmd160  cb943e35e512e30b1a1ee9a9af23e200de7fc2fd \
-                        sha256  50ba342bcc50da4b4590ee91a6586f9d0aab43907596c2a0995e6f0868353e7a \
-                        size    976956 \
-                    golang.org/x/crypto \
-                        lock    9e8e0b390897 \
-                        rmd160  bd4738a1bbf4d94ec5f840e7425ffa473c6b97bd \
-                        sha256  1b740a92e71e7215af0a8c3651c5e4925eaaf0f49e718ffd2dc8310452894236 \
-                        size    1732591 \
+                        lock    036812b2e83c \
+                        rmd160  f42be6eb3565d2ed3d1066ea1a7f69437c8bb1e6 \
+                        sha256  6f1daceb16cd75bdbf35da6c50aa352d1995d68ccd0049851d27686f451fad92 \
+                        size    18756 \
                     github.com/saracen/walker \
-                        lock    v0.1.1 \
-                        rmd160  e67c5be594fe7f19d8ad45b89675095604b51888 \
-                        sha256  c6d2759f59c616980eb6afe86cbc1adb615b8ab56bf52cf428afcffb0a718910 \
-                        size    10718 \
+                        lock    v0.1.2 \
+                        rmd160  1b55e475639f6a540a5470caf2e0517e1394e2d8 \
+                        sha256  4d4c83c864f8300ff7576195ac7a1056b01005c2a6742414a6385d5c64d6b3c9 \
+                        size    11298 \
+                    github.com/rivo/uniseg \
+                        lock    v0.2.0 \
+                        rmd160  33577def583aa2db50b69ca601e5d29ab201ebc4 \
+                        sha256  2832965221246272462a03ffc8e159c94d8f534827f660f1ac4fc77e5ccd644c \
+                        size    44037 \
                     github.com/mattn/go-shellwords \
-                        lock    v1.0.10 \
-                        rmd160  5cd8df0280d795cc159d4be9039b193418375f4c \
-                        sha256  3691f606a48a973e02cb57e1ce724500a29cff5cad229dae24179ee3094561ae \
-                        size    5149 \
+                        lock    v1.0.11 \
+                        rmd160  6f262db0fb01afc26566a52cfe350c02218d056b \
+                        sha256  480c08a3a6d24008e0fac687a75f318f095a5108578605f9d7e560581c02eb4a \
+                        size    6112 \
                     github.com/mattn/go-runewidth \
-                        lock    v0.0.9 \
-                        rmd160  412c0e508e55f4fe437be0f71d7d22eca2b4366f \
-                        sha256  4f0f4a22257ccecfb6beae88052d850380ecc0e806d6bcc92d3656ebcac3b638 \
-                        size    16716 \
+                        lock    v0.0.12 \
+                        rmd160  56fc1bfe9eb51e2c283d005ac369b3757ecae355 \
+                        sha256  63f20c04796f9f991a67f7ccf0e09c418b8e454d5cbd424943a5ade2f0065e6e \
+                        size    17358 \
                     github.com/mattn/go-isatty \
                         lock    v0.0.12 \
                         rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
                         sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
                         size    4549 \
                     github.com/lucasb-eyer/go-colorful \
-                        lock    v1.0.3 \
-                        rmd160  0d0a283ba00c871d123c951efea0605a869951aa \
-                        sha256  ecd902ddda5d05cc8a857873bf8b984a5cd2d7b75f1185edcfc2c472707958b3 \
-                        size    430208 \
+                        lock    v1.2.0 \
+                        rmd160  a4183d0625e6c94474942cdc544c1061d35c4e34 \
+                        sha256  fbad1aade4444bf51409f5b6a008cc14c7a7cdd1af856841fc1170605fae3914 \
+                        size    970841 \
                     github.com/gdamore/tcell \
                         lock    v1.4.0 \
                         rmd160  479ce3d189ac02a4de5219054f537cc173c28b43 \


### PR DESCRIPTION
#### Description
fzf: update to 0.27.0
* update vendors using `go2port`

###### Tested on
macOS 10.15.7 19H524
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?