### PR TITLE
gcc11: new port

### DIFF
--- a/lang/gcc11/Portfile
+++ b/lang/gcc11/Portfile
@@ -1,0 +1,379 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                                       1.0
+PortGroup           select                       1.0
+PortGroup           compiler_blacklist_versions  1.0
+PortGroup           active_variants              1.1
+PortGroup           conflicts_build              1.0
+PortGroup           cltversion                   1.0
+
+epoch               6
+name                gcc11
+
+homepage            https://gcc.gnu.org/
+
+platforms           darwin
+categories          lang
+maintainers         nomaintainer
+# an exception in the license allows dependents to not be GPL
+license             {GPL-3+ Permissive}
+description         The GNU compiler collection
+long_description    The GNU compiler collection, including front ends for \
+                    C, C++, Objective-C, Objective-C++ and Fortran.
+
+version             11.1.0
+subport             libgcc11 { conflicts libgcc-devel }
+
+checksums           rmd160  083384ca351ea1cb6e04d15425af2103c908edf4 \
+                    sha256  4c4a6fb8a8396059241c2e674b85b351c26a5d678274007f076957afa1cc9ddf \
+                    size    78877216
+
+# Primary releases
+master_sites        https://ftpmirror.gnu.org/gcc/gcc-${version}/ \
+                    https://mirror.its.dal.ca/gnu/gcc/gcc-${version}/ \
+                    https://mirrors.kernel.org/gnu/gcc/gcc-${version}/ \
+                    https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/gcc/gcc-${version}/ \
+                    https://ftp-stud.hs-esslingen.de/pub/Mirrors/ftp.gnu.org/gcc/gcc-${version}/ \
+                    https://mirror.yongbok.net/gnu/gcc/gcc-${version}/ \
+                    http://mirror.koddos.net/gcc/releases/gcc-${version}/ \
+                    ftp://ftp.gwdg.de/pub/linux/gcc/releases/gcc-${version}/ \
+                    ftp://gcc.ftp.nluug.nl/mirror/languages/gcc/releases/gcc-${version}/ \
+                    ftp://gcc.gnu.org/pub/gcc/releases/gcc-${version}/ \
+                    gnu:gcc/gcc-${version}
+
+distname            gcc-${version}
+use_xz              yes
+patchfiles          patch-Make-lang.in.diff
+
+depends_build-append \
+                    port:texinfo
+depends_lib-append  port:cctools \
+                    port:gmp \
+                    path:lib/pkgconfig/isl.pc:isl \
+                    port:ld64 \
+                    port:libiconv \
+                    port:libmpc \
+                    port:mpfr \
+                    port:zlib
+depends_run-append  port:gcc_select \
+                    port:libgcc
+
+depends_skip_archcheck-append gcc_select ld64 cctools
+license_noconflict  gmp mpfr ppl libmpc zlib
+
+set major           [lindex [split ${version} .-] 0]
+
+platform darwin {
+    configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+}
+
+set gcc_configure_langs {c c++ objc obj-c++ lto fortran}
+if {${subport} eq "gcc11"} {
+    lappend gcc_configure_langs jit
+}
+
+configure.dir       ${workpath}/build
+configure.cmd       ${worksrcpath}/configure
+configure.args      --enable-languages=[join ${gcc_configure_langs} ","] \
+                    --libdir=${prefix}/lib/${name} \
+                    --includedir=${prefix}/include/${name} \
+                    --infodir=${prefix}/share/info \
+                    --mandir=${prefix}/share/man \
+                    --datarootdir=${prefix}/share/gcc-${major} \
+                    --with-local-prefix=${prefix} \
+                    --with-system-zlib \
+                    --disable-nls \
+                    --program-suffix=-mp-${major} \
+                    --with-gxx-include-dir=${prefix}/include/${name}/c++/ \
+                    --with-gmp=${prefix} \
+                    --with-mpfr=${prefix} \
+                    --with-mpc=${prefix} \
+                    --with-isl=${prefix} \
+                    --disable-multilib \
+                    --enable-lto \
+                    --enable-libstdcxx-time \
+                    --with-as=${prefix}/bin/as \
+                    --with-ld=${prefix}/bin/ld \
+                    --with-ar=${prefix}/bin/ar \
+                    --with-bugurl=https://trac.macports.org/newticket \
+                    --enable-host-shared
+
+# see https://lists.macports.org/pipermail/macports-dev/2017-August/036209.html
+# --disable-tls does not limit functionality
+# it only determines how std::call_once works
+configure.args-append \
+                    --disable-tls
+
+configure.env-append \
+                    AR_FOR_TARGET=${prefix}/bin/ar \
+                    AS_FOR_TARGET=${prefix}/bin/as \
+                    LD_FOR_TARGET=${prefix}/bin/ld \
+                    NM_FOR_TARGET=${prefix}/bin/nm \
+                    OBJDUMP_FOR_TARGET=${prefix}/bin/objdump \
+                    RANLIB_FOR_TARGET=${prefix}/bin/ranlib \
+                    STRIP_FOR_TARGET=${prefix}/bin/strip \
+                    OTOOL=${prefix}/bin/otool \
+                    OTOOL64=${prefix}/bin/otool
+
+# clang (as) from Xcode 12.5 has various problems with gcc build
+if { ${os.platform} eq "darwin" && \
+         ( [ vercmp ${xcodeversion} 12.5 ] >= 0 || [ vercmp ${cltversion} 12.5 ] >= 0 ) } {
+
+    pre-configure {
+        ui_warn "Applying '--without-build-config' workaround to Xcode ${xcodeversion} / CLT ${cltversion}"
+        ui_warn "If versions > 12.5 please check if it is still required"
+    }
+
+    # clang 11 and older have issues with macOS 11.3 (Xcode 12.5) SDK
+    # https://trac.macports.org/ticket/62770
+    compiler.blacklist-append {macports-clang-[5-9].0} {macports-clang-1[0-1]}
+
+    # gcc has build issues on macOS 11.3 with the use of Xcode clang as 'as'
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100340
+    # https://trac.macports.org/ticket/62775
+    configure.args-append  --without-build-config
+
+}
+
+pre-configure {
+
+    # Set package info
+    configure.args-append --with-pkgversion="MacPorts ${name} ${version}_${revision}${portvariants}"
+
+    if {${configure.sdkroot} ne ""} {
+        # We should be using --with-build-sysroot here.  Using --with-sysroot
+        # changes the behavior of the installed gcc to look in that sysroot
+        # by default instead of /.  Using --with-build-sysroot is supposed
+        # to be used during the build but not impact the installed product.
+        # Unfortunately, the build fails because the value doesn't get
+        # plumbed everywhere it is supposed to.
+        #
+        # https://trac.macports.org/ticket/53726
+        # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=79885
+
+        # if the sdkroot is one of the current, rapidly changing SDKS, use the generic one
+        configure.args-append --with-sysroot="[regsub {MacOSX1[1-9]\.[0-9]+\.sdk} ${configure.sdkroot} {MacOSX.sdk}]"
+    }
+
+}
+
+# https://trac.macports.org/ticket/29067
+# https://trac.macports.org/ticket/29104
+# https://trac.macports.org/ticket/47996
+# https://trac.macports.org/ticket/58493
+compiler.blacklist-append {clang < 800} gcc-4.0 *gcc-4.2 {llvm-gcc-4.2 < 2336.1} {macports-clang-3.[4-7]}
+
+# https://build.macports.org/builders/ports-10.13_x86_64-builder/builds/105513/steps/install-port/logs/stdio
+# c++/v1/functional:1408:2: error: no member named 'fancy_abort' in namespace 'std::__1'; did you mean simply 'fancy_abort'?
+compiler.blacklist-append {clang < 1000}
+
+# "-stdlib" would be passed on to the bootstrap compiler if present
+configure.cxx_stdlib
+
+build.dir           ${configure.dir}
+build.target        bootstrap-lean
+use_parallel_build  yes
+
+destroot.target     install install-info-host
+
+# Is this gcc release supported here.
+if { ${os.major} < 11 } {
+    known_fail      yes
+    pre-fetch {
+        ui_error "${name} ${version} is not supported on Darwin ${os.major}"
+        return -code error "incompatible OS X version"
+    }
+}
+
+# gcc cannot build if libunwind-headers is active
+conflicts_build-append libunwind-headers
+
+# List of dylibs to be installed
+# Note that we really don't want to include libgcc_ext.10.[45].dylib here, but install_name_tool
+# doesn't know how to change the id of stubs, and it's easier than recreating them for each
+# gcc port.
+set dylibs {libgcc_ext.10.4.dylib libgcc_ext.10.5.dylib libgcc_s.1.dylib libgcc_s.2.dylib libgfortran.5.dylib libquadmath.0.dylib libstdc++.6.dylib libobjc-gnu.4.dylib libgomp.1.dylib libitm.1.dylib libssp.0.dylib libasan.6.dylib libubsan.1.dylib libatomic.1.dylib}
+
+if {${subport} eq "libgcc11"} {
+
+    # Set conflict against port providing primary runtime
+    if { ${os.major} < 10 } {
+        conflicts libgcc7
+    } else {
+        conflicts libgcc10
+    }
+
+    # Activate hack for new libgcc
+    # https://trac.macports.org/wiki/PortfileRecipes#deactivatehack
+    pre-activate {
+        if {![catch {set installed [lindex [registry_active libgcc9] 0]}]} {
+            # Extract the epoch of the installed libgcc9
+            set _epoch [lindex $installed 5]
+            # If < 3 need to deactivate
+            if {[vercmp $_epoch 3] < 0} {
+                registry_deactivate_composite libgcc9 "" [list ports_nodepcheck 1]
+            }
+        }
+        if {![catch {set installed [lindex [registry_active libgcc-devel] 0]}]} {
+            # Extract the epoch of the installed libgcc-devel
+            set _epoch [lindex $installed 5]
+            # If < 4 need to deactivate
+            if {[vercmp $_epoch 4] < 0} {
+                registry_deactivate_composite libgcc-devel "" [list ports_nodepcheck 1]
+            }
+        }
+        if {![catch {set installed [lindex [registry_active libgcc10] 0]}]} {
+            # Extract the epoch of the installed libgcc10
+            set _epoch [lindex $installed 5]
+            # If < 5 need to deactivate
+            if {[vercmp $_epoch 5] < 0} {
+                registry_deactivate_composite libgcc10 "" [list ports_nodepcheck 1]
+            }
+        }
+    }
+
+    configure.args-replace \
+        --libdir=${prefix}/lib/${name} \
+        --libdir=${prefix}/lib/libgcc
+
+    # see https://trac.macports.org/ticket/54766
+    configure.args-replace \
+        --includedir=${prefix}/include/${name} \
+        --includedir=${prefix}/include/gcc
+
+    configure.args-replace \
+        --with-gxx-include-dir=${prefix}/include/${name}/c++/ \
+        --with-gxx-include-dir=${prefix}/include/gcc/c++/
+
+    # http://trac.macports.org/ticket/35770
+    # http://trac.macports.org/ticket/38814
+    # While there can be multiple versions of these runtimes in a single
+    # process, it is not possible to pass objects between different versions,
+    # so we simplify this by having the libgcc port provide the newest version
+    # of these runtimes for all versions of gcc to use.
+    #
+    # If there is a binary incompatible change to the runtime in a future
+    # version of gcc, then the latest version of gcc to provide a given ABI
+    # version should continue to provide a subport for that and older gcc
+    # versions.
+
+    depends_run
+    depends_lib-delete   port:zlib
+    depends_build-append {*}${depends_lib}
+    depends_lib          port:zlib
+
+    post-destroot {
+
+        # Temporary working dir for dylibs
+        file mkdir ${destroot}${prefix}/lib/libgcc.merged
+
+        # loop over libs to install
+        foreach dylib ${dylibs} {
+
+            # Different OS versions (e.g. Leopard) or architectures (e.g. PPC) don't produce all the dylibs
+            # https://trac.macports.org/ticket/40098
+            # https://trac.macports.org/ticket/40100
+            if {! [file exists ${destroot}${prefix}/lib/libgcc/${dylib}]} {
+                continue
+            }
+
+            move ${destroot}${prefix}/lib/libgcc/${dylib} ${destroot}${prefix}/lib/libgcc.merged
+            if {[variant_exists universal] && [variant_isset universal]} {
+                foreach archdir [glob ${destroot}${prefix}/lib/libgcc/*/] {
+                    set archdir_nodestroot [string map "${destroot}/ /" ${archdir}]
+                    if {[file exists ${archdir}/${dylib}]} {
+                        system "install_name_tool -id ${prefix}/lib/libgcc/${dylib} ${archdir}/${dylib}"
+                        foreach link [glob -tails -directory ${archdir} *.dylib] {
+                            system "install_name_tool -change ${archdir_nodestroot}${link} ${prefix}/lib/libgcc/${link} ${archdir}/${dylib}"
+                        }
+                        system "lipo -create -output ${destroot}${prefix}/lib/libgcc.merged/${dylib}~ ${destroot}${prefix}/lib/libgcc.merged/${dylib} ${archdir}/${dylib} && mv ${destroot}${prefix}/lib/libgcc.merged/${dylib}~ ${destroot}${prefix}/lib/libgcc.merged/${dylib}"
+                    }
+                }
+            }
+
+            # strip debug symbols to supress debugger warnings:
+            # http://trac.macports.org/attachment/ticket/34831
+            if {! [string match *libgcc_ext* ${dylib}]} {
+                system "strip -x ${destroot}${prefix}/lib/libgcc.merged/${dylib}"
+            }
+        }
+
+        file delete -force ${destroot}${prefix}/bin
+        file delete -force ${destroot}${prefix}/share
+        file delete -force ${destroot}${prefix}/lib/libgcc
+        file delete -force ${destroot}${prefix}/libexec
+
+        move ${destroot}${prefix}/lib/libgcc.merged ${destroot}${prefix}/lib/libgcc
+
+        # For binary compatibility with binaries that linked against the old libstdcxx port
+        ln -s libgcc/libstdc++.6.dylib ${destroot}${prefix}/lib/libstdc++.6.dylib
+    }
+
+} else {
+
+    post-destroot {
+
+        file delete ${destroot}${prefix}/share/info/dir
+
+        foreach file [glob ${destroot}${prefix}/share/{info,man/man7}/*] {
+            set extension [file extension ${file}]
+            set newfile [regsub "${extension}$" ${file} "-mp-${major}${extension}"]
+            file rename ${file} ${newfile}
+        }
+
+        # loop over libs to install
+        foreach dylib ${dylibs} {
+            # Different OS versions (e.g. Leopard) or architectures (e.g. PPC) don't produce all the dylibs
+            # https://trac.macports.org/ticket/40098
+            # https://trac.macports.org/ticket/40100
+            if {[file exists ${destroot}${prefix}/lib/${name}/${dylib}]} {
+                delete ${destroot}${prefix}/lib/${name}/${dylib}
+                ln -s ${prefix}/lib/libgcc/${dylib} ${destroot}${prefix}/lib/${name}/${dylib}
+            }
+            if {[variant_exists universal] && [variant_isset universal]} {
+                foreach archdir [glob ${destroot}${prefix}/lib/${name}/*/] {
+                    if {[file exists ${archdir}/${dylib}]} {
+                        delete ${archdir}/${dylib}
+                        ln -s ${prefix}/lib/libgcc/${dylib} ${archdir}/${dylib}
+                    }
+                }
+            }
+        }
+
+    }
+
+    select.group        gcc
+    select.file         ${filespath}/mp-${name}
+
+}
+
+platform powerpc {
+    configure.universal_archs ppc ppc64
+}
+platform i386 {
+    configure.universal_archs i386 x86_64
+}
+variant universal {
+    configure.args-delete --disable-multilib
+}
+# the generated compiler doesn't accept -arch
+configure.env-append \
+    "CPP=${configure.cc} -E" \
+    "CXXCPP=${configure.cxx} -E"
+build.env-append \
+    "CPP=${configure.cc} -E" \
+    "CXXCPP=${configure.cxx} -E"
+configure.cc-append [get_canonical_archflags]
+configure.cc_archflags
+configure.cxx-append ${configure.cxx_archflags}
+configure.cxx_archflags
+configure.objc_archflags
+configure.ld_archflags
+configure.universal_cflags
+configure.universal_cxxflags
+configure.universal_ldflags
+configure.universal_args
+
+livecheck.type      regex
+livecheck.url       http://mirror.koddos.net/gcc/releases/
+livecheck.regex     gcc-(${major}\\.\[0-9.\]+)/

