### PR TITLE
skaffold: update to 1.24.0

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 1.23.0 v
+github.setup        GoogleContainerTools skaffold 1.24.0 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  ee5195aeef6c441385ced27c5fb4d1e6b8432176 \
-                    sha256  1877bd2e52471e77f03b3b78c4740fb4880f462a3c345f006f9416bfe0f041c9 \
-                    size    19234938
+checksums           rmd160  20e3fc876187a3c5e3b881296b5f552802a10ffc \
+                    sha256  6572049400a4e311b3c09e1f653eb5b9a9bb605795bec697f0084102263c57a9 \
+                    size    19299560
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 1.24.0.

###### Tested on

macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?