### PR TITLE
zulu-jdk: obsolete and replace by openjdk*-zulu

### DIFF
--- a/java/zulu-jdk/Portfile
+++ b/java/zulu-jdk/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem       1.0
+PortGroup        obsolete 1.0
 
 name             zulu-jdk
 categories       java devel
@@ -9,320 +10,81 @@ platforms        darwin
 license          GPL-2
 homepage         https://www.azul.com/downloads/zulu-community/
 
-supported_archs  x86_64 arm64
+replaced_by      openjdk11-zulu
 
-set zulu_build   ca
-
-# define the TLS version
-set major                  11
-
-set jdk_version(x64)       $major
-set zulu_version(x64)      $major
-set jdk_version(aarch64)   $major
-set zulu_version(aarch64)  $major
-
+# Remove after 2022-05-07
 subport zulu-jdk7 {
-
-    set jdk_version(x64)       7.0.285
-    set zulu_version(x64)      7.42.0.51
-    set major                  7
-    revision                   0
-
-    supported_archs            x86_64
-
-    checksums                  zulu${zulu_version(x64)}-${zulu_build}-jdk${jdk_version(x64)}-macosx_x64.zip \
-        rmd160                 6abb91781f1f224cc78bdb090ef4dec7eb46947d \
-        sha256                 68141d1b5a31b01574d443c9b8ceb516aaebbb33ed366a724ec5d516ca7c26cd \
-        size                   70803383
-
-    set zulu_use_rosetta       yes
-
-    variant without_xawt description "Xawt is linking with X11 at /opt/X11/lib that should be installed separately" {
-        set zulu_without_jre_xawt  yes
-    }
-
-    default_variants           +without_xawt
+    version     7.42.0.51
+    revision    1
+    replaced_by openjdk8-zulu
 }
 
+# Remove after 2022-05-07
 subport zulu-jdk8 {
-
-    set jdk_version(aarch64)   8.0.282
-    set jdk_version(x64)       8.0.282
-    set zulu_version(aarch64)  8.52.0.23
-    set zulu_version(x64)      8.52.0.23
-    set major                  8
-    revision                   0
-
-
-    checksums                  zulu${zulu_version(aarch64)}-ca-jdk${jdk_version(aarch64)}-macosx_aarch64.zip \
-        rmd160                 b755fb53526dbd1abde74c6cd28a6df3df73a87e \
-        sha256                 bff18757bf74fa6c2399aa2fcce2d1a8fede37c110a55ac4198d97805a940f00 \
-        size                   110196924 \
-        zulu${zulu_version(x64)}-${zulu_build}-jdk${jdk_version(x64)}-macosx_x64.zip \
-        rmd160                 009504969d68711a4b25eae2c34d0be6e4b0f6a4 \
-        sha256                 a2f161b41dc8e812e223645dbbf8f57fc1224006aab9243d1b1d7f2502c95f11 \
-        size                   114357405
+    version     8.52.0.23
+    revision    1
+    replaced_by openjdk8-zulu
 }
 
+# Remove after 2022-05-07
 subport zulu-jdk9 {
-
-    set jdk_version(x64)       9.0.7
-    set zulu_version(x64)      9.0.7.1
-    set major                  9
-    revision                   0
-
-    supported_archs            x86_64
-
-    checksums                  zulu${zulu_version(x64)}-${zulu_build}-jdk${jdk_version(x64)}-macosx_x64.zip \
-        rmd160                 0edab1af1873860d28844f9e8deae145e3601af7 \
-        sha256                 4b1f8529ff3a8bebc974e2a22395cb27ad8750e386c8c4d1b0a1b16f89cfcf66 \
-        size                   195923680
-
-    set zulu_no_bundle         yes
-    set zulu_use_rosetta       yes
+    version     9.0.7.1
+    revision    1
+    replaced_by openjdk11-zulu
 }
 