--- a/lang/gcc11/files/mp-gcc11
+++ b/lang/gcc11/files/mp-gcc11
@@ -1,0 +1,6 @@
+bin/gcc-mp-11
+bin/cpp-mp-11
+bin/g++-mp-11
+-
+bin/gcov-mp-11
+bin/gfortran-mp-11

--- a/lang/gcc11/files/patch-Make-lang.in.diff
+++ b/lang/gcc11/files/patch-Make-lang.in.diff
@@ -1,0 +1,49 @@
+--- gcc/jit/Make-lang.in.orig	2021-04-27 11:00:13.000000000 +0100
++++ gcc/jit/Make-lang.in	2021-05-02 20:58:10.000000000 +0100
+@@ -53,14 +53,17 @@
+ 
+ else
+ 
+-LIBGCCJIT_LINKER_NAME = libgccjit.so
+-
+-LIBGCCJIT_SONAME = $(LIBGCCJIT_LINKER_NAME).$(LIBGCCJIT_VERSION_NUM)
+-LIBGCCJIT_FILENAME = \
+-  $(LIBGCCJIT_SONAME).$(LIBGCCJIT_MINOR_NUM).$(LIBGCCJIT_RELEASE_NUM)
+-
+-LIBGCCJIT_LINKER_NAME_SYMLINK = $(LIBGCCJIT_LINKER_NAME)
+-LIBGCCJIT_SONAME_SYMLINK = $(LIBGCCJIT_SONAME)
++ifeq ($(strip $(filter-out darwin%,$(target_os))),)
++	LIBGCCJIT_LINKER_NAME = libgccjit.dylib
++	LIBGCCJIT_FILENAME = libgccjit.$(LIBGCCJIT_VERSION_NUM).dylib
++else
++	LIBGCCJIT_LINKER_NAME = libgccjit.so
++	LIBGCCJIT_SONAME = $(LIBGCCJIT_LINKER_NAME).$(LIBGCCJIT_VERSION_NUM)
++	LIBGCCJIT_FILENAME = \
++	$(LIBGCCJIT_SONAME).$(LIBGCCJIT_MINOR_NUM).$(LIBGCCJIT_RELEASE_NUM)
++	LIBGCCJIT_LINKER_NAME_SYMLINK = $(LIBGCCJIT_LINKER_NAME)
++	LIBGCCJIT_SONAME_SYMLINK = $(LIBGCCJIT_SONAME)
++endif
+ 
+ # Conditionalize the use of the LD_VERSION_SCRIPT_OPTION and
+ # LD_SONAME_OPTION depending if configure found them, using $(if)
+@@ -323,6 +326,12 @@
+ jit.install-common: installdirs jit.install-headers
+ 	$(INSTALL_PROGRAM) $(LIBGCCJIT_FILENAME) \
+ 	  $(DESTDIR)$(libdir)/$(LIBGCCJIT_FILENAME)
++ifeq ($(strip $(filter-out darwin%,$(target_os))),)
++	install_name_tool -id $(libdir)/$(LIBGCCJIT_FILENAME) $(DESTDIR)/$(libdir)/$(LIBGCCJIT_FILENAME)
++	ln -sf \
++	  $(LIBGCCJIT_FILENAME) \
++	  $(DESTDIR)/$(libdir)/$(LIBGCCJIT_LINKER_NAME)
++else
+ 	ln -sf \
+ 	  $(LIBGCCJIT_FILENAME) \
+ 	  $(DESTDIR)$(libdir)/$(LIBGCCJIT_SONAME_SYMLINK)
+@@ -330,6 +339,7 @@
+ 	  $(LIBGCCJIT_SONAME_SYMLINK)\
+ 	  $(DESTDIR)$(libdir)/$(LIBGCCJIT_LINKER_NAME_SYMLINK)
+ endif
++endif
+ 
+ jit.install-man:
+ 

--- a/lang/libgcc/Portfile
+++ b/lang/libgcc/Portfile
@@ -5,7 +5,7 @@ PortGroup select    1.0
 
 epoch               3
 name                libgcc
-version             3.0
+version             4.0
 revision            0
 
 conflicts           libgcc-devel
@@ -36,7 +36,7 @@ if { ${os.major} < 10 } {
     if { ${os.major} < 11 } {
         set gcc_version 8
     } else {
-        set gcc_version 10
+        set gcc_version 11
     }
 }
 depends_lib port:libgcc${gcc_version}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

New port: gcc11, mostly copied from gcc10 and gcc-devel, also update libgcc to 4.0 and reference libgcc11 on macOS >= 11.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.3.1
Xcode 12.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
