### PR TITLE
openjdk: don't mirror or distribute prebuilt binaries

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -6,7 +6,8 @@ name             openjdk
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
 platforms        darwin
-license          GPL-2
+# These ports use prebuilt binaries, 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
 supported_archs  x86_64
 
 # Latest Long Term Support (LTS) major version
@@ -43,7 +44,7 @@ set long_description_graalvm \
 
 subport openjdk8 {
     version      8u282
-    revision     0
+    revision     1
 
     set build    08
 
@@ -63,7 +64,7 @@ subport openjdk8 {
 
 subport openjdk8-graalvm {
     version      21.0.0.2
-    revision     0
+    revision     1
 
     description  GraalVM Community Edition based on OpenJDK 8
     long_description ${long_description_graalvm}
@@ -79,7 +80,7 @@ subport openjdk8-graalvm {
 
 subport openjdk8-openj9 {
     version      8u282
-    revision     0
+    revision     1
 
     set build    08
     set openj9_version 0.24.0
@@ -98,7 +99,7 @@ subport openjdk8-openj9 {
 
 subport openjdk8-openj9-large-heap {
     version      8u282
-    revision     0
+    revision     1
 
     set build    08
     set openj9_version 0.24.0
@@ -126,7 +127,7 @@ subport openjdk10 {
 
 subport openjdk11 {
     version      11.0.10
-    revision     0
+    revision     1
 
     set build    9
 
@@ -144,7 +145,7 @@ subport openjdk11 {
 
 subport openjdk11-graalvm {
     version      21.0.0.2
-    revision     0
+    revision     1
 
     description  GraalVM Community Edition based on OpenJDK 11
     long_description ${long_description_graalvm}
@@ -160,7 +161,7 @@ subport openjdk11-graalvm {
 
 subport openjdk11-openj9 {
     version      11.0.10
-    revision     0
+    revision     1
 
     set build    9
     set openj9_version 0.24.0
@@ -179,7 +180,7 @@ subport openjdk11-openj9 {
 
 subport openjdk11-openj9-large-heap {
     version      11.0.10
-    revision     0
+    revision     1
 
     set build    9
     set openj9_version 0.24.0
@@ -270,7 +271,7 @@ subport openjdk15-openj9-large-heap {
 
 subport openjdk16 {
     version      16
-    revision     0
+    revision     1
 
     set build    36
 
@@ -288,7 +289,7 @@ subport openjdk16 {
 
 subport openjdk16-openj9 {
     version      16
-    revision     0
+    revision     1
 
     set build    36
     set openj9_version 0.25.0


### PR DESCRIPTION
#### Description

`openjdk*` ports use prebuilt binararies. MacPorts should not mirror or distribute these.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?