+# Remove after 2022-05-07
 subport zulu-jdk10 {
-
-    set jdk_version(x64)       10.0.2
-    set zulu_version(x64)      10.3.5
-    set major                  10
-    revision                   0
-
-    supported_archs            x86_64
-
-    checksums                  zulu${zulu_version(x64)}-${zulu_build}-jdk${jdk_version(x64)}-macosx_x64.zip \
-        rmd160                 874308e47bd8bebc0783b182a081fcf21ed88004 \
-        sha256                 ffeada0b80d51f1d18a703926538c2f9e1cfe1f51f968a726b866387ac74fd16 \
-        size                   208176633
-
-    set zulu_no_bundle         yes
-    set zulu_use_rosetta       yes
+    version     10.3.5
+    revision    1
+    replaced_by openjdk11-zulu
 }
 
+# Remove after 2022-05-07
 subport zulu-jdk11 {
-
-    set jdk_version(aarch64)   11.0.10
-    set jdk_version(x64)       11.0.10
-    set zulu_version(aarch64)  11.45.27
-    set zulu_version(x64)      11.45.27
-    set major                  11
-    revision                   0
-
-    checksums                  zulu${zulu_version(aarch64)}-${zulu_build}-jdk${jdk_version(aarch64)}-macosx_aarch64.zip \
-        rmd160                 7d655e1ea4e288a4c9939d39c692e0b1359b1ff5 \
-        sha256                 141ef9f81fb3b458578b7cc5e448cb6f904338df70bb9aeb8e112700b0eb2c04 \
-        size                   182940257 \
-                               zulu${zulu_version(x64)}-${zulu_build}-jdk${jdk_version(x64)}-macosx_x64.zip \
-        rmd160                 caa41b1de707e1136827353f0d4c0bef6a187f26 \
-        sha256                 6d9a7f23a476d115a3e676d91ad0c718f774407ef586259ca0eeac7e1f3e6cde \
-        size                   199969956
+    version     11.45.27
+    revision    1
+    replaced_by openjdk11-zulu
 }
 
+# Remove after 2022-05-07
 subport zulu-jdk12 {
-
-    set jdk_version(x64)       12.0.2
-    set zulu_version(x64)      12.3.11
-    set major                  12
-    revision                   0
-
-    supported_archs            x86_64
-
-    checksums                  zulu${zulu_version(x64)}-${zulu_build}-jdk${jdk_version(x64)}-macosx_x64.zip \
-        rmd160                 ec52ca999579f607bd7a278f2340ee052e429505 \
-        sha256                 8e8b686c625c95ed693c039b27f81751c58fba8090b8141ea632877de5503639 \
-        size                   203549959
-
-    set zulu_no_bundle         yes
-    set zulu_use_rosetta       yes
+    version     12.3.11
+    revision    1
+    replaced_by openjdk13-zulu
 }
 
+# Remove after 2022-05-07
 subport zulu-jdk13 {
-
-    set jdk_version(aarch64)   13.0.6
-    set jdk_version(x64)       13.0.6
-    set zulu_version(aarch64)  13.37.21
-    set zulu_version(x64)      13.37.21
-    set major                  13
-    revision                   0
-
-    checksums                  zulu${zulu_version(aarch64)}-${zulu_build}-jdk${jdk_version(aarch64)}-macosx_aarch64.zip \
-        rmd160                 ab0966d78e5c67b9efb86a360210169a6fabb4bd \
-        sha256                 5d22062838a0574e2043f2870a1285e8da5d206fdeb8cae7b34505b1d2b901c6 \
-        size                   183297252 \
-                               zulu${zulu_version(x64)}-${zulu_build}-jdk${jdk_version(x64)}-macosx_x64.zip \
-        rmd160                 d9c8bff6246999455a03912d1e8460b15646eb9d \
-        sha256                 680e29cb87346cbec75654cb530ab1ad73b6ba9003022cecf7c5f39c74b73726 \
-        size                   204917095
+    version     13.37.21
+    revision    1
+    replaced_by openjdk13-zulu
 }
 
