### PR TITLE
gexiv2: use Python 3.9 by default

### DIFF
--- a/gnome/gexiv2/Portfile
+++ b/gnome/gexiv2/Portfile
@@ -5,7 +5,7 @@ PortGroup           meson 1.0
 
 name                gexiv2
 version             0.12.1
-revision            0
+revision            1
 license             GPL-2+
 set branch          [join [lrange [split ${version} .] 0 1] .]
 description         gexiv2 is a GObject-based wrapper around the exiv2 library.
@@ -63,7 +63,7 @@ if {![variant_isset python36] && \
     ![variant_isset python37] && \
     ![variant_isset python38] && \
     ![variant_isset python39]} {
-    default_variants +python38
+    default_variants +python39
 }
 
 patchfiles          patch-python-bins.diff


### PR DESCRIPTION
#### Description

Use Python 3.9 as it is now the default for MacPorts.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
