### PR TITLE
libgpg-error: fix universal build on BigSur

### DIFF
--- a/devel/libgpg-error/Portfile
+++ b/devel/libgpg-error/Portfile
@@ -2,7 +2,16 @@
 
 PortSystem      1.0
 PortGroup       conflicts_build 1.0
-PortGroup       muniversal 1.0
+
+# we will only use the muniversal PG on < 10.14
+set using_muniversal_PG false
+if {${os.platform} eq "darwin" && ${os.major} < 18} {
+
+	set using_muniversal_PG true
+	PortGroup muniversal 1.0
+
+	merger_must_run_binaries yes
+}
 
 name            libgpg-error
 version         1.42
@@ -41,9 +50,8 @@ platform darwin 8 {
 if {![info exists universal_possible]} {
     set universal_possible [expr {${os.universal_supported} && [llength ${configure.universal_archs}] >= 2}]
 }
-if {${universal_possible} && [variant_isset universal]} {
+if {${universal_possible} && [variant_isset universal] && ${using_muniversal_PG}} {
     # muniversal's *.h merger does not handle \-continued lines properly
-    merger_must_run_binaries    yes
     patchfiles-append           patch-gen-posix-lock-obj_c.diff
     configure.cppflags-append   -DNO_LINE_CONT
 }


### PR DESCRIPTION
only use the muniversal PG on < 10.14

closes: https://trac.macports.org/ticket/62722

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
