### PR TITLE
carthage: update to 0.38.0

### DIFF
--- a/devel/carthage/Portfile
+++ b/devel/carthage/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           xcodeversion 1.0
 
 use_xcode           yes
-github.setup        Carthage Carthage 0.37.0
+github.setup        Carthage Carthage 0.38.0
 name                carthage
 categories          devel
 platforms           darwin
@@ -48,7 +48,7 @@ variant bash_completion {
     }
 }
 
-variant zsh_completion description {Install zsh completion} {
+variant zsh_completion {
     depends_run-append path:${prefix}/bin/zsh:zsh
 
     post-destroot {


### PR DESCRIPTION
#### Description

Increments the version number. Based on what was done last time: https://github.com/macports/macports-ports/commit/466abdca05982d0a983fe00b3aa0fa73ec20f0b9

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.2 20D64 arm64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
