### PR TITLE
matterhorn: new port, version 50200.12.0

### DIFF
--- a/net/matterhorn/Portfile
+++ b/net/matterhorn/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell_cabal 1.0
+
+name                matterhorn
+version             50200.12.0
+revision            0
+checksums           rmd160  74c512db62830e3bc1ea13a3a69e155262af561f \
+                    sha256  7861c3d3d2c75d935d8aee1d5711c89b3ebb745034001a5d6b50b217097b5d67 \
+                    size    934331
+
+master_sites        https://hackage.haskell.org/package/${name}-${version}
+
+description         A feature-rich Unix terminal client for the \
+                    Mattermost chat system.
+long_description    ${description}
+
+homepage            https://github.com/matterhorn-chat/matterhorn/
+
+categories          net
+platforms           darwin
+supported_archs     noarch
+maintainers         {isi.edu:calvin @cardi} openmaintainer
+license             BSD
+
+test.run            yes


### PR DESCRIPTION
#### Description
matterhorn: new port, version 50200.12.0

###### Tested on
macOS 10.15.7 19H524 x86_64
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?