### PR TITLE
foundationdb: configure cmake to use python39 port

### DIFF
--- a/databases/foundationdb/Portfile
+++ b/databases/foundationdb/Portfile
@@ -28,7 +28,12 @@ checksums           rmd160  2bf9a258d5db140d232fb6355fc810010824c014 \
 depends_lib-append  port:mono
 depends_build-append port:python39
 
-# The FoundationDB build can easily run out of memory and crash, 
+# make sure FoundationDB uses python from the python3.9 port
+pre-configure {
+    configure.env     PYTHON_ROOT_DIR=${prefix}/bin/python3.9
+}
+
+# The FoundationDB build can easily run out of memory and crash,
 # so the recommendation is to use "ninja -j1" when building.
 use_parallel_build  no
 cmake.generator     Ninja


### PR DESCRIPTION
#### Description

Configure `cmake` to always use python installed from `port:python39`. The `foundationdb` port build depends on `port:python39` but `cmake` was allowed to find the python to use on its own when could result in inconsistent behavior.

Also cleaned out a trailing whitespace to make `port lint` happy.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91 x86_64
Xcode 12.4 12D4e

macOS 10.15.7 19H114 x86_64
Xcode 12.4 12D4e

macOS 10.14.6 18G8022 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
