### PR TITLE
cmake{,-bootstrap}: fix arm64 +universal configure

### DIFF
--- a/devel/cmake-bootstrap/Portfile
+++ b/devel/cmake-bootstrap/Portfile
@@ -71,7 +71,7 @@ configure.universal_args
 configure.post_args
 
 # CMake's configure script doesn't recognize `--host`.
-array set merger_host {i386 {} x86_64 {} ppc {} ppc64 {}}
+array set merger_host {i386 {} x86_64 {} ppc {} ppc64 {} arm64 {}}
 
 # Leopard's Rosetta has some difficulties configuring the ppc slice
 platform darwin 9 {

--- a/devel/cmake/Portfile
+++ b/devel/cmake/Portfile
@@ -166,7 +166,7 @@ if {${subport} eq ${name}} {
     configure.universal_args
 
     # CMake's configure script doesn't recognize `--host`.
-    array set merger_host {i386 {} x86_64 {} ppc {} ppc64 {}}
+    array set merger_host {i386 {} x86_64 {} ppc {} ppc64 {} arm64 {}}
 
     platform darwin 8 {
         configure.ldflags-append -Wl,-framework -Wl,ApplicationServices


### PR DESCRIPTION
#### Description

Updates the merger_host logic, similar to the openssl port:
https://github.com/macports/macports-ports/blob/379b7a57766bc6252f853994385749c4cd596050/devel/openssl/Portfile#L92

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
