### PR TITLE
taskwarrior-tui: Update to 0.13.11

### DIFF
--- a/office/taskwarrior-tui/Portfile
+++ b/office/taskwarrior-tui/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        kdheepak taskwarrior-tui 0.13.8 v
+github.setup        kdheepak taskwarrior-tui 0.13.11 v
 revision            0
 
 description         A terminal user interface for taskwarrior
@@ -17,9 +17,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 license             MIT
 
-checksums           rmd160  9266c0935fc59bf210bfefbaae68eb0a1f210087 \
-                    sha256  29693bad8e6d2ce211c9a9f73821c57ab42b064e963be73f5209735178de42e3 \
-                    size    56637
+checksums           rmd160  26cb5c3a4e57433bfedf7e7262e29e45003a70ad \
+                    sha256  d9db2868ab0864eb329d27f53daedadf355ff7b7fcefd9f63c2419e779c8e289 \
+                    size    58823
 
 build.pre_args      --release -v -j${build.jobs}
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
