### PR TITLE
wireguard-go: update to 0.0.20210424

### DIFF
--- a/net/wireguard-go/Portfile
+++ b/net/wireguard-go/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-go
-version             0.0.20210323
+version             0.0.20210424
 revision            0
-checksums           rmd160  b7937ac593f8636980c0a9a1fb83cbf61fe863f6 \
-                    sha256  88e864b28bbf4502bbef71c7a8483921f7888fdb09cff1dbc90e9551e1ab5e24 \
-                    size    105056
+checksums           rmd160  10dcd710cad724ebaa008d3c0db7571c3f1291ee \
+                    sha256  0f9a7c0657e6119d317a0bab453aeb5140111b186ae10f62cfa081eecf2f03ba \
+                    size    105496
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
#### Description
wireguard-go: update to 0.0.20210424

###### Tested on
macOS 10.15.7 19H524
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
