### PR TITLE
rclone: update to 1.55.0

### DIFF
--- a/net/rclone/Portfile
+++ b/net/rclone/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/ncw/rclone 1.54.0 v
+go.setup            github.com/ncw/rclone 1.55.0 v
 revision            0
 
 homepage            http://rclone.org
@@ -19,11 +19,12 @@ long_description \
 license             MIT
 
 checksums \
-    rmd160  3e999acb2beaf38768dfb4459ecb297615a36625 \
-    sha256  914948948e8f1914d9292ebdc18b3cd876bc6acc9177eedbd8908a03d12c73aa \
-    size    14940914
+    rmd160  4970c7f3851be9474654f5687554c698b0b0abf0 \
+    sha256  4002d10859ed910f4196db8dcc00732f75553aa972ea262884d69b649754d924 \
+    size    15068393
 
 platforms           darwin
+installs_libs       no
 
 # FIXME: This port currently can't be built without allowing go mod to fetch
 # dependencies during the build phase. See


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
