### PR TITLE
opencollada: backport patches to allow compiling on macOS 11

### DIFF
--- a/graphics/opencollada/Portfile
+++ b/graphics/opencollada/Portfile
@@ -5,6 +5,7 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 
 github.setup        KhronosGroup OpenCOLLADA 1.6.68 v
+revision            1
 name                opencollada
 categories          graphics
 platforms           darwin
@@ -32,9 +33,9 @@ compiler.cxx_standard 2011
 
 post-patch {
     # A MacPorts build is basically similar to a Unix build process
-    reinplace -E "s|\(NOT UNIX\)|\\1 AND NOT APPLE|g" \
+    reinplace -E {s/(NOT UNIX)/\1 AND NOT APPLE/g} \
         ${worksrcpath}/CMakeLists.txt
-    reinplace -E "s|\(UNIX\)|\\1 OR APPLE|g" \
+    reinplace -E {s/(UNIX)/\1 OR APPLE/g} \
         ${worksrcpath}/OpenCOLLADAConfig.cmake.in
 
     # The version of the PCRE library that is delivered with OpenCOLLADA
@@ -45,7 +46,7 @@ post-patch {
 option(PCRENATIVE \"Set to build using the systems native pcre lib instead of the delivered lib\" ON)\\
 " \
         ${worksrcpath}/CMakeLists.txt
-    reinplace -E "s|\(if.*PCRE_FOUND\)|\\1 AND PCRENATIVE|" \
+    reinplace -E {s/(if.*PCRE_FOUND)/\1 AND PCRENATIVE/} \
         ${worksrcpath}/CMakeLists.txt
 
     # OpenCOLLADA puts its CMake package config files in the wrong place
@@ -60,12 +61,11 @@ option(PCRENATIVE \"Set to build using the systems native pcre lib instead of th
     # lib/opencollada!). Since this rpath is established during link
     # time, moving libUTF.dylib or creating a symbolic link in
     # ${prefix}/lib during the destroot phase won't fix the issue.
-    set regexes [list \
-        "s|\(EXECUTABLE_OUTPUT_PATH.*bin\)|\\1/opencollada|" \
-        "s|\(LIBRARY_OUTPUT_PATH.*lib\)|\\1/opencollada|" \
+    foreach re [list \
+        {s|(EXECUTABLE_OUTPUT_PATH.*bin)|\1/opencollada|} \
+        {s|(LIBRARY_OUTPUT_PATH.*lib)|\1/opencollada|} \
         "s|\(PROPERTIES\)\( OUTPUT_NAME\)|\\1 INSTALL_NAME_DIR \${OPENCOLLADA_INST_LIBRARY}\\2|g" \
-    ]
-    foreach re $regexes {
+    ] {
         reinplace -E $re ${worksrcpath}/CMakeLists.txt
     }
 
@@ -75,6 +75,28 @@ option(PCRENATIVE \"Set to build using the systems native pcre lib instead of th
 #include <cmath>\\
 " \
         ${worksrcpath}/GeneratedSaxParser/src/GeneratedSaxParserUtils.cpp
+
+    # Backport patches implemented by Blender to allow OpenCOLLADA to be
+    # compiled on macOS 11.
+    # References:
+    # * https://github.com/blender/blender/commit/9715ad5acad9a42b65efd64b6c7fbe157f949bfb
+    # * See the patch file build_files/build_environment/patches/opencollada.diff
+    #   in the Blender source code.
+    set files [list \
+        ${worksrcpath}/DAEValidator/library/src/Dae.cpp \
+        ${worksrcpath}/DAEValidator/library/src/DaeValidator.cpp \
+    ]
+    set regexes [list \
+        {s/(const auto) & (element : elements)/\1 \2/} \
+        {s/(const auto) & (node : nodes)/\1 \2/} \
+    ]
+    if {${os.major} >= 20} {
+        foreach f $files {
+            foreach re $regexes {
+                reinplace -E $re $f
+            }
+        }
+    }
 }
 
 configure.args-append   -DUSE_SHARED=ON \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

This PR implements patches that have been backported from the Blender source code that allows OpenCOLLADA to be compiled on macOS 11.

Fixes https://trac.macports.org/ticket/62706

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->