### PR TITLE
sslscan : update to v2.0.9

### DIFF
--- a/net/sslscan/Portfile
+++ b/net/sslscan/Portfile
@@ -3,8 +3,8 @@
 PortSystem 1.0
 PortGroup github 1.0
 
-github.setup    rbsec sslscan 1.11.13-rbsec
-revision        1
+github.setup    rbsec sslscan 2.0.9
+revision        0
 categories      net
 maintainers     {raimue @raimue} \
                 openmaintainer
@@ -17,11 +17,11 @@ long_description \
 platforms       darwin
 license         {GPL-3+ OpenSSLException}
 
-depends_lib     port:openssl10
+depends_lib     port:openssl
 
-checksums       rmd160  3be945a7e5fcf11f3ec99d7ef37ebc5b4b2ca57c \
-                sha256  f3015b6a9f5a6b4fb4a911da45443dbd76e09ef0c55973f82b0807bba834847a \
-                size    57014
+checksums       rmd160  e5019515e819a2d250b161be06aaa18748a6769e \
+                sha256  513344d55fc64491895ae7f96d07d8fc93dd901c894fd956aa15325779a8b2a8 \
+                size    109511
 
 # implicit declaration of inet_ntop
 patchfiles      sslscan.c.patch
@@ -30,8 +30,8 @@ use_configure   no
 
 build.args      PREFIX="${prefix}" \
                 CC="${configure.cc}" \
-                CPPFLAGS="-I${prefix}/include/openssl-1.0" \
+                CPPFLAGS="-I${prefix}/include/openssl" \
                 CFLAGS="${configure.cflags} [get_canonical_archflags cc]" \
-                LDFLAGS="[get_canonical_archflags ld] -L${prefix}/lib/openssl-1.0"
+                LDFLAGS="[get_canonical_archflags ld] -L${prefix}/lib"
 
 destroot.args   PREFIX="${prefix}"


### PR DESCRIPTION
#### Description
Changes:
1. Version & revision changed
2. Hashes & size fixed to reflect new tarball
3. Change dependency & build flags to use current OpenSSL.

Closes: https://trac.macports.org/ticket/62476

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) on $(uname -m)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G8022 on x86_64
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
