### PR TITLE
zstd: update to 1.5.0

### DIFF
--- a/archivers/zstd/Portfile
+++ b/archivers/zstd/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           clang_dependency 1.0
 
-github.setup        facebook zstd 1.4.9 v
+github.setup        facebook zstd 1.5.0 v
 
-checksums           rmd160  7094ac7e00bf5d8551ced0cfcfd6ed66bc327836 \
-                    sha256  29ac74e19ea28659017361976240c4b5c5c24db3b89338731a6feb97c038d293 \
-                    size    1821109
+checksums           rmd160  0edbe1beaf89e9b565daa75cf96e3a8428064af3 \
+                    sha256  5194fbfa781fcf45b98c5e849651aa7b3b0a008c6b72d4a0db760f3002291e94 \
+                    size    1851389
 
 categories          archivers devel
 platforms           darwin
@@ -45,10 +45,6 @@ platform darwin 8 {
     depends_build-append port:gmake
     build.cmd    gmake
 }
-
-# https://github.com/facebook/zstd/issues/2169
-# https://trac.macports.org/ticket/60542
-use_parallel_build  no
 
 build.target        allmost
 build.post_args     V=1


### PR DESCRIPTION
#### Description

 * update to 1.5.0
 * remove obsolete workaround for https://trac.macports.org/ticket/60542

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G9028 x86_64
Xcode 11.3.1 11C504


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
