### PR TITLE
dns-server: fix typos in long_description, notes

### DIFF
--- a/net/dns-server/Portfile
+++ b/net/dns-server/Portfile
@@ -23,7 +23,7 @@ long_description        DNS server working configuration for named \
                         records, MX, SPF, DKIM, and DMARC records for \
                         email servers, and URI, TXT, and SRV records \
                         for Kerberos servers. This configuration is \
-                        based upon macOS Server.app's VPN server prior \
+                        based upon macOS Server.app's DNS server prior \
                         to its deprecation in Server.app version 5.7. \
                         See `man named`.
 
@@ -214,7 +214,7 @@ Post Installation:
 	host ${named_host} ${host_lan_ip_address}
 	host ${host_lan_ip_address} ${host_lan_ip_address}
 
-    A rndc.key fil is automatically created with the command:
+    A rndc.key file is automatically created with the command:
 
 	rndc-confgen -A hmac-sha512 -a -c ${prefix}/var/named/rndc.key -u named
 


### PR DESCRIPTION
#### Description

Corrects `VPN server` reference to `DNS server`.
Corrects `fil` to `file`.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
