### PR TITLE
kitty: Add terminfo to prefix

### DIFF
--- a/aqua/kitty/Portfile
+++ b/aqua/kitty/Portfile
@@ -7,7 +7,7 @@ PortGroup           gpg_verify 1.0
 
 github.setup        kovidgoyal kitty 0.20.3 v
 github.tarball_from releases
-revision            0
+revision            1
 
 categories          aqua
 platforms           macosx
@@ -66,6 +66,7 @@ python.default_version \
 depends_build-append \
                     port:lcms2 \
                     port:librsvg \
+                    port:ncurses \
                     port:optipng \
                     port:pkgconfig
 
@@ -84,6 +85,13 @@ pre-build {
 
 destroot {
     copy ${worksrcpath}/kitty.app ${destroot}${applications_dir}
+
+    # Add terminfo to $prefix for is handled correctly when executing
+    # commands with sudo.
+    set terminfo_path ${prefix}/share/terminfo/78
+    xinstall -d ${destroot}${terminfo_path}
+    xinstall -m 0644 ${worksrcpath}/terminfo/x/xterm-kitty \
+        ${destroot}${terminfo_path}
 
     # add shell completion files
     set bash_complete ${prefix}/share/bash-completion/completions


### PR DESCRIPTION
Although terminfo is included inside Kitty.app, terminfo is not handled correctly when executing commands with sudo.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
