### PR TITLE
doctl: Update to 1.59.0 and add fish completion

### DIFF
--- a/www/doctl/Portfile
+++ b/www/doctl/Portfile
@@ -3,12 +3,12 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/digitalocean/doctl 1.56.0 v
+go.setup            github.com/digitalocean/doctl 1.59.0 v
 revision            0
 
-checksums           rmd160  4fa8f2ac39f2899972520109525ec4d412fdc060 \
-                    sha256  fc5b3b148962f098d4f5bd90b67c06fd9ad3c184d7305b14181aeea1d2bac7c0 \
-                    size    5164863
+checksums           rmd160  7f84c681571b357cce17a8c26515865644e1bdea \
+                    sha256  c90b1ae69e43ecb795596519b8feb5cc1d55523c91b0337916fdb563337ae753 \
+                    size    5199147
 
 categories          www devel
 platforms           darwin
@@ -39,26 +39,19 @@ build.target        ${worksrcpath}/cmd/${name}
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin
-}
 
-variant bash_completion {
-    depends_run-append path:etc/bash_completion:bash-completion
-    post-destroot {
-        set completions_path ${destroot}${prefix}/share/bash-completion/completions
-        xinstall -d ${completions_path}
-        set completion-file [open ${completions_path}/${name} "w"]
-        puts ${completion-file} [exec ${destroot}${prefix}/bin/${name} completion bash]
-        close ${completion-file}
-    }
-}
+    set bash_completion ${prefix}/share/bash-completion/completions
+    xinstall -d ${destroot}${bash_completion}
+    exec ${destroot}${prefix}/bin/${name} completion bash >> \
+        ${destroot}${bash_completion}/${name}
+    
+    set zsh_completion ${prefix}/share/zsh/site-functions
+    xinstall -d ${destroot}${zsh_completion}
+    exec ${destroot}${prefix}/bin/${name} completion zsh >> \
+        ${destroot}${zsh_completion}/_${name}
 
-variant zsh_completion description {Install zsh completion} {
-    depends_run-append path:${prefix}/bin/zsh:zsh
-    post-destroot {
-        set site-functions ${destroot}${prefix}/share/zsh/site-functions
-        xinstall -d ${site-functions}
-        set completion-file [open ${site-functions}/_${name} "w"]
-        puts ${completion-file} [exec ${destroot}${prefix}/bin/${name} completion zsh]
-        close ${completion-file}
-    }
+    set fish_completion ${prefix}/share/fish/vendor_completions.d
+    xinstall -d ${destroot}${fish_completion}
+    exec ${destroot}${prefix}/bin/${name} completion fish >> \
+        ${destroot}${fish_completion}/${name}.fish
 }


### PR DESCRIPTION
Changes:
* Update to 1.59.0
* Move completion variants to destroot
* Add completion for fish

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
