### PR TITLE
multiple p5-* ports: add Perl 5.32 subport

### DIFF
--- a/perl/p5-browser-open/Portfile
+++ b/perl/p5-browser-open/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         Browser-Open 0.04 ../by-authors/id/C/CF/CFRANKS
 license             {Artistic-1 GPL}
 maintainers         nomaintainer

--- a/perl/p5-canary-stability/Portfile
+++ b/perl/p5-canary-stability/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         Canary-Stability 2013 ../../authors/id/M/ML/MLEHMANN
 # licensed under the same terms as perl itself per COPYING
 license             {Artistic-1 GPL}

--- a/perl/p5-capture-tiny/Portfile
+++ b/perl/p5-capture-tiny/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         Capture-Tiny 0.48 ../../authors/id/D/DA/DAGOLDEN
 
 platforms           darwin

--- a/perl/p5-carp-clan/Portfile
+++ b/perl/p5-carp-clan/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         Carp-Clan 6.08
 license             {Artistic-1 GPL}
 maintainers         nomaintainer

--- a/perl/p5-class-data-inheritable/Portfile
+++ b/perl/p5-class-data-inheritable/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         Class-Data-Inheritable 0.08
 revision            4
 license             {Artistic-1 GPL}

--- a/perl/p5-class-isa/Portfile
+++ b/perl/p5-class-isa/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         Class-ISA 0.36
 license             {Artistic-1 GPL}
 maintainers         nomaintainer

--- a/perl/p5-common-sense/Portfile
+++ b/perl/p5-common-sense/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         common-sense 3.75 ../../authors/id/M/ML/MLEHMANN
 platforms           darwin
 maintainers         nomaintainer

--- a/perl/p5-cpan-meta-requirements/Portfile
+++ b/perl/p5-cpan-meta-requirements/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         CPAN-Meta-Requirements 2.140
 license             {Artistic-1 GPL}
 maintainers         nomaintainer

--- a/perl/p5-cpan-meta-yaml/Portfile
+++ b/perl/p5-cpan-meta-yaml/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         CPAN-Meta-YAML 0.018 ../by-authors/id/D/DA/DAGOLDEN/
 license             {Artistic-1 GPL}
 maintainers         nomaintainer

--- a/perl/p5-data-dump/Portfile
+++ b/perl/p5-data-dump/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         Data-Dump 1.23
 maintainers         nomaintainer
 license             {Artistic-1 GPL}

--- a/perl/p5-devel-checkbin/Portfile
+++ b/perl/p5-devel-checkbin/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         Devel-CheckBin 0.04
 license             {Artistic-1 GPL}
 maintainers         nomaintainer

--- a/perl/p5-devel-cycle/Portfile
+++ b/perl/p5-devel-cycle/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         Devel-Cycle 1.12
 license             {Artistic-1 GPL}
 maintainers         nomaintainer

--- a/perl/p5-devel-hide/Portfile
+++ b/perl/p5-devel-hide/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         Devel-Hide 0.0013 ../../authors/id/D/DC/DCANTRELL
 license             {Artistic-1 GPL}
 maintainers         nomaintainer

--- a/perl/p5-devel-overrideglobalrequire/Portfile
+++ b/perl/p5-devel-overrideglobalrequire/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         Devel-OverrideGlobalRequire 0.001
 
 platforms           darwin

--- a/perl/p5-devel-stacktrace/Portfile
+++ b/perl/p5-devel-stacktrace/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 epoch               1
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         Devel-StackTrace 2.04 ../../authors/id/D/DR/DROLSKY/
 license             Artistic-2
 maintainers         nomaintainer

--- a/perl/p5-extutils-config/Portfile
+++ b/perl/p5-extutils-config/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         ExtUtils-Config 0.008
 platforms           darwin
 maintainers         nomaintainer

--- a/perl/p5-extutils-depends/Portfile
+++ b/perl/p5-extutils-depends/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         ExtUtils-Depends 0.8000
 license             {Artistic-1 GPL}
 maintainers         nomaintainer

--- a/perl/p5-extutils-helpers/Portfile
+++ b/perl/p5-extutils-helpers/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         ExtUtils-Helpers 0.026
 platforms           darwin
 maintainers         nomaintainer

--- a/perl/p5-extutils-install/Portfile
+++ b/perl/p5-extutils-install/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         ExtUtils-Install 2.20 ../../authors/id/B/BI/BINGOS
 revision            0
 license             {Artistic-1 GPL}

--- a/perl/p5-extutils-makemaker/Portfile
+++ b/perl/p5-extutils-makemaker/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         ExtUtils-MakeMaker 7.60
 license             {Artistic-1 GPL}
 maintainers         nomaintainer

--- a/perl/p5-extutils-manifest/Portfile
+++ b/perl/p5-extutils-manifest/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         ExtUtils-Manifest 1.73
 license             {Artistic-1 GPL}
 maintainers         nomaintainer

--- a/perl/p5-file-path/Portfile
+++ b/perl/p5-file-path/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         File-Path 2.18 ../../authors/id/J/JK/JKEENAN
 license             {Artistic-1 GPL}
 maintainers         nomaintainer

