### PR TITLE
udunits2: Fix retroactive license

### DIFF
--- a/science/udunits2/Portfile
+++ b/science/udunits2/Portfile
@@ -8,6 +8,11 @@ distname            udunits-${version}
 revision            0
 maintainers         {takeshi @tenomoto}
 license             Apache-2.0
+#                     The OSI-approved Apache-2.0 license is retroactively approved for
+#                     UDUNITS 2.2.28 by the upstream developer.  Please see:
+#                     https://github.com/Unidata/UDUNITS-2/issues/105#issuecomment-830422445
+#                     Please remove this comment on the next UDUNITS update that changes the
+#                     license embedded in the source code to Apache-2.0, as expected.
 platforms           darwin
 categories          science
 


### PR DESCRIPTION
Comment change only.
Add comment about Apache-2.0 license retroactively approved by upstream developer.
Changes binary distributability from private to public.

Also see previous PR #10347.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
N/A

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->