### PR TITLE
kotlin: update to 1.5.0

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           java 1.0
 
-github.setup        JetBrains kotlin 1.4.32 v
+github.setup        JetBrains kotlin 1.5.0 v
 revision            0
 github.tarball_from releases
 distname            ${name}-compiler-${version}
@@ -23,9 +23,9 @@ long_description    Kotlin is a pragmatic programming language for JVM \
 
 homepage            https://kotlinlang.org/
 
-checksums           rmd160  a699b923bf83828370cba5204eab5e470bfa0513 \
-                    sha256  dfef23bb86bd5f36166d4ec1267c8de53b3827c446d54e82322c6b6daad3594c \
-                    size    62880903
+checksums           rmd160  3bfc147a506188cc67cf83b13c36255f3acc78dc \
+                    sha256  0343fc1f628fec1beccc9e534d2b8b7a0f8964b97e21563585d44d6d928ed1b7 \
+                    size    61733880
 
 java.version        1.8+
 java.fallback       openjdk8


### PR DESCRIPTION
#### Description

Update to Kotlin 1.5.0.

###### Tested on

macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?