### PR TITLE
josm: update to 17833

### DIFF
--- a/gis/JOSM/Portfile
+++ b/gis/JOSM/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                JOSM
-version             17702
+version             17833
 categories          gis editors java
 platforms           darwin
 license             GPL-2+
@@ -19,9 +19,9 @@ homepage            https://josm.openstreetmap.de
 master_sites        ${homepage}/download/macosx/
 distname            josm-macos-${version}-java16
 
-checksums           rmd160  5b29910ff0c19f515a5ea0ba9e3ee41a532719f0 \
-                    sha256  f3da34654b4eb88f3e2f0d27c38b5c60e993731234ce8ad6f4a2a0dae1652764 \
-                    size    39723069
+checksums           rmd160  7119b463e0dddb9f6fe2e60111dae95767a73c3b \
+                    sha256  3ccff0357aad1306a5868ad61ea5475ac6a21afeb4485ac75d9adbd4cc3f42a4 \
+                    size    39774608
 
 extract.mkdir       yes
 


### PR DESCRIPTION
#### Description
[2021-04-28: Stable release 17833](https://josm.openstreetmap.de/wiki/Changelog#stable-release-21.04)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
