### PR TITLE
openjdk: add arm64 arch for openjdk*-zulu subports

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -8,7 +8,12 @@ maintainers      {breun.nl:nils @breun} openmaintainer
 platforms        darwin
 # These ports use prebuilt binaries, 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
-supported_archs  x86_64
+
+if {[string match *-zulu ${subport}]} {
+    supported_archs  x86_64 arm64
+} else {
+    supported_archs  x86_64
+}
 
 # Latest Long Term Support (LTS) major version
 version          11
@@ -136,14 +141,22 @@ subport openjdk8-zulu {
     long_description ${long_description_zulu}
 
     master_sites https://cdn.azul.com/zulu/bin/
-    distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
+
+    if {${configure.build_arch} eq "x86_64"} {
+        distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
+        checksums    rmd160  886fe3a9b2161d63ce14bd10be8f571984e4f82d \
+                     sha256  369e0d0d76d73cb161978ff07d7020820bb3cd2465f6f91219bb6492e302f4dd \
+                     size    108162260
+    } elseif {${configure.build_arch} eq "arm64"} {
+        distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
+        checksums    rmd160  cafab852e7263d3b1077b7b37f8d9019f4d3797a \
+                     sha256  2cf0af3118dd4b6244724308b190587804a76ad7919b6da5c377392a1d4f8817 \
+                     size    105926746
+    }
+
     worksrcdir   ${distname}/zulu-8.jdk
 
     configure.cxx_stdlib libstdc++
-
-    checksums    rmd160  886fe3a9b2161d63ce14bd10be8f571984e4f82d \
-                 sha256  369e0d0d76d73cb161978ff07d7020820bb3cd2465f6f91219bb6492e302f4dd \
-                 size    108162260
 }
 
 # Remove after 2022-04-30
@@ -230,12 +243,20 @@ subport openjdk11-zulu {
     long_description ${long_description_zulu}
 
     master_sites https://cdn.azul.com/zulu/bin/
-    distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    worksrcdir   ${distname}/zulu-11.jdk
 
-    checksums    rmd160  49e6888a1ec6749b09ac5daf725e46d9cb02e8f2 \
-                 sha256  866b25c47aa3bedddc57fbe38fd7d2e0f888d314b85d1e88b2fb12100f3c166c \
-                 size    195386841
+    if {${configure.build_arch} eq "x86_64"} {
+        distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
+        checksums    rmd160  49e6888a1ec6749b09ac5daf725e46d9cb02e8f2 \
+                     sha256  866b25c47aa3bedddc57fbe38fd7d2e0f888d314b85d1e88b2fb12100f3c166c \
+                     size    195386841
+    } elseif {${configure.build_arch} eq "arm64"} {
+        distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
+        checksums    rmd160  62a60cf4ffaa67a4d0cc2627fae9dfa438f98a29 \
+                     sha256  0c52621329b0d148c816b4c21e91386240bf57eb53ecfc4a6201f59ee983dc18 \
+                     size    179158961
+    }
+
+    worksrcdir   ${distname}/zulu-11.jdk
 }
 
 # Remove after 2022-02-15
@@ -290,12 +311,20 @@ subport openjdk13-zulu {
     long_description ${long_description_zulu}
 
     master_sites https://cdn.azul.com/zulu/bin/
-    distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    worksrcdir   ${distname}/zulu-13.jdk
 
-    checksums    rmd160  f84e38dc8b92928b6aed9e35b6da3eb5f63e4b23 \
-                 sha256  a53b31c4eb6db57feceefd16ebadd07525514bdec8dbab6f9644e81ac1b97543 \
-                 size    200105932
+    if {${configure.build_arch} eq "x86_64"} {
+        distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
+        checksums    rmd160  f84e38dc8b92928b6aed9e35b6da3eb5f63e4b23 \
+                     sha256  a53b31c4eb6db57feceefd16ebadd07525514bdec8dbab6f9644e81ac1b97543 \
+                     size    200105932
+    } elseif {${configure.build_arch} eq "arm64"} {
+        distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
+        checksums    rmd160  2422909438bbe13ce0810b4f57d111f514d1a842 \
+                     sha256  0dcca3161a2490792a9853c7d7bb511199f79cc58d3dab1b11af1c2fe22f06d8 \
+                     size    179462701
+    }
+
+    worksrcdir   ${distname}/zulu-13.jdk
 }
 
 # Remove after 2022-02-15
@@ -350,12 +379,20 @@ subport openjdk15-zulu {
     long_description ${long_description_zulu}
 
     master_sites https://cdn.azul.com/zulu/bin/
-    distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    worksrcdir   ${distname}/zulu-15.jdk
 
-    checksums    rmd160  9b67ab3d55b7b358417dbd22e5d8c10d67ed4370 \
-                 sha256  87df2e9adc1e27c2ffe9a1f8b88d0ba3eeb4cc81c77fc6a3a02788e22484d07b \
-                 size    201723476
+    if {${configure.build_arch} eq "x86_64"} {
+        distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
+        checksums    rmd160  9b67ab3d55b7b358417dbd22e5d8c10d67ed4370 \
+                     sha256  87df2e9adc1e27c2ffe9a1f8b88d0ba3eeb4cc81c77fc6a3a02788e22484d07b \
+                     size    201723476
+    } elseif {${configure.build_arch} eq "arm64"} {
+        distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
+        checksums    rmd160  1960d11a0302cefaad80d1895184b6a4fb9f8374 \
+                     sha256  200c210f2754b718b24a52dfe8801255ee69b44dc1de9ef6795e343909ea087a \
+                     size    176323405
+    }
+
+    worksrcdir   ${distname}/zulu-15.jdk
 }
 
 subport openjdk16 {
@@ -421,12 +458,20 @@ subport openjdk16-zulu {
     long_description ${long_description_zulu}
 
     master_sites https://cdn.azul.com/zulu/bin/
-    distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    worksrcdir   ${distname}/zulu-16.jdk
 
-    checksums    rmd160  8cadf828e853a739b3860dc4e2066c6713e3baac \
-                 sha256  1f403942ce9f0ba7bfd3f5e0b2f9cae68fcafd4f08cb048b4fb9d75644b030ca \
-                 size    206494507
+    if {${configure.build_arch} eq "x86_64"} {
+        distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
+        checksums    rmd160  8cadf828e853a739b3860dc4e2066c6713e3baac \
+                     sha256  1f403942ce9f0ba7bfd3f5e0b2f9cae68fcafd4f08cb048b4fb9d75644b030ca \
+                     size    206494507
+    } elseif {${configure.build_arch} eq "arm64"} {
+        distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
+        checksums    rmd160  861151ded393157ef1a86a2329dedae57805154a \
+                     sha256  47f50e9c120130a77a77e65ccdb4ca4e101fe662bb429ba95668811c8618ab67 \
+                     size    195101232
+    }
+
+    worksrcdir   ${distname}/zulu-16.jdk
 }
 
 if {${os.platform} eq "darwin"} {


### PR DESCRIPTION
#### Description

Add arm64 arch for Azul Zulu OpenJDK subports.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.3 20E232 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?