### PR TITLE
ccache: update to 4.3

### DIFF
--- a/devel/ccache/Portfile
+++ b/devel/ccache/Portfile
@@ -8,12 +8,12 @@ PortGroup           github 1.0
 # src/third_party/blake3/CMakeLists.txt checks CMAKE_SIZEOF_VOID_P
 PortGroup           muniversal 1.0
 
-github.setup        ccache ccache 4.2.1 v
+github.setup        ccache ccache 4.3 v
 revision            0
 
-checksums           rmd160  c580eab617ae3fd10d2f7799e804740d4e2c04d8 \
-                    sha256  9d6ba1cdefdc690401f404b747d81a9a1802b17af4235815866b7620d980477e \
-                    size    431484
+checksums           rmd160  907f02934fbb19fa4641a5a2816bfde288e0c9f8 \
+                    sha256  504a0f2184465c306826f035b4bc00bae7500308d6af4abbfb50e33a694989b4 \
+                    size    433508
 
 categories          devel
 platforms           darwin freebsd


### PR DESCRIPTION
#### Description

Update to 4.3. This release fixes a problem that affected me.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G9028 x86_64
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
