### PR TITLE
spring-boot-cli: update to 2.4.5

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            spring-boot-cli
-version         2.4.4
+version         2.4.5
 revision        0
 
 categories      java
@@ -30,9 +30,9 @@ master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/
 
 distname        ${name}-${version}-bin
 
-checksums       rmd160  443bd98cd6244d9dffc2c9f551db17904dc13266 \
-                sha256  d0b5e2293db691a706f5fed6547e0921362f0168d03e2707a104c814f1af3318 \
-                size    11702754
+checksums       rmd160  52568aee7019576aeec48c5eeef842badea0043b \
+                sha256  44a7238ad89dfc1d5abbf412256f8423f32f54d5a17b44b572de4eaf5aac9f04 \
+                size    11694538
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
#### Description

Update to Spring Boot CLI 2.4.5.

###### Tested on

macOS 11.3 20E232 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?