### PR TITLE
kustomize: update to 4.1.2

### DIFF
--- a/devel/kustomize/Portfile
+++ b/devel/kustomize/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/kubernetes-sigs/kustomize 4.1.0 kustomize/v
+go.setup            github.com/kubernetes-sigs/kustomize 4.1.2 kustomize/v
 revision            0
 
 categories          devel
@@ -23,9 +23,9 @@ long_description    kustomize lets you customize raw, template-free YAML files f
 
 homepage            https://kustomize.io
 
-checksums           rmd160  4d10950bbeeec6d81788e7614e6331d4da55b9bd \
-                    sha256  6978e50fbbee6dd5f526f666522b5ee1fd4e4c37dc1acbd03b816f6f47f528d0 \
-                    size    25488515
+checksums           rmd160  1002f9f8bdf84704697b18ded15f97c628ebce0f \
+                    sha256  8095d910f6ae252172014203d00d78a96aa6b3eb285a8e3bbaa9ec018c22331f \
+                    size    25475014
 
 build.dir           ${worksrcpath}/${name}
 


### PR DESCRIPTION
#### Description

Update to Kustomize 4.1.2.

###### Tested on

macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?