### PR TITLE
google-cloud-sdk: update to 339.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             338.0.0
+version             339.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  63a706306bd727c5f6dedca12e978bcdcc7751ce \
-                    sha256  c6f74996b1ac03a4ced045e7db9ac7abb477661dd4708a0c859d1901ca9a47a3 \
-                    size    89044244
+    checksums       rmd160  7745cb4c43d83b6ff4b9c22973ab1efa979818fb \
+                    sha256  1321c57ce737e1c6a877e253945e8fc85158b5a6900257a0944ae3603e4c16f9 \
+                    size    89279533
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  00c6ba3c5c40c5364683b9f50bbaa8ab6f6edf70 \
-                    sha256  cff5641001846e50632b2ac30138d94b6df7d5254a3c44cad978df0f81f1f117 \
-                    size    85294246
+    checksums       rmd160  c11f5781ec5dbbab913f04caac779abf6c8d8b01 \
+                    sha256  d32bd4d0677bc3a2dcf5cf2f090c0864b5beea4606b5924a216a3980d1d166f5 \
+                    size    85524505
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  e1730c0542224dd0bb84cffc050c367ddfe2f1f2 \
-                    sha256  d06c53e2cb17cad7c47fe11ee509b4a4d10ab218c7e9d8965f770259c29d2dac \
-                    size    85221530
+    checksums       rmd160  b465e6c2f9f99d6306f375da3609e4383311f7fe \
+                    sha256  f37099fdabdb89440d8ad93d082f636bcbea71fc4b32885f2748ffef4517b473 \
+                    size    85452641
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 339.0.0.

###### Tested on

macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?