### PR TITLE
netdata: new port

### DIFF
--- a/sysutils/netdata/Portfile
+++ b/sysutils/netdata/Portfile
@@ -1,0 +1,88 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+
+github.setup            netdata netdata 1.29.3 v
+revision                0
+
+github.tarball_from     releases
+distname                ${name}-v${version}
+
+maintainers             {@gpanders greg:gpanders.com} openmaintainer
+categories              sysutils
+platforms               darwin
+license                 GPL-3
+
+description             Real-time performance monitoring done right
+long_description        Netdata's distributed, real-time monitoring Agent \
+                        collects thousands of metrics from systems, hardware, \
+                        containers, and applications with zero configuration. \
+                        It runs permanently on all your physical/virtual servers, \
+                        containers, cloud deployments, and edge/IoT devices, and \
+                        is perfectly safe to install on your systems mid-incident \
+                        without any preparation.
+
+depends_build-append    port:autoconf \
+                        port:automake \
+                        port:pkgconfig
+
+depends_lib-append      port:libuv \
+                        port:lz4 \
+                        port:json-c \
+                        port:openssl \
+                        port:judy \
+                        lib:libuuid:libuuid
+
+checksums               rmd160  f029a3324d088ce7829e2363785c63beeab8fc82 \
+                        sha256  eeba8b18519a9123a3cc8b450dcd042e23a3b145a78a7017a14c47ed36d923df \
+                        size    6737320
+
+configure.args          --disable-dependency-tracking \
+                        --disable-silent-rules \
+                        --prefix=${prefix} \
+                        --sysconfdir=${prefix}/etc \
+                        --localstatedir=${prefix}/var \
+                        --libexecdir=${prefix}/libexec \
+                        --libdir=${prefix}/lib \
+                        --with-math \
+                        --with-zlib \
+                        --enable-dbengine \
+                        --with-user=netdata
+
+startupitem.create      yes
+startupitem.executable  ${prefix}/sbin/netdata -D
+
+set netdata_user        netdata
+set netdata_group       netdata
+
+set netdata_conf_dir    ${prefix}/etc/${name}
+set netdata_cache_dir   ${prefix}/var/cache/${name}
+set netdata_log_dir     ${prefix}/var/log/${name}
+set netdata_lib_dir     ${prefix}/var/lib/${name}
+set netdata_web_dir     ${prefix}/share/${name}/web
+
+add_users ${netdata_user} group=${netdata_group}
+
+use_autoreconf yes
+
+destroot.keepdirs-append \
+                        ${destroot}${netdata_cache_dir} \
+                        ${destroot}${netdata_log_dir} \
+                        ${destroot}${netdata_lib_dir}
+
+post-destroot {
+    xinstall -m 0644 ${worksrcpath}/system/netdata.conf ${destroot}${netdata_conf_dir}
+
+    reinplace "s|web files owner = .*|web files owner = netdata|" ${destroot}${netdata_conf_dir}/netdata.conf
+    reinplace "s|NETDATA_USER_CONFIG_DIR=\"/|NETDATA_USER_CONFIG_DIR=\"${prefix}/|" ${destroot}${netdata_conf_dir}/edit-config
+    reinplace "s|NETDATA_STOCK_CONFIG_DIR=\"/|NETDATA_STOCK_CONFIG_DIR=\"${prefix}/|" ${destroot}${netdata_conf_dir}/edit-config
+
+    xinstall -d -o ${netdata_user} -g ${netdata_group} ${destroot}${netdata_cache_dir}
+    xinstall -d -o ${netdata_user} -g ${netdata_group} ${destroot}${netdata_log_dir}
+    xinstall -d -o ${netdata_user} -g ${netdata_group} ${destroot}${netdata_lib_dir}
+
+    system "chown -R ${netdata_user}:${netdata_group} ${destroot}${netdata_web_dir}"
+
+    touch ${destroot}${netdata_conf_dir}/.opt-out-from-anonymous-statistics
+}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Add a port for [netdata](https://netdata.cloud).

Some notes:

- This port uses a (slightly) older version of netdata because there is an [open issue building the newest version on macOS](https://github.com/netdata/netdata/issues/10842)
- AFAIK this won't (can't) work with the Netdata Cloud feature, since building their Agent Cloud Link requires a static library for libmosquitto (I don't know why) and obviously MacPorts can only provide the shared library. If this feature is requested by someone someday then we can figure out a solution, but in the meantime I'm going to assume that the cloud feature won't be used much, if at all.

###### Tested on
macOS 10.15.7 19H524 on x86_64
Xcode 12.4 12D4e


###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
