### PR TITLE
qtads: specify minimum requirements and indicate no license conflict

### DIFF
--- a/games/qtads/Portfile
+++ b/games/qtads/Portfile
@@ -3,14 +3,10 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
-PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        realnc qtads 3.0.0 v
 revision            0
 github.tarball_from releases
-
-# clang: error: unknown argument: '-fno-sized-deallocation'
-compiler.blacklist-append {clang < 800}
 
 categories          games
 platforms           darwin
@@ -32,6 +28,18 @@ checksums           rmd160  d4791de09461ae7417ac8d384953636669da9e55 \
                     size    5325048
 
 use_xz              yes
+
+# QTads does not use or link to OpenSSL directly. It merely uses Qt, for which OpenSSL is
+# optional and can be toggled off through a variant.
+license_noconflict  openssl
+
+# Minimum requirements taken from qtads.pro :
+
+compiler.c_standard 2011
+compiler.cxx_standard \
+                    2014
+
+qt5.min_version     5.5
 
 depends_lib-append  port:libsdl2 \
                     port:libsndfile \


### PR DESCRIPTION
 * indicate no license conflict with openssl
 * specify minium standards and Qt version
 * compiler blacklist not necessary for C++14-supporting compilers

#### Description

I expect that the compiler blacklist should no longer be necessary once C++14 has been specified as a minimum requirement. `-fno-sized-deallocation` is a C++14-specific flag. But I was unable to test on an old macOS version which this change would affect.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
