### PR TITLE
py-configparser: update to 5.0.2

### DIFF
--- a/python/py-configparser/Portfile
+++ b/python/py-configparser/Portfile
@@ -5,37 +5,48 @@ PortGroup           python 1.0
 
 name                py-configparser
 epoch               1
-version             4.0.2
+version             5.0.2
 revision            0
+
 categories-append   devel
 platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27
-
-maintainers         {stromnov @stromnov} openmaintainer
+homepage            https://github.com/jaraco/configparser
 
 description         Configparser from Python 3.8 to Python 2.6-3.7
 long_description    ${description}
 
-homepage            https://github.com/jaraco/configparser/
-master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+maintainers         {stromnov @stromnov} openmaintainer
 
-distname            ${python.rootname}-${version}
-
-checksums           rmd160  9b6a5b12490e72c47ce2b1d190a35687c2d2c7eb \
-                    sha256  c7d282687a5308319bf3d2e7706e575c635b0a470342641c93bea0ea3b5331df \
-                    size    72498
-
-# 4.0.2 is the last py27-compatible version
-livecheck.type      none
+python.versions     27 39
 
 if {${name} ne ${subport}} {
+
+    # 4.0.2 is the last py27-compatible version
+    if {${python.version} == 27} {
+        version             4.0.2
+
+        depends_lib-append  port:py${python.version}-backports
+
+        distname            ${python.rootname}-${version}
+
+        checksums           rmd160  9b6a5b12490e72c47ce2b1d190a35687c2d2c7eb \
+                            sha256  c7d282687a5308319bf3d2e7706e575c635b0a470342641c93bea0ea3b5331df \
+                            size    72498
+    } else {
+        depends_build-append \
+                            port:py${python.version}-toml
+
+        checksums           rmd160  4ff3a2f5f7313e1df0459a7a75b114acbd4caf58 \
+                            sha256  85d5de102cfe6d14a5172676f09d19c465ce63d6019cf0a4ef13385fc535e828 \
+                            size    71248
+    }
+
     depends_build-append \
                         port:py${python.version}-setuptools \
                         port:py${python.version}-setuptools_scm
-    depends_lib-append  port:py${python.version}-backports
 
     post-destroot {
         foreach f {__init__.py __init__.pyc __init__.pyo __pycache__} {
@@ -45,4 +56,6 @@ if {${name} ne ${subport}} {
             }
         }
     }
+
+    livecheck.type      none
 }


### PR DESCRIPTION
- Add Python 3.9 subport

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1030 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
