### PR TITLE
py-pymc3: add missing deps to py-semver and py-cachetools

### DIFF
--- a/python/py-pymc3/Portfile
+++ b/python/py-pymc3/Portfile
@@ -24,31 +24,21 @@ checksums           rmd160  75be7016d2aaaa1619c26230f105c3316bdb3799 \
                     sha256  7447b3f08f63fd2b5880582c7d7ffd51466f66720c747d4f0ae1cba6df59ca76 \
                     size    1958281
 
-python.versions     36 37 38 39
+python.versions     37 38 39
 
 if {${name} ne ${subport}} {
    depends_lib-append \
                     port:py${python.version}-arviz \
+                    port:py${python.version}-cachetools \
                     port:py${python.version}-dill \
                     port:py${python.version}-fastprogress \
                     port:py${python.version}-numpy \
                     port:py${python.version}-pandas \
                     port:py${python.version}-patsy \
                     port:py${python.version}-scipy \
+                    port:py${python.version}-semver \
                     port:py${python.version}-theano-pymc \
                     port:py${python.version}-typing_extensions
-
-    if {${python.version} == 36} {
-        github.setup    pymc-devs pymc3 3.10.0 v
-        revision        0
-        checksums       rmd160  52e9e6990d31c58087465455c9ba3769af2e29e9 \
-                        sha256  1a586003856fd3d17764e2ef538e2c362d854c5f92caafe8e4502b90fa6333f6 \
-                        size    104562192
-
-        depends_lib-append \
-                        port:py${python.version}-contextvars \
-                        port:py${python.version}-dataclasses
-    }
 
     livecheck.type      none
 } else {


### PR DESCRIPTION
#### Description

Add missing dependencies to py-semver and py-cachetools (otherwise "import pymc3" fails in Python interpreter 3.8).

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H524 x86_64
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
