### PR TITLE
mame: update to 0.230

### DIFF
--- a/emulators/mame/Portfile
+++ b/emulators/mame/Portfile
@@ -62,14 +62,15 @@ if {${g_mame_os_major} >= 18} {
 
 if {${g_mame_latest}} {
     set g_mame_release \
-                    "0229"
+                    "0230"
 
     revision        0
 
     checksums       \
-                    rmd160  785ca63ce613fe79d3b33e1178730c47fc96b93e \
-                    sha256  414921771ada0804a8c7f3540e33338e8495e16a3bca78a5a2b355abafa51e6a \
-                    size    195637912
+                    rmd160  b8577137743aaedec17c9cf93719a0f1eec30e2a \
+                    sha256  39ea744a9a49acf10990dfc95094663201b8219255c439da4028c57490ab3488 \
+                    size    195819564
+
 } else {
     set g_mame_release \
                     "0226"


### PR DESCRIPTION
#### Description

Update Mame to 0.230

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
