### PR TITLE
openjdk: update to latest versions

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -13,16 +13,6 @@ supported_archs  x86_64
 # Latest Long Term Support (LTS) major version
 version          11
 
-if {${subport} eq "openjdk"} {
-    # The openjdk port is not installable, but recommends users to install the latest Long Term Support (LTS) subport
-    PortGroup    obsolete 1.0
-    replaced_by  openjdk${version}
-}
-
-# Dummy default values for the obsoleted openjdk port
-set build        0
-set openj9_version 0
-
 set long_description_adoptopenjdk_intro \
    "OpenJDK build provided by AdoptOpenJDK, built from a fully open-source set of build scripts and infrastructure."
 
@@ -47,6 +37,39 @@ set long_description_zulu \
     specification that contains all the Java components needed to build and run Java SE applications. Zulu has been\
     verified by passing all tests of the OpenJDK Community Technology Compatibility Kit (TCK) as available for each\
     respective Java SE version."
+
+# Dummy default values for the obsoleted openjdk port
+set build        0
+set openj9_version 0
+
+set obsoleted_ports {
+    openjdk
+    openjdk8-openj9-large-heap
+    openjdk10
+    openjdk11-openj9-large-heap
+    openjdk12
+    openjdk12-openj9
+    openjdk12-openj9-large-heap
+    openjdk13
+    openjdk13-openj9
+    openjdk13-openj9-large-heap
+    openjdk14
+    openjdk14-openj9
+    openjdk14-openj9-large-heap
+    openjdk15
+    openjdk15-openj9
+    openjdk15-openj9-large-heap
+}
+
+if {${subport} in ${obsoleted_ports}} {
+    PortGroup    obsolete 1.0
+
+}
+
+if {${subport} eq "openjdk"} {
+    # The openjdk port is not installable, but recommends users to install the latest Long Term Support (LTS) subport
+    replaced_by  openjdk${version}
+}
 
 subport openjdk8 {
     version      8u292
@@ -85,11 +108,11 @@ subport openjdk8-graalvm {
 }
 
 subport openjdk8-openj9 {
-    version      8u282
-    revision     1
+    version      8u292
+    revision     0
 
-    set build    08
-    set openj9_version 0.24.0
+    set build    10
+    set openj9_version 0.26.0
 
     description  Open Java Development Kit 8 (AdoptOpenJDK) with Eclipse OpenJ9 VM
     long_description ${long_description_adoptopenjdk_openj9}
@@ -98,9 +121,9 @@ subport openjdk8-openj9 {
     distname     OpenJDK8U-jdk_x64_mac_openj9_${version}b${build}_openj9-${openj9_version}
     worksrcdir   jdk${version}-b${build}
 
-    checksums    rmd160  b66caafe41d50052fa438dfcef5fdf58430f42c8 \
-                 sha256  265d4fb01b61ed7a3a9fae6a50bcf6322687b5f08de8598d8e42263cbd8b5772 \
-                 size    115586057
+    checksums    rmd160  15c82bb986080025de06ddaab2e08a4a493fb389 \
+                 sha256  d262bc226895e80b7e80d61905e65fe043ca0a3e3b930f7b88ddfacb8835e939 \
+                 size    118492789
 }
 
 subport openjdk8-zulu {
@@ -123,31 +146,17 @@ subport openjdk8-zulu {
                  size    108162260
 }
 
+# Remove after 2022-04-30
 subport openjdk8-openj9-large-heap {
     version      8u282
-    revision     1
-
-    set build    08
-    set openj9_version 0.24.0
-
-    description  Open Java Development Kit 8 (AdoptOpenJDK) with Eclipse OpenJ9 VM for large heap sizes
-    long_description ${long_description_adoptopenjdk_openj9xl}
-
-    master_sites https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
-    distname     OpenJDK8U-jdk_x64_mac_openj9_macosXL_${version}b${build}_openj9-${openj9_version}
-    worksrcdir   jdk${version}-b${build}
-
-    checksums    rmd160  e4797c143ca666baa428a252bb130251af25a1b2 \
-                 sha256  64f2b106bc5c65ed963a72893e3d676df58704718dd86fc0fcbbb61e615e4742 \
-                 size    116297701
+    revision     2
+    replaced_by  openjdk8-openj9
 }
 
 # Remove after 2021-11-28
 subport openjdk10 {
     version      10.0.2
     revision     3
-
-    PortGroup    obsolete 1.0
     replaced_by  openjdk11
 }
 
@@ -186,11 +195,11 @@ subport openjdk11-graalvm {
 }
 
 subport openjdk11-openj9 {
-    version      11.0.10
-    revision     1
+    version      11.0.11
+    revision     0
 
     set build    9
-    set openj9_version 0.24.0
+    set openj9_version 0.26.0
 
     description  Open Java Development Kit 11 (AdoptOpenJDK) with Eclipse OpenJ9 VM
     long_description ${long_description_adoptopenjdk_openj9}
@@ -199,28 +208,16 @@ subport openjdk11-openj9 {
     distname     OpenJDK11U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
     worksrcdir   jdk-${version}+${build}
 
-    checksums    rmd160  68da07a92466f0ce17d814e29f20985b95689853 \
-                 sha256  58f931dc30160b04da2d94af32e0dfa384f4b2cf92b7217c0937fd057e668d54 \
-                 size    196594593
+    checksums    rmd160  32a90e5a4a660b5e62a12c998a4ac4282334b2a3 \
+                 sha256  797cee6b9f6e18bcc026ee9dcebbce81d62ca897038402d247630b25d41efe15 \
+                 size    202089267
 }
 
+# Remove after 2022-04-30
 subport openjdk11-openj9-large-heap {
     version      11.0.10
-    revision     1
-
-    set build    9
-    set openj9_version 0.24.0
-
-    description  Open Java Development Kit 11 (AdoptOpenJDK) with Eclipse OpenJ9 VM for large heap sizes
-    long_description ${long_description_adoptopenjdk_openj9xl}
-
-    master_sites https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
-    distname     OpenJDK11U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
-    worksrcdir   jdk-${version}+${build}
-
-    checksums    rmd160  66e4e36eb013a66d7970c3874046b80e771cd36d \
-                 sha256  ac6998c1a7945dab9d008e3702a69ed86488321aea197961f72375e8bc8bc114 \
-                 size    195829115
+    revision     2
+    replaced_by  openjdk11-openj9
 }
 
 subport openjdk11-zulu {
@@ -245,36 +242,42 @@ subport openjdk11-zulu {
 subport openjdk12 {
     version      12.0.2
     revision     1
+    replaced_by  openjdk16
 }
 
 # Remove after 2022-02-15
 subport openjdk12-openj9 {
     version      12.0.2
     revision     1
+    replaced_by  openjdk16-openj9
 }
 
 # Remove after 2022-02-15
 subport openjdk12-openj9-large-heap {
     version      12.0.2
     revision     1
+    replaced_by  openjdk16-openj9
 }
 
 # Remove after 2022-02-15
 subport openjdk13 {
     version      13.0.2
     revision     1
+    replaced_by  openjdk16
 }
 
 # Remove after 2022-02-15
 subport openjdk13-openj9 {
     version      13.0.2
     revision     1
+    replaced_by  openjdk16-openj9
 }
 
 # Remove after 2022-02-15
 subport openjdk13-openj9-large-heap {
     version      13.0.2
     revision     1
+    replaced_by  openjdk16-openj9
 }
 
 subport openjdk13-zulu {
@@ -299,36 +302,42 @@ subport openjdk13-zulu {
 subport openjdk14 {
     version      14.0.2
     revision     1
+    replaced_by  openjdk16
 }
 
 # Remove after 2022-02-15
 subport openjdk14-openj9 {
     version      14.0.2
     revision     1
+    replaced_by  openjdk16-openj9
 }
 
 # Remove after 2022-02-15
 subport openjdk14-openj9-large-heap {
     version      14.0.2
     revision     1
+    replaced_by  openjdk16-openj9
 }
 
 # Remove after 2022-03-22
 subport openjdk15 {
     version      15.0.2
     revision     1
+    replaced_by  openjdk16
 }
 
 # Remove after 2022-03-22
 subport openjdk15-openj9 {
     version      15.0.2
     revision     1
+    replaced_by  openjdk16-openj9
 }
 
 # Remove after 2022-03-22
 subport openjdk15-openj9-large-heap {
     version      15.0.2
     revision     1
+    replaced_by  openjdk16-openj9
 }
 
 subport openjdk15-zulu {
@@ -350,21 +359,21 @@ subport openjdk15-zulu {
 }
 
 subport openjdk16 {
-    version      16
-    revision     1
+    version      16.0.1
+    revision     0
 
-    set build    36
+    set build    9
 
     description  Open Java Development Kit 16 (AdoptOpenJDK) with HotSpot VM
     long_description ${long_description_adoptopenjdk_hotspot}
 
     master_sites https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-${version}%2B${build}/
-    distname     OpenJDK16-jdk_x64_mac_hotspot_${version}_${build}
+    distname     OpenJDK16U-jdk_x64_mac_hotspot_${version}_${build}
     worksrcdir   jdk-${version}+${build}
 
-    checksums    rmd160  7ef653cce09364235a659cc9dd721281fec95d98 \
-                 sha256  b66761b55fd493ed2a5f4df35a32b338ec34a9e0a1244439e3156561ab27c511 \
-                 size    199955659
+    checksums    rmd160  267a6b47ffc2edccb827acf01bca5fde6e029861 \
+                 sha256  3be78eb2b0bf0a6edef2a8f543958d6e249a70c71e4d7347f9edb831135a16b8 \
+                 size    199997543
 }
 
 subport openjdk16-graalvm {
@@ -384,29 +393,29 @@ subport openjdk16-graalvm {
 }
 
 subport openjdk16-openj9 {
-    version      16
-    revision     1
+    version      16.0.1
+    revision     0
 
-    set build    36
-    set openj9_version 0.25.0
+    set build    9
+    set openj9_version 0.26.0
 
     description  Open Java Development Kit 16 (AdoptOpenJDK) with Eclipse OpenJ9 VM
     long_description ${long_description_adoptopenjdk_openj9}
 
     master_sites https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
-    distname     OpenJDK16-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
+    distname     OpenJDK16U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
     worksrcdir   jdk-${version}+${build}
 
-    checksums    rmd160  94087f2b59cc2a27d289488f7b76a714a57706b5 \
-                 sha256  e6075cbe939b4de165cc8b4b91352f8885d549873f5cd419e75eba737502542e \
-                 size    206412428
+    checksums    rmd160  a6b458d6652512f9df22f997ecb10b02ee7c7b92 \
+                 sha256  6d4241c6ede2167fb71bd57f7a770a74564ee007c06bcae98e1abc3c1de4756f \
+                 size    205958282
 }
 
 subport openjdk16-zulu {
-    version      16.28.11
+    version      16.30.15
     revision     0
 
-    set openjdk_version 16.0.0
+    set openjdk_version 16.0.1
 
     description  Azul Zulu Community OpenJDK 16 (Short Term Support)
     long_description ${long_description_zulu}
@@ -415,9 +424,9 @@ subport openjdk16-zulu {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
     worksrcdir   ${distname}/zulu-16.jdk
 
-    checksums    rmd160  1c60ae0f5ab1f6d3482ca5470145a5fd0b93f543 \
-                 sha256  6d47ef22dc56ce1f5a102ed39e21d9a97320f0bb786818e2c686393109d79bc5 \
-                 size    206457844
+    checksums    rmd160  8cadf828e853a739b3860dc4e2066c6713e3baac \
+                 sha256  1f403942ce9f0ba7bfd3f5e0b2f9cae68fcafd4f08cb048b4fb9d75644b030ca \
+                 size    206494507
 }
 
 if {${os.platform} eq "darwin"} {
@@ -435,16 +444,6 @@ if {${os.platform} eq "darwin"} {
             return -code error
         }
     }
-}
-
-if {${subport} in [list openjdk12 openjdk13 openjdk14 openjdk15]} {
-    PortGroup    obsolete 1.0
-    # Can replace with openjdk17 when it is added and openjdk16 is obsoleted
-    replaced_by  openjdk16
-} elseif {${subport} in [list openjdk12-openj9 openjdk12-openj9-large-heap openjdk13-openj9 openjdk13-openj9-large-heap openjdk14-openj9 openjdk14-openj9-large-heap openjdk15-openj9 openjdk15-openj9-large-heap]} {
-    PortGroup    obsolete 1.0
-    # Can replace with openjdk17-openj9 when it is added and openjdk16-openj9 is obsoleted
-    replaced_by  openjdk16-openj9
 }
 
 if {[string match *-graalvm ${subport}]} {


### PR DESCRIPTION
#### Description

Update to the latest versions of AdoptOpenJDK OpenJ9 (8u292, 11.0.11, 16.0.1) and Azul Zulu (16.0.1).

###### Tested on

macOS 11.3 20E232 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?