### PR TITLE
foundationdb: new port

### DIFF
--- a/databases/foundationdb/Portfile
+++ b/databases/foundationdb/Portfile
@@ -1,0 +1,75 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+
+github.setup        apple foundationdb 6.3.12
+revision            0
+
+categories          databases
+license             Apache-2
+maintainers         {me.com:spam_brian @brianwells} openmaintainer
+platforms           darwin
+description         FoundationDB is a distributed database providing ACID transactions.
+long_description    \
+    FoundationDB is a scalable, fault-tolerant, ordered \
+    key-value store with full ACID transactions.  This port \
+    will install version ${version} of the FoundationDB \
+    binaries suitable for development on macOS.
+
+homepage            https://www.foundationdb.org/
+
+checksums           rmd160  2bf9a258d5db140d232fb6355fc810010824c014 \
+                    sha256  034f69d4ddf7faccd7cae2a6438d64643ac98a3a9c7b3e6ed2a03105c480df95 \
+                    size    9694306
+
+depends_lib-append  port:mono
+
+# The FoundationDB build can easily run out of memory and crash, 
+# so the recommendation is to use "ninja -j1" when building.
+use_parallel_build  no
+cmake.generator     Ninja
+
+destroot {
+    # install compiled binaries
+
+    xinstall -d -m 755 ${destroot}${prefix}/bin
+    xinstall -m 755 ${workpath}/build/packages/bin/fdbcli \
+        ${workpath}/build/packages/bin/fdbbackup \
+        ${destroot}${prefix}/bin
+    foreach x {backup_agent dr_agent fastrestore_tool fdbdr fdbrestore} {
+        ln -f -s fdbbackup ${destroot}${prefix}/bin/${x}
+    }
+    
+    xinstall -d -m 755 ${destroot}${prefix}/lib
+    xinstall -m 755 ${workpath}/build/packages/lib/libfdb_c.dylib \
+        ${destroot}${prefix}/lib
+
+    xinstall -d -m 755 ${destroot}${prefix}/libexec
+    xinstall -m 755 ${workpath}/build/packages/bin/fdbmonitor \
+        ${destroot}${prefix}/libexec
+
+    xinstall -d -m 755 ${destroot}${prefix}/sbin
+    xinstall -m 755 ${workpath}/build/packages/bin/fdbserver \
+        ${destroot}${prefix}/sbin
+
+    # install header files
+
+    xinstall -d -m 755 ${destroot}${prefix}/include/foundationdb
+    xinstall -m 755 ${worksrcpath}/bindings/c/foundationdb/fdb_c.h \
+        ${workpath}/build/bindings/c/foundationdb/fdb_c_options.g.h \
+        ${worksrcpath}/fdbclient/vexillographer/fdb.options \
+        ${destroot}${prefix}/include/foundationdb
+
+    # install sample config files and adjust paths
+
+    xinstall -d -m 755 ${destroot}${prefix}/etc/foundationdb
+    xinstall -m 755 ${worksrcpath}/packaging/osx/foundationdb.conf.new \
+        ${destroot}${prefix}/etc/foundationdb
+
+    reinplace "s|/usr/local/etc/|${prefix}/etc/|g" ${destroot}${prefix}/etc/foundationdb/foundationdb.conf.new
+    reinplace "s|/usr/local/libexec/|${prefix}/sbin/|g" ${destroot}${prefix}/etc/foundationdb/foundationdb.conf.new
+    reinplace "s|/usr/local/foundationdb/backup_agent/backup_agent|${prefix}/bin/backup_agent|g" ${destroot}${prefix}/etc/foundationdb/foundationdb.conf.new
+    reinplace "s|/usr/local/foundationdb/|${prefix}/foundationdb/|g" ${destroot}${prefix}/etc/foundationdb/foundationdb.conf.new
+}


### PR DESCRIPTION
New port for FoundationDB starting at version 6.3.12

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91 x86_64
Xcode 12.4 12D4e

macOS 10.15.7 19H114 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
