### PR TITLE
sbcl: fix build with old sbcl

### DIFF
--- a/lang/sbcl/Portfile
+++ b/lang/sbcl/Portfile
@@ -35,7 +35,8 @@ use_bzip2       yes
 patchfiles \
     patch-contrib-sb-posix-posix-tests.lisp.diff \
     patch-use-right-gcc.diff \
-    patch-sbcl-realtime.diff
+    patch-sbcl-realtime.diff \
+    patch-compilation-with-old-sbcl.diff
 
 distfiles       ${name}-${version}-source${extract.suffix}:sbcl
 worksrcdir      ${name}-${version}

--- a/lang/sbcl/files/patch-compilation-with-old-sbcl.diff
+++ b/lang/sbcl/files/patch-compilation-with-old-sbcl.diff
@@ -1,0 +1,22 @@
+https://bugs.launchpad.net/sbcl/+bug/1926629
+https://github.com/sbcl/sbcl/commit/217da9588a8eac9c21ee8487447ea028cf81be14
+--- src/compiler/ir1tran.lisp
++++ src/compiler/ir1tran.lisp
+@@ -329,7 +329,7 @@
+ ;;; CONSTANT might be circular. We also check that the constant (and
+ ;;; any subparts) are dumpable at all.
+ (defun ensure-externalizable (constant)
+-  (declare (inline alloc-xset))
++  (declare #-sb-xc-host (inline alloc-xset))
+   (dx-let ((xset (alloc-xset)))
+     (named-let grovel ((value constant))
+       ;; Unless VALUE is an object which which can't contain other objects,
+@@ -386,7 +386,7 @@
+ ;;; A constant is trivially externalizable if it involves no INSTANCE types
+ ;;; or any un-dumpable object.
+ (defun trivially-externalizable-p (constant)
+-  (declare (inline alloc-xset))
++  (declare #-sb-xc-host (inline alloc-xset))
+   (dx-let ((xset (alloc-xset)))
+     (named-let ok ((value constant))
+       (if (or (dumpable-leaflike-p value) (xset-member-p value xset))


### PR DESCRIPTION
#### Description

SBCL 2.1.4 cannot be compiled with old versions of SBCL. Fix this by applying the corresponding upstream patch.

Upstream bug: https://bugs.launchpad.net/sbcl/+bug/1926629
Upstream fix: https://github.com/sbcl/sbcl/commit/217da9588a8eac9c21ee8487447ea028cf81be14

Closes: https://trac.macports.org/ticket/62787

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
