### PR TITLE
sdrangel: migrate from opencv to opencv3

### DIFF
--- a/science/SDRangel/Portfile
+++ b/science/SDRangel/Portfile
@@ -20,7 +20,7 @@ github.setup          f4exb sdrangel 6.10.1 v
 checksums             rmd160  acd967dade21d5d6badfcba9f77afb3b34e2acdb \
                       sha256  6bb38bb384f027a6d100c230c9f59755dcb13da405aea21763fd5f841984b203 \
                       size    47338664
-revision              0
+revision              1
 
 # check just the version 6 branch for now
 github.livecheck.regex (6\[0-9.]*)
@@ -40,6 +40,8 @@ patchfiles-append     disable-remotetx.patch
 # revert https://github.com/f4exb/sdrangel/issues/492
 patchfiles-append     revert_cm256cc.patch
 
+set opencv_ver        3
+
 depends_lib-append \
     port:boost \
     port:codec2 \
@@ -50,7 +52,7 @@ depends_lib-append \
     path:lib/libusb.dylib:libusb \
     port:libiconv \
     port:libopus \
-    port:opencv \
+    port:opencv${opencv_ver} \
     port:serialDV
 
 qt5.depends_component \
@@ -82,6 +84,9 @@ configure.args-append \
     -DIconv_LIBRARY=${prefix}/lib/libiconv.dylib \
     -DIconv_INCLUDE_DIR=${prefix}/include \
     -DRX_SAMPLE_24BIT=ON
+
+cmake.module_path-append \
+    ${prefix}/libexec/opencv${opencv_ver}/cmake
 
 variant debug description {Enable debug messages} {
     configure.args-append   \


### PR DESCRIPTION
#### Description

Migrate port from `opencv` to `opencv3`.

Maintainers/Reviewers: Note that this is a transparent, drop-in change, as port `opencv3` is essentially identical to `opencv`. The only thing that differs, is where the headers and shared libraries are located.

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G2136
Xcode 9.2 9C40b

macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
