### PR TITLE
chromedriver-78: remove obsolete port

### DIFF
--- a/www/chromedriver/Portfile
+++ b/www/chromedriver/Portfile
@@ -132,16 +132,6 @@ subport ${name}-79 {
     livecheck.type  none
 }
 
-subport ${name}-78 {
-    version         78.0.3904.70
-
-    # This subport can be removed on September 8, 2020.
-    PortGroup       obsolete 1.0
-
-    distfiles
-    livecheck.type      none
-}
-
 livecheck.type      regex
 livecheck.url       http://chromedriver.storage.googleapis.com/LATEST_RELEASE
 livecheck.regex     {^(.*)$}


### PR DESCRIPTION
Obsoleted in 5e778112e2 over one year ago

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
