### PR TITLE
ctags: update license to indicate that the library part is public domain

### DIFF
--- a/devel/ctags/Portfile
+++ b/devel/ctags/Portfile
@@ -12,7 +12,14 @@ checksums           rmd160  191495869fbfa2f77a9619a4920eba26d02eface \
 categories          devel
 platforms           darwin freebsd
 maintainers         nomaintainer
-license             GPL-2
+
+# This port contains two components:
+#  - The ctags executable, which is GPL-2.
+#  - The readtags library, which is the only part that can be linked to,
+#    and is public domain.
+# The following license specification avoids license conflicts with
+# GPL-2-incompatible ports that link to readtags.
+license             {GPL-2 public-domain}
 
 # developer_cmds installs BSD ctags.
 conflicts           developer_cmds


### PR DESCRIPTION
#### Description

The library part of `ctags` is public domain. This change avoids license conflicts for library-dependents of ctags.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
