### PR TITLE
openjdk: no universal_variant

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -8,6 +8,8 @@ maintainers      {breun.nl:nils @breun} openmaintainer
 platforms        darwin
 # These ports use prebuilt binaries, 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
+# These ports use prebuilt binaries for a particular architecture, they are not universal binaries
+universal_variant no
 
 if {[string match *-zulu ${subport}]} {
     supported_archs  x86_64 arm64


### PR DESCRIPTION
#### Description

The `openjdk*` ports install prebuilt binaries, which are not universal.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?