### PR TITLE
flyctl: New port

### DIFF
--- a/devel/flyctl/Portfile
+++ b/devel/flyctl/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        superfly flyctl 0.0.216 v
+revision            0
+categories          devel
+platforms           darwin
+supported_archs     arm64 x86_64
+license             Apache-2
+maintainers         {netinertia.co.uk:jamesog @jamesog} \
+                    openmaintainer
+
+description         Command line tools for fly.io services
+long_description    ${name} is a command-line interface for fly.io.
+
+homepage            https://fly.io
+
+github.tarball_from releases
+distname            ${name}_${version}_macOS_${build_arch}
+
+checksums           rmd160  58b5717c723b3252773e71e7850e4cded97c0250 \
+                    sha256  fdab337dcd61df20d5b8629cb7c6b1ace3a28db9307ba256fc33f137efbf1d67 \
+                    size    16696177
+
+use_configure       no
+installs_libs       no
+
+build {}
+
+extract.mkdir       yes
+
+destroot {
+    xinstall -m 0755 -W ${worksrcpath} ${name} ${destroot}${prefix}/bin
+    ln -s ${prefix}/bin/${name} ${destroot}${prefix}/bin/fly
+}
+
+# Only match releases. Pre-releaes have a "-pre-N" suffix
+github.livecheck.regex {(\d+(?:\.\d+)+)}


### PR DESCRIPTION
#### Description

`flyctl` is a CLI tool for managing deployments on fly.io.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.3 20E232 x86_64


###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
