### PR TITLE
libreoffice: add upstream patch to support macOS 11.3 SDK

### DIFF
--- a/office/libreoffice/Portfile
+++ b/office/libreoffice/Portfile
@@ -157,6 +157,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 19} {
 }
 
 patchfiles \
+    patch-11.3-sdk.diff \
     patch-configure.diff \
     patch-ucb_ucp_webdav_webdavprovider_cxx.diff \
     patch-unpack-sources-fix-for-bsd-find.diff

--- a/office/libreoffice/files/patch-11.3-sdk.diff
+++ b/office/libreoffice/files/patch-11.3-sdk.diff
@@ -1,0 +1,65 @@
+From bc35e5fe5922a71749c65a9b2d0412e4a3f34128 Mon Sep 17 00:00:00 2001
+From: Tor Lillqvist <tml@collabora.com>
+Date: Tue, 27 Apr 2021 11:38:38 +0300
+Subject: [PATCH] Accept macOS SDK 11.3
+
+Change-Id: I210ae30e51d796990f88340da8b29f4c7080f5d2
+Reviewed-on: https://gerrit.libreoffice.org/c/core/+/114702
+Tested-by: Tor Lillqvist <tml@collabora.com>
+Reviewed-by: Tor Lillqvist <tml@collabora.com>
+---
+ configure.ac | 17 +++++++++++++----
+ 1 file changed, 13 insertions(+), 4 deletions(-)
+
+diff --git configure.ac.old configure.ac
+index e3fa28c32298..e24605fcb54f 100644
+--- configure.ac
++++ configure.ac
+@@ -3108,7 +3108,7 @@ if test $_os = Darwin; then
+     # higher than or equal to the minimum required should be found.
+ 
+     AC_MSG_CHECKING([what macOS SDK to use])
+-    for _macosx_sdk in ${with_macosx_sdk-11.1 11.0 10.15 10.14 10.13}; do
++    for _macosx_sdk in ${with_macosx_sdk-11.3 11.1 11.0 10.15 10.14 10.13}; do
+         MACOSX_SDK_PATH=`xcrun --sdk macosx${_macosx_sdk} --show-sdk-path 2> /dev/null`
+         if test -d "$MACOSX_SDK_PATH"; then
+             with_macosx_sdk="${_macosx_sdk}"
+@@ -3143,8 +3143,11 @@ if test $_os = Darwin; then
+     11.1)
+         MACOSX_SDK_VERSION=110100
+         ;;
++    11.3)
++        MACOSX_SDK_VERSION=110300
++        ;;
+     *)
+-        AC_MSG_ERROR([with-macosx-sdk $with_macosx_sdk is not a supported value, supported values are 10.13--11.1])
++        AC_MSG_ERROR([with-macosx-sdk $with_macosx_sdk is not a supported value, supported values are 10.13--11.3])
+         ;;
+     esac
+ 
+@@ -3209,8 +3212,11 @@ if test $_os = Darwin; then
+     11.1)
+         MAC_OS_X_VERSION_MIN_REQUIRED="110100"
+         ;;
++    11.3)
++        MAC_OS_X_VERSION_MIN_REQUIRED="110300"
++        ;;
+     *)
+-        AC_MSG_ERROR([with-macosx-version-min-required $with_macosx_version_min_required is not a supported value, supported values are 10.10--11.1])
++        AC_MSG_ERROR([with-macosx-version-min-required $with_macosx_version_min_required is not a supported value, supported values are 10.10--11.3])
+         ;;
+     esac
+ 
+@@ -3274,8 +3280,11 @@ if test $_os = Darwin; then
+     11.1)
+         MAC_OS_X_VERSION_MAX_ALLOWED="110100"
+         ;;
++    11.3)
++        MAC_OS_X_VERSION_MAX_ALLOWED="110300"
++        ;;
+     *)
+-        AC_MSG_ERROR([with-macosx-version-max-allowed $with_macosx_version_max_allowed is not a supported value, supported values are 10.10--11.1])
++        AC_MSG_ERROR([with-macosx-version-max-allowed $with_macosx_version_max_allowed is not a supported value, supported values are 10.10--11.3])
+         ;;
+     esac
+ 


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/62827
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [x] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