+# Remove after 2022-05-07
 subport zulu-jdk14 {
-
-    set jdk_version(x64)       14.0.2
-    set zulu_version(x64)      14.29.23
-    set major                  14
-    revision                   0
-
-    supported_archs            x86_64
-
-    checksums                  zulu${zulu_version(x64)}-${zulu_build}-jdk${jdk_version(x64)}-macosx_x64.zip \
-        rmd160                 f97f9d7d7ad526797ff8dcd32ab9c5187aa4f5cb \
-        sha256                 57e737d639a6927c82626fd18257751e6bb4d64e291b8fac62ddad01255a1d77 \
-        size                   207255111
-
-    set zulu_use_rosetta       yes
+    version     14.29.23
+    revision    1
+    replaced_by openjdk15-zulu
 }
 
+# Remove after 2022-05-07
 subport zulu-jdk15 {
-
-    set jdk_version(aarch64)   15.0.2
-    set jdk_version(x64)       15.0.2
-    set zulu_version(aarch64)  15.29.15
-    set zulu_version(x64)      15.29.15
-    set major                  15
-    revision                   0
-
-    checksums                  zulu${zulu_version(x64)}-${zulu_build}-jdk${jdk_version(x64)}-macosx_aarch64.zip \
-        rmd160                 6d63e36737403f0664c9bfb303420e6dc6e29f04 \
-        sha256                 4f6f75d99eb7392c42a49e740de50f9ee346a21f76a8d1bb5317c40fda767c85 \
-        size                   179987981 \
-                               zulu${zulu_version(x64)}-${zulu_build}-jdk${jdk_version(x64)}-macosx_x64.zip \
-        rmd160                 64f61c447516150577b5f39d105a55e2cc72e545 \
-        sha256                 2a54122297c050caab353dfd8125286db75d25c8629574c056ec824c074f3958 \
-        size                   206555469
+    version     15.29.15
+    revision    1
+    replaced_by openjdk15-zulu
 }
 
+# Remove after 2022-05-07
 subport zulu-jdk16 {
-
-    set jdk_version(aarch64)   16.0.0-ea.33
-    set jdk_version(x64)       16.0.0-ea.33
-    set zulu_version(aarch64)  16.0.83
-    set zulu_version(x64)      16.0.83
-    set major                  16
-    revision                   0
-
-    set zulu_build             ea
-
-    checksums                  zulu${zulu_version(aarch64)}-${zulu_build}-jdk${jdk_version(aarch64)}-macosx_aarch64.zip \
-        rmd160                 0867d95c829647109f2a924e5a2b59f0b669bf6e \
-        sha256                 d86b66b3edb3d818a2b6034c3cf08ec0ef8b5fadec871f87f363d0b5bf2bf28b \
-        size                   199599833 \
-                               zulu${zulu_version(x64)}-${zulu_build}-jdk${jdk_version(x64)}-macosx_x64.zip \
-        rmd160                 1c6cc6f6e6403f3ab786a9be81a65968be3a480d \
-        sha256                 4651b72f575dc3ae8a326bf7c1f55e98f2bdbe62fd2ffa88fce49a602ee78132 \
-        size                   211155022
+    version     16.0.83
+    revision    1
+    replaced_by openjdk16-zulu
 }
 
+# Remove after 2022-05-07
 subport zulu-jdk17 {
-
-    set jdk_version(aarch64)   17.0.0-ea.6
-    set jdk_version(x64)       17.0.0-ea.6
-    set zulu_version(aarch64)  17.0.21
-    set zulu_version(x64)      17.0.21
-    set major                  17
-    revision                   0
-
-    set zulu_build             ea
-
-    checksums                  zulu${zulu_version(aarch64)}-${zulu_build}-jdk${jdk_version(aarch64)}-macosx_aarch64.zip \
-        rmd160                 197d7674b84bc738b61563f7bb89cce83f3eee90 \
-        sha256                 a381a595c1d8281982d72488d50652c268eb853aa7d5b26bab312c6110f64c26 \
-        size                   200606692 \
-                               zulu${zulu_version(x64)}-${zulu_build}-jdk${jdk_version(x64)}-macosx_x64.zip \
-        rmd160                 dc87e4f74487c540aee2af37c5691dbfd7ac3cbb \
-        sha256                 fc081e5af2283a14888dead20ca03d19e23bbee770e9637e727313786b1ff7ea \
-        size                   212223878
+    version     17.0.21
+    revision    1
+    replaced_by openjdk16-zulu
 }
