### PR TITLE
qt4-mac: fix drawing performance issues with Big Sur

### DIFF
--- a/aqua/qt4-mac/Portfile
+++ b/aqua/qt4-mac/Portfile
@@ -11,7 +11,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                qt4-mac
 version             4.8.7
-revision            11
+revision            12
 set branch          [join [lrange [split ${version} .] 0 1] .]
 
 categories          aqua
@@ -374,6 +374,14 @@ patchfiles-append patch-qt4-openssl111.diff
 if {![variant_isset cxx11]} {
     patchfiles-append patch-compiler_standard.diff
 }
+
+# Fix slow drawing on Big Sur.
+# See:
+# - https://developer.apple.com/forums/thread/663256
+# - https://gist.github.com/lukaskubanek/9a61ac71dc0db8bb04db2028f2635779
+# - https://trac.wxwidgets.org/ticket/19111
+# The fix can only be compiled with the 10.12 SDK or later.
+patchfiles-append patch-qt4-contentsformat.diff
 
 # the configure script uses the compiler version to determine if QtXmlPatterns and QtWebKit can be built
 # the logic does not work for newer versions of GCC or Clang (masquerading as GCC)

--- a/aqua/qt4-mac/files/patch-qt4-contentsformat.diff
+++ b/aqua/qt4-mac/files/patch-qt4-contentsformat.diff
@@ -1,0 +1,29 @@
+--- src/gui/kernel/qcocoaview_mac.mm.orig	2021-04-22 11:42:11.000000000 -0700
++++ src/gui/kernel/qcocoaview_mac.mm	2021-04-22 11:43:21.000000000 -0700
+@@ -997,6 +997,18 @@
+     }
+ }
+ 
++#if defined(MAC_OS_X_VERSION_10_12) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_12
++- (void) viewWillDraw
++{
++    if (NSAppKitVersionNumber >= 2022.00) // Big Sur
++    {
++        CALayer* layer = self.layer;
++        layer.contentsFormat = kCAContentsFormatRGBA8Uint;
++    }
++    
++    [super viewWillDraw];
++}
++#endif
+ 
+ // NSTextInput Protocol implementation
+ 
+--- src/gui/kernel/mac.pri.orig	2021-04-22 13:28:24.000000000 -0700
++++ src/gui/kernel/mac.pri	2021-04-22 13:28:54.000000000 -0700
+@@ -1,4 +1,4 @@
+ !x11:!embedded:!qpa:mac {
+-   LIBS_PRIVATE += -framework Carbon -lz
++   LIBS_PRIVATE += -framework QuartzCore -framework Carbon -lz
+    *-mwerks:INCLUDEPATH += compat
+ }


### PR DESCRIPTION
#### Description

Big Sur changed the default contents format for backing layers, which affected the performance of many legacy applications (see [here](https://discuss.pixls.us/t/natron-node-graph-slow-in-big-sur/24618) and https://github.com/NatronGitHub/Natron/issues/606  for a report on Natron, which uses this port).

This is further described (and fixed) in:

- https://developer.apple.com/forums/thread/663256
- https://gist.github.com/lukaskubanek/9a61ac71dc0db8bb04db2028f2635779
- https://trac.wxwidgets.org/ticket/19111

This patch applies a fix [similar to the one found in wxWidgets](https://github.com/wxWidgets/wxWidgets/blob/master/src/osx/cocoa/window.mm#L887).

Tested by compiling on 10.6 (which doesn't change anything, since the fix can only be applied when compiling on 10.12+), compiling on 10.15, and executing on 11.2: the performance issue is gone!

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.6, 10.15, 11.2
Xcode 8.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
