### PR TITLE
auto-multiple-choice-devel: use segregated opencv4 pkgconfig

### DIFF
--- a/x11/auto-multiple-choice/Portfile
+++ b/x11/auto-multiple-choice/Portfile
@@ -37,11 +37,14 @@ if {${subport} eq ${name}} {
     set amc.version.main        1.5.0
     set amc.version.secondary   rc2-4-g4357dcbf
     version                 ${amc.version.main}_${amc.version.secondary}
+    revision                1
     checksums               rmd160  e258d7fb16af0b71f06573b0f088f730856bfdd0 \
                             sha256  a02734bf0177bae3fb72d34f80863c3dc0f74f2080244d22e50bc629cfa0c788 \
                             size    11125547
 
-    depends_lib-append      port:opencv4
+    set opencv_ver          4
+    depends_lib-append      port:opencv${opencv_ver}
+    build.env-append        PKG_CONFIG_PATH=${prefix}/lib/opencv${opencv_ver}/pkgconfig
 
     conflicts               auto-multiple-choice
 }


### PR DESCRIPTION
#### Description

auto-multiple-choice-devel: use segregated opencv4 pkgconfig

NOTE: This PR is dependent upon merging of [PR 10802 - opencv4: segregate pkgconfig, to avoid conflicts with other opencv ports](https://github.com/macports/macports-ports/pull/10802).

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G2136
Xcode 9.2 9C40b

macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
