### PR TITLE
librsvg: remove Python as runtime dependency

### DIFF
--- a/graphics/librsvg/Portfile
+++ b/graphics/librsvg/Portfile
@@ -36,9 +36,6 @@ license_noconflict  gobject-introspection \
                     rust \
                     vala
 
-set pyversion       3.8
-depends_run-append  port:python[join [split ${pyversion} "."] ""]
-
 # cargo does not build on 10.7 or earlier
 # https://trac.macports.org/ticket/55794
 


### PR DESCRIPTION
 * See: https://trac.macports.org/ticket/59920

#### Description

librsvg no longer seems to need Python, as it does not install any scripts that use Python.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
