### PR TITLE
vf-1: bump default python version to 39

### DIFF
--- a/net/vf-1/Portfile
+++ b/net/vf-1/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-name                vf-1
 github.setup        solderpunk vf-1 0.0.11 v
+revision            1
 categories          net python
 platforms           darwin
 license             BSD
@@ -21,7 +21,7 @@ long_description    A full-featured gopher client. VF-1's features include:\
 
 github.tarball_from archive
 
-python.default_version     38
+python.default_version     39
 
 checksums           rmd160  2f569ef10cc28a21a18b099fdecd3f1ec774cff4 \
                     sha256  021d2020cddb5ef83e9c26038df95bbb4a6ad9c4cdc7303cbda9c4129856db0e \


### PR DESCRIPTION
#### Description

bump default python version to 3.9

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. macOS 11.3 20E232 x86_64
Xcode 12.4 12D4e


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
