### PR TITLE
ossp-uuid: fix arm64 +universal configure

### DIFF
--- a/devel/ossp-uuid/Portfile
+++ b/devel/ossp-uuid/Portfile
@@ -41,6 +41,9 @@ configure.args          --without-perl \
 
 
 if {[variant_isset universal]} {
+    # configure fails with aarch64 but it seems to work fine with arm
+    set merger_host(arm64) arm-apple-${os.platform}${os.version}
+
     if { ${os.arch} eq "i386" } {
         if { ${os.major} >= 10 } {
             set merger_configure_env(ppc) ac_cv_va_copy=yes


### PR DESCRIPTION
#### Description

Updates merger_host  for arm64, similar to db62 port:
https://github.com/macports/macports-ports/blob/36a4990f197af54e31881f5e5a59b880c51116dd/databases/db62/Portfile#L103-L104

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
