### PR TITLE
mpich: ensure target compilers are added to depends_lib

### DIFF
--- a/science/mpich/Portfile
+++ b/science/mpich/Portfile
@@ -6,15 +6,30 @@ PortGroup           compilers 1.0
 PortGroup           muniversal 1.0
 PortGroup           legacysupport 1.1
 
+#===============================================================================
+#
+# *** IMPORTANT NOTE ***
+#
+# When making logic changes to this port, PLEASE review port 'openmpi' to see
+# if the same changes should be applied. While the subports and variants aren't
+# exactly the same between the two - and things like configure arguments
+# certainly differ, as they're different code bases - much of the core logic
+# is very similar. (And often identical.)
+#
+# Please help us avoid divergent MPI ports, which cause serious migraines.
+#
+#===============================================================================
+
 # make sure to keep in sync with mpi-doc
 name                mpich
 version             3.4.1
-revision            1
+revision            2
 
 license             BSD
 categories          science parallel net
 platforms           darwin
 maintainers         {eborisch @eborisch} \
+                    {@mascguy} \
                     openmaintainer
 
 description         Message Passing Interface (MPI) Library
@@ -206,15 +221,22 @@ if {${name} ne ${subport} && [string first "-devel" $subport] < 0} {
     set all_name [split ${subport} -]
     conflicts-append mpich-devel-[join [lrange ${all_name} 1 end] -]
 
-    # As we are making wrappers, we depend on the compilers to exist. The
-    # compilers group already does this for gcc, but not clangXX.  This adds
-    # clang-X.X to the depends_lib (not just depends_build)
-    if {[regexp {clang[5-9]\d} ${cname}] == 1} {
+    # As we are making wrappers, we depend on the compilers to exist.
+    # Add them to depends_lib, not just depends_build.
+    if {[regexp {clang[3-9]\d} ${cname}] == 1} {
+        # Ports for Clang versions < 10 are named: clang-<major>.<minor>
         set cport_name          [regsub {(\d)(\d)} ${cname} {-\1.\2}]
-        depends_lib-append      port:${cport_name}
     } elseif {[regexp {clang\d\d} ${cname}] == 1} {
+        # Ports for Clang version >= 10 are named: clang-<major><minor>
         set cport_name          [regsub {(\d)(\d)} ${cname} {-\1\2}]
+    } elseif {([regexp {gcc\d} ${cname}] == 1) || ([regexp {gcc\d\d} ${cname}] == 1)} {
+        # Ports for GCC have names exactly matching our subports, so use as-is
+        set cport_name          ${cname}
+    }
+    if {[info exists cport_name]} {
+        ui_debug "Adding compiler to depends_lib: ${cport_name}"
         depends_lib-append      port:${cport_name}
+        unset cport_name
     }
 
     if {[lsearch -exact {mp llvm clang} ${cname}] != -1} {


### PR DESCRIPTION
#### Description

* Ensure all target compilers are added to depends_lib
* Add myself as a maintainer

Fixes: [62803 - mpich: declare lib dependency on target compiler](https://trac.macports.org/ticket/62803)

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G2136
Xcode 9.2 9C40b

macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
