### PR TITLE
gh: bump revision

### DIFF
--- a/devel/gh/Portfile
+++ b/devel/gh/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 
 github.setup        cli cli 1.8.1 v
-revision            0
+revision            1
 name                gh
 categories          devel
 platforms           darwin


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
This bumps the revision number after the [recent update to gh](https://github.com/macports/macports-ports/commit/ac9b4f7b3f11dac4c5a873b3fabb4340ea275bfc)
