### PR TITLE
git-chglog: Update to 0.14.2

### DIFF
--- a/sysutils/git-chglog/Portfile
+++ b/sysutils/git-chglog/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/git-chglog/git-chglog 0.14.1 v
+go.setup            github.com/git-chglog/git-chglog 0.14.2 v
 revision            0
 
 categories          sysutils
@@ -25,9 +25,9 @@ test.run            yes
 test.args           -v
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  b3024f062892bb6ae391f85ba1f42af28d1087f8 \
-                        sha256  712cf401939cf141b27e7324b740aa6820d57e969db35e04e45d85483b9836d9 \
-                        size    548533
+                        rmd160  03eb27ec9ccc6dce95b48f21835d31070e56bfde \
+                        sha256  ce25cf7630626d7b23a69f3f764cb30366d903bb5d454a0d743115d61d091fdb \
+                        size    548589
 
 go.vendors          gopkg.in/yaml.v3 \
                         lock    9f266ea9e77c \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
