### PR TITLE
saml2aws: New port

### DIFF
--- a/security/saml2aws/Portfile
+++ b/security/saml2aws/Portfile
@@ -1,0 +1,318 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/Versent/saml2aws 2.30.0 v
+revision            0
+categories          security
+platforms           darwin
+license             MIT
+maintainers         {netinertia.co.uk:jamesog @jamesog} \
+                    openmaintainer
+
+description         Log in to AWS using a SAML IDP
+long_description    CLI tool which enables you to login and retrieve AWS \
+                    temporary credentials using a SAML IDP.
+
+homepage            https://github.com/Versent/saml2aws
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  0cdd193229f49d1a0585f6fb71442baf41a9f7a3 \
+                        sha256  34de318eb3a725a392433d19da3991e30f67304b8db6340d061795661f703d76 \
+                        size    214434
+
+go.vendors          gopkg.in/yaml.v3 \
+                        lock    496545a6307b \
+                        rmd160  16a43936d8ae6243895e23465132977d3a1193c2 \
+                        sha256  333e78b3b9cb73b3572d62f692d32426a8554b86c93025ea032f779395869e84 \
+                        size    90145 \
+                    gopkg.in/yaml.v2 \
+                        lock    v2.4.0 \
+                        rmd160  66e9feb7944b3804efa63155ed9b618717b8955c \
+                        sha256  72812077e7f20278003de6ab0d85053d89131d64c443f39115a022114fd032b6 \
+                        size    73231 \
+                    gopkg.in/square/go-jose.v2 \
+                        lock    v2.5.1 \
+                        rmd160  10a379638c09a20ade414966ef16fe39c0c5b9fc \
+                        sha256  e37bde7e74fe293083f1194e1317244286c5a6ef1b7c641946496077cfb74610 \
+                        size    309912 \
+                    gopkg.in/ini.v1 \
+                        lock    v1.62.0 \
+                        rmd160  70c98aa78bb3ead6de8c1dc2d17265e183e7a5d0 \
+                        sha256  501dd9bad8bedbe8db250306c996c442fb19668430beb64ae313958f34d5f6be \
+                        size    50323 \
+                    gopkg.in/check.v1 \
+                        lock    038fdea0a05b \
+                        rmd160  0f1896097db9d42b2fb5d62999bb52c77635f758 \
+                        sha256  a82bd5c6960aa523c4dd8b30d52c3a7e8a5382e91f25862ef277bedf5c107007 \
+                        size    31647 \
+                    golang.org/x/text \
+                        lock    v0.3.5 \
+                        rmd160  2bc41a433ef7cbbf321afed39256a65d43ef3c8b \
+                        sha256  148ec80befd0392454a5d7756abcebeb74f863e6e4b1e1ff63bbe06c2b49e120 \
+                        size    8349629 \
+                    golang.org/x/term \
+                        lock    2321bbc49cbf \
+                        rmd160  94c32506cb76cee410574c49d6b4cfe294a8159d \
+                        sha256  3bf7b61de210c621fb70e697c0020789bfbe426754d0f743978e77f84a7472f1 \
+                        size    15286 \
+                    golang.org/x/sys \
+                        lock    8ebf48af031b \
+                        rmd160  d661d5b39f4f15538e641a1eb2212f81febdf862 \
+                        sha256  48cc64e0c62e486d83fc3402f7a8e7fc274dc5076085770d2cbbced22e2b0c1f \
+                        size    1110262 \
+                    golang.org/x/net \
+                        lock    5f4716e94777 \
+                        rmd160  895f92b5004f164eb6b391054a0539cae27edaa1 \
+                        sha256  36948241880ee379819f082f08eb171362d95d0f341c6d2dfcb2475ec18289e9 \
+                        size    1251410 \
+                    golang.org/x/crypto \
+                        lock    eec23a3978ad \
+                        rmd160  098b29e5fb0c1a0fa7a118e433eb5d952053391b \
+                        sha256  da658dad4a60a368edea1cbb28651cf44b46b06fdd726462c5696aa5283f12c2 \
+                        size    1725759 \
+                    github.com/tidwall/match \
+                        lock    v1.0.0 \
+                        rmd160  2476b0ca44d73f07db77436555066cc0dfc6d768 \
+                        sha256  111ada47abfd8a45266f95330840ec7dd63adde18ba743bb00b3d840f9bf44d8 \
+                        size    4275 \
+                    github.com/tidwall/gjson \
+                        lock    v1.1.1 \
+                        rmd160  b684027f6a4a143eefb40d426ec8fd7be2462316 \
+                        sha256  28d12108599e2278ad3861cb846c27ccef6c65ce7a9f27007763f0dcb24ded90 \
+                        size    39971 \
+                    github.com/stretchr/testify \
+                        lock    v1.7.0 \
+                        rmd160  adae5096e8c4cfcc8e3f6d096646d1165b5ef49a \
+                        sha256  f7dde97d0c9634483ae6ea273968f80f3105c22382a1f841886cd20d57586642 \
+                        size    91096 \
+                    github.com/stretchr/objx \
+                        lock    v0.3.0 \
+                        rmd160  a65e81e93f5c05771e99e7ecd7701b4f7166ec55 \
+                        sha256  31196760451635317c33f55c706a1bdda1f4720ec85f47735e7f9e681b610df2 \
+                        size    80495 \
+                    github.com/smartystreets/goconvey \
+                        lock    v1.6.4 \
+                        rmd160  a3dfad6131b94d809efad84d30ce45828c6da756 \
+                        sha256  a03963296bb6d031934a651c1e637e8ab2ce9604ce6a16c158ff551e44e7ba79 \
+                        size    1478824 \
+                    github.com/smartystreets/assertions \
+                        lock    v1.0.0 \
+                        rmd160  8fedd5565a5283a7708236397595879588dc9787 \
+                        sha256  0d65770741aba0134c82bdc4a8a7192ca2e17b4f0ea6d9785b811a1c97c8c06f \
+                        size    84426 \
+                    github.com/skratchdot/open-golang \
+                        lock    eef842397966 \
+                        rmd160  1c1ff96072a72d95d27888f1ef0587217e634aec \
+                        sha256  295985c3a5dfaf26e2bfbb679f730a7ec12aab6c5389cd937e1768909eb3d7f6 \
+                        size    7070 \
+                    github.com/sirupsen/logrus \
+                        lock    v1.7.1 \
+                        rmd160  a30b5ebc15609af46a7322434fef4b4fbce70eab \
+                        sha256  de4a37e323cb32b39cf2914bd7ec6f536aa56514b8c3b8982880e02c0e4dc294 \
+                        size    46804 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/pkg/errors \
+                        lock    v0.9.1 \
+                        rmd160  dc065c655f8a24c6519b58f9d1202eb266ecda40 \
+                        sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
+                        size    13422 \
+                    github.com/niemeyer/pretty \
+                        lock    a10e7caefd8e \
+                        rmd160  46bcfc3db9e3d98acbacd1f96d9483fa360f88b7 \
+                        sha256  97b952a32175ba84349ef352e523bfa15bf3a06e07e44458a908061fbc519b40 \
+                        size    9405 \
+                    github.com/mxschmitt/playwright-go \
+                        lock    v0.1100.0 \
+                        rmd160  7d2432dff200a585d773743a8dc0673f1d2a4af5 \
+                        sha256  00f1e20f480928102465ea2155a146c14009e51a24e6595c15075febafa30ff4 \
+                        size    106125 \
+                    github.com/mtibben/percent \
+                        lock    v0.2.1 \
+                        rmd160  9271475f842555667e1f0dc5e5f7a2310d71ba9a \
+                        sha256  02873199713ddd96cb5b37738117ac860d13306db9e48ffb0ea539b2ea833ebd \
+                        size    2166 \
+                    github.com/mitchellh/go-homedir \
+                        lock    v1.1.0 \
+                        rmd160  44b3985e40e5bbb22d11f8622c340f9ed727ea91 \
+                        sha256  024c8a57316c7fbc0eb23cdbfd57f72a74b51beb83d714034d67ee9aba48100c \
+                        size    3366 \
+                    github.com/mgutz/ansi \
+                        lock    9520e82c474b \
+                        rmd160  fea73fc246ac2b229bb91accba053fed2ea63536 \
+                        sha256  75eaed501d7d121ad75c83246fecdc6222dbbbd3fcb4140c8775e219fff440ce \
+                        size    4878 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.12 \
+                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
+                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
+                        size    4549 \
+                    github.com/mattn/go-colorable \
+                        lock    v0.1.8 \
+                        rmd160  e9948731b241336e8d5aa2a2e25dff26a9dccebe \
+                        sha256  7e815dc076eeb34bf44a348eea7ae9b7a432b37462543cc5b382350d0e91c5f0 \
+                        size    9576 \
+                    github.com/marshallbrekka/go-u2fhost \
+                        lock    3ccdec8c8105 \
+                        rmd160  ec19b7efeb10e6a94ab600d3e130a6fdce29cd0e \
+                        sha256  18fc44b99d204d304a53b00a7608523aafb716d4bd35931f61c56ccf45920ebc \
+                        size    22921 \
+                    github.com/magefile/mage \
+                        lock    v1.11.0 \
+                        rmd160  533487d054da86fbf3d97540c5b43621704b671b \
+                        sha256  970b9c343d36dc2354000bbb9bab89da694cfc36eb5069f49a6cc81aefffd26e \
+                        size    8795685 \
+                    github.com/kr/text \
+                        lock    v0.2.0 \
+                        rmd160  48558c7e8ff67d510f83c66883907e95f4783163 \
+                        sha256  2f2e21ac8a9d523e88cbba4039441defc4a66bfaa78811c900a88fcf28729c4c \
+                        size    8702 \
+                    github.com/kr/pty \
+                        lock    v1.1.4 \
+                        rmd160  c8f7af2b21280ca0435670d02994d1b257061ae4 \
+                        sha256  2a532b818413bde2d59a84f3937a3b933cf85683979e8ce67e153f373c4ff498 \
+                        size    5830 \
+                    github.com/keybase/go-keychain \
+                        lock    48d3d31d256d \
+                        rmd160  9f9b4e381e6522d13e6f675d914f65e84c3fee5a \
+                        sha256  84d5739de8988877414dbea79607cadfaa09a6c6d38f6d54324ae584530e563b \
+                        size    2340429 \
+                    github.com/kballard/go-shellquote \
+                        lock    95032a82bc51 \
+                        rmd160  40415cd59ece9fb38b22170feec07f1f48d518a2 \
+                        sha256  41aa42696f96fb2783c5135d71ff1ec5938dfe178b51eb703e509c8ac0e7db4e \
+                        size    4335 \
+                    github.com/jtolds/gls \
+                        lock    v4.20.0 \
+                        rmd160  31d8656bd6c1426338ceaac9535198244248b254 \
+                        sha256  04069406ca336d355eab62b4ab9e84b820ac968ac1e20bd3777efec2d3843446 \
+                        size    7305 \
+                    github.com/jmespath/go-jmespath \
+                        lock    v0.4.0 \
+                        rmd160  ca4955ff89de514b5eff01a7a244626cecf0927e \
+                        sha256  0fe6d784c9c75ae5aa25396283a07f94c06955a4ed775990149c17caee4112c4 \
+                        size    128827 \
+                    github.com/hinshun/vt10x \
+                        lock    1954e6464174 \
+                        rmd160  29d948e8755fbc4fd5000745a47d20b27ab7fae4 \
+                        sha256  31abe1530ab54f5e7dd1892d7affcc45cabade93345357aaad61a50daf11eb55 \
+                        size    1231513 \
+                    github.com/gsterjov/go-libsecret \
+                        lock    a6f4afe4910c \
+                        rmd160  d1833e02c728e148960113fa28dbd4828f4b2c3c \
+                        sha256  f7edbec029cace110cdf89fa29b7b3396068e41440ec529288ebfa9b4d1560fb \
+                        size    3071 \
+                    github.com/gopherjs/gopherjs \
+                        lock    0766667cb4d1 \
+                        rmd160  fe92e39110b5c188dcce98abb3b9aa1b64d68f94 \
+                        sha256  abe56698d0855027a1f6030a44924895d781b19526aa8f9b3ef49ed4199f7c57 \
+                        size    217261 \
+                    github.com/google/uuid \
+                        lock    v1.2.0 \
+                        rmd160  9717876312bfbe146a478d24bdb41bf8bb4a6ade \
+                        sha256  ddfae8a6ac3b56a02db288778b424a123c14efe44cdab70e4bab0b1e6dd13114 \
+                        size    14154 \
+                    github.com/godbus/dbus \
+                        lock    v4.1.0 \
+                        rmd160  a5f33db9bdab3ed956745965c1f8c27dfe8e8292 \
+                        sha256  4fe3c261fa88573cb48bad97302ca4f81cb93e0858294165ec8c0877efa66c43 \
+                        size    53485 \
+                    github.com/dvsekhvalnov/jose2go \
+                        lock    v1.5.0 \
+                        rmd160  4274d180b827f40ebbaf970fb515c5adafb9475d \
+                        sha256  e5b8529fc40411b40ac42a72651b4b3aa0e54882fe02c523bebcd5c578d56c22 \
+                        size    68535 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/danwakefield/fnmatch \
+                        lock    cbb64ac3d964 \
+                        rmd160  19ae7b520847e16b0e8ac23ee5e6c51db3831f46 \
+                        sha256  2b045b8a716e3ca32d2a930781cd421b042d0e861fa3d36a79ed5535b2e5308a \
+                        size    4960 \
+                    github.com/danieljoos/wincred \
+                        lock    v1.1.0 \
+                        rmd160  bf99a9ff12330c5a453b4e1ed39f3b907b9a22b8 \
+                        sha256  57408be23c8b5b13bdac168e5a6c3223ea5875ad78d36cb0c01ce916bd45a712 \
+                        size    9554 \
+                    github.com/beevik/etree \
+                        lock    v1.0.1 \
+                        rmd160  ab633e4f99f1edac96a017b96c2756bcccc10975 \
+                        sha256  a9030f8390a96846f3773fd08f32e0f59a551f863bd48347718ad7286ccadfde \
+                        size    19174 \
+                    github.com/bearsh/hid \
+                        lock    v1.3.0 \
+                        rmd160  529f0c3f366d15ad2c0fb3b36802a6aa960a19f3 \
+                        sha256  9f60bd2f5724bb7d76d690bbf03c58b18a4001b793f69cd8db52b34217d31b39 \
+                        size    302848 \
+                    github.com/aws/aws-sdk-go \
+                        lock    v1.37.11 \
+                        rmd160  a48096c3ed2b2bdc1c9bcf9dfc8bcd876e1ea6d1 \
+                        sha256  25776e4df0ff78be37df01811999694fe912e1e33541722a04fdb7378da643f5 \
+                        size    18217221 \
+                    github.com/avast/retry-go \
+                        lock    v2.6.0 \
+                        rmd160  14dde11e31bbd3ec56c8e877f94ba2253d6a5507 \
+                        sha256  140bc76ff8a6593e19009f675095db2f57944bb580567efd58f50a24808f11b3 \
+                        size    7856 \
+                    github.com/andybalholm/cascadia \
+                        lock    v1.1.0 \
+                        rmd160  c4c18622997b68be3afade1a286db552a1bfaba6 \
+                        sha256  8d077c4917c7122f69fc6b2cfcace0d7c7d74ce41268361a3de180798853cfea \
+                        size    15498 \
+                    github.com/alecthomas/units \
+                        lock    f65c72e2690d \
+                        rmd160  b2e546a67c8fc98bcb78645cb7432db04a959b47 \
+                        sha256  d3cf74fc50db9c23dd095994a98712431a8e29c3fc34ac958073c5d548de94a7 \
+                        size    4925 \
+                    github.com/alecthomas/template \
+                        lock    fb15b899a751 \
+                        rmd160  34faebabc9eeabdf4e3efc70015e1f858ad787cf \
+                        sha256  7bdd81cd04955c4251637e7196751a4626ae822382b9cbb33ea53eb5f8ce00e5 \
+                        size    55322 \
+                    github.com/alecthomas/kingpin \
+                        lock    v2.2.6 \
+                        rmd160  af6db4648ec7638fb5cab49fd9536caa705f5fed \
+                        sha256  31378085783496cff78c7d41479ccd6206c4f4e3892909ef0c2cd39e2de3b039 \
+                        size    44374 \
+                    github.com/PuerkitoBio/goquery \
+                        lock    v1.5.1 \
+                        rmd160  1f13a037c7c319907cb75674bdc5acce0e3369af \
+                        sha256  489a73e1e607b6305f7c1d30d0b05c9690605d922e1d92f6051bc3103e64e29f \
+                        size    101385 \
+                    github.com/Netflix/go-expect \
+                        lock    c93bf25de8e8 \
+                        rmd160  a4e10dd1f05c584ae80408e373cc5b9e90581dc7 \
+                        sha256  896ec6b1f14446e88345be7dc7a8575957040b5a3729da1698ca88138e085ee2 \
+                        size    14580 \
+                    github.com/Azure/go-ntlmssp \
+                        lock    4b934ac9dad3 \
+                        rmd160  a9d84049237c3d91dfbcfe448a4858f04000c349 \
+                        sha256  030a586ebf369ea46229e5346c782242f8491c7b49bb45536caade48fa05b0ab \
+                        size    7836 \
+                    github.com/AlecAivazis/survey \
+                        lock    v2.2.2 \
+                        rmd160  1bf5615c08324a08622c1e37b1de44dd70b2d80f \
+                        sha256  c10907f4c476a7764380cc269a52085594e40d58c5f615f988de207462698a8e \
+                        size    1567003 \
+                    github.com/99designs/keyring \
+                        lock    v1.1.6 \
+                        rmd160  fed84ad2f3fa455b50a91c75cbbbc033d60bdb78 \
+                        sha256  b33af1f522aefa76f028853a7e4cda5fe32f5a121bdae489043339c12e0d3f61 \
+                        size    23282
+
+build.pre_args      -trimpath -ldflags \"-s -w -X main.Version=${version}\"
+build.args          ./cmd/${name}
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin
+}
+
+github.livecheck.regex {(\d+(?:\.\d+)+)}


### PR DESCRIPTION
#### Description

saml2aws is a CLI tool which enables you to login and retrieve AWS temporary credentials using a SAML IDP.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.3 20E232 x86_64

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
