### PR TITLE
gdb: Update to 10.2

### DIFF
--- a/devel/gdb/Portfile
+++ b/devel/gdb/Portfile
@@ -5,7 +5,7 @@ PortGroup       muniversal 1.0
 PortGroup       compiler_blacklist_versions 1.0
 
 name            gdb
-version         10.1
+version         10.2
 revision        0
 categories      devel
 license         GPL-3+
@@ -33,9 +33,9 @@ supported_archs x86_64 i386
 
 master_sites    gnu
 
-checksums       rmd160  87163d96863e4923691f0c1bd34f58e30f2685e8 \
-                sha256  f12f388b99e1408c01308c3f753313fafa45517740c81ab7ed0d511b13e2cf55 \
-                size    40245323
+checksums       rmd160  be6e1cea6f50a6a7cdaab925828524b278573ec4 \
+                sha256  b33ad58d687487a821ec8d878daab0f716be60d0936f2e3ac5cf08419ce70350 \
+                size    40267550
 
 # these dependencies are listed under depends_lib rather than depends_build
 # because gdb will link with libraries they provide if installed.


### PR DESCRIPTION
#### Description

I'm running through `port livecheck installed` and trying to update things that have an open maintainer or no maintainer.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.4 20F5046g
Xcode 12.5 12E262 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
