### PR TITLE
dns-server: fix typo in long_description

### DIFF
--- a/net/dns-server/Portfile
+++ b/net/dns-server/Portfile
@@ -214,7 +214,7 @@ Post Installation:
 	host ${named_host} ${host_lan_ip_address}
 	host ${host_lan_ip_address} ${host_lan_ip_address}
 
-    A rndc.key fil is automatically created with the command:
+    A rndc.key file is automatically created with the command:
 
 	rndc-confgen -A hmac-sha512 -a -c ${prefix}/var/named/rndc.key -u named
 

--- a/net/dns-server/Portfile
+++ b/net/dns-server/Portfile
@@ -23,7 +23,7 @@ long_description        DNS server working configuration for named \
                         records, MX, SPF, DKIM, and DMARC records for \
                         email servers, and URI, TXT, and SRV records \
                         for Kerberos servers. This configuration is \
-                        based upon macOS Server.app's VPN server prior \
+                        based upon macOS Server.app's DNS server prior \
                         to its deprecation in Server.app version 5.7. \
                         See `man named`.
 


### PR DESCRIPTION
#### Description

Corrects `VPN server` reference to `DNS server`.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
