### PR TITLE
retroarch: new port

### DIFF
--- a/emulators/retroarch/Portfile
+++ b/emulators/retroarch/Portfile
@@ -1,0 +1,46 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           xcode 1.0
+
+github.setup        libretro RetroArch 1.9.1 v
+revision            0
+
+name                retroarch
+platforms           darwin
+license             GPL-3
+maintainers         {gmail.com:audvare @Tatsh} openmaintainer
+categories          emulators games
+description         Frontend for the libretro API.
+long_description    {*}${description}
+
+checksums           rmd160  2c4f65be5cb1be55da9f242af9721c5098fe01dc \
+                    sha256  e1fb48a0c9f8ce4ca31699c9611727e3b04b127d7c7eb2de171809279681ddf3 \
+                    size    39878651
+
+# See https://github.com/libretro/RetroArch/issues/8641
+patchfiles          patch-${name}-library-dirs.diff
+
+xcode.project       ${worksrcpath}/pkg/apple/RetroArch.xcodeproj
+xcode.target        RetroArch
+xcode.destroot.settings \
+    CODE_SIGN_IDENTITY=- \
+    CODE_SIGN_STYLE=Manual \
+    ENABLE_HARDENED_RUNTIME=NO \
+    GCC_TREAT_WARNINGS_AS_ERRORS=NO
+
+# Compile and install in one step, for now. See https://trac.macports.org/ticket/57137
+build {}
+
+if {${os.platform} eq "darwin" && ${os.major} < 10} {
+    known_fail yes
+    pre-fetch {
+        ui_error "${name} @${version} requires Mac OS X 10.6 or later."
+        return -code error "incompatible Mac OS X version"
+    }
+}
+
+notes {
+    On first run, go to "Online Updater" and choose each item beginning with "Update" (e.g. "Update Core Info Files").
+}

