### PR TITLE
openjdk8: update to 8u292

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -49,10 +49,10 @@ set long_description_zulu \
     respective Java SE version."
 
 subport openjdk8 {
-    version      8u282
-    revision     1
+    version      8u292
+    revision     0
 
-    set build    08
+    set build    10
 
     description  Open Java Development Kit 8 (AdoptOpenJDK) with HotSpot VM
     long_description ${long_description_adoptopenjdk_hotspot}
@@ -63,9 +63,9 @@ subport openjdk8 {
 
     configure.cxx_stdlib libstdc++
 
-    checksums    rmd160  3187d760b3cbeaaf01d47481f069a3e2d1011cfd \
-                 sha256  1766d756f6e4a5d41b539f2ecf83e5a33e9336bd75f1602e8f4b4afbb8f47aaa \
-                 size    101808251
+    checksums    rmd160  680c91c140f50774e20efabe58c9780a9a62b94a \
+                 sha256  5646fbe9e4138c902c910bb7014d41463976598097ad03919e4848634c7e8007 \
+                 size    103785976
 }
 
 subport openjdk8-graalvm {


### PR DESCRIPTION
#### Description

Update to AdoptOpenJDK 8u292.

###### Tested on

macOS 11.2.3 20D91 on x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?