### PR TITLE
gmic: enable OpenCV usage

### DIFF
--- a/science/gmic/Portfile
+++ b/science/gmic/Portfile
@@ -15,7 +15,7 @@ if {${subport} ne "gmic" && ${subport} ne "gmic-clib"} {
 
 name                gmic
 version             2.9.7
-revision            0
+revision            1
 license             CeCILL
 categories          science graphics
 platforms           darwin
@@ -38,7 +38,7 @@ master_sites        https://gmic.eu/files/source/
 # gmic will pick up include files from opencv, opencv3 dods not conflict
 conflicts_build     opencv
 
-use_parallel_build  no
+use_parallel_build  yes
 
 distfiles           ${name}_${version}${extract.suffix}
 
@@ -93,16 +93,11 @@ if {${subport} eq ${name}} {
 
     configure.args-append       -DCUSTOM_CFLAGS=ON \
                                 -DENABLE_OPENMP=OFF \
-                                -DENABLE_X=OFF
+                                -DENABLE_X=OFF \
+                                -DENABLE_OPENCV=ON
 
     # insert path to opencv4 libraries, as cmake fails to do so
-    # update and revision bump to new version of opencv4
-    set opencv4_version 4.5.1
-    post-configure {
-        reinplace  "s|-lopencv_gapi.${opencv4_version}|-L${prefix}/lib/opencv4 -lopencv_gapi.${opencv4_version}|g" \
-                   ${build.dir}/CMakeFiles/gmic.dir/link.txt \
-                   ${build.dir}/CMakeFiles/libgmic.dir/link.txt
-    }
+    configure.ldflags-append    -L${prefix}/lib/opencv4
 
     variant x11 {
         configure.args-replace  -DENABLE_X=OFF \


### PR DESCRIPTION
#### Description

* Enable OpenCV usage for gmic, as it is now disabled by default starting with 2.9.7
* Simplify, and harden, OpenCV linking via `configure.ldflags`, rather than patching
* Enable parallel build to reduce build time

Fixes: https://trac.macports.org/ticket/62738

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G2136
Xcode 9.2 9C40b

macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
