### PR TITLE
dotnet: new set of ports

### DIFF
--- a/dotnet/aspnetcore-runtime-2.1/Portfile
+++ b/dotnet/aspnetcore-runtime-2.1/Portfile
@@ -1,0 +1,46 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                aspnetcore-runtime-2.1
+version             2.1.27
+revision            0
+categories          dotnet
+license             MIT
+maintainers         {tsabirgaliev @tsabirgaliev} openmaintainer
+
+description         ASP.NET Core is a cross-platform .NET framework for building modern \
+                    cloud-based web applications on Windows, Mac, or Linux.
+
+long_description    .NET is a free, cross-platform, open source developer platform \
+                    for building many different types of applications. \
+                    \
+                    With .NET, you can use multiple languages, editors, and libraries \
+                    to build for web, mobile, desktop, games, and IoT.
+
+homepage            https://dotnet.microsoft.com/
+platforms           darwin
+supported_archs     x86_64
+distname            aspnetcore-runtime-${version}-osx-x64
+master_sites        https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/${version}/
+
+checksums           rmd160  9c801205795efa5529c2aea823f4f96b83872c5c \
+                    sha256  18c2ea1f5da7a977e46000617b8d80b14ade569e728a5d0468237b124a5d94c8 \
+                    size    58547763
+
+worksrcdir          ${name}-${version}
+extract.mkdir       yes
+
+use_configure       no
+
+depends_run         port:dotnet-cli
+
+build {}
+
+destroot {
+    set dotnet_home ${prefix}/share/dotnet
+    set runtime_dir /shared/Microsoft.AspNetCore.App
+    xinstall -d ${destroot}${dotnet_home}${runtime_dir}
+
+    move ${worksrcpath}${runtime_dir}/${version} ${destroot}${dotnet_home}${runtime_dir}
+}

--- a/dotnet/aspnetcore-runtime-3.1/Portfile
+++ b/dotnet/aspnetcore-runtime-3.1/Portfile
@@ -1,0 +1,46 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                aspnetcore-runtime-3.1
+version             3.1.14
+revision            0
+categories          dotnet
+license             MIT
+maintainers         {tsabirgaliev @tsabirgaliev} openmaintainer
+
+description         ASP.NET Core is a cross-platform .NET framework for building modern \
+                    cloud-based web applications on Windows, Mac, or Linux.
+
+long_description    .NET is a free, cross-platform, open source developer platform \
+                    for building many different types of applications. \
+                    \
+                    With .NET, you can use multiple languages, editors, and libraries \
+                    to build for web, mobile, desktop, games, and IoT.
+
+homepage            https://dotnet.microsoft.com/
+platforms           darwin
+supported_archs     x86_64
+distname            aspnetcore-runtime-${version}-osx-x64
+master_sites        https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/${version}/
+
+checksums           rmd160  db3325f3e2f81861ceb95c95a33f5122a18a4dc2 \
+                    sha256  0aa95b6a342c2b3c0d5116efb96bf3a76e17a118ef98920432a78b6a42ff1927 \
+                    size    37762429
+
+worksrcdir          ${name}-${version}
+extract.mkdir       yes
+
+use_configure       no
+
+depends_run         port:dotnet-cli
+
+build {}
+
+destroot {
+    set dotnet_home ${prefix}/share/dotnet
+    set runtime_dir /shared/Microsoft.AspNetCore.App
+    xinstall -d ${destroot}${dotnet_home}${runtime_dir}
+
+    move ${worksrcpath}${runtime_dir}/${version} ${destroot}${dotnet_home}${runtime_dir}
+}

--- a/dotnet/aspnetcore-runtime-devel/Portfile
+++ b/dotnet/aspnetcore-runtime-devel/Portfile
@@ -1,0 +1,46 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                aspnetcore-runtime-devel
+version             5.0.5
+revision            0
+categories          dotnet
+license             MIT
+maintainers         {tsabirgaliev @tsabirgaliev} openmaintainer
+
+description         ASP.NET Core is a cross-platform .NET framework for building modern \
+                    cloud-based web applications on Windows, Mac, or Linux.
+
+long_description    .NET is a free, cross-platform, open source developer platform \
+                    for building many different types of applications. \
+                    \
+                    With .NET, you can use multiple languages, editors, and libraries \
+                    to build for web, mobile, desktop, games, and IoT.
+
+homepage            https://dotnet.microsoft.com/
+platforms           darwin
+supported_archs     x86_64
+distname            aspnetcore-runtime-${version}-osx-x64
+master_sites        https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/${version}/
+
+checksums           rmd160  953b420090625a2c25d205e1cfdc252aa0946dd0 \
+                    sha256  48abb337affc1439f038225bcdff0114f15a57ed9e63b61696d5019d35b39186 \
+                    size    38794603
+
+worksrcdir          ${name}-${version}
+extract.mkdir       yes
+
+use_configure       no
+
+depends_run         port:dotnet-cli
+
+build {}
+
+destroot {
+    set dotnet_home ${prefix}/share/dotnet
+    set runtime_dir /shared/Microsoft.AspNetCore.App
+    xinstall -d ${destroot}${dotnet_home}${runtime_dir}
+
+    move ${worksrcpath}${runtime_dir}/${version} ${destroot}${dotnet_home}${runtime_dir}
+}

