### PR TITLE
Add JSON-enabled variant to `mtr`

### DIFF
--- a/net/mtr/Portfile
+++ b/net/mtr/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                mtr
 version             0.94
-revision            0
+revision            1
 categories          net
 platforms           darwin
 license             GPL-2
@@ -24,14 +24,16 @@ long_description    mtr combines the functionality of the 'traceroute' \
 homepage            http://www.bitwizard.nl/mtr/
 
 depends_build       port:pkgconfig
-depends_lib         port:ncurses
+depends_lib         port:ncurses \
+                    port:jansson
 
 master_sites        ftp://ftp.bitwizard.nl/mtr/
 checksums           rmd160  b5559299a31ec1d030a80c4e165b5ee1d7f707c2 \
                     sha256  3f7c82d5e8b13e73ce891259d159426375e5181421a689699fb2b2a931dd9dbe \
                     size    293925
 
-configure.args      --without-gtk
+configure.args      --without-gtk \
+                    --with-jansson
 
 post-destroot {
     file attributes ${destroot}${prefix}/sbin/mtr-packet -permissions +s


### PR DESCRIPTION
#### Description

This change creates a `+json` variant of `mtr` that enables JSON output via the `--json` flag. If upstream would prefer to enable this by default, I'd be happy to refactor it to do so.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.2.3 20D91 on x86_64
Xcode 12.4 12D4e

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

