### PR TITLE
pyinfra: new port

### DIFF
--- a/sysutils/pyinfra/Portfile
+++ b/sysutils/pyinfra/Portfile
@@ -1,0 +1,50 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                pyinfra
+version             1.4
+revision            0
+
+homepage            https://pyinfra.com
+
+description         pyinfra automates infrastructure super fast at massive \
+                    scale.
+
+long_description    {*}${description}  It can be used for ad-hoc command \
+                    execution, service deployment, configuration management \
+                    and more. Core design features include super fast \
+                    execution over thousands of hosts with predictable \
+                    performance, agentless execution against \
+                    SSH/Docker/subprocess/winrm hosts, extendable with any \
+                    Python package as configured & written in standard \
+                    Python, and integrated with Docker, Vagrant/Mech & \
+                    Ansible out of the box.
+
+platforms           darwin
+license             MIT
+categories          sysutils python
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+supported_archs     noarch
+
+checksums           rmd160  3c428307414bc86d06126ddb7aeb5fbbba007cdd \
+                    sha256  3cad5ca81b4d842091f39a6e24ea8117e9c2fcb1a4abfcfb254bf1617d87dca0 \
+                    size    166876
+
+python.default_version      39
+
+depends_lib-append  port:py${python.version}-setuptools
+
+depends_run-append  port:py${python.version}-click          \
+                    port:py${python.version}-colorama       \
+                    port:py${python.version}-configparser   \
+                    port:py${python.version}-dateutil       \
+                    port:py${python.version}-distro         \
+                    port:py${python.version}-gevent         \
+                    port:py${python.version}-jinja2         \
+                    port:py${python.version}-paramiko       \
+                    port:py${python.version}-pywinrm        \
+                    port:py${python.version}-six            \
+                    port:py${python.version}-yaml


### PR DESCRIPTION
#### Description

New port for the **[pyinfra](https://pyinfra.com/)** configuration management tool.

<img src="https://pyinfra.com/static/example_deploy.gif" />

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1030 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
