### PR TITLE
ldid: Fix Makefile patch file

### DIFF
--- a/devel/ldid/patch-Makefile.diff
+++ b/devel/ldid/patch-Makefile.diff
@@ -1,0 +1,10 @@
+--- Makefile.orig	2021-04-15 14:27:01.000000000 -1000
++++ Makefile	2021-04-16 22:30:00.000000000 +0200
+@@ -5,5 +5,5 @@
+ 
+ OPENSSL_LDFLAGS := $(shell pkg-config --libs libcrypto)
+ OPENSSL_CFLAGS  := $(shell pkg-config --cflags libcrypto)
+-PLIST_LDFLAGS   := $(shell pkg-config --libs libplist)
++PLIST_LDFLAGS   := $(shell pkg-config --libs libplist-2.0)
+ PLIST_CFLAGS    := $(shell pkg-config --cflags libplist)
+ CFLAGS          := $(OPENSSL_CFLAGS) $(PLIST_CFLAGS) -O2


### PR DESCRIPTION
#### Description

`Makefile` was recently changed, breaking the patch in Macports. This fixes the patch.

###### Type(s)
- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
