### PR TITLE
pymol: add -devel port

### DIFF
--- a/science/pymol/Portfile
+++ b/science/pymol/Portfile
@@ -7,6 +7,7 @@ PortGroup           github 1.0
 
 github.setup        schrodinger pymol-open-source 2.4.0 v
 name                pymol
+conflicts           pymol-devel
 revision            2
 
 categories          science chemistry
@@ -25,6 +26,17 @@ homepage            https://www.pymol.org/
 checksums           rmd160  e7a962473732172b370e6c7a880384e7a1ffa62e \
                     sha256  b0af15082c44c92c285cab341506da50407619f5dee09d98fdf2802e356219fd \
                     size    10552074
+
+subport pymol-devel {
+    github.setup    schrodinger pymol-open-source 4a3c72ace1f8e39e80db4026d45222f8b7a44169
+    version         20210428-[string range ${github.version} 0 7]
+    conflicts       pymol
+    revision        0
+    maintainers     {reneeotten @reneeotten} openmaintainer
+    checksums       rmd160  b8f596935a043a3ecde7b8f0e1c914b74277d1d0 \
+                    sha256  92f39021487fa1c3da1840721c7ad4c3992dfcb54d73fef27fb30842828425a8 \
+                    size    10469954
+}
 
 variant python27 conflicts python36 python37 python38 python39 description {Use Python 2.7} {}
 variant python36 conflicts python27 python37 python38 python39 description {Use Python 3.6} {}
@@ -91,8 +103,21 @@ patchfiles          pymol_shell.diff \
                     pdb2pqr.patch \
                     setup.py.diff
 
+if {${subport} eq "pymol-devel"} {
+    patchfiles-delete \
+                    apbs-psize.patch  \
+                    python_string_split.patch \
+                    pdb2pqr.patch \
+    patchfiles-replace \
+                    setup.py.diff \
+                    patch-devel-setup.py.diff
+}
+
 post-patch {
-    reinplace  "s|@PREFIX@|${prefix}|g" ${worksrcpath}/setup.py ${worksrcpath}/modules/pmg_tk/startup/apbs_tools.py
+    reinplace  "s|@PREFIX@|${prefix}|g" ${worksrcpath}/setup.py
+    if { [ file exists ${worksrcpath}/modules/pmg_tk/startup/apbs_tools.py ] } {
+        reinplace  "s|@PREFIX@|${prefix}|g" ${worksrcpath}/modules/pmg_tk/startup/apbs_tools.py
+    }
     reinplace  "s|@@PYTHON_PKGDIR@@|${python.pkgd}|g" ${worksrcpath}/setup/pymol_macports
     reinplace  "s|@@PYTHON_BINARY@@|${python.bin}|g" ${worksrcpath}/setup/pymol_macports
     reinplace  "s|cxx + ' ' + cxxflags|'${configure.cxx} ' + cxxflags|g" ${worksrcpath}/monkeypatch_distutils.py

--- a/science/pymol/Portfile
+++ b/science/pymol/Portfile
@@ -26,35 +26,35 @@ checksums           rmd160  e7a962473732172b370e6c7a880384e7a1ffa62e \
                     sha256  b0af15082c44c92c285cab341506da50407619f5dee09d98fdf2802e356219fd \
                     size    10552074
 
-compiler.cxx_standard 2011
-
-variant python27 conflicts python35 python36 python37 python38 description {Use Python 2.7} {}
-variant python35 conflicts python27 python36 python37 python38 description {Use Python 3.5} {}
-variant python36 conflicts python27 python35 python37 python38 description {Use Python 3.6} {}
-variant python37 conflicts python27 python35 python36 python38 description {Use Python 3.7} {}
-variant python38 conflicts python27 python35 python36 python37 description {Use Python 3.8} {}
+variant python27 conflicts python36 python37 python38 python39 description {Use Python 2.7} {}
+variant python36 conflicts python27 python37 python38 python39 description {Use Python 3.6} {}
+variant python37 conflicts python27 python36 python38 python39 description {Use Python 3.7} {}
+variant python38 conflicts python27 python36 python37 python39 description {Use Python 3.8} {}
+variant python39 conflicts python27 python36 python37 python38 description {Use Python 3.9} {}
 
 if {[variant_isset python27]} {
     python.default_version 27
-} elseif {[variant_isset python35]} {
-    python.default_version 35
 } elseif {[variant_isset python36]} {
     python.default_version 36
 } elseif {[variant_isset python37]} {
     python.default_version 37
 } elseif {[variant_isset python38]} {
     python.default_version 38
+} elseif {[variant_isset python39]} {
+    python.default_version 39
 } else {
     if {[variant_isset x11]} {
         # The APBS Tools plugin requires pdb2pqr, which can't be run under python3 yet
         default_variants +python27
         python.default_version 27
     } else {
-        default_variants +python38
-        python.default_version 38
+        default_variants +python39
+        python.default_version 39
     }
 }
 python.link_binaries no
+
+compiler.cxx_standard 2011
 
 depends_lib-append  port:freetype \
                     port:glew \

--- a/science/pymol/files/patch-devel-setup.py.diff
+++ b/science/pymol/files/patch-devel-setup.py.diff
@@ -1,0 +1,11 @@
+--- setup.py.orig	2020-07-06 11:00:54.000000000 -0400
++++ setup.py	2020-07-06 11:01:23.000000000 -0400
+@@ -86,7 +86,7 @@
+     X11 = ['/usr/X11'] * (not options.osx_frameworks)
+ 
+     if sys.platform == 'darwin':
+-        for prefix in ['/sw', '/opt/local', '/usr/local']:
++        for prefix in ['@@PREFIX@@', '/usr/local']:
+             if sys.base_prefix.startswith(prefix):
+                 return [prefix] + X11
+ 


### PR DESCRIPTION
#### Description
Track the development version of `pymol` in a `-devel` subport since they don't tag minor releases on GitHub.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1030 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? No tests with `-devel` version.
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
