### PR TITLE
opencv3: update to 3.4.14; fix paths in pkgconfig

### DIFF
--- a/graphics/opencv3/Portfile
+++ b/graphics/opencv3/Portfile
@@ -6,8 +6,8 @@ PortGroup           compiler_blacklist_versions 1.0
 PortGroup           legacysupport 1.0
 
 name                opencv3
-version             3.4.13
-revision            1
+version             3.4.14
+revision            0
 categories          graphics science
 platforms           darwin
 license             BSD
@@ -35,10 +35,11 @@ distname            ${version}
 distfiles           ${distname}${extract.suffix}:opencv
 
 # don't forget to also update the checksums under the contrib variant.
-checksums           ${distname}${extract.suffix} \
-                    rmd160  39f8733cb2f58d2a955e3c74e7a52f16b1b78d9c \
-                    sha256  70230049194ae03ed8bfaab6cd1388569aa1b5c482d8b50d3af1cd2ae5a0b95d \
-                    size    87573369
+checksums-append \
+                    ${distname}${extract.suffix} \
+                    rmd160  ba13d3a7b4d69228e8f9309b6f9f9daee73a69aa \
+                    sha256  dfeb91c93d494be590afbe342ebb61742381f901fe2e0376987b1581f74948d1 \
+                    size    87648110
 
 platform macosx {
     if {${os.major} <= 10} {
@@ -452,20 +453,24 @@ if {${name} eq ${subport}} {
 
     variant dc1394 description {Use libdc1394 for FireWire camera; breaks compatibility with Apple iSight FireWire camera} {
         depends_lib-append  port:libdc1394
-        configure.args-replace  -DWITH_1394=OFF \
+        configure.args-replace \
+                            -DWITH_1394=OFF \
                             -DWITH_1394=ON
-        configure.args-append   -DHAVE_DC1394_2=ON
+        configure.args-append \
+                            -DHAVE_DC1394_2=ON
     }
 
     variant qt4 conflicts qt5 description {Build with Qt4 Backend support} {
         PortGroup           qt4 1.0
-        configure.args-replace  -DWITH_QT=OFF \
+        configure.args-replace \
+                            -DWITH_QT=OFF \
                             -DWITH_QT=4
     }
 
     variant qt5 conflicts qt4 description {Build with Qt5 Backend support} {
         PortGroup           qt5 1.0
-        configure.args-replace  -DWITH_QT=OFF \
+        configure.args-replace \
+                            -DWITH_QT=OFF \
                             -DWITH_QT=5
     }
 
@@ -477,34 +482,45 @@ if {${name} eq ${subport}} {
         java.version        1.6+
         # Use latest LTS Java version as fallback
         java.fallback       openjdk11
-        depends_build-append    port:apache-ant
-        configure.args-replace  -DBUILD_opencv_java=OFF \
+        depends_build-append \
+                            port:apache-ant
+        configure.args-replace \
+                            -DBUILD_opencv_java=OFF \
                             -DBUILD_opencv_java=ON
     }
 
     if {[variant_isset java] && ![variant_isset python27]} {
-        configure.args-replace  -DPYTHON_EXECUTABLE=OFF \
+        configure.args-replace \
+                            -DPYTHON_EXECUTABLE=OFF \
                             -DPYTHON_EXECUTABLE=/usr/bin/python
-        configure.args-delete   -DBUILD_opencv_python2=OFF
+        configure.args-delete \
+                            -DBUILD_opencv_python2=OFF
     }
 
     variant tbb description {Use Intel TBB} {
-        depends_lib-append      port:tbb
-        configure.args-replace  -DWITH_TBB=OFF \
+        depends_lib-append  \
+                            port:tbb
+        configure.args-replace \
+                            -DWITH_TBB=OFF \
                             -DWITH_TBB=ON
-        configure.args-append   -DHAVE_TBB=ON \
+        configure.args-append \
+                            -DHAVE_TBB=ON \
                             -DTBB_INCLUDE_DIRS=${prefix}/include
     }
 
     variant vtk description {Include VTK support} {
-        depends_lib-append      port:vtk
-        configure.args-replace  -DWITH_VTK=OFF \
+        depends_lib-append  \
+                            port:vtk
+        configure.args-replace \
+                            -DWITH_VTK=OFF \
                             -DWITH_VTK=ON
     }
 
     variant gdal description {Include GDAL support} {
-        depends_lib-append      port:gdal
-        configure.args-replace  -DWITH_GDAL=OFF \
+        depends_lib-append \
+                            port:gdal
+        configure.args-replace \
+                            -DWITH_GDAL=OFF \
                             -DWITH_GDAL=ON
     }
 
@@ -512,10 +528,11 @@ if {${name} eq ${subport}} {
         master_sites-append     https://github.com/opencv/opencv_contrib/archive:opencv_contrib
         distfiles-append        ${version}.zip:opencv_contrib
         checksums-append        ${version}.zip \
-                            rmd160  e3fe150fa131a4cf7cd9e0bf9f6a597df6e8f3f3 \
-                            sha256  4412a8b1a9d55b4bac489d79c21c567e0bf69272e6fbc7f45a68a7b72fb59066 \
-                            size    56393041
-        configure.args-append   -DOPENCV_EXTRA_MODULES_PATH=${workpath}/opencv_contrib-${version}/modules \
+                                rmd160  13c4602866dd64d96f7666c9910e6befe7cbdb60 \
+                                sha256  e43874c9d1922c5c1a5826855730327c793bfb8f6e4074cd2f30983d4a220a14 \
+                                size    56393741
+        configure.args-append \
+                            -DOPENCV_EXTRA_MODULES_PATH=${workpath}/opencv_contrib-${version}/modules \
                             -DBUILD_PROTOBUF=YES
         depends_lib-append      \
                             port:gflags \
@@ -530,7 +547,7 @@ if {${name} eq ${subport}} {
             ln -s ${workpath}/opencv_contrib-${version} ${worksrcpath}/opencv_contrib
         }
 
-        extract.only            ${distname}${extract.suffix}
+        extract.only        ${distname}${extract.suffix}
 #                            ${version}.zip
 
         # dnn_modern:
@@ -539,16 +556,16 @@ if {${name} eq ${subport}} {
         distfiles-append        v1.0.0a3.tar.gz:tiny-dnn
 
         checksums-append        v1.0.0a3.tar.gz \
-                            rmd160 1d44a0f0c3b0a6f31a333afdfb246526c42336ad \
-                            sha256 e2c61ce8c5debaa644121179e9dbdcf83f497f39de853f8dd5175846505aa18b \
-                            size 12885646
+                                rmd160  1d44a0f0c3b0a6f31a333afdfb246526c42336ad \
+                                sha256  e2c61ce8c5debaa644121179e9dbdcf83f497f39de853f8dd5175846505aa18b \
+                                size    12885646
 
         configure.args-append  -DOPENCV_TINY_DNN_URL=file://${distpath}/
 
         # xfeatures2d/boostdesc:
         master_sites-append    https://raw.githubusercontent.com/opencv/opencv_3rdparty/34e4206aef44d50e6bbcd0ab06354b52e7466d26:boostdesc
 
-        distfiles-append       boostdesc_bgm.i:boostdesc \
+        distfiles-append   boostdesc_bgm.i:boostdesc \
                            boostdesc_bgm_bi.i:boostdesc \
                            boostdesc_bgm_hd.i:boostdesc \
                            boostdesc_binboost_064.i:boostdesc \
@@ -556,7 +573,7 @@ if {${name} eq ${subport}} {
                            boostdesc_binboost_256.i:boostdesc \
                            boostdesc_lbgm.i:boostdesc
 
-        checksums-append       boostdesc_bgm.i \
+        checksums-append   boostdesc_bgm.i \
                                rmd160 a090147b1ff8cdb23cbb3898cb5cd9cdb181f000 \
                                sha256 c441a027f15b9b8ff6c006b0775cd86781169ebd5b6257a94bdce668010d5df5 \
                                size 14852 \
@@ -590,12 +607,12 @@ if {${name} eq ${subport}} {
         #xfeatures2d/vggdesc:
         master_sites-append    https://raw.githubusercontent.com/opencv/opencv_3rdparty/fccf7cd6a4b12079f73bbfb21745f9babcd4eb1d:vggdesc
 
-        distfiles-append       vgg_generated_48.i:vggdesc \
+        distfiles-append   vgg_generated_48.i:vggdesc \
                            vgg_generated_64.i:vggdesc \
                            vgg_generated_80.i:vggdesc \
                            vgg_generated_120.i:vggdesc
 
-        checksums-append       vgg_generated_48.i \
+        checksums-append   vgg_generated_48.i \
                                rmd160 fdb2d976ec287c4989e9d3b6f95104a0bef9c9a4 \
                                sha256 71274a67ab0896865e27de830eda0065e387d75fe071dab4a887e2430ccb8a35 \
                                size 773330 \
@@ -617,9 +634,9 @@ if {${name} eq ${subport}} {
         #face:
         master_sites-append    https://raw.githubusercontent.com/opencv/opencv_3rdparty/8afa57abc8229d611c4937165d20e2a2d9fc5a12:face
 
-        distfiles-append       face_landmark_model.dat:face
+        distfiles-append   face_landmark_model.dat:face
 
-        checksums-append       face_landmark_model.dat \
+        checksums-append   face_landmark_model.dat \
                            rmd160 3a4e4a80f2c74a6af2b36b4d74e3c6d59c347ce0 \
                            sha256 eeab592db2861a6c94d592a48456cf59945d31483ce94a6bc4d3a4e318049ba3 \
                            size 72368157
@@ -710,18 +727,42 @@ proc opencv_soft_link_binaries {p_bin_main_dir p_bin_port_dir p_destroot p_prefi
     return 0
 }
 
+proc opencv_fix_pkgconfig {p_destroot p_prefix p_subport p_parent_subport_name} {
+    if {${p_subport} eq ${p_parent_subport_name}} {
+        set pkgconfig_file \
+            "${p_destroot}${p_prefix}/lib/${p_parent_subport_name}/pkgconfig/opencv.pc"
+
+        ui_debug "opencv_fix_pkgconfig: fixing pkgconfig file ${pkgconfig_file}"
+
+        # Fix paths
+        reinplace "s|\$\{exec_prefix\}\/||g" \
+            ${pkgconfig_file}
+        reinplace "s|\$\{prefix\}\/||g" \
+            ${pkgconfig_file}
+
+        # http://trac.macports.org/ticket/42702
+        if {[variant_isset qt4] || [variant_isset qt5]} {
+            reinplace "s|-L//System/Library/Frameworks ||g" \
+                ${pkgconfig_file}
+            reinplace "s|-lOpenGL.framework|-framework OpenGL|g" \
+                ${pkgconfig_file}
+        }
+    }
+
+    return 0
+}
+
 proc opencv_post_destroot {} {
-    global prefix
     global destroot
+    global prefix
+    global subport
     global parent_subport_name
 
-    # http://trac.macports.org/ticket/42702
-    if {[variant_isset qt4] || [variant_isset qt5]} {
-        reinplace "s|-L//System/Library/Frameworks ||g" \
-            ${destroot}${prefix}/lib/${parent_subport_name}/pkgconfig/opencv.pc
-        reinplace "s|-lOpenGL.framework|-framework OpenGL|g" \
-            ${destroot}${prefix}/lib/${parent_subport_name}/pkgconfig/opencv.pc
-    }
+    opencv_fix_pkgconfig \
+        ${destroot} \
+        ${prefix} \
+        ${subport} \
+        ${parent_subport_name}
 
     set bin_main_dir \
         "${destroot}${prefix}/bin"


### PR DESCRIPTION
#### Description

* Update opencv3 to 3.4.14
* Fix paths in generated pkgconfig

Fixes: https://trac.macports.org/ticket/62462
Fixes: https://trac.macports.org/ticket/61908

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G2136
Xcode 9.2 9C40b

macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
