### PR TITLE
hwloc: update to 2.4.1; add new variants opencl and cuda

### DIFF
--- a/devel/hwloc/Portfile
+++ b/devel/hwloc/Portfile
@@ -5,7 +5,7 @@ PortGroup           active_variants 1.1
 
 name                hwloc
 set branch          2.4
-version             ${branch}.0
+version             ${branch}.1
 epoch               1
 categories          devel
 platforms           darwin
@@ -23,16 +23,27 @@ long_description \
 homepage            https://www.open-mpi.org/projects/hwloc/
 master_sites        https://www.open-mpi.org/software/hwloc/v${branch}/downloads/
 
-checksums           rmd160  863d1f1f78b20f8d3d370be8b85aa1c636be9233 \
-                    sha256  30404065dc1d6872b0181269d0bb2424fbbc6e3b0a80491aa373109554006544 \
-                    size    6965149
+checksums           rmd160  246a33becaaf623aec8d6fcdd6efd5864c248d72 \
+                    sha256  4267fe1193a8989f3ab7563a7499e047e77e33fed8f4dec16822a7aebcf78459 \
+                    size    6956102
 
 depends_build       port:pkgconfig
 depends_lib-append  port:libxml2
-configure.args      --without-x --disable-cairo
+configure.args      --without-x \
+                    --disable-cairo \
+                    --disable-cuda \
+                    --disable-opencl
 
 livecheck.type      regex
 livecheck.regex     "${name} v(\[0-9.\]+) "
+
+variant cuda description {Enable CUDA support} {
+    configure.args-replace  --disable-cuda --enable-cuda
+}
+
+variant opencl description {Enable OpenCL support} {
+    configure.args-replace  --disable-opencl --enable-opencl
+}
 
 variant gui description {Add graphical output capability} {
     depends_lib-append      path:bin/openssl:openssl \
@@ -48,3 +59,8 @@ variant gui description {Add graphical output capability} {
 }
 
 default_variants    +gui
+
+notes {
+  OpenCL and CUDA support is now disabled by default. They may be enabled by new\
+  variants opencl and cuda, respectively.
+}


### PR DESCRIPTION
#### Description

* Update hwloc to 2.4.1
* Explicitly disable OpenCL and CUDA support by default, to avoid issues with certain MacOS releases (like Big Sur).
* Add new variants `opencl` and `cuda`, to allow users to re-enable that functionality if desired.
* Add port note mentioning the change, along with the new variants.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G2136
Xcode 9.2 9C40b

macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
