### PR TITLE
google-cloud-sdk: update to 337.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             336.0.0
+version             337.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,14 +21,14 @@ supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  2107b6ee6ed9ee2e8b2ed6f35c0604e5e48ee93b \
-                    sha256  ab6974c6f627e4bec9474169d15165c9ddacc5f8b1b3076b47e07ec29e84d77b \
-                    size    88758594
+    checksums       rmd160  3b282bd3840f30aa79d29b85c5c717745f9b33b6 \
+                    sha256  ae70b48ed51c4a025f606842213e7aaa7f40ada9d17df5578f8a7cb2383806a2 \
+                    size    88862581
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  5a2172fc723f13c41e2089bd9b194d7b32ddc42e \
-                    sha256  e1f049c536491e77ff9bfb8e29755ba7006a43c7dd8911350848b668025f6039 \
-                    size    85006509
+    checksums       rmd160  40abd309a46fceba9ee3196d11667be89364c1c3 \
+                    sha256  f9828404af0f166afbaf4d9f00e8c1fab0d3a54b5a7f7cda0e0402712508e522 \
+                    size    85108235
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 337.0.0.

###### Tested on

macOS 11.2.3 20D91 on x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?