### PR TITLE
podman, stgit, xh: Fix install fish completion

### DIFF
--- a/devel/stgit/Portfile
+++ b/devel/stgit/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 
 github.setup        stacked-git stgit 1.0 v
 github.tarball_from releases
-revision            2
+revision            3
 
 categories          devel python
 platforms           darwin
@@ -59,9 +59,9 @@ post-destroot {
     xinstall -d ${destroot}${prefix}/share/zsh/site-functions
     move ${destroot}${prefix}/share/stgit/completion/stgit.zsh \
         ${destroot}${prefix}/share/zsh/site-functions/_stg
-    xinstall -d ${destroot}${prefix}/share/fish/completions
+    xinstall -d ${destroot}${prefix}/share/fish/vendor_completions.d
     move ${destroot}${prefix}/share/stgit/completion/stg.fish \
-        ${destroot}${prefix}/share/fish/completions/stg.fish
+        ${destroot}${prefix}/share/fish/vendor_completions.d/stg.fish
 
     # Install vim and emacs plugin
     xinstall -d ${destroot}${prefix}/share/vim/vimfiles/ftdetect

--- a/net/xh/Portfile
+++ b/net/xh/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cargo  1.0
 
 github.setup        ducaale xh 0.9.2 v
-revision            0
+revision            1
 
 categories          net www
 platforms           darwin
@@ -30,8 +30,8 @@ destroot {
 
     xinstall -d -m 755 ${destroot}${prefix}/share/bash-completion/completions
     xinstall -m 644 ${worksrcpath}/completions/xh.bash ${destroot}${prefix}/share/bash-completion/completions/xh
-    xinstall -d -m 755 ${destroot}${prefix}/share/fish/completions
-    xinstall -m 644 ${worksrcpath}/completions/xh.fish ${destroot}${prefix}/share/fish/completions/
+    xinstall -d -m 755 ${destroot}${prefix}/share/fish/vendor_completions.d
+    xinstall -m 644 ${worksrcpath}/completions/xh.fish ${destroot}${prefix}/share/fish/vendor_completions.d/
     xinstall -d -m 755 ${destroot}${prefix}/share/zsh/site-functions
     xinstall -m 644 ${worksrcpath}/completions/_xh ${destroot}${prefix}/share/zsh/site-functions/
 }

--- a/sysutils/podman/Portfile
+++ b/sysutils/podman/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           golang 1.0
 
 go.setup            github.com/containers/podman 3.1.0 v
-revision            0
+revision            1
 
 categories          sysutils
 license             Apache-2
@@ -39,36 +39,17 @@ destroot {
     xinstall -d ${destroot}${prefix}/share/man/man1
     xinstall -m 640 {*}[glob ${worksrcpath}/docs/build/remote/darwin/*.1] \
         ${destroot}${prefix}/share/man/man1/
-}
 
-variant bash_completion {
-    depends_run-append path:etc/bash_completion:bash-completion
-
-    post-destroot {
-        set completions_path ${prefix}/share/bash-completion/completions
-        xinstall -d ${destroot}${completions_path}
-        xinstall -m 0644 ${worksrcpath}/completions/bash/${name}-remote ${destroot}${completions_path}/
-    }
-}
-
-variant zsh_completion {
-    depends_run-append path:${prefix}/bin/zsh:zsh
-
-    post-destroot {
-        set site-functions ${destroot}${prefix}/share/zsh/site-functions
-        xinstall -d ${site-functions}
-        xinstall -m 0644 ${worksrcpath}/completions/zsh/_${name}-remote ${site-functions}/
-    }
-}
-
-variant fish_completion description {Enable completion support for fish} {
-    depends_run-append path:${prefix}/bin/fish:fish
-
-    post-destroot {
-        set completions_path ${prefix}/share/fish/completions
-        xinstall -d ${destroot}${completions_path}
-        xinstall -m 644 ${worksrcpath}/completions/fish/${name}-remote.fish ${destroot}${completions_path}/
-    }
+    # Add shell completion
+    xinstall -d ${destroot}${prefix}/share/bash-completion/completions
+    xinstall -m 0644 ${worksrcpath}/completions/bash/${name}-remote \
+        ${destroot}${prefix}/share/bash-completion/completions/
+    xinstall -d ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -m 0644 ${worksrcpath}/completions/zsh/_${name}-remote \
+        ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -d ${destroot}${prefix}/share/fish/vendor_completions.d
+    xinstall -m 644 ${worksrcpath}/completions/fish/${name}-remote.fish \
+        ${destroot}${prefix}/share/fish/vendor_completions.d/
 }
 
 github.livecheck.regex  {([^"r-]+)}


### PR DESCRIPTION
See https://github.com/macports/macports-ports/pull/10633 and https://fishshell.com/docs/current/completions.html#where-to-put-completions

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
