### PR TITLE
kitty: Build without `-Werror`

### DIFF
--- a/aqua/kitty/Portfile
+++ b/aqua/kitty/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 
 github.setup        kovidgoyal kitty 0.20.1 v
 github.tarball_from releases
-revision            1
+revision            2
 
 categories          aqua
 platforms           macosx
@@ -32,6 +32,9 @@ checksums           rmd160  f14a923892e26886f8079b3aaa39bcb362b21699 \
 
 use_xz              yes
 
+# Changes is already in master, remove the patch in next version
+patchfiles-append   patch-turn-off-werror.diff
+
 patchfiles-append   patch-kitty-no-deprecated-declarations.diff
 
 python.default_version \
@@ -47,7 +50,8 @@ depends_lib-append  port:harfbuzz
 
 build.cmd           "${python.bin} setup.py"
 build.target        kitty.app
-build.args-append   --verbose --update-check-interval=0
+build.args-append   --ignore-compiler-warnings \
+                    --update-check-interval=0 --verbose
 
 compiler.c_standard 2011
 

--- a/aqua/kitty/files/patch-kitty-no-deprecated-declarations.diff
+++ b/aqua/kitty/files/patch-kitty-no-deprecated-declarations.diff
@@ -1,11 +1,11 @@
 --- setup.py.orig
 +++ setup.py
-@@ -289,7 +289,7 @@
-         cppflags.append('-DDEBUG_{}'.format(el.upper().replace('-', '_')))
+@@ -294,7 +294,7 @@
+     march = '-march=native' if native_optimizations else ''
      cflags_ = os.environ.get(
          'OVERRIDE_CFLAGS', (
--            '-Wextra {} -Wno-missing-field-initializers -Wall -Wstrict-prototypes {}'
-+            '-Wextra {} -Wno-missing-field-initializers -Wno-deprecated-declarations -Wall -Wstrict-prototypes {}'
-             ' -pedantic-errors -Werror {} {} -fwrapv {} {} -pipe {} -fvisibility=hidden {}'
-         ).format(
-             float_conversion,
+-            f'-Wextra {float_conversion} -Wno-missing-field-initializers -Wall -Wstrict-prototypes {std}'
++            f'-Wextra {float_conversion} -Wno-missing-field-initializers -Wno-deprecated-declarations -Wall -Wstrict-prototypes {std}'
+             f' -pedantic-errors {werror} {optimize} {sanitize_flag} -fwrapv {stack_protector} {missing_braces}'
+             f' -pipe {march} -fvisibility=hidden {fortify_source}'
+         )

--- a/aqua/kitty/files/patch-turn-off-werror.diff
+++ b/aqua/kitty/files/patch-turn-off-werror.diff
@@ -1,0 +1,63 @@
+From 12763e19d84c40e1274de8868622f799ca3f6b88 Mon Sep 17 00:00:00 2001
+From: Kovid Goyal <kovid@kovidgoyal.net>
+Date: Sat, 24 Apr 2021 18:32:57 +0530
+Subject: [PATCH] Add a build argument to turn off -Werror
+
+--- setup.py.orig
++++ setup.py
+@@ -261,6 +261,7 @@ def init_env(
+     canberra_library: Optional[str] = None,
+     extra_logging: Iterable[str] = (),
+     extra_include_dirs: Iterable[str] = (),
++    ignore_compiler_warnings: bool = False
+ ) -> Env:
+     native_optimizations = native_optimizations and not sanitize and not debug
+     if native_optimizations and is_macos and is_arm:
+@@ -287,19 +288,15 @@ def init_env(
+     cppflags = shlex.split(cppflags_)
+     for el in extra_logging:
+         cppflags.append('-DDEBUG_{}'.format(el.upper().replace('-', '_')))
++    werror = '' if ignore_compiler_warnings else '-Werror'
++    std = '' if is_openbsd else '-std=c11'
++    sanitize_flag = ' '.join(sanitize_args)
++    march = '-march=native' if native_optimizations else ''
+     cflags_ = os.environ.get(
+         'OVERRIDE_CFLAGS', (
+-            '-Wextra {} -Wno-missing-field-initializers -Wall -Wstrict-prototypes {}'
+-            ' -pedantic-errors -Werror {} {} -fwrapv {} {} -pipe {} -fvisibility=hidden {}'
+-        ).format(
+-            float_conversion,
+-            '' if is_openbsd else '-std=c11',
+-            optimize,
+-            ' '.join(sanitize_args),
+-            stack_protector,
+-            missing_braces,
+-            '-march=native' if native_optimizations else '',
+-            fortify_source
++            f'-Wextra {float_conversion} -Wno-missing-field-initializers -Wall -Wstrict-prototypes {std}'
++            f' -pedantic-errors {werror} {optimize} {sanitize_flag} -fwrapv {stack_protector} {missing_braces}'
++            f' -pipe {march} -fvisibility=hidden {fortify_source}'
+         )
+     )
+     cflags = shlex.split(cflags_) + shlex.split(
+@@ -754,7 +751,7 @@ def init_env_from_args(args: Options, native_optimizations: bool = False) -> Non
+     env = init_env(
+         args.debug, args.sanitize, native_optimizations, args.link_time_optimization, args.profile,
+         args.egl_library, args.startup_notification_library, args.canberra_library,
+-        args.extra_logging, args.extra_include_dirs
++        args.extra_logging, args.extra_include_dirs, args.ignore_compiler_warnings
+     )
+ 
+ 
+@@ -1234,6 +1231,11 @@ def option_parser() -> argparse.ArgumentParser:  # {{{
+         action='store_false',
+         help='Turn off Link Time Optimization (LTO).'
+     )
++    p.add_argument(
++        '--ignore-compiler-warnings',
++        default=False, action='store_true',
++        help='Ignore any warnings from the compiler while building'
++    )
+     return p
+ # }}}
+ 


### PR DESCRIPTION
This should fix https://trac.macports.org/ticket/62732. Unfortunately, I cannot test this on macOS 10.12 or 10.13.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) on $(uname -m)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
