### PR TITLE
wireguard-tools: update to 1.0.20210424

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-tools
-version             1.0.20210315
+version             1.0.20210424
 revision            0
-checksums           rmd160  8934a827fc70e6b74c7931a6e5cc579f96fd0179 \
-                    sha256  af001d5492be6bf58ef0bebe04b446b6f50eb53e1226fab679cc34af40733a22 \
-                    size    96988
+checksums           rmd160  b624edd5f96e7e004cee91e9278b5f38d5ffc3a2 \
+                    sha256  b288b0c43871d919629d7e77846ef0b47f8eeaa9ebc9cedeee8233fc6cc376ad \
+                    size    96816
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
#### Description
wireguard-tools: update to 1.0.20210424

###### Tested on
macOS 10.15.7 19H524
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?