### PR TITLE
mpg123: update license

### DIFF
--- a/audio/mpg123/Portfile
+++ b/audio/mpg123/Portfile
@@ -8,7 +8,7 @@ version             1.26.5
 revision            0
 categories          audio
 maintainers         nomaintainer
-license             GPL-2 LGPL-2.1
+license             LGPL-2.1
 
 description         fast mp3 player for linux and unix systems
 long_description \


### PR DESCRIPTION
#### Description

mpg123 used to be part LGPL-2.1 and part GPL-2. See `doc/ROAD_TO_LGPL` in the source distribution. The last GPL-2 bit was removed in 1.16.0. See the entry in the `NEWS` file.

Since GPL-2 (note _not_ GPL-2+!) is incompatible with GPL-3, the indicated licensing was blocking some dependent ports from being distributed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
