### PR TITLE
webkit-gtk: Fix build failure with bison-3.7.x

### DIFF
--- a/www/webkit-gtk/Portfile
+++ b/www/webkit-gtk/Portfile
@@ -77,7 +77,8 @@ patchfiles          clang-assertions.patch \
                     libedit.patch \
                     remove-cf-available.patch \
                     RenderThemeGtk2-toRenderBox.patch \
-                    patch-icu_fix.diff
+                    patch-icu_fix.diff \
+                    bison-3.7.patch
 
 conflicts_build     google-test
 

--- a/www/webkit-gtk/files/bison-3.7.patch
+++ b/www/webkit-gtk/files/bison-3.7.patch
@@ -1,0 +1,9 @@
+--- Source/WebCore/css/makegrammar.pl.orig	2021-04-28 22:41:03.000000000 +0300
++++ Source/WebCore/css/makegrammar.pl	2021-04-28 22:42:11.000000000 +0300
+@@ -91,5 +91,5 @@
+ close HEADER;
+ 
+ unlink("$fileBase.cpp.h");
+-unlink("$fileBase.hpp");
++# not working for bison-3.7.x: unlink("$fileBase.hpp");
+ 


### PR DESCRIPTION
#### Description

This is a patch that fixes https://trac.macports.org/ticket/60977.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14042 x86_64
Xcode 9.4.1 9F2000

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
