### PR TITLE
plumed and py-plumed: update to 2.7.1

### DIFF
--- a/python/py-plumed/Portfile
+++ b/python/py-plumed/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        plumed plumed2 2.7.0 v
+github.setup        plumed plumed2 2.7.1 v
 name                py-plumed
 categories          python
 
@@ -18,9 +18,9 @@ long_description    ${description} They allow the plumed library to be directly 
 
 homepage            http://www.plumed.org
 
-checksums           rmd160  607a3908f8548f88ac14c990e38a6fe99b40c3ea \
-                    sha256  ab61d82cba0b67e7ce7c05be1dc84fbfd686d73ac8747dcbb1f0e550cdbd743b \
-                    size    98830315
+checksums           rmd160  2137586dbc890732d0e632c8b4ec483aa0c00598 \
+                    sha256  c5ecc6c13eb45a9e009c1fedf07d91f5a02f2600ff29f1cd481f4a0d17e12908 \
+                    size    106402240
 
 python.versions     36 37 38 39
 

--- a/science/plumed/Portfile
+++ b/science/plumed/Portfile
@@ -6,9 +6,8 @@ PortGroup           mpi 1.0
 PortGroup           linear_algebra 1.0
 PortGroup           debug 1.0
 
-github.setup        plumed plumed2 2.7.0 v
+github.setup        plumed plumed2 2.7.1 v
 name                plumed
-revision            1
 
 categories          science
 
@@ -26,9 +25,9 @@ platforms           darwin
 
 homepage            http://www.plumed.org/
 
-checksums           rmd160  607a3908f8548f88ac14c990e38a6fe99b40c3ea \
-                    sha256  ab61d82cba0b67e7ce7c05be1dc84fbfd686d73ac8747dcbb1f0e550cdbd743b \
-                    size    98830315
+checksums           rmd160  2137586dbc890732d0e632c8b4ec483aa0c00598 \
+                    sha256  c5ecc6c13eb45a9e009c1fedf07d91f5a02f2600ff29f1cd481f4a0d17e12908 \
+                    size    106402240
 
 # Enable optional features.
 # --enable-asmjit:        Compile internal asmjit. Notice that internal asmjit is protected in
@@ -89,7 +88,8 @@ configure.cxxflags-replace -Os -O3
 # only requested packages are linked.
 configure.ldflags-append \
                     -lxdrfile -lz -lgsl
-depends_lib-append  port:gawk \
+depends_lib-append  port:fftw-3 \
+                    port:gawk \
                     port:gsl \
                     port:xdrfile \
                     port:zlib
@@ -119,14 +119,14 @@ pre-configure {
 # plumed-devel subport
 # This subport installs the developer version
 subport plumed-devel {
-    github.setup        plumed plumed2 c280bb02880f0e3cf208aae5928bd0f831cf01d9
-    version             2.8-20201223
+    github.setup        plumed plumed2 834465597679194d662f5eb1734041c3c4fcaf43
+    version             2.8-20210416
     description         ${description} (development version)
     long_description    ${long_description} (development version)
     conflicts plumed
-    checksums           rmd160  2a19bef89c5e984dbfa792316aec466dadc898b1 \
-                        sha256  985635c741efcfffcdc14ef5b11de9efac87bfe1cadb4c9e554ca3a1676a2847 \
-                        size    99855493
+    checksums           rmd160  f8e7676713a1920565e1b793abfb90499a01aeac \
+                        sha256  12ced9b250623e3d5b0442934a0169051fed85827ef9ceddfc758f346f318d0c \
+                        size    107085872
 }
 
 # Allow running tests from MacPorts


### PR DESCRIPTION
#### Description

Update plumed and py-plumed ports. I took the occasion to add a missing dependency for plumed (fftw-3).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
