### PR TITLE
cgal5: update to 5.2.1

### DIFF
--- a/gis/cgal5/Portfile
+++ b/gis/cgal5/Portfile
@@ -17,7 +17,7 @@ long_description        \
 
 platforms               darwin
 
-github.setup            CGAL cgal 5.2 v
+github.setup            CGAL cgal 5.2.1 v
 revision                0
 conflicts               cgal4
 github.tarball_from     releases
@@ -31,9 +31,9 @@ use_xz                  yes
 
 homepage                http://www.cgal.org/
 
-checksums           rmd160  eeb889813254f542172a610863bfefae07b72a94 \
-                    sha256  744c86edb6e020ab0238f95ffeb9cf8363d98cde17ebb897d3ea93dac4145923 \
-                    size    23250240
+checksums           rmd160  58a1632cce68c0f06830434158d9d5e6af47b452 \
+                    sha256  7e80b710a2b05cf7c22ce6fd8000905957c2263ab0048185b5010172b5bc19e6 \
+                    size    23256952
 
 
 worksrcdir              CGAL-${version}
@@ -43,14 +43,13 @@ depends_lib-append      port:boost \
                         port:gmp \
                         path:include/eigen3/Eigen/Eigen:eigen3
 
-compiler.cxx_standard   2011
+compiler.cxx_standard   2014
 compiler.thread_local_storage yes
 
 configure.args-append   -DCGAL_HEADER_ONLY=OFF
 
 variant headers_only description "Install only the headers" {
-    configure.args-delete   -DCGAL_HEADER_ONLY=OFF
-    configure.args-append   -DCGAL_HEADER_ONLY=ON
+    configure.args-replace   -DCGAL_HEADER_ONLY=OFF -DCGAL_HEADER_ONLY=ON
 }
 
 github.livecheck.regex  {([0-9.]+)}


### PR DESCRIPTION

#### Description

 * update to 5.2.1
 * require C++14 (per the documentation)
 * minor portfile improvement

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G9028 x86_64
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
