### PR TITLE
cloc: Update to 1.88

### DIFF
--- a/textproc/cloc/Portfile
+++ b/textproc/cloc/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           perl5 1.0
 
-github.setup        AlDanial cloc 1.84
+github.setup        AlDanial cloc 1.88
 revision            0
 perl5.branches      5.28
 categories          textproc devel
@@ -18,9 +18,9 @@ long_description    cloc counts blank lines, comment lines, and physical \
                     Given two versions of a code base, cloc can compute \
                     differences in blank, comment, and source lines.
 
-checksums           rmd160  5538b760db2c1bc0aa06e6fb2094820c1a35a143 \
-                    sha256  66246ca354414f78528e8e412828f04915517546587253312e68dcb660e5a29f \
-                    size    514902
+checksums           rmd160  e07f68e57e1920f5fd2ea6b0207859471e5b2ab2 \
+                    sha256  e81e311cd75f296b6e00a2d9083f3eb18e85b4b53f9ae06e80b52f29e8788eee \
+                    size    548431
 
 depends_run-append  port:perl${perl5.major} \
                     port:p${perl5.major}-algorithm-diff \


### PR DESCRIPTION
#### Description

I'm running through `port livecheck installed` and trying to update things that have an open maintainer or no maintainer.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.4 20F5046g
Xcode 12.5 12E262 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
