### PR TITLE
translate-shell: update to 0.9.6.12

### DIFF
--- a/textproc/translate-shell/Portfile
+++ b/textproc/translate-shell/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        soimort translate-shell 0.9.6.11 v
+github.setup        soimort translate-shell 0.9.6.12 v
 categories          textproc
 maintainers         nomaintainer
 supported_archs     noarch
@@ -17,9 +17,9 @@ license             public-domain
 
 homepage            http://www.soimort.org/translate-shell/
 
-checksums           rmd160  3c212fca6cf51cf68633e45f046e9ad39f368f76 \
-                    sha256  d19d90bafc40b32acf97f96d9ebe14048b472148992572c4706de1763932e7ff \
-                    size    76770
+checksums           rmd160  f7c524f52d839b7a3ec1d860efd3c4ee35e92439 \
+                    sha256  c6be7cdaa7572e56c6207faa5396e7951366d9db5969b947fcff18a2723bc61c \
+                    size    77588
 
 depends_build       port:gawk
 


### PR DESCRIPTION
Update to the latest version of translate-shell 0.9.6.12.

See: https://github.com/soimort/translate-shell/releases/tag/v0.9.6.12.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1030 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
