### PR TITLE
gh: install fish completions to vendor dir

### DIFF
--- a/devel/gh/Portfile
+++ b/devel/gh/Portfile
@@ -58,9 +58,9 @@ destroot {
     exec ${destroot}${prefix}/bin/gh completion -s zsh >> \
         ${destroot}${prefix}/share/zsh/site-functions/_gh
 
-    xinstall -d ${destroot}${prefix}/share/fish/completions
+    xinstall -d ${destroot}${prefix}/share/fish/vendor_completions.d
     exec ${destroot}${prefix}/bin/gh completion -s fish >> \
-        ${destroot}${prefix}/share/fish/completions/gh.fish
+        ${destroot}${prefix}/share/fish/vendor_completions.d/gh.fish
 }
 
 github.livecheck.regex {([0-9.]+)}


### PR DESCRIPTION
#### Description

Installing `gh` with fish installed fails with:

```
--->  Fetching archive for gh
--->  Attempting to fetch gh-1.8.1_0.darwin_18.x86_64.tbz2 from https://ywg.ca.packages.macports.org/mirror/macports/packages/gh
--->  Attempting to fetch gh-1.8.1_0.darwin_18.x86_64.tbz2.rmd160 from https://ywg.ca.packages.macports.org/mirror/macports/packages/gh
--->  Installing gh @1.8.1_0
--->  Activating gh @1.8.1_0
Error: Failed to activate gh: Image error: /opt/local/share/fish/completions/gh.fish is being used by the active fish port.  Please deactivate this port first, or use 'port -f activate gh' to force the activation.
Error: See /opt/local/var/macports/logs/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_devel_gh/gh/main.log for details.
Error: Follow https://guide.macports.org/#project.tickets to report a bug.
Error: Processing of port gh failed
```

This is because the port attempts to install the fish completions to `share/fish/completions`, which is reserved for completions provided by fish itself. Third party completions should be installed to `share/fish/vendor_completions.d`. 

See https://fishshell.com/docs/current/completions.html#where-to-put-completions

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G8022
Xcode 11.3.1 11C505


###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
