### PR TITLE
nomacs: migrate to opencv4

### DIFF
--- a/aqua/nomacs/Portfile
+++ b/aqua/nomacs/Portfile
@@ -6,7 +6,7 @@ PortGroup               cmake 1.1
 PortGroup               github 1.0
 
 github.setup            nomacs nomacs 3.16.224
-revision                0
+revision                1
 checksums               rmd160  3bbf6f0939f86b024e27d2afaa7bebe71fe172b7 \
                         sha256  6a1b87a2873ea67f7ec87bfa4695cc0594af047234af86f4d19a30038e373240 \
                         size    1932553
@@ -24,17 +24,23 @@ categories              aqua graphics
 platforms               darwin
 homepage                https://nomacs.org
 
+set opencv_ver 4
+
 depends_lib-append      port:exiv2 \
                         port:libraw \
                         port:zlib \
                         port:tiff \
-                        port:opencv
+                        port:opencv${opencv_ver}
 qt5.depends_component   qtsvg qttools
 
 worksrcdir              ${worksrcdir}/ImageLounge
 
-configure.args-append   -DCMAKE_INSTALL_PREFIX="${applications_dir}"
-configure.args-append   -DQT_QMAKE_EXECUTABLE=${qt_qmake_cmd}
+cmake.module_path-append \
+                        ${prefix}/libexec/opencv${opencv_ver}/cmake
+
+configure.args-append   \
+                        -DCMAKE_INSTALL_PREFIX="${applications_dir}" \
+                        -DQT_QMAKE_EXECUTABLE=${qt_qmake_cmd}
 
 #give name consistent with other macOS applications
 #allow high resolution


### PR DESCRIPTION
#### Description

Migrate port from `opencv` to `opencv4`.

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G2136
Xcode 9.2 9C40b

macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
