### PR TITLE
fontforge: add +python39 variant, make default

### DIFF
--- a/graphics/fontforge/Portfile
+++ b/graphics/fontforge/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake 1.1
 PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        fontforge fontforge 20200314
-revision            1
+revision            2
 github.tarball_from releases
 use_xz              yes
 
@@ -83,7 +83,7 @@ configure.args-append -DENABLE_GUI=False \
                       -DENABLE_WRITE_PFM=False \
                       -DENABLE_X11=False
 
-variant python37 conflicts python38 description {Enable Python support (Python 3.7)} {
+variant python37 conflicts python38 python39 description {Enable Python support (Python 3.7)} {
     depends_lib-append      port:python37
     configure.args-replace  -DENABLE_PYTHON_EXTENSION=False \
                             -DENABLE_PYTHON_EXTENSION=True
@@ -95,7 +95,7 @@ variant python37 conflicts python38 description {Enable Python support (Python 3
                             "${frameworks_dir}/Python.framework/Versions/3.7/lib/pkgconfig"
 }
 
-variant python38 conflicts python37 description {Enable Python support (Python 3.8)} {
+variant python38 conflicts python37 python39 description {Enable Python support (Python 3.8)} {
     depends_lib-append      port:python38
     configure.args-replace  -DENABLE_PYTHON_EXTENSION=False \
                             -DENABLE_PYTHON_EXTENSION=True
@@ -107,6 +107,18 @@ variant python38 conflicts python37 description {Enable Python support (Python 3
                             "${frameworks_dir}/Python.framework/Versions/3.8/lib/pkgconfig"
 }
 
+variant python39 conflicts python37 python38 description {Enable Python support (Python 3.9)} {
+    depends_lib-append      port:python39
+    configure.args-replace  -DENABLE_PYTHON_EXTENSION=False \
+                            -DENABLE_PYTHON_EXTENSION=True
+    configure.args-replace  -DENABLE_PYTHON_SCRIPTING=False \
+                            -DENABLE_PYTHON_SCRIPTING=True
+    configure.args-append   -DPython3_EXECUTABLE="${prefix}/bin/python3.9" \
+                            -DPYHOOK_INSTALL_DIR="${frameworks_dir}/Python.framework/Versions/3.9/lib/python3.9/site-packages"
+    configure.pkg_config_path \
+                            "${frameworks_dir}/Python.framework/Versions/3.9/lib/pkgconfig"
+}
+
 variant gui description {Enable GUI support} {
     PortGroup               app 1.0
     depends_lib-append      port:gtk3
@@ -116,6 +128,6 @@ variant gui description {Enable GUI support} {
 }
 
 default_variants    +gui
-if {![variant_isset python37] && ![variant_isset python38]} {
-    default_variants-append +python38
+if {![variant_isset python37] && ![variant_isset python38] && ![variant_isset python39]} {
+    default_variants-append +python39
 }


### PR DESCRIPTION
#### Description

Use Python 3.9 as it is now the default for MacPorts.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
