### PR TITLE
qt5*: fix +universal configure

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -1035,8 +1035,8 @@ foreach {module module_info} [array get modules] {
             patchfiles-append patch-qmake_flags.diff
             post-patch {
                 if {[variant_exists universal] && [variant_isset universal]} {
-                    set arch_replace_cxx [portconfigure::configure_get_universal_cflags]
-                    set arch_replace_ld  [portconfigure::configure_get_universal_ldflags]
+                    set arch_replace_cxx [portconfigure::configure_get_universal_archflags]
+                    set arch_replace_ld  [portconfigure::configure_get_universal_archflags]
                 } else {
                     set arch_replace_cxx [portconfigure::configure_get_archflags cxx]
                     set arch_replace_ld  [portconfigure::configure_get_ld_archflags]
@@ -1130,16 +1130,16 @@ foreach {module module_info} [array get modules] {
             }
 
             # respect configure.universal_archs or build_arch
-            #post-patch {
-            #    if {[variant_exists universal] && [variant_isset universal]} {
-            #        set arch_replace ${configure.universal_archs}
-            #    } else {
-            #        set arch_replace ${build_arch}
-            #    }
-            #    reinplace \
-            #        "s|__MACPORTS_DEVICE_ARCHS__|${arch_replace}|g" \
-            #        ${worksrcpath}/mkspecs/common/macx.conf
-            #}
+            post-patch {
+                if {[variant_exists universal] && [variant_isset universal]} {
+                    set arch_replace ${configure.universal_archs}
+                } else {
+                    set arch_replace ${build_arch}
+                }
+                reinplace \
+                    "s|__MACPORTS_DEVICE_ARCHS__|${arch_replace}|g" \
+                    ${worksrcpath}/mkspecs/common/macx.conf
+            }
 
             # use MacPorts X11
             post-patch {

--- a/aqua/qt5/files/patch-mkspecs.diff
+++ b/aqua/qt5/files/patch-mkspecs.diff
@@ -45,7 +45,7 @@ diff --git mkspecs/common/macx.conf mkspecs/common/macx.conf
 index 4ba0a8ea..5f75283f 100644
 --- mkspecs/common/macx.conf
 +++ mkspecs/common/macx.conf
-@@ -3,9 +3,9 @@
+@@ -3,9 +3,10 @@
  #
  
  QMAKE_PLATFORM         += macos osx macx
@@ -54,6 +54,7 @@ index 4ba0a8ea..5f75283f 100644
  
 -QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.13
 +QMAKE_MACOSX_DEPLOYMENT_TARGET = __MACPORTS_DEPLOYMENT_TARGET__
++QMAKE_APPLE_DEVICE_ARCHS = __MACPORTS_DEVICE_ARCHS__
  
  # Should be 10.15, but as long as the CI builds with
  # older SDKs we have to keep this.

--- a/aqua/qt511/Portfile
+++ b/aqua/qt511/Portfile
@@ -912,8 +912,8 @@ foreach {module module_info} [array get modules] {
             patchfiles-append patch-qmake_flags.diff
             post-patch {
                 if {[variant_exists universal] && [variant_isset universal]} {
-                    set arch_replace_cxx [portconfigure::configure_get_universal_cflags]
-                    set arch_replace_ld  [portconfigure::configure_get_universal_ldflags]
+                    set arch_replace_cxx [portconfigure::configure_get_universal_archflags]
+                    set arch_replace_ld  [portconfigure::configure_get_universal_archflags]
                 } else {
                     set arch_replace_cxx [portconfigure::configure_get_archflags cxx]
                     set arch_replace_ld  [portconfigure::configure_get_ld_archflags]

--- a/aqua/qt513/Portfile
+++ b/aqua/qt513/Portfile
@@ -914,8 +914,8 @@ foreach {module module_info} [array get modules] {
             patchfiles-append patch-qmake_flags.diff
             post-patch {
                 if {[variant_exists universal] && [variant_isset universal]} {
-                    set arch_replace_cxx [portconfigure::configure_get_universal_cflags]
-                    set arch_replace_ld  [portconfigure::configure_get_universal_ldflags]
+                    set arch_replace_cxx [portconfigure::configure_get_universal_archflags]
+                    set arch_replace_ld  [portconfigure::configure_get_universal_archflags]
                 } else {
                     set arch_replace_cxx [portconfigure::configure_get_archflags cxx]
                     set arch_replace_ld  [portconfigure::configure_get_ld_archflags]

--- a/aqua/qt59/Portfile
+++ b/aqua/qt59/Portfile
@@ -914,8 +914,8 @@ foreach {module module_info} [array get modules] {
             patchfiles-append patch-qmake_flags.diff
             post-patch {
                 if {[variant_exists universal] && [variant_isset universal]} {
-                    set arch_replace_cxx [portconfigure::configure_get_universal_cflags]
-                    set arch_replace_ld  [portconfigure::configure_get_universal_ldflags]
+                    set arch_replace_cxx [portconfigure::configure_get_universal_archflags]
+                    set arch_replace_ld  [portconfigure::configure_get_universal_archflags]
                 } else {
                     set arch_replace_cxx [portconfigure::configure_get_archflags cxx]
                     set arch_replace_ld  [portconfigure::configure_get_ld_archflags]


### PR DESCRIPTION
#### Description

Commit https://github.com/macports/macports-base/commit/b00e8efdbc330c7c59b08fb881c069a1b8a8e851 removed `configure_get_universal_cflags` and `configure_get_universal_ldflags`, this replaces usages within the qt5* ports to use `configure_get_universal_archflags` directly.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

