### PR TITLE
igraph: update to 0.9.2

### DIFF
--- a/math/igraph/Portfile
+++ b/math/igraph/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        igraph igraph 0.9.1
+github.setup        igraph igraph 0.9.2
 revision            0
 github.tarball_from releases
 
@@ -19,12 +19,13 @@ homepage            https://igraph.org
 platforms           darwin
 depends_lib         port:arpack \
                     port:glpk \
+                    port:gmp \
                     port:libxml2 \
                     port:SuiteSparse_CXSparse
 
-checksums           rmd160  3f35656783543e0fd4d9169ec05e00f8d7affe0f \
-                    sha256  1902810650e8f9d98feefa3eca735db5a879416d00a08f68aad2ca07964cee9f \
-                    size    3803713
+checksums           rmd160  433e8cb78287600b6d8b2d9173faa2e8ea5d4f42 \
+                    sha256  fda86b5253daa3b994aaaa7aef0b8e4780dc8b2efbbdbf0aa71af9fedaecb073 \
+                    size    3805091
 
 test.run            yes
 test.target         check
@@ -37,7 +38,6 @@ compiler.cxx_standard \
 #  - Build a shared library.
 #  - Enable link-time optimization when available.
 #  - Set features and the use of externaly libraries explicitly---do not leave this to auto-detection.
-#  - As of igraph 0.9.1, linking to GMP provides no tangible benefits, thus disable this.
 #  - Use the vecLib BLAS/LAPACK.
 configure.args-append \
                     -DUSE_CCACHE=OFF \
@@ -49,7 +49,7 @@ configure.args-append \
                     -DIGRAPH_USE_INTERNAL_BLAS=OFF \
                     -DIGRAPH_USE_INTERNAL_CXSPARSE=OFF \
                     -DIGRAPH_USE_INTERNAL_GLPK=OFF \
-                    -DIGRAPH_USE_INTERNAL_GMP=ON \
+                    -DIGRAPH_USE_INTERNAL_GMP=OFF \
                     -DIGRAPH_USE_INTERNAL_LAPACK=OFF \
                     -DBLA_VENDOR=Apple
 


### PR DESCRIPTION
 * update to 0.9.2
 * enable GMP as external dependency

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G8022
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
