### PR TITLE
openjdk: add subports for Azul Zulu Community

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -42,6 +42,12 @@ set long_description_graalvm \
     "GraalVM is a universal virtual machine for running applications written in JavaScript, Python, Ruby, R,\
     JVM-based languages like Java, Scala, Groovy, Kotlin, Clojure, and LLVM-based languages such as C and C++."
 
+set long_description_zulu \
+    "Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
+    specification that contains all the Java components needed to build and run Java SE applications. Zulu has been\
+    verified by passing all tests of the OpenJDK Community Technology Compatibility Kit (TCK) as available for each\
+    respective Java SE version."
+
 subport openjdk8 {
     version      8u282
     revision     1
@@ -95,6 +101,26 @@ subport openjdk8-openj9 {
     checksums    rmd160  b66caafe41d50052fa438dfcef5fdf58430f42c8 \
                  sha256  265d4fb01b61ed7a3a9fae6a50bcf6322687b5f08de8598d8e42263cbd8b5772 \
                  size    115586057
+}
+
+subport openjdk8-zulu {
+    version      8.52.0.23
+    revision     0
+
+    set openjdk_version 8.0.282
+
+    description  Azul Zulu Community OpenJDK 8 (Long Term Support)
+    long_description ${long_description_zulu}
+
+    master_sites https://cdn.azul.com/zulu/bin/
+    distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
+    worksrcdir   ${distname}/zulu-8.jdk
+
+    configure.cxx_stdlib libstdc++
+
+    checksums    rmd160  117faab576f513b106ac0d2aa149d3563f58b218 \
+                 sha256  3c8ba3629d9f896a4f5edd2021ee1e7b5b9fb9c4a6866c96dbae1adb9424df9e \
+                 size    109825757
 }
 
 subport openjdk8-openj9-large-heap {
@@ -197,6 +223,24 @@ subport openjdk11-openj9-large-heap {
                  size    195829115
 }
 
+subport openjdk11-zulu {
+    version      11.45.27
+    revision     0
+
+    set openjdk_version 11.0.10
+
+    description  Azul Zulu Community OpenJDK 11 (Long Term Support)
+    long_description ${long_description_zulu}
+
+    master_sites https://cdn.azul.com/zulu/bin/
+    distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
+    worksrcdir   ${distname}/zulu-11.jdk
+
+    checksums    rmd160  deb4a140f240c8fd3916258bad9d92df3ad41db2 \
+                 sha256  d13f1fcc5ae3b51cc0bdcc627405aa5edd47f44ad0abf45dc7bc809c173a55a7 \
+                 size    195105665
+}
+
 # Remove after 2022-02-15
 subport openjdk12 {
     version      12.0.2
@@ -233,6 +277,24 @@ subport openjdk13-openj9-large-heap {
     revision     1
 }
 
+subport openjdk13-zulu {
+    version      13.37.21
+    revision     0
+
+    set openjdk_version 13.0.6
+
+    description  Azul Zulu Community OpenJDK 13 (Medium Term Support)
+    long_description ${long_description_zulu}
+
+    master_sites https://cdn.azul.com/zulu/bin/
+    distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
+    worksrcdir   ${distname}/zulu-13.jdk
+
+    checksums    rmd160  60ab845ffc7deba5317ddf1bbce5d5ef07c8dcd1 \
+                 sha256  13685e768c3346ddf59e054b6ac9582f71557e6935523d1a998d914920249009 \
+                 size    199904938
+}
+
 # Remove after 2022-02-15
 subport openjdk14 {
     version      14.0.2
@@ -267,6 +329,24 @@ subport openjdk15-openj9 {
 subport openjdk15-openj9-large-heap {
     version      15.0.2
     revision     1
+}
+
+subport openjdk15-zulu {
+    version      15.29.15
+    revision     0
+
+    set openjdk_version 15.0.2
+
+    description  Azul Zulu Community OpenJDK 15 (Medium Term Support)
+    long_description ${long_description_zulu}
+
+    master_sites https://cdn.azul.com/zulu/bin/
+    distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
+    worksrcdir   ${distname}/zulu-15.jdk
+
+    checksums    rmd160  b808f91a0206e0e7d7300221ac9d4ae906b2c0c1 \
+                 sha256  d59d9b8910e7ff2c7b82db4e3d3017b64e7ad5e8d0ffd38bc23c6a6e1902a042 \
+                 size    201667361
 }
 
 subport openjdk16 {
@@ -306,12 +386,38 @@ subport openjdk16-openj9 {
                  size    206412428
 }
 
-# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-if {${os.platform} eq "darwin" && ${os.major} < 14} {
-    known_fail yes
-    pre-fetch {
-        ui_error "${name} ${version} is only supported on Mac OS X 10.10 Yosemite or later."
-        return -code error
+subport openjdk16-zulu {
+    version      16.28.11
+    revision     0
+
+    set openjdk_version 16.0.0
+
+    description  Azul Zulu Community OpenJDK 16 (Short Term Support)
+    long_description ${long_description_zulu}
+
+    master_sites https://cdn.azul.com/zulu/bin/
+    distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
+    worksrcdir   ${distname}/zulu-16.jdk
+
+    checksums    rmd160  1c60ae0f5ab1f6d3482ca5470145a5fd0b93f543 \
+                 sha256  6d47ef22dc56ce1f5a102ed39e21d9a97320f0bb786818e2c686393109d79bc5 \
+                 size    206457844
+}
+
+if {${os.platform} eq "darwin"} {
+    # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+    if {[string match *-zulu ${subport}] && ${os.major} < 17} {
+        known_fail yes
+        pre-fetch {
+            ui_error "${name} ${version} is only supported on Mac OS X 10.13 Mavericks or later."
+            return -code error
+        }
+    } elseif {${os.major} < 14} {
+        known_fail yes
+        pre-fetch {
+            ui_error "${name} ${version} is only supported on Mac OS X 10.10 Yosemite or later."
+            return -code error
+        }
     }
 }
 
@@ -327,6 +433,8 @@ if {${subport} in [list openjdk12 openjdk13 openjdk14 openjdk15]} {
 
 if {[string match *-graalvm ${subport}]} {
     homepage     https://www.graalvm.org
+} elseif {[string match *-zulu ${subport}]} {
+    homepage     https://www.azul.com/downloads/zulu-community/
 } else {
     homepage     https://adoptopenjdk.net
 }


### PR DESCRIPTION
#### Description

New subports for Azul Zulu Community OpenJDK builds.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?