### PR TITLE
screen: bump apple patch to screen-24

### DIFF
--- a/sysutils/screen/Portfile
+++ b/sysutils/screen/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                screen
 version             4.8.0
-revision            0
+revision            1
 homepage            https://www.gnu.org/software/screen/
 description         Screen manager with VT100/ANSI terminal emulation
 long_description    \
@@ -42,7 +42,7 @@ checksums           ${distname}${extract.suffix} \
                     size    4883
 
 patchfiles          patch-apple.diff \
-                    patch-config.h.in.diff \
+                    patch-acconfig.h.diff \
                     patch-configure_no_implicit_defs.diff \
                     patch-xcode-12-implicit-function-fixes.diff
 depends_lib         port:ncurses
@@ -53,13 +53,6 @@ post-extract {
 }
 
 use_autoconf    yes
-autoconf.cmd    ./autogen.sh
-
-# need for autoconf
-depends_build-append \
-    port:autoconf    \
-    port:automake    \
-    port:libtool
 
 configure.args      --mandir=${prefix}/share/man \
                     --infodir=${prefix}/share/info \

--- a/sysutils/screen/files/patch-acconfig.h.diff
+++ b/sysutils/screen/files/patch-acconfig.h.diff
@@ -5,11 +5,9 @@ screen's utmp editing.
 
 This also fixes the "/var/run/utmp: No such file or directory"
 errors as a consequence of the above.
-
-diff -rU 3 config.h.in config.h.in
---- config.h.in	2020-02-05 15:26:32.000000000 -0500
-+++ config.h.in	2020-02-07 21:17:08.307798880 -0500
-@@ -192,14 +192,14 @@
+--- acconfig.h	2021-05-08 19:39:20.099088823 -0400
++++ acconfig.h	2021-05-08 20:11:16.299603971 -0400
+@@ -191,14 +191,14 @@
   * If screen is installed with permissions to update /etc/utmp (such
   * as if it is installed set-uid root), define UTMPOK.
   */
@@ -26,10 +24,12 @@ diff -rU 3 config.h.in config.h.in
  
  /* Set LOGOUTOK to one (1)
   * if you want the user to be able to log her/his windows out.
-@@ -215,7 +215,7 @@
+@@ -214,7 +214,7 @@
   * Set CAREFULUTMP to one (1) if you want that users have at least one
   * window per screen session logged in.
   */
 -#define LOGOUTOK 1
 +#undef LOGOUTOK
  #undef CAREFULUTMP
+ 
+ 

--- a/sysutils/screen/files/patch-apple.diff
+++ b/sysutils/screen/files/patch-apple.diff
@@ -1,6 +1,6 @@
 Apple's changes between upstream screen-4.0.3
-and their release of screen, called screen-22.
-You can view the screen-22 source at
+and their release of screen, called screen-24.
+You can view the screen-24 source at
 https://opensource.apple.com/tarballs/screen/
 
 Upstream screen-4.0.3 is released under the GPLv2,
@@ -11,28 +11,27 @@ This patch was then rebased against the latest upstream
 GNU Screen, which was version 4.6.2 and no longer required
 many of Apple's changes. This was done by David Gilman
 for MacPorts.
-
-diff -rU 3 screen.c screen.c
---- screen.c	2020-02-05 15:09:38.000000000 -0500
-+++ screen.c	2020-02-07 21:17:51.105940911 -0500
-@@ -118,6 +118,14 @@
+--- screen.c	2021-05-08 19:39:20.092413588 -0400
++++ screen.c	2021-05-08 19:48:03.152597182 -0400
+@@ -118,6 +118,15 @@
  
  #include "logfile.h" /* islogfile, logfflush, logfopen/logfclose */
  
 +#ifdef __APPLE__
 +#include <TargetConditionals.h>
-+#if !TARGET_OS_EMBEDDED
++#if !(TARGET_OS_IPHONE && !TARGET_OS_SIMULATOR)
 +#include <vproc.h>
 +#include <vproc_priv.h>
++#include <err.h>
 +#endif
 +#endif
 +
  #ifdef DEBUG
  FILE *dfp;
  #endif
-@@ -1051,6 +1059,15 @@
-         Panic(0, "No $SCREENDIR with multi screens, please.");
- #endif
+@@ -1206,6 +1215,16 @@
+ 	  Attacher();
+ 	  /* NOTREACHED */
      }
 +#ifdef __APPLE__
 +    else if (!multi && real_uid == eff_uid) {
@@ -43,14 +42,15 @@ diff -rU 3 screen.c screen.c
 +      }
 +    }
 +#endif	/* __APPLE__ */
- 
++
  #ifdef MULTIUSER
-     if (multiattach) {
-@@ -1314,6 +1331,11 @@
+     if (multiattach)
+       Panic(0, "Can't create sessions of other users.");
+@@ -1314,6 +1333,11 @@
    freopen("/dev/null", "w", stderr);
    debug("-- screen.back debug started\n");
  
-+#if defined(__APPLE__) && !TARGET_OS_EMBEDDED
++#if defined(__APPLE__) && !(TARGET_OS_IPHONE && !TARGET_OS_SIMULATOR)
 +	if (_vprocmgr_detach_from_console(0) != NULL)
 +		errx(1, "can't detach from console");
 +#endif
@@ -58,10 +58,8 @@ diff -rU 3 screen.c screen.c
    /*  This guarantees that the session owner is listed, even when we
     *  start detached. From now on we should not refer to 'LoginName'
     *  any more, use users->u_name instead.
-
-diff -rU 3 gwindow.c gwindow.c
---- window.c	2020-02-05 15:09:38.000000000 -0500
-+++ window.c	2020-02-07 21:17:51.108845249 -0500
+--- window.c	2021-05-08 19:39:20.102441294 -0400
++++ window.c	2021-05-08 19:40:40.447225064 -0400
 @@ -33,6 +33,9 @@
  #include <sys/stat.h>
  #include <signal.h>
@@ -72,10 +70,10 @@ diff -rU 3 gwindow.c gwindow.c
  #ifndef sun
  # include <sys/ioctl.h>
  #endif
-@@ -1484,6 +1487,40 @@
+@@ -1682,6 +1685,40 @@
+   return r;
  }
  
- #ifndef HAVE_EXECVPE
 +#ifdef __APPLE__
 +#ifdef RUN_LOGIN
 +/*
@@ -111,5 +109,5 @@ diff -rU 3 gwindow.c gwindow.c
 +#endif /* __APPLE__ */
 +
  void
- execvpe(prog, args, env)
- char *prog, **args, **env;
+ FreePseudowin(w)
+ struct win *w;


### PR DESCRIPTION
also fix autoconf and friends, and refresh patches

Closes: https://trac.macports.org/ticket/62791

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H524 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
