### PR TITLE
groovy: update to 3.0.8

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            groovy
-version         3.0.7
+version         3.0.8
 revision        0
 
 categories      lang java
@@ -37,13 +37,13 @@ long_description Groovy... \
                   you can use Java
 
 homepage        https://groovy-lang.org/
-master_sites    https://dl.bintray.com/${name}/maven/
+master_sites    https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/
 distname        apache-${name}-binary-${version}
 use_zip         yes
 
-checksums       rmd160  5b7152283a2d50ef6db2a31dc174963963737de9 \
-                sha256  b9e2041cb83a963922f6761a0b037c5784670616632142b8d7002b7c3a96b7f5 \
-                size    43340743
+checksums       rmd160  d2b7cfc10d49e6e45c5c558161ff66ebf0055a31 \
+                sha256  87cf2a61b77f6378ae1081cfda9d14bc651271b25ffac57fc936cd17662e3240 \
+                size    43955659
 
 worksrcdir      ${name}-${version}
 


### PR DESCRIPTION
#### Description

Update to Groovy 3.0.8.

###### Tested on

macOS 11.2.3 20D91
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?