--- a/dotnet/dotnet-cli/Portfile
+++ b/dotnet/dotnet-cli/Portfile
@@ -1,0 +1,54 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                dotnet-cli
+version             5.0.5
+revision            0
+categories          dotnet
+license             MIT
+maintainers         {tsabirgaliev @tsabirgaliev} openmaintainer
+
+description         The .NET command-line interface (CLI) is a cross-platform toolchain \
+                    for developing, building, running, and publishing .NET applications.
+
+long_description    .NET is a free, cross-platform, open source developer platform \
+                    for building many different types of applications. \
+                    \
+                    With .NET, you can use multiple languages, editors, and libraries \
+                    to build for web, mobile, desktop, games, and IoT.
+
+homepage            https://dotnet.microsoft.com/
+platforms           darwin
+supported_archs     x86_64
+distname            dotnet-runtime-${version}-osx-x64
+master_sites        https://dotnetcli.azureedge.net/dotnet/Runtime/${version}/
+
+checksums           rmd160  77da2aba986838c6e317f135af8f7f6b26fc6b91 \
+                    sha256  6092dad3e088c5e719b82c13730c130a7e765601d15126b878747c8f3ecf93fc \
+                    size    30414340
+
+worksrcdir          ${name}-${version}
+extract.mkdir       yes
+
+use_configure       no
+
+build {}
+
+destroot {
+    set dotnet_home ${prefix}/share/dotnet
+    set target ${destroot}${dotnet_home}
+
+    # Create the target directory
+    xinstall -d ${target}
+
+    # Copy over the needed elements of our directory tree
+    move ${worksrcpath}/dotnet \
+         ${worksrcpath}/ThirdPartyNotices.txt \
+         ${worksrcpath}/LICENSE.txt \
+         ${worksrcpath}/host \
+         ${target}
+
+    # Symlink dotnet into the bin directory
+    ln -s ${dotnet_home}/dotnet ${destroot}${prefix}/bin
+}

--- a/dotnet/dotnet-runtime-2.1/Portfile
+++ b/dotnet/dotnet-runtime-2.1/Portfile
@@ -1,0 +1,45 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                dotnet-runtime-2.1
+version             2.1.27
+revision            0
+categories          dotnet
+license             MIT
+maintainers         {tsabirgaliev @tsabirgaliev} openmaintainer
+
+description         .NET is a cross-platform runtime for cloud, mobile, desktop, and IoT apps.
+
+long_description    .NET is a free, cross-platform, open source developer platform \
+                    for building many different types of applications. \
+                    \
+                    With .NET, you can use multiple languages, editors, and libraries \
+                    to build for web, mobile, desktop, games, and IoT.
+
+homepage            https://dotnet.microsoft.com/
+platforms           darwin
+supported_archs     x86_64
+distname            dotnet-runtime-${version}-osx-x64
+master_sites        https://dotnetcli.azureedge.net/dotnet/Runtime/${version}/
+
+checksums           rmd160  8df74fc01ee31821add010c7bce158a5a6e21585 \
+                    sha256  be77c17c3aca964fea43c1a10a543368a3834dc22aa86a9834d69ffea4632454 \
+                    size    27707460
+
+worksrcdir          ${name}-${version}
+extract.mkdir       yes
+
+use_configure       no
+
+depends_run         port:dotnet-cli
+
+build {}
+
+destroot {
+    set dotnet_home ${prefix}/share/dotnet
+    set runtime_dir /shared/Microsoft.NETCore.App
+    xinstall -d ${destroot}${dotnet_home}${runtime_dir}
+
+    move ${worksrcpath}${runtime_dir}/${version} ${destroot}${dotnet_home}${runtime_dir}
+}

