### PR TITLE
sqlitebrowser: make qttools a build dependency

### DIFF
--- a/databases/sqlitebrowser/Portfile
+++ b/databases/sqlitebrowser/Portfile
@@ -70,7 +70,9 @@ platform darwin {
     use_parallel_build  no
     depends_lib-append  port:sqlite3
     qt5.depends_component \
-                        qtmacextras qttools
+                        qtmacextras
+    qt5.depends_build_component \
+                        qttools
 
     destroot {
             copy "${worksrcpath}/src/DB Browser for SQLite.app" ${destroot}${applications_dir}


### PR DESCRIPTION
#### Description

This makes qttools a build dependency instead of a library dependency, so this port wouldn't force the installation of all qt dev tools.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G9028 x86_64
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
