### PR TITLE
boost: force thread_local off on < 10.7

### DIFF
--- a/devel/boost/Portfile
+++ b/devel/boost/Portfile
@@ -61,6 +61,11 @@ post-extract {
 
 patchfiles-append patch-apple-clang-no-libcxx.diff
 
+# libcxxabi installed by the libcxx port on the buildbot does not
+# have the cxa_thread_atexit support, so until this is fixed
+# we have to force thread_local off on < 10.7 when using libc++
+patchfiles-append patch-boost-libcpp-force-thread-local-off.diff
+
 # temporary patch to fix: explicit template instanciations in
 # boost::serialization don't get exported with all compilers; this fix
 # is already in the boost repo & will be part of a future release. See

--- a/devel/boost/files/patch-boost-libcpp-force-thread-local-off.diff
+++ b/devel/boost/files/patch-boost-libcpp-force-thread-local-off.diff
@@ -1,0 +1,13 @@
+--- boost/config/stdlib/libcpp.hpp
++++ boost/config/stdlib/libcpp.hpp
+@@ -15,6 +15,10 @@
+ #  endif
+ #endif
+ 
++#if defined(__APPLE__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1070
++#  define BOOST_NO_CXX11_THREAD_LOCAL
++#endif
++
+ #define BOOST_STDLIB "libc++ version " BOOST_STRINGIZE(_LIBCPP_VERSION)
+ 
+ #define BOOST_HAS_THREADS


### PR DESCRIPTION
libcxxabi installed on the buildbot does not have
cxa_thread_atexit so until this is fixed we must
disable thread_local on < 10.7

closes: https://trac.macports.org/ticket/62242

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
