### PR TITLE
hwloc: disable GUI variant by default

### DIFF
--- a/devel/hwloc/Portfile
+++ b/devel/hwloc/Portfile
@@ -58,9 +58,8 @@ variant gui description {Add graphical output capability} {
                             --x-libraries=${prefix}/lib
 }
 
-default_variants    +gui
-
 notes {
-  OpenCL and CUDA support is now disabled by default. They may be enabled by new\
-  variants opencl and cuda, respectively.
+  * GUI support is now disabled by default. It can be enabled via variant gui.
+  * OpenCL and CUDA support is now disabled by default. It can be enabled by variants\
+  opencl and cuda, respectively.
 }


### PR DESCRIPTION
#### Description

hwloc: disable GUI support by default, to avoid pulling in various X11-related dependencies for dependent ports like `openmpi` and `mpich`.

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G2136
Xcode 9.2 9C40b

macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
