### PR TITLE
rclone: update to 1.55.1

### DIFF
--- a/net/rclone/Portfile
+++ b/net/rclone/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/ncw/rclone 1.55.0 v
+go.setup            github.com/ncw/rclone 1.55.1 v
 revision            0
 
 homepage            http://rclone.org
@@ -19,9 +19,9 @@ long_description \
 license             MIT
 
 checksums \
-    rmd160  4970c7f3851be9474654f5687554c698b0b0abf0 \
-    sha256  4002d10859ed910f4196db8dcc00732f75553aa972ea262884d69b649754d924 \
-    size    15068393
+    rmd160  f5246d1017603601638d846d11d613b06606ca18 \
+    sha256  df557d2f31842b7476600808e4582cd1e0e28580747275b9021c78cce7d4e9f8 \
+    size    15073386
 
 platforms           darwin
 installs_libs       no


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
