### PR TITLE
openmpi: update to 4.1.1; add new variants heterogeneous and mpi1; enable use of published binaries for all compiler-specific subports

### DIFF
--- a/science/openmpi/Portfile
+++ b/science/openmpi/Portfile
@@ -7,9 +7,23 @@ PortGroup           compilers 1.0
 PortGroup           muniversal 1.0
 PortGroup           legacysupport 1.0
 
+#===============================================================================
+#
+# *** IMPORTANT NOTE ***
+#
+# When making logic changes to this port, PLEASE review port 'mpich' to see
+# if the same changes should be applied. While the subports and variants aren't
+# exactly the same between the two - and things like configure arguments
+# certainly differ, as they're different code bases - much of the core logic
+# is very similar. (And often identical.)
+#
+# Please help us avoid divergent MPI ports, which cause serious migraines.
+#
+#===============================================================================
+
 name                openmpi
-version             4.1.0
-revision            1
+version             4.1.1
+revision            0
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          science parallel net
 platforms           darwin
@@ -29,9 +43,9 @@ homepage            https://www.open-mpi.org/
 set subdir          ompi/v${branch}/downloads/
 master_sites        https://www.open-mpi.org/software/${subdir}
 
-checksums           rmd160  15e3b5429e74f0f39a46ca0cc35de92b68ea21d0 \
-                    sha256  73866fb77090819b6a8c85cb8539638d37d6877455825b74e289d647a39fd5b5 \
-                    size    10022171
+checksums           rmd160  60fff94c4c7a4bfaaa11285f35d76265516ed8b0 \
+                    sha256  e24f7a778bd11a71ad0c14587a7f5b00e68a71aa5623e2157bafee3d44c07cda \
+                    size    10052770
 
 use_bzip2           yes
 
@@ -185,13 +199,35 @@ if {${cname} in ${clist_unsupported}} {
         set cname                   mp
     }
 
-    # Force buildbot to skip this since openmpi depends on hwloc and that would
-    # be different for a user's machine
-    archive_sites
+    # As we are making wrappers, we depend on the compilers to exist.
+    # Add them to depends_lib, not just depends_build.
+    if {[regexp {clang[3-9]\d} ${cname}] == 1} {
+        # Ports for Clang versions < 10 are named: clang-<major>.<minor>
+        set cport_name          [regsub {(\d)(\d)} ${cname} {-\1.\2}]
+    } elseif {[regexp {clang\d\d} ${cname}] == 1} {
+        # Ports for Clang version >= 10 are named: clang-<major><minor>
+        set cport_name          [regsub {(\d)(\d)} ${cname} {-\1\2}]
+    } elseif {([regexp {gcc\d} ${cname}] == 1) || ([regexp {gcc\d\d} ${cname}] == 1)} {
+        # Ports for GCC have names exactly matching our subports, so use as-is
+        set cport_name          ${cname}
+    }
+    if {[info exists cport_name]} {
+        ui_debug "Adding compiler to depends_lib: ${cport_name}"
+        depends_lib-append      port:${cport_name}
+        unset cport_name
+    }
+
+    if {[lsearch -exact {mp llvm clang} ${cname}] != -1} {
+        # Force local builds with Xcode-provided compilers (avoid issues with
+        # different Xcode versions on buildbot and user machines)
+        ui_debug "Disabling binary use for subport: ${subport}"
+        archive_sites
+    }
 
     depends_build-append        port:pkgconfig
     depends_lib-append          port:hwloc \
-                                port:libevent
+                                port:libevent \
+                                port:zlib
     depends_run                 port:mpi_select port:mpi-doc
     select.group                mpi
     select.file                 ${filespath}/${name}-${cname}
@@ -214,7 +250,8 @@ if {${cname} in ${clist_unsupported}} {
         --docdir=${prefix}/share/docdelete \
         --mandir=${prefix}/share/mandelete \
         --with-hwloc=${prefix} \
-        --with-libevent=${prefix}
+        --with-libevent=${prefix} \
+        --with-zlib=${prefix}
 
     post-destroot {
         if {[string first "-devel" $subport] > 0} {
@@ -302,6 +339,14 @@ you execute 'mpicc' etc.) please run:
     variant valgrind description {enable valgrind support} {
         depends_lib-append    path:${prefix}/lib/pkgconfig/valgrind.pc:valgrind
         configure.args-append --enable-debug --enable-memchecker --with-valgrind=${prefix}
+    }
+
+    variant heterogeneous description {enable heterogeneous support} {
+        configure.args-append --enable-heterogeneous
+    }
+
+    variant mpi1 description {enable legacy mpi1 compatibility} {
+        configure.args-append --enable-mpi1-compatibility
     }
 
     if {![info exists universal_possible]} {


### PR DESCRIPTION
#### Description

* Update `openmpi` to 4.1.1. In addition to general bug fixes, upstream also fixed Big Sur ARM builds.
* Add new variants `heterogeneous` and `mpi1`
* Enable use of published binaries for all compiler-specific subports, to match mpich
* Add lib dependency for zlib, and corresponding configure flag
* Ensure target compilers are added to depends_lib

Fixes Included:
* [62795 - openmpi: declare lib dependency on target compiler](https://trac.macports.org/ticket/62795)
* [62788 - openmpi: opportunistically uses zlib; add formal dependency and configure flag](https://trac.macports.org/ticket/62788)
* [62783 - openmpi: validate that buildbot binaries are hardware-independent](https://trac.macports.org/ticket/62783)
* [62214 - openmpi-default +gccdevel fails to build on aarch64 with "error: address argument to atomic operation must be a pointer to integer or pointer"](https://trac.macports.org/ticket/62214)
* [62070 - mpif90-openmpi-gcc10 fails to link FORTRAN program](https://trac.macports.org/ticket/62070)
* [59547 - openmpi-gcc9 & enable-mpi1-compatibility](https://trac.macports.org/ticket/59547)

Reviewers/Maintainers:
* Given the number of subports that need to be built, there's little chance that the CI jobs will complete successfully. (Though I won't complain if they do!)
* The use of published binaries has been thoroughly researched, and tested. See ticket: [62783 - openmpi: validate that buildbot binaries are hardware-independent](https://trac.macports.org/ticket/62783)

###### Type(s)
- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G2136
Xcode 9.2 9C40b

macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
