### PR TITLE
xaos: correct usage of qt5 portgroup

### DIFF
--- a/graphics/xaos/Portfile
+++ b/graphics/xaos/Portfile
@@ -36,9 +36,7 @@ checksums               rmd160  8ddff5c13e22db46acba0ff04a0b0a8a7cb7edca \
                         sha256  bf21d3f50d7c1626c5c96da475f84ea24d24a164ec6cc2bbc4ee229bc4a65967 \
                         size    10916985
 
-depends_lib-append      port:qt5-qtbase
-
-depends_build-append    port:qt5-qttools
+qt5.depends_build_component qttools
 
 destroot {
     # See tools/deploy-mac for the origin of the following four steps:


### PR DESCRIPTION
#### Description

This should fix the port on older macOS

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G8022
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
