### PR TITLE
opencolorio: don't build bitcode with system Clang

### DIFF
--- a/graphics/osl/Portfile
+++ b/graphics/osl/Portfile
@@ -8,6 +8,7 @@ PortGroup               compiler_blacklist_versions 1.0
 
 github.setup            AcademySoftwareFoundation OpenShadingLanguage 1.10.10 Release-
 name                    osl
+revision                1
 categories              graphics
 platforms               darwin
 license                 BSD
@@ -37,17 +38,15 @@ compiler.cxx_standard   2011
 #                   ^
 compiler.blacklist-append {clang < 800}
 
-# s:12:39: error: expected ')' at end of argument list
-# define hidden float @osl_sin_ff(float %0) local_unnamed_addr #0 {
-#                                       ^
-compiler.blacklist-append {clang > 1200}
-
 # Keep this value synchronized with the
 # newest LLVM that is compatible with OSL
 set llvm_version 9.0
 
+# MacPorts Clang is used "to generate bitcode"
+# See variable LLVM_BC_GENERATOR
 depends_build-append    port:flex \
-                        port:bison
+                        port:bison \
+                        port:clang-$llvm_version
 depends_lib-append      port:llvm-$llvm_version \
                         port:boost \
                         port:openexr \


### PR DESCRIPTION
To generate bitcode, the same Clang as LLVM is used if found.
See the variable LLVM_BC_GENERATOR.
Otherwise, the system C++ compiler is used, which cases an error:
    s:12:39: error: expected ')' at end of argument list
    define hidden float @osl_sin_ff(float %0) local_unnamed_addr #0 {

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
