### PR TITLE
inkscape: use Python 3.9 by default

### DIFF
--- a/graphics/inkscape/Portfile
+++ b/graphics/inkscape/Portfile
@@ -9,7 +9,7 @@ cmake.generator     Ninja
 name                inkscape
 conflicts           inkscape-devel inkscape-gtk3-devel
 version             0.92.5
-revision            6
+revision            7
 license             GPL-3+
 maintainers         {devans @dbevans} openmaintainer
 categories          graphics gnome
@@ -31,7 +31,7 @@ checksums           rmd160  360feade19ee48dd081bb43df68189717a63267b \
                     size    32175410
 
 set python_major    3
-set python_minor    8
+set python_minor    9
 set python_version  ${python_major}${python_minor}
 
 # this port only uses boost headers during build


### PR DESCRIPTION
#### Description

Use Python 3.9 as it is now the default for MacPorts. 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
