### PR TITLE
AutoRaise: update to 2.1.0

### DIFF
--- a/sysutils/AutoRaise/Portfile
+++ b/sysutils/AutoRaise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           xcode 1.0
 
-github.setup        lhaeger AutoRaise 2.0.0 launcher-v
+github.setup        lhaeger AutoRaise 2.1.0 launcher-v
 revision            0
 
 categories          sysutils
@@ -19,9 +19,9 @@ long_description    ${description} after a configurable delay. There is also an 
 
 github.tarball_from archive
 
-checksums           rmd160  137c40c7528b6af39eeab8e727ffc0ad49b46240 \
-                    sha256  851b6e3ef7d8a60c4cb9b08e40ce0f45f0228be3ae18d00c395c40632c4587a1 \
-                    size    374257
+checksums           rmd160  3894d02525b67ed99e000b01048c3eb88cfa5b02 \
+                    sha256  37a89324e94fc5e121ef37887a26d8a6bc0c8ac5dfe3d681abd0fb1a83a933f2 \
+                    size    374397
 
 xcode.configuration Release
 

--- a/sysutils/AutoRaise/Portfile
+++ b/sysutils/AutoRaise/Portfile
@@ -23,6 +23,28 @@ checksums           rmd160  3894d02525b67ed99e000b01048c3eb88cfa5b02 \
                     sha256  37a89324e94fc5e121ef37887a26d8a6bc0c8ac5dfe3d681abd0fb1a83a933f2 \
                     size    374397
 
+# fail if Swift 5 is not supported
+if {[vercmp ${xcodeversion} 10.2] < 0} {
+    known_fail yes
+    pre-fetch {
+        ui_error "${name} @${version} requires at least Xcode 10.2 with support for Swift 5."
+        ui_error "See https://guide.macports.org/chunked/installing.xcode.html for download links."
+        return -code error "incompatible Xcode version"
+    }
+}
+
+# use the SDK version that came with the Xcode version in use, even if that does not match the macOS version
+# see https://trac.macports.org/ticket/62816 for more details
+if {[vercmp ${xcodeversion} 11.0] < 0} {
+    configure.sdk_version 10.14
+} elseif {[vercmp ${xcodeversion} 12.2] < 0} {
+    configure.sdk_version 10.15
+} elseif {[vercmp ${xcodeversion} 12.3] < 0} {
+    configure.sdk_version 11
+} elseif {[vercmp ${xcodeversion} 12.5] < 0} {
+    configure.sdk_version 11.1
+}
+
 xcode.configuration Release
 
 post-destroot {

--- a/sysutils/AutoRaise/Portfile
+++ b/sysutils/AutoRaise/Portfile
@@ -25,11 +25,6 @@ checksums           rmd160  137c40c7528b6af39eeab8e727ffc0ad49b46240 \
 
 xcode.configuration Release
 
-variant cli \
-    requires        universal \
-    description     installs the AutoRaise cli as ${prefix}/bin/${name} \
-    {
-    post-destroot {
-        xinstall -m 0755 -W ${worksrcpath} ${name} ${destroot}${prefix}/bin
-    }
+post-destroot {
+    ln -s ${applications_dir}/${name}.app/Contents/Resources/${name}  ${destroot}${prefix}/bin/${name}
 }

--- a/sysutils/AutoRaise/Portfile
+++ b/sysutils/AutoRaise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           xcode 1.0
 
-github.setup        lhaeger AutoRaise 1.9.0 launcher-v
+github.setup        lhaeger AutoRaise 2.0.0 launcher-v
 revision            0
 
 categories          sysutils
@@ -19,9 +19,9 @@ long_description    ${description} after a configurable delay. There is also an 
 
 github.tarball_from archive
 
-checksums           rmd160  1add5f43cb447dd20074ba2ec84ca4079340f2c7 \
-                    sha256  3e8da5ecee6f7ab244942bf451e06f1425da74ed909076b082bb80e0a5a88b47 \
-                    size    374254
+checksums           rmd160  137c40c7528b6af39eeab8e727ffc0ad49b46240 \
+                    sha256  851b6e3ef7d8a60c4cb9b08e40ce0f45f0228be3ae18d00c395c40632c4587a1 \
+                    size    374257
 
 xcode.configuration Release
 


### PR DESCRIPTION
###### Tested on

macOS 10.15.7 19H524 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?