### PR TITLE
flyctl: Add checksums for both architectures

### DIFF
--- a/devel/flyctl/Portfile
+++ b/devel/flyctl/Portfile
@@ -20,9 +20,14 @@ homepage            https://fly.io
 github.tarball_from releases
 distname            ${name}_${version}_macOS_${build_arch}
 
-checksums           rmd160  58b5717c723b3252773e71e7850e4cded97c0250 \
+checksums           ${name}_${version}_macOS_x86_64${extract.suffix} \
+                    rmd160  58b5717c723b3252773e71e7850e4cded97c0250 \
                     sha256  fdab337dcd61df20d5b8629cb7c6b1ace3a28db9307ba256fc33f137efbf1d67 \
-                    size    16696177
+                    size    16696177 \
+                    ${name}_${version}_macOS_arm64${extract.suffix} \
+                    rmd160  8081609236c0bcd567ec48d9358a94671cc41350 \
+                    sha256  c4e28e7077cc39db255433d8d2a39805fed9b21b34896c594c1a24c45280b168 \
+                    size    16488109
 
 use_configure       no
 installs_libs       no


### PR DESCRIPTION
#### Description

The initial submission only had checksums for x86_64. Now we have the
checksums for both x86_64 and arm64.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.3 20E232 x86_64

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
