### PR TITLE
mpich: Include gcc11 cases as needed.

### DIFF
--- a/_resources/port1.0/group/compilers-1.0.tcl
+++ b/_resources/port1.0/group/compilers-1.0.tcl
@@ -785,7 +785,7 @@ proc compilers::add_fortran_legacy_support {} {
         } else {
             set fortran_compiler    [fortran_variant_name]
         }
-        if {${fortran_compiler} in "gcc10 gccdevel"} {
+        if {${fortran_compiler} in "gcc11 gcc10 gccdevel"} {
             configure.fflags-delete     -fallow-argument-mismatch
             configure.fcflags-delete    -fallow-argument-mismatch
             configure.f90flags-delete   -fallow-argument-mismatch

--- a/science/mpich/Portfile
+++ b/science/mpich/Portfile
@@ -363,7 +363,9 @@ if {${name} ne ${subport} && [string first "-devel" $subport] < 0} {
         } {}
         default_variants-append     +fortran
 
-        if {${cname} eq "gcc10" || ${cname} eq "gccdevel"} {
+        if {${cname} eq "gcc10" ||
+            ${cname} eq "gcc11" ||
+            ${cname} eq "gccdevel"} {
             # see https://lists.mpich.org/pipermail/discuss/2020-January/005862.html
             # see https://github.com/pmodels/mpich/issues/4300
             # see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91556
@@ -376,6 +378,7 @@ if {${name} ne ${subport} && [string first "-devel" $subport] < 0} {
     } else {
         append long_description " (AND THE FORTRAN COMPILER SELECTED BY THE VARIANT, IF ANY)"
 
+        compilers.allow_arguments_mismatch yes
         compilers.choose   fc f77 f90
         compilers.setup    default_fortran
 
@@ -391,13 +394,6 @@ if {${name} ne ${subport} && [string first "-devel" $subport] < 0} {
 
             if {[variant_isset g95]} {
                 configure.args-append lt_cv_ld_force_load=no
-            }
-
-            if {[variant_isset gcc10] || [variant_isset gccdevel]} {
-                # see https://lists.mpich.org/pipermail/discuss/2020-January/005862.html
-                # see https://github.com/pmodels/mpich/issues/4300
-                # see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91556
-                configure.fflags-append -fallow-argument-mismatch
             }
         }
     }


### PR DESCRIPTION
Fixes https://trac.macports.org/ticket/62866

Maintainer update.