--- a/perl/p5-file-readbackwards/Portfile
+++ b/perl/p5-file-readbackwards/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         File-ReadBackwards 1.05
 # licensed under the same terms as Perl per README
 license             {Artistic-1 GPL}

--- a/perl/p5-file-sharedir-install/Portfile
+++ b/perl/p5-file-sharedir-install/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         File-ShareDir-Install 0.13
 license             {Artistic-1 GPL}
 maintainers         nomaintainer

--- a/perl/p5-file-temp/Portfile
+++ b/perl/p5-file-temp/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         File-Temp 0.2311
 license             {Artistic-1 GPL}
 maintainers         nomaintainer

--- a/perl/p5-getopt-long/Portfile
+++ b/perl/p5-getopt-long/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         Getopt-Long 2.52
 revision            0
 license             {Artistic-1 GPL-2+}

--- a/perl/p5-heap/Portfile
+++ b/perl/p5-heap/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         Heap 0.80
 revision            4
 license             {Artistic-1 GPL}

--- a/perl/p5-html-tagset/Portfile
+++ b/perl/p5-html-tagset/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         HTML-Tagset 3.20
 revision            4
 license             {Artistic-1 GPL}

--- a/perl/p5-inc-latest/Portfile
+++ b/perl/p5-inc-latest/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         inc-latest 0.500 ../by-authors/id/D/DA/DAGOLDEN/
 license             {Artistic-1 GPL}
 maintainers         nomaintainer

--- a/perl/p5-io-all/Portfile
+++ b/perl/p5-io-all/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         IO-All 0.87
 platforms           darwin
 maintainers         nomaintainer

--- a/perl/p5-io-string/Portfile
+++ b/perl/p5-io-string/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         IO-String 1.08
 revision            4
 license             {Artistic-1 GPL}

--- a/perl/p5-math-bigint/Portfile
+++ b/perl/p5-math-bigint/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         Math-BigInt 1.999818
 maintainers         nomaintainer
 categories-append   math

--- a/perl/p5-math-complex/Portfile
+++ b/perl/p5-math-complex/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         Math-Complex 1.59
 license             {Artistic-1 GPL}
 maintainers         nomaintainer

--- a/perl/p5-number-compare/Portfile
+++ b/perl/p5-number-compare/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         Number-Compare 0.03
 revision            2
 platforms           darwin

--- a/perl/p5-scalar-list-utils/Portfile
+++ b/perl/p5-scalar-list-utils/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         Scalar-List-Utils 1.56
 license             {Artistic-1 GPL}
 maintainers         nomaintainer

--- a/perl/p5-scope-guard/Portfile
+++ b/perl/p5-scope-guard/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         Scope-Guard 0.21 ../../authors/id/C/CH/CHOCOLATE/
 license             {Artistic-1 GPL}
 maintainers         nomaintainer

--- a/perl/p5-sub-install/Portfile
+++ b/perl/p5-sub-install/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         Sub-Install 0.928
 revision            1
 license             {Artistic-1 GPL}

--- a/perl/p5-sub-uplevel/Portfile
+++ b/perl/p5-sub-uplevel/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 epoch               1
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         Sub-Uplevel 0.2800
 maintainers         nomaintainer
 license             {Artistic-1 GPL}

--- a/perl/p5-test-deep/Portfile
+++ b/perl/p5-test-deep/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         Test-Deep 1.130
 license             {Artistic-1 GPL}
 maintainers         nomaintainer

--- a/perl/p5-test-harness/Portfile
+++ b/perl/p5-test-harness/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         Test-Harness 3.42
 license             {Artistic-1 GPL}
 platforms           darwin

--- a/perl/p5-test-output/Portfile
+++ b/perl/p5-test-output/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         Test-Output 1.033
 platforms           darwin
 maintainers         nomaintainer

--- a/perl/p5-test-utf8/Portfile
+++ b/perl/p5-test-utf8/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         Test-utf8 1.02
 license             {Artistic-1 GPL}
 maintainers         nomaintainer

--- a/perl/p5-test-without-module/Portfile
+++ b/perl/p5-test-without-module/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         Test-Without-Module 0.20
 license             {Artistic-1 GPL}
 maintainers         nomaintainer

--- a/perl/p5-text-balanced/Portfile
+++ b/perl/p5-text-balanced/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         Text-Balanced 2.04
 license             {Artistic-1 GPL}
 maintainers         nomaintainer

--- a/perl/p5-tie-ixhash/Portfile
+++ b/perl/p5-tie-ixhash/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           perl5 1.0
 
-perl5.branches      5.26 5.28 5.30
+perl5.branches      5.26 5.28 5.30 5.32
 perl5.setup         Tie-IxHash 1.23
 revision            1
 license             {Artistic-1 GPL}


### PR DESCRIPTION
#### Description
Ping @dbevans @mojca
Here is an initial batch of adding p5.32-* subports for nomaintainer ports, if it is acceptable to start offering them in batches (without any missing dependencies) without offering p5.32-* subports yet for all Perl modules. I may only be able to help add right away those which I've already been using.
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7
Xcode 12.4 command line tools
Perl 5.32.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
