### PR TITLE
openjdk11: update to 11.0.11

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -152,8 +152,8 @@ subport openjdk10 {
 }
 
 subport openjdk11 {
-    version      11.0.10
-    revision     1
+    version      11.0.11
+    revision     0
 
     set build    9
 
@@ -164,9 +164,9 @@ subport openjdk11 {
     distname     OpenJDK11U-jdk_x64_mac_hotspot_${version}_${build}
     worksrcdir   jdk-${version}+${build}
 
-    checksums    rmd160  3c1f62a95095aee9f0ee3d02ba4a4a67f5425ba1 \
-                 sha256  ee7c98c9d79689aca6e717965747b8bf4eec5413e89d5444cc2bd6dbd59e3811 \
-                 size    186160219
+    checksums    rmd160  5cd7c7ac1fa84fcaeab677076d80b4970cbf9334 \
+                 sha256  d851a220e77473a4b483d8bd6b6570e04fd83fdd48d6584b58b041f5997186c2 \
+                 size    186275966
 }
 
 subport openjdk11-graalvm {


### PR DESCRIPTION
#### Description

Update to AdoptOpenJDK 11.0.11.

###### Tested on

macOS 11.2.3 20D91 on x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?