### PR TITLE
exim: attempt to fix build on 10.11 and earlier

### DIFF
--- a/mail/exim/Portfile
+++ b/mail/exim/Portfile
@@ -2,6 +2,11 @@
 
 PortSystem              1.0
 
+# clock_gettime(), openat()
+PortGroup               legacysupport 1.1
+
+legacysupport.newest_darwin_requires_legacy 15
+
 name                    exim
 version                 4.94.2
 revision                0


### PR DESCRIPTION
#### Description
See build failures: https://ports.macports.org/port/exim/builds
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### ~~Tested on~~
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
Untested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
