### PR TITLE
ghidra: replace zulu-jdk11 dependency with openjdk11-zulu

### DIFF
--- a/devel/ghidra/Portfile
+++ b/devel/ghidra/Portfile
@@ -12,7 +12,7 @@ distname            ${name}_${version}_PUBLIC_20201229
 checksums           rmd160  2b7a239329ba515010ff52725da08eb656f168f7 \
                     sha256  8cf8806dd5b8b7c7826f04fad8b86fc7e07ea380eae497f3035f8c974de72cf8 \
                     size    317805407
-revision            0
+revision            1
 
 categories          devel
 maintainers         {1e0.co.uk:dev @hexagonal-sun} openmaintainer
@@ -22,7 +22,7 @@ long_description    ${description}
 license             Apache
 platforms           darwin
 
-depends_lib-append  port:zulu-jdk11
+depends_lib-append  port:openjdk11-zulu
 use_configure       no
 universal_variant   no
 


### PR DESCRIPTION
#### Description

Replacing dependency on `zulu-jdk11` with the more up-to-date and maintained `openjdk11-zulu` port in preparation of obsoleting the `zulu-jdk*` ports.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->