### PR TITLE
wezterm: update to 20210502-154244-3f7122cb

### DIFF
--- a/aqua/wezterm/Portfile
+++ b/aqua/wezterm/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        wez wezterm 20210405-110924-a5bb5be8
-revision            1
+github.setup        wez wezterm 20210502-154244-3f7122cb
+revision            0
 
 homepage            https://wezfurlong.org/wezterm
 


### PR DESCRIPTION
#### Description

Update Wezterm to version 20210502-154244-3f7122cb

###### Tested on

macOS 11.3 20E232 arm64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?