### PR TITLE
skaffold: update to 1.23.0

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,13 +3,12 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 1.22.0 v
+github.setup        GoogleContainerTools skaffold 1.23.0 v
 revision            0
 
 categories          devel
 maintainers         {breun.nl:nils @breun} openmaintainer
 platforms           darwin
-supported_archs     x86_64
 license             Apache-2
 
 description         Skaffold is a command line tool that facilitates continuous development for Kubernetes applications
@@ -23,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  b9002c5c098c2dbb49da704d93e883380a19efc8 \
-                    sha256  d9cee2e079b32b289d0e8c2c64fe2b403822aa9a4127482339b88f3160805639 \
-                    size    19194009
+checksums           rmd160  ee5195aeef6c441385ced27c5fb4d1e6b8432176 \
+                    sha256  1877bd2e52471e77f03b3b78c4740fb4880f462a3c345f006f9416bfe0f041c9 \
+                    size    19234938
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 1.23.0, also build for arm64.

###### Tested on

macOS 11.3 20E232 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?