### PR TITLE
pngquant: update to 2.15.0

### DIFF
--- a/graphics/pngquant/Portfile
+++ b/graphics/pngquant/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        kornelski pngquant 2.14.1
+github.setup        kornelski pngquant 2.15.0
 revision            0
 categories          graphics
 platforms           darwin
@@ -22,9 +22,9 @@ homepage            http://pngquant.org/
 master_sites        ${homepage}
 distfiles           ${name}-${version}-src${extract.suffix}
 
-checksums           rmd160  4c5de16f0cd001c58c6de01b4a4b4774884a8f6b \
-                    sha256  70fd2c1bdaa763378e89c14a554e3b9ab7869ca2334ad34ed2cd6ad3cb37f443 \
-                    size    147201
+checksums           rmd160  993d9c2aadb220bb12efe1889a9cbffe9858b801 \
+                    sha256  c5051b9eb3de5acd1ee3b5b4cc87036b25289277fcef8f293a35f84da71e5a04 \
+                    size    149409
 
 depends_lib-append  port:libpng \
                     port:lcms2 \
@@ -60,6 +60,9 @@ post-destroot {
         README.md \
         ${destroot}${docdir}
 }
+
+test.run            yes
+test.target         test
 
 livecheck.type      regex
 livecheck.url       ${homepage}releases.html


### PR DESCRIPTION


#### Description

 * update to 2.15.0
 * enable tests, which are included in the source package started with this version

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G9028 x86_64
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
