### PR TITLE
google-cloud-sdk: update to 338.0.0, add arm64 support

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             337.0.0
+version             338.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -17,18 +17,23 @@ long_description    Google Cloud SDK is a set of tools for Google Cloud Platform
                     interactively or in your automated scripts.
 
 platforms           darwin
-supported_archs     i386 x86_64
+supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  3b282bd3840f30aa79d29b85c5c717745f9b33b6 \
-                    sha256  ae70b48ed51c4a025f606842213e7aaa7f40ada9d17df5578f8a7cb2383806a2 \
-                    size    88862581
+    checksums       rmd160  63a706306bd727c5f6dedca12e978bcdcc7751ce \
+                    sha256  c6f74996b1ac03a4ced045e7db9ac7abb477661dd4708a0c859d1901ca9a47a3 \
+                    size    89044244
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  40abd309a46fceba9ee3196d11667be89364c1c3 \
-                    sha256  f9828404af0f166afbaf4d9f00e8c1fab0d3a54b5a7f7cda0e0402712508e522 \
-                    size    85108235
+    checksums       rmd160  00c6ba3c5c40c5364683b9f50bbaa8ab6f6edf70 \
+                    sha256  cff5641001846e50632b2ac30138d94b6df7d5254a3c44cad978df0f81f1f117 \
+                    size    85294246
+} elseif { ${configure.build_arch} eq "arm64" } {
+    distname        ${name}-${version}-darwin-arm
+    checksums       rmd160  e1730c0542224dd0bb84cffc050c367ddfe2f1f2 \
+                    sha256  d06c53e2cb17cad7c47fe11ee509b4a4d10ab218c7e9d8965f770259c29d2dac \
+                    size    85221530
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 338.0.0, and added arm64 as a supported architecture.

###### Tested on

macOS 11.3 20E232 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?