### PR TITLE
swig3: replace zulu-jdk8 dependency with openjdk8-zulu

### DIFF
--- a/devel/swig3/Portfile
+++ b/devel/swig3/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 
 name            swig3
 version         3.0.12
-revision        2
+revision        3
 checksums       rmd160  41877e9de3ff598731ef36161f77fa66dec3c301 \
                 sha256  7cf9f447ae7ed1c51722efc45e7f14418d15d7a1e143ac9f09a668999f4fc94d \
                 size    8149820
@@ -99,7 +99,7 @@ subport swig3-java {
     java.version            1.4+
     if { ${build_arch} eq "arm64"   } {
         # Set fallback to an LTS Java version
-        java.fallback           zulu-jdk8
+        java.fallback           openjdk8-zulu
     } else {
         # Set fallback to an LTS Java version
         java.fallback           openjdk8


### PR DESCRIPTION
#### Description

Replacing dependency on `zulu-jdk8` with the more up-to-date and maintained `openjdk8-zulu` port in preparation of obsoleting the `zulu-jdk*` ports.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
