### PR TITLE
openjdk: update to GraalVM 21.1.0

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -170,8 +170,8 @@ subport openjdk11 {
 }
 
 subport openjdk11-graalvm {
-    version      21.0.0.2
-    revision     1
+    version      21.1.0
+    revision     0
 
     description  GraalVM Community Edition based on OpenJDK 11
     long_description ${long_description_graalvm}
@@ -180,9 +180,9 @@ subport openjdk11-graalvm {
     distname     graalvm-ce-java11-darwin-amd64-${version}
     worksrcdir   graalvm-ce-java11-${version}
     
-    checksums    rmd160  64053c14a3e03b49d69564d99fad84453c097afb \
-                 sha256  6714be01bd17c2c049435c02e19dd2bcba96ea9e44152911ed0082bc968618d6 \
-                 size    448204139
+    checksums    rmd160  61d5ec36d1671168fbcc236e4653a3be24198a69 \
+                 sha256  b53cd5a085fea39cb27fc0e3974f00140c8bb774fb2854d72db99e1be405ae2b \
+                 size    396142137
 }
 
 subport openjdk11-openj9 {
@@ -365,6 +365,22 @@ subport openjdk16 {
     checksums    rmd160  7ef653cce09364235a659cc9dd721281fec95d98 \
                  sha256  b66761b55fd493ed2a5f4df35a32b338ec34a9e0a1244439e3156561ab27c511 \
                  size    199955659
+}
+
+subport openjdk16-graalvm {
+    version      21.1.0
+    revision     0
+
+    description  GraalVM Community Edition based on OpenJDK 16
+    long_description ${long_description_graalvm}
+
+    master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/
+    distname     graalvm-ce-java16-darwin-amd64-${version}
+    worksrcdir   graalvm-ce-java16-${version}
+
+    checksums    rmd160  4bec36c128b42d324f6e7a513501e7c7c7b2fd4c \
+                 sha256  dafece9d03251304a6d9fc242862cfc08b85e2b8921d3b019a8a19b95af78e2c \
+                 size    404268013
 }
 
 subport openjdk16-openj9 {


### PR DESCRIPTION
#### Description

Update to [GraalVM 21.1.0](https://github.com/graalvm/graalvm-ce-builds/releases/tag/vm-21.1.0).

###### Tested on

macOS 11.2.3 20D91 on x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?