### PR TITLE
welle.io: update welle.io-devel to 20210411

### DIFF
--- a/multimedia/welle.io/Portfile
+++ b/multimedia/welle.io/Portfile
@@ -109,15 +109,15 @@ if {${subport} eq ${name}} {
         -DGIT_COMMIT_HASH=${version}
 } else {
     # devel
-    github.setup            AlbrechtL welle.io c39d3420cc30281e03835b3182f34d8617eb7ebf
+    github.setup            AlbrechtL welle.io debec2f163962b3341324db009cdd352d98f1e60
     set githash             [string range ${github.version} 0 6]
-    version                 20200822+git${githash}
+    version                 20210411+git${githash}
 
     conflicts               welle.io
 
-    checksums               rmd160  97d5fa6aa2a47a3616e15f1dff85f6bb7b6425cf \
-                            sha256  a29e959ac3e4085e6a1bafb194c41933e86112f73f826f450982e32202a99360	 \
-                            size    1651607
+    checksums               rmd160  e15b7a6cf677f31742a5ce5a3432e5eadddd668d \
+                            sha256  ed3cb548cdc0f05892db31d4606b6b17a0338ecfc9ea5cd8a39ebb808bc69266 \
+                            size    1670280
 
     configure.pre_args-append \
         -DGIT_COMMIT_HASH=${githash}


### PR DESCRIPTION
#### Description

﻿welle.io: update welle.io-devel to 20210411

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010
Xcode 7.3.1 7D1014

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
