### PR TITLE
libreoffice: use ui_error instead of notes

### DIFF
--- a/office/libreoffice/Portfile
+++ b/office/libreoffice/Portfile
@@ -148,10 +148,10 @@ if {${os.platform} eq "darwin" && ${os.major} < 19} {
     known_fail yes
     pre-fetch {
         ui_error "Building ${name} @${version} requires macOS 10.15 or later."
-        notes-append "
-Consider downloading a version from LibreOffice's website:
-https://www.libreoffice.org/download/download/
-"
+        ui_error ""
+        ui_error "Consider downloading a version from LibreOffice's website:"
+        ui_error "https://www.libreoffice.org/download/download/"
+        ui_error ""
         return -code error "incompatible OS X version"
     }
 }


### PR DESCRIPTION
#### Description

https://github.com/macports/macports-ports/commit/09f30de98a117fc682d254d1a6ebda33172eab64#r50079028

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
