### PR TITLE
qDMR: new port

### DIFF
--- a/science/qdmr/Portfile
+++ b/science/qdmr/Portfile
@@ -1,0 +1,54 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+PortGroup           app 1.0
+PortGroup           qt5 1.0
+
+name                qdmr
+maintainers         @hmatuschek
+version             0.7.3
+
+categories          science
+license             GPL-3
+platforms           darwin macosx
+
+description         qDMR is a codeplug programming software (CPS) for cheap DMR radios.
+long_description    ${description}: \
+        qDMR is a feature-rich codeplug programming tool for cheap DMR radios.\
+        Currently supported radios are: Radioddity/Baofen RD-5R, TyT MD-UV390, \
+        Retevis RT3S, OpenGD77 firmware (GD77,RD-5R,DM-1801), Anytone AT-D878UV, \
+        Anytone AT-D868UVE.
+
+homepage            https://dm3mat.darc.de/qdmr/
+
+github.setup        hmatuschek qdmr ${version} v
+
+checksums           rmd160  3f22de23ea1b91f5feae4724a81140624f7de3eb \
+                    sha256  6c49e3f092cd57a84cca602f567fa4a301c3891415477d93a172d6c15e3731b6 \
+                    size    3752134
+
+qt5.depends_build_component \
+    qttools
+
+qt5.depends_component \
+    qtserialport \
+    qtlocation
+ 
+depends_lib \
+    port:libusb
+
+configure.args-append \
+    -DBUILD_TESTS=OFF \
+    -DBUILD_DOCS=OFF \
+    -DBUILD_MAN=OFF
+
+patchfiles          patch-ambiguous-abs-fix.diff
+
+app.create yes
+app.name qDMR
+app.executable qdmr
+app.icon dist/qdmr.png
+app.retina no
+

--- a/science/qdmr/files/patch-ambiguous-abs-fix.diff
+++ b/science/qdmr/files/patch-ambiguous-abs-fix.diff
@@ -1,0 +1,10 @@
+--- lib/d868uv_codeplug.cc.orig	2021-05-13 00:50:55.000000000 +0200
++++ lib/d868uv_codeplug.cc	2021-05-13 00:51:13.000000000 +0200
+@@ -6,6 +6,7 @@
+ #include "userdatabase.hh"
+ #include "config.h"
+ #include "logger.hh"
++#include <cmath>
+ 
+ #include <QTimeZone>
+ #include <QtEndian>


### PR DESCRIPTION
#### Description
Adds qDMR port.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.3.1 20E241 x86_64
Xcode 12.4 12D4e

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