--- a/dotnet/dotnet-runtime-3.1/Portfile
+++ b/dotnet/dotnet-runtime-3.1/Portfile
@@ -1,0 +1,45 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                dotnet-runtime-3.1
+version             3.1.14
+revision            0
+categories          dotnet
+license             MIT
+maintainers         {tsabirgaliev @tsabirgaliev} openmaintainer
+
+description         .NET is a cross-platform runtime for cloud, mobile, desktop, and IoT apps.
+
+long_description    .NET is a free, cross-platform, open source developer platform \
+                    for building many different types of applications. \
+                    \
+                    With .NET, you can use multiple languages, editors, and libraries \
+                    to build for web, mobile, desktop, games, and IoT.
+
+homepage            https://dotnet.microsoft.com/
+platforms           darwin
+supported_archs     x86_64
+distname            dotnet-runtime-${version}-osx-x64
+master_sites        https://dotnetcli.azureedge.net/dotnet/Runtime/${version}/
+
+checksums           rmd160  815ca063a1e3c44897c21a9f41bbf8152329bec5 \
+                    sha256  acefbeea739ab4127a1192fc41eebe0878398f03cf15b9bde7249bae65efdd97 \
+                    size    29835946
+
+worksrcdir          ${name}-${version}
+extract.mkdir       yes
+
+use_configure       no
+
+depends_run         port:dotnet-cli
+
+build {}
+
+destroot {
+    set dotnet_home ${prefix}/share/dotnet
+    set runtime_dir /shared/Microsoft.NETCore.App
+    xinstall -d ${destroot}${dotnet_home}${runtime_dir}
+
+    move ${worksrcpath}${runtime_dir}/${version} ${destroot}${dotnet_home}${runtime_dir}
+}

--- a/dotnet/dotnet-runtime-devel/Portfile
+++ b/dotnet/dotnet-runtime-devel/Portfile
@@ -1,0 +1,45 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                dotnet-runtime-devel
+version             5.0.5
+revision            0
+categories          dotnet
+license             MIT
+maintainers         {tsabirgaliev @tsabirgaliev} openmaintainer
+
+description         .NET is a cross-platform runtime for cloud, mobile, desktop, and IoT apps.
+
+long_description    .NET is a free, cross-platform, open source developer platform \
+                    for building many different types of applications. \
+                    \
+                    With .NET, you can use multiple languages, editors, and libraries \
+                    to build for web, mobile, desktop, games, and IoT.
+
+homepage            https://dotnet.microsoft.com/
+platforms           darwin
+supported_archs     x86_64
+distname            dotnet-runtime-${version}-osx-x64
+master_sites        https://dotnetcli.azureedge.net/dotnet/Runtime/${version}/
+
+checksums           rmd160  77da2aba986838c6e317f135af8f7f6b26fc6b91 \
+                    sha256  6092dad3e088c5e719b82c13730c130a7e765601d15126b878747c8f3ecf93fc \
+                    size    30414340
+
+worksrcdir          ${name}-${version}
+extract.mkdir       yes
+
+use_configure       no
+
+depends_run         port:dotnet-cli
+
+build {}
+
+destroot {
+    set dotnet_home ${prefix}/share/dotnet
+    set runtime_dir /shared/Microsoft.NETCore.App
+    xinstall -d ${destroot}${dotnet_home}${runtime_dir}
+
+    move ${worksrcpath}${runtime_dir}/${version} ${destroot}${dotnet_home}${runtime_dir}
+}

--- a/dotnet/dotnet-sdk-2.1/Portfile
+++ b/dotnet/dotnet-sdk-2.1/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                dotnet-sdk-2.1
+version             2.1.815
+revision            0
+categories          dotnet devel
+license             MIT
+maintainers         {tsabirgaliev @tsabirgaliev} openmaintainer
+
+description         Core functionality needed to create .NET Core projects, that is \
+                    shared between Visual Studio and CLI
+
+long_description    .NET is a free, cross-platform, open source developer platform \
+                    for building many different types of applications. \
+                    \
+                    With .NET, you can use multiple languages, editors, and libraries \
+                    to build for web, mobile, desktop, games, and IoT.
+
+homepage            https://dotnet.microsoft.com/
+platforms           darwin
+distname            dotnet-sdk-${version}-osx-x64
+master_sites        https://dotnetcli.azureedge.net/dotnet/Sdk/${version}/
+
+checksums           rmd160  cab02ea0a20de47cefa2ab68959a0f6f6bf4c24f \
+                    sha256  77b8da0b9d00da0284f7d6e8525d3ab65efa640e0e8b6b236fcd497b73ea0d62 \
+                    size    167443553
+
+worksrcdir          ${name}-${version}
+extract.mkdir       yes
+
+use_configure       no
+
+depends_run         port:dotnet-cli \
+                    port:dotnet-runtime-2.1 \
+                    port:aspnetcore-runtime-2.1
+
+build {}
+
+destroot {
+    set dotnet_home ${prefix}/share/dotnet
+
+    # Create the target directory
+    xinstall -d ${destroot}${dotnet_home}/sdk
+
+    move ${worksrcpath}/sdk/${version} ${destroot}${dotnet_home}/sdk
+}

