### PR TITLE
bitwarden-cli: update to 1.16.0

### DIFF
--- a/security/bitwarden-cli/Portfile
+++ b/security/bitwarden-cli/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        bitwarden cli 1.15.1 v
+github.setup        bitwarden cli 1.16.0 v
 revision            0
 
 name                bitwarden-cli
@@ -16,9 +16,9 @@ description         Bitwarden password manager CLI
 long_description    CLI implementation of the Bitwarden password manager.
 homepage            https://bitwarden.com
 
-checksums           rmd160  60a228382ca8feb4c871e6f70c52648c3d9f610b \
-                    sha256  ecb0f098a09d58ac813d862305b32c1c3bae3e2285444c1ff326560ab29c25eb \
-                    size    19376210
+checksums           rmd160  4d13f4cb51dda6213c47cf808240258285e172f2 \
+                    sha256  2f9a4685105fc944b035191c47af4a8418b8bb189e76e915d2d959a8976dab54 \
+                    size    19097424
 
 github.tarball_from releases
 distname            bw-macos-${version}


### PR DESCRIPTION
#### Description

For changelog, see: https://github.com/bitwarden/cli/releases/tag/v1.16.0

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1030 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
