### PR TITLE
micronaut: update to 2.5.1

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       java 1.0
 
-github.setup    micronaut-projects micronaut-starter 2.5.0 v
+github.setup    micronaut-projects micronaut-starter 2.5.1 v
 revision        0
 name            micronaut
 categories      java
@@ -12,6 +12,7 @@ platforms       darwin
 maintainers     {breun.nl:nils @breun} openmaintainer
 license         Apache-2
 supported_archs x86_64
+universal_variant no
 
 description     Micronaut is a modern, JVM-based, full-stack framework \
                 for building modular, easily testable microservice and serverless applications.
@@ -53,9 +54,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  f6e467a105d687c5c64e3d68d3ea3b1cf0c46530 \
-                sha256  e2e97dc73400c3e2a8c1d949a153e54c17788764860055a301f57bd65a4c8377 \
-                size    20052836
+checksums       rmd160  3a7f3d6f46fc84c7f10f280d6e154141732329d4 \
+                sha256  c5424a5a8b2f009a374047c440ec59b6b83d9ac27a0972ecd6b0c80186b03071 \
+                size    20074972
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 2.5.1.

###### Tested on

macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?