### PR TITLE
git: credential_osxkeychain: create global gitconfig

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                git
 version             2.31.1
-revision            0
+revision            1
 
 description         A fast version control system
 long_description    Git is a fast, scalable, distributed open source version \
@@ -214,7 +214,26 @@ variant credential_osxkeychain description {Install git credential-osxkeychain u
     post-destroot {
         xinstall -m 755 "${worksrcpath}/contrib/credential/osxkeychain/git-credential-osxkeychain" \
             "${destroot}${prefix}/libexec/git-core/"
+
+        # Create a global gitconfig file that sets credential.helper to
+        # osxkeychain. This can be overriden on a per-user basis in the user's
+        # own git config file
+        set f [open ${destroot}${prefix}/etc/gitconfig w 0644]
+        puts ${f} "\[credential]\n\thelper = osxkeychain"
     }
+
+    notes "
+A gitconfig file has been created at ${prefix}/etc/gitconfig to enable the
+osxkeychain credential helper. If you do not wish to use this credential
+helper, you can override this setting in your own git config file, e.g.
+
+    \[credential]
+            helper = some_other_credential_helper
+
+For more information, run
+
+    git help credentials
+"
 }
 
 variant diff_highlight description {Install git diff-highlight utility from contrib} {


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
When using the `+credential_osxkeychain` variant (enabled by default), also create a global `gitconfig` file that enables this credential helper. This means that the osxkeychain credential helper will "just work" by default without the user needing to take any further action. This is entirely non-destructive and non-invasive: since a user's gitconfig file will always override the system gitconfig file, if a user already has a credential helper configured this will not change anything.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H524 x86_64
Xcode 12.4 12D4e


###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
