### PR TITLE
py-dns-lexicon: remove poetry dependency

### DIFF
--- a/python/py-dns-lexicon/Portfile
+++ b/python/py-dns-lexicon/Portfile
@@ -7,13 +7,14 @@ PortGroup           select 1.0
 name                py-dns-lexicon
 version             3.6.0
 epoch               1
-revision            0
+revision            1
 categories-append   net
 license             MIT
+supported_archs     noarch
 maintainers         {mps @Schamschula} openmaintainer
 description         Manipulate DNS records on various DNS providers in a \
                     standardized/agnostic way.
-long_description    ${description}
+long_description    {*}${description}
 platforms           darwin
 homepage            https://github.com/AnalogJ/lexicon
 
@@ -24,15 +25,19 @@ checksums           rmd160  3ecbdecae07aabe1d31f28a3f4374c636b2df501 \
                     size    156047
 
 if {${name} ne ${subport}} {
-    depends_lib-append  \
+    depends_run-append  \
+                    port:py${python.version}-beautifulsoup4 \
                     port:py${python.version}-cryptography \
                     port:py${python.version}-dnspython \
-                    port:py${python.version}-future \
                     port:py${python.version}-requests \
                     port:py${python.version}-tldextract \
-                    port:py${python.version}-yaml
+                    port:py${python.version}-yaml \
+                    port:lexicon_select
 
-    if {${python.version} < 37} {
+    depends_lib-append \
+                    port:py${python.version}-setuptools
+
+    if {${python.version} eq 27} {
         python.rootname \
                     lexicon
         version     3.3.28
@@ -42,33 +47,11 @@ if {${name} ne ${subport}} {
         checksums   rmd160  350bc0315c4f176ab2774387f17110c1cc29cd37 \
                     sha256  0dc0c1a9a33ec53a6ac8eb78d1faf1d0062cce9338bbc80e6e45fb7e621599a7 \
                     size    6840070
-
-        depends_build-append \
-                    port:py${python.version}-setuptools
-
-    } else {
-        PortGroup       active_variants 1.1
-
-        python.pep517   yes
-
-        require_active_variants \
-                    poetry python${python.version}
-
-        depends_build-append \
-                    port:poetry \
-                    port:py${python.version}-poetry-core \
-                    port:py${python.version}-wheel
-
-        depends_lib-append  \
-                    port:py${python.version}-beautifulsoup4
+        
+        depends_run-append \
+                    port:py${python.version}-future \
     }
 
-    post-destroot {
-        # binary is not set to executable, see https://trac.macports.org/ticket/62297
-        file attributes ${destroot}${frameworks_dir}/Python.framework/Versions/${python.branch}/bin/lexicon -permissions a+x
-    }
-
-    depends_run         port:lexicon_select
     select.group        lexicon
     select.file         ${filespath}/lexicon${python.version}
 

--- a/python/py-dns-lexicon/files/lexicon27
+++ b/python/py-dns-lexicon/files/lexicon27
@@ -1,1 +1,1 @@
-${frameworks_dir}/Python.framework/Versions/2.7/bin/lexicon
+bin/lexicon-2.7

--- a/python/py-dns-lexicon/files/lexicon36
+++ b/python/py-dns-lexicon/files/lexicon36
@@ -1,1 +1,1 @@
-${frameworks_dir}/Python.framework/Versions/3.6/bin/lexicon
+bin/lexicon-3.6

--- a/python/py-dns-lexicon/files/lexicon37
+++ b/python/py-dns-lexicon/files/lexicon37
@@ -1,1 +1,1 @@
-${frameworks_dir}/Python.framework/Versions/3.7/bin/lexicon
+bin/lexicon-3.7

--- a/python/py-dns-lexicon/files/lexicon38
+++ b/python/py-dns-lexicon/files/lexicon38
@@ -1,1 +1,1 @@
-${frameworks_dir}/Python.framework/Versions/3.8/bin/lexicon
+bin/lexicon-3.8

--- a/python/py-dns-lexicon/files/lexicon39
+++ b/python/py-dns-lexicon/files/lexicon39
@@ -1,1 +1,1 @@
-${frameworks_dir}/Python.framework/Versions/3.9/bin/lexicon
+bin/lexicon-3.9


### PR DESCRIPTION
#### Description

See https://trac.macports.org/ticket/62297
See https://trac.macports.org/ticket/62296
Closes https://trac.macports.org/ticket/62682

- Remove py-future dependency for unpinned version (https://github.com/AnalogJ/lexicon/commit/f20cb118f7ae280b8baa3bf35e692c3e04b52bb3)
- Set setuptools as a lib dependency due to [scripts](https://github.com/AnalogJ/lexicon/blob/db82a948febee04972bb648ac59471b292c7e394/pyproject.toml#L73-L74) and add `supported_archs     noarch` (https://github.com/macports/macports-ports/pull/6314#issuecomment-585490282)
- Simplify symlink
- Unpin py36 version since it seems to still be supported

CC @reneeotten in case I've done anything foolish :)

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
