### PR TITLE
openjdk11-zulu: update to 11.48.21

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -224,10 +224,10 @@ subport openjdk11-openj9-large-heap {
 }
 
 subport openjdk11-zulu {
-    version      11.45.27
+    version      11.48.21
     revision     0
 
-    set openjdk_version 11.0.10
+    set openjdk_version 11.0.11
 
     description  Azul Zulu Community OpenJDK 11 (Long Term Support)
     long_description ${long_description_zulu}
@@ -236,9 +236,9 @@ subport openjdk11-zulu {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
     worksrcdir   ${distname}/zulu-11.jdk
 
-    checksums    rmd160  deb4a140f240c8fd3916258bad9d92df3ad41db2 \
-                 sha256  d13f1fcc5ae3b51cc0bdcc627405aa5edd47f44ad0abf45dc7bc809c173a55a7 \
-                 size    195105665
+    checksums    rmd160  49e6888a1ec6749b09ac5daf725e46d9cb02e8f2 \
+                 sha256  866b25c47aa3bedddc57fbe38fd7d2e0f888d314b85d1e88b2fb12100f3c166c \
+                 size    195386841
 }
 
 # Remove after 2022-02-15


### PR DESCRIPTION
#### Description

Update to Azul Zulu Community 11.48.21 (OpenJDK 11.0.11).

###### Tested on

macOS 11.2.3 20D91 on x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?