### PR TITLE
py-ansible: Further performance tweak to patch

### DIFF
--- a/python/py-ansible/Portfile
+++ b/python/py-ansible/Portfile
@@ -37,12 +37,14 @@ python.versions 27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
     patch {
-        foreach f [ exec find ${worksrcpath} -type f \
-                    {(} -name "*.py" -or -name "*.yml" -or -name "*.yaml" {)} \
-                    -exec grep -lE {/etc/ansible|/usr/share/ansible} {{}} {;} ] {
-            reinplace -q "s#/etc/ansible#${prefix}/etc/ansible#g" ${f}
-            reinplace -q "s#/usr/share/ansible#${prefix}/share/ansible#g" ${f}
-        }
+        # This is a little ugly, but it works, and it is over 10x faster on
+        # systems with anti-virus than using a foreach (even a foreach limited
+        # to matching files).
+        system -W ${worksrcpath} \
+            "find -E . -type f -regex '.*\.(py|ya?ml)' \
+                  -exec egrep -l '(/etc|/usr/share)/ansible' '{}' '+' |
+             xargs sed -i '' -e 's^/etc/ansible^${prefix}/etc/ansible^g' \
+                       -e 's^/usr/share/ansible^${prefix}/share/ansible^g'"
     }
     depends_lib-append  port:py${python.version}-ansible-base
     livecheck.type  none


### PR DESCRIPTION
This further improves (building on 63bac4a947 from @tsabirgaliev) the time required to patch py*-ansible; from 200s to 14s on my 2019 MBP with Apex One anti-virus software. (I'm guessing the AV software may have something to do with it.)

This uses:
 * a single excecution of find
 * multiple (from find) executions of egrep as needed, but as few as possible (multiple files per execution)
 * a single execution of xargs
 * (via xargs) multiple executions of sed as needed, again with multiple files each time / as few executions as possible, and with both replace steps in each execution.