### PR TITLE
Update rust-src port: Standard library installation fixes.

### DIFF
--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -339,6 +339,11 @@ subport rust-src {
     depends_build
     depends_lib
 
+    # Remove after next rust version update
+    if { ${version} eq "1.51.0" } {
+        revision [expr ${revision} + 1]
+    }
+
     set rust_source_dir ${destroot}${prefix}/lib/rustlib/src/rust
 
     description     Source code for the rust programming language
@@ -351,6 +356,7 @@ subport rust-src {
     destroot {
         xinstall -d ${rust_source_dir}
         move ${worksrcpath}/src ${rust_source_dir}/src
+        move ${worksrcpath}/library ${rust_source_dir}/library
 
         # correct the permissions
         system -W ${rust_source_dir} "find . -type d -exec chmod 755 {} \\;"


### PR DESCRIPTION
#### Description

Since Rust standard library was moved out from https://github.com/rust-lang/rust/tree/master/src directory to https://github.com/rust-lang/rust/tree/master/library, it is required to update the Portfile to reflect these changes to keep Rust standard library sources being installed along with Rust compiler sources as it was before.

This is also related to some old trac issue: https://trac.macports.org/ticket/58034.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524 x86_64
CommandLine Tools

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
