### PR TITLE
sse2neon: new port

### DIFF
--- a/devel/sse2neon/Portfile
+++ b/devel/sse2neon/Portfile
@@ -1,0 +1,59 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           compiler_blacklist_versions 1.0
+PortGroup           makefile 1.0
+
+github.setup        DLTcollab sse2neon d55a36ae38cb79ce4587d7fd7f47c53a4ab55d57
+version             0.0.0
+revision            20210505
+categories          devel
+platforms           darwin
+license             MIT
+maintainers         @jasonliu-- openmaintainer
+
+description         library for translating Intel SSE intrinsics to \
+                    ARM Neon intrinsics
+long_description    sse2neon is a C/C++ header file that translates \
+                    Intel SSE (Streaming SIMD Extensions) intrinsics \
+                    to ARM Neon intrinsics. This allows code that uses \
+                    SSE intrinsics to compile and run on ARM \
+                    processors without needing to rewrite the code to \
+                    directly use Neon intrinsics. \
+                    \n \
+                    \nIf you need to translate more advanced Intel \
+                    intrinsics (such as AVX) to ARM intrinsics, then \
+                    please consider using SIMDe (SIMD everywhere) \
+                    instead of sse2neon.
+
+checksums           rmd160  7e9dd4321de629478476654af737d587ec2c4dab \
+                    sha256  9f1d7915b71b6920e12fd0d2358562f6dcd9e6477d81f3d785b2724c53557658 \
+                    size    88677
+
+compiler.blacklist-append   {clang < 1103}
+
+use_configure       no
+build.target        {}
+destroot.target     {}
+
+post-destroot {
+    xinstall ${worksrcpath}/sse2neon.h ${destroot}${prefix}/include
+}
+
+variant tests description {Build unit tests} {
+    post-destroot {
+        set destroot_share ${destroot}${prefix}/share/${name}
+        if {![file exists $destroot_share]} {
+            file mkdir $destroot_share
+        }
+        copy ${worksrcpath}/tests $destroot_share/
+    }
+}
+
+default_variants    +tests
+
+if {![variant_isset tests]} {
+    build           {}
+    destroot        {}
+}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

[sse2neon](https://github.com/DLTcollab/sse2neon) is a library that allows code that has been written to use Intel SSE intrinsics to run on ARM processors.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->