### PR TITLE
kitty: Fix build on macOS 10.12

### DIFF
--- a/aqua/kitty/Portfile
+++ b/aqua/kitty/Portfile
@@ -33,7 +33,8 @@ checksums           rmd160  f14a923892e26886f8079b3aaa39bcb362b21699 \
 use_xz              yes
 
 # Changes is already in master, remove the patch in next version
-patchfiles-append   patch-turn-off-werror.diff
+patchfiles-append   patch-turn-off-werror.diff \
+                    patch-fix-compilation-on-macos-10.12.diff
 
 patchfiles-append   patch-kitty-no-deprecated-declarations.diff
 

--- a/aqua/kitty/files/patch-fix-compilation-on-macos-10.12.diff
+++ b/aqua/kitty/files/patch-fix-compilation-on-macos-10.12.diff
@@ -1,0 +1,19 @@
+From: Luflosi <luflosi@luflosi.de>
+Date: Wed, 21 Apr 2021 16:23:42 +0200
+Subject: [PATCH] Fix compilation on macOS 10.12
+
+--- glfw/cocoa_window.m.orig
++++ glfw/cocoa_window.m
+@@ -32,6 +32,12 @@
+ #include <float.h>
+ #include <string.h>
+ 
++#if (MAC_OS_X_VERSION_MAX_ALLOWED < 101300)
++#define NSControlStateValueOn NSOnState
++#define NSControlStateValueOff NSOffState
++#define NSControlStateValueMixed NSMixedState
++#endif
++
+ 
+ static uint32_t
+ vk_code_to_functional_key_code(uint8_t key_code) {  // {{{


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
