### PR TITLE
py-pip: upgrade to version 21.1.1

### DIFF
--- a/python/py-pip/Portfile
+++ b/python/py-pip/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-pip
-version             21.1
+version             21.1.1
 revision            0
 categories-append   www
 platforms           darwin
@@ -23,9 +23,9 @@ long_description    pip is a replacement for easy_install. It uses mostly the \
 
 homepage            http://www.pip-installer.org/
 
-checksums           rmd160  f9974cf40a4d7884377dd0fccb3c0025d47f5ee6 \
-                    sha256  a810bf07c3723a28621c29abe8e34429fa082c337f89aea9a795865416b66d3e \
-                    size    1552101
+checksums           rmd160  172f8a752a49f654a610038e158a7d69a58a6a62 \
+                    sha256  51ad01ddcd8de923533b01a870e7b987c2eb4d83b50b89e1bf102723ff9fed8b \
+                    size    1552786
 
 # keep older Python versions here, do add the EOL version to the list below
 python.versions     26 27 33 34 35 36 37 38 39


### PR DESCRIPTION
#### Description

pip 21.1 can generate errors when doing `pip install --user`. It refers users to checkout [pip issue 9617](https://github.com/pypa/pip/issues/9617).  Upgrading to the latest stable pip fixes the issue.

Here is an example of a slightly redacted error message the current version can generate:

```
WARNING: Value for scheme.platlib does not match. Please report this to <https://github.com/pypa/pip/issues/9617>
distutils: /Users/ccatlett/Library/Python/3.9/lib/python/site-packages
sysconfig: /Users/ccatlett/Library/Python/3.9/lib/python3.9/site-packages
WARNING: Value for scheme.purelib does not match. Please report this to <https://github.com/pypa/pip/issues/9617>
distutils: /Users/ccatlett/Library/Python/3.9/lib/python/site-packages
sysconfig: /Users/ccatlett/Library/Python/3.9/lib/python3.9/site-packages
WARNING: Additional context:
user = True
home = None
root = None
prefix = None
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1030 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
