### PR TITLE
micronaut: update to 2.5.0

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       java 1.0
 
-github.setup    micronaut-projects micronaut-starter 2.4.2 v
+github.setup    micronaut-projects micronaut-starter 2.5.0 v
 revision        0
 name            micronaut
 categories      java
@@ -53,9 +53,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  9a6a078d24e3fc664fddb73c920d89ba4bfc0e09 \
-                sha256  9e74596439688dd9ac96e3d098e5ec9ce59fc25c59e8744c548e8356741a832b \
-                size    20056146
+checksums       rmd160  f6e467a105d687c5c64e3d68d3ea3b1cf0c46530 \
+                sha256  e2e97dc73400c3e2a8c1d949a153e54c17788764860055a301f57bd65a4c8377 \
+                size    20052836
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 2.5.0.

###### Tested on

macOS 11.3 20E232 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?