### PR TITLE
py-autobahn: update to 21.3.1

### DIFF
--- a/python/py-autobahn/Portfile
+++ b/python/py-autobahn/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-autobahn
-version             20.7.1
+version             21.3.1
 platforms           darwin
 license             MIT
 maintainers         {mojca @mojca} openmaintainer
@@ -16,9 +16,9 @@ homepage            https://crossbar.io/autobahn
 master_sites        pypi:a/autobahn
 distname            autobahn-${version}
 
-checksums           rmd160  d38811290f505c10cc941abd4cbd745e15f3136d \
-                    sha256  86bbce30cdd407137c57670993a8f9bfdfe3f8e994b889181d85e844d5aa8dfb \
-                    size    1260579
+checksums           rmd160  08a87f69aad9be6fc0b216604131838cf4d44ac1 \
+                    sha256  e126c1f583e872fb59e79d36977cfa1f2d0a8a79f90ae31f406faae7664b8e03 \
+                    size    351296
 
 python.versions     38 39
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

There are some dependencies that I didn't really check (autobahn is known for backward incompatibility):
- buildbot (@ryandesign)
- magin-wormhole (@herbygillot)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
  - (PR #8142 mentions autobahn, but I'm not sure in what way exactly, @herbygillot)
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
