### PR TITLE
opencv4: segregate pkgconfig, to avoid conflicts with other opencv ports

### DIFF
--- a/graphics/opencv4/Portfile
+++ b/graphics/opencv4/Portfile
@@ -8,7 +8,7 @@ PortGroup           github 1.0
 # Note: Dependent ports, like gmic, may need a rev-bump when updating opencv4
 github.setup        opencv opencv 4.5.2
 name                opencv4
-revision            0
+revision            1
 categories          graphics science
 platforms           darwin
 license             BSD
@@ -539,10 +539,34 @@ proc opencv_soft_link_binaries {p_bin_main_dir p_bin_port_dir p_destroot p_prefi
     return 0
 }
 
+proc opencv_fix_pkgconfig {p_destroot p_prefix p_subport p_parent_subport_name} {
+    if {${p_subport} eq ${p_parent_subport_name}} {
+        set pkgconfig_file \
+            "${p_destroot}${p_prefix}/lib/${p_parent_subport_name}/pkgconfig/opencv4.pc"
+
+        ui_debug "opencv_fix_pkgconfig: fixing pkgconfig file ${pkgconfig_file}"
+
+        # Fix paths
+        reinplace "s|\$\{exec_prefix\}\/||g" \
+            ${pkgconfig_file}
+        reinplace "s|\$\{prefix\}\/||g" \
+            ${pkgconfig_file}
+    }
+
+    return 0
+}
+
 proc opencv_post_destroot {} {
-    global prefix
     global destroot
+    global prefix
+    global subport
     global parent_subport_name
+
+    opencv_fix_pkgconfig \
+        ${destroot} \
+        ${prefix} \
+        ${subport} \
+        ${parent_subport_name}
 
     set bin_main_dir \
                     "${destroot}${prefix}/bin"
@@ -592,17 +616,6 @@ post-extract {
 post-destroot {
     ui_debug "${subport}: phase post-destroot running"
     opencv_post_destroot
-
-    if {${name} eq ${subport}} {
-        # Move opencv4.pc to standard location
-        xinstall -d ${destroot}${prefix}/lib/pkgconfig
-        move ${destroot}${prefix}/lib/opencv4/pkgconfig/opencv4.pc \
-             ${destroot}${prefix}/lib/pkgconfig/
-
-        # Fix paths in opencv4.pc
-        reinplace "s|\$\{exec_prefix\}\/||g" ${destroot}${prefix}/lib/pkgconfig/opencv4.pc
-        reinplace "s|\$\{prefix\}\/||g" ${destroot}${prefix}/lib/pkgconfig/opencv4.pc
-    }
 }
 
 if {[string match "py*" ${subport}]} {

--- a/graphics/opencv4/Portfile
+++ b/graphics/opencv4/Portfile
@@ -5,7 +5,6 @@ PortGroup           cmake 1.1
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 
-# Note: Dependent ports, like gmic, may need a rev-bump when updating opencv4
 github.setup        opencv opencv 4.5.2
 name                opencv4
 revision            1

--- a/science/gmic/Portfile
+++ b/science/gmic/Portfile
@@ -15,7 +15,7 @@ if {${subport} ne "gmic" && ${subport} ne "gmic-clib"} {
 
 name                gmic
 version             2.9.7
-revision            1
+revision            2
 license             CeCILL
 categories          science graphics
 platforms           darwin
@@ -96,6 +96,7 @@ if {${subport} eq ${name}} {
 
     variant opencv4 description {compile with OpenCV support} {
         configure.args-append   -DENABLE_OPENCV=ON
+        configure.env-append    PKG_CONFIG_PATH=${prefix}/lib/opencv4/pkgconfig
         configure.ldflags-append \
                                 -L${prefix}/lib/opencv4
 


### PR DESCRIPTION
#### Description

* opencv4: segregate pkgconfig, to avoid conflicts with other opencv ports
* gmic: use segregated opencv4 pkgconfig

Note to Maintainers/Reviewers:
* Sibling port opencv3 already uses a segregated pkgconfig, and this change ensures that opencv4 is consistent with that strategy.
* Port `gmic` was specifically tested with variant `+opencv4` enabled, to validate that opencv4 is found.
* Port `py-gmic` will need to be updated after this PR has been merged. Covered by: [PR 10820 - py-gmic: use segregated pkgconfig](https://github.com/macports/macports-ports/pull/10820)
* Port `auto-multiple-choice-devel` will need to be updated after this PR has been merged. Covered by: [PR 10804 - auto-multiple-choice-devel: use segregated opencv4 pkgconfig](https://github.com/macports/macports-ports/pull/10804)
* Other ports dependent upon opencv4 don't find it via pkgconfig, so this change won't affect them. However, I'm happy to rev-bump them anyway, just-in-case. (Preferably via separate PRs, otherwise the CI jobs are likely to fail due to timeout.)

Verified that the following dependent ports still build - and find/use opencv4 - after the change:
* gerbil
* nomacs
* openimageio
* py-pytorch

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G2136
Xcode 9.2 9C40b

macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
