### PR TITLE
openjdk13-zulu: update to 13.40.15

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -278,10 +278,10 @@ subport openjdk13-openj9-large-heap {
 }
 
 subport openjdk13-zulu {
-    version      13.37.21
+    version      13.40.15
     revision     0
 
-    set openjdk_version 13.0.6
+    set openjdk_version 13.0.7
 
     description  Azul Zulu Community OpenJDK 13 (Medium Term Support)
     long_description ${long_description_zulu}
@@ -290,9 +290,9 @@ subport openjdk13-zulu {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
     worksrcdir   ${distname}/zulu-13.jdk
 
-    checksums    rmd160  60ab845ffc7deba5317ddf1bbce5d5ef07c8dcd1 \
-                 sha256  13685e768c3346ddf59e054b6ac9582f71557e6935523d1a998d914920249009 \
-                 size    199904938
+    checksums    rmd160  f84e38dc8b92928b6aed9e35b6da3eb5f63e4b23 \
+                 sha256  a53b31c4eb6db57feceefd16ebadd07525514bdec8dbab6f9644e81ac1b97543 \
+                 size    200105932
 }
 
 # Remove after 2022-02-15


### PR DESCRIPTION
#### Description

Update to Azul Zulu Community 13.40.15 (OpenJDK 13.0.7).

###### Tested on

macOS 11.2.3 20D91 on x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?