### PR TITLE
dash: Update to 0.5.11.3

### DIFF
--- a/shells/dash/Portfile
+++ b/shells/dash/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                dash
-version             0.5.11.1
+version             0.5.11.3
 categories          shells
 license             GPL-2+
 platforms           darwin
@@ -16,9 +16,9 @@ long_description    DASH is a direct descendant of the NetBSD version of ash \
 homepage            http://gondor.apana.org.au/~herbert/dash
 
 master_sites        ${homepage}/files/
-checksums           rmd160  361ebf870d55287264a0b3a68d702df5aa4a298f \
-                    sha256  73c881f146e329ac54962766760fd62cb8bdff376cd6c2f5772eecc1570e1611 \
-                    size    244439
+checksums           rmd160  d5a1845a9f11bcda5ee5afa4f35c692f91e0fa03 \
+                    sha256  62b9f1676ba6a7e8eaec541a39ea037b325253240d1f378c72360baa1cbcbc2a \
+                    size    244507
 
 patchfiles          0001-fix-dirent64-et-al-on-darwin.patch
 


### PR DESCRIPTION
#### Description

I'm running through `port livecheck installed` and trying to update things that have an open maintainer or no maintainer.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.4 20F5055c
Xcode 12.5 12E262 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
