### PR TITLE
opensc: Update to 0.21

### DIFF
--- a/security/opensc/Portfile
+++ b/security/opensc/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 
 name                    opensc
-github.setup            OpenSC OpenSC 0.20.0
+github.setup            OpenSC OpenSC 0.21.0
 categories              security
 platforms               darwin
 license                 LGPL-2.1
@@ -23,9 +23,9 @@ long_description        OpenSC provides a set of libraries and utilities to \
                         aims to be compatible with every software/card that \
                         does so, too.
 
-checksums               rmd160  13a34bfeed42b1bd804c6b047666a8d83d76395d \
-                        sha256  3f6a70a3b301a00dd2ddd12d1185fcffd3787f4d370acc00a12fe413159c7e00 \
-                        size    1654047
+checksums               rmd160  c26066235dd317b0b4e772a5174d22049cc3d314 \
+                        sha256  6e10622fbae8b3ffb6172394d48e2b3cc93f80d46b9ad67c7cd50b09907b51ee \
+                        size    1751522
 
 distname                opensc-${version}
 


### PR DESCRIPTION
#### Description

This bumps OpenSC to version 0.21, I've only quickly run some tools in OpenSC on Catalina 
(Intel-based Mac), no in-depth tests.

Resolves (as per upstream release notes):
- CVE-2020-26570
- CVE-2020-26571
- CVE-2020-26572

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [x] security fix

###### Tested on

macOS 10.15.7 19H1030 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? -> (opensc has no tests turned on. see 'test.run' in portfile(7))
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
