### PR TITLE
skaffold: update to 1.22.0

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 1.21.0 v
+github.setup        GoogleContainerTools skaffold 1.22.0 v
 revision            0
 
 categories          devel
@@ -23,9 +23,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  8c5654a0c9852752b465c4021783dd202c461faf \
-                    sha256  b82018c8e1937e29972d907c71b8eb28fd3f44e73a94525ec1d4f28511a243c5 \
-                    size    19136936
+checksums           rmd160  b9002c5c098c2dbb49da704d93e883380a19efc8 \
+                    sha256  d9cee2e079b32b289d0e8c2c64fe2b403822aa9a4127482339b88f3160805639 \
+                    size    19194009
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 1.22.0.

###### Tested on

macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?