### PR TITLE
mlt: migrate to opencv3

### DIFF
--- a/multimedia/mlt/Portfile
+++ b/multimedia/mlt/Portfile
@@ -8,7 +8,7 @@ PortGroup           active_variants 1.1
 github.setup        mltframework mlt 6.24.0 v
 github.tarball_from releases
 
-epoch               3
+epoch               4
 categories          multimedia
 maintainers         {dennedy.org:dan @ddennedy} {gmail.com:rjvbertin @RJVB} openmaintainer
 license             GPL-2+
@@ -158,8 +158,12 @@ variant gpl3 description {enable GPLv3 components} {
 # the opencv dependency must match our choice of Qt version, which is
 # another reason why opencv support is provided through a variant.
 variant opencv description {enable OpenCV support} {
-    depends_lib-append      port:opencv
-    configure.args-delete   --disable-opencv
+    set opencv_ver          3
+    depends_lib-append      port:opencv${opencv_ver}
+    configure.env-append    PKG_CONFIG_PATH=${prefix}/lib/opencv${opencv_ver}/pkgconfig
+    configure.args-replace  --disable-opencv \
+                            --enable-opencv
+
     if {[variant_isset qt4]} {
         require_active_variants opencv qt4
     } elseif {[variant_isset qt5]} {


### PR DESCRIPTION
#### Description

Migrate mlt from opencv, to opencv3

Specifically tested both the default install, as well as variant `+opencv`. For the latter, verified that opencv3 is being properly found during configure phase, and that binaries are linking to opencv3 shared libs.

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G2136
Xcode 9.2 9C40b

macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
