### PR TITLE
py-gevent:  add zope-event and zope-interface as dependencies

### DIFF
--- a/python/py-gevent/Portfile
+++ b/python/py-gevent/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-gevent
 version             21.1.2
-revision            1
+revision            2
 categories-append   devel
 platforms           darwin
 license             MIT
@@ -35,7 +35,9 @@ if {${name} ne ${subport}} {
                         port:c-ares \
                         port:libuv \
                         port:py${python.version}-greenlet \
-                        port:py${python.version}-cffi
+                        port:py${python.version}-cffi \
+                        port:py${python.version}-zope-event \
+                        port:py${python.version}-zopeinterface
 
     build.env-append    GEVENTSETUP_EMBED=0
     destroot.env-append GEVENTSETUP_EMBED=0


### PR DESCRIPTION
#### Description

`py-gevent` is missing dependencies on `zope-event` and `zope-interface`:

https://github.com/gevent/gevent/blob/f567d6bca7a4bba5e42c6cd463ae3cf8efb549a8/setup.py#L221-L232

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1030 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
