### PR TITLE
sourcehut: new portgroup

### DIFF
--- a/_resources/port1.0/group/sourcehut-1.0.tcl
+++ b/_resources/port1.0/group/sourcehut-1.0.tcl
@@ -1,0 +1,63 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+#
+# This PortGroup accommodates projects hosted with sourcehut, either at sr.ht
+# or on individual instances (via sourcehut.instance)
+
+options sourcehut.author sourcehut.project sourcehut.version sourcehut.tag_prefix sourcehut.tag_suffix
+
+options sourcehut.instance
+default sourcehut.instance {https://git.sr.ht}
+
+options sourcehut.homepage
+default sourcehut.homepage {${sourcehut.instance}/~${sourcehut.author}/${sourcehut.project}}
+
+# Later code assumes that sourcehut.master_sites is a simple string, not a list.
+options sourcehut.master_sites
+default sourcehut.master_sites {${sourcehut.homepage}/archive/}
+
+options sourcehut.livecheck.branch
+default sourcehut.livecheck.branch master
+
+options sourcehut.livecheck.regex
+default sourcehut.livecheck.regex {(\[0-9]\[^<]+)}
+
+proc sourcehut.setup {srht_author srht_project srht_version {srht_tag_prefix ""} {srht_tag_suffix ""}} {
+    global extract.suffix sourcehut.author sourcehut.project sourcehut.version sourcehut.tag_prefix sourcehut.tag_suffix
+    global sourcehut.homepage sourcehut.master_sites sourcehut.livecheck.branch PortInfo
+
+    sourcehut.author           ${srht_author}
+    sourcehut.project          ${srht_project}
+    sourcehut.version          ${srht_version}
+    sourcehut.tag_prefix       ${srht_tag_prefix}
+    sourcehut.tag_suffix       ${srht_tag_suffix}
+
+    if {!([info exists PortInfo(name)] && (${PortInfo(name)} ne ${sourcehut.project}))} {
+        name                ${sourcehut.project}
+    }
+
+    version                 ${sourcehut.version}
+    default homepage        ${sourcehut.homepage}
+    git.url                 ${sourcehut.homepage}
+    git.branch              [join ${sourcehut.tag_prefix}]${sourcehut.version}[join ${sourcehut.tag_suffix}]
+    default master_sites    {${sourcehut.master_sites}}
+    distname                [join ${sourcehut.tag_prefix}]${sourcehut.version}[join ${sourcehut.tag_suffix}]
+
+    # If the version is composed entirely of hex characters, and is at least 7
+    # characters long, and is not exactly 8 decimal digits (which might be a
+    # version in YYYYMMDD format), and no tag prefix or suffix is provided, then
+    # assume we are using a commit hash and livecheck commits; otherwise
+    # livecheck tags.
+    if {[join ${sourcehut.tag_prefix}] eq "" && \
+        [join ${sourcehut.tag_suffix}] eq "" && \
+        [regexp "^\[0-9a-f\]{7,}\$" ${sourcehut.version}] && \
+        ![regexp "^\[0-9\]{8}\$" ${sourcehut.version}]} {
+        livecheck.type          regexm
+        default livecheck.url   {${sourcehut.homepage}/log/${sourcehut.livecheck.branch}/rss.xml}
+        default livecheck.regex {commit/(\[0-9a-f\]{[string length ${sourcehut.version}]})\[0-9a-f\]*</guid>}
+    } else {
+        livecheck.type          regex
+        default livecheck.url   {${sourcehut.homepage}/refs/rss.xml}
+        default livecheck.regex {refs/[join ${sourcehut.tag_prefix}][join ${sourcehut.livecheck.regex}][join ${sourcehut.tag_suffix}]</guid>}
+    }
+    livecheck.version       ${sourcehut.version}
+}

--- a/textproc/scdoc/Portfile
+++ b/textproc/scdoc/Portfile
@@ -2,19 +2,15 @@
 
 PortSystem          1.0
 PortGroup           makefile 1.0
+PortGroup           sourcehut 1.0
 
-name                scdoc
-version             1.11.1
+sourcehut.setup     sircmpwn scdoc 1.11.1
 categories          textproc
 license             MIT
 maintainers         nomaintainer
 description         Simple man page generator.
 long_description    scdoc is a simple man page generator for POSIX systems written in C99.
 platforms           darwin
-homepage            https://git.sr.ht/~sircmpwn/scdoc/
-master_sites        https://git.sr.ht/~sircmpwn/scdoc/archive/
-distname            ${version}
-worksrcdir          ${name}-${distname}
 
 # scdoc 1.11.1's checksums have changed
 # https://trac.macports.org/wiki/PortfileRecipes#stealth-updates
@@ -31,6 +27,3 @@ installs_libs       no
 
 test.run            yes
 test.target         check
-
-livecheck.url       https://git.sr.ht/~sircmpwn/scdoc/refs/rss.xml
-livecheck.regex     ${homepage}refs/\(\[0-9.\]+\)


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Add a PortGroup for [sourcehut](https://sourcehut.org).

This copies the GitHub and GitLab port groups heavily.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