-
-set zulu_arch(arm64)       aarch64
-set zulu_arch(x86_64)      x64
-
-if {![info exists zulu_arch(${build_arch})]} {
-    set zulu_arch(${build_arch}) ${build_arch}
-}
-
-set zulu_name(arm64)       macosx
-set zulu_name(x86_64)      macosx
-
-if {![info exists zulu_name(${build_arch})]} {
-    set zulu_name(${build_arch}) macosx
-}
-
-if {[info exists zulu_use_rosetta]} {
-    set zulu_arch(arm64)     $zulu_arch(x86_64)
-    set zulu_name(arm64)     $zulu_name(x86_64)
-}
-
-if {![info exists zulu_version($zulu_arch($build_arch))]} {
-    set zulu_version($zulu_arch($build_arch)) $major
-    distfiles
-}
-if {![info exists jdk_version($zulu_arch($build_arch))]} {
-    set jdk_version($zulu_arch($build_arch)) $major
-}
-
-version     $zulu_version($zulu_arch($build_arch))
-
-if {${subport} eq "zulu-jdk"} {
-    PortGroup    obsolete 1.0
-    replaced_by  zulu-jdk${major}
-}
-
-
-if {${os.platform} eq "darwin" && ${os.major} < 14} {
-    known_fail yes
-    pre-fetch {
-        ui_error "${name} ${version} is only supported on OS X 10.10 Yosemite or later."
-        return -code error
-    }
-}
-
-description  Open Java Development Kit ${major} (Zulu) with HotSpot VM
-long_description OpenJDK build provided by Azul, built from a fully \
-    open-source set of build scripts and infrastructure. \
-    \
-    HotSpot is the VM from the OpenJDK community and  the most widely used VM. \
-    It is suitable for all workloads.
-
-master_sites   https://cdn.azul.com/zulu/bin/
-distname       zulu$zulu_version($zulu_arch($build_arch))-${zulu_build}-jdk$jdk_version($zulu_arch($build_arch))-$zulu_name($build_arch)_$zulu_arch($build_arch)
-use_zip        yes
-worksrcdir     zulu$zulu_version($zulu_arch($build_arch))
-use_configure  no
-
-if {$major < 9} {
-    configure.cxx_stdlib libstdc++
-}
-
-
-build {}
-
-# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
-destroot.violate_mtree yes
-
-set target /Library/Java/JavaVirtualMachines/${subport}
-set destroot_target ${destroot}${target}
-
-destroot {
-    if {[info exists zulu_no_bundle]} {
-        xinstall -m 755 -d ${destroot_target}/Contents/Home
-        copy {*}[glob ${worksrcpath}/*] ${destroot_target}/Contents/Home
-    } else {
-        xinstall -m 755 -d ${destroot_target}
-        copy ${worksrcpath}/zulu-${major}.jdk/Contents ${destroot_target}
-    }
-    if {[info exists zulu_without_jre_xawt]} {
-        file delete -force ${destroot_target}/Contents/Home/jre/lib/xawt
-    }
-}
-
-notes "
-If you have more than one JDK installed you can make ${subport} the default\
-by adding the following line to your shell profile:
-
-    export JAVA_HOME=${target}/Contents/Home
-"
-
-livecheck.type       regex
-livecheck.url        [lindex ${master_sites} 0]
-livecheck.regex      zulu(\[0-9.\]+)-${zulu_build}-jdk$major\.\[0-9.\\-ea\]+-$zulu_name($build_arch)_$zulu_arch($build_arch)\.zip


### PR DESCRIPTION
#### Description

Obsolete unmaintained and outdated `zulu-jdk*` ports and replace by `openjdk*-zulu`. Any other ports that had dependencies on `zulu-jdk*` have already been updated to use `openjdk*-zulu` instead.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?