### PR TITLE
kubectl: add new subport for 1.21.0

### DIFF
--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -13,12 +13,20 @@ homepage                https://kubectl.docs.kubernetes.io/
 maintainers             {@patarra gmail.com:patarra} \
                         {lbschenkel @lbschenkel} \
                         @pedrohdz \
+                        {gmail.com:herby.gillot @herbygillot} \
                         openmaintainer
 
 subport kubectl_select {}
 
 # *NOTE* Remember to update `latestVersion` on a version upgrade.
-set latestVersion       kubectl-1.20
+set latestVersion       kubectl-1.21
+
+subport kubectl-1.21 {
+    set patchNumber     0
+    checksums           rmd160  79f96bdd83826a940bc723a8a140c6c46832c5f4 \
+                        sha256  f9dcc271590486dcbde481a65e89fbda0f79d71c59b78093a418aa35c980c41b \
+                        size    54487216
+}
 
 subport kubectl-1.20 {
     set patchNumber     4


### PR DESCRIPTION
- add @herbygillot as co-maintainer

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