--- a/emulators/retroarch/files/patch-retroarch-library-dirs.diff
+++ b/emulators/retroarch/files/patch-retroarch-library-dirs.diff
@@ -1,0 +1,125 @@
+--- configuration.c.old	2021-04-27 14:31:02.000000000 -0400
++++ configuration.c	2021-04-27 14:44:00.000000000 -0400
+@@ -1274,15 +1274,15 @@
+    SETTING_PATH("netplay_spectate_password",  settings->paths.netplay_spectate_password, false, NULL, true);
+ #endif
+    SETTING_PATH("libretro_directory",
+-         settings->paths.directory_libretro, false, NULL, false);
++         settings->paths.directory_libretro, false, "~/Library/Application Support/RetroArch/cores", false);
+    SETTING_PATH("core_options_path",
+          settings->paths.path_core_options, false, NULL, true);
+    SETTING_PATH("libretro_info_path",
+-         settings->paths.path_libretro_info, false, NULL, true);
++         settings->paths.path_libretro_info, false, "~/Library/Application Support/RetroArch/info", true);
+    SETTING_PATH("content_database_path",
+-         settings->paths.path_content_database, false, NULL, true);
++         settings->paths.path_content_database, false, "~/Library/Application Support/RetroArch/database/rdb", true);
+    SETTING_PATH("cheat_database_path",
+-         settings->paths.path_cheat_database, false, NULL, true);
++         settings->paths.path_cheat_database, false, "~/Library/Application Support/RetroArch/cht", true);
+ #ifdef HAVE_MENU
+    SETTING_PATH("menu_wallpaper",
+          settings->paths.path_menu_wallpaper, false, NULL, true);
+@@ -1290,15 +1290,15 @@
+          settings->paths.path_rgui_theme_preset, false, NULL, true);
+ #endif
+    SETTING_PATH("content_favorites_path",
+-         settings->paths.path_content_favorites, false, NULL, true);
++         settings->paths.path_content_favorites, false, "~/Library/Application Support/RetroArch/config/content_favorites.lpl", true);
+    SETTING_PATH("content_history_path",
+          settings->paths.path_content_history, false, NULL, true);
+    SETTING_PATH("content_image_history_path",
+-         settings->paths.path_content_image_history, false, NULL, true);
++         settings->paths.path_content_image_history, false, "~/Library/Application Support/RetroArch/config/content_image_history.lpl", true);
+    SETTING_PATH("content_music_history_path",
+-         settings->paths.path_content_music_history, false, NULL, true);
++         settings->paths.path_content_music_history, false, "~/Library/Application Support/RetroArch/config/content_music_history.lpl", true);
+    SETTING_PATH("content_video_history_path",
+-         settings->paths.path_content_video_history, false, NULL, true);
++         settings->paths.path_content_video_history, false, "~/Library/Application Support/RetroArch/config/content_video_history.lpl", true);
+ #ifdef HAVE_OVERLAY
+    SETTING_PATH("input_overlay",
+          settings->paths.path_overlay, false, NULL, true);
+@@ -1318,31 +1318,31 @@
+    SETTING_PATH("video_font_path",
+          settings->paths.path_font, false, NULL, true);
+    SETTING_PATH("cursor_directory",
+-         settings->paths.directory_cursor, false, NULL, true);
++         settings->paths.directory_cursor, false, "~/Library/Application Support/RetroArch/database/cursors", true);
+    SETTING_PATH("screenshot_directory",
+          settings->paths.directory_screenshot, true, NULL, true);
+    SETTING_PATH("system_directory",
+-         settings->paths.directory_system, true, NULL, true);
++         settings->paths.directory_system, true, "~/Library/Application Support/RetroArch/system", true);
+    SETTING_PATH("cache_directory",
+          settings->paths.directory_cache, false, NULL, true);
+    SETTING_PATH("input_remapping_directory",
+-         settings->paths.directory_input_remapping, false, NULL, true);
++         settings->paths.directory_input_remapping, false, "~/Library/Application Support/RetroArch/config/remaps", true);
+    SETTING_PATH("resampler_directory",
+          settings->paths.directory_resampler, false, NULL, true);
+    SETTING_PATH("video_shader_dir",
+-         settings->paths.directory_video_shader, true, NULL, true);
++         settings->paths.directory_video_shader, true, "~/Library/Application Support/RetroArch/shaders", true);
+    SETTING_PATH("video_filter_dir",
+-         settings->paths.directory_video_filter, true, NULL, true);
++         settings->paths.directory_video_filter, true, "~/Library/Application Support/RetroArch/video_filters", true);
+    SETTING_PATH("core_assets_directory",
+-         settings->paths.directory_core_assets, true, NULL, true);
++         settings->paths.directory_core_assets, true, "~/Library/Application Support/RetroArch/downloads", true);
+    SETTING_PATH("assets_directory",
+-         settings->paths.directory_assets, true, NULL, true);
++         settings->paths.directory_assets, true, "~/Library/Application Support/RetroArch/assets", true);
+    SETTING_PATH("dynamic_wallpapers_directory",
+          settings->paths.directory_dynamic_wallpapers, true, NULL, true);
+    SETTING_PATH("thumbnails_directory",
+          settings->paths.directory_thumbnails, true, NULL, true);
+    SETTING_PATH("playlist_directory",
+-         settings->paths.directory_playlist, true, NULL, true);
++         settings->paths.directory_playlist, true, "~/Library/Application Support/RetroArch/playlists", true);
+    SETTING_PATH("content_favorites_directory",
+          settings->paths.directory_content_favorites, true, NULL, true);
+    SETTING_PATH("content_history_directory",
+@@ -1356,26 +1356,26 @@
+    SETTING_PATH("runtime_log_directory",
+          settings->paths.directory_runtime_log, true, NULL, true);
+    SETTING_PATH("joypad_autoconfig_dir",
+-         settings->paths.directory_autoconfig, false, NULL, true);
++         settings->paths.directory_autoconfig, false, "~/Library/Application Support/RetroArch/autoconfig", true);
+    SETTING_PATH("audio_filter_dir",
+-         settings->paths.directory_audio_filter, true, NULL, true);
++         settings->paths.directory_audio_filter, true, "~/Library/Application Support/RetroArch/audio_filters", true);
+    SETTING_PATH("savefile_directory",
+-         dir_get_ptr(RARCH_DIR_SAVEFILE), true, NULL, false);
++         dir_get_ptr(RARCH_DIR_SAVEFILE), true, "~/Library/Application Support/RetroArch/saves", false);
+    SETTING_PATH("savestate_directory",
+-         dir_get_ptr(RARCH_DIR_SAVESTATE), true, NULL, false);
++         dir_get_ptr(RARCH_DIR_SAVESTATE), true, "~/Library/Application Support/RetroArch/states", false);
+ #ifdef HAVE_MENU
+    SETTING_PATH("rgui_browser_directory",
+          settings->paths.directory_menu_content, true, NULL, true);
+    SETTING_PATH("rgui_config_directory",
+-         settings->paths.directory_menu_config, true, NULL, true);
++         settings->paths.directory_menu_config, true, "~/Library/Application Support/RetroArch/config", true);
+ #endif
+ #ifdef HAVE_OVERLAY
+    SETTING_PATH("overlay_directory",
+-         settings->paths.directory_overlay, true, NULL, true);
++         settings->paths.directory_overlay, true, "~/Library/Application Support/RetroArch/overlays", true);
+ #endif
+ #ifdef HAVE_VIDEO_LAYOUT
+    SETTING_PATH("video_layout_directory",
+-         settings->paths.directory_video_layout, true, NULL, true);
++         settings->paths.directory_video_layout, true, "~/Library/Application Support/RetroArch/layouts", true);
+ #endif
+    SETTING_PATH(
+          "screenshot_directory",
+@@ -1392,7 +1392,7 @@
+       }
+    }
+ 
+-   SETTING_ARRAY("log_dir", settings->paths.log_dir, true, NULL, true);
++   SETTING_ARRAY("log_dir", settings->paths.log_dir, true, "~/Library/Application Support/RetroArch/logs", true);
+ 
+    *size = count;
+ 


### PR DESCRIPTION
#### Description

RetroArch expects to be able to write downloaded cores and other 'system' data into the app bundle and this is not a normal behaviour in any other macOS app especially now with app bundle integrity checks. Because of this and because MacPorts installs with files certain permissions, this version has a patch applied that sets default directories to be in `~/Library/Application Support/RetroArch`.

This will allow downloading cores on first launch without needing extra configuration, and without writing into `~/Documents` (a fallback path).

The alternative to downloading cores is to have ports for each core. This should be encouraged when cores are stable, but they do not have to be in this package or even reference it as a dependency.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
