### PR TITLE
hugo: update to 0.83.1

### DIFF
--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gohugoio/hugo 0.82.1 v
+go.setup            github.com/gohugoio/hugo 0.83.1 v
 revision            0
-checksums           rmd160  868fde70a74a41cc5a620c48764b0f35bd9feed7 \
-                    sha256  77ff51f0f261e5f9f17156367c03bd210fccba019d367a0ed4cd8f6014efe8a5 \
-                    size    38471771
+checksums           rmd160  b119f985fb23efdf1918c4cb5d5cf752480a1723 \
+                    sha256  eb0339ddb3f44c12b6426969da7420bab96522c744de49031b6c874b110ad701 \
+                    size    38667787
 
 categories          www
 platforms           darwin


### PR DESCRIPTION
#### Description
hugo: update to 0.83.1

###### Tested on
macOS 10.15.7 19H524
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
