### PR TITLE
SIMDe: new port

### DIFF
--- a/devel/simde/Portfile
+++ b/devel/simde/Portfile
@@ -1,0 +1,55 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           compiler_blacklist_versions 1.0
+PortGroup           meson 1.0
+
+github.setup        simd-everywhere simde 0.7.2 v
+categories          devel
+platforms           darwin
+license             MIT
+maintainers         @jasonliu-- openmaintainer
+
+description         library that implements SIMD instruction sets for \
+                    systems which don't natively support them
+long_description    SIMDe (SIMD everywhere) is a header-only library \
+                    that provides fast, portable implementations of \
+                    SIMD (Single Instruction, Multiple Data) \
+                    intrinsics on hardware which doesn't natively \
+                    them, such as calling Intel SSE or AVX functions \
+                    on an ARM processor, or calling ARM Neon functions \
+                    on an Intel processor. \
+                    \n \
+                    \nThis makes porting code to other architectures \
+                    much easier in some key ways. First, instead of \
+                    forcing you to rewrite everything for each \
+                    architecture, SIMDe lets you get a port up and \
+                    running almost effortlessly. Second, SIMDe makes \
+                    it easier to write code targeting ISA extensions \
+                    you don't have access to, without needing to \
+                    resort to using an emulator.
+
+checksums           rmd160  7b814ba0603038012d6ea663deb673afa31430f4 \
+                    sha256  7df5285772f28ced8e3dff824a84f5fadb45654974e1e17d0f6a5c984f9b24ad \
+                    size    3822187
+
+compiler.blacklist-append   {clang < 802}
+
+pre-configure {
+    if {![variant_isset tests]} {
+        configure.args-append   -Dtests=false
+    }
+}
+
+variant tests description {Build unit tests} {
+    post-destroot {
+        set destroot_share ${destroot}${prefix}/share/${name}
+        if {![file exists $destroot_share]} {
+            file mkdir $destroot_share
+        }
+        copy ${build.dir}/test $destroot_share/
+    }
+}
+
+default_variants    +tests


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

[SIMDe](https://github.com/simd-everywhere/simde) (SIMD everywhere) is a header-only library that provides fast, portable implementations of SIMD intrinsics on hardware that doesn't natively support them, such as calling Intel SSE or AVX functions on an ARM processor, or calling ARM Neon functions on an Intel processor.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->