### PR TITLE
google-cloud-sdk: update to 336.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             335.0.0
-revision            1
+version             336.0.0
+revision            0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -21,14 +21,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  4a8ce96a2bc53629c0c70b070abe02ad6aa1d4c4 \
-                    sha256  e1d244cc85486d30eb79ffb06b9fde8c7c63c4d5ca16cae34805deb071475654 \
-                    size    88691550
+    checksums       rmd160  2107b6ee6ed9ee2e8b2ed6f35c0604e5e48ee93b \
+                    sha256  ab6974c6f627e4bec9474169d15165c9ddacc5f8b1b3076b47e07ec29e84d77b \
+                    size    88758594
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  3b303dbf8df0c5cd9f0e403ca43c82289929d33d \
-                    sha256  10c281ec93214058d04badec1832d57932c11a79e9cf5fa0da4bb0e7f92b1a6d \
-                    size    84928337
+    checksums       rmd160  5a2172fc723f13c41e2089bd9b194d7b32ddc42e \
+                    sha256  e1f049c536491e77ff9bfb8e29755ba7006a43c7dd8911350848b668025f6039 \
+                    size    85006509
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 336.0.0.

###### Tested on

macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?