### PR TITLE
vulture: update to 2.3

### DIFF
--- a/devel/vulture/Portfile
+++ b/devel/vulture/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                vulture
-version             2.1
+version             2.3
 categories          devel python
 platforms           darwin
 license             MIT
@@ -15,13 +15,13 @@ long_description    {*}${description}
 
 homepage            https://github.com/jendrikseipp/${name}
 
-checksums           rmd160  eb5c1a7a9b4ca329add8c2e2401133273109024c \
-                    sha256  933bf7f3848e9e39ecab6a12faa59d5185471c887534abac13baea6fe8138cc2 \
-                    size    42300
+checksums           rmd160  3ee33534b63f40e95b098d74c34f39e9ef936c91 \
+                    sha256  03d5a62bcbe9ceb9a9b0575f42d71a2d414070229f2e6f95fa6e7c71aaaed967 \
+                    size    51630
 
 python.default_version  39
 
-depends_build-append    port:py${python.version}-setuptools \
-                        port:py${python.version}-toml
+depends_build-append    port:py${python.version}-setuptools
+depends_run-append      port:py${python.version}-toml
 
 livecheck.type      pypi


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1030 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
