### PR TITLE
py-gmic: use segregated opencv4 pkgconfig

### DIFF
--- a/python/py-gmic/Portfile
+++ b/python/py-gmic/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-gmic
 version             2.9.4-alpha1
-revision            2
+revision            3
 
 # gmic and py-gmic should be the same version
 set gmic_version    2.9.4
@@ -60,6 +60,9 @@ if {${name} ne ${subport}} {
                     port:xorg-libice \
                     port:xorg-libsm \
                     port:zlib
+
+    build.env-append \
+                    PKG_CONFIG_PATH=${prefix}/lib/opencv4/pkgconfig
 
     patch.dir       ${build.dir}
     patchfiles      patch-setup.py.diff


### PR DESCRIPTION
#### Description

py-gmic: use segregated opencv4 pkgconfig

NOTE: This PR is dependent upon merging of [PR 10802 - opencv4: segregate pkgconfig, to avoid conflicts with other opencv ports](https://github.com/macports/macports-ports/pull/10802).

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G2136
Xcode 9.2 9C40b

macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