--- a/dotnet/dotnet-sdk-3.1/Portfile
+++ b/dotnet/dotnet-sdk-3.1/Portfile
@@ -1,0 +1,49 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                dotnet-sdk-3.1
+version             3.1.408
+revision            0
+categories          dotnet devel
+license             MIT
+maintainers         {tsabirgaliev @tsabirgaliev} openmaintainer
+
+description         Core functionality needed to create .NET Core projects, that is \
+                    shared between Visual Studio and CLI
+
+long_description    .NET is a free, cross-platform, open source developer platform \
+                    for building many different types of applications. \
+                    \
+                    With .NET, you can use multiple languages, editors, and libraries \
+                    to build for web, mobile, desktop, games, and IoT.
+
+homepage            https://dotnet.microsoft.com/
+platforms           darwin
+supported_archs     x86_64
+distname            dotnet-sdk-${version}-osx-x64
+master_sites        https://dotnetcli.azureedge.net/dotnet/Sdk/${version}/
+
+checksums           rmd160  44cdbca8225809e8a72dfa64e4df49e722e6155a \
+                    sha256  0008988f83c795bbccece69934e0e85f023a180fbc6d863687ce00ce640d89c7 \
+                    size    120554555
+
+worksrcdir          ${name}-${version}
+extract.mkdir       yes
+
+use_configure       no
+
+depends_run         port:dotnet-cli \
+                    port:dotnet-runtime-3.1 \
+                    port:aspnetcore-runtime-3.1
+
+build {}
+
+destroot {
+    set dotnet_home ${prefix}/share/dotnet
+
+    # Create the target directory
+    xinstall -d ${destroot}${dotnet_home}/sdk
+
+    move ${worksrcpath}/sdk/${version} ${destroot}${dotnet_home}/sdk
+}

--- a/dotnet/dotnet-sdk-devel/Portfile
+++ b/dotnet/dotnet-sdk-devel/Portfile
@@ -1,0 +1,49 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                dotnet-sdk-devel
+version             5.0.202
+revision            0
+categories          dotnet devel
+license             MIT
+maintainers         {tsabirgaliev @tsabirgaliev} openmaintainer
+
+description         Core functionality needed to create .NET Core projects, that is \
+                    shared between Visual Studio and CLI
+
+long_description    .NET is a free, cross-platform, open source developer platform \
+                    for building many different types of applications. \
+                    \
+                    With .NET, you can use multiple languages, editors, and libraries \
+                    to build for web, mobile, desktop, games, and IoT.
+
+homepage            https://dotnet.microsoft.com/
+platforms           darwin
+supported_archs     x86_64
+distname            dotnet-sdk-${version}-osx-x64
+master_sites        https://dotnetcli.azureedge.net/dotnet/Sdk/${version}/
+
+checksums           rmd160  40c6aa6ea582ae4e7d7b7a69f9a74190d067d680 \
+                    sha256  6f270432de6c41d74f8ec19c999ae62189f253dacfd1d095131ddc10bf6d9d52 \
+                    size    135159658
+
+worksrcdir          ${name}-${version}
+extract.mkdir       yes
+
+use_configure       no
+
+depends_run         port:dotnet-cli \
+                    port:dotnet-runtime-devel \
+                    port:aspnetcore-runtime-devel
+
+build {}
+
+destroot {
+    set dotnet_home ${prefix}/share/dotnet
+
+    # Create the target directory
+    xinstall -d ${destroot}${dotnet_home}/sdk
+
+    move ${worksrcpath}/sdk/${version} ${destroot}${dotnet_home}/sdk
+}


### PR DESCRIPTION
These ports come as a single patch because they are usually used together. I broke them into fine grained parts to make updates easier.

The LTS versions 2.1 and 3.1 can be installed with *Current* version side-by-side. These are the *supported* versions. More info on versioning is [here](https://dotnet.microsoft.com/platform/support/policy).

`dotnet-sdk` depends from `dotnet-runtime` + `aspnet-runtime`. All `*-runtime` ports depend on `dotnet-cli`

Closes: https://trac.macports.org/ticket/58655

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
