### PR TITLE
llvm-11: use system python for set-xcode-analyzer

### DIFF
--- a/lang/llvm-11/Portfile
+++ b/lang/llvm-11/Portfile
@@ -25,7 +25,7 @@ checksums               rmd160  f566b4b75c8f30418f19069a9a84864ead766401 \
 
 name                    llvm-${llvm_version}
 revision                0
-subport                 clang-${llvm_version} { revision 2 }
+subport                 clang-${llvm_version} { revision 3 }
 subport                 flang-${llvm_version} { revision 0 }
 subport                 lldb-${llvm_version} { revision 0 }
 set suffix              mp-${llvm_version}
@@ -523,9 +523,6 @@ if {${subport} eq "llvm-${llvm_version}"} {
             # pythonfullpath is set above, depending on presence of system python2.7
             reinplace "s|/usr/bin/env python|${pythonfullpath}|g" \
                  ${worksrcpath}/tools/clang/tools/scan-view/bin/scan-view
-
-            reinplace "s|/usr/bin/python|${pythonfullpath}|g" \
-                ${worksrcpath}/tools/clang/tools/scan-build/bin/set-xcode-analyzer
         }
     }
 


### PR DESCRIPTION
 * Fixes: https://trac.macports.org/ticket/62308

#### Description

This fixes https://trac.macports.org/ticket/62308. I tested on macOS 10.14.6 by manually reverting the `set-xcode-analyzer` back to use `/usr/bin/python` (I did not use the modified portfile to rebuild the port). I use Xcode 11.3.1 and I confirm that the `set-xcode-analyzer` script works correctly after this script, and that my Xcode version can successfully use MacPorts's clang-11 for static analysis.

The same fix can probably be applied to other versions of the Clang port as well, but I only looked at version 11. I would rather leave this change to the maintainers, or at least wait until this PR is approved before putting in effort into additional changes.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
