### PR TITLE
netdata-dashboard: new subport

### DIFF
--- a/sysutils/netdata/Portfile
+++ b/sysutils/netdata/Portfile
@@ -5,7 +5,7 @@ PortGroup               github 1.0
 PortGroup               legacysupport 1.1
 
 github.setup            netdata netdata 1.29.3 v
-revision                0
+revision                1
 
 github.tarball_from     releases
 distname                ${name}-v${version}
@@ -23,9 +23,10 @@ long_description        Netdata's distributed, real-time monitoring Agent \
                         containers, cloud deployments, and edge/IoT devices, and \
                         is perfectly safe to install on your systems mid-incident \
                         without any preparation.
-                        
-compiler.thread_local_storage   yes
- 
+
+compiler.thread_local_storage \
+                        yes
+
 depends_build-append    port:autoconf \
                         port:automake \
                         port:pkgconfig
@@ -53,9 +54,6 @@ configure.args          --disable-dependency-tracking \
                         --enable-dbengine \
                         --with-user=netdata
 
-startupitem.create      yes
-startupitem.executable  ${prefix}/sbin/netdata -D
-
 set netdata_user        netdata
 set netdata_group       netdata
 
@@ -67,25 +65,66 @@ set netdata_web_dir     ${prefix}/share/${name}/web
 
 add_users ${netdata_user} group=${netdata_group}
 
-use_autoreconf yes
+if { ${name} eq ${subport} } {
+    use_autoreconf yes
+    depends_run-append      port:${name}-dashboard
 
-destroot.keepdirs-append \
-                        ${destroot}${netdata_cache_dir} \
-                        ${destroot}${netdata_log_dir} \
-                        ${destroot}${netdata_lib_dir}
+    startupitem.create      yes
+    startupitem.executable  ${prefix}/sbin/netdata -D
 
-post-destroot {
-    xinstall -m 0644 ${worksrcpath}/system/netdata.conf ${destroot}${netdata_conf_dir}
+    destroot.keepdirs-append \
+                            ${destroot}${netdata_cache_dir} \
+                            ${destroot}${netdata_log_dir} \
+                            ${destroot}${netdata_lib_dir}
 
-    reinplace "s|web files owner = .*|web files owner = netdata|" ${destroot}${netdata_conf_dir}/netdata.conf
-    reinplace "s|NETDATA_USER_CONFIG_DIR=\"/|NETDATA_USER_CONFIG_DIR=\"${prefix}/|" ${destroot}${netdata_conf_dir}/edit-config
-    reinplace "s|NETDATA_STOCK_CONFIG_DIR=\"/|NETDATA_STOCK_CONFIG_DIR=\"${prefix}/|" ${destroot}${netdata_conf_dir}/edit-config
+    post-destroot {
+        xinstall -m 0644 ${worksrcpath}/system/netdata.conf ${destroot}${netdata_conf_dir}
 
-    xinstall -d -o ${netdata_user} -g ${netdata_group} ${destroot}${netdata_cache_dir}
-    xinstall -d -o ${netdata_user} -g ${netdata_group} ${destroot}${netdata_log_dir}
-    xinstall -d -o ${netdata_user} -g ${netdata_group} ${destroot}${netdata_lib_dir}
+        reinplace "s|web files owner = .*|web files owner = netdata|" ${destroot}${netdata_conf_dir}/netdata.conf
+        reinplace "s|NETDATA_USER_CONFIG_DIR=\"/|NETDATA_USER_CONFIG_DIR=\"${prefix}/|" ${destroot}${netdata_conf_dir}/edit-config
+        reinplace "s|NETDATA_STOCK_CONFIG_DIR=\"/|NETDATA_STOCK_CONFIG_DIR=\"${prefix}/|" ${destroot}${netdata_conf_dir}/edit-config
 
-    system "chown -R ${netdata_user}:${netdata_group} ${destroot}${netdata_web_dir}"
+        xinstall -d -o ${netdata_user} -g ${netdata_group} ${destroot}${netdata_cache_dir}
+        xinstall -d -o ${netdata_user} -g ${netdata_group} ${destroot}${netdata_log_dir}
+        xinstall -d -o ${netdata_user} -g ${netdata_group} ${destroot}${netdata_lib_dir}
 
-    touch ${destroot}${netdata_conf_dir}/.opt-out-from-anonymous-statistics
+        touch ${destroot}${netdata_conf_dir}/.opt-out-from-anonymous-statistics
+
+        # Delete any files provided by netdata-dashboard to avoid conflicts. We
+        # can't just delete the whole directory because this directory contains
+        # some files that are not present in netdata/dashboard. This will
+        # hopefully change someday, see
+        # https://github.com/netdata/dashboard/issues/83
+        foreach f [glob -dir ${netdata_web_dir} * **/*] {
+            delete ${destroot}${f}
+        }
+
+        system "chown -R ${netdata_user}:${netdata_group} ${destroot}${netdata_web_dir}"
+    }
+
+}
+
+subport ${name}-dashboard {
+    description         Static assets for the Netdata Agent dashboard.
+    long_description    {*}${description}
+
+    github.setup        netdata dashboard 2.16.0 v
+    revision            0
+
+    github.tarball_from releases
+    distname            dashboard
+
+    checksums           rmd160  1c0c4b221bb64a651f5f3a2bec7f80ab1535959d \
+                        sha256  5b791a3a5a5beee411877e687b0f1a852b6ed87178952402714d44c4659abdae \
+                        size    6315714
+
+    use_configure       no
+
+    extract {}
+    build {}
+
+    destroot {
+        xinstall -d -o ${netdata_user} -g ${netdata_group} ${destroot}${netdata_web_dir}
+        system "tar -C ${destroot}${netdata_web_dir} -xf ${distpath}/${distname}.tar.gz --strip-components 1"
+    }
 }


### PR DESCRIPTION
#### Description

Netdata split out the web dashboard from the core repo, so we need to manually pull that down during installation.

The netdata agent (https://github.com/netdata/netdata) includes an older version of the dashboard bundled with it, but this is being kept just for backwards compatibility. New installations need to include the dashboard from https://github.com/netdata/dashboard (see [docs](https://community.netdata.cloud/t/i-have-an-old-version-of-the-netdata-agent-dashboard/1207) and the [discussion with Netdata](https://github.com/netdata/netdata/pull/11013#issuecomment-824987164)).

I welcome any criticism or suggestions from more experienced maintainers on the best way to manage two separate upstream repos. If the method I used here is not optimal I'm more than happy to update it.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) on $(uname -m)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524 on x86_64
Xcode 12.4 12D4e


###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
