### PR TITLE
melonds: new port

### DIFF
--- a/emulators/melonds/Portfile
+++ b/emulators/melonds/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+PortGroup           qt5 1.0
+
+github.setup        Arisotura melonDS 0.9.2
+revision            0
+
+name                melonds
+platforms           darwin
+license             GPL-3
+maintainers         {gmail.com:audvare @Tatsh} openmaintainer
+categories          emulators games
+description         Nintendo DS emulator.
+long_description    {*}${description}
+
+checksums           rmd160  87d6585506c8abdae6bf7417708e1b30578b1927 \
+                    sha256  d20ce23725e63be5c60d42c87ed504015aa57ddf57c5161302c98e1837e9acae \
+                    size    1331032
+
+depends_lib-append  port:gettext \
+                    path:lib/pkgconfig/glib-2.0.pc:glib2 \
+                    port:libarchive \
+                    port:libepoxy \
+                    port:libiconv \
+                    port:libsdl2 \
+                    port:libslirp
+
+destroot {
+    move ${workpath}/build/melonDS.app ${destroot}${applications_dir}
+}
+
+if {${os.platform} eq "darwin" && ${os.major} < 18} {
+    post-install {
+        ui_warn "${name} @${version} is only supported on macOS 10.14 or later and may not work properly on your OS version."
+    }
+}


### PR DESCRIPTION
#### Description

Nintendo DS emulator.

[Homepage](http://melonds.kuribo64.net/)
[Repository](https://github.com/Arisotura/melonDS)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [x] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
