### PR TITLE
google-cloud-sdk: update to 340.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             339.0.0
+version             340.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  7745cb4c43d83b6ff4b9c22973ab1efa979818fb \
-                    sha256  1321c57ce737e1c6a877e253945e8fc85158b5a6900257a0944ae3603e4c16f9 \
-                    size    89279533
+    checksums       rmd160  4e4a824bd36871dd8e5bce8b6426d165c7a52b1a \
+                    sha256  f72220861a448842866b07ecda53634483771867cc36f64051cf9c79b110e831 \
+                    size    89377113
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  c11f5781ec5dbbab913f04caac779abf6c8d8b01 \
-                    sha256  d32bd4d0677bc3a2dcf5cf2f090c0864b5beea4606b5924a216a3980d1d166f5 \
-                    size    85524505
+    checksums       rmd160  eda3a7aab4cb67af30bb0fed5d05cdc07015e11d \
+                    sha256  ad746cceaef1ca8dce3a7d72c1482d2db5f1336f38e7863b168db2211f82e8a9 \
+                    size    85625473
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  b465e6c2f9f99d6306f375da3609e4383311f7fe \
-                    sha256  f37099fdabdb89440d8ad93d082f636bcbea71fc4b32885f2748ffef4517b473 \
-                    size    85452641
+    checksums       rmd160  239fbd03cea5bbe17c1a985083f77180434f88b1 \
+                    sha256  9455f566a144df17ed52289fbe4aaaaa8447ddd7ae5b0868bce9824052f8955b \
+                    size    85554659
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 340.0.0.

###### Tested on

macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?