### PR TITLE
qtads: new port

### DIFF
--- a/games/qtads/Portfile
+++ b/games/qtads/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           qmake5 1.0
+
+github.setup        realnc qtads 3.0.0 v
+revision            0
+github.tarball_from releases
+
+categories          games
+platforms           darwin
+license             GPL-3
+maintainers         nomaintainer
+
+distname            ${github.project}-${github.version}-source
+
+description         A multimedia TADS interactive fiction player.
+long_description    QTads is a so called \"interpreter\" for games created with the Text \
+                    Adventure Development System, or \"TADS\" for short, a C-like object \
+                    oriented programming language for authoring Interactive Fiction \
+                    (similar to the Infocom or Legend Entertainment games, like \"Zork\").
+
+homepage            https://realnc.github.io/qtads/
+
+checksums           rmd160  d4791de09461ae7417ac8d384953636669da9e55 \
+                    sha256  430b5de04d2d2cafe4cd2614cd034c5fb71e0ba39ec1e5d058613b43a92e0407 \
+                    size    5325048
+
+use_xz              yes
+
+depends_lib         port:libsdl2 \
+                    port:libsndfile \
+                    port:mpg123 \
+                    port:fluidsynth \
+                    port:libvorbis
+
+destroot {
+    copy ${worksrcpath}/QTads.app ${destroot}${applications_dir}
+}


### PR DESCRIPTION
#### Description

QTads is an interpreter for interactive fiction (= text adventure) games in the TADS format. See https://realnc.github.io/qtads/

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G8022
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
