### PR TITLE
openjdk8-zulu: update to 8.54.0.21

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -104,10 +104,10 @@ subport openjdk8-openj9 {
 }
 
 subport openjdk8-zulu {
-    version      8.52.0.23
+    version      8.54.0.21
     revision     0
 
-    set openjdk_version 8.0.282
+    set openjdk_version 8.0.292
 
     description  Azul Zulu Community OpenJDK 8 (Long Term Support)
     long_description ${long_description_zulu}
@@ -118,9 +118,9 @@ subport openjdk8-zulu {
 
     configure.cxx_stdlib libstdc++
 
-    checksums    rmd160  117faab576f513b106ac0d2aa149d3563f58b218 \
-                 sha256  3c8ba3629d9f896a4f5edd2021ee1e7b5b9fb9c4a6866c96dbae1adb9424df9e \
-                 size    109825757
+    checksums    rmd160  886fe3a9b2161d63ce14bd10be8f571984e4f82d \
+                 sha256  369e0d0d76d73cb161978ff07d7020820bb3cd2465f6f91219bb6492e302f4dd \
+                 size    108162260
 }
 
 subport openjdk8-openj9-large-heap {


### PR DESCRIPTION
#### Description

Update to Azul Zulu Community 8.54.0.21 (OpenJDK 8u292).

###### Tested on

macOS 11.2.3 20D91 on x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?