### PR TITLE
s3cmd: add Python dateutil and magic dependencies

### DIFF
--- a/net/s3cmd/Portfile
+++ b/net/s3cmd/Portfile
@@ -31,6 +31,8 @@ supported_archs     noarch
 python.default_version  38
 
 depends_build-append    port:py${python.default_version}-setuptools
-depends_run-append      path:share/curl/curl-ca-bundle.crt:curl-ca-bundle
+depends_run-append      path:share/curl/curl-ca-bundle.crt:curl-ca-bundle \
+                        port:py${python.default_version}-dateutil \
+                        port:py${python.default_version}-magic
 
 github.livecheck.regex  {([0-9.]+)}


### PR DESCRIPTION
#### Description

Adds two missing runtime dependencies for s3cmd, py##-dateutil and py##-magic. The former is used by things such as the `ls` command, to list file, directory, or bucket dates. `s3cmd ls` is not even functional without `datetime`. The latter is used during upload to supply MIME types of files. The package will still function without it, but will not handle automatic MIME type submission.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.3.1 20E241 arm64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
