### PR TITLE
fish: fix a failing test

### DIFF
--- a/shells/fish/Portfile
+++ b/shells/fish/Portfile
@@ -35,8 +35,7 @@ patchfiles              patch-share_config_fish.diff \
 post-patch {
     reinplace "s|@@PREFIX@@|${prefix}/bin|g"     "${worksrcpath}/share/config.fish"
 
-    # skip these 2 failing tests for now, future updates should try enabling them
-    file rename "${worksrcpath}/tests/checks/jobs.fish" "${worksrcpath}/tests/checks/jobs.fish.skip"
+    # skip failing tests for now, future updates should try enabling them
     file rename "${worksrcpath}/tests/checks/sigint.fish" "${worksrcpath}/tests/checks/sigint.fish.skip"
 }
 
@@ -66,6 +65,10 @@ depends_test-append     port:py39-pexpect
 test.env-append         TERM=nsterm
 test.run                yes
 test.target             test
+
+pre-test {
+    append portsandbox_profile " (allow process-exec (literal \"/bin/ps\") (with no-profile))"
+}
 
 notes "
 To set MacPorts' ${name} as default login shell, run:


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
