### PR TITLE
webkit2-gtk: fix build on newer systems

### DIFF
--- a/www/webkit2-gtk/Portfile
+++ b/www/webkit2-gtk/Portfile
@@ -103,6 +103,10 @@ patchfiles-append    patch-bundle-link-webcore.diff
 # https://bugs.webkit.org/show_bug.cgi?id=207871
 patchfiles-append    patch-WTF-wtf-getVTablePointer.diff
 
+# Fix build errors due to -WWc++11-narrowing
+# https://bugs.webkit.org/show_bug.cgi?id=211193
+patchfiles-append    patch-bool_narrowed.diff
+
 # it is preferred to use the WebKit built in bmalloc if it builds on a given os.
 # it has improved security features, but not all systems can build it at present.
 

--- a/www/webkit2-gtk/files/patch-bool_narrowed.diff
+++ b/www/webkit2-gtk/files/patch-bool_narrowed.diff
@@ -1,0 +1,11 @@
+--- Source/WebCore/style/StyleResolver.cpp
++++ Source/WebCore/style/StyleResolver.cpp
+@@ -107,7 +107,7 @@ Resolver::Resolver(Document& document)
+     if (view)
+         m_mediaQueryEvaluator = MediaQueryEvaluator { view->mediaType() };
+     else
+-        m_mediaQueryEvaluator = MediaQueryEvaluator { "all" };
++        m_mediaQueryEvaluator = MediaQueryEvaluator { "all", false };
+ 
+     if (root) {
+         m_rootDefaultStyle = styleForElement(*root, m_document.renderStyle(), nullptr, RuleMatchingBehavior::MatchOnlyUserAgentRules).renderStyle;


### PR DESCRIPTION
No revbump since port either builds correctly or not at all.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.3 20E232 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
