### PR TITLE
syncthing: update to 1.16.1

### DIFF
--- a/net/syncthing/Portfile
+++ b/net/syncthing/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/syncthing/syncthing 1.15.1 v
+go.setup            github.com/syncthing/syncthing 1.16.1 v
 categories          net
 platforms           darwin
 license             MPL-2
@@ -18,9 +18,9 @@ long_description    Syncthing replaces proprietary sync and cloud services \
 homepage            https://syncthing.net
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  751e7570d0eafc1f187864f1e374e9f4ab92dc98 \
-                        sha256  607ca3f2004d8fe0c38083b4cfa9947dfbdab1b4cbb73c25e49094e473672241 \
-                        size    6110774
+                        rmd160  c63a3fe5d9bc2345330f6e5675ebe5308f0462e2 \
+                        sha256  1cedb69a7ef3f692c123138e6d36187ee41e738127112f31cdfd6ffa0cecf16e \
+                        size    6086654
 
 go.vendors          gopkg.in/yaml.v3 \
                         lock    9f266ea9e77c \
@@ -399,10 +399,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  7d4569b405660ffcd4eb36d911a112d0e88a2c20141275e2aaad46b112d032c7 \
                         size    158977 \
                     github.com/ccding/go-stun \
-                        lock    v0.1.2 \
-                        rmd160  74e2d7c70fcbd544cc5623641ceed2d35dbb5bef \
-                        sha256  8472b29182200724c4758b5b4e5d0105c53b91ed1cff0091ec0443f597f72f43 \
-                        size    14119 \
+                        lock    v0.1.3 \
+                        rmd160  0f44206289f1515e2022efb959b830e839b0627f \
+                        sha256  a3e483ee68a3aa7ce51b46a2b0249aed8f2f4274de4e66283ffb102ca4f73549 \
+                        size    14592 \
                     github.com/calmh/xdr \
                         lock    v1.1.0 \
                         rmd160  944babe70dbef7a20b2db97dfe6bd892f8953ca9 \


### PR DESCRIPTION
#### Description

Updates syncthing to 1.16.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
