### PR TITLE
swig: replace zulu-jdk8 dependency with openjdk8-zulu

### DIFF
--- a/devel/swig/Portfile
+++ b/devel/swig/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 
 name            swig
 version         4.0.2
-revision        1
+revision        2
 checksums       rmd160 1a995ebc0ff1a11d9d1002357673e655f6a0d2b2 \
                 sha256 d53be9730d8d58a16bf0cbd1f8ac0c0c3e1090573168bfa151b01eb47fa906fc \
                 size   8097014
@@ -96,7 +96,7 @@ subport swig-java {
     java.version            1.4+
     if { ${build_arch} eq "arm64"  } {
         # Set fallback to an LTS Java version
-        java.fallback           zulu-jdk8
+        java.fallback           openjdk8-zulu
     } else {
         # Set fallback to an LTS Java version
         java.fallback           openjdk8


### PR DESCRIPTION
#### Description

Replacing dependency on `zulu-jdk8` with the more up-to-date and maintained `openjdk8-zulu` port in preparation of obsoleting the `zulu-jdk*` ports.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->