### PR TITLE
mpich: Disable alloca

### DIFF
--- a/science/mpich/Portfile
+++ b/science/mpich/Portfile
@@ -23,7 +23,7 @@ PortGroup           legacysupport 1.1
 # make sure to keep in sync with mpi-doc
 name                mpich
 version             3.4.1
-revision            2
+revision            3
 
 license             BSD
 categories          science parallel net
@@ -185,7 +185,6 @@ configure.args      --disable-dependency-tracking    \
                     --with-pm=hydra                  \
                     --with-thread-package=posix      \
                     --with-hwloc-prefix=${prefix}    \
-                    --enable-alloca                  \
                     "F90FLAGS='' F90=''"
 
 variant threads description {Build with full thread support} {


### PR DESCRIPTION
Maintainer update.

Running into repeatable crashes with this option enabled; goes away when turned off; occurs across ch3 and ch4.

Removing --enable-alloca and revbumping.