### PR TITLE
libheif: avoid aom on < 10.6

### DIFF
--- a/multimedia/libheif/Portfile
+++ b/multimedia/libheif/Portfile
@@ -44,3 +44,9 @@ if {${os.platform} eq "darwin" && ${os.major} < 14} {
     depends_lib-delete      port:rav1e
     configure.args-append   --disable-rav1e
 }
+
+if {${os.platform} eq "darwin" && ${os.major} < 10} {
+    # https://trac.macports.org/ticket/62619
+    depends_lib-delete      port:aom
+    configure.args-append   --disable-aom
+}


### PR DESCRIPTION
see: https://trac.macports.org/ticket/62619

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

