### PR TITLE
Fix py-mitmproxy

### DIFF
--- a/python/py-h2/Portfile
+++ b/python/py-h2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-h2
-version             3.2.0
+version             4.0.0
 revision            0
 
 categories-append   net www
@@ -29,9 +29,9 @@ homepage            https://python-hyper.org/projects/${python.rootname}/
 distname            ${python.rootname}-${version}
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}/
 
-checksums           rmd160  21731cd61668464d4a69b39a5fad657bb760a83f \
-                    sha256  875f41ebd6f2c44781259005b157faed1a5031df3ae5aa7bcb4628a6c0782f14 \
-                    size    2215889
+checksums           rmd160  0807fb5a8aa8294662413269879ec80e7871d410 \
+                    sha256  bb7ac7099dd67a857ed52c815a6192b6b1f5ba6b516237fc24a085341340593d \
+                    size    2143850
 
 python.versions     27 35 36 37 38 39
 

--- a/python/py-hpack/Portfile
+++ b/python/py-hpack/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        python-hyper hpack 3.0.0 v
+github.setup        python-hyper hpack 4.0.0 v
 name                py-hpack
 revision            1
 
@@ -26,9 +26,9 @@ homepage            https://python-hyper.org/hpack/
 # Need this as I switched from pypi to github for files required by tests
 dist_subdir         ${name}/${version}_1
 
-checksums           rmd160  b9a96210a7713ad5dfbbabf78118cc2ba8d05a44 \
-                    sha256  184bb68e6a4c421cef59c96e6ef788ea7dac86127cf2a0af51d096a5477417c4 \
-                    size    5307313
+checksums           rmd160  c449de11ba7f73acbffee7abc1a4c61fa5af82e7 \
+                    sha256  631714245360141d404e5c03d86a000cc7cefe84cb731112d1339033bfb83e79 \
+                    size    5303301
 
 python.versions     27 35 36 37 38 39
 
@@ -49,7 +49,7 @@ if {${name} ne ${subport}} {
         set docdir ${prefix}/share/doc/${subport}
         xinstall -d ${destroot}${docdir}
         xinstall -m 0644 -W ${worksrcpath} README.rst LICENSE \
-            HISTORY.rst CONTRIBUTORS.rst ${destroot}${docdir}
+            CHANGELOG.rst CONTRIBUTORS.rst ${destroot}${docdir}
     }
 
     livecheck.type  none

--- a/python/py-hyperframe/Portfile
+++ b/python/py-hyperframe/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-hyperframe
-version             5.2.0
+version             6.0.1
 revision            0
 
 categories-append   net www
@@ -21,13 +21,13 @@ long_description    \
     This library is used directly by hyper and a number of other projects to \
     provide HTTP/2 frame decoding logic.
 
-homepage            https://python-hyper.org/hyperframe
+homepage            https://python-hyper.org/projects/hyperframe/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  0c7914243dead0a0fcd40fe06642f25f02979f83 \
-                    sha256  a9f5c17f2cc3c719b917c4f33ed1c61bd1f8dfac4b1bd23b7c80b3400971b41f \
-                    size    19115
+checksums           rmd160  80fe234fb9d1f4260a4f83b66436002f79919c9e \
+                    sha256  ae510046231dc8e9ecb1a6586f63d2347bf4c8905914aa84ba585ae85f28a914 \
+                    size    25008
 
 python.versions     27 35 36 37 38 39
 
@@ -36,7 +36,7 @@ if {${name} ne ${subport}} {
         set docdir ${prefix}/share/doc/${subport}
         xinstall -d ${destroot}${docdir}
         xinstall -m 0644 -W ${worksrcpath} README.rst CONTRIBUTORS.rst \
-            HISTORY.rst LICENSE ${destroot}${docdir}
+            CHANGELOG.rst LICENSE ${destroot}${docdir}
     }
 
     depends_test-append \

--- a/python/py-mitmproxy/Portfile
+++ b/python/py-mitmproxy/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 
 
 github.setup        mitmproxy mitmproxy 6.0.2 v
-revision            0
+revision            1
 
 name                py-${github.project}
 
@@ -38,7 +38,8 @@ python.versions     37 38 39
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
 
-    depends_lib-append      port:py${python.version}-asn1 \
+    depends_lib-append      port:py${python.version}-asgiref \
+                            port:py${python.version}-asn1 \
                             port:py${python.version}-blinker \
                             port:py${python.version}-brotli \
                             port:py${python.version}-click \
@@ -49,6 +50,7 @@ if {${name} ne ${subport}} {
                             port:py${python.version}-hyperframe \
                             port:py${python.version}-kaitaistruct \
                             port:py${python.version}-ldap3 \
+                            port:py${python.version}-msgpack \
                             port:py${python.version}-openssl \
                             port:py${python.version}-parsing \
                             port:py${python.version}-passlib \

--- a/python/py-openssl/Portfile
+++ b/python/py-openssl/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup python    1.0
 PortGroup github    1.0
 
-github.setup        pyca pyopenssl 19.1.0
+github.setup        pyca pyopenssl 20.0.1
 revision            1
 name                py-openssl
 categories-append   devel security
@@ -21,9 +21,9 @@ homepage            https://pyopenssl.org/
 supported_archs     noarch
 installs_libs       no
 
-checksums           rmd160  174a362b5fc78abda9cb2efa96a088c116895d96 \
-                    sha256  14af660e869ca14ac6dedcbfb0b9f261822c9795c49454d954af9cddd21e7510 \
-                    size    165329
+checksums           rmd160  86fe3c5164547340e833d6a528da1cabd9a40872 \
+                    sha256  937599412298adf3fc522cf0831909815f244fd83eec068eef9f36a2380e478a \
+                    size    170792
 
 python.versions     27 36 37 38 39
 

--- a/python/py-urwid/Portfile
+++ b/python/py-urwid/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        urwid urwid 2.0.1 release-
+github.setup        urwid urwid 2.1.2 release-
 name                py-${name}
 revision            0
 
@@ -20,9 +20,9 @@ long_description    \
 
 homepage            http://urwid.org/
 
-checksums           rmd160  35600850053629027be799fa0297a0a3b162063a \
-                    sha256  870fa60cb4cc7403be2e5e0d99e04dbe71183a036a6df630146827e64114c951 \
-                    size    588040
+checksums           rmd160  4d8666717bee9d9fdabcc1c7b551ff583a28e307 \
+                    sha256  c21112c3c524110dd5cad78f7987a9fe0c57a66b756e1e0385e572b946ec86d1 \
+                    size    607749
 
 python.versions     27 35 36 37 38 39
 


### PR DESCRIPTION
#### Description

Current versions of mitmproxy don't run because of various missing dependencies.

Since this is my first PR against MacPorts, I hope it is formatted correctly, I was a bit overwhelmed with all the guidelines.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114 x86_64
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
  - The tests seem to be if-guarded and won't execute
